### PR TITLE
Bridge work to move instruction pointers to CodeGenerator

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -4138,3 +4138,31 @@ OMR::CodeGenerator::lowerTree(TR::Node *root, TR::TreeTop *tt)
    TR_ASSERT(0, "Unimplemented lowerTree() called for an opcode that needs to be lowered");
    return NULL;
    }
+
+
+TR::Instruction *
+OMR::CodeGenerator::getFirstInstruction()
+   {
+   return self()->comp()->getFirstInstruction();
+   }
+
+
+TR::Instruction *
+OMR::CodeGenerator::setFirstInstruction(TR::Instruction *fi)
+   {
+   return self()->comp()->setFirstInstruction(fi);
+   }
+
+
+TR::Instruction *
+OMR::CodeGenerator::getAppendInstruction()
+   {
+   return self()->comp()->getAppendInstruction();
+   }
+
+
+TR::Instruction *
+OMR::CodeGenerator::setAppendInstruction(TR::Instruction *ai)
+   {
+   return self()->comp()->setAppendInstruction(ai);
+   }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -362,6 +362,38 @@ class OMR_EXTENSIBLE CodeGenerator
    TR_BitVector *getLiveLocals() {return _liveLocals;}
    TR_BitVector *setLiveLocals(TR_BitVector *v) {return (_liveLocals = v);}
 
+   /**
+    * @brief Returns the first TR::Instruction in the stream of instructions for
+    *        this method.  This instruction's "previous" link should be NULL.
+    *
+    * @return The first instruction in this method; NULL if not yet set.
+    */
+   TR::Instruction *getFirstInstruction();
+
+   /**
+    * @brief Sets the first TR::Instruction in the stream of instructions for
+    *        this method.  This instruction's "previous" link should be NULL.
+    *
+    * @return The instruction being set.
+    */
+   TR::Instruction *setFirstInstruction(TR::Instruction *fi);
+
+   /**
+    * @brief Returns the last TR::Instruction in the stream of instructions for
+    *        this method.  This instruction's "next" link should be NULL.
+    *
+    * @return The last instruction in this method; NULL if not yet set.
+    */
+   TR::Instruction *getAppendInstruction();
+
+   /**
+    * @brief Sets the last TR::Instruction in the stream of instructions for
+    *        this method.  This instruction's "next" link should be NULL.
+    *
+    * @return The instruction being set.
+    */
+   TR::Instruction *setAppendInstruction(TR::Instruction *ai);
+
    TR::TreeTop *getCurrentEvaluationTreeTop() {return _currentEvaluationTreeTop;}
    TR::TreeTop *setCurrentEvaluationTreeTop(TR::TreeTop *tt) {return (_currentEvaluationTreeTop = tt);}
 


### PR DESCRIPTION
As part of the work to relocate the management of the `TR::Instruction`
pointers from the Compilation object to the CodeGenerator, introduce
the same functions in the code generator that simply call their
counterparts in the Compilation object.

This is only to help stage the transition effort in OMR and all
known downstream projects.  The appropriate instruction fields
will be moved into the CodeGenerator once all callsites have been
updated.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>