### PR TITLE
Correct ireturn child types in ShiftAndRotate tests

### DIFF
--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -180,7 +180,7 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (%s (bconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (b2i (%s (bconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -197,7 +197,7 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (%s (bload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (b2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -221,7 +221,7 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (%s (sconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (s2i (%s (sconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -239,7 +239,7 @@ TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (%s (sload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (s2i (%s (sload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -345,7 +345,7 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (%s (bconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (bu2i (%s (bconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -362,7 +362,7 @@ TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (%s (bload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (bu2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -385,7 +385,7 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (%s (sconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int16 (block (ireturn (su2i (%s (sconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -402,7 +402,7 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (%s (sload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int16 args=[Int16, Int32] (block (ireturn (su2i (%s (sload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);


### PR DESCRIPTION
These tests fail on s390x due to the missing conversions before `ireturn`.

The choice of doing a `signed` vs `unsigned` widening is based off of how the oracle is set up right now. From where our IL stands today, `ireturn` has no way of deciphering whether the left child of the `*shr` OpCode (which conventionally would dictate the signedness of the resulting shift) was signed or unsigned to begin with. So the “right choice” here, is to mimic how the oracle interprets the resulting bits while producing its result.

Something to keep mind, in this instance (and for future tests similar to this), the goal is to validate whether the associated Opcode (`*shr` in this case) behaves as expected. `ireturn` and the said conversion before it, are just part of "extracting the computed result”. So the “extraction process” must follow the same convention as the associated Test Oracle for the Test Case to be deemed valid.

(see the discussion below for details)

Fixes Issue: #1903

Related Issues: #1901
