### PR TITLE
Fix abort during JitBuilder compile logging

### DIFF
--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -575,6 +575,18 @@ MethodBuilder::DefineFunction(const char* const name,
 const char *
 MethodBuilder::getSymbolName(int32_t slot)
    {
+   // Sometimes the code generators will manufacture a symbol reference themselves with no way
+   // to properly assign a cpIndex, that these symbol references show up here with slot == -1
+   // when JIT logging. One specific case is when the code generate converts an indirect store to
+   // a known stack allocated object using a constant offset to a store with a different offset
+   // based of the stack pointer (because it knows exactly which stack slot is being referenced),
+   // but there could be other cases. This escape clause doesn't feel like a great solution to this
+   // problem, but since the assertions only really catch while create JIT logs (names are only
+   // needed when generating logs), it's actually more useful to allow the compilation to continue
+   // so that the full log can be generated rather than aborting.
+   if (slot == -1)
+      return "Unknown";
+
    SlotToSymNameMap::iterator it = _symbolNameFromSlot.find(slot);
    TR_ASSERT_FATAL(it != _symbolNameFromSlot.end(), "No symbol found in slot %d", slot);
 


### PR DESCRIPTION
There are cases when the code generate manufactures a symbol reference
and cannot assign an appropriate cpIndex (e.g. converting an indirect
access to a stack allocated array or object into a "more" direct access
via the stack pointer). In these cases, if the JIT is logging its
output, the JIT will ask MethodBuilder for the name of a symbol at
slot -1 which naturally causes an assertion. This commit returns
the name "Unknown" for slot -1 because this assertion only occurs
during JIT logging and it's usually better to allow the logging
to continue than to abort prematurely just because such a symbol
was created and logged.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>