### PR TITLE
CMake: Remove experimental warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,6 @@ cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 message(STATUS "Starting with CMake version ${CMAKE_VERSION}")
 
-# Warn user that CMake support is currently experimental
-message(WARNING
-"CMake support is currently experimental.\n\
-Various components may fail to compile with default configuration options, and some are not even attempted.")
-
 include(cmake/versions.cmake) # Required for OMR_VERSION
 
 project(omr VERSION ${OMR_VERSION} LANGUAGES CXX C)


### PR DESCRIPTION
CMake support is no longer in the experimental stage, so remove warning.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>