### PR TITLE
Small fixes and additions to Tril printing routines

### DIFF
--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -111,7 +111,7 @@ void printASTValue(FILE* file, const ASTValue* value) {
     const ASTValue* v = value;
     int isList = v->next != NULL;
     if (isList) {
-        printf("[");
+        fprintf(file,"[");
     }
     printASTValueUnion(file, v);
     while (v->next) {
@@ -127,13 +127,17 @@ void printASTValue(FILE* file, const ASTValue* value) {
 void printASTArgs(FILE* file, const ASTNodeArg* args) {
     const ASTNodeArg* a = args;
     while (a) {
-        printf(" ");
+        fprintf(file," ");
         if (a->getName() != NULL && strcmp("", a->getName()) != 0) {
             fprintf(file, "%s=", a->getName());
         }
         printASTValue(file, a->getValue());
         a = a->next;
     }
+}
+
+void printTreesToStdErr(const ASTNode* trees) {
+   printTrees(stderr, trees, 1);
 }
 
 void printTrees(FILE* file, const ASTNode* trees, int indent) {

--- a/fvtest/tril/tril/ast.h
+++ b/fvtest/tril/tril/ast.h
@@ -107,6 +107,13 @@ void printASTValue(FILE* file, const ASTValue* value);
 void printASTArgs(FILE* file, const ASTNodeArg* args);
 void printTrees(FILE* file, const ASTNode* trees, int indent);
 
+/** 
+ * Dump trees to stderr by default. 
+ *
+ * Useful for calling in a debugger
+ */
+void printTreesToStdErr(const ASTNode* trees);
+
 /**
  * @brief Parse an input file containing Tril code
  * @param in is a handle pointing to the input file


### PR DESCRIPTION
- Correct defaulting to stdout in some places.
- Add printTreesToStdErr to support calling in a
  debugger that may not have a good definition for
  stderr or stdout 

