### PR TITLE
Support doing linkage definition on call sites in Tril

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(comptest
 	LongAndAsRotateTest.cpp
 	MockStrategyTest.cpp
 	LogicalTest.cpp
+	LinkageTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "JitTest.hpp"
+#include "default_compiler.hpp"
+
+/* Template for mapping a C/C++ type to
+ * a TR type, and type prefix.
+ */
+template<typename T>
+struct TypeToString {
+   static const char * type;
+   static const char * prefix;
+};
+
+template<> const char * TypeToString<int32_t>::type = "Int32";
+template<> const char * TypeToString<int64_t>::type = "Int64";
+template<> const char * TypeToString<float>  ::type = "Float";
+template<> const char * TypeToString<double> ::type = "Double";
+
+template<> const char * TypeToString<int32_t>::prefix = "i";
+template<> const char * TypeToString<int64_t>::prefix = "l";
+template<> const char * TypeToString<float>  ::prefix = "f";
+template<> const char * TypeToString<double> ::prefix = "d";
+
+TEST(TypeToString,TestTemplate) {
+   EXPECT_STREQ("Int32", TypeToString<int32_t>::type);
+   EXPECT_STREQ("Double", TypeToString<double>::type);
+}
+
+
+template <typename T>
+T passThrough(T x) { return x; }
+
+
+template <typename T>
+class LinkageTest : public TRTest::JitTest {};
+
+typedef ::testing::Types<int32_t, int64_t, float, double> InputTypes;
+TYPED_TEST_CASE(LinkageTest, InputTypes);
+
+TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
+    char inputTrees[200] = {0};
+    const auto format_string = "(method return=%s args=[%s] (block (%sreturn (%scall address=%p args=[%s] linkage=system (%sload parm=0)) )  ))";
+    std::snprintf(inputTrees, 200, format_string, TypeToString<TypeParam>::type, // Return
+                                                  TypeToString<TypeParam>::type, //Args
+                                                  TypeToString<TypeParam>::prefix, //return
+                                                  TypeToString<TypeParam>::prefix, //call
+                                                  &passThrough<TypeParam>, //address
+                                                  TypeToString<TypeParam>::type, //args
+                                                  TypeToString<TypeParam>::prefix //load
+                                                  );
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    // Execution of this test is disabled on non-X86 platforms, as we
+    // do not have trampoline support, and so this call may be out of
+    // range for some architectures.
+#ifdef TR_TARGET_X86
+    Tril::DefaultCompiler compiler{trees};
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam)>();
+
+    EXPECT_EQ(static_cast<TypeParam>(0), entry_point( static_cast<TypeParam>(0)))  << "Input Trees: " << inputTrees;
+    EXPECT_EQ(static_cast<TypeParam>(1), entry_point( static_cast<TypeParam>(1)))  << "Input Trees: " << inputTrees;
+    EXPECT_EQ(static_cast<TypeParam>(-1), entry_point(static_cast<TypeParam>(-1))) << "Input Trees: " << inputTrees;
+#endif
+}
+
+template <typename T>
+T fourthArg(T a, T b, T c, T d) { return d; }
+
+
+TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
+    char inputTrees[400] = {0};
+    const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=%p args=[%s,%s,%s,%s] linkage=system"
+                                 " (%sload parm=0)"
+                                 " (%sload parm=1)"
+                                 " (%sload parm=2)"
+                                 " (%sload parm=3)"
+                                 ") )  ))";
+
+    std::snprintf(inputTrees, 400, format_string, TypeToString<TypeParam>::type,   // Return
+                                                  TypeToString<TypeParam>::type,   // Args
+                                                  TypeToString<TypeParam>::type,   // Args
+                                                  TypeToString<TypeParam>::type,   // Args
+                                                  TypeToString<TypeParam>::type,   // Args
+                                                  TypeToString<TypeParam>::prefix, // return
+                                                  TypeToString<TypeParam>::prefix, // call
+                                                  &fourthArg<TypeParam>,           // address
+                                                  TypeToString<TypeParam>::type,   // args
+                                                  TypeToString<TypeParam>::type,   // args
+                                                  TypeToString<TypeParam>::type,   // args
+                                                  TypeToString<TypeParam>::type,   // args
+                                                  TypeToString<TypeParam>::prefix, // load
+                                                  TypeToString<TypeParam>::prefix, // load
+                                                  TypeToString<TypeParam>::prefix, // load
+                                                  TypeToString<TypeParam>::prefix  // load
+                                                  );
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    // Execution of this test is disabled on non-X86 platforms, as we
+    // do not have trampoline support, and so this call may be out of
+    // range for some architectures.
+#ifdef TR_TARGET_X86
+    Tril::DefaultCompiler compiler{trees};
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+
+    auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>();
+
+    EXPECT_EQ(static_cast<TypeParam>(1024),    entry_point(0,0,0,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
+    EXPECT_EQ(static_cast<TypeParam>(-1),      entry_point(0,0,0,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
+    EXPECT_EQ(static_cast<TypeParam>(0xf0f0f), entry_point(0,0,0,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
+#endif
+}

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include "il/DataTypes.hpp"
 #include "ast.hpp"
+#include "codegen/LinkageConventionsEnum.hpp"
 
 namespace Tril { 
 /**
@@ -71,6 +72,23 @@ static std::vector<TR::DataTypes> parseArgTypes(const ASTNode* node) {
    }
 
    return argTypes;
+}
+
+/**
+ * @brief  Convert a linkage convention name to a LinkageConvention 
+ *         appropriate for setting on a MethodSymbol. 
+ *
+ * @return the linkage convention, or TR_None if the name is not 
+ *         recognized. 
+ */
+static TR_LinkageConventions convertStringToLinkage(const char * linkageName) { 
+   std::string ln = linkageName;  
+   if (ln == "system") {
+      return TR_System;
+   }
+
+   // Not found
+   return TR_None; 
 }
 
 }

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -330,6 +330,8 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
      int i = 0;
      while (t) {
          auto child = toTRNode(t);
+         if (child == NULL) 
+            return NULL; 
          TraceIL("Setting n%dn (%p) as child %d of n%dn (%p)\n", child->getGlobalIndex(), child, i, node->getGlobalIndex(), node);
          node->setAndIncChild(i, child);
          t = t->next;
@@ -417,6 +419,8 @@ bool Tril::TRLangBuilder::injectIL() {
        const ASTNode* t = block->getChildren();
        while (t) {
            auto node = toTRNode(t);
+           if (node == NULL) 
+              return false;
            const auto tt = genTreeTop(node);
            TraceIL("Created TreeTop %p for node n%dn (%p)\n", tt, node->getGlobalIndex(), node);
            t = t->next;


### PR DESCRIPTION
~_Note: Only 8e87394 is new, as this PR builds on top of #1910_~

This PR is a feedback request for specifying linkage on a call. The hope is that this kind of functionality can be used to test a PR similar to #1899. 

This PR only covers the setting the linkage on calls. However, a very similar mechanism should be usable to set the linkage on the Tril described method itself, so that it receives parameters based on the specified linkage.


I also explored the use of Type Parameterized tests in google test, coming to the conclusion I didn't really like them for this, as it makes the test cases awkward. 