### PR TITLE
Remove CodeGenerator notion of warm/cold areas of a method

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -486,11 +486,10 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
       }
 
    self()->setEstimatedWarmLength(estimate);
-   self()->setEstimatedColdLength(0);
 
    cursorInstruction = comp->getFirstInstruction();
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), self()->getEstimatedColdLength(), &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -485,11 +485,11 @@ void OMR::ARM::CodeGenerator::doBinaryEncoding()
       estimate = identifyFarConditionalBranches(estimate, self());
       }
 
-   self()->setEstimatedWarmLength(estimate);
+   self()->setEstimatedCodeLength(estimate);
 
    cursorInstruction = comp->getFirstInstruction();
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -189,7 +189,7 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
 
      if (debug("dumpCodeSizes"))
         {
-        diagnostic("%08d   %s\n", cg->getWarmCodeLength()+ cg->getColdCodeLength(), comp->signature());
+        diagnostic("%08d   %s\n", cg->getWarmCodeLength(), comp->signature());
         }
 
      if (comp->getCurrentMethod() == NULL)
@@ -197,12 +197,11 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         comp->getMethodSymbol()->setMethodAddress(cg->getBinaryBufferStart());
         }
 
-     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength() && cg->getColdCodeLength() <= 0,
+     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength(),
                "Method length estimate must be conservatively large\n"
-               "    warmCodeLength = %d, estimatedWarmLength = %d \n"
-               "    coldCodeLength = %d",
-               cg->getWarmCodeLength(), cg->getEstimatedWarmLength(),
-               cg->getColdCodeLength());
+               "    warmCodeLength = %d, estimatedWarmLength = %d \n",
+               cg->getWarmCodeLength(), cg->getEstimatedWarmLength()
+               );
 
      // also trace the interal stack atlas
      cg->getStackAtlas()->close(cg);
@@ -265,7 +264,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
                   "\nAmount of code memory consumed for this function         = %d"
                   "\nAmount of snippet code memory consumed for this function = %d\n\n",
                   cg->getEstimatedMethodLength(),
-                  cg->getWarmCodeLength() + cg->getColdCodeLength(),
+                  cg->getWarmCodeLength(),
                   snippetLength);
       }
    }

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -197,12 +197,12 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         comp->getMethodSymbol()->setMethodAddress(cg->getBinaryBufferStart());
         }
 
-     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength() && cg->getColdCodeLength() <= cg->getEstimatedColdLength(),
+     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength() && cg->getColdCodeLength() <= 0,
                "Method length estimate must be conservatively large\n"
                "    warmCodeLength = %d, estimatedWarmLength = %d \n"
-               "    coldCodeLength = %d, estimatedColdLength = %d",
+               "    coldCodeLength = %d",
                cg->getWarmCodeLength(), cg->getEstimatedWarmLength(),
-               cg->getColdCodeLength(),cg->getEstimatedColdLength());
+               cg->getColdCodeLength());
 
      // also trace the interal stack atlas
      cg->getStackAtlas()->close(cg);
@@ -247,8 +247,6 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
    if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
       {
       diagnostic("\nbuffer start = %8x, code start = %8x, buffer length = %d", cg->getBinaryBufferStart(), cg->getCodeStart(), cg->getEstimatedWarmLength());
-      if (cg->getEstimatedColdLength())
-         diagnostic(" + %d", cg->getEstimatedColdLength());
       diagnostic("\n");
       const char * title = "Post Binary Instructions";
 

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -197,10 +197,10 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         comp->getMethodSymbol()->setMethodAddress(cg->getBinaryBufferStart());
         }
 
-     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedWarmLength(),
+     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedCodeLength(),
                "Method length estimate must be conservatively large\n"
-               "    warmCodeLength = %d, estimatedWarmLength = %d \n",
-               cg->getWarmCodeLength(), cg->getEstimatedWarmLength()
+               "    warmCodeLength = %d, estimatedCodeLength = %d \n",
+               cg->getWarmCodeLength(), cg->getEstimatedCodeLength()
                );
 
      // also trace the interal stack atlas
@@ -241,7 +241,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
 
    if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
       {
-      diagnostic("\nbuffer start = %8x, code start = %8x, buffer length = %d", cg->getBinaryBufferStart(), cg->getCodeStart(), cg->getEstimatedWarmLength());
+      diagnostic("\nbuffer start = %8x, code start = %8x, buffer length = %d", cg->getBinaryBufferStart(), cg->getCodeStart(), cg->getEstimatedCodeLength());
       diagnostic("\n");
       const char * title = "Post Binary Instructions";
 
@@ -263,7 +263,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
       diagnostic("\nAmount of code memory allocated for this function        = %d"
                   "\nAmount of code memory consumed for this function         = %d"
                   "\nAmount of snippet code memory consumed for this function = %d\n\n",
-                  cg->getEstimatedMethodLength(),
+                  cg->getEstimatedCodeLength(),
                   cg->getWarmCodeLength(),
                   snippetLength);
       }

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -189,7 +189,7 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
 
      if (debug("dumpCodeSizes"))
         {
-        diagnostic("%08d   %s\n", cg->getWarmCodeLength(), comp->signature());
+        diagnostic("%08d   %s\n", cg->getCodeLength(), comp->signature());
         }
 
      if (comp->getCurrentMethod() == NULL)
@@ -197,10 +197,10 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         comp->getMethodSymbol()->setMethodAddress(cg->getBinaryBufferStart());
         }
 
-     TR_ASSERT(cg->getWarmCodeLength() <= cg->getEstimatedCodeLength(),
+     TR_ASSERT(cg->getCodeLength() <= cg->getEstimatedCodeLength(),
                "Method length estimate must be conservatively large\n"
-               "    warmCodeLength = %d, estimatedCodeLength = %d \n",
-               cg->getWarmCodeLength(), cg->getEstimatedCodeLength()
+               "    codeLength = %d, estimatedCodeLength = %d \n",
+               cg->getCodeLength(), cg->getEstimatedCodeLength()
                );
 
      // also trace the interal stack atlas
@@ -211,11 +211,11 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         {
         if (TR::Compiler->target.is64Bit())
         {
-        setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getWarmCodeLength(),"SLIPDLL64", comp);
+        setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getCodeLength(),"SLIPDLL64", comp);
         }
      else
         {
-        setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getWarmCodeLength(),"SLIPDLL31", comp);
+        setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getCodeLength(),"SLIPDLL31", comp);
         }
      }
 
@@ -264,7 +264,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
                   "\nAmount of code memory consumed for this function         = %d"
                   "\nAmount of snippet code memory consumed for this function = %d\n\n",
                   cg->getEstimatedCodeLength(),
-                  cg->getWarmCodeLength(),
+                  cg->getCodeLength(),
                   snippetLength);
       }
    }

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -213,14 +213,10 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         if (TR::Compiler->target.is64Bit())
         {
         setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getWarmCodeLength(),"SLIPDLL64", comp);
-        if (cg->getColdCodeStart())
-           setDllSlip((char*)cg->getColdCodeStart(),(char*)cg->getColdCodeStart()+cg->getColdCodeLength(),"SLIPDLL64", comp);
         }
      else
         {
         setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getWarmCodeLength(),"SLIPDLL31", comp);
-        if (cg->getColdCodeStart())
-           setDllSlip((char*)cg->getColdCodeStart(),(char*)cg->getColdCodeStart()+cg->getColdCodeLength(),"SLIPDLL31", comp);
         }
      }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1171,12 +1171,6 @@ OMR::CodeGenerator::getCodeStart()
    }
 
 uint32_t
-OMR::CodeGenerator::getWarmCodeLength() // cast explicitly
-   {
-   return (uint32_t)(self()->getCodeEnd() - self()->getCodeStart());
-   }
-
-uint32_t
 OMR::CodeGenerator::getCodeLength() // cast explicitly
    {
    return (uint32_t)(self()->getCodeEnd() - self()->getCodeStart());

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1050,12 +1050,6 @@ OMR::CodeGenerator::getSupportsConstantOffsetInAddressing(int64_t value)
    return self()->getSupportsConstantOffsetInAddressing();
    }
 
-bool
-OMR::CodeGenerator::getIsInWarmCodeCache()
-   {
-   return _flags2.testAny(IsInWarmCodeCache) && !self()->isOutOfLineColdPath();
-   }
-
 void
 OMR::CodeGenerator::toggleIsInOOLSection()
    {

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -212,7 +212,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _binaryBufferCursor(NULL),
      _largestOutgoingArgSize(0),
      _warmCodeEnd(NULL),
-     _coldCodeStart(NULL),
      _estimatedWarmLength(0),
      _estimatedSnippetStart(0),
      _accumulatedInstructionLengthError(0),
@@ -1181,7 +1180,7 @@ OMR::CodeGenerator::getWarmCodeLength() // cast explicitly
 uint32_t
 OMR::CodeGenerator::getColdCodeLength() // cast explicitly
    {
-   return (uint32_t)(_coldCodeStart ? self()->getCodeEnd() - self()->getColdCodeStart() : 0);
+   return (uint32_t)0;
    }
 
 uint32_t

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -214,7 +214,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _warmCodeEnd(NULL),
      _coldCodeStart(NULL),
      _estimatedWarmLength(0),
-     _estimatedColdLength(0),
      _estimatedSnippetStart(0),
      _accumulatedInstructionLengthError(0),
      _registerSaveDescription(0),

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1178,12 +1178,6 @@ OMR::CodeGenerator::getWarmCodeLength() // cast explicitly
    }
 
 uint32_t
-OMR::CodeGenerator::getColdCodeLength() // cast explicitly
-   {
-   return (uint32_t)0;
-   }
-
-uint32_t
 OMR::CodeGenerator::getCodeLength() // cast explicitly
    {
    return (uint32_t)(self()->getCodeEnd() - self()->getCodeStart());

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -211,7 +211,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _binaryBufferStart(NULL),
      _binaryBufferCursor(NULL),
      _largestOutgoingArgSize(0),
-     _warmCodeEnd(NULL),
      _estimatedCodeLength(0),
      _estimatedSnippetStart(0),
      _accumulatedInstructionLengthError(0),
@@ -1174,7 +1173,7 @@ OMR::CodeGenerator::getCodeStart()
 uint32_t
 OMR::CodeGenerator::getWarmCodeLength() // cast explicitly
    {
-   return (uint32_t)(self()->getWarmCodeEnd() - self()->getCodeStart());
+   return (uint32_t)(self()->getCodeEnd() - self()->getCodeStart());
    }
 
 uint32_t
@@ -2604,8 +2603,8 @@ OMR::CodeGenerator::allocateCodeMemory(uint32_t size, bool isCold, bool isMethod
 void
 OMR::CodeGenerator::resizeCodeMemory()
    {
-   int32_t warmCodeLength = self()->getWarmCodeEnd()-self()->getBinaryBufferStart();
-   self()->fe()->resizeCodeMemory(self()->comp(), self()->getBinaryBufferStart(), warmCodeLength);
+   int32_t codeLength = self()->getCodeEnd()-self()->getBinaryBufferStart();
+   self()->fe()->resizeCodeMemory(self()->comp(), self()->getBinaryBufferStart(), codeLength);
    }
 
 bool

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -212,7 +212,7 @@ OMR::CodeGenerator::CodeGenerator() :
      _binaryBufferCursor(NULL),
      _largestOutgoingArgSize(0),
      _warmCodeEnd(NULL),
-     _estimatedWarmLength(0),
+     _estimatedCodeLength(0),
      _estimatedSnippetStart(0),
      _accumulatedInstructionLengthError(0),
      _registerSaveDescription(0),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -749,8 +749,6 @@ class OMR_EXTENSIBLE CodeGenerator
    uint8_t *setBinaryBufferStart(uint8_t *b) {return (_binaryBufferStart = b);}
 
    uint8_t *getCodeStart();
-   uint8_t *getWarmCodeEnd()              {return _binaryBufferCursor;}
-   uint8_t *setWarmCodeEnd(uint8_t *c)    {return (_warmCodeEnd = c);}
    uint8_t *getCodeEnd()                  {return _binaryBufferCursor;}
    uint32_t getWarmCodeLength();
    uint32_t getCodeLength();
@@ -1864,7 +1862,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR_GCStackMap *_methodStackMap;
    TR::list<TR::Block*> _counterBlocks;
    uint8_t *_binaryBufferStart;
-   uint8_t *_warmCodeEnd;
    uint8_t *_binaryBufferCursor;
    TR::SparseBitVector _extendedToInt64GlobalRegisters;
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -747,10 +747,8 @@ class OMR_EXTENSIBLE CodeGenerator
    uint8_t *setBinaryBufferStart(uint8_t *b) {return (_binaryBufferStart = b);}
 
    uint8_t *getCodeStart();
-   uint8_t *getWarmCodeEnd()              {return _coldCodeStart ? _warmCodeEnd : _binaryBufferCursor;}
+   uint8_t *getWarmCodeEnd()              {return _binaryBufferCursor;}
    uint8_t *setWarmCodeEnd(uint8_t *c)    {return (_warmCodeEnd = c);}
-   uint8_t *getColdCodeStart()            {return _coldCodeStart;}
-   uint8_t *setColdCodeStart(uint8_t *c)  {return (_coldCodeStart = c);}
    uint8_t *getCodeEnd()                  {return _binaryBufferCursor;}
    uint32_t getWarmCodeLength();
    uint32_t getColdCodeLength();
@@ -1866,7 +1864,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR::Block*> _counterBlocks;
    uint8_t *_binaryBufferStart;
    uint8_t *_warmCodeEnd;
-   uint8_t *_coldCodeStart;
    uint8_t *_binaryBufferCursor;
    TR::SparseBitVector _extendedToInt64GlobalRegisters;
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -751,7 +751,6 @@ class OMR_EXTENSIBLE CodeGenerator
    uint8_t *setWarmCodeEnd(uint8_t *c)    {return (_warmCodeEnd = c);}
    uint8_t *getCodeEnd()                  {return _binaryBufferCursor;}
    uint32_t getWarmCodeLength();
-   uint32_t getColdCodeLength();
    uint32_t getCodeLength();
 
    uint8_t *getBinaryBufferCursor() {return _binaryBufferCursor;}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -739,9 +739,11 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Binary encoding code cache
    //
-   uint32_t getEstimatedWarmLength()           {return _estimatedWarmLength;}
-   uint32_t setEstimatedWarmLength(uint32_t l) {return (_estimatedWarmLength = l);}
-   uint32_t getEstimatedMethodLength()           {return _estimatedWarmLength;}
+   uint32_t getEstimatedWarmLength()           {return _estimatedCodeLength;} // DEPRECATED
+   uint32_t setEstimatedWarmLength(uint32_t l) {return (_estimatedCodeLength = l);} // DEPRECATED
+
+   uint32_t getEstimatedCodeLength()           {return _estimatedCodeLength;}
+   uint32_t setEstimatedCodeLength(uint32_t l) {return (_estimatedCodeLength = l);}
 
    uint8_t *getBinaryBufferStart()           {return _binaryBufferStart;}
    uint8_t *setBinaryBufferStart(uint8_t *b) {return (_binaryBufferStart = b);}
@@ -1922,7 +1924,7 @@ class OMR_EXTENSIBLE CodeGenerator
    uint32_t _vmThreadLiveCount;
    uint32_t _largestOutgoingArgSize;
 
-   uint32_t _estimatedWarmLength;
+   uint32_t _estimatedCodeLength;
    int32_t _estimatedSnippetStart;
    int32_t _accumulatedInstructionLengthError;
    int32_t _frameSizeInBytes;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -750,7 +750,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    uint8_t *getCodeStart();
    uint8_t *getCodeEnd()                  {return _binaryBufferCursor;}
-   uint32_t getWarmCodeLength();
    uint32_t getCodeLength();
 
    uint8_t *getBinaryBufferCursor() {return _binaryBufferCursor;}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1640,10 +1640,6 @@ class OMR_EXTENSIBLE CodeGenerator
    void incOutOfLineColdPathNestedDepth(){_outOfLineColdPathNestedDepth++;}
    void decOutOfLineColdPathNestedDepth(){_outOfLineColdPathNestedDepth--;}
 
-   bool getIsInWarmCodeCache();
-   void setIsInWarmCodeCache() {_flags2.set(IsInWarmCodeCache);}
-   void resetIsInWarmCodeCache() {_flags2.reset(IsInWarmCodeCache);}
-
    bool getMethodModifiedByRA() {return _flags2.testAny(MethodModifiedByRA);}
    void setMethodModifiedByRA() {_flags2.set(MethodModifiedByRA);}
    void resetMethodModifiedByRA() {_flags2.reset(MethodModifiedByRA);}
@@ -1750,7 +1746,7 @@ class OMR_EXTENSIBLE CodeGenerator
       SupportsReverseLoadAndStore                         = 0x00400000,
       SupportsLoweringConstLDivPower2                     = 0x00800000,
       DisableFpGRA                                        = 0x01000000,
-      IsInWarmCodeCache                                   = 0x02000000,
+      // Available                                        = 0x02000000,
       MethodModifiedByRA                                  = 0x04000000,
       SchedulingInstrCleanupNeeded                        = 0x08000000,
       // Available                                        = 0x10000000,

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -741,9 +741,7 @@ class OMR_EXTENSIBLE CodeGenerator
    //
    uint32_t getEstimatedWarmLength()           {return _estimatedWarmLength;}
    uint32_t setEstimatedWarmLength(uint32_t l) {return (_estimatedWarmLength = l);}
-   uint32_t getEstimatedColdLength()           {return _estimatedColdLength;}
-   uint32_t setEstimatedColdLength(uint32_t l) {return (_estimatedColdLength = l);}
-   uint32_t getEstimatedMethodLength()           {return _estimatedWarmLength+_estimatedColdLength;}
+   uint32_t getEstimatedMethodLength()           {return _estimatedWarmLength;}
 
    uint8_t *getBinaryBufferStart()           {return _binaryBufferStart;}
    uint8_t *setBinaryBufferStart(uint8_t *b) {return (_binaryBufferStart = b);}
@@ -1929,7 +1927,6 @@ class OMR_EXTENSIBLE CodeGenerator
    uint32_t _largestOutgoingArgSize;
 
    uint32_t _estimatedWarmLength;
-   uint32_t _estimatedColdLength;
    int32_t _estimatedSnippetStart;
    int32_t _accumulatedInstructionLengthError;
    int32_t _frameSizeInBytes;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2066,11 +2066,10 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
       }
 
    self()->setEstimatedWarmLength(data.estimate);
-   self()->setEstimatedColdLength(0);
 
    data.cursorInstruction = self()->comp()->getFirstInstruction();
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), self()->getEstimatedColdLength(), &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2065,11 +2065,11 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
       data.estimate = identifyFarConditionalBranches(data.estimate, self());
       }
 
-   self()->setEstimatedWarmLength(data.estimate);
+   self()->setEstimatedCodeLength(data.estimate);
 
    data.cursorInstruction = self()->comp()->getFirstInstruction();
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
 
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);

--- a/compiler/runtime/OMRCodeMetaData.cpp
+++ b/compiler/runtime/OMRCodeMetaData.cpp
@@ -34,7 +34,7 @@ OMR::CodeMetaData::self()
 OMR::CodeMetaData::CodeMetaData(TR::Compilation *comp)
    {
    _codeAllocStart = comp->cg()->getBinaryBufferStart();
-   _codeAllocSize = comp->cg()->getEstimatedMethodLength();
+   _codeAllocSize = comp->cg()->getEstimatedCodeLength();
 
    _interpreterEntryPC = comp->cg()->getCodeStart();
    

--- a/compiler/runtime/OMRCodeMetaData.cpp
+++ b/compiler/runtime/OMRCodeMetaData.cpp
@@ -39,7 +39,7 @@ OMR::CodeMetaData::CodeMetaData(TR::Compilation *comp)
    _interpreterEntryPC = comp->cg()->getCodeStart();
    
    _compiledEntryPC = _interpreterEntryPC;
-   _compiledEndPC = comp->cg()->getWarmCodeEnd();
+   _compiledEndPC = comp->cg()->getCodeEnd();
 
    _hotness = comp->cg()->getMethodHotness();
    }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1888,7 +1888,6 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // the allocated size by 4.
    #define OVER_ESTIMATION 4
    self()->setEstimatedWarmLength(estimate+OVER_ESTIMATION);
-   self()->setEstimatedColdLength(0);
 
    if (self()->comp()->getOption(TR_TraceCG))
       {
@@ -1906,7 +1905,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       }
 
    uint8_t * coldCode = NULL;
-   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), self()->getEstimatedColdLength(), &coldCode);
+   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
    TR_ASSERT(temp, "Failed to allocate primary code area.");
 
    if (TR::Compiler->target.is64Bit() && self()->comp()->getCodeCacheSwitched() && self()->getPicSlotCount() != 0)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1887,7 +1887,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // adjacent block. For this reason it is better to overestimate
    // the allocated size by 4.
    #define OVER_ESTIMATION 4
-   self()->setEstimatedWarmLength(estimate+OVER_ESTIMATION);
+   self()->setEstimatedCodeLength(estimate+OVER_ESTIMATION);
 
    if (self()->comp()->getOption(TR_TraceCG))
       {
@@ -1905,7 +1905,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       }
 
    uint8_t * coldCode = NULL;
-   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
+   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
    TR_ASSERT(temp, "Failed to allocate primary code area.");
 
    if (TR::Compiler->target.is64Bit() && self()->comp()->getCodeCacheSwitched() && self()->getPicSlotCount() != 0)

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6322,12 +6322,12 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
       _extentOfLitPool = self()->setEstimatedOffsetForConstantDataSnippets(_extentOfLitPool);
       }
 
-   self()->setEstimatedWarmLength(data.estimate);
+   self()->setEstimatedCodeLength(data.estimate);
 
    data.cursorInstruction = self()->comp()->getFirstInstruction();
 
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
 
 
    self()->setBinaryBufferStart(temp);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6323,12 +6323,11 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
       }
 
    self()->setEstimatedWarmLength(data.estimate);
-   self()->setEstimatedColdLength(0);
 
    data.cursorInstruction = self()->comp()->getFirstInstruction();
 
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), self()->getEstimatedColdLength(), &coldCode);
+   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedWarmLength(), 0, &coldCode);
 
 
    self()->setBinaryBufferStart(temp);


### PR DESCRIPTION
* Remove deprecated estimated cold code functions
* Remove deprecated cold code start functions
* Remove and fold deprecated getColdCodeLength
* Rename deprecated EstimatedWarmLength functions
* Rename deprecated WarmCodeEnd functions
* Rename deprecated WarmCodeLength functions
* Remove unused IsInWarmCodeCache CodeGenerator flag and functions