### PR TITLE
X86 fastcall convention support

### DIFF
--- a/compiler/codegen/OMRLinkageConventions.enum
+++ b/compiler/codegen/OMRLinkageConventions.enum
@@ -29,3 +29,4 @@
    TR_System,
    TR_Helper,
    TR_J9JNILinkage,
+   TR_FastCall,

--- a/compiler/x/CMakeLists.txt
+++ b/compiler/x/CMakeLists.txt
@@ -52,6 +52,7 @@ compiler_library(x
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRRealRegister.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRRegisterDependency.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRSnippet.cpp
+	${CMAKE_CURRENT_LIST_DIR}/codegen/X86FastCallLinkage.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/X86SystemLinkage.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRCodeGenerator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp

--- a/compiler/x/amd64/codegen/AMD64FastCallConfig.hpp
+++ b/compiler/x/amd64/codegen/AMD64FastCallConfig.hpp
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/X86FastCallLinkage.hpp"
+
+// Windows: Microsoft x64 calling convention
+// Linux:   System V AMD64 ABI.
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::IntParamRegisters[] =
+   {
+#ifdef WINDOWS
+   TR::RealRegister::ecx,
+   TR::RealRegister::edx,
+#else
+   TR::RealRegister::edi,
+   TR::RealRegister::esi,
+   TR::RealRegister::edx,
+   TR::RealRegister::ecx,
+#endif
+   TR::RealRegister::r8,
+   TR::RealRegister::r9,
+   };
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::FloatParamRegisters[] =
+   {
+   TR::RealRegister::xmm0,
+   TR::RealRegister::xmm1,
+   TR::RealRegister::xmm2,
+   TR::RealRegister::xmm3,
+#ifndef WINDOWS
+   TR::RealRegister::xmm4,
+   TR::RealRegister::xmm5,
+   TR::RealRegister::xmm6,
+   TR::RealRegister::xmm7,
+#endif
+   };
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::CallerSavedRegisters[] =
+   {
+   TR::RealRegister::eax,
+   TR::RealRegister::ecx,
+   TR::RealRegister::edx,
+#ifndef WINDOWS
+   TR::RealRegister::edi,
+   TR::RealRegister::esi,
+#endif
+   TR::RealRegister::r8,
+   TR::RealRegister::r9,
+   TR::RealRegister::r10,
+   TR::RealRegister::r11,
+   TR::RealRegister::xmm0,
+   TR::RealRegister::xmm1,
+   TR::RealRegister::xmm2,
+   TR::RealRegister::xmm3,
+   TR::RealRegister::xmm4,
+   TR::RealRegister::xmm5,
+   TR::RealRegister::xmm6,
+   TR::RealRegister::xmm7,
+   TR::RealRegister::xmm8,
+   TR::RealRegister::xmm9,
+   TR::RealRegister::xmm10,
+   TR::RealRegister::xmm11,
+   TR::RealRegister::xmm12,
+   TR::RealRegister::xmm13,
+   TR::RealRegister::xmm14,
+   TR::RealRegister::xmm15,
+   };
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::CalleeSavedRegisters[] =
+   {
+   TR::RealRegister::ebx,
+#ifdef WINDOWS
+   TR::RealRegister::edi,
+   TR::RealRegister::esi,
+#endif
+   TR::RealRegister::ebp,
+   TR::RealRegister::esp,
+   TR::RealRegister::r12,
+   TR::RealRegister::r13,
+   TR::RealRegister::r14,
+   TR::RealRegister::r15,
+   };
+
+const bool   TR::X86FastCallCallSite::CalleeCleanup = false;
+const size_t TR::X86FastCallCallSite::StackSlotSize = 8;
+
+// Windows X86-64 requires caller reserves shadow space for parameters passed via registers
+#ifdef WINDOWS
+const bool TR::X86FastCallCallSite::RegisterParameterShadowOnStack = true;
+#else
+const bool TR::X86FastCallCallSite::RegisterParameterShadowOnStack = false;
+#endif

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -51,6 +51,7 @@
 #else
 #include "x/i386/codegen/IA32SystemLinkage.hpp"
 #endif
+#include "x/codegen/X86FastCallLinkage.hpp"
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"
 #include "compile/SymbolReferenceTable.hpp"
@@ -512,6 +513,9 @@ OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 
    switch (lc)
       {
+      case TR_FastCall:
+         linkage = new (self()->trHeapMemory()) TR::X86FastCallLinkage(self());
+         break;
       case TR_Private:
          // HACK HACK HACK "intentional" fall through to system linkage
       case TR_Helper:

--- a/compiler/x/codegen/RealRegisterManager.hpp
+++ b/compiler/x/codegen/RealRegisterManager.hpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/Machine.hpp"
+#include "codegen/Register.hpp"
+#include "codegen/RegisterDependency.hpp"
+#include "codegen/RegisterPair.hpp"
+#include "env/jittypes.h"
+#include "il/DataTypes.hpp"
+
+
+// An utility to manage real registers and their corresponding virtual registers
+class RealRegisterManager
+   {
+   public:
+   RealRegisterManager(TR::CodeGenerator* cg) :
+      _cg(cg),
+      _numberOfRegistersInUse(0)
+      {
+      memset(_registers, 0x0, sizeof(_registers));
+      }
+   ~RealRegisterManager()
+      {
+      // RAII: stop using all registers
+      for (uint8_t i = (uint8_t)TR::RealRegister::NoReg; i < (uint8_t)TR::RealRegister::NumRegisters; i++)
+         {
+         if (_registers[i] != NULL)
+            {
+            _cg->stopUsingRegister(_registers[i]);
+            }
+         }
+      }
+   // Find or allocate a virtual register which is bind to the given real register
+   TR::Register* use(TR::RealRegister::RegNum reg)
+      {
+      if (_registers[reg] == NULL)
+         {
+         bool isGPR = reg >= TR::RealRegister::FirstGPR && reg <= TR::RealRegister::LastGPR;
+         _registers[reg] = _cg->allocateRegister(isGPR ? TR_GPR : TR_FPR);
+         _numberOfRegistersInUse++;
+         }
+      return _registers[reg];
+      }
+   // Build the dependencies for each virtual-real register pair
+   TR::RegisterDependencyConditions* buildRegisterDependencyConditions()
+      {
+      TR::RegisterDependencyConditions* deps = generateRegisterDependencyConditions(numberOfRegistersInUse(),
+                                                                                    numberOfRegistersInUse(),
+                                                                                    _cg);
+      for (uint8_t i = (uint8_t)TR::RealRegister::NoReg; i < (uint8_t)TR::RealRegister::NumRegisters; i++)
+         {
+         if (_registers[i] != NULL)
+            {
+            deps->addPreCondition(_registers[i], (TR::RealRegister::RegNum)i, _cg);
+            deps->addPostCondition(_registers[i], (TR::RealRegister::RegNum)i, _cg);
+            }
+         }
+      return deps;
+      }
+   inline uint8_t numberOfRegistersInUse() const
+      {
+      return _numberOfRegistersInUse;
+      }
+
+   private:
+   uint8_t            _numberOfRegistersInUse;
+   TR::Register*      _registers[TR::RealRegister::NumRegisters];
+   TR::CodeGenerator* _cg;
+   };

--- a/compiler/x/codegen/X86FastCallLinkage.cpp
+++ b/compiler/x/codegen/X86FastCallLinkage.cpp
@@ -1,0 +1,244 @@
+/*******************************************************************************
+* Copyright (c) 2000, 2018 IBM Corp. and others
+*
+* This program and the accompanying materials are made available under
+* the terms of the Eclipse Public License 2.0 which accompanies this
+* distribution and is available at http://eclipse.org/legal/epl-2.0
+* or the Apache License, Version 2.0 which accompanies this distribution
+* and is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* This Source Code may also be made available under the following Secondary
+* Licenses when the conditions for such availability set forth in the
+* Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+* version 2 with the GNU Classpath Exception [1] and GNU General Public
+* License, version 2 with the OpenJDK Assembly Exception [2].
+*
+* [1] https://www.gnu.org/software/classpath/license.html
+* [2] http://openjdk.java.net/legal/assembly-exception.html
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+*******************************************************************************/
+
+#include "codegen/X86FastCallLinkage.hpp"
+
+#include "codegen/Machine.hpp"
+#include "codegen/Register.hpp"
+#include "codegen/RegisterDependency.hpp"
+#include "codegen/RegisterPair.hpp"
+#include "codegen/RealRegisterManager.hpp"
+#include "env/jittypes.h"
+#include "il/DataTypes.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "x/codegen/X86Instruction.hpp"
+
+#ifdef TR_TARGET_64BIT
+#include "x/amd64/codegen/AMD64FastCallConfig.hpp"
+#else
+#include "x/i386/codegen/IA32FastCallConfig.hpp"
+#endif
+
+const size_t TR::X86FastCallCallSite::NumberOfIntParamRegisters   = sizeof(IntParamRegisters)   / sizeof(IntParamRegisters[0]);
+const size_t TR::X86FastCallCallSite::NumberOfFloatParamRegisters = sizeof(FloatParamRegisters) / sizeof(FloatParamRegisters[0]);
+const size_t TR::X86FastCallCallSite::StackIndexAdjustment        = RegisterParameterShadowOnStack ? NumberOfIntParamRegisters : 0;
+
+// Calculate preserved register map.
+// The map is a constant that the C++ compiler *should* be able to determine at compile time
+static uint32_t X86FastCallCallSiteCalculatePreservedRegisterMapForGC()
+   {
+   uint32_t ret = 0;
+   for (size_t i = 0;
+        i < sizeof(TR::X86FastCallCallSite::CalleeSavedRegisters) / sizeof(TR::X86FastCallCallSite::CalleeSavedRegisters[0]);
+        i++)
+      {
+      ret |= TR::RealRegister::gprMask(TR::X86FastCallCallSite::CalleeSavedRegisters[i]);
+      }
+   return ret;
+   }
+const uint32_t TR::X86FastCallCallSite::PreservedRegisterMapForGC = X86FastCallCallSiteCalculatePreservedRegisterMapForGC();
+
+TR::Register* TR::X86FastCallCallSite::BuildCall()
+   {
+   TR_ASSERT(CalleeCleanup || cg()->getLinkage()->getProperties().getReservesOutgoingArgsInPrologue(),
+             "Caller must reserve outgoing args in prologue unless callee cleans up stack");
+
+   if (cg()->comp()->getOption(TR_TraceCG))
+      {
+      traceMsg(cg()->comp(), "X86 FastCall: [%04d] %s\n", _SymRef->getReferenceNumber(), cg()->getDebug()->getName(_SymRef));
+      }
+   RealRegisterManager RealRegisters(cg());
+   TR::RealRegister*   ESP = cg()->machine()->getRealRegister(TR::RealRegister::esp);
+
+   // Preserve caller saved registers
+   for (size_t i = 0;
+        i < sizeof(CallerSavedRegisters) / sizeof(CallerSavedRegisters[0]);
+        i++)
+      {
+      RealRegisters.use(CallerSavedRegisters[i]);
+      }
+   // Find the return register, EAX/RAX/XMM0
+   TR::Register* EAX = RealRegisters.use(TR::RealRegister::eax);
+   TR::Register* XMM0 = RealRegisters.use(TR::RealRegister::xmm0);
+
+   // Build parameters, parameters in _Params are Right-to-Left (RTL)
+   TR::Register* IntParams[NumberOfIntParamRegisters] = {};
+   TR::Register* FloatParams[NumberOfFloatParamRegisters] = {};
+   TR_Stack<TR::Register*> StackParams(cg()->trMemory());
+
+   size_t IntParamIndex = 0;
+#ifndef WINDOWS
+   size_t FloatParamIndex = 0;
+#else
+   auto& FloatParamIndex = IntParamIndex;
+#endif
+
+   for (size_t i = _Params.size(); i > 0; i--)
+      {
+      auto param = _Params[i-1];
+      switch(param->getKind())
+         {
+         case TR_GPR:
+            if (IntParamIndex < NumberOfIntParamRegisters)
+               {
+               IntParams[IntParamIndex++] = param;
+               }
+            else
+               {
+               StackParams.push(param);
+               }
+            break;
+         case TR_FPR:
+            if (FloatParamIndex < NumberOfFloatParamRegisters)
+               {
+               FloatParams[FloatParamIndex++] = param;
+               }
+            else
+               {
+               StackParams.push(param);
+               if(TR::Compiler->target.is32Bit() && !param->isSinglePrecision())
+                  {
+                  StackParams.push(NULL);
+                  }
+               }
+            break;
+         default:
+            TR_ASSERT(false, "Unsupported call param data type: #%d", (int)param->getKind());
+         }
+      }
+
+   // Reserve stack for parameters
+   auto SizeOfParamsOnStack = (StackParams.size() + StackIndexAdjustment)*StackSlotSize;
+   if (CalleeCleanup && SizeOfParamsOnStack > 0)
+      {
+      generateRegImmInstruction(SUBRegImms(), _Node, ESP, SizeOfParamsOnStack, cg());
+      }
+   // Parameters passed by stack
+   while(!StackParams.isEmpty())
+      {
+      auto param = StackParams.pop();
+      if(param)
+         {
+         auto opcode = param->getKind() == TR_GPR ? SMemReg() :
+                       param->isSinglePrecision() ? MOVSSMemReg : MOVSDMemReg;
+         generateMemRegInstruction(opcode,
+                                   _Node,
+                                   generateX86MemoryReference(ESP, StackParams.size()*StackSlotSize, cg()),
+                                   param,
+                                   cg());
+         }
+      }
+   // Parameters passed by FPR
+#if defined(WINDOWS) && defined(TR_TARGET_32BIT)
+   TR_ASSERT(NumberOfFloatParamRegisters == 0, "FastCallLinkage with float parameters is not supported on 32-bit Windows!");
+#endif
+   for (size_t i = NumberOfFloatParamRegisters; i > 0; i--)
+      {
+      auto param = FloatParams[i-1];
+      if(param)
+         {
+         generateRegRegInstruction(MOVDQURegReg,
+                                   _Node,
+                                   RealRegisters.use(FloatParamRegisters[i-1]),
+                                   param,
+                                   cg());
+         }
+      }
+   // Parameters passed by GPR
+   for (size_t i = NumberOfIntParamRegisters; i > 0; i--)
+      {
+      auto param = IntParams[i-1];
+      if(param)
+         {
+         generateRegRegInstruction(MOVRegReg(),
+                                   _Node,
+                                   RealRegisters.use(IntParamRegisters[i-1]),
+                                   param,
+                                   cg());
+         }
+      }
+
+   // Call helper
+   auto instr = TR::Compiler->target.is32Bit() || _SymRef->getSymbol()->castToMethodSymbol()->isHelper() ?
+       (TR::Instruction*)generateImmSymInstruction(CALLImm4,
+                                                   _Node,
+                                                   (uintptrj_t)_SymRef->getMethodAddress(),
+                                                   _SymRef,
+                                                   RealRegisters.buildRegisterDependencyConditions(),
+                                                   cg())  :
+       (TR::Instruction*)generateMemInstruction(CALLMem,
+                                                _Node,
+                                                generateX86MemoryReference(cg()->create8ByteData(_Node, (uintptrj_t)_SymRef->getMethodAddress()), cg()),
+                                                RealRegisters.buildRegisterDependencyConditions(),
+                                                cg());
+   instr->setNeedsGCMap(PreservedRegisterMapForGC);
+
+   // Stack adjustment
+   if (CalleeCleanup)
+      {
+      TR_ASSERT(TR::Compiler->target.is32Bit(), "Callee cleanup is only allowed on 32-bit");
+      ((TR::X86ImmInstruction*)instr)->setAdjustsFramePointerBy(-SizeOfParamsOnStack);
+      }
+   else
+      {
+      if (SizeOfParamsOnStack > cg()->getLargestOutgoingArgSize())
+         {
+         cg()->setLargestOutgoingArgSize(SizeOfParamsOnStack);
+         }
+      }
+
+   // Return value
+   TR::Register* ret = NULL;
+   switch (_ReturnType)
+      {
+      case TR::NoType:
+         break;
+      case TR::Address:
+         ret = cg()->allocateCollectedReferenceRegister();
+         generateRegRegInstruction(MOVRegReg(), _Node, ret, EAX, cg());
+         break;
+      case TR::Int8:
+      case TR::Int16:
+      case TR::Int32:
+#ifdef TR_TARGET_64BIT
+      case TR::Int64:
+#endif
+         ret = cg()->allocateRegister();
+         generateRegRegInstruction(MOVRegReg(), _Node, ret, EAX, cg());
+         break;
+      case TR::Float:
+      case TR::Double:
+         ret = cg()->allocateRegister(TR_FPR);
+         if (_ReturnType == TR::Float)
+            {
+            ret->setIsSinglePrecision();
+            }
+         generateRegRegInstruction(MOVDQURegReg, _Node, ret, XMM0, cg());
+         break;
+      default:
+         TR_ASSERT(false, "Unsupported call return data type: #%d", (int)_ReturnType);
+         break;
+      }
+   return ret;
+}

--- a/compiler/x/codegen/X86FastCallLinkage.hpp
+++ b/compiler/x/codegen/X86FastCallLinkage.hpp
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef X86_FASTCALLLINKAGE_INCL
+#define X86_FASTCALLLINKAGE_INCL
+
+#include "codegen/Linkage.hpp"
+#include "env/jittypes.h"
+
+namespace TR { class CodeGenerator; }
+namespace TR { class Instruction; }
+namespace TR { class LabelSymbol; }
+namespace TR { class Node; }
+namespace TR { class RegisterDependencyConditions; }
+
+#define INCOMPLETELINKAGE  "This class is only used to generate call-out sequence but no call-in sequence, so it is not used as a complete linkage."
+
+// This class implements following calling conventions on different platforms:
+//     X86-32 Windows and Linux: fastcall
+//     X86-64 Windows          : Microsoft x64 calling convention, an extension of fastcall
+//     X86-64 Linux            : System V AMD64 ABI
+// This initial version has following limitations:
+//     1. Floating point parameters are not currently in-support.
+//     2. Return value can only be at most pointer size, i.e. DWORD on X86-32 and QWORD on X86-64.
+namespace TR {
+class X86FastCallCallSite
+   {
+   public:
+   X86FastCallCallSite(TR::Node* callNode, TR::CodeGenerator* cg) :
+      _cg(cg),
+      _Node(callNode),
+      _ReturnType(callNode->getDataType()),
+      _SymRef(callNode->getSymbolReference()),
+      _Params(cg->trMemory())
+      {}
+   X86FastCallCallSite(TR::Node* callNode, TR::DataType callReturnType, TR::SymbolReference* callSymRef, TR::CodeGenerator* cg) :
+      _cg(cg),
+      _Node(callNode),
+      _ReturnType(callReturnType),
+      _SymRef(callSymRef),
+      _Params(cg->trMemory())
+      {}
+   void AddParam(TR::Register* param)
+      {
+      _Params.add(param);
+      }
+   TR::Register* BuildCall();
+   TR::CodeGenerator* cg() const
+      {
+      return _cg;
+      }
+   static const uint32_t                 PreservedRegisterMapForGC;
+   static const bool                     CalleeCleanup;
+   static const bool                     RegisterParameterShadowOnStack;
+   static const size_t                   StackSlotSize;
+   static const size_t                   NumberOfIntParamRegisters;
+   static const size_t                   NumberOfFloatParamRegisters;
+   static const size_t                   StackIndexAdjustment;
+   static const TR::RealRegister::RegNum IntParamRegisters[];
+   static const TR::RealRegister::RegNum FloatParamRegisters[];
+   static const TR::RealRegister::RegNum CallerSavedRegisters[];
+   static const TR::RealRegister::RegNum CalleeSavedRegisters[];
+
+   private:
+   TR::CodeGenerator*      _cg;
+   TR::Node*               _Node;
+   TR::SymbolReference*    _SymRef;
+   TR::DataType            _ReturnType;
+   TR_Array<TR::Register*> _Params;
+   };
+
+class X86FastCallLinkage : public TR::Linkage
+   {
+   public:
+   X86FastCallLinkage(TR::CodeGenerator *cg) : TR::Linkage(cg) {}
+   const X86LinkageProperties& getProperties() { return _Properties; }
+   virtual void createPrologue(TR::Instruction *cursor) { TR_ASSERT(false, INCOMPLETELINKAGE); }
+   virtual void createEpilogue(TR::Instruction *cursor) { TR_ASSERT(false, INCOMPLETELINKAGE); }
+   virtual TR::Register* buildIndirectDispatch(TR::Node *callNode) { TR_ASSERT(false, "Indirect dispatch is not currently supported"); return NULL; }
+   virtual TR::Register* buildDirectDispatch(TR::Node* callNode, bool spillFPRegs) { return buildCall(callNode); }
+   protected:
+   inline TR::Register* buildCall(TR::Node* node, TR::Register* thisPointer = NULL)
+      {
+      X86FastCallCallSite CallSite(node, cg());
+      // Evaluate children
+      for (int i = 0; i < node->getNumChildren(); i++)
+         {
+         cg()->evaluate(node->getChild(i));
+         }
+      // Setup parameters
+      for (int i = node->getNumChildren() - 1; i >= 0; i--)
+         {
+         CallSite.AddParam(node->getChild(i)->getRegister());
+         }
+      // Supply this-pointer as the first parameter if necessary
+      if (thisPointer)
+         {
+         CallSite.AddParam(thisPointer);
+         }
+      TR::Register* ret = CallSite.BuildCall();
+      // Release children
+      for (int i = 0; i < node->getNumChildren(); i++)
+         {
+         cg()->decReferenceCount(node->getChild(i));
+         }
+      return ret;
+      }
+   private:
+   X86LinkageProperties _Properties;
+};
+
+}
+#endif

--- a/compiler/x/i386/codegen/IA32FastCallConfig.hpp
+++ b/compiler/x/i386/codegen/IA32FastCallConfig.hpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/X86FastCallLinkage.hpp"
+
+// Windows: fastcall with integer parameters only
+// Linux:   fastcall + sseregparm
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::IntParamRegisters[] =
+   {
+   TR::RealRegister::ecx,
+   TR::RealRegister::edx,
+   };
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::FloatParamRegisters[] =
+   {
+   TR::RealRegister::xmm0,
+   TR::RealRegister::xmm1,
+   TR::RealRegister::xmm2,
+   };
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::CallerSavedRegisters[] =
+   {
+   TR::RealRegister::eax,
+   TR::RealRegister::ecx,
+   TR::RealRegister::edx,
+   TR::RealRegister::edi,
+   TR::RealRegister::esi,
+   TR::RealRegister::xmm0,
+   TR::RealRegister::xmm1,
+   TR::RealRegister::xmm2,
+   TR::RealRegister::xmm3,
+   TR::RealRegister::xmm4,
+   TR::RealRegister::xmm5,
+   TR::RealRegister::xmm6,
+   TR::RealRegister::xmm7,
+   };
+
+const TR::RealRegister::RegNum TR::X86FastCallCallSite::CalleeSavedRegisters[] =
+   {
+   TR::RealRegister::ebx,
+   TR::RealRegister::edi,
+   TR::RealRegister::esi,
+   TR::RealRegister::ebp,
+   TR::RealRegister::esp,
+   };
+
+const bool   TR::X86FastCallCallSite::CalleeCleanup = true;
+const size_t TR::X86FastCallCallSite::StackSlotSize = 4;
+const bool   TR::X86FastCallCallSite::RegisterParameterShadowOnStack = false;

--- a/fvtest/compilertest/build/files/target/x.mk
+++ b/fvtest/compilertest/build/files/target/x.mk
@@ -52,6 +52,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRRealRegister.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRRegisterDependency.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRSnippet.cpp \
+    $(JIT_OMR_DIRTY_DIR)/x/codegen/X86FastCallLinkage.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/X86SystemLinkage.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/XMMBinaryArithmeticAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRCodeGenerator.cpp

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -85,6 +85,9 @@ static TR_LinkageConventions convertStringToLinkage(const char * linkageName) {
    std::string ln = linkageName;  
    if (ln == "system") {
       return TR_System;
+   }
+   else if (ln == "fastcall") {
+      return TR_FastCall;
    }
 
    // Not found

--- a/jitbuilder/build/files/target/x.mk
+++ b/jitbuilder/build/files/target/x.mk
@@ -53,6 +53,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRRealRegister.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRRegisterDependency.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRSnippet.cpp \
+    $(JIT_OMR_DIRTY_DIR)/x/codegen/X86FastCallLinkage.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/X86SystemLinkage.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/codegen/OMRCodeGenerator.cpp \
     $(JIT_OMR_DIRTY_DIR)/x/env/OMRDebugEnv.cpp \


### PR DESCRIPTION
Introducing a new linkage TR_FastCall. It is mapped to the following calling convention in each platform:
64-bit Linux: System V AMD64 ABI (same as TR_System)
64-bit Windows: Microsoft x64 calling convention (same as TR_System)
32-bit Linux: fastcall with sseregparm
32-bit Windows: fastcall

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>