### PR TITLE
Downgrade minimum compiler version for Compiler Tril Tests

### DIFF
--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -22,6 +22,26 @@
 #include "OpCodeTest.hpp"
 #include "jitbuilder_compiler.hpp"
 
+int32_t iadd(int32_t l, int32_t r) {
+    return l+r;
+}
+
+int32_t isub(int32_t l, int32_t r) {
+    return l-r;
+}
+
+int32_t imul(int32_t l, int32_t r) {
+    return l*r;
+}
+
+int32_t idiv(int32_t l, int32_t r) {
+    return l/r;
+}
+
+int32_t irem(int32_t l, int32_t r) {
+    return l%r;
+}
+
 class Int32Arithmetic : public TRTest::BinaryOpTest<int32_t> {};
 
 TEST_P(Int32Arithmetic, UsingConst) {
@@ -60,12 +80,13 @@ TEST_P(Int32Arithmetic, UsingLoadParam) {
     ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
 }
 
+
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()),
     ::testing::Values(
-        std::make_tuple("iadd", [](int32_t l, int32_t r){return l+r;}),
-        std::make_tuple("isub", [](int32_t l, int32_t r){return l-r;}),
-        std::make_tuple("imul", [](int32_t l, int32_t r){return l*r;}) )));
+        std::make_tuple("iadd", iadd),
+        std::make_tuple("isub", isub),
+        std::make_tuple("imul", imul) )));
 
 /**
  * @brief Filter function for *div opcodes
@@ -93,5 +114,5 @@ INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int32Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(
         TRTest::filter(TRTest::const_value_pairs<int32_t, int32_t>(), div_filter<int32_t> )),
     ::testing::Values(
-        std::make_tuple("idiv", [](int32_t l, int32_t r){return l/r;}),
-        std::make_tuple("irem", [](int32_t l, int32_t r){return l%r;}) )));
+        std::make_tuple("idiv", idiv),
+        std::make_tuple("irem", irem) )));

--- a/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
+++ b/fvtest/compilertriltest/IfxcmpgeReductionTest.cpp
@@ -24,11 +24,9 @@
 #include "JitTest.hpp"
 #include "jitbuilder_compiler.hpp"
 
+// C++11 upgrade (Issue #1916).
 template <typename ValType>
-using IfxcmpgeReductionParamType = std::tuple<ValType, ValType, int32_t (*)(ValType, ValType)>;
-
-template <typename ValType>
-class IfxcmpgeReductionTest : public ::testing::TestWithParam<IfxcmpgeReductionParamType<ValType>>
+class IfxcmpgeReductionTest : public ::testing::TestWithParam<std::tuple<ValType, ValType, int32_t (*)(ValType, ValType)>>
    {
    public:
 
@@ -68,7 +66,7 @@ struct IfxcmpgeReductionParamStruct
  *     Given an instance of IfxcmpgeReductionParamType, returns an equivalent instance of IfxcmpgeReductionParamStruct.
  */
 template <typename ValType>
-IfxcmpgeReductionParamStruct<ValType> to_struct(IfxcmpgeReductionParamType<ValType> param)
+IfxcmpgeReductionParamStruct<ValType> to_struct(std::tuple<ValType, ValType, int32_t (*)(ValType, ValType)> param)
    {
    IfxcmpgeReductionParamStruct<ValType> s;
 
@@ -105,15 +103,15 @@ TEST_P(Int8ReductionTest, Reduction)
          "      (band"
          "        (i2b"
          "          (iload parm=0) )"
-         "        (bconst %s) )"
-         "      (bconst %s) ) )"
+         "        (bconst %d) )"
+         "      (bconst %d) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of the 'bconst' in 'band'
+         param.val2  // value of the 'bconst' in 'ifbcmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -149,15 +147,15 @@ TEST_P(UInt8ReductionTest, Reduction)
          "      (band"
          "        (i2b"
          "          (iload parm=0) )"
-         "        (bconst %s) )"
-         "      (bconst %s) ) )"
+         "        (bconst %d) )"
+         "      (bconst %d) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'bconst' in 'band'
+         param.val2  // value of 'bconst' in 'ifbucmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -193,15 +191,15 @@ TEST_P(Int16ReductionTest, Reduction)
          "      (sand"
          "        (i2s"
          "          (iload parm=0) )"
-         "        (sconst %s) )"
-         "      (sconst %s) ) )"
+         "        (sconst %d) )"
+         "      (sconst %d) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'sconst' in 'sand'
+         param.val2  // value of 'sconst' in 'ifscmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -237,15 +235,15 @@ TEST_P(UInt16ReductionTest, Reduction)
          "      (sand"
          "        (i2s"
          "          (iload parm=0) )"
-         "        (sconst %s) )"
-         "      (sconst %s) ) )"
+         "        (sconst %d) )"
+         "      (sconst %d) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'sconst' in 'sand'
+         param.val2  // value of 'sconst' in 'ifsucmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -280,15 +278,15 @@ TEST_P(Int32ReductionTest, Reduction)
          "    (ificmpge target=\"t\""
          "      (iand"
          "        (iload parm=0)"
-         "        (iconst %s) )"
-         "      (iconst %s) ) )"
+         "        (iconst %d) )"
+         "      (iconst %d) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'iconst' in 'iand'
+         param.val2  // value of 'iconst' in 'ificmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -323,15 +321,15 @@ TEST_P(UInt32ReductionTest, Reduction)
          "    (ifiucmpge target=\"t\""
          "      (iand"
          "        (iload parm=0)"
-         "        (iconst %s) )"
-         "      (iconst %s) ) )"
+         "        (iconst %d) )"
+         "      (iconst %d) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'iconst' in 'iand'
+         param.val2  // value of 'iconst' in 'ifiucmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -366,15 +364,15 @@ TEST_P(Int64ReductionTest, Reduction)
          "    (iflcmpge target=\"t\""
          "      (land"
          "        (lload parm=0)"
-         "        (lconst %s) )"
-         "      (lconst %s) ) )"
+         "        (lconst %lld) )"
+         "      (lconst %lld) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'lconst' in 'land'
+         param.val2  // value of 'lconst' in 'iflcmpge'
          );
 
    auto trees = parseString(inputTrees);
@@ -409,15 +407,15 @@ TEST_P(UInt64ReductionTest, Reduction)
          "    (iflucmpge target=\"t\""
          "      (land"
          "        (lload parm=0)"
-         "        (lconst %s) )"
-         "      (lconst %s) ) )"
+         "        (lconst %llu) )"
+         "      (lconst %llu) ) )"
          "  (block name=\"f\""
          "    (ireturn (iconst 0) ) )"
          "  (block name=\"t\""
          "    (ireturn (iconst 1) ) ) )",
 
-         std::to_string(param.val2).c_str(), // value of and const
-         std::to_string(param.val2).c_str()  // value of the of the if const
+         param.val2, // value of 'lconst' in 'land'
+         param.val2  // value of 'lconst' in 'iflucmpge'
          );
 
    auto trees = parseString(inputTrees);

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -218,11 +218,11 @@ C filter(C range, Predicate pred) {
 /**
  * @brief A family of functions returning constants of the specified type
  */
-template <typename T> constexpr T zero_value() { return static_cast<T>(0); }
-template <typename T> constexpr T one_value() { return static_cast<T>(1); }
-template <typename T> constexpr T negative_one_value() { return static_cast<T>(-1); }
-template <typename T> constexpr T positive_value() { return static_cast<T>(42); }
-template <typename T> constexpr T negative_value() { return static_cast<T>(-42); }
+template <typename T> const T zero_value() { return static_cast<T>(0); }
+template <typename T> const T one_value() { return static_cast<T>(1); }
+template <typename T> const T negative_one_value() { return static_cast<T>(-1); }
+template <typename T> const T positive_value() { return static_cast<T>(42); }
+template <typename T> const T negative_value() { return static_cast<T>(-42); }
 
 /**
  * @brief Convenience function returning possible test inputs of the specified type
@@ -230,16 +230,18 @@ template <typename T> constexpr T negative_value() { return static_cast<T>(-42);
 template <typename T>
 std::vector<T> const_values()
    {
-   return std::vector<T>{ zero_value<T>(),
-                          one_value<T>(),
-                          negative_one_value<T>(),
-                          positive_value<T>(),
-                          negative_value<T>(),
-                          std::numeric_limits<T>::min(),
-                          std::numeric_limits<T>::max(),
-                          std::numeric_limits<T>::min() + 1,
-                          std::numeric_limits<T>::max() - 1
-                        };
+   T inputArray[] = { zero_value<T>(),
+                      one_value<T>(),
+                      negative_one_value<T>(),
+                      positive_value<T>(),
+                      negative_value<T>(),
+                      std::numeric_limits<T>::min(),
+                      std::numeric_limits<T>::max(),
+                      static_cast<T>(std::numeric_limits<T>::min() + 1),
+                      static_cast<T>(std::numeric_limits<T>::max() - 1)
+                    };
+   
+   return std::vector<T>(inputArray, inputArray + sizeof(inputArray) / sizeof(T));
    }
 
 /**

--- a/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
+++ b/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
@@ -62,6 +62,7 @@ TEST(PtrTest, ExpectNotNullWithNullValue)
    EXPECT_NONFATAL_FAILURE(EXPECT_NOTNULL(NULL), "");
    }
 
+
 TEST(TRTestCombineVectorTest, CombineEmptyVectorsOfSameType)
    {
    using namespace std;
@@ -83,7 +84,8 @@ TEST(TRTestCombineVectorTest, CombineEmptyVectorsOfDifferentTypes)
 TEST(TRTestCombineVectorTest, CombineEmptyAndNonEmptyVectorsOfSameType)
    {
    using namespace std;
-   auto v = TRTest::combine(vector<int>{}, vector<int>{{1, 2, 3}});
+   int test_array[3] = {1, 2 ,3}; 
+   auto v = TRTest::combine(vector<int>{}, vector<int> (test_array, test_array+3));
    ::testing::StaticAssertTypeEq<vector<tuple<int,int>>, decltype (v)>();
    ASSERT_TRUE(v.empty())
          << "Combining any vector with an empty vector should always result in another empty vector.";
@@ -101,7 +103,8 @@ TEST(TRTestCombineVectorTest, CombineEmptyAndNonEmptyVectorsOfDifferentTypes)
 TEST(TRTestCombineVectorTest, CombineNonEmptyAndEmptyVectorsOfSameType)
    {
    using namespace std;
-   auto v = TRTest::combine(vector<int>{{1, 2, 3}}, vector<int>{});
+   int test_array[] = {1, 2, 3};
+   auto v = TRTest::combine(vector<int> (test_array, test_array+3), vector<int>{});
    ::testing::StaticAssertTypeEq<vector<tuple<int,int>>, decltype (v)>();
    ASSERT_TRUE(v.empty())
          << "Combining any vector with an empty vector should always result in another empty vector.";
@@ -110,7 +113,8 @@ TEST(TRTestCombineVectorTest, CombineNonEmptyAndEmptyVectorsOfSameType)
 TEST(TRTestCombineVectorTest, CombineNonEmptyAndEmptyVectorsOfDifferentTypes)
    {
    using namespace std;
-   auto v = TRTest::combine(vector<long>{{1, 2, 3}}, vector<char>{});
+   long test_array[] = {1, 2 ,3};
+   auto v = TRTest::combine(vector<long>(test_array, test_array+3), vector<char>{});
    ::testing::StaticAssertTypeEq<vector<tuple<long,char>>, decltype (v)>();
    ASSERT_TRUE(v.empty())
          << "Combining any vector with an empty vector should always result in another empty vector.";
@@ -119,8 +123,10 @@ TEST(TRTestCombineVectorTest, CombineNonEmptyAndEmptyVectorsOfDifferentTypes)
 TEST(TRTestCombineVectorTest, CombineNonEmptyVectorsOfSameType)
    {
    using namespace std;
-   auto v1 = vector<int>{{1, 2, 3}};
-   auto v2 = vector<int>{{4, 5}};
+   int test_array1[] = {1, 2, 3};
+   int test_array2[] = {4, 5};
+   auto v1 = vector<int> (test_array1, test_array1 + 3);
+   auto v2 = vector<int> (test_array2, test_array2 + 2);
    auto v = TRTest::combine(v1, v2);
    ::testing::StaticAssertTypeEq<vector<tuple<int,int>>, decltype (v)>();
    ASSERT_EQ(v1.size() * v2.size(), v.size())
@@ -130,8 +136,10 @@ TEST(TRTestCombineVectorTest, CombineNonEmptyVectorsOfSameType)
 TEST(TRTestCombineVectorTest, CombineNonEmptyVectorsOfDifferentTypes)
    {
    using namespace std;
-   auto v1 = vector<long>{{1, 2, 3}};
-   auto v2 = vector<char>{'a', 'b'};
+   long test_array1[3] = {1, 2, 3};
+   char test_array2[2] = {'a', 'b'};
+   auto v1 = vector<long> (test_array1, test_array1 + 3);
+   auto v2 = vector<char> (test_array1, test_array1 + 3);
    auto v = TRTest::combine(v1, v2);
    ::testing::StaticAssertTypeEq<vector<tuple<long,char>>, decltype (v)>();
    ASSERT_EQ(v1.size() * v2.size(), v.size())
@@ -210,59 +218,69 @@ TEST(TRTestCombineBraceInitTest, CombineNonEmptyListsOfDifferentTypes)
          << "Size of combined lists should be the product of the sizes of the two individual lists.";
    }
 
+
+bool returnFalse(char c) {
+    return false;
+}
+
+bool returnTrue(char c) {
+    return true;
+}
+
 TEST(TRTestFilter, FilterNothingFromEmptyVector)
    {
    auto v_in = std::vector<char>{};
-   auto v_out = TRTest::filter(v_in, [](char c){ return false; }); // should filter nothing
+   auto v_out = TRTest::filter(v_in, returnFalse); // should filter nothing
    ASSERT_TRUE(v_out.empty()) << "Filtering an empty vector should result in another empty vector.";
    }
 
 TEST(TRTestFilter, FilterEverythingFromEmptyVector)
    {
    auto v_in = std::vector<char>{};
-   auto v_out = TRTest::filter(v_in, [](char c){ return true; }); // should filter everything
+   auto v_out = TRTest::filter(v_in, returnTrue); // should filter everything
    ASSERT_TRUE(v_out.empty()) << "Filtering an empty vector should result in another empty vector.";
    }
 
 TEST(TRTestFilter, FilterNothingFromVector)
    {
    auto v_in = std::vector<char>{'a', 'b', 'c'};
-   auto v_out = TRTest::filter(v_in, [](char c){ return false; }); // should filter nothing
+   auto v_out = TRTest::filter(v_in, returnFalse); // should filter nothing
    ASSERT_EQ(v_in, v_out) << "Filtering nothing should just return the vector unchanged.";
    }
 
 TEST(TRTestFilter, FilterEverythingFromVector)
    {
    auto v_in = std::vector<char>{'a', 'b', 'c'};
-   auto v_out = TRTest::filter(v_in, [](char c){ return true; }); // should filter everything
+   auto v_out = TRTest::filter(v_in, returnTrue); // should filter everything
    ASSERT_TRUE(v_out.empty()) << "Filtering everything from vector should result in an empty vector.";
    }
 
+bool isChar_c(char l) {
+     return l=='c';
+}
+
 TEST(TRTestFilter, FilterVectorWithNoOccurrences)
    {
-   auto pred = [](char c){ return c == 'c'; };
    auto v_in = std::vector<char>{'a', 'b', 'd', 'e'};
-   auto v_out = TRTest::filter(v_in, pred);
+   auto v_out = TRTest::filter(v_in, isChar_c);
    ASSERT_EQ(v_in, v_out)
          << "Filtering a vector that doesn't contain elements matching the predicate should just return the same vector.";
-   ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), pred))
+   ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), isChar_c))
          << "Filtering should leave no elements matching the filter predicate.";
    }
 
 TEST(TRTestFilter, FilterVectorWithOneOccurrence)
    {
-   auto pred = [](char c){ return c == 'c'; };
    auto v_in = std::vector<char>{'a', 'b', 'c', 'd', 'e'};
-   auto v_out = TRTest::filter(v_in, pred);
-   ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), pred))
+   auto v_out = TRTest::filter(v_in, isChar_c);
+   ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), isChar_c))
          << "Filtering should leave no elements matching the filter predicate.";
    }
 
 TEST(TRTestFilter, FilterVectorWithManyOccurrences)
    {
-   auto pred = [](char c){ return c == 'c'; };
    auto v_in = std::vector<char>{'a', 'c', 'b', 'c', 'c', 'd', 'c', 'e', 'c'};
-   auto v_out = TRTest::filter(v_in, pred);
-   ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), pred))
+   auto v_out = TRTest::filter(v_in, isChar_c);
+   ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), isChar_c))
          << "Filtering should leave no elements matching the filter predicate.";
    }

--- a/fvtest/compilertriltest/OpCodeTest.hpp
+++ b/fvtest/compilertriltest/OpCodeTest.hpp
@@ -34,32 +34,7 @@
 namespace TRTest
 {
 
-/**
- * @brief Type for holding argument to parameterized opcode tests
- * @tparam Ret the type returned by the opcode
- * @tparam Args the types of the arguments to the opcode
- *
- * This type is just a tuple that packages the different parts of a argument for
- * an opcode test. The first field is another tuple holding the input values to
- * be given to the opcode for testing. The second field is a two-tuple containing
- * the opcode's name as a string, and a pointer to an oracle function that
- * returns the expected return value of the opcode test when given the input
- * values from the first part of the outer tuple.
- */
-template <typename Ret, typename... Args>
-using ParamType = std::tuple<std::tuple<Args...>, std::tuple<std::string, Ret (*)(Args...)> >;
-
-/**
- * @brief Type for holding argument to parameterized binary opcode tests
- */
-template <typename Ret, typename Left, typename Right>
-using BinaryOpParamType = ParamType<Ret, Left, Right>;
-
-/**
- * @brief Struct equivalent to the BinaryOpParamType tuple
- *
- * Used for easier unpacking of test argument.
- */
+// C++11 upgrade (Issue #1916).
 template <typename Ret, typename Left, typename Right>
 struct BinaryOpParamStruct {
         Left lhs;
@@ -73,7 +48,7 @@ struct BinaryOpParamStruct {
  *    of BinaryOpParamStruct
  */
 template <typename Ret, typename Left, typename Right>
-BinaryOpParamStruct<Ret, Left, Right> to_struct(BinaryOpParamType<Ret, Left, Right> param) {
+BinaryOpParamStruct<Ret, Left, Right> to_struct(std::tuple<std::tuple<Left,Right>, std::tuple<std::string, Ret (*)(Left,Right)>> param) {
     BinaryOpParamStruct<Ret, Left, Right> s;
     s.lhs = std::get<0>(std::get<0>(param));
     s.rhs = std::get<1>(std::get<0>(param));
@@ -85,10 +60,10 @@ BinaryOpParamStruct<Ret, Left, Right> to_struct(BinaryOpParamType<Ret, Left, Rig
 //~ Opcode test fixtures ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename Ret, typename... Args>
-class OpCodeTest : public JitTest, public ::testing::WithParamInterface<ParamType<Ret, Args...>> {};
+class OpCodeTest : public JitTest, public ::testing::WithParamInterface< std::tuple<std::tuple<Args...>, std::tuple<std::string, Ret (*)(Args...)>> > {};
 
 template <typename T>
-class BinaryOpTest : public JitTest, public ::testing::WithParamInterface<BinaryOpParamType<T,T,T>> {};
+class BinaryOpTest : public JitTest, public ::testing::WithParamInterface< std::tuple< std::tuple<T,T>, std::tuple<std::string, T (*)(T,T)>> > {};
 
 } // namespace CompTest
 

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -25,8 +25,11 @@
 template <typename T> static
 std::vector<std::tuple<T, int32_t>> test_input_values()
    {
-   return TRTest::combine(TRTest::const_values<T>(), std::vector<int32_t>{0, 1, 5, 8, 25, 8*sizeof(T) - 1, 8*sizeof(T)});
+   int32_t inputArray[] = {0, 1, 5, 8, 25, 8*sizeof(T) - 1, 8*sizeof(T)};
+   return TRTest::combine(TRTest::const_values<T>(), std::vector<int32_t>(inputArray, inputArray + sizeof(inputArray)/sizeof(int32_t)));
    }
+
+
 
 template <typename T> static T rotate(T a, int32_t b)
    {
@@ -124,10 +127,10 @@ TEST_P(Int32ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int32ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<int32_t>()),
-    ::testing::Values( std::make_tuple("ishl", shift_left<int32_t>),
-                       std::make_tuple("ishr", shift_right<int32_t>),
-                       std::make_tuple("irol", rotate<int32_t >) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<int32_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("ishl", static_cast<int32_t(*)(int32_t, int32_t)>(shift_left)),
+                       std::make_tuple("ishr", static_cast<int32_t(*)(int32_t, int32_t)>(shift_right)),
+                       std::make_tuple("irol", static_cast<int32_t(*)(int32_t, int32_t)>(rotate)) )));
 
 class Int64ShiftAndRotate : public ShiftAndRotateArithmetic<int64_t> {};
 
@@ -166,10 +169,10 @@ TEST_P(Int64ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int64ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<int64_t>()),
-    ::testing::Values( std::make_tuple("lshl", shift_left<int64_t>),
-                       std::make_tuple("lshr", shift_right<int64_t>),
-                       std::make_tuple("lrol", rotate<int64_t >) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<int64_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("lshl", static_cast<int64_t(*)(int64_t, int32_t)>(shift_left)),
+                       std::make_tuple("lshr", static_cast<int64_t(*)(int64_t, int32_t)>(shift_right)),
+                       std::make_tuple("lrol", static_cast<int64_t(*)(int64_t,int32_t)>(rotate)) )));
 
 class Int8ShiftAndRotate : public ShiftAndRotateArithmetic<int8_t> {};
 
@@ -208,9 +211,9 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int8ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<int8_t>()),
-    ::testing::Values( std::make_tuple("bshl", shift_left<int8_t>),
-                       std::make_tuple("bshr", shift_right<int8_t>) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<int8_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("bshl", static_cast<int8_t(*)(int8_t, int32_t)>(shift_left)),
+                       std::make_tuple("bshr", static_cast<int8_t(*)(int8_t, int32_t)>(shift_right)) )));
 
 class Int16ShiftAndRotate : public ShiftAndRotateArithmetic<int16_t> {};
 
@@ -251,9 +254,10 @@ TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
 #endif
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int16ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<int16_t>()),
-    ::testing::Values( std::make_tuple("sshl", shift_left<int16_t>),
-                       std::make_tuple("sshr", shift_right<int16_t>) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<int16_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("sshl", static_cast<int16_t(*)(int16_t, int32_t)>(shift_left)),
+                       std::make_tuple("sshr", static_cast<int16_t(*)(int16_t, int32_t)>(shift_right))
+                     )));
 
 class UInt32ShiftAndRotate : public ShiftAndRotateArithmetic<uint32_t> {};
 
@@ -292,8 +296,8 @@ TEST_P(UInt32ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt32ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<uint32_t>()),
-    ::testing::Values( std::make_tuple("iushr", shift_right<uint32_t>) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint32_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("iushr", static_cast< uint32_t (*) (uint32_t, int32_t) > (shift_right)) )));
 
 class UInt64ShiftAndRotate : public ShiftAndRotateArithmetic<uint64_t> {};
 
@@ -332,8 +336,8 @@ TEST_P(UInt64ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt64ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<uint64_t>()),
-    ::testing::Values( std::make_tuple("lushr", shift_right<uint64_t>) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint64_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("lushr", static_cast< uint64_t (*) (uint64_t, int32_t) > (shift_right)) )));
 
 class UInt8ShiftAndRotate : public ShiftAndRotateArithmetic<uint8_t> {};
 
@@ -372,8 +376,8 @@ TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt8ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<uint8_t>()),
-    ::testing::Values( std::make_tuple("bushr", shift_right<uint8_t>) )));
+    ::testing::ValuesIn( static_cast< std::vector<std::tuple<uint8_t, int32_t>> (*) (void) > (test_input_values)()),
+    ::testing::Values( std::make_tuple("bushr", static_cast<uint8_t (*) (uint8_t, int32_t)>(shift_right)) )));
 
 class UInt16ShiftAndRotate : public ShiftAndRotateArithmetic<uint16_t> {};
 
@@ -412,5 +416,5 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
 }
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, UInt16ShiftAndRotate, ::testing::Combine(
-    ::testing::ValuesIn(test_input_values<uint16_t>()),
-    ::testing::Values( std::make_tuple("sushr", shift_right<uint16_t>) )));
+    ::testing::ValuesIn(static_cast< std::vector<std::tuple<uint16_t, int32_t>> (*) (void) >(test_input_values)()),
+    ::testing::Values( std::make_tuple("sushr", static_cast<uint16_t (*) (uint16_t, int32_t)>(shift_right)) )));

--- a/fvtest/compilertriltest/SimplifierFoldAndTest.cpp
+++ b/fvtest/compilertriltest/SimplifierFoldAndTest.cpp
@@ -49,7 +49,7 @@ class SimplifierFoldAndIlVerifier : public TR::IlVerifier
       return 0;
       }
 
-   int32_t verify(TR::ResolvedMethodSymbol *sym) override
+   int32_t verify(TR::ResolvedMethodSymbol *sym)
       {
       for(TR::PreorderNodeIterator iter(sym->getFirstTreeTop(), sym->comp()); iter.currentTree(); ++iter)
          {

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -21,6 +21,7 @@
 
 #ifndef COMPILER_UTIL_HPP
 #define COMPILER_UTIL_HPP
+#include <stdexcept>
 #include "il/DataTypes.hpp"
 
 namespace Tril { 
@@ -45,7 +46,7 @@ static TR::DataTypes getTRDataTypes(const std::string& name) {
    else if (name == "VectorDouble") return TR::VectorDouble;
    else if (name == "NoType") return TR::NoType;
    else {
-      throw std::runtime_error{std::string{"Unknown type name: "}.append(name)};
+      throw std::runtime_error{static_cast<const std::string&>(std::string{"Unknown type name: "}.append(name))};
    }
 }
 


### PR DESCRIPTION
This commit lowers the minimum compiler version required to
run the compiler tests built using Tril, to at least as far
as GCC 4.4.6. Essentially not requiring full C++11 support.

Related to PR #1718 

Fixes #1697 