### PR TITLE
Implement a treetop order extended block iterator

### DIFF
--- a/compiler/infra/ILWalk.cpp
+++ b/compiler/infra/ILWalk.cpp
@@ -624,3 +624,63 @@ void TR::AllBlockIterator::logCurrentLocation()
          traceMsg(comp(), "BLOCK  %s finished\n", _name);
       }
    }
+
+TR::TreeTopOrderExtendedBlockIterator::TreeTopOrderExtendedBlockIterator(TR::Compilation* comp, const char* name)
+   :
+      BlockIterator(comp, name), _currBlock(comp->getStartBlock()), _nextBlock(_currBlock->getNextExtendedBlock())
+   {
+   logCurrentLocation();
+   }
+
+TR::Block* TR::TreeTopOrderExtendedBlockIterator::getFirst()
+   {
+   return _currBlock;
+   }
+
+TR::Block* TR::TreeTopOrderExtendedBlockIterator::getLast()
+   {
+   if (_nextBlock != NULL)
+      {
+      return _nextBlock->getPrevBlock();
+      }
+   else
+      {
+      TR::Block* lastBlock = _currBlock;
+
+      for (TR::Block* nextBlock = _currBlock->getNextBlock(); nextBlock != NULL; lastBlock = nextBlock, nextBlock = lastBlock->getNextBlock())
+         {
+         // Void
+         }
+
+      return lastBlock;
+      }
+   }
+
+void TR::TreeTopOrderExtendedBlockIterator::operator++()
+   {
+   TR_ASSERT(_currBlock != NULL, "Cannot increment an TreeTopOrderExtendedBlockIterator that has already finished iterating");
+
+   _currBlock = _nextBlock;
+
+   if (_nextBlock != NULL)
+      {
+      _nextBlock = _nextBlock->getNextExtendedBlock();
+
+      logCurrentLocation();
+      }
+   }
+
+void TR::TreeTopOrderExtendedBlockIterator::logCurrentLocation()
+   {
+   if (isLoggingEnabled())
+      {
+      if (getFirst() != NULL)
+         {
+         traceMsg(comp(), "BLOCK %s @ block_%d\n", _name, getFirst()->getNumber());
+         }
+      else
+         {
+         traceMsg(comp(), "BLOCK %s finished\n", _name);
+         }
+      }
+   }

--- a/compiler/infra/ILWalk.hpp
+++ b/compiler/infra/ILWalk.hpp
@@ -343,6 +343,42 @@ class AllBlockIterator: protected BlockIterator
    void operator ++() { stepForward(); }
    };
 
+/** \brief
+ *     Iterates through extended basic block sequences in a treetop order, where treetop order means the order in 
+ *     which the extended basic blocks appear in a trace log file.
+ */
+class TreeTopOrderExtendedBlockIterator : protected BlockIterator
+   {
+
+   public:
+
+      TreeTopOrderExtendedBlockIterator(TR::Compilation* comp, const char* name = NULL);
+
+   /** \brief
+    *     Returns the first basic block in the current iteration of the extended basic block sequence.
+    */
+   TR::Block* getFirst();
+
+   /** \brief
+    *     Returns the last basic block in the current iteration of the extended basic block sequence.
+    */
+   TR::Block* getLast();
+
+   /** \brief
+    *     Advances the iterator to the next extended basic block in TreeTop order.
+    */
+   void operator ++();
+
+   private:
+
+   void logCurrentLocation();
+
+   private:
+
+   TR::Block* _currBlock;
+   TR::Block* _nextBlock;
+   };
+
 }
 
 #endif


### PR DESCRIPTION
Implement an iterator which traverses extended basic blocks in a
treetop ordering, where treetop order means the order in which the
extended basic blocks appear in a trace log file.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>