### PR TITLE
Reverse logic in getDataType

### DIFF
--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -683,9 +683,9 @@ OMR::Node::setBranchDestination(TR::TreeTop * p)
 TR::DataType
 OMR::Node::getDataType()
    {
-   if (!_opCode.hasNoDataType())
-      return _opCode.getDataType();
-   return self()->computeDataType();
+   if (_opCode.hasNoDataType())
+      return self()->computeDataType();
+   return _opCode.getDataType();
    }
 
 TR::DataType


### PR DESCRIPTION
This avoids the peculiar double-negative construction of
if (not has no data type)

Signed-off-by: Matthew Gaudet <magaudet@ca.ibm.com>