### PR TITLE
Stop versioning unimportant checks in outer loops

### DIFF
--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -101,10 +101,10 @@ bool TR_Structure::contains(TR_Structure *other, TR_Structure *commonParent)
    return false;
    }
 
-TR_Structure *TR_Structure::getContainingLoop()
+TR_RegionStructure *TR_Structure::getContainingLoop()
    {
-   for (TR_Structure *p = getParent(); p != NULL ; p = p->getParent())
-      if (p->asRegion()->isNaturalLoop())
+   for (TR_RegionStructure *p = getParent(); p != NULL ; p = p->getParent())
+      if (p->isNaturalLoop())
          return p;
    return NULL;
    }

--- a/compiler/optimizer/Structure.hpp
+++ b/compiler/optimizer/Structure.hpp
@@ -101,7 +101,7 @@ class TR_Structure
    //
    bool  contains(TR_Structure *other, TR_Structure *commonParent = NULL);
 
-   TR_Structure *getContainingLoop();
+   TR_RegionStructure *getContainingLoop();
 
    // Finds the common parent of this and other
    // note that if A contains B, then the common parent is parent(A)


### PR DESCRIPTION
Upon entry into a loop, a very low frequency check may not run at all before control exits the loop. If a check isn't going to run, the loop can complete normally even if that check would fail. As a result, versioning the check is likely to spuriously send execution to the cold loop. Furthermore, there is little benefit to be had from removing a check that seldom runs. For these reasons, versioner tries to avoid versioning "unimportant" checks.

Unimportant checks have so far been identified based on the frequency ratio between the check and the header of the loop under consideration. But this can cause an inconsistency when an outer loop contains an inner loop that contains a check, and the check is invariant w.r.t. to the outer loop.

If the inner loop iterates more frequently than the outer loop, as is often the case, then it's possible that an unimportant check within the inner loop is too frequent to look unimportant at the level of the outer loop. In this case, the entire outer loop, including the inner loop! can be versioned based on the check, even though it would not be considered important enough to version the inner loop only.

This commit avoids the inconsistency by considering the headers of any inner loops within which a check is nested. To determine whether the check is unimportant, its frequency is compared to the frequency of the hottest header. The original importance test is available under the environment variable `TR_loopVersionerUseOuterHeaderForImportance`.
