### PR TITLE
Extract concurrent GC delegate from CLI (fix osx compile)

### DIFF
--- a/gc/base/standard/ConcurrentCardTableForWC.cpp
+++ b/gc/base/standard/ConcurrentCardTableForWC.cpp
@@ -113,7 +113,7 @@ void
 MM_ConcurrentCardTableForWC::prepareCardTableAsyncEventHandler(OMR_VMThread *omrVMThread, void *userData)
 {
 	MM_ConcurrentCardTableForWC *cardTable  = (MM_ConcurrentCardTableForWC *)userData;
-	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(omrVMThread);
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(omrVMThread);
 
 	cardTable->prepareCardTable(env);
 }
@@ -123,7 +123,7 @@ MM_ConcurrentCardTableForWC::prepareCardTableAsyncEventHandler(OMR_VMThread *omr
  * 
  */
 void
-MM_ConcurrentCardTableForWC::prepareCardTable(MM_EnvironmentStandard *env)
+MM_ConcurrentCardTableForWC::prepareCardTable(MM_EnvironmentBase *env)
 {
 	CardCleanPhase currentPhase = _cardCleanPhase;
 	
@@ -153,7 +153,7 @@ MM_ConcurrentCardTableForWC::prepareCardTable(MM_EnvironmentStandard *env)
  * miss any object references. 
  */
 void
-MM_ConcurrentCardTableForWC::prepareCardsForCleaning(MM_EnvironmentStandard *env)
+MM_ConcurrentCardTableForWC::prepareCardsForCleaning(MM_EnvironmentBase *env)
 {
 	/* First call superclass which will set card cleaning range for next
 	 * phase of card cleaning
@@ -196,7 +196,7 @@ MM_ConcurrentCardTableForWC::prepareCardsForCleaning(MM_EnvironmentStandard *env
  * @return TRUE if exclusive access acquired; FALSE otherwise
  */
 MMINLINE bool
-MM_ConcurrentCardTableForWC::getExclusiveCardTableAccess(MM_EnvironmentStandard *env, CardCleanPhase currentPhase, bool threadAtSafePoint)
+MM_ConcurrentCardTableForWC::getExclusiveCardTableAccess(MM_EnvironmentBase *env, CardCleanPhase currentPhase, bool threadAtSafePoint)
 {
 	/* Because the WC CardTable requires exclusive access to prepare the cards for cleaning, we cannot gain
 	 * exclusive access to the card table if the thread is not at a safe point. Request async call back
@@ -233,7 +233,7 @@ MM_ConcurrentCardTableForWC::getExclusiveCardTableAccess(MM_EnvironmentStandard 
  * Release exclusive control of the card table
  */
 MMINLINE void
-MM_ConcurrentCardTableForWC::releaseExclusiveCardTableAccess(MM_EnvironmentStandard *env)
+MM_ConcurrentCardTableForWC::releaseExclusiveCardTableAccess(MM_EnvironmentBase *env)
 {
 	/* Cache the current value */
 	CardCleanPhase currentPhase = _cardCleanPhase;
@@ -265,7 +265,7 @@ MM_ConcurrentCardTableForWC::releaseExclusiveCardTableAccess(MM_EnvironmentStand
  * @return Number of active cards in the the chunk
  */ 
 uintptr_t
-MM_ConcurrentCardTableForWC::countCardsInRange(MM_EnvironmentStandard *env, Card *chunkStart, Card *chunkEnd)
+MM_ConcurrentCardTableForWC::countCardsInRange(MM_EnvironmentBase *env, Card *chunkStart, Card *chunkEnd)
 {
 	uintptr_t cardsInRange = 0;
 	CleaningRange  *cleaningRange = _cleaningRanges;
@@ -306,7 +306,7 @@ MM_ConcurrentCardTableForWC::countCardsInRange(MM_EnvironmentStandard *env, Card
  * MARK_SAFE_CARD_DIRTY.
  */ 
 void
-MM_ConcurrentCardTableForWC::prepareCardTableChunk(MM_EnvironmentStandard *env, Card *chunkStart, Card *chunkEnd, CardAction action)
+MM_ConcurrentCardTableForWC::prepareCardTableChunk(MM_EnvironmentBase *env, Card *chunkStart, Card *chunkEnd, CardAction action)
 {
 	uintptr_t prepareUnitFactor, prepareUnitSize;
 	
@@ -410,7 +410,7 @@ MM_ConcurrentCardTableForWC::prepareCardTableChunk(MM_EnvironmentStandard *env, 
  * not cleaned back to card_DIRTY so that they are rescanned during final card cleaning.
  */ 
 void
-MM_ConcurrentCardTableForWC::initializeFinalCardCleaning(MM_EnvironmentStandard *env)
+MM_ConcurrentCardTableForWC::initializeFinalCardCleaning(MM_EnvironmentBase *env)
 {
 	/* Did we get as far as preparing the card table for cleaning ? */
 	if (_cardTablePreparedForCleaning ) {

--- a/gc/base/standard/ConcurrentCardTableForWC.hpp
+++ b/gc/base/standard/ConcurrentCardTableForWC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@
 
 #include "Base.hpp"
 #include "ConcurrentCardTable.hpp"
-#include "EnvironmentStandard.hpp"
+#include "EnvironmentBase.hpp"
 #include "ConcurrentSafepointCallback.hpp"
 
 
@@ -60,12 +60,12 @@ class MM_ConcurrentCardTableForWC : public MM_ConcurrentCardTable
 	bool initialize(MM_EnvironmentBase *env, MM_Heap *heap);
 	virtual void tearDown(MM_EnvironmentBase *env);
 		
-	virtual	void prepareCardsForCleaning(MM_EnvironmentStandard *env);
-	virtual bool getExclusiveCardTableAccess(MM_EnvironmentStandard *env, CardCleanPhase currentPhase, bool threadAtSafePoint);
-	virtual void releaseExclusiveCardTableAccess(MM_EnvironmentStandard *env);
-	void prepareCardTable(MM_EnvironmentStandard *env);
+	virtual	void prepareCardsForCleaning(MM_EnvironmentBase *env);
+	virtual bool getExclusiveCardTableAccess(MM_EnvironmentBase *env, CardCleanPhase currentPhase, bool threadAtSafePoint);
+	virtual void releaseExclusiveCardTableAccess(MM_EnvironmentBase *env);
+	void prepareCardTable(MM_EnvironmentBase *env);
 		
-	uintptr_t countCardsInRange(MM_EnvironmentStandard *env, Card *rangeStart, Card *rangeEnd);
+	uintptr_t countCardsInRange(MM_EnvironmentBase *env, Card *rangeStart, Card *rangeEnd);
 	
 	MMINLINE virtual void concurrentCleanCard(Card *card)
 	{
@@ -82,8 +82,8 @@ class MM_ConcurrentCardTableForWC : public MM_ConcurrentCardTable
 public:
 	static MM_ConcurrentCardTable	*newInstance(MM_EnvironmentBase *env, MM_Heap *heap, MM_MarkingScheme *markingScheme, MM_ConcurrentGC *collector);
 	
-	void prepareCardTableChunk(MM_EnvironmentStandard *env, Card *chunkStart, Card *chunkEnd, CardAction action);
-	virtual void initializeFinalCardCleaning(MM_EnvironmentStandard *env);
+	void prepareCardTableChunk(MM_EnvironmentBase *env, Card *chunkStart, Card *chunkEnd, CardAction action);
+	virtual void initializeFinalCardCleaning(MM_EnvironmentBase *env);
 	
 	static void prepareCardTableAsyncEventHandler(OMR_VMThread *omrVMThread, void *userData);
 	
@@ -91,7 +91,7 @@ public:
 	 * as we know such cards are sure to be cleaned in future either after a STW card table 
 	 * prepare phase or during FCC.
 	 */  
-	MMINLINE virtual bool isObjectInUncleanedDirtyCard(MM_EnvironmentStandard *env, omrobjectptr_t object)
+	MMINLINE virtual bool isObjectInUncleanedDirtyCard(MM_EnvironmentBase *env, omrobjectptr_t object)
 	{
 		return false;	
 	}


### PR DESCRIPTION
Fix OSX compilation issue. Replace MM_EnvironmentStandard with
MM_EnvironmentBase everywhere in MM_ConcurrentCardTableForWC as for
base class MM_ConcurrentCardTable.

Signed-off-by: Kim Briggs <briggs@ca.ibm.com>