### PR TITLE
Remove OMR_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ message(STATUS "Starting with CMake version ${CMAKE_VERSION}")
 include(cmake/versions.cmake) # Required for OMR_VERSION
 
 project(omr VERSION ${OMR_VERSION} LANGUAGES CXX C)
-set(OMR_ROOT ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "Root of OMR")
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 

--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -47,7 +47,7 @@ set(TR_TARGET_ARCH    ${TR_HOST_ARCH})
 set(TR_TARGET_SUBARCH ${TR_HOST_SUBARCH})
 set(TR_TARGET_BITS    ${TR_HOST_BITS})
 
-set(MASM2GAS_PATH ${OMR_ROOT}/tools/compiler/scripts/masm2gas.pl)
+set(MASM2GAS_PATH ${omr_SOURCE_DIR}/tools/compiler/scripts/masm2gas.pl)
 
 # Mark a target as consuming the compiler components.
 #
@@ -297,10 +297,10 @@ function(create_omr_compiler_library)
 		${${COMPILER_NAME}_ROOT}/${TR_TARGET_ARCH}/${TR_TARGET_SUBARCH}
 		${${COMPILER_NAME}_ROOT}/${TR_TARGET_ARCH}
 		${${COMPILER_NAME}_ROOT}
-		${OMR_ROOT}/compiler/${TR_TARGET_ARCH}/${TR_TARGET_SUBARCH}
-		${OMR_ROOT}/compiler/${TR_TARGET_ARCH}
-		${OMR_ROOT}/compiler
-		${OMR_ROOT}
+		${omr_SOURCE_DIR}/compiler/${TR_TARGET_ARCH}/${TR_TARGET_SUBARCH}
+		${omr_SOURCE_DIR}/compiler/${TR_TARGET_ARCH}
+		${omr_SOURCE_DIR}/compiler
+		${omr_SOURCE_DIR}
 		${COMPILER_INCLUDES}
 		CACHE INTERNAL "Include header list for ${COMPILER}"
 	)
@@ -311,7 +311,7 @@ function(create_omr_compiler_library)
 	# Generate a build name file.
 	set(BUILD_NAME_FILE "${CMAKE_BINARY_DIR}/${COMPILER_NAME}Name.cpp")
 	add_custom_command(OUTPUT ${BUILD_NAME_FILE}
-		COMMAND perl ${OMR_ROOT}/tools/compiler/scripts/generateVersion.pl ${COMPILER_NAME} > ${BUILD_NAME_FILE}
+		COMMAND perl ${omr_SOURCE_DIR}/tools/compiler/scripts/generateVersion.pl ${COMPILER_NAME} > ${BUILD_NAME_FILE}
 		VERBATIM
 		COMMENT "Generate ${BUILD_NAME_FILE}"
 	)
@@ -344,7 +344,7 @@ function(create_omr_compiler_library)
 	#
 	# This macro computes an appropriate target directory.
 	macro(add_compiler_subdirectory dir)
-		add_subdirectory(${OMR_ROOT}/compiler/${dir}
+		add_subdirectory(${omr_SOURCE_DIR}/compiler/${dir}
 			${CMAKE_CURRENT_BINARY_DIR}/compiler/${dir}_${COMPILER_NAME})
 	endmacro(add_compiler_subdirectory)
 

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -48,16 +48,16 @@ elseif(OMR_ARCH_POWER)
 		p/runtime/AsmUtil.spp
 		p/runtime/CodeDispatch.spp
 		p/runtime/CodeSync.cpp
-		${OMR_ROOT}/compiler/p/runtime/OMRCodeCacheConfig.cpp
+		${omr_SOURCE_DIR}/compiler/p/runtime/OMRCodeCacheConfig.cpp
 		#target
 		p/codegen/Evaluator.cpp
-		${OMR_ROOT}/compiler/p/env/OMRDebugEnv.cpp
+		${omr_SOURCE_DIR}/compiler/p/env/OMRDebugEnv.cpp
 	)
 elseif(OMR_ARCH_S390)
 	list(APPEND COMPILERTEST_FILES 
 		z/codegen/Evaluator.cpp
 		z/codegen/TestCodeGenerator.cpp
-		${OMR_ROOT}/compiler/z/env/OMRDebugEnv.cpp
+		${omr_SOURCE_DIR}/compiler/z/env/OMRDebugEnv.cpp
 	)
 endif()
 
@@ -68,7 +68,7 @@ create_omr_compiler_library(
 		JITTEST
 		TEST_PROJECT_SPECIFIC
 		PROD_WITH_ASSUMES
-		INCLUDES ${OMR_ROOT}/fvtest
+		INCLUDES ${omr_SOURCE_DIR}/fvtest
 )
 add_executable(compilertest
 	tests/main.cpp

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -33,8 +33,8 @@ set(JITBUILDER_OBJECTS
 	optimizer/JBOptimizer.cpp
 	optimizer/Optimizer.hpp
 	runtime/JBCodeCacheManager.cpp
-	${OMR_ROOT}/compiler/ilgen/VirtualMachineOperandArray.cpp
-	${OMR_ROOT}/compiler/ilgen/VirtualMachineOperandStack.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/VirtualMachineOperandArray.cpp
+	${omr_SOURCE_DIR}/compiler/ilgen/VirtualMachineOperandStack.cpp
 )
 
 if(OMR_ARCH_X86)
@@ -53,7 +53,7 @@ elseif(OMR_ARCH_POWER)
 		p/runtime/CodeSync.cpp
 		p/runtime/AsmUtil.spp
 		p/runtime/CodeDispatch.spp
-		${OMR_ROOT}/compiler/p/env/OMRDebugEnv.cpp
+		${omr_SOURCE_DIR}/compiler/p/env/OMRDebugEnv.cpp
 	)
 endif()
 


### PR DESCRIPTION
Variable is not needed as cmake gives us omr_SOURCE_DIR with the same
contents.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>