### PR TITLE
Preliminary Call Support in Tril

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(comptest
 	SimplifierFoldAndTest.cpp
 	IfxcmpgeReductionTest.cpp
 	VectorTest.cpp
+	CallTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/CallTest.cpp
+++ b/fvtest/compilertriltest/CallTest.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "JitTest.hpp"
+#include "default_compiler.hpp"
+
+class CallTest : public TRTest::JitTest {};
+
+int32_t oracleBoracle(int32_t x) { return x + 1123; } // Randomish number to avoid accidental test passes.
+
+TEST_F(CallTest, icallOracle) { 
+   // Construsts what is essentially a thunk.
+    char inputTrees[200] = {0};
+    const auto format_string = "(method return=Int32 args=[Int32] (block (ireturn (icall address=%p args=[Int32] (iload parm=0)) )  ))";
+    std::snprintf(inputTrees, 200, format_string, &oracleBoracle);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    Tril::DefaultCompiler compiler{trees};
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t)>();
+
+    EXPECT_EQ(oracleBoracle(-1), entry_point(-1));
+    EXPECT_EQ(oracleBoracle(-128), entry_point(-128));
+    EXPECT_EQ(oracleBoracle(128), entry_point(128));
+    EXPECT_EQ(oracleBoracle(1280), entry_point(1280));
+
+}

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -62,9 +62,9 @@ static std::vector<TR::DataTypes> parseArgTypes(const ASTNode* node) {
 
    std::vector<TR::DataTypes> argTypes;
    auto argTypesArg = node->getArgByName("args");
-   if (argTypesArg != nullptr) {
+   if (argTypesArg != NULL) {
       auto typeValue = argTypesArg->getValue();
-      while (typeValue != nullptr) {
+      while (typeValue != NULL) {
          argTypes.push_back(getTRDataTypes(typeValue->getString()));
          typeValue = typeValue->next;
       }

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -23,6 +23,7 @@
 #define COMPILER_UTIL_HPP
 #include <stdexcept>
 #include "il/DataTypes.hpp"
+#include "ast.hpp"
 
 namespace Tril { 
 /**
@@ -48,6 +49,28 @@ static TR::DataTypes getTRDataTypes(const std::string& name) {
    else {
       throw std::runtime_error{static_cast<const std::string&>(std::string{"Unknown type name: "}.append(name))};
    }
+}
+
+/**
+ * @brief Return a parsed array of DataTypes from a node with an 
+ *        "args" list.
+ * @param node is the node being processed.
+ * @return the std::vector of TR::DataTypes corresponding to the 
+ *         args=[Type1,Type2,...] attached to the ASTNode. 
+ */
+static std::vector<TR::DataTypes> parseArgTypes(const ASTNode* node) { 
+
+   std::vector<TR::DataTypes> argTypes;
+   auto argTypesArg = node->getArgByName("args");
+   if (argTypesArg != nullptr) {
+      auto typeValue = argTypesArg->getValue();
+      while (typeValue != nullptr) {
+         argTypes.push_back(getTRDataTypes(typeValue->getString()));
+         typeValue = typeValue->next;
+      }
+   }
+
+   return argTypes;
 }
 
 }

--- a/fvtest/tril/tril/method_info.hpp
+++ b/fvtest/tril/tril/method_info.hpp
@@ -45,15 +45,7 @@ class MethodInfo {
         explicit MethodInfo(const ASTNode* methodNode) : _methodNode{methodNode} {
             auto returnTypeArg = _methodNode->getArgByName("return");
             _returnType = getTRDataTypes(returnTypeArg->getValue()->getString());
-
-            auto argTypesArg = _methodNode->getArgByName("args");
-            if (argTypesArg != NULL) {
-                auto typeValue = argTypesArg->getValue();
-                while (typeValue != NULL) {
-                    _argTypes.push_back(getTRDataTypes(typeValue->getString()));
-                    typeValue = typeValue->next;
-                }
-            }
+            _argTypes = parseArgTypes(_methodNode); 
 
             auto nameArg = _methodNode->getArgByName("name");
             if (nameArg != NULL) {


### PR DESCRIPTION
This adds support for creating calls from Tril code to externally defined functions. 

~Currently WIP because the patch as presented is dependent on #1858 being merged first, as it's the PR that contains 0ae512e~