### PR TITLE
Replace 'J9CONST_TABLE' with 'const'

### DIFF
--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -536,11 +536,6 @@ typedef struct U_128 {
 #define PTR_LONG_VALUE(dstPtr, aLongPtr) (*(aLongPtr) = *(dstPtr))
 #endif
 
-/* Macro used when declaring tables which require relocations. */
-#ifndef J9CONST_TABLE
-#define J9CONST_TABLE const
-#endif
-
 /* ANSI qsort is not always available */
 #ifndef J9_SORT
 #define J9_SORT(base, nmemb, size, compare) qsort((base), (nmemb), (size), (compare))

--- a/util/hookable/hookable.cpp
+++ b/util/hookable/hookable.cpp
@@ -44,7 +44,7 @@ static intptr_t J9HookReserve(struct J9HookInterface **hookInterface, uintptr_t 
 static uintptr_t J9HookAllocateAgentID(struct J9HookInterface **hookInterface);
 static void J9HookDeallocateAgentID(struct J9HookInterface **hookInterface, uintptr_t agentID);
 
-static J9CONST_TABLE J9HookInterface hookFunctionTable = {
+static const J9HookInterface hookFunctionTable = {
 	J9HookDispatch,
 	J9HookDisable,
 	J9HookReserve,


### PR DESCRIPTION
J9CONST_TABLE is defined in OMR to be 'const' and only exists for
historical reasons. This makes the code clearer and move obvious
about what is occuring.

This is a mechanical conversion from J9CONST_TABLE -> const.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>