### PR TITLE
Switch OS X to use Unix Makefiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,11 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
-    - os: osx
-      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR="Unix Makefiles"
     - os: linux
       compiler: clang
   include:
-    # Auto tool builds
-    # 32 bit Linux x86
+    ## Auto tool builds
+    #  32 bit Linux x86
     - os: linux
       addons:
         apt:
@@ -90,9 +88,9 @@ matrix:
             - llvm-3.4
       env: RUN_LINT=yes RUN_BUILD=no SPEC=linux_x86-64 PLATFORM=amd64-linux64-gcc
       dist: precise
-    # CMake builds
-    # Ninja builds
-    # 64 bit Linux x86
+    ## CMake builds
+    #  Ninja builds
+    #  64 bit Linux x86
     - os: linux
       addons:
         apt:
@@ -104,9 +102,6 @@ matrix:
             - libdwarf-dev
             - libelf-dev 
             - ninja-build
-      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja
-    # 64 bit OS X
-    - os: osx
       env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja
 before_script:
   - ulimit -c unlimited


### PR DESCRIPTION
Simplify the yml file and speed up the OS X builds slightly but not
using the Ninja generator.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>