### PR TITLE
CMake: Allow out-of-tree hookgen

### DIFF
--- a/cmake/modules/OmrHookgen.cmake
+++ b/cmake/modules/OmrHookgen.cmake
@@ -23,21 +23,61 @@ if(OMR_HOOKGEN_)
 	return()
 endif()
 set(OMR_HOOKGEN_ 1)
+include(CMakeParseArguments)
 
 # Process an input hookgen file to generate output source files.
-# Usage: omr_add_hookgen(<input> <output>...)
-# TODO: currently output in source tree, should be in build tree
-# TODO: Dependecy checking is broken, since it checks for output in build tree rather than src
-function(omr_add_hookgen input)
-	get_filename_component(input_dir "${input}" DIRECTORY)
-	add_custom_command(
-		OUTPUT ${ARGN}
-		COMMAND hookgen ${CMAKE_CURRENT_SOURCE_DIR}/${input}
-		DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${input_dir}
-	)
-endfunction(omr_add_hookgen)
+# Usage: omr_add_hookgen(INPUT <input> [PRIVATE_DIR <private_header_dir>] [PUBLIC_DIR <public_header_dir>]
+# public headers are written to public_header_dir (defaults to current binary dir)
+# private headers are written to private_heade_dir (defautls to current binary dir)
+function(omr_add_hookgen)
+	cmake_parse_arguments(OPT "" "INPUT;PRIVATE_DIR;PUBLIC_DIR" "TARGETS" ${ARGN})
 
-macro(add_hookgen)
-	omr_add_hookgen(${ARGN})
-endmacro(add_hookgen)
+	if(NOT OPT_INPUT)
+		message(FATAL_ERROR "value for INPUT must be specified")
+	endif()
+
+	#if private_dir or public_dir not specified, default to CMAKE_CURRENT_BINARY_DIR
+	if(NOT OPT_PRIVATE_DIR)
+		set(OPT_PRIVATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+	endif()
+	if(NOT OPT_PUBLIC_DIR)
+		set(OPT_PUBLIC_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+	endif()
+
+	get_filename_component(input_filename "${OPT_INPUT}" NAME)
+
+	file(READ "${OPT_INPUT}" hook_def)
+	string(REGEX MATCH "<privateHeader>[^<]*" private_header "${hook_def}")
+	string(REGEX MATCH "<publicHeader>[^<]*" public_header "${hook_def}")
+	if((NOT public_header) OR (NOT private_header))
+		messeage(FATAL_ERROR "Header extraction failed for ${input}")
+	endif()
+
+	string(REPLACE "<privateHeader>" "" private_header "${private_header}")
+	string(STRIP "${private_header}" private_header)
+	get_filename_component(private_header "${private_header}" NAME)
+
+	string(REPLACE "<publicHeader>" "" public_header "${public_header}")
+	string(STRIP "${public_header}" public_header)
+	get_filename_component(public_header "${public_header}" NAME)
+
+	# Hookgen does not accept absoulte paths, they must be relative to the input file
+	# So we need to figure out what that would be
+	file(RELATIVE_PATH private_path "${CMAKE_CURRENT_BINARY_DIR}" "${OPT_PRIVATE_DIR}/${private_header}")
+	file(RELATIVE_PATH public_path "${CMAKE_CURRENT_BINARY_DIR}" "${OPT_PUBLIC_DIR}/${public_header}")
+
+	string(REGEX REPLACE "<privateHeader>[^<]*" "<privateHeader>${private_path}" hook_def "${hook_def}")
+	string(REGEX REPLACE "<publicHeader>[^<]*" "<publicHeader>${public_path}" hook_def "${hook_def}")
+
+	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${input_filename}" "${hook_def}")
+
+	# Make cmake step depend on .hdf file, since we need to regen the modified .hdf
+	set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${OPT_INPUT}")
+
+	add_custom_command(
+		OUTPUT "${OPT_PRIVATE_DIR}/${private_header}" "${OPT_PUBLIC_DIR}/${public_header}"
+		COMMAND hookgen "${CMAKE_CURRENT_BINARY_DIR}/${input_filename}"
+		DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${OPT_INPUT}"
+	)
+
+endfunction(omr_add_hookgen)

--- a/cmake/modules/OmrHookgen.cmake
+++ b/cmake/modules/OmrHookgen.cmake
@@ -26,11 +26,11 @@ set(OMR_HOOKGEN_ 1)
 include(CMakeParseArguments)
 
 # Process an input hookgen file to generate output source files.
-# Usage: omr_add_hookgen(INPUT <input> [PRIVATE_DIR <private_header_dir>] [PUBLIC_DIR <public_header_dir>]
+# Usage: (INPUT <input> [PRIVATE_DIR <private_header_dir>] [PUBLIC_DIR <public_header_dir>]
 # public headers are written to public_header_dir (defaults to current binary dir)
-# private headers are written to private_heade_dir (defautls to current binary dir)
+# private headers are written to private_header_dir (defaults to current binary dir)
 function(omr_add_hookgen)
-	cmake_parse_arguments(OPT "" "INPUT;PRIVATE_DIR;PUBLIC_DIR" "TARGETS" ${ARGN})
+	cmake_parse_arguments(OPT "" "INPUT;PRIVATE_DIR;PUBLIC_DIR" "" ${ARGN})
 
 	if(NOT OPT_INPUT)
 		message(FATAL_ERROR "value for INPUT must be specified")
@@ -50,7 +50,7 @@ function(omr_add_hookgen)
 	string(REGEX MATCH "<privateHeader>[^<]*" private_header "${hook_def}")
 	string(REGEX MATCH "<publicHeader>[^<]*" public_header "${hook_def}")
 	if((NOT public_header) OR (NOT private_header))
-		messeage(FATAL_ERROR "Header extraction failed for ${input}")
+		message(FATAL_ERROR "Header extraction failed for ${input}")
 	endif()
 
 	string(REPLACE "<privateHeader>" "" private_header "${private_header}")
@@ -61,7 +61,7 @@ function(omr_add_hookgen)
 	string(STRIP "${public_header}" public_header)
 	get_filename_component(public_header "${public_header}" NAME)
 
-	# Hookgen does not accept absoulte paths, they must be relative to the input file
+	# Hookgen does not accept absolute paths, they must be relative to the input file
 	# So we need to figure out what that would be
 	file(RELATIVE_PATH private_path "${CMAKE_CURRENT_BINARY_DIR}" "${OPT_PRIVATE_DIR}/${private_header}")
 	file(RELATIVE_PATH public_path "${CMAKE_CURRENT_BINARY_DIR}" "${OPT_PUBLIC_DIR}/${public_header}")

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -19,10 +19,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-add_hookgen(hooksample.hdf
-	${CMAKE_CURRENT_SOURCE_DIR}/hooksample.h
-	${CMAKE_CURRENT_SOURCE_DIR}/hooksample_internal.h
-)
+omr_add_hookgen(INPUT hooksample.hdf)
 
 add_executable(omralgotest
 	algoTest.cpp
@@ -35,6 +32,9 @@ add_executable(omralgotest
 	hooktest.c
 	main.cpp
 	pooltest.c
+
+	# We need to introduce dependencies on the hookgen step.
+	"${CMAKE_CURRENT_BINARY_DIR}/hooksample.h"
 )
 
 target_link_libraries(omralgotest
@@ -44,6 +44,8 @@ target_link_libraries(omralgotest
 	omrcore
 	${OMR_GC_LIB}
 )
+
+target_include_directories(omralgotest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 #TODO hack to get building
 if(OMR_HOST_OS STREQUAL "win")

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -20,25 +20,26 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ###############################################################################
 
-add_hookgen(include/omrmm.hdf
-	${CMAKE_CURRENT_SOURCE_DIR}/../include_core/mmomrhook.h
-	${CMAKE_CURRENT_SOURCE_DIR}/base/mmomrhook_internal.h
+omr_add_hookgen(
+	INPUT include/omrmm.hdf
+	PUBLIC_DIR "${omr_BINARY_DIR}"
+	TARGETS omrgc_hookgen
 )
-add_hookgen(base/omrmmprivate.hdf
-	${CMAKE_CURRENT_SOURCE_DIR}/base/mmprivatehook.h
-	${CMAKE_CURRENT_SOURCE_DIR}/base/mmprivatehook_internal.h
+
+omr_add_hookgen(
+	INPUT base/omrmmprivate.hdf
+	TARGETS omrgc_hookgen
+)
+
+add_custom_target(omrgc_hookgen
+	DEPENDS
+		"${omr_BINARY_DIR}/mmomrhook.h"
+		"${CMAKE_CURRENT_BINARY_DIR}/mmprivatehook.h"
 )
 
 add_tracegen(base/j9mm.tdf)
 add_tracegen(base/omrmm.tdf)
 add_tracegen(verbose/j9vgc.tdf)
-add_custom_target(omrgc_hookgen
-		DEPENDS
-		${CMAKE_CURRENT_SOURCE_DIR}/../include_core/mmomrhook.h
-		${CMAKE_CURRENT_SOURCE_DIR}/base/mmomrhook_internal.h
-		${CMAKE_CURRENT_SOURCE_DIR}/base/mmprivatehook.h
-		${CMAKE_CURRENT_SOURCE_DIR}/base/mmprivatehook_internal.h
-)
 
 # Ideally We would handle the tracegen stuff like the hookgen stuff above
 # But for whatever reason that breaks the ninja builds


### PR DESCRIPTION
Modify the hookgen handling to allow generating files outside of the
source tree. This is not trivial since the output files are specified
as a relative path in the .hdf file (which are relative to the .hdf).

To work arround this omr_add_hookgen, reads in the .hdf file, identifies
the output header names, rewrites them as relative path (relative to
the current binary dir), and then outputs the modified hdf into
CMAKE_CURRENT_BINARY_DIR, and runs hookgen on that. This allows us to
generate the hookgen files in the build tree, without making any changes
which would likely break the existing autconf/makefile builds.

Signed-off-by: Devin Nakamura <dnakamura@ca.ibm.com>