### PR TITLE
Prevent suspending native stack walk threads for z/TPF.

### DIFF
--- a/thread/unix/thrdsup.c
+++ b/thread/unix/thrdsup.c
@@ -99,6 +99,10 @@ call_omrthread_init(void)
 	zos_init_yielding();
 #endif
 
+#if  defined(OMRZTPF)
+	ztpf_init_proc();
+#endif /* defined(OMRZTPF) */
+
 #if J9THREAD_USE_MONOTONIC_COND_CLOCK
 	initCondAttr(); /* ignore the result */
 #endif


### PR DESCRIPTION
Prevent suspending native stack walk threads for z/TPF.
In addition, call special z/TPF thread initialization routines.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>