### PR TITLE
Migrate nodeNeeds2Regs from Compilation to Node

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -181,7 +181,7 @@ OMR::Compilation::getHotnessName(TR_Hotness h)
 
 bool OMR::Compilation::nodeNeeds2Regs(TR::Node*node)
    {
-   return (node->getType().isInt64() && TR::Compiler->target.is32Bit() && !self()->cg()->use64BitRegsOn32Bit());
+   return node->requiresRegisterPair(self());
    }
 
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -260,7 +260,7 @@ OMR::Node::Node(TR::Node * from, uint16_t numChildren)
 
    if (from->getOpCode().isStoreReg() || from->getOpCode().isLoadReg())
       {
-      if (comp->nodeNeeds2Regs(from))
+      if (from->requiresRegisterPair(comp))
          {
          self()->setLowGlobalRegisterNumber(from->getLowGlobalRegisterNumber());
          self()->setHighGlobalRegisterNumber(from->getHighGlobalRegisterNumber());
@@ -1791,7 +1791,7 @@ OMR::Node::duplicateTree_DEPRECATED(bool duplicateChildren)
 
    if (newRoot->getOpCode().isStoreReg() || newRoot->getOpCode().isLoadReg())
       {
-      if (comp->nodeNeeds2Regs(newRoot))
+      if (newRoot->requiresRegisterPair(comp))
          {
          newRoot->setLowGlobalRegisterNumber(self()->getLowGlobalRegisterNumber());
          newRoot->setHighGlobalRegisterNumber(self()->getHighGlobalRegisterNumber());
@@ -4239,6 +4239,13 @@ OMR::Node::countChildren(TR::ILOpCodes opcode)
       }
    return count;
    }
+
+bool
+OMR::Node::requiresRegisterPair(TR::Compilation *comp)
+   {
+   return (self()->getType().isInt64() && TR::Compiler->target.is32Bit() && !comp->cg()->use64BitRegsOn32Bit());
+   }
+
 
 /**
  * Node field functions end

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -456,6 +456,15 @@ public:
 
    bool                   addressPointsAtObject();
 
+   /**
+    * @brief Answers whether the act of evaluating this node will
+    *        require a register pair (two registers) to hold the
+    *        result.
+    * @param comp, the TR::Compilation object
+    * @return true if two registers are required; false otherwise
+    */
+   bool                   requiresRegisterPair(TR::Compilation *comp);
+
    /// Decide whether it is safe to replace the next reference to this node with
    /// a copy of the node, i.e. make sure it is not killed between the first
    /// reference and the next reference.

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -1566,7 +1566,7 @@ TR_GlobalRegisterAllocator::transformNode(
                   setSignExtensionNotRequired(true, rc->getGlobalRegisterNumber());
                }
 
-            if (comp()->nodeNeeds2Regs(node))
+            if (node->requiresRegisterPair(comp()))
                {
                node->setLowGlobalRegisterNumber(rc->getLowGlobalRegisterNumber());
                node->setHighGlobalRegisterNumber(rc->getHighGlobalRegisterNumber());
@@ -2175,7 +2175,7 @@ TR_GlobalRegisterAllocator::prepareForBlockExit(
             TR::Node *actualValue = value;
             value = TR::Node::create(TR::PassThrough, 1, value);
 
-            if (comp()->nodeNeeds2Regs(actualValue))
+            if (actualValue->requiresRegisterPair(comp()))
                {
                value->setLowGlobalRegisterNumber(extgr->getCurrentRegisterCandidate()->getLowGlobalRegisterNumber());
                value->setHighGlobalRegisterNumber(extgr->getCurrentRegisterCandidate()->getHighGlobalRegisterNumber());
@@ -3012,7 +3012,7 @@ TR_GlobalRegister::createLoadFromRegister(TR::Node * n, TR::Compilation *comp)
    load = TR::Node::create(n, comp->il.opCodeForRegisterLoad(dt));
    load->setRegLoadStoreSymbolReference(rc->getSymbolReference());
 
-   if (comp->nodeNeeds2Regs(load))
+   if (load->requiresRegisterPair(comp))
       {
       load->setLowGlobalRegisterNumber(rc->getLowGlobalRegisterNumber());
       load->setHighGlobalRegisterNumber(rc->getHighGlobalRegisterNumber());
@@ -3022,7 +3022,7 @@ TR_GlobalRegister::createLoadFromRegister(TR::Node * n, TR::Compilation *comp)
    if (!rc->is8BitGlobalGPR())
       load->setIsInvalid8BitGlobalRegister(true);
    setValue(load);
-   if (comp->nodeNeeds2Regs(load))
+   if (load->requiresRegisterPair(comp))
       dumpOptDetails(comp, "%s create load [%p] from Register %d (low word) and Register %d (high word)\n", OPT_DETAILS, load, rc->getLowGlobalRegisterNumber(), rc->getHighGlobalRegisterNumber());
    else
       dumpOptDetails(comp, "%s create load [%p] %s from Register %d\n", OPT_DETAILS, load, rc->getSymbolReference()->getSymbol()->isMethodMetaData() ? rc->getSymbolReference()->getSymbol()->castToMethodMetaDataSymbol()->getName():"", rc->getGlobalRegisterNumber());
@@ -3087,7 +3087,7 @@ TR_GlobalRegister::createStoreToRegister(TR::TreeTop * prevTreeTop, TR::Node *no
       store->setNeedsSignExtension(true);
       }
 
-   if (comp->nodeNeeds2Regs(store))
+   if (store->requiresRegisterPair(comp))
       {
       store->setLowGlobalRegisterNumber(rc->getLowGlobalRegisterNumber());
       store->setHighGlobalRegisterNumber(rc->getHighGlobalRegisterNumber());
@@ -3108,7 +3108,7 @@ TR_GlobalRegister::createStoreToRegister(TR::TreeTop * prevTreeTop, TR::Node *no
    setValue(load);
    setAutoContainsRegisterValue(true);
 
-   if (comp->nodeNeeds2Regs(store))
+   if (store->requiresRegisterPair(comp))
       dumpOptDetails(comp, "%s create store [%p] of symRef#%d to Register %d (low word) and Register %d (high word)\n", OPT_DETAILS, store, rc->getSymbolReference()->getReferenceNumber(), rc->getLowGlobalRegisterNumber(), rc->getHighGlobalRegisterNumber());
    else
       dumpOptDetails(comp, "%s create store [%p] of %s symRef#%d to Register %d\n", OPT_DETAILS, store,
@@ -3154,7 +3154,7 @@ TR_GlobalRegister::createStoreFromRegister(vcount_t visitCount, TR::TreeTop * pr
 
    if (i != -1)
       {
-      if (comp->nodeNeeds2Regs(store))
+      if (store->requiresRegisterPair(comp))
          dumpOptDetails(comp, "%s create store [%p] from Register %d (low word) and Register %d (high word)\n", OPT_DETAILS, store, rc->getLowGlobalRegisterNumber(), rc->getHighGlobalRegisterNumber());
       else
          dumpOptDetails(comp, "%s create store [%p] from Register %d for %s #%d\n", OPT_DETAILS, store,
@@ -5203,7 +5203,7 @@ TR_LiveRangeSplitter::replaceAutosUsedIn(
 #endif
                             );
             int32_t numRegsForCandidate = 1;
-            if (comp()->nodeNeeds2Regs(node))
+            if (node->requiresRegisterPair(comp()))
                numRegsForCandidate = 2;
 
             bool candidateIsLiveOnExit = false;

--- a/compiler/optimizer/RegDepCopyRemoval.cpp
+++ b/compiler/optimizer/RegDepCopyRemoval.cpp
@@ -209,7 +209,7 @@ TR::RegDepCopyRemoval::readRegDeps()
 
       // Avoid register pairs for simplicity, at least for now
       bool isRegPairDep = depNode->getHighGlobalRegisterNumber() != (TR_GlobalRegisterNumber)-1;
-      bool valueNeedsRegPair = comp()->nodeNeeds2Regs(depValue);
+      bool valueNeedsRegPair = depValue->requiresRegisterPair(comp());
       TR_ASSERT(isRegPairDep == valueNeedsRegPair, "mismatch on number of registers required for n%un\n", depNode->getGlobalIndex());
       if (isRegPairDep)
          {

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -707,7 +707,7 @@ bool TR_RegisterCandidate::rcNeeds2Regs(TR::Compilation *comp)
 bool
 TR_RegisterCandidate::hasSameGlobalRegisterNumberAs(TR::Node *node, TR::Compilation *comp)
    {
-   if (comp->nodeNeeds2Regs(node))
+   if (node->requiresRegisterPair(comp))
       return (getLowGlobalRegisterNumber() == node->getLowGlobalRegisterNumber())
           && (getHighGlobalRegisterNumber() == node->getHighGlobalRegisterNumber());
    else


### PR DESCRIPTION
A node should be responsible for answering whether it requires a register
pair or not.

Move the functionality to the Node class, rename the function to
`requiresRegisterPair`, and add some documentation.

Redirect the Compilation query to the Node query to allow downstream
projects to complete refactoring.  The Compilation shim will be removed
when this has been completed in all known downstream projects.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>