### PR TITLE
GC: Reorganize forge structures

### DIFF
--- a/example/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/example/glue/CollectorLanguageInterfaceImpl.cpp
@@ -61,7 +61,7 @@ MM_CollectorLanguageInterfaceImpl::newInstance(MM_EnvironmentBase *env)
 	OMR_VM *omrVM = env->getOmrVM();
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVM);
 
-	cli = (MM_CollectorLanguageInterfaceImpl *)extensions->getForge()->allocate(sizeof(MM_CollectorLanguageInterfaceImpl), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	cli = (MM_CollectorLanguageInterfaceImpl *)extensions->getForge()->allocate(sizeof(MM_CollectorLanguageInterfaceImpl), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != cli) {
 		new(cli) MM_CollectorLanguageInterfaceImpl(omrVM);
 		if (!cli->initialize(omrVM)) {

--- a/example/glue/VerboseManagerImpl.cpp
+++ b/example/glue/VerboseManagerImpl.cpp
@@ -38,7 +38,7 @@ MM_VerboseManagerImpl::newInstance(MM_EnvironmentBase *env, OMR_VM* vm)
 {
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(vm);
 
-	MM_VerboseManagerImpl *verboseManager = (MM_VerboseManagerImpl *)extensions->getForge()->allocate(sizeof(MM_VerboseManagerImpl), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_VerboseManagerImpl *verboseManager = (MM_VerboseManagerImpl *)extensions->getForge()->allocate(sizeof(MM_VerboseManagerImpl), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (verboseManager) {
 		new(verboseManager) MM_VerboseManagerImpl(vm);
 		if(!verboseManager->initialize(env)) {

--- a/gc/base/AllocationCategory.hpp
+++ b/gc/base/AllocationCategory.hpp
@@ -1,0 +1,32 @@
+#if !defined(OMR_GC_ALLOCATIONCATEGORY_HPP_)
+#define OMR_GC_ALLOCATIONCATEGORY_HPP_
+
+namespace OMR {
+namespace GC {
+
+/**
+ * Forge allocation categories.
+ */
+struct AllocationCategory {
+	enum Enum {
+		FIXED = 0,           /** Memory that is a fixed cost of running the garbage collector (e.g. memory for GCExtensions) */
+		WORK_PACKETS,        /** Memory that is used for work packets  */
+		REFERENCES,          /** Memory that is used to track soft, weak, and phantom references */
+		FINALIZE,            /** Memory that is used to track and finalize objects */
+		DIAGNOSTIC,          /** Memory that is used to track gc behaviour (e.g. gc check, verbose gc) */
+		REMEMBERED_SET,      /** Memory that is used to track the remembered set */
+		GC_HEAP,             /** Memory that is used for the GC's heap */
+		JAVA_HEAP = GC_HEAP, /** Java alias for GC_HEAP */
+		OTHER,               /** Memory that does not fall into any of the above categories */
+
+		/* Must be last, do not use this category! */
+		CATEGORY_COUNT
+	};
+};
+
+} /* namespace GC */
+} /* namespace OMR */
+
+typedef OMR::GC::AllocationCategory MM_AllocationCategory;
+
+#endif /* OMR_GC_ALLOCATIONCATEGORY_HPP_ */

--- a/gc/base/AllocationInterfaceGeneric.cpp
+++ b/gc/base/AllocationInterfaceGeneric.cpp
@@ -35,7 +35,7 @@
 MM_AllocationInterfaceGeneric*
 MM_AllocationInterfaceGeneric::newInstance(MM_EnvironmentBase *env)
 {
-	MM_AllocationInterfaceGeneric *allocationInterface = (MM_AllocationInterfaceGeneric *)env->getForge()->allocate(sizeof(MM_AllocationInterfaceGeneric), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_AllocationInterfaceGeneric *allocationInterface = (MM_AllocationInterfaceGeneric *)env->getForge()->allocate(sizeof(MM_AllocationInterfaceGeneric), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(NULL != allocationInterface) {
 		new(allocationInterface) MM_AllocationInterfaceGeneric(env);
 		if(!allocationInterface->initialize(env)) {

--- a/gc/base/Dispatcher.cpp
+++ b/gc/base/Dispatcher.cpp
@@ -33,7 +33,7 @@ MM_Dispatcher::newInstance(MM_EnvironmentBase *env)
 {
 	MM_Dispatcher *dispatcher;
 	
-	dispatcher = (MM_Dispatcher *)env->getForge()->allocate(sizeof(MM_Dispatcher), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	dispatcher = (MM_Dispatcher *)env->getForge()->allocate(sizeof(MM_Dispatcher), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (dispatcher) {
 		new(dispatcher) MM_Dispatcher(env);
 		if(!dispatcher->initialize(env)) {

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -263,7 +263,7 @@ public:
 	 * Get the memory forge
 	 * @return The memory forge
 	 */
-	MMINLINE MM_Forge *getForge() { return getExtensions()->getForge(); }
+	MMINLINE OMR::GC::Forge *getForge() { return getExtensions()->getForge(); }
 
 	/**
 	 * Get the thread's priority.

--- a/gc/base/Forge.cpp
+++ b/gc/base/Forge.cpp
@@ -43,7 +43,7 @@ Forge::initialize(OMRPortLibrary* port)
 {
 	_portLibrary = port;
 
-	if (0 != omrthread_monitor_init_with_name(&_mutex, 0, "MM_Forge")) {
+	if (0 != omrthread_monitor_init_with_name(&_mutex, 0, "OMR::GC::Forge")) {
 		return false;
 	}	
 

--- a/gc/base/Forge.cpp
+++ b/gc/base/Forge.cpp
@@ -131,8 +131,8 @@ Forge::free(void* memoryPointer)
  *
  * @return an array of memory usage statistics indexed using the MM_AllocationCategory enumeration
  */
-MM_MemoryStatistics*
-MM_Forge::getCurrentStatistics()
+OMR_GC_MemoryStatistics*
+Forge::getCurrentStatistics()
 {
 	return _statistics;
 }

--- a/gc/base/Forge.cpp
+++ b/gc/base/Forge.cpp
@@ -30,7 +30,7 @@ namespace GC {
 
 struct MemoryHeader {
 	uintptr_t allocatedBytes;
-	MM_AllocationCategory::Enum category;
+	OMR::GC::AllocationCategory::Enum category;
 };
 
 union AlignedMemoryHeader {
@@ -47,8 +47,8 @@ Forge::initialize(OMRPortLibrary* port)
 		return false;
 	}	
 
-	for (uintptr_t i = 0; i < MM_AllocationCategory::CATEGORY_COUNT; i++) {
-		_statistics[i].category = (MM_AllocationCategory::Enum) i;
+	for (uintptr_t i = 0; i < OMR::GC::AllocationCategory::CATEGORY_COUNT; i++) {
+		_statistics[i].category = (OMR::GC::AllocationCategory::Enum) i;
 		_statistics[i].allocated = 0;
 		_statistics[i].highwater = 0;
 	}
@@ -77,7 +77,7 @@ Forge::tearDown()
  * @return a pointer to the allocated memory, or NULL if the request could not be performed
  */
 void* 
-Forge::allocate(std::size_t bytesRequested, MM_AllocationCategory::Enum category, const char* callsite)
+Forge::allocate(std::size_t bytesRequested, OMR::GC::AllocationCategory::Enum category, const char* callsite)
 {
 	AlignedMemoryHeader* memoryPointer;
 
@@ -129,7 +129,7 @@ Forge::free(void* memoryPointer)
  * Returns the current memory usage statistics for the garbage collector.  Each entry in the array corresponds to a memory usage category type.
  * To locate memory usage statistics for a particular category, use the enumeration value as the array index (e.g. stats[REFERENCES]).
  *
- * @return an array of memory usage statistics indexed using the MM_AllocationCategory enumeration
+ * @return an array of memory usage statistics indexed using the OMR::GC::AllocationCategory enumeration
  */
 OMR_GC_MemoryStatistics*
 Forge::getCurrentStatistics()

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -40,7 +40,7 @@ MM_GCExtensionsBase::newInstance(MM_EnvironmentBase* env)
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	MM_GCExtensionsBase* extensions;
 
-	/* Avoid using MM_Forge to allocate memory for the extension, since MM_Forge itself has not been created! */
+	/* Avoid using OMR::GC::Forge to allocate memory for the extension, since OMR::GC::Forge itself has not been created! */
 	extensions = static_cast<MM_GCExtensionsBase*>(omrmem_allocate_memory(sizeof(MM_GCExtensionsBase), OMRMEM_CATEGORY_MM));
 	if (extensions) {
 		new (extensions) MM_GCExtensionsBase();
@@ -55,7 +55,7 @@ MM_GCExtensionsBase::newInstance(MM_EnvironmentBase* env)
 void
 MM_GCExtensionsBase::kill(MM_EnvironmentBase* env)
 {
-	/* Avoid using MM_Forge to free memory for the extension, since MM_Forge was not used to allocate the memory */
+	/* Avoid using OMR::GC::Forge to free memory for the extension, since OMR::GC::Forge was not used to allocate the memory */
 	OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 	tearDown(env);
 	omrmem_free_memory(this);

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -90,7 +90,7 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
-	if (!rememberedSet.initialize(env, MM_AllocationCategory::REMEMBERED_SET)) {
+	if (!rememberedSet.initialize(env, OMR::GC::AllocationCategory::REMEMBERED_SET)) {
 		goto failed;
 	}
 	rememberedSet.setGrowSize(J9_SCV_REMSET_SIZE);

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -201,7 +201,7 @@ private:
 
 protected:
 	OMR_VM* _omrVM;
-	MM_Forge _forge;
+	OMR::GC::Forge _forge;
 	MM_Collector* _globalCollector; /**< The global collector for the system */
 #if defined(OMR_GC_OBJECT_MAP)
 	MM_ObjectMap *_objectMap;
@@ -779,7 +779,7 @@ public:
 	 * Gets a pointer to the memory forge
 	 * @return Pointer to the memory forge
 	 */
-	MMINLINE MM_Forge* getForge() { return &_forge; }
+	MMINLINE OMR::GC::Forge* getForge() { return &_forge; }
 
 	MMINLINE uintptr_t getRememberedCount()
 	{

--- a/gc/base/HeapRegionManager.cpp
+++ b/gc/base/HeapRegionManager.cpp
@@ -55,7 +55,7 @@ MM_HeapRegionManager::MM_HeapRegionManager(MM_EnvironmentBase* env, uintptr_t re
 MM_HeapRegionManager*
 MM_HeapRegionManager::newInstance(MM_EnvironmentBase* env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor)
 {
-	MM_HeapRegionManager *regionManager = (MM_HeapRegionManager *)env->getForge()->allocate(sizeof(MM_HeapRegionManager), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_HeapRegionManager *regionManager = (MM_HeapRegionManager *)env->getForge()->allocate(sizeof(MM_HeapRegionManager), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (regionManager) {
 		new(regionManager) MM_HeapRegionManager(env, regionSize, tableDescriptorSize, regionDescriptorInitializer, regionDescriptorDestructor);
 		if (!regionManager->initialize(env)) {
@@ -240,7 +240,7 @@ MM_HeapRegionManager::findFirstUsedRegion(MM_HeapRegionDescriptor* start)
 MM_HeapRegionDescriptor*
 MM_HeapRegionManager::internalAllocateAuxiliaryRegionDescriptor(MM_EnvironmentBase* env, void* lowAddress, void* highAddress)
 {
-	MM_HeapRegionDescriptor* desc = (MM_HeapRegionDescriptor*)env->getForge()->allocate(_tableDescriptorSize, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_HeapRegionDescriptor* desc = (MM_HeapRegionDescriptor*)env->getForge()->allocate(_tableDescriptorSize, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != desc) {
 		if (!_regionDescriptorInitializer(env, this, desc, lowAddress, highAddress)) {
 			desc = NULL;
@@ -265,7 +265,7 @@ MM_HeapRegionManager::internalAllocateAndInitializeRegionTable(MM_EnvironmentBas
 	uintptr_t regionSize = getRegionSize();
 	uintptr_t regionCount = size / regionSize;
 	uintptr_t sizeInBytes = regionCount * _tableDescriptorSize;
-	MM_HeapRegionDescriptor* table = (MM_HeapRegionDescriptor*)env->getForge()->allocate(sizeInBytes, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_HeapRegionDescriptor* table = (MM_HeapRegionDescriptor*)env->getForge()->allocate(sizeInBytes, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != table) {
 		/* the table has been allocated so initialize the descriptors inside it and the meta-data to use the table */
 		memset((void*)table, 0, sizeInBytes);

--- a/gc/base/HeapRegionManagerTarok.cpp
+++ b/gc/base/HeapRegionManagerTarok.cpp
@@ -42,7 +42,7 @@ MM_HeapRegionManagerTarok::MM_HeapRegionManagerTarok(MM_EnvironmentBase *env, ui
 MM_HeapRegionManagerTarok *
 MM_HeapRegionManagerTarok::newInstance(MM_EnvironmentBase *env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor)
 {
-	MM_HeapRegionManagerTarok *regionManager = (MM_HeapRegionManagerTarok *)env->getForge()->allocate(sizeof(MM_HeapRegionManagerTarok), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_HeapRegionManagerTarok *regionManager = (MM_HeapRegionManagerTarok *)env->getForge()->allocate(sizeof(MM_HeapRegionManagerTarok), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != regionManager) {
 		new(regionManager) MM_HeapRegionManagerTarok(env, regionSize, tableDescriptorSize, regionDescriptorInitializer, regionDescriptorDestructor);
 		if (!regionManager->initialize(env)) {
@@ -64,7 +64,7 @@ MM_HeapRegionManagerTarok::initialize(MM_EnvironmentBase *env)
 		_freeRegionTableSize = maximumNodeNumber + 1;
 
 		uintptr_t freeRegionTableSizeInBytes = _freeRegionTableSize * sizeof(MM_HeapRegionDescriptor *);
-		_freeRegionTable = (MM_HeapRegionDescriptor **)env->getForge()->allocate(freeRegionTableSizeInBytes, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+		_freeRegionTable = (MM_HeapRegionDescriptor **)env->getForge()->allocate(freeRegionTableSizeInBytes, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 		if (NULL == _freeRegionTable) {
 			return false;
 		}

--- a/gc/base/HeapSplit.cpp
+++ b/gc/base/HeapSplit.cpp
@@ -50,7 +50,7 @@ class MM_MemorySubSpace;
 MM_HeapSplit *
 MM_HeapSplit::newInstance(MM_EnvironmentBase *env, uintptr_t heapAlignment, uintptr_t lowExtentSize, uintptr_t highExtentSize, MM_HeapRegionManager *regionManager)
 {
-	MM_HeapSplit *heap = (MM_HeapSplit *)env->getForge()->allocate(sizeof(MM_HeapSplit), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_HeapSplit *heap = (MM_HeapSplit *)env->getForge()->allocate(sizeof(MM_HeapSplit), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	
 	if (NULL != heap) {
 		new(heap) MM_HeapSplit(env, lowExtentSize, highExtentSize, regionManager);

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -54,7 +54,7 @@ MM_HeapVirtualMemory::newInstance(MM_EnvironmentBase* env, uintptr_t heapAlignme
 {
 	MM_HeapVirtualMemory* heap;
 
-	heap = (MM_HeapVirtualMemory*)env->getForge()->allocate(sizeof(MM_HeapVirtualMemory), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	heap = (MM_HeapVirtualMemory*)env->getForge()->allocate(sizeof(MM_HeapVirtualMemory), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (heap) {
 		new (heap) MM_HeapVirtualMemory(env, heapAlignment, size, regionManager);
 		if (!heap->initialize(env, size)) {

--- a/gc/base/MarkMap.cpp
+++ b/gc/base/MarkMap.cpp
@@ -45,7 +45,7 @@
 MM_MarkMap *
 MM_MarkMap::newInstance(MM_EnvironmentBase *env, uintptr_t maxHeapSize)
 {
-	MM_MarkMap *markMap = (MM_MarkMap *)env->getForge()->allocate(sizeof(MM_MarkMap), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_MarkMap *markMap = (MM_MarkMap *)env->getForge()->allocate(sizeof(MM_MarkMap), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != markMap) {
 		new(markMap) MM_MarkMap(env, maxHeapSize);
 		if (!markMap->initialize(env)) {

--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -51,7 +51,7 @@ MM_MarkingScheme::newInstance(MM_EnvironmentBase *env)
 {
 	MM_MarkingScheme *markingScheme;
 
-	markingScheme = (MM_MarkingScheme *)env->getForge()->allocate(sizeof(MM_MarkingScheme), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	markingScheme = (MM_MarkingScheme *)env->getForge()->allocate(sizeof(MM_MarkingScheme), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (markingScheme) {
 		new(markingScheme) MM_MarkingScheme(env);
 		if (!markingScheme->initialize(env)) {

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -33,7 +33,7 @@
 MM_MemoryManager*
 MM_MemoryManager::newInstance(MM_EnvironmentBase* env)
 {
-	MM_MemoryManager* memoryManager = (MM_MemoryManager*)env->getForge()->allocate(sizeof(MM_MemoryManager), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_MemoryManager* memoryManager = (MM_MemoryManager*)env->getForge()->allocate(sizeof(MM_MemoryManager), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 	if (NULL != memoryManager) {
 		new (memoryManager) MM_MemoryManager(env);

--- a/gc/base/MemoryPoolAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolAddressOrderedList.cpp
@@ -59,7 +59,7 @@ MM_MemoryPoolAddressOrderedList::newInstance(MM_EnvironmentBase *env, uintptr_t 
 {
 	MM_MemoryPoolAddressOrderedList *memoryPool;
 
-	memoryPool = (MM_MemoryPoolAddressOrderedList *)env->getForge()->allocate(sizeof(MM_MemoryPoolAddressOrderedList), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memoryPool = (MM_MemoryPoolAddressOrderedList *)env->getForge()->allocate(sizeof(MM_MemoryPoolAddressOrderedList), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memoryPool) {
 		memoryPool = new(memoryPool) MM_MemoryPoolAddressOrderedList(env, minimumFreeEntrySize, name);
 		if (!memoryPool->initialize(env)) {

--- a/gc/base/MemoryPoolBumpPointer.cpp
+++ b/gc/base/MemoryPoolBumpPointer.cpp
@@ -40,7 +40,7 @@
 MM_MemoryPoolBumpPointer *
 MM_MemoryPoolBumpPointer::newInstance(MM_EnvironmentBase *env, uintptr_t minimumFreeEntrySize)
 {
-	MM_MemoryPoolBumpPointer *memoryPool = (MM_MemoryPoolBumpPointer *)env->getForge()->allocate(sizeof(MM_MemoryPoolBumpPointer), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_MemoryPoolBumpPointer *memoryPool = (MM_MemoryPoolBumpPointer *)env->getForge()->allocate(sizeof(MM_MemoryPoolBumpPointer), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != memoryPool) {
 		memoryPool = new(memoryPool) MM_MemoryPoolBumpPointer(env, minimumFreeEntrySize);
 		if (!memoryPool->initialize(env)) {

--- a/gc/base/MemoryPoolHybrid.cpp
+++ b/gc/base/MemoryPoolHybrid.cpp
@@ -56,7 +56,7 @@ MM_MemoryPoolHybrid::newInstance(MM_EnvironmentBase* env, uintptr_t minimumFreeE
 {
 	MM_MemoryPoolHybrid* memoryPool;
 
-	memoryPool = (MM_MemoryPoolHybrid*)env->getForge()->allocate(sizeof(MM_MemoryPoolHybrid), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memoryPool = (MM_MemoryPoolHybrid*)env->getForge()->allocate(sizeof(MM_MemoryPoolHybrid), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memoryPool) {
 		memoryPool = new (memoryPool) MM_MemoryPoolHybrid(env, minimumFreeEntrySize, maxSplit, name);
 		if (!memoryPool->initialize(env)) {

--- a/gc/base/MemoryPoolLargeObjects.cpp
+++ b/gc/base/MemoryPoolLargeObjects.cpp
@@ -68,7 +68,7 @@ MM_MemoryPoolLargeObjects::newInstance(MM_EnvironmentBase* env, MM_MemoryPoolAdd
 {
 	MM_MemoryPoolLargeObjects* memoryPool;
 
-	memoryPool = (MM_MemoryPoolLargeObjects*)env->getForge()->allocate(sizeof(MM_MemoryPoolLargeObjects), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memoryPool = (MM_MemoryPoolLargeObjects*)env->getForge()->allocate(sizeof(MM_MemoryPoolLargeObjects), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != memoryPool) {
 		memoryPool = new (memoryPool) MM_MemoryPoolLargeObjects(env, largeObjectArea, smallObjectArea);
 		if (!memoryPool->initialize(env)) {
@@ -117,7 +117,7 @@ MM_MemoryPoolLargeObjects::initialize(MM_EnvironmentBase* env)
 		omrtty_printf("LOA Initialize: SOA subpool %p LOA subpool %p\n ", _memoryPoolSmallObjects, _memoryPoolLargeObjects);
 	}
 
-	_loaFreeRatioHistory = (double*)env->getForge()->allocate(_extensions->loaFreeHistorySize * sizeof(double), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_loaFreeRatioHistory = (double*)env->getForge()->allocate(_extensions->loaFreeHistorySize * sizeof(double), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 	if (NULL == _loaFreeRatioHistory){
 		return false;

--- a/gc/base/MemoryPoolSplitAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedList.cpp
@@ -62,7 +62,7 @@ MM_MemoryPoolSplitAddressOrderedList::newInstance(MM_EnvironmentBase* env, uintp
 {
 	MM_MemoryPoolSplitAddressOrderedList* memoryPool;
 
-	memoryPool = (MM_MemoryPoolSplitAddressOrderedList*)env->getForge()->allocate(sizeof(MM_MemoryPoolSplitAddressOrderedList), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memoryPool = (MM_MemoryPoolSplitAddressOrderedList*)env->getForge()->allocate(sizeof(MM_MemoryPoolSplitAddressOrderedList), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memoryPool) {
 		memoryPool = new (memoryPool) MM_MemoryPoolSplitAddressOrderedList(env, minimumFreeEntrySize, maxSplit, name);
 		if (!memoryPool->initialize(env)) {

--- a/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
@@ -147,7 +147,7 @@ MM_MemoryPoolSplitAddressOrderedListBase::initialize(MM_EnvironmentBase* env)
 	 */
 	_sweepPoolManager = extensions->sweepPoolManagerSmallObjectArea;
 
-	_currentThreadFreeList = (uintptr_t*)extensions->getForge()->allocate(sizeof(uintptr_t) * _heapFreeListCount, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_currentThreadFreeList = (uintptr_t*)extensions->getForge()->allocate(sizeof(uintptr_t) * _heapFreeListCount, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL == _currentThreadFreeList) {
 		return false;
 	} else {
@@ -156,7 +156,7 @@ MM_MemoryPoolSplitAddressOrderedListBase::initialize(MM_EnvironmentBase* env)
 		}
 	}
 
-	_heapFreeLists = (J9ModronHeapFreeList*)extensions->getForge()->allocate(sizeof(J9ModronHeapFreeList) * _heapFreeListCountExtended, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_heapFreeLists = (J9ModronHeapFreeList*)extensions->getForge()->allocate(sizeof(J9ModronHeapFreeList) * _heapFreeListCountExtended, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL == _heapFreeLists) {
 		return false;
 	} else {
@@ -180,7 +180,7 @@ MM_MemoryPoolSplitAddressOrderedListBase::initialize(MM_EnvironmentBase* env)
 	/* If we ever subclass MM_LargeObjectAllocateStats we will have to allocate this as an array of pointers to MM_LargeObjectAllocateStats and invoke newInstance instead of just initialize
 	 * Than, we may also need to virtualize initialize() and tearDown().
 	 */
-	_largeObjectAllocateStatsForFreeList = (MM_LargeObjectAllocateStats*)extensions->getForge()->allocate(sizeof(MM_LargeObjectAllocateStats) * _heapFreeListCountExtended, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_largeObjectAllocateStatsForFreeList = (MM_LargeObjectAllocateStats*)extensions->getForge()->allocate(sizeof(MM_LargeObjectAllocateStats) * _heapFreeListCountExtended, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 	if (NULL == _largeObjectAllocateStatsForFreeList) {
 		return false;

--- a/gc/base/MemorySpace.cpp
+++ b/gc/base/MemorySpace.cpp
@@ -39,7 +39,7 @@
 MM_MemorySpace *
 MM_MemorySpace::newInstance(MM_EnvironmentBase *env, MM_Heap *heap, MM_PhysicalArena *physicalArena, MM_MemorySubSpace *memorySubSpace, MM_InitializationParameters *parameters, const char *name, const char *description)
 {
-	MM_MemorySpace *memorySpace = (MM_MemorySpace *)env->getForge()->allocate(sizeof(MM_MemorySpace), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_MemorySpace *memorySpace = (MM_MemorySpace *)env->getForge()->allocate(sizeof(MM_MemorySpace), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memorySpace) {
 		new(memorySpace) MM_MemorySpace(heap, physicalArena, parameters, name, description);
 		if (!memorySpace->initialize(env, memorySubSpace)) {

--- a/gc/base/MemoryStatistics.hpp
+++ b/gc/base/MemoryStatistics.hpp
@@ -1,0 +1,16 @@
+#if !defined(OMR_GC_MEMORYSTATISTICS_HPP_)
+#define OMR_GC_MEMORYSTATISTICS_HPP_
+
+#include "omrcfg.h"
+#include "AllocationCategory.hpp"
+#include <stdint.h>
+
+struct OMR_GC_MemoryStatistics {
+	OMR::GC::AllocationCategory::Enum category;
+	uintptr_t allocated;
+	uintptr_t highwater;
+};
+
+typedef OMR_GC_MemoryStatistics MM_MemoryStatistics;
+
+#endif /* OMR_GC_MEMORYSTATISTICS_HPP_ */

--- a/gc/base/MemorySubSpaceFlat.cpp
+++ b/gc/base/MemorySubSpaceFlat.cpp
@@ -277,7 +277,7 @@ MM_MemorySubSpaceFlat::newInstance(
 {
 	MM_MemorySubSpaceFlat* memorySubSpace;
 
-	memorySubSpace = (MM_MemorySubSpaceFlat*)env->getForge()->allocate(sizeof(MM_MemorySubSpaceFlat), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memorySubSpace = (MM_MemorySubSpaceFlat*)env->getForge()->allocate(sizeof(MM_MemorySubSpaceFlat), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memorySubSpace) {
 		new (memorySubSpace) MM_MemorySubSpaceFlat(env, physicalSubArena, childMemorySubSpace, usesGlobalCollector, minimumSize, initialSize, maximumSize, memoryType, objectFlags);
 		if (!memorySubSpace->initialize(env)) {

--- a/gc/base/MemorySubSpaceGenerational.cpp
+++ b/gc/base/MemorySubSpaceGenerational.cpp
@@ -204,7 +204,7 @@ MM_MemorySubSpaceGenerational::newInstance(MM_EnvironmentBase *env, MM_MemorySub
 {
 	MM_MemorySubSpaceGenerational *memorySubSpace;
 	
-	memorySubSpace = (MM_MemorySubSpaceGenerational *)env->getForge()->allocate(sizeof(MM_MemorySubSpaceGenerational), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memorySubSpace = (MM_MemorySubSpaceGenerational *)env->getForge()->allocate(sizeof(MM_MemorySubSpaceGenerational), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memorySubSpace) {
 		new(memorySubSpace) MM_MemorySubSpaceGenerational(env, memorySubSpaceNew, memorySubSpaceOld, usesGlobalCollector, minimumSize, minimumSizeNew, initialSizeNew, maximumSizeNew, minimumSizeOld, initialSizeOld, maximumSizeOld, maximumSize);
 		if (!memorySubSpace->initialize(env)) {

--- a/gc/base/MemorySubSpaceGeneric.cpp
+++ b/gc/base/MemorySubSpaceGeneric.cpp
@@ -543,7 +543,7 @@ MM_MemorySubSpaceGeneric::newInstance(MM_EnvironmentBase* env, MM_MemoryPool* me
 {
 	MM_MemorySubSpaceGeneric* memorySubSpace;
 
-	memorySubSpace = (MM_MemorySubSpaceGeneric*)env->getForge()->allocate(sizeof(MM_MemorySubSpaceGeneric), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memorySubSpace = (MM_MemorySubSpaceGeneric*)env->getForge()->allocate(sizeof(MM_MemorySubSpaceGeneric), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != memorySubSpace) {
 		new (memorySubSpace) MM_MemorySubSpaceGeneric(env, memoryPool, regionPool, usesGlobalCollector, minimumSize, initialSize, maximumSize, memoryType, objectFlags);
 		if (!memorySubSpace->initialize(env)) {

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -385,7 +385,7 @@ MM_MemorySubSpaceSemiSpace::newInstance(MM_EnvironmentBase *env, MM_Collector *c
 {
 	MM_MemorySubSpaceSemiSpace *memorySubSpace;
 	
-	memorySubSpace = (MM_MemorySubSpaceSemiSpace *)env->getForge()->allocate(sizeof(MM_MemorySubSpaceSemiSpace), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memorySubSpace = (MM_MemorySubSpaceSemiSpace *)env->getForge()->allocate(sizeof(MM_MemorySubSpaceSemiSpace), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memorySubSpace) {
 		new(memorySubSpace) MM_MemorySubSpaceSemiSpace(env, collector, physicalSubArena, memorySubSpaceAllocate, memorySubSpaceSurvivor, usesGlobalCollector, minimumSize, initialSize, maximumSize);
 		if (!memorySubSpace->initialize(env)) {

--- a/gc/base/NUMAManager.cpp
+++ b/gc/base/NUMAManager.cpp
@@ -95,7 +95,7 @@ MM_NUMAManager::recacheNUMASupport(MM_EnvironmentBase *env)
 	if (0 != nodeCount) {
 		/* we want to support NUMA either via the machine's physical NUMA or our simulated (aka "purely logical") NUMA */ 
 		uintptr_t nodeArraySize = sizeof(J9MemoryNodeDetail) * nodeCount;
-		_activeNodes = (J9MemoryNodeDetail *)env->getForge()->allocate(nodeArraySize, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+		_activeNodes = (J9MemoryNodeDetail *)env->getForge()->allocate(nodeArraySize, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 		if (NULL == _activeNodes) {
 			result = false;
 		} else {
@@ -151,7 +151,7 @@ MM_NUMAManager::recacheNUMASupport(MM_EnvironmentBase *env)
 			/* Affinity Leader array allocation and construction */
 			if (0 != _affinityLeaderCount) {
 				uintptr_t affinityLeaderArraySize = sizeof(J9MemoryNodeDetail) * _affinityLeaderCount;
-				_affinityLeaders = (J9MemoryNodeDetail *)env->getForge()->allocate(affinityLeaderArraySize, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+				_affinityLeaders = (J9MemoryNodeDetail *)env->getForge()->allocate(affinityLeaderArraySize, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 				if (NULL == _affinityLeaders) {
 					result = false;
 				} else {
@@ -172,7 +172,7 @@ MM_NUMAManager::recacheNUMASupport(MM_EnvironmentBase *env)
 			if (0 != _freeProcessorPoolNodeCount) {
 				/* allocate a free processor pool */
 				uintptr_t processorPoolArraySize = sizeof(J9MemoryNodeDetail) * _freeProcessorPoolNodeCount;
-				_freeProcessorPoolNodes = (J9MemoryNodeDetail *)env->getForge()->allocate(processorPoolArraySize, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+				_freeProcessorPoolNodes = (J9MemoryNodeDetail *)env->getForge()->allocate(processorPoolArraySize, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 				if (NULL == _freeProcessorPoolNodes) {
 					result = false;
 				} else {

--- a/gc/base/NonVirtualMemory.cpp
+++ b/gc/base/NonVirtualMemory.cpp
@@ -68,7 +68,7 @@ MM_NonVirtualMemory::reserveMemory(J9PortVmemParams* params)
 	if (alignment > 0) {
 		bytesToAllocate += (alignment - 1);
 	}
-	_baseAddress = _extensions->getForge()->allocate(bytesToAllocate, OMR::GC::AllocationCategory::JAVA_HEAP, OMR_GET_CALLSITE());
+	_baseAddress = _extensions->getForge()->allocate(bytesToAllocate, OMR::GC::AllocationCategory::GC_HEAP, OMR_GET_CALLSITE());
 	void* addressToReturn = _baseAddress;
 	if ((NULL != _baseAddress) && (alignment > 0)) {
 		addressToReturn = (void*)(((uintptr_t)addressToReturn + alignment - 1) & ~(alignment - 1));

--- a/gc/base/NonVirtualMemory.cpp
+++ b/gc/base/NonVirtualMemory.cpp
@@ -42,7 +42,7 @@
 MM_NonVirtualMemory*
 MM_NonVirtualMemory::newInstance(MM_EnvironmentBase* env, uintptr_t heapAlignment, uintptr_t size, uint32_t memoryCategory)
 {
-	MM_NonVirtualMemory* vmem = (MM_NonVirtualMemory*)env->getForge()->allocate(sizeof(MM_NonVirtualMemory), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_NonVirtualMemory* vmem = (MM_NonVirtualMemory*)env->getForge()->allocate(sizeof(MM_NonVirtualMemory), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (vmem) {
 		new (vmem) MM_NonVirtualMemory(env, heapAlignment);
 		if (!vmem->initialize(env, size, NULL, NULL, 0, memoryCategory)) {
@@ -68,7 +68,7 @@ MM_NonVirtualMemory::reserveMemory(J9PortVmemParams* params)
 	if (alignment > 0) {
 		bytesToAllocate += (alignment - 1);
 	}
-	_baseAddress = _extensions->getForge()->allocate(bytesToAllocate, MM_AllocationCategory::JAVA_HEAP, OMR_GET_CALLSITE());
+	_baseAddress = _extensions->getForge()->allocate(bytesToAllocate, OMR::GC::AllocationCategory::JAVA_HEAP, OMR_GET_CALLSITE());
 	void* addressToReturn = _baseAddress;
 	if ((NULL != _baseAddress) && (alignment > 0)) {
 		addressToReturn = (void*)(((uintptr_t)addressToReturn + alignment - 1) & ~(alignment - 1));

--- a/gc/base/ObjectMap.cpp
+++ b/gc/base/ObjectMap.cpp
@@ -39,7 +39,7 @@ MM_ObjectMap::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ObjectMap *objectMap;
 
-	objectMap = (MM_ObjectMap *)env->getForge()->allocate(sizeof(MM_ObjectMap), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	objectMap = (MM_ObjectMap *)env->getForge()->allocate(sizeof(MM_ObjectMap), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (objectMap) {
 		new(objectMap) MM_ObjectMap(env);
 		if (!objectMap->initialize(env)) {

--- a/gc/base/PacketList.cpp
+++ b/gc/base/PacketList.cpp
@@ -36,7 +36,7 @@ MM_PacketList::initialize(MM_EnvironmentBase *env)
 	_sublistCount = extensions->packetListSplit;
 	Assert_MM_true(0 < _sublistCount);
 
-	_sublists = (struct PacketSublist *)extensions->getForge()->allocate(sizeof(struct PacketSublist) * _sublistCount, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_sublists = (struct PacketSublist *)extensions->getForge()->allocate(sizeof(struct PacketSublist) * _sublistCount, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL == _sublists) {
 		result = false;
 	} else {

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -206,7 +206,7 @@ MM_ParallelDispatcher::newInstance(MM_EnvironmentBase *env, omrsig_handler_fn ha
 void
 MM_ParallelDispatcher::kill(MM_EnvironmentBase *env)
 {
-	MM_Forge *forge = env->getForge();
+	OMR::GC::Forge *forge = env->getForge();
 
 	if(_slaveThreadMutex) {
 		omrthread_monitor_destroy(_slaveThreadMutex);
@@ -240,7 +240,7 @@ MM_ParallelDispatcher::kill(MM_EnvironmentBase *env)
 bool
 MM_ParallelDispatcher::initialize(MM_EnvironmentBase *env)
 {
-	MM_Forge *forge = env->getForge();
+	OMR::GC::Forge *forge = env->getForge();
 
 	_threadCountMaximum = env->getExtensions()->gcThreadCount;
 	Assert_MM_true(0 < _threadCountMaximum);

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -192,7 +192,7 @@ MM_ParallelDispatcher::newInstance(MM_EnvironmentBase *env, omrsig_handler_fn ha
 {
 	MM_ParallelDispatcher *dispatcher;
 	
-	dispatcher = (MM_ParallelDispatcher *)env->getForge()->allocate(sizeof(MM_ParallelDispatcher), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	dispatcher = (MM_ParallelDispatcher *)env->getForge()->allocate(sizeof(MM_ParallelDispatcher), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (dispatcher) {
 		new(dispatcher) MM_ParallelDispatcher(env, handler, handler_arg, defaultOSStackSize);
 		if(!dispatcher->initialize(env)) {
@@ -252,19 +252,19 @@ MM_ParallelDispatcher::initialize(MM_EnvironmentBase *env)
 	}
 
 	/* Initialize the thread tables */
-	_threadTable = (omrthread_t *)forge->allocate(_threadCountMaximum * sizeof(omrthread_t), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_threadTable = (omrthread_t *)forge->allocate(_threadCountMaximum * sizeof(omrthread_t), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(!_threadTable) {
 		goto error_no_memory;
 	}
 	memset(_threadTable, 0, _threadCountMaximum * sizeof(omrthread_t));
 
-	_statusTable = (uintptr_t *)forge->allocate(_threadCountMaximum * sizeof(uintptr_t *), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_statusTable = (uintptr_t *)forge->allocate(_threadCountMaximum * sizeof(uintptr_t *), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(!_statusTable) {
 		goto error_no_memory;
 	}
 	memset(_statusTable, 0, _threadCountMaximum * sizeof(uintptr_t *));
 
-	_taskTable = (MM_Task **)forge->allocate(_threadCountMaximum * sizeof(MM_Task *), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_taskTable = (MM_Task **)forge->allocate(_threadCountMaximum * sizeof(MM_Task *), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(!_taskTable) {
 		goto error_no_memory;
 	}

--- a/gc/base/ParallelHeapWalker.cpp
+++ b/gc/base/ParallelHeapWalker.cpp
@@ -88,7 +88,7 @@ MM_ParallelHeapWalker::newInstance(MM_ParallelGlobalGC *globalCollector, MM_Mark
 {
 	MM_ParallelHeapWalker *heapWalker;
 
-	heapWalker = (MM_ParallelHeapWalker *)env->getForge()->allocate(sizeof(MM_ParallelHeapWalker), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	heapWalker = (MM_ParallelHeapWalker *)env->getForge()->allocate(sizeof(MM_ParallelHeapWalker), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (heapWalker) {
 		new(heapWalker) MM_ParallelHeapWalker(globalCollector, markMap);
 	}

--- a/gc/base/PhysicalArenaRegionBased.cpp
+++ b/gc/base/PhysicalArenaRegionBased.cpp
@@ -40,7 +40,7 @@
 MM_PhysicalArenaRegionBased *
 MM_PhysicalArenaRegionBased::newInstance(MM_EnvironmentBase *env, MM_Heap *heap)
 {
-	MM_PhysicalArenaRegionBased *arena = (MM_PhysicalArenaRegionBased *)env->getForge()->allocate(sizeof(MM_PhysicalArenaRegionBased), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_PhysicalArenaRegionBased *arena = (MM_PhysicalArenaRegionBased *)env->getForge()->allocate(sizeof(MM_PhysicalArenaRegionBased), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (arena) {
 		new(arena) MM_PhysicalArenaRegionBased(env, heap);
 		if(!arena->initialize(env)) {

--- a/gc/base/PhysicalArenaVirtualMemory.cpp
+++ b/gc/base/PhysicalArenaVirtualMemory.cpp
@@ -41,7 +41,7 @@ MM_PhysicalArenaVirtualMemory::newInstance(MM_EnvironmentBase* env, MM_Heap* hea
 {
 	MM_PhysicalArenaVirtualMemory* arena;
 
-	arena = (MM_PhysicalArenaVirtualMemory*)env->getForge()->allocate(sizeof(MM_PhysicalArenaVirtualMemory), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	arena = (MM_PhysicalArenaVirtualMemory*)env->getForge()->allocate(sizeof(MM_PhysicalArenaVirtualMemory), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (arena) {
 		new (arena) MM_PhysicalArenaVirtualMemory(env, heap);
 		if (!arena->initialize(env)) {

--- a/gc/base/PhysicalSubArenaRegionBased.cpp
+++ b/gc/base/PhysicalSubArenaRegionBased.cpp
@@ -49,7 +49,7 @@ MM_PhysicalSubArenaRegionBased::MM_PhysicalSubArenaRegionBased(MM_Heap *heap)
 MM_PhysicalSubArenaRegionBased *
 MM_PhysicalSubArenaRegionBased::newInstance(MM_EnvironmentBase *env, MM_Heap *heap)
 {
-	MM_PhysicalSubArenaRegionBased *arena = (MM_PhysicalSubArenaRegionBased *)env->getForge()->allocate(sizeof(MM_PhysicalSubArenaRegionBased), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_PhysicalSubArenaRegionBased *arena = (MM_PhysicalSubArenaRegionBased *)env->getForge()->allocate(sizeof(MM_PhysicalSubArenaRegionBased), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (arena) {
 		new(arena) MM_PhysicalSubArenaRegionBased(heap);
 		if(!arena->initialize(env)) {

--- a/gc/base/PhysicalSubArenaVirtualMemoryFlat.cpp
+++ b/gc/base/PhysicalSubArenaVirtualMemoryFlat.cpp
@@ -45,7 +45,7 @@ MM_PhysicalSubArenaVirtualMemoryFlat::newInstance(MM_EnvironmentBase *env, MM_He
 {
 	MM_PhysicalSubArenaVirtualMemoryFlat *subArena;
 
-	subArena = (MM_PhysicalSubArenaVirtualMemoryFlat *)env->getForge()->allocate(sizeof(MM_PhysicalSubArenaVirtualMemoryFlat), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	subArena = (MM_PhysicalSubArenaVirtualMemoryFlat *)env->getForge()->allocate(sizeof(MM_PhysicalSubArenaVirtualMemoryFlat), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(subArena) {
 		new(subArena) MM_PhysicalSubArenaVirtualMemoryFlat(heap);
 		if(!subArena->initialize(env)) {

--- a/gc/base/ReferenceChainWalkerMarkMap.cpp
+++ b/gc/base/ReferenceChainWalkerMarkMap.cpp
@@ -40,7 +40,7 @@
 MM_ReferenceChainWalkerMarkMap *
 MM_ReferenceChainWalkerMarkMap::newInstance(MM_EnvironmentBase *env, uintptr_t maxHeapSize)
 {
-	MM_ReferenceChainWalkerMarkMap *markMap = (MM_ReferenceChainWalkerMarkMap *)env->getForge()->allocate(sizeof(MM_ReferenceChainWalkerMarkMap), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_ReferenceChainWalkerMarkMap *markMap = (MM_ReferenceChainWalkerMarkMap *)env->getForge()->allocate(sizeof(MM_ReferenceChainWalkerMarkMap), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != markMap) {
 		new(markMap) MM_ReferenceChainWalkerMarkMap(env, maxHeapSize);
 		if (!markMap->initialize(env)) {

--- a/gc/base/SweepHeapSectioning.cpp
+++ b/gc/base/SweepHeapSectioning.cpp
@@ -96,7 +96,7 @@ MM_ParallelSweepChunkArray::initialize(MM_EnvironmentBase* env, bool useVmem)
 			}
 		} else {
 			if (0 != _size) {
-				_array = (MM_ParallelSweepChunk*)env->getForge()->allocate(_size * sizeof(MM_ParallelSweepChunk), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+				_array = (MM_ParallelSweepChunk*)env->getForge()->allocate(_size * sizeof(MM_ParallelSweepChunk), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 				result = (NULL != _array);
 			} else {
 				result = true;
@@ -131,7 +131,7 @@ MM_ParallelSweepChunkArray::newInstance(MM_EnvironmentBase* env, uintptr_t size,
 {
 	MM_ParallelSweepChunkArray* array;
 
-	array = (MM_ParallelSweepChunkArray*)env->getForge()->allocate(sizeof(MM_ParallelSweepChunkArray), MM_AllocationCategory::OTHER, OMR_GET_CALLSITE());
+	array = (MM_ParallelSweepChunkArray*)env->getForge()->allocate(sizeof(MM_ParallelSweepChunkArray), OMR::GC::AllocationCategory::OTHER, OMR_GET_CALLSITE());
 	if (NULL != array) {
 		new (array) MM_ParallelSweepChunkArray(size);
 		if (!array->initialize(env, useVmem)) {

--- a/gc/base/SweepPoolManagerAddressOrderedList.cpp
+++ b/gc/base/SweepPoolManagerAddressOrderedList.cpp
@@ -31,7 +31,7 @@ MM_SweepPoolManagerAddressOrderedList::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SweepPoolManagerAddressOrderedList *sweepPoolManager;
 
-	sweepPoolManager = (MM_SweepPoolManagerAddressOrderedList *)env->getForge()->allocate(sizeof(MM_SweepPoolManagerAddressOrderedList), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	sweepPoolManager = (MM_SweepPoolManagerAddressOrderedList *)env->getForge()->allocate(sizeof(MM_SweepPoolManagerAddressOrderedList), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sweepPoolManager) {
 		new(sweepPoolManager) MM_SweepPoolManagerAddressOrderedList(env);
 		if (!sweepPoolManager->initialize(env)) {

--- a/gc/base/SweepPoolManagerHybrid.cpp
+++ b/gc/base/SweepPoolManagerHybrid.cpp
@@ -34,7 +34,7 @@ MM_SweepPoolManagerHybrid::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SweepPoolManagerHybrid *sweepPoolManager;
 	
-	sweepPoolManager = (MM_SweepPoolManagerHybrid *)env->getForge()->allocate(sizeof(MM_SweepPoolManagerHybrid), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	sweepPoolManager = (MM_SweepPoolManagerHybrid *)env->getForge()->allocate(sizeof(MM_SweepPoolManagerHybrid), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sweepPoolManager) {
 		new(sweepPoolManager) MM_SweepPoolManagerHybrid(env);
 		if (!sweepPoolManager->initialize(env)) { 

--- a/gc/base/SweepPoolManagerSplitAddressOrderedList.cpp
+++ b/gc/base/SweepPoolManagerSplitAddressOrderedList.cpp
@@ -31,7 +31,7 @@ MM_SweepPoolManagerSplitAddressOrderedList::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SweepPoolManagerSplitAddressOrderedList *sweepPoolManager;
 	
-	sweepPoolManager = (MM_SweepPoolManagerSplitAddressOrderedList *)env->getForge()->allocate(sizeof(MM_SweepPoolManagerSplitAddressOrderedList), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	sweepPoolManager = (MM_SweepPoolManagerSplitAddressOrderedList *)env->getForge()->allocate(sizeof(MM_SweepPoolManagerSplitAddressOrderedList), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sweepPoolManager) {
 		new(sweepPoolManager) MM_SweepPoolManagerSplitAddressOrderedList(env);
 		if (!sweepPoolManager->initialize(env)) { 

--- a/gc/base/TLHAllocationInterface.cpp
+++ b/gc/base/TLHAllocationInterface.cpp
@@ -54,7 +54,7 @@ MM_TLHAllocationInterface::newInstance(MM_EnvironmentBase *env)
 {
 	MM_TLHAllocationInterface *allocationInterface;
 
-	allocationInterface = (MM_TLHAllocationInterface *)env->getForge()->allocate(sizeof(MM_TLHAllocationInterface), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	allocationInterface = (MM_TLHAllocationInterface *)env->getForge()->allocate(sizeof(MM_TLHAllocationInterface), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != allocationInterface) {
 		new(allocationInterface) MM_TLHAllocationInterface(env);
 		if (!allocationInterface->initialize(env)) {

--- a/gc/base/VirtualMemory.cpp
+++ b/gc/base/VirtualMemory.cpp
@@ -44,7 +44,7 @@
 MM_VirtualMemory*
 MM_VirtualMemory::newInstance(MM_EnvironmentBase* env, uintptr_t heapAlignment, uintptr_t size, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t tailPadding, void* preferredAddress, void* ceiling, uintptr_t mode, uintptr_t options, uint32_t memoryCategory)
 {
-	MM_VirtualMemory* vmem = (MM_VirtualMemory*)env->getForge()->allocate(sizeof(MM_VirtualMemory), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_VirtualMemory* vmem = (MM_VirtualMemory*)env->getForge()->allocate(sizeof(MM_VirtualMemory), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 	if (vmem) {
 		new (vmem) MM_VirtualMemory(env, heapAlignment, pageSize, pageFlags, tailPadding, mode);

--- a/gc/base/WorkPacketOverflow.cpp
+++ b/gc/base/WorkPacketOverflow.cpp
@@ -33,7 +33,7 @@ MM_WorkPacketOverflow::newInstance(MM_EnvironmentBase *env, MM_WorkPackets *work
 {
 	MM_WorkPacketOverflow *overflow;
 
-	overflow = (MM_WorkPacketOverflow *)env->getForge()->allocate(sizeof(MM_WorkPacketOverflow), MM_AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
+	overflow = (MM_WorkPacketOverflow *)env->getForge()->allocate(sizeof(MM_WorkPacketOverflow), OMR::GC::AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
 	if (overflow) {
 		new(overflow) MM_WorkPacketOverflow(env, workPackets);
 		if (!overflow->initialize(env)) {

--- a/gc/base/WorkPackets.cpp
+++ b/gc/base/WorkPackets.cpp
@@ -47,7 +47,7 @@ MM_WorkPackets::newInstance(MM_EnvironmentBase *env)
 {
 	MM_WorkPackets *workPackets;
 	
-	workPackets = (MM_WorkPackets *)env->getForge()->allocate(sizeof(MM_WorkPackets), MM_AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
+	workPackets = (MM_WorkPackets *)env->getForge()->allocate(sizeof(MM_WorkPackets), OMR::GC::AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
 	if (workPackets) {
 		new(workPackets) MM_WorkPackets(env);
 		if (!workPackets->initialize(env)) {
@@ -176,7 +176,7 @@ MM_WorkPackets::initWorkPacketsBlock(MM_EnvironmentBase *env)
 
 	Assert_MM_true(_packetsBlocksTop < _maxPacketsBlocks);
 	/* Build the output packet list */
-	if (NULL == (_packetsStart[_packetsBlocksTop] = (MM_Packet *) env->getForge()->allocate(blockSize, MM_AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE()))) {
+	if (NULL == (_packetsStart[_packetsBlocksTop] = (MM_Packet *) env->getForge()->allocate(blockSize, OMR::GC::AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE()))) {
 		return false;
 	}
 	memset((void *)_packetsStart[_packetsBlocksTop], 0, totalHeaderSize); /* initialize only MM_Packet's to avoid paging the rest of the block */

--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -927,7 +927,7 @@
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
-		<data type="struct MM_MemoryStatistics*" name="statistics" description="" />
+		<data type="struct OMR_GC_MemoryStatistics*" name="statistics" description="" />
 	</event>
 
 	<event>

--- a/gc/base/segregated/AllocationContextSegregated.cpp
+++ b/gc/base/segregated/AllocationContextSegregated.cpp
@@ -47,7 +47,7 @@
 MM_AllocationContextSegregated *
 MM_AllocationContextSegregated::newInstance(MM_EnvironmentBase *env, MM_GlobalAllocationManagerSegregated *gam, MM_RegionPoolSegregated *regionPool)
 {
-	MM_AllocationContextSegregated *allocCtxt = (MM_AllocationContextSegregated *)env->getForge()->allocate(sizeof(MM_AllocationContextSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_AllocationContextSegregated *allocCtxt = (MM_AllocationContextSegregated *)env->getForge()->allocate(sizeof(MM_AllocationContextSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (allocCtxt) {
 		new(allocCtxt) MM_AllocationContextSegregated(env, gam, regionPool);
 		if (!allocCtxt->initialize(env)) {

--- a/gc/base/segregated/ConfigurationSegregated.cpp
+++ b/gc/base/segregated/ConfigurationSegregated.cpp
@@ -63,7 +63,7 @@ MM_ConfigurationSegregated::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ConfigurationSegregated *configuration;
 
-	configuration = (MM_ConfigurationSegregated *) env->getForge()->allocate(sizeof(MM_ConfigurationSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	configuration = (MM_ConfigurationSegregated *) env->getForge()->allocate(sizeof(MM_ConfigurationSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(NULL != configuration) {
 		new(configuration) MM_ConfigurationSegregated(env);
 		if(!configuration->initialize(env)) {

--- a/gc/base/segregated/GlobalAllocationManagerSegregated.cpp
+++ b/gc/base/segregated/GlobalAllocationManagerSegregated.cpp
@@ -35,7 +35,7 @@
 MM_GlobalAllocationManagerSegregated*
 MM_GlobalAllocationManagerSegregated::newInstance(MM_EnvironmentBase *env, MM_RegionPoolSegregated *regionPool)
 {
-	MM_GlobalAllocationManagerSegregated *allocationManager = (MM_GlobalAllocationManagerSegregated *)env->getForge()->allocate(sizeof(MM_GlobalAllocationManagerSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_GlobalAllocationManagerSegregated *allocationManager = (MM_GlobalAllocationManagerSegregated *)env->getForge()->allocate(sizeof(MM_GlobalAllocationManagerSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (allocationManager) {
 		allocationManager = new(allocationManager) MM_GlobalAllocationManagerSegregated(env);
 		if (!allocationManager->initialize(env, regionPool)) {
@@ -117,7 +117,7 @@ MM_GlobalAllocationManagerSegregated::initializeAllocationContexts(MM_Environmen
 {
 	Assert_MM_true(0 != _managedAllocationContextCount);
 
-	MM_AllocationContextSegregated **contexts = (MM_AllocationContextSegregated **)env->getForge()->allocate(sizeof(MM_AllocationContextSegregated*) * _managedAllocationContextCount, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_AllocationContextSegregated **contexts = (MM_AllocationContextSegregated **)env->getForge()->allocate(sizeof(MM_AllocationContextSegregated*) * _managedAllocationContextCount, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL == contexts) {
 		return false;
 	}

--- a/gc/base/segregated/LockingFreeHeapRegionList.cpp
+++ b/gc/base/segregated/LockingFreeHeapRegionList.cpp
@@ -32,7 +32,7 @@
 MM_LockingFreeHeapRegionList *
 MM_LockingFreeHeapRegionList::newInstance(MM_EnvironmentBase *env, MM_HeapRegionList::RegionListKind regionListKind, bool singleRegionsOnly)
 {
-	MM_LockingFreeHeapRegionList *fpl = (MM_LockingFreeHeapRegionList *)env->getForge()->allocate(sizeof(MM_LockingFreeHeapRegionList), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_LockingFreeHeapRegionList *fpl = (MM_LockingFreeHeapRegionList *)env->getForge()->allocate(sizeof(MM_LockingFreeHeapRegionList), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (fpl) {
 		new (fpl) MM_LockingFreeHeapRegionList(regionListKind, singleRegionsOnly);
 		if (!fpl->initialize(env)) {

--- a/gc/base/segregated/LockingHeapRegionQueue.cpp
+++ b/gc/base/segregated/LockingHeapRegionQueue.cpp
@@ -41,7 +41,7 @@
 MM_LockingHeapRegionQueue *
 MM_LockingHeapRegionQueue::newInstance(MM_EnvironmentBase *env, RegionListKind regionListKind, bool singleRegionsOnly, bool concurrentAccess, bool trackFreeBytes)
 {
-	MM_LockingHeapRegionQueue *regionList = (MM_LockingHeapRegionQueue *)env->getForge()->allocate(sizeof(MM_LockingHeapRegionQueue), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_LockingHeapRegionQueue *regionList = (MM_LockingHeapRegionQueue *)env->getForge()->allocate(sizeof(MM_LockingHeapRegionQueue), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (regionList) {
 		new (regionList) MM_LockingHeapRegionQueue(regionListKind, singleRegionsOnly, concurrentAccess, trackFreeBytes);
 		if (!regionList->initialize(env)) {

--- a/gc/base/segregated/MemoryPoolSegregated.cpp
+++ b/gc/base/segregated/MemoryPoolSegregated.cpp
@@ -56,7 +56,7 @@
 MM_MemoryPoolSegregated *
 MM_MemoryPoolSegregated::newInstance(MM_EnvironmentBase *env, MM_RegionPoolSegregated *regionPool, uintptr_t minimumFreeEntrySize, MM_GlobalAllocationManagerSegregated *gam)
 {
-	MM_MemoryPoolSegregated *memoryPool = (MM_MemoryPoolSegregated *)env->getForge()->allocate(sizeof(MM_MemoryPoolSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_MemoryPoolSegregated *memoryPool = (MM_MemoryPoolSegregated *)env->getForge()->allocate(sizeof(MM_MemoryPoolSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (memoryPool) {
 		memoryPool = new(memoryPool) MM_MemoryPoolSegregated(env, regionPool, minimumFreeEntrySize, gam);
 		if (!memoryPool->initialize(env)) {

--- a/gc/base/segregated/MemorySubSpaceSegregated.cpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.cpp
@@ -242,7 +242,7 @@ MM_MemorySubSpaceSegregated::newInstance(
 {
 	MM_MemorySubSpaceSegregated *memorySubSpace;
 
-	memorySubSpace = (MM_MemorySubSpaceSegregated *)env->getForge()->allocate(sizeof(MM_MemorySubSpaceSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	memorySubSpace = (MM_MemorySubSpaceSegregated *)env->getForge()->allocate(sizeof(MM_MemorySubSpaceSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != memorySubSpace) {
 		new(memorySubSpace) MM_MemorySubSpaceSegregated(env, physicalSubArena, memoryPool, usesGlobalCollector, minimumSize, initialSize, maximumSize);
 		if (!memorySubSpace->initialize(env)) {

--- a/gc/base/segregated/OverflowSegregated.cpp
+++ b/gc/base/segregated/OverflowSegregated.cpp
@@ -46,7 +46,7 @@ MM_OverflowSegregated *
 MM_OverflowSegregated::newInstance(MM_EnvironmentBase *env, MM_WorkPackets *workPackets)
 {
 	Assert_MM_true(env->getExtensions()->isSegregatedHeap());
-	MM_OverflowSegregated *overflow = (MM_OverflowSegregated *)env->getForge()->allocate(sizeof(MM_OverflowSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_OverflowSegregated *overflow = (MM_OverflowSegregated *)env->getForge()->allocate(sizeof(MM_OverflowSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != overflow) {
 		new(overflow) MM_OverflowSegregated(env,workPackets);
 		if (!overflow->initialize(env)) {

--- a/gc/base/segregated/RegionPoolSegregated.cpp
+++ b/gc/base/segregated/RegionPoolSegregated.cpp
@@ -53,7 +53,7 @@ MM_RegionPoolSegregated::newInstance(MM_EnvironmentBase *env, MM_HeapRegionManag
 {
 	MM_RegionPoolSegregated *regionPool;
 
-	regionPool = (MM_RegionPoolSegregated *)env->getForge()->allocate(sizeof(MM_RegionPoolSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	regionPool = (MM_RegionPoolSegregated *)env->getForge()->allocate(sizeof(MM_RegionPoolSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != regionPool) {
 		regionPool = new(regionPool) MM_RegionPoolSegregated(env, heapRegionManager);
 		if (!regionPool->initialize(env)) {
@@ -91,7 +91,7 @@ MM_RegionPoolSegregated::initialize(MM_EnvironmentBase *env)
 	for (szClass=OMR_SIZECLASSES_MIN_SMALL; szClass<=OMR_SIZECLASSES_MAX_SMALL; szClass++) {
 		for (int32_t i=0; i<NUM_DEFRAG_BUCKETS; i++) {
 			uintptr_t splitAvailableListsSize = sizeof(MM_LockingHeapRegionQueue) * _splitAvailableListSplitCount;
-			_smallAvailableRegions[szClass][i] = (MM_LockingHeapRegionQueue *)env->getForge()->allocate(splitAvailableListsSize, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+			_smallAvailableRegions[szClass][i] = (MM_LockingHeapRegionQueue *)env->getForge()->allocate(splitAvailableListsSize, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 			if (NULL == _smallAvailableRegions[szClass][i]) {
 				return false;
 			}

--- a/gc/base/segregated/SegregatedAllocationInterface.cpp
+++ b/gc/base/segregated/SegregatedAllocationInterface.cpp
@@ -50,7 +50,7 @@ MM_SegregatedAllocationInterface::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SegregatedAllocationInterface *allocationInterface;
 	
-	allocationInterface = (MM_SegregatedAllocationInterface *)env->getForge()->allocate(sizeof(MM_SegregatedAllocationInterface), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	allocationInterface = (MM_SegregatedAllocationInterface *)env->getForge()->allocate(sizeof(MM_SegregatedAllocationInterface), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(NULL != allocationInterface) {
 		new(allocationInterface) MM_SegregatedAllocationInterface(env);
 		if(!allocationInterface->initialize(env)) {

--- a/gc/base/segregated/SegregatedAllocationTracker.cpp
+++ b/gc/base/segregated/SegregatedAllocationTracker.cpp
@@ -35,7 +35,7 @@ MM_SegregatedAllocationTracker*
 MM_SegregatedAllocationTracker::newInstance(MM_EnvironmentBase *env, volatile uintptr_t *globalBytesInUse, uintptr_t flushThreshold)
 {
 	MM_SegregatedAllocationTracker* allocationTracker;
-	allocationTracker = (MM_SegregatedAllocationTracker*)env->getForge()->allocate(sizeof(MM_SegregatedAllocationTracker), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	allocationTracker = (MM_SegregatedAllocationTracker*)env->getForge()->allocate(sizeof(MM_SegregatedAllocationTracker), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(NULL != allocationTracker) {
 		new(allocationTracker) MM_SegregatedAllocationTracker(env);
 		if(!allocationTracker->initialize(env, globalBytesInUse, flushThreshold)) {

--- a/gc/base/segregated/SegregatedGC.cpp
+++ b/gc/base/segregated/SegregatedGC.cpp
@@ -56,7 +56,7 @@ MM_SegregatedGC::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SegregatedGC *globalGC;
 
-	globalGC = (MM_SegregatedGC *)env->getForge()->allocate(sizeof(MM_SegregatedGC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	globalGC = (MM_SegregatedGC *)env->getForge()->allocate(sizeof(MM_SegregatedGC), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != globalGC) {
 		new(globalGC) MM_SegregatedGC(env);
 		if (!globalGC->initialize(env)) { 

--- a/gc/base/segregated/SegregatedMarkingScheme.cpp
+++ b/gc/base/segregated/SegregatedMarkingScheme.cpp
@@ -35,7 +35,7 @@ MM_SegregatedMarkingScheme::newInstance(MM_EnvironmentBase *env)
 {
 	MM_SegregatedMarkingScheme *instance;
 	
-	instance = (MM_SegregatedMarkingScheme *)env->getForge()->allocate(sizeof(MM_SegregatedMarkingScheme), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	instance = (MM_SegregatedMarkingScheme *)env->getForge()->allocate(sizeof(MM_SegregatedMarkingScheme), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (instance) {
 		new(instance) MM_SegregatedMarkingScheme(env);
 		if (!instance->initialize(env)) { 

--- a/gc/base/segregated/SizeClasses.cpp
+++ b/gc/base/segregated/SizeClasses.cpp
@@ -35,7 +35,7 @@ MM_SizeClasses::newInstance(MM_EnvironmentBase* env)
 {
 	MM_SizeClasses* sizeClasses;
 	
-	sizeClasses = (MM_SizeClasses*)env->getForge()->allocate(sizeof(MM_SizeClasses), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	sizeClasses = (MM_SizeClasses*)env->getForge()->allocate(sizeof(MM_SizeClasses), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sizeClasses) {
 		new(sizeClasses) MM_SizeClasses(env);
 		if (!sizeClasses->initialize(env)) {

--- a/gc/base/segregated/SweepSchemeSegregated.cpp
+++ b/gc/base/segregated/SweepSchemeSegregated.cpp
@@ -50,7 +50,7 @@ MM_SweepSchemeSegregated::newInstance(MM_EnvironmentBase *env, MM_MarkMap *markM
 {
 	MM_SweepSchemeSegregated *instance;
 	
-	instance = (MM_SweepSchemeSegregated *)env->getForge()->allocate(sizeof(MM_SweepSchemeSegregated), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	instance = (MM_SweepSchemeSegregated *)env->getForge()->allocate(sizeof(MM_SweepSchemeSegregated), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != instance) {
 		new(instance) MM_SweepSchemeSegregated(env, markMap);
 		if (!instance->initialize(env)) {

--- a/gc/base/segregated/WorkPacketsSegregated.cpp
+++ b/gc/base/segregated/WorkPacketsSegregated.cpp
@@ -39,7 +39,7 @@ MM_WorkPacketsSegregated::newInstance(MM_EnvironmentBase *env)
 {
 	MM_WorkPacketsSegregated *workPackets;
 
-	workPackets = (MM_WorkPacketsSegregated *)env->getForge()->allocate(sizeof(MM_WorkPacketsSegregated), MM_AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
+	workPackets = (MM_WorkPacketsSegregated *)env->getForge()->allocate(sizeof(MM_WorkPacketsSegregated), OMR::GC::AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
 	if (NULL != workPackets) {
 		new(workPackets) MM_WorkPacketsSegregated(env);
 		if (!workPackets->initialize(env)) {

--- a/gc/base/standard/CompactScheme.cpp
+++ b/gc/base/standard/CompactScheme.cpp
@@ -80,7 +80,7 @@ MM_CompactScheme::newInstance(MM_EnvironmentBase *env, MM_MarkingScheme *marking
 {
 	MM_CompactScheme *compactScheme;
 
-	compactScheme = (MM_CompactScheme *)env->getForge()->allocate(sizeof(MM_CompactScheme), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	compactScheme = (MM_CompactScheme *)env->getForge()->allocate(sizeof(MM_CompactScheme), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (compactScheme) {
 		new(compactScheme) MM_CompactScheme(env, markingScheme);
 		if (!compactScheme->initialize(env)) {

--- a/gc/base/standard/ConcurrentCardTable.cpp
+++ b/gc/base/standard/ConcurrentCardTable.cpp
@@ -437,7 +437,7 @@ MM_ConcurrentCardTable::heapReconfigured(MM_EnvironmentBase *env)
 MM_ConcurrentCardTable *
 MM_ConcurrentCardTable::newInstance(MM_EnvironmentBase *env, MM_Heap *heap, MM_MarkingScheme *markingScheme, MM_ConcurrentGC *collector)
 {
-	MM_ConcurrentCardTable *cardTable = (MM_ConcurrentCardTable *)env->getForge()->allocate(sizeof(MM_ConcurrentCardTable), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_ConcurrentCardTable *cardTable = (MM_ConcurrentCardTable *)env->getForge()->allocate(sizeof(MM_ConcurrentCardTable), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != cardTable) {
 		new(cardTable) MM_ConcurrentCardTable(env, markingScheme, collector);
 		if (!cardTable->initialize(env, heap)) {
@@ -1562,7 +1562,7 @@ MM_ConcurrentCardTable::determineCleaningRanges(MM_EnvironmentBase *env)
 			}
 
 			uintptr_t sizeRequired = sizeof(CleaningRange) * numRanges;
-			_cleaningRanges = (CleaningRange *) env->getForge()->allocate(sizeRequired, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+			_cleaningRanges = (CleaningRange *) env->getForge()->allocate(sizeRequired, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 			_maxCleaningRanges = numRanges;
 		} else {
 			/* Address first range for next round of card cleaning */

--- a/gc/base/standard/ConcurrentCardTableForWC.cpp
+++ b/gc/base/standard/ConcurrentCardTableForWC.cpp
@@ -53,7 +53,7 @@ MM_ConcurrentCardTableForWC::newInstance(MM_EnvironmentBase *env, MM_Heap *heap,
 {
 	MM_ConcurrentCardTableForWC *cardTable;
 	
-	cardTable = (MM_ConcurrentCardTableForWC *)env->getForge()->allocate(sizeof(MM_ConcurrentCardTableForWC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	cardTable = (MM_ConcurrentCardTableForWC *)env->getForge()->allocate(sizeof(MM_ConcurrentCardTableForWC), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != cardTable) {
 		new(cardTable) MM_ConcurrentCardTableForWC(env, markingScheme, collector);
 		if (!cardTable->initialize(env, heap)) {

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -735,7 +735,7 @@ error_no_memory:
 void
 MM_ConcurrentGC::tearDown(MM_EnvironmentBase *env)
 {
-	MM_Forge *forge = env->getForge();
+	OMR::GC::Forge *forge = env->getForge();
 
 	if (NULL != _cardTable){
 		_cardTable->kill(env);

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -544,7 +544,7 @@ MM_ConcurrentGC::signalThreadsToDirtyCardsAsyncEventHandler(OMR_VMThread *omrVMT
 MM_ConcurrentGC *
 MM_ConcurrentGC::newInstance(MM_EnvironmentBase *env)
 {
-	MM_ConcurrentGC *concurrentGC = (MM_ConcurrentGC *)env->getForge()->allocate(sizeof(MM_ConcurrentGC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_ConcurrentGC *concurrentGC = (MM_ConcurrentGC *)env->getForge()->allocate(sizeof(MM_ConcurrentGC), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != concurrentGC) {
 		new(concurrentGC) MM_ConcurrentGC(env);
 		if (!concurrentGC->initialize(env)) {
@@ -603,7 +603,7 @@ MM_ConcurrentGC::initialize(MM_EnvironmentBase *env)
 
 	if (_conHelperThreads > 0) {
 		/* Get storage for concurrent helper thread table */
-		_conHelpersTable = (omrthread_t *)env->getForge()->allocate(_conHelperThreads * sizeof(omrthread_t), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+		_conHelpersTable = (omrthread_t *)env->getForge()->allocate(_conHelperThreads * sizeof(omrthread_t), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 		if(!_conHelpersTable) {
 			goto error_no_memory;
 		}
@@ -696,7 +696,7 @@ MM_ConcurrentGC::initialize(MM_EnvironmentBase *env)
 			/* Get storage for metering history table */
 			uintptr_t historySize = _meteringHistorySize * sizeof(MeteringHistory);
 
-			_meteringHistory = (MeteringHistory *)env->getForge()->allocate(historySize, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+			_meteringHistory = (MeteringHistory *)env->getForge()->allocate(historySize, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 			if(!_meteringHistory) {
 				goto error_no_memory;
@@ -886,7 +886,7 @@ MM_ConcurrentGC::determineInitWork(MM_EnvironmentBase *env)
 			/* TODO: dynamically allocating this structure.  Should the VM tear itself down
 			 * in this scenario?
 			 */
-			_initRanges = (InitWorkItem *) env->getForge()->allocate(sizeof(InitWorkItem) * _numInitRanges, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+			_initRanges = (InitWorkItem *) env->getForge()->allocate(sizeof(InitWorkItem) * _numInitRanges, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 			if (NULL == _initRanges) {
 				initDone = true;
 				_numPhysicalInitRanges = 0;

--- a/gc/base/standard/ConcurrentOverflow.cpp
+++ b/gc/base/standard/ConcurrentOverflow.cpp
@@ -49,7 +49,7 @@ MM_ConcurrentOverflow::newInstance(MM_EnvironmentBase *env,MM_WorkPackets *workP
 {
 	MM_ConcurrentOverflow *overflow;
 
-	overflow = (MM_ConcurrentOverflow *)env->getForge()->allocate(sizeof(MM_ConcurrentOverflow), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	overflow = (MM_ConcurrentOverflow *)env->getForge()->allocate(sizeof(MM_ConcurrentOverflow), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != overflow) {
 		new(overflow) MM_ConcurrentOverflow(env,workPackets);
 		if (!overflow->initialize(env)) {

--- a/gc/base/standard/ConcurrentSafepointCallback.cpp
+++ b/gc/base/standard/ConcurrentSafepointCallback.cpp
@@ -32,7 +32,7 @@ MM_ConcurrentSafepointCallback::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ConcurrentSafepointCallback *callback;
 
-	callback = (MM_ConcurrentSafepointCallback *)env->getForge()->allocate(sizeof(MM_ConcurrentSafepointCallback), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	callback = (MM_ConcurrentSafepointCallback *)env->getForge()->allocate(sizeof(MM_ConcurrentSafepointCallback), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != callback) {
 		new(callback) MM_ConcurrentSafepointCallback(env);
 	}

--- a/gc/base/standard/ConcurrentSweepScheme.cpp
+++ b/gc/base/standard/ConcurrentSweepScheme.cpp
@@ -337,7 +337,7 @@ MM_ConcurrentSweepScheme::newInstance(MM_EnvironmentBase *env, MM_GlobalCollecto
 {
 	MM_ConcurrentSweepScheme *sweepScheme;
 	
-	sweepScheme = (MM_ConcurrentSweepScheme *)env->getForge()->allocate(sizeof(MM_ConcurrentSweepScheme), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	sweepScheme = (MM_ConcurrentSweepScheme *)env->getForge()->allocate(sizeof(MM_ConcurrentSweepScheme), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sweepScheme) {
 		new(sweepScheme) MM_ConcurrentSweepScheme(env, collector);
 		if (!sweepScheme->initialize(env)) { 

--- a/gc/base/standard/ConfigurationFlat.cpp
+++ b/gc/base/standard/ConfigurationFlat.cpp
@@ -46,7 +46,7 @@ MM_ConfigurationFlat::newInstance(MM_EnvironmentBase* env)
 {
 	MM_ConfigurationFlat* configuration;
 
-	configuration = (MM_ConfigurationFlat*)env->getForge()->allocate(sizeof(MM_ConfigurationFlat), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	configuration = (MM_ConfigurationFlat*)env->getForge()->allocate(sizeof(MM_ConfigurationFlat), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != configuration) {
 		new (configuration) MM_ConfigurationFlat(env);
 		if (!configuration->initialize(env)) {

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -52,7 +52,7 @@ MM_ConfigurationGenerational::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ConfigurationGenerational *configuration;
 	
-	configuration = (MM_ConfigurationGenerational *) env->getForge()->allocate(sizeof(MM_ConfigurationGenerational), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	configuration = (MM_ConfigurationGenerational *) env->getForge()->allocate(sizeof(MM_ConfigurationGenerational), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(NULL != configuration) {
 		new(configuration) MM_ConfigurationGenerational(env);
 		if(!configuration->initialize(env)) {

--- a/gc/base/standard/CopyScanCacheChunk.cpp
+++ b/gc/base/standard/CopyScanCacheChunk.cpp
@@ -35,7 +35,7 @@ MM_CopyScanCacheChunk::newInstance(MM_EnvironmentBase* env, uintptr_t cacheEntry
 {
 	MM_CopyScanCacheChunk *chunk;
 	
-	chunk = (MM_CopyScanCacheChunk *)env->getForge()->allocate(sizeof(MM_CopyScanCacheChunk) + cacheEntryCount * sizeof(MM_CopyScanCacheStandard), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	chunk = (MM_CopyScanCacheChunk *)env->getForge()->allocate(sizeof(MM_CopyScanCacheChunk) + cacheEntryCount * sizeof(MM_CopyScanCacheStandard), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (chunk) {
 		new(chunk) MM_CopyScanCacheChunk();
 		chunk->_baseCache = (MM_CopyScanCacheStandard *)(chunk + 1);

--- a/gc/base/standard/CopyScanCacheList.cpp
+++ b/gc/base/standard/CopyScanCacheList.cpp
@@ -42,7 +42,7 @@ MM_CopyScanCacheList::initialize(MM_EnvironmentBase *env, volatile uintptr_t *ca
 	_sublistCount = extensions->cacheListSplit;
 	Assert_MM_true(0 < _sublistCount);
 
-	_sublists = (struct CopyScanCacheSublist *)extensions->getForge()->allocate(sizeof(struct CopyScanCacheSublist) * _sublistCount, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_sublists = (struct CopyScanCacheSublist *)extensions->getForge()->allocate(sizeof(struct CopyScanCacheSublist) * _sublistCount, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL == _sublists) {
 		result = false;
 	} else {

--- a/gc/base/standard/HeapRegionManagerStandard.cpp
+++ b/gc/base/standard/HeapRegionManagerStandard.cpp
@@ -35,7 +35,7 @@ MM_HeapRegionManagerStandard::MM_HeapRegionManagerStandard(MM_EnvironmentBase *e
 MM_HeapRegionManagerStandard *
 MM_HeapRegionManagerStandard::newInstance(MM_EnvironmentBase *env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor)
 {
-	MM_HeapRegionManagerStandard *regionManager = (MM_HeapRegionManagerStandard *)env->getForge()->allocate(sizeof(MM_HeapRegionManagerStandard), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_HeapRegionManagerStandard *regionManager = (MM_HeapRegionManagerStandard *)env->getForge()->allocate(sizeof(MM_HeapRegionManagerStandard), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (regionManager) {
 		new(regionManager) MM_HeapRegionManagerStandard(env, regionSize, tableDescriptorSize, regionDescriptorInitializer, regionDescriptorDestructor);
 		if (!regionManager->initialize(env)) {

--- a/gc/base/standard/HeapWalker.cpp
+++ b/gc/base/standard/HeapWalker.cpp
@@ -105,7 +105,7 @@ MM_HeapWalker::newInstance(MM_EnvironmentBase *env)
 {
 	MM_HeapWalker *heapWalker;
 
-	heapWalker = (MM_HeapWalker *)env->getForge()->allocate(sizeof(MM_HeapWalker), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	heapWalker = (MM_HeapWalker *)env->getForge()->allocate(sizeof(MM_HeapWalker), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (heapWalker) {
 		new(heapWalker) MM_HeapWalker();
 	}

--- a/gc/base/standard/OverflowStandard.cpp
+++ b/gc/base/standard/OverflowStandard.cpp
@@ -43,7 +43,7 @@
 MM_OverflowStandard *
 MM_OverflowStandard::newInstance(MM_EnvironmentBase *env, MM_WorkPackets *workPackets)
 {
-	MM_OverflowStandard *overflow = (MM_OverflowStandard *)env->getForge()->allocate(sizeof(MM_OverflowStandard), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_OverflowStandard *overflow = (MM_OverflowStandard *)env->getForge()->allocate(sizeof(MM_OverflowStandard), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != overflow) {
 		new(overflow) MM_OverflowStandard(env,workPackets);
 		if (!overflow->initialize(env)) {

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -191,7 +191,7 @@ MM_ParallelGlobalGC::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ParallelGlobalGC *globalGC;
 		
-	globalGC = (MM_ParallelGlobalGC *)env->getForge()->allocate(sizeof(MM_ParallelGlobalGC), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	globalGC = (MM_ParallelGlobalGC *)env->getForge()->allocate(sizeof(MM_ParallelGlobalGC), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (globalGC) {
 		new(globalGC) MM_ParallelGlobalGC(env);
 		if (!globalGC->initialize(env)) { 

--- a/gc/base/standard/ParallelSweepScheme.cpp
+++ b/gc/base/standard/ParallelSweepScheme.cpp
@@ -155,7 +155,7 @@ MM_ParallelSweepScheme::newInstance(MM_EnvironmentBase *env)
 {
 	MM_ParallelSweepScheme *sweepScheme;
 	
-	sweepScheme = (MM_ParallelSweepScheme *)env->getForge()->allocate(sizeof(MM_ParallelSweepScheme), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	sweepScheme = (MM_ParallelSweepScheme *)env->getForge()->allocate(sizeof(MM_ParallelSweepScheme), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sweepScheme) {
 		new(sweepScheme) MM_ParallelSweepScheme(env);
 		if (!sweepScheme->initialize(env)) { 

--- a/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
+++ b/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
@@ -53,7 +53,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::newInstance(MM_EnvironmentBase *env, 
 {
 	MM_PhysicalSubArenaVirtualMemorySemiSpace *subArena;
 	
-	subArena = (MM_PhysicalSubArenaVirtualMemorySemiSpace *)env->getForge()->allocate(sizeof(MM_PhysicalSubArenaVirtualMemorySemiSpace), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	subArena = (MM_PhysicalSubArenaVirtualMemorySemiSpace *)env->getForge()->allocate(sizeof(MM_PhysicalSubArenaVirtualMemorySemiSpace), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if(subArena) {
 		new(subArena) MM_PhysicalSubArenaVirtualMemorySemiSpace(heap);
 		if(!subArena->initialize(env)) {

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -179,7 +179,7 @@ MM_Scavenger::newInstance(MM_EnvironmentStandard *env, MM_HeapRegionManager *reg
 {
 	MM_Scavenger *scavenger;
 
-	scavenger = (MM_Scavenger *)env->getForge()->allocate(sizeof(MM_Scavenger), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	scavenger = (MM_Scavenger *)env->getForge()->allocate(sizeof(MM_Scavenger), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (scavenger) {
 		new(scavenger) MM_Scavenger(env, regionManager);
 		if (!scavenger->initialize(env)) {

--- a/gc/base/standard/SweepHeapSectioningSegmented.cpp
+++ b/gc/base/standard/SweepHeapSectioningSegmented.cpp
@@ -204,7 +204,7 @@ MM_SweepHeapSectioningSegmented::reassignChunks(MM_EnvironmentBase *env)
 MM_SweepHeapSectioningSegmented *
 MM_SweepHeapSectioningSegmented::newInstance(MM_EnvironmentBase *env)
 {
-	MM_SweepHeapSectioningSegmented *sweepHeapSectioning = (MM_SweepHeapSectioningSegmented *)env->getForge()->allocate(sizeof(MM_SweepHeapSectioningSegmented), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_SweepHeapSectioningSegmented *sweepHeapSectioning = (MM_SweepHeapSectioningSegmented *)env->getForge()->allocate(sizeof(MM_SweepHeapSectioningSegmented), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (sweepHeapSectioning) {
 		new(sweepHeapSectioning) MM_SweepHeapSectioningSegmented(env);
 		if (!sweepHeapSectioning->initialize(env)) {

--- a/gc/base/standard/WorkPacketsConcurrent.cpp
+++ b/gc/base/standard/WorkPacketsConcurrent.cpp
@@ -37,7 +37,7 @@
 MM_WorkPacketsConcurrent *
 MM_WorkPacketsConcurrent::newInstance(MM_EnvironmentBase *env)
 {
-	MM_WorkPacketsConcurrent *workPackets = (MM_WorkPacketsConcurrent *)env->getForge()->allocate(sizeof(MM_WorkPacketsConcurrent), MM_AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
+	MM_WorkPacketsConcurrent *workPackets = (MM_WorkPacketsConcurrent *)env->getForge()->allocate(sizeof(MM_WorkPacketsConcurrent), OMR::GC::AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
 	if (NULL != workPackets) {
 		new(workPackets) MM_WorkPacketsConcurrent(env);
 		if (!workPackets->initialize(env)) {

--- a/gc/base/standard/WorkPacketsStandard.cpp
+++ b/gc/base/standard/WorkPacketsStandard.cpp
@@ -36,7 +36,7 @@ MM_WorkPacketsStandard::newInstance(MM_EnvironmentBase *env)
 {
 	MM_WorkPacketsStandard *workPackets;
 	
-	workPackets = (MM_WorkPacketsStandard *)env->getForge()->allocate(sizeof(MM_WorkPacketsStandard), MM_AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
+	workPackets = (MM_WorkPacketsStandard *)env->getForge()->allocate(sizeof(MM_WorkPacketsStandard), OMR::GC::AllocationCategory::WORK_PACKETS, OMR_GET_CALLSITE());
 	if (NULL != workPackets) {
 		new(workPackets) MM_WorkPacketsStandard(env);
 		if (!workPackets->initialize(env)) {

--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -89,7 +89,7 @@ heapCreationHelper(OMR_VM *omrVM, MM_StartupManager *startupManager, bool create
 
 	/* The 'fake' environment is necessary because obtaining an environment for a thread
 	 * is done by calling out to MM_Configuration, which itself uses the environment
-	 * to obtain pointers to MM_GCExtensionsBase and MM_Forge, etc. While this circular
+	 * to obtain pointers to MM_GCExtensionsBase and OMR::GC::Forge, etc. While this circular
 	 * dependency could be eliminated, it would require changes to many interfaces. */
 	MM_EnvironmentBase envBase(omrVM);
 

--- a/gc/stats/LargeObjectAllocateStats.cpp
+++ b/gc/stats/LargeObjectAllocateStats.cpp
@@ -43,7 +43,7 @@ MM_FreeEntrySizeClassStats::initialize(MM_EnvironmentBase *env, uintptr_t maxAll
 	_maxVeryLargeEntrySizes = 0;
 
 	if (0 != _maxSizeClasses) {
-		_count = (uintptr_t *)env->getForge()->allocate(sizeof(uintptr_t) * _maxSizeClasses, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+		_count = (uintptr_t *)env->getForge()->allocate(sizeof(uintptr_t) * _maxSizeClasses, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 		if (NULL == _count) {
 			return false;
@@ -51,20 +51,20 @@ MM_FreeEntrySizeClassStats::initialize(MM_EnvironmentBase *env, uintptr_t maxAll
 
 		/* _maxFrequentAllocateSizes is set to 0 when we use this structure to gather TLH allocation profile, which has no need for frequent allocations */
 		if (0 != _maxFrequentAllocateSizes) {
-			_frequentAllocationHead = (FrequentAllocation **)env->getForge()->allocate(sizeof(FrequentAllocation *) * _maxSizeClasses, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+			_frequentAllocationHead = (FrequentAllocation **)env->getForge()->allocate(sizeof(FrequentAllocation *) * _maxSizeClasses, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 			if (NULL == _frequentAllocationHead) {
 				return false;
 			}
 
-			_frequentAllocation = (FrequentAllocation *)env->getForge()->allocate(sizeof(FrequentAllocation) * MAX_FREE_ENTRY_COUNTERS_PER_FREQ_ALLOC_SIZE * _maxFrequentAllocateSizes, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+			_frequentAllocation = (FrequentAllocation *)env->getForge()->allocate(sizeof(FrequentAllocation) * MAX_FREE_ENTRY_COUNTERS_PER_FREQ_ALLOC_SIZE * _maxFrequentAllocateSizes, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 			if (NULL == _frequentAllocation) {
 				return false;
 			}
 
 			if (simulation) {
-				_fractionFrequentAllocation = (float *)env->getForge()->allocate(sizeof(float)*_maxFrequentAllocateSizes, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+				_fractionFrequentAllocation = (float *)env->getForge()->allocate(sizeof(float)*_maxFrequentAllocateSizes, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 				if (NULL == _fractionFrequentAllocation) {
 					return false;
 				}
@@ -82,7 +82,7 @@ MM_FreeEntrySizeClassStats::initialize(MM_EnvironmentBase *env, uintptr_t maxAll
 					guarantyEnoughPoolSizeForVeryLargeEntry = false;
 				}
 
-				_veryLargeEntryPool = (FrequentAllocation *)env->getForge()->allocate(sizeof(FrequentAllocation) * count, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+				_veryLargeEntryPool = (FrequentAllocation *)env->getForge()->allocate(sizeof(FrequentAllocation) * count, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 				if (NULL == _veryLargeEntryPool) {
 					return false;
@@ -486,7 +486,7 @@ MM_LargeObjectAllocateStats::newInstance(MM_EnvironmentBase *env, uint16_t maxAl
 {
 	MM_LargeObjectAllocateStats *largeObjectAllocateStats;
 
-	largeObjectAllocateStats = (MM_LargeObjectAllocateStats *)env->getForge()->allocate(sizeof(MM_LargeObjectAllocateStats), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	largeObjectAllocateStats = (MM_LargeObjectAllocateStats *)env->getForge()->allocate(sizeof(MM_LargeObjectAllocateStats), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 	if(NULL != largeObjectAllocateStats) {
 		new(largeObjectAllocateStats) MM_LargeObjectAllocateStats();
@@ -572,7 +572,7 @@ MM_LargeObjectAllocateStats::initialize(MM_EnvironmentBase *env, uint16_t maxAll
 	}
 #endif
 
-	_sizeClassSizes = (uintptr_t *)env->getForge()->allocate(sizeof(uintptr_t) * _freeEntrySizeClassStats._maxSizeClasses, MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	_sizeClassSizes = (uintptr_t *)env->getForge()->allocate(sizeof(uintptr_t) * _freeEntrySizeClassStats._maxSizeClasses, OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 
 	if (NULL == _sizeClassSizes) {
 		return false;

--- a/gc/structs/SublistPool.cpp
+++ b/gc/structs/SublistPool.cpp
@@ -46,7 +46,7 @@
  * @return true if the initialization is successful, false otherwise.
  */
 bool
-MM_SublistPool::initialize(MM_EnvironmentBase *env, MM_AllocationCategory::Enum category)
+MM_SublistPool::initialize(MM_EnvironmentBase *env, OMR::GC::AllocationCategory::Enum category)
 {
 	memset(this, 0, sizeof(*this));
 	_allocCategory = category;

--- a/gc/structs/SublistPool.hpp
+++ b/gc/structs/SublistPool.hpp
@@ -62,7 +62,7 @@ private:
 	uintptr_t _currentSize;
 	uintptr_t _maxSize;
 	volatile uintptr_t _count; /**< A count for number of elements across all sublistPuddles */
-	MM_AllocationCategory::Enum _allocCategory;
+	OMR::GC::AllocationCategory::Enum _allocCategory;
 	
 	MM_SublistPuddle *_previousList; /**< A list of the non-empty puddles when #startProcessingSublist() was called */
 	
@@ -77,7 +77,7 @@ private:
 
 protected:
 public:
-	bool initialize(MM_EnvironmentBase *env, MM_AllocationCategory::Enum category);
+	bool initialize(MM_EnvironmentBase *env, OMR::GC::AllocationCategory::Enum category);
 	void tearDown(MM_EnvironmentBase *env);
 
 	MMINLINE void setGrowSize(uintptr_t growSize) { _growSize = growSize; }
@@ -133,7 +133,7 @@ public:
 		, _currentSize(0)
 		, _maxSize(0)
 		, _count(0)
-		, _allocCategory(MM_AllocationCategory::OTHER)
+		, _allocCategory(OMR::GC::AllocationCategory::OTHER)
 		, _previousList(NULL)
 	{}
 

--- a/gc/structs/SublistPuddle.cpp
+++ b/gc/structs/SublistPuddle.cpp
@@ -70,7 +70,7 @@ MM_SublistPuddle::initialize(MM_EnvironmentBase *env, uintptr_t size, MM_Sublist
  * @return An initialized instance of a sublist puddle with backing store
  */
 MM_SublistPuddle *
-MM_SublistPuddle::newInstance(MM_EnvironmentBase *env, uintptr_t size, MM_SublistPool *parent, MM_AllocationCategory::Enum category)
+MM_SublistPuddle::newInstance(MM_EnvironmentBase *env, uintptr_t size, MM_SublistPool *parent, OMR::GC::AllocationCategory::Enum category)
 {
 	MM_SublistPuddle *puddle = (MM_SublistPuddle *) env->getForge()->allocate(size + sizeof(MM_SublistPuddle), category, OMR_GET_CALLSITE());
 

--- a/gc/structs/SublistPuddle.hpp
+++ b/gc/structs/SublistPuddle.hpp
@@ -73,7 +73,7 @@ private:
 
 protected:
 public:
-	static MM_SublistPuddle *newInstance(MM_EnvironmentBase *env, uintptr_t size, MM_SublistPool *parent, MM_AllocationCategory::Enum category);
+	static MM_SublistPuddle *newInstance(MM_EnvironmentBase *env, uintptr_t size, MM_SublistPool *parent, OMR::GC::AllocationCategory::Enum category);
 	static void kill(MM_EnvironmentBase *env, MM_SublistPuddle *puddle);
 	void tearDown(MM_EnvironmentBase *env) {};
 

--- a/gc/verbose/VerboseBuffer.cpp
+++ b/gc/verbose/VerboseBuffer.cpp
@@ -38,7 +38,7 @@ MM_VerboseBuffer::newInstance(MM_EnvironmentBase *env, uintptr_t size)
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 	
-	MM_VerboseBuffer *verboseBuffer = (MM_VerboseBuffer *) extensions->getForge()->allocate(sizeof(MM_VerboseBuffer), MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	MM_VerboseBuffer *verboseBuffer = (MM_VerboseBuffer *) extensions->getForge()->allocate(sizeof(MM_VerboseBuffer), OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if(NULL != verboseBuffer) {
 		new(verboseBuffer) MM_VerboseBuffer(env);
 		if (!verboseBuffer->initialize(env, size)) {
@@ -62,7 +62,7 @@ MM_VerboseBuffer::initialize(MM_EnvironmentBase *env, uintptr_t size)
 		return false;
 	}
 	
-	if(NULL == (_buffer = (char *) extensions->getForge()->allocate(size, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE()))) {
+	if(NULL == (_buffer = (char *) extensions->getForge()->allocate(size, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE()))) {
 		return false;
 	}
 	
@@ -136,7 +136,7 @@ MM_VerboseBuffer::ensureCapacity(MM_EnvironmentBase *env, uintptr_t spaceNeeded)
 		uintptr_t currentSize = this->currentSize();
 		uintptr_t newStringLength = currentSize + spaceNeeded;
 		uintptr_t newSize = newStringLength + (newStringLength / 2);
-		char* newBuffer = (char *) extensions->getForge()->allocate(newSize, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+		char* newBuffer = (char *) extensions->getForge()->allocate(newSize, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 		if(NULL == newBuffer) {
 			result = false;
 		} else {

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -43,7 +43,7 @@ MM_VerboseHandlerOutput::newInstance(MM_EnvironmentBase *env, MM_VerboseManager 
 {
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 
-	MM_VerboseHandlerOutput *verboseHandlerOutput = (MM_VerboseHandlerOutput*)extensions->getForge()->allocate(sizeof(MM_VerboseHandlerOutput), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_VerboseHandlerOutput *verboseHandlerOutput = (MM_VerboseHandlerOutput*)extensions->getForge()->allocate(sizeof(MM_VerboseHandlerOutput), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != verboseHandlerOutput) {
 		new(verboseHandlerOutput) MM_VerboseHandlerOutput(extensions);
 		if(!verboseHandlerOutput->initialize(env, manager)) {

--- a/gc/verbose/VerboseManager.cpp
+++ b/gc/verbose/VerboseManager.cpp
@@ -47,7 +47,7 @@ MM_VerboseManager::newInstance(MM_EnvironmentBase *env, OMR_VM* vm)
 {
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(vm);
 	
-	MM_VerboseManager *verboseManager = (MM_VerboseManager *)extensions->getForge()->allocate(sizeof(MM_VerboseManager), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_VerboseManager *verboseManager = (MM_VerboseManager *)extensions->getForge()->allocate(sizeof(MM_VerboseManager), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (verboseManager) {
 		new(verboseManager) MM_VerboseManager(vm);
 		if(!verboseManager->initialize(env)) {

--- a/gc/verbose/VerboseWriter.cpp
+++ b/gc/verbose/VerboseWriter.cpp
@@ -94,7 +94,7 @@ MM_VerboseWriter::initialize(MM_EnvironmentBase* env)
 	const char* version = omrgc_get_version(env->getOmrVM());
 	/* The length is -2 for the "%s" in VERBOSEGC_HEADER and +1 for '\0' */
 	uintptr_t headerLength = strlen(version) + strlen(VERBOSEGC_HEADER) - 1;
-	_header = (char*)ext->getForge()->allocate(sizeof(char) * headerLength, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	_header = (char*)ext->getForge()->allocate(sizeof(char) * headerLength, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if (NULL == _header) {
 		return false;
 	}
@@ -102,7 +102,7 @@ MM_VerboseWriter::initialize(MM_EnvironmentBase* env)
 
 	/* Initialize _footer */
 	uintptr_t footerLength = strlen(VERBOSEGC_FOOTER) + 1;
-	_footer = (char*)ext->getForge()->allocate(sizeof(char) * footerLength, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	_footer = (char*)ext->getForge()->allocate(sizeof(char) * footerLength, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if (NULL == _footer) {
 		ext->getForge()->free(_header);
 		return false;

--- a/gc/verbose/VerboseWriterChain.cpp
+++ b/gc/verbose/VerboseWriterChain.cpp
@@ -45,7 +45,7 @@ MM_VerboseWriterChain::newInstance(MM_EnvironmentBase *env)
 {
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 	
-	MM_VerboseWriterChain *chain = (MM_VerboseWriterChain *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterChain), MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	MM_VerboseWriterChain *chain = (MM_VerboseWriterChain *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterChain), OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if(NULL != chain) {
 		new(chain) MM_VerboseWriterChain();
 		if(!chain->initialize(env)) {

--- a/gc/verbose/VerboseWriterFileLogging.cpp
+++ b/gc/verbose/VerboseWriterFileLogging.cpp
@@ -176,7 +176,7 @@ MM_VerboseWriterFileLogging::initializeFilename(MM_EnvironmentBase *env, const c
 			nameLen += sizeof(".%seq") - 1;
 		}
 
-		_filename = (char*)extensions->getForge()->allocate(nameLen, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+		_filename = (char*)extensions->getForge()->allocate(nameLen, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 		if (NULL == _filename) {
 			return false;
 		}
@@ -206,7 +206,7 @@ MM_VerboseWriterFileLogging::initializeFilename(MM_EnvironmentBase *env, const c
 			strcpy(write, ".%seq");
 		}
 	} else {
-		_filename = (char*)extensions->getForge()->allocate(strlen(filename) + 1, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+		_filename = (char*)extensions->getForge()->allocate(strlen(filename) + 1, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 		if (NULL == _filename) {
 			return false;
 		}
@@ -236,7 +236,7 @@ MM_VerboseWriterFileLogging::expandFilename(MM_EnvironmentBase *env, uintptr_t c
 	}
 	
 	uintptr_t len = omrstr_subst_tokens(NULL, 0, _filename, _tokens);
-	char *filenameToOpen = (char*)extensions->getForge()->allocate(len, MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	char *filenameToOpen = (char*)extensions->getForge()->allocate(len, OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if (NULL != filenameToOpen) {
 		omrstr_subst_tokens(filenameToOpen, len, _filename, _tokens);
 	}

--- a/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingBuffered.cpp
@@ -45,7 +45,7 @@ MM_VerboseWriterFileLoggingBuffered::newInstance(MM_EnvironmentBase *env, MM_Ver
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 	
-	MM_VerboseWriterFileLoggingBuffered *agent = (MM_VerboseWriterFileLoggingBuffered *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterFileLoggingBuffered), MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	MM_VerboseWriterFileLoggingBuffered *agent = (MM_VerboseWriterFileLoggingBuffered *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterFileLoggingBuffered), OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if(agent) {
 		new(agent) MM_VerboseWriterFileLoggingBuffered(env, manager);
 		if(!agent->initialize(env, filename, numFiles, numCycles)) {

--- a/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
+++ b/gc/verbose/VerboseWriterFileLoggingSynchronous.cpp
@@ -45,7 +45,7 @@ MM_VerboseWriterFileLoggingSynchronous::newInstance(MM_EnvironmentBase *env, MM_
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 	
-	MM_VerboseWriterFileLoggingSynchronous *agent = (MM_VerboseWriterFileLoggingSynchronous *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterFileLoggingSynchronous), MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	MM_VerboseWriterFileLoggingSynchronous *agent = (MM_VerboseWriterFileLoggingSynchronous *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterFileLoggingSynchronous), OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if(agent) {
 		new(agent) MM_VerboseWriterFileLoggingSynchronous(env, manager);
 		if(!agent->initialize(env, filename, numFiles, numCycles)) {

--- a/gc/verbose/VerboseWriterHook.cpp
+++ b/gc/verbose/VerboseWriterHook.cpp
@@ -44,7 +44,7 @@ MM_VerboseWriterHook::newInstance(MM_EnvironmentBase *env)
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 	
-	MM_VerboseWriterHook *agent = (MM_VerboseWriterHook *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterHook), MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	MM_VerboseWriterHook *agent = (MM_VerboseWriterHook *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterHook), OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if (agent) {
 		new(agent) MM_VerboseWriterHook(env);
 		if(!agent->initialize(env)){

--- a/gc/verbose/VerboseWriterStreamOutput.cpp
+++ b/gc/verbose/VerboseWriterStreamOutput.cpp
@@ -42,7 +42,7 @@ MM_VerboseWriterStreamOutput::newInstance(MM_EnvironmentBase *env, const char *f
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 
-	MM_VerboseWriterStreamOutput *agent = (MM_VerboseWriterStreamOutput *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterStreamOutput), MM_AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
+	MM_VerboseWriterStreamOutput *agent = (MM_VerboseWriterStreamOutput *)extensions->getForge()->allocate(sizeof(MM_VerboseWriterStreamOutput), OMR::GC::AllocationCategory::DIAGNOSTIC, OMR_GET_CALLSITE());
 	if(agent) {
 		new(agent) MM_VerboseWriterStreamOutput(env);
 		if(!agent->initialize(env, filename)) {

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
@@ -77,7 +77,7 @@ MM_VerboseHandlerOutputStandard::newInstance(MM_EnvironmentBase *env, MM_Verbose
 {
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(env->getOmrVM());
 
-	MM_VerboseHandlerOutputStandard *verboseHandlerOutput = (MM_VerboseHandlerOutputStandard *)extensions->getForge()->allocate(sizeof(MM_VerboseHandlerOutputStandard), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_VerboseHandlerOutputStandard *verboseHandlerOutput = (MM_VerboseHandlerOutputStandard *)extensions->getForge()->allocate(sizeof(MM_VerboseHandlerOutputStandard), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != verboseHandlerOutput) {
 		new(verboseHandlerOutput) MM_VerboseHandlerOutputStandard(extensions);
 		if(!verboseHandlerOutput->initialize(env, manager)) {

--- a/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/glue/CollectorLanguageInterfaceImpl.cpp
@@ -51,7 +51,7 @@ MM_CollectorLanguageInterfaceImpl::newInstance(MM_EnvironmentBase *env)
 	OMR_VM *omrVM = env->getOmrVM();
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVM);
 
-	cli = (MM_CollectorLanguageInterfaceImpl *)extensions->getForge()->allocate(sizeof(MM_CollectorLanguageInterfaceImpl), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	cli = (MM_CollectorLanguageInterfaceImpl *)extensions->getForge()->allocate(sizeof(MM_CollectorLanguageInterfaceImpl), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (NULL != cli) {
 		new(cli) MM_CollectorLanguageInterfaceImpl(omrVM);
 		if (!cli->initialize(omrVM)) {

--- a/glue/VerboseManagerImpl.cpp
+++ b/glue/VerboseManagerImpl.cpp
@@ -39,7 +39,7 @@ MM_VerboseManagerImpl::newInstance(MM_EnvironmentBase *env, OMR_VM* vm)
 {
 	MM_GCExtensionsBase* extensions = MM_GCExtensionsBase::getExtensions(vm);
 
-	MM_VerboseManagerImpl *verboseManager = (MM_VerboseManagerImpl *)extensions->getForge()->allocate(sizeof(MM_VerboseManagerImpl), MM_AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	MM_VerboseManagerImpl *verboseManager = (MM_VerboseManagerImpl *)extensions->getForge()->allocate(sizeof(MM_VerboseManagerImpl), OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
 	if (verboseManager) {
 		new(verboseManager) MM_VerboseManagerImpl(vm);
 		if(!verboseManager->initialize(env)) {


### PR DESCRIPTION
Move AllocationCategory to the OMR::GC namespace. Leave
MM_MemoryStatistics as is, it needs to be forward-declarable in the
hookgen headers. However, add an OMR::GC::MemoryStatistics typedef.

While I'm here, add a GC_HEAP category that aliases the old JAVA_HEAP category.

/cc @charliegracie @ktbriggs 

Signed-off-by: Robert Young <rwy0717@gmail.com>