### PR TITLE
Add .vs directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ Testing/
 /.settings/
 
 # Visual Studio
+/.vs
 *.dir/
 *.opensdf
 *.sdf


### PR DESCRIPTION
Visual Studio 2017 uses the .vs directory to store metadata on folder
type projects such as OMR. These files should never be committed to the
repository and as such are great candidates to be ignored during
staging of git commits.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>