### PR TITLE
Allow for non-JNI Unsafe methods

### DIFF
--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -420,12 +420,21 @@ bool TR_RedundantAsyncCheckRemoval::callDoesAnImplicitAsyncCheck(TR::Node *callN
        (symbol->getRecognizedMethod()==TR::java_lang_Integer_rotateLeft) ||
        (symbol->getRecognizedMethod()==TR::java_lang_Long_rotateLeft) ||
        (symbol->getRecognizedMethod()==TR::java_lang_Integer_rotateRight) ||
-       (symbol->getRecognizedMethod()==TR::java_lang_Long_rotateRight) ||
-       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z) ||
-       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z) ||
-       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z)
+       (symbol->getRecognizedMethod()==TR::java_lang_Long_rotateRight)
        )
        return false;
+
+   // Beginning in Java9 we use the same enum values for both the
+   // sun.misc.Unsafe wrappers and the jdk.internal.misc.Unsafe JNI methods, so
+   // for these we need to do an additional test to check if they are the native
+   // versions or not.
+   if (symbol->isNative() && 
+       ((symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z) ||
+       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z) ||
+       (symbol->getRecognizedMethod()==TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z)) 
+      )
+      return false;
+
 
    if ((symbol->getRecognizedMethod()==TR::java_math_BigDecimal_DFPPerformHysteresis)  ||
        (symbol->getRecognizedMethod()==TR::java_math_BigDecimal_DFPUseDFP) ||


### PR DESCRIPTION
In Java9 sun.misc.Unsafe JNI methods are moved to jdk.internal and
replaced with simple wrappers. This leads to a few places in the
code where we do the wrong thing by assuming that the recognized
Unsafe method is a JNI method.
This commit adds explicit tests to differentiate between the JNI
methods and the non-JNI wrappers.