### PR TITLE
WIP: Fix ShiftAndRotate test failures and remove ireturn Il validation

### DIFF
--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -657,7 +657,7 @@
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int32,
    /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer,
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), // ireturn is used to return all types smaller than Int32
+   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType),
    /* .swapChildrenOpCode   = */ TR::BadILOp,
    /* .reverseBranchOpCode  = */ TR::BadILOp,
    /* .booleanCompareOpCode = */ TR::BadILOp,

--- a/compiler/ras/ILValidator.cpp
+++ b/compiler/ras/ILValidator.cpp
@@ -260,12 +260,12 @@ bool TR::ILValidator::treesAreValid(TR::TreeTop *start, TR::TreeTop *stop)
          for (auto i = 0; i < actChildCount; ++i)
             {
             auto childOpcode = node->getChild(i)->getOpCode();
-            const auto expChildType = opcode.expectedChildType(i);
-            const auto actChildType = childOpcode.getDataType().getDataType();
-            const auto expChildTypeName = (expChildType >= TR::NumTypes) ? "UnspecifiedChildType" : TR::DataType::getName(expChildType);
-            const auto actChildTypeName = TR::DataType::getName(actChildType);
             if (childOpcode.getOpCodeValue() != TR::GlRegDeps)
                {
+               const auto expChildType = opcode.expectedChildType(i);
+               const auto actChildType = childOpcode.getDataType().getDataType();
+               const auto expChildTypeName = (expChildType >= TR::NumTypes) ? "UnspecifiedChildType" : TR::DataType::getName(expChildType);
+               const auto actChildTypeName = TR::DataType::getName(actChildType);
                validityRule(iter, ((expChildType >= TR::NumTypes) || (actChildType == expChildType)),
                             "Child %d has unexpected type %s (expected %s)" , i, actChildTypeName, expChildTypeName);
                }
@@ -274,15 +274,6 @@ bool TR::ILValidator::treesAreValid(TR::TreeTop *start, TR::TreeTop *stop)
                // make sure the node is allowed to have a GlRegDeps child
                // and make sure that it is the last child
                validityRule(iter, opcode.canHaveGlRegDeps() && (i == actChildCount - 1), "Unexpected GlRegDeps child %d", i);
-               }
-
-            // ireturn may have i, or s, or b returns. 
-            if (opcode.getOpCodeValue() == TR::ireturn) 
-               {
-               validityRule(iter,(actChildType == TR::Int32 ||
-                                  actChildType == TR::Int16 ||
-                                  actChildType == TR::Int8),
-                                 "ireturn has an invalid child type %s (expected Int{8,16,32})", actChildTypeName);
                }
             }
          }

--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -77,8 +77,6 @@ INSTANTIATE_TEST_CASE_P(ILValidatorTest, WellformedTrees, ::testing::Values(
     "(method return=Int32 (block (ireturn (acmpge (aconst 4) (aconst 4)))))",
     "(method return=Int32 (block (ireturn (scmpeq (sconst 1) (sconst 3)))))",
     "(method return=Int32 (block (ireturn (lcmpeq (lconst 1) (lconst 3)))))"
-    "(method return=Int32 (block (ireturn (sconst 1) )))",                  // ireturn may return i,b or s  
-    "(method return=Int32 (block (ireturn (bconst 1) )))"                  // ireturn may return i,b or s  
     ));
 
 class CommoningTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<int32_t, int32_t>> {};

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -177,7 +177,7 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (%s (bconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (b2i (%s (bconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -194,7 +194,7 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (%s (bload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (b2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -218,7 +218,7 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (%s (sconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (s2i (%s (sconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -236,7 +236,7 @@ TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (%s (sload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (s2i (%s (sload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -341,7 +341,7 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (%s (bconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (bu2i (%s (bconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -358,7 +358,7 @@ TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (%s (bload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (bu2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -381,7 +381,7 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (%s (sconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (su2i (%s (sconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -398,7 +398,7 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (%s (sload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (su2i (%s (sload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);


### PR DESCRIPTION
This fixes `ShiftAndRotate` `comptest` failures on s390x. The tests fail due to illformed trees being passed to the Codegenrator where the `ireturn` opcode has an incorrect child type. Also removes existing IL Validation rules that check whether `ireturn` has children with any of the said incorrect types.

Note that as outlined in PR #1900, this is one of the two `comptest` Test Suites where it passes on the `x86` architecture but fails on `s390x`. Though the problem itself is architecture agnostic.
See https://github.com/eclipse/omr/issues/1901 for more on this.

Fixes Issue https://github.com/eclipse/omr/issues/1903

Related to: Issue https://github.com/eclipse/omr/issues/1901, PR #1842 

Signed-off-by: Rwitaban (Ray) Banerjee <rayb@ca.ibm.com>