### PR TITLE
Fix slot assertions logging JitBuilder compiles

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -283,7 +283,11 @@ IlBuilder::Copy(TR::IlValue *value)
    {
    TR::DataType dt = value->getDataType();
    TR::SymbolReference *newSymRef = symRefTab()->createTemporary(_methodSymbol, dt);
+   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+   sprintf(name, "_T%u", newSymRef->getCPIndex());
+   newSymRef->getSymbol()->getAutoSymbol()->setName(name);
    newSymRef->getSymbol()->setNotCollected();
+   _methodBuilder->defineSymbol(name, newSymRef);
 
    storeToTemp(newSymRef, loadValue(value));
 
@@ -727,7 +731,11 @@ IlBuilder::CreateLocalArray(int32_t numElements, TR::IlType *elementType)
    TR::SymbolReference *localArraySymRef = symRefTab()->createLocalPrimArray(size,
                                                                              methodSymbol(),
                                                                              8 /*FIXME: JVM-specific - byte*/);
+   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+   sprintf(name, "_T%u", localArraySymRef->getCPIndex());
+   localArraySymRef->getSymbol()->getAutoSymbol()->setName(name);
    localArraySymRef->setStackAllocatedArrayAccess();
+   _methodBuilder->defineSymbol(name, localArraySymRef);
 
    TR::Node *arrayAddress = TR::Node::createWithSymRef(TR::loadaddr, 0, localArraySymRef);
    TR::IlValue *arrayAddressValue = newValue(TR::Address, arrayAddress);
@@ -747,7 +755,11 @@ IlBuilder::CreateLocalStruct(TR::IlType *structType)
    TR::SymbolReference *localStructSymRef = symRefTab()->createLocalPrimArray(size,
                                                                              methodSymbol(),
                                                                              8 /*FIXME: JVM-specific - byte*/);
+   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+   sprintf(name, "_T%u", localStructSymRef->getCPIndex());
+   localStructSymRef->getSymbol()->getAutoSymbol()->setName(name);
    localStructSymRef->setStackAllocatedArrayAccess();
+   _methodBuilder->defineSymbol(name, localStructSymRef);
 
    TR::Node *structAddress = TR::Node::createWithSymRef(TR::loadaddr, 0, localStructSymRef);
    TR::IlValue *structAddressValue = newValue(TR::Address, structAddress);

--- a/compiler/ilgen/IlValue.cpp
+++ b/compiler/ilgen/IlValue.cpp
@@ -59,6 +59,7 @@ OMR::IlValue::storeToAuto()
       char *name = (char *) comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
       sprintf(name, "_T%u", symRef->getCPIndex());
       symRef->getSymbol()->getAutoSymbol()->setName(name);
+      _methodBuilder->defineSymbol(name, symRef);
 
       // create store and its treetop
       TR::Node *storeNode = TR::Node::createStore(symRef, _nodeThatComputesValue);


### PR DESCRIPTION
We added more strenuous assertions when looking up symbol names
by slot number and that exposed a number of problems logging
JitBuilder compiles because there are a few places where we
did not register the symbol name after creating a new local slot.
Apparently, we never tested the new assertions while logging.

Spots fixed by this commit:
   1) CreateLocalArray
   2) CreateLocalStruct
   3) Copy
   4) IlValue when it stores a value needed in another block

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>