### PR TITLE
Add Vector test support to Tril

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(comptest
 	ShiftAndRotateTest.cpp
 	SimplifierFoldAndTest.cpp
 	IfxcmpgeReductionTest.cpp
+	VectorTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/VectorTest.cpp
+++ b/fvtest/compilertriltest/VectorTest.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "JitTest.hpp"
+#include "jitbuilder_compiler.hpp"
+
+class VectorTest : public TRTest::JitTest {};
+
+
+TEST_F(VectorTest, VDoubleAdd) { 
+
+   auto inputTrees = "(method return= NoType args=[Address,Address,Address]           "
+                     "  (block                                                        "
+                     "     (vstorei type=VectorDouble offset=0                        "
+                     "         (aload parm=0)                                         "
+                     "            (vadd                                               "
+                     "                 (vloadi type=VectorDouble (aload parm=1))      "
+                     "                 (vloadi type=VectorDouble (aload parm=2))))    "
+                     "     (return)))                                                 ";
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::JitBuilderCompiler compiler{trees};
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<void (*)(double[],double[],double[])>();
+    //TODO: What do we query to determine vector width?  
+    // -- This test currently assumes 128bit SIMD  
+
+    double output[] =  {0.0, 0.0};
+    double inputA[] =  {1.0, 2.0};
+    double inputB[] =  {1.0, 2.0};
+
+    entry_point(output,inputA,inputB); 
+    EXPECT_DOUBLE_EQ(inputA[0] + inputB[0], output[0]); // Epsilon = 4ULP -- is this necessary? 
+    EXPECT_DOUBLE_EQ(inputA[1] + inputB[1], output[1]); // Epsilon = 4ULP -- is this necessary? 
+
+}

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -37,6 +37,12 @@ static TR::DataTypes getTRDataTypes(const std::string& name) {
    else if (name == "Address") return TR::Address;
    else if (name == "Float") return TR::Float;
    else if (name == "Double") return TR::Double;
+   else if (name == "VectorInt8") return TR::VectorInt8;
+   else if (name == "VectorInt16") return TR::VectorInt16;
+   else if (name == "VectorInt32") return TR::VectorInt32;
+   else if (name == "VectorInt64") return TR::VectorInt64;
+   else if (name == "VectorFloat") return TR::VectorFloat;
+   else if (name == "VectorDouble") return TR::VectorDouble;
    else if (name == "NoType") return TR::NoType;
    else {
       throw std::runtime_error{std::string{"Unknown type name: "}.append(name)};

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef COMPILER_UTIL_HPP
+#define COMPILER_UTIL_HPP
+#include "il/DataTypes.hpp"
+
+namespace Tril { 
+/**
+ * @brief Gets the TR::DataTypes value from the data type's name
+ * @param name is the name of the data type as a string
+ * @return the TR::DataTypes value corresponding to the specified name
+ */
+static TR::DataTypes getTRDataTypes(const std::string& name) {
+   if (name == "Int8") return TR::Int8;
+   else if (name == "Int16") return TR::Int16;
+   else if (name == "Int32") return TR::Int32;
+   else if (name == "Int64") return TR::Int64;
+   else if (name == "Address") return TR::Address;
+   else if (name == "Float") return TR::Float;
+   else if (name == "Double") return TR::Double;
+   else if (name == "NoType") return TR::NoType;
+   else {
+      throw std::runtime_error{std::string{"Unknown type name: "}.append(name)};
+   }
+}
+
+}
+
+#endif
+

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -185,15 +185,16 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
         }
      }
      else if (opcode.isLoadIndirect() || opcode.isStoreIndirect()) {
+         TraceIL("  is indirect store/load with ");
          // If not specified, offset will default to zero. 
          int32_t offset = 0; 
          if (tree->getArgByName("offset")) {
             offset = tree->getArgByName("offset")->getValue()->get<int32_t>();
          } else { 
-            // warning("Should specify offset on indirect load and stores -- has defaulted to zero"); 
+            TraceIL(" (default) ");
          }
+         TraceIL("offset %d ", offset);
 
-         TraceIL("  is indirect store/load with offset %d\n", offset);
          const auto name = tree->getName();
          auto compilation = TR::comp();
          TR::DataType type;  
@@ -207,10 +208,12 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
             if (tree->getArgByName("type") != NULL) { 
                auto nameoftype = tree->getArgByName("type")->getValue()->getString();
                type = getTRDataTypes(nameoftype); 
+               TraceIL(" of vector type %s\n", nameoftype);
             } else { 
                return NULL;
             } 
          } else { 
+            TraceIL("\n");
             type = opcode.getType();
          }
          TR::Symbol *sym = TR::Symbol::createNamedShadow(compilation->trHeapMemory(), type, TR::DataType::getSize(opcode.getType()), (char*)name);

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -24,6 +24,7 @@
 
 #include "il/DataTypes.hpp"
 #include "ilgen.hpp"
+#include "compiler_util.hpp"
 
 #include <vector>
 #include <string>
@@ -89,25 +90,6 @@ class MethodInfo {
          * @brief Returns the number of arguments the Tril method takes
          */
         std::size_t getArgCount() const { return _argTypes.size(); }
-
-        /**
-         * @brief Gets the TR::DataTypes value from the data type's name
-         * @param name is the name of the data type as a string
-         * @return the TR::DataTypes value corresponding to the specified name
-         */
-        static TR::DataTypes getTRDataTypes(const std::string& name) {
-            if (name == "Int8") return TR::Int8;
-            else if (name == "Int16") return TR::Int16;
-            else if (name == "Int32") return TR::Int32;
-            else if (name == "Int64") return TR::Int64;
-            else if (name == "Address") return TR::Address;
-            else if (name == "Float") return TR::Float;
-            else if (name == "Double") return TR::Double;
-            else if (name == "NoType") return TR::NoType;
-            else {
-                throw std::runtime_error{std::string{"Unknown type name: "}.append(name)};
-            }
-        }
 
     private:
         const ASTNode* _methodNode;


### PR DESCRIPTION
Allow writing tests using some vector constructs in Tril

The changes allow one to write a tril test case such as 

    (method return="NoType" args=[Address,Address,Address] 
     (block 
      (vstorei type=VectorDouble offset=0 
       (aload parm=0) 
       (vadd 
        (vloadi type=VectorDouble (aload parm=0))
        (vloadi type=VectorDouble (aload parm=1))))
       (return)))
