### PR TITLE
Disable recomp in MimicInterpreterFrameShape

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1882,6 +1882,8 @@ OMR::Options::Options(
          {
          optimizationPlan->setOptLevel(noOpt);
          self()->setOption (TR_DisableInterpreterProfiling, true);
+         if (self()->allowRecompilation())
+            self()->setAllowRecompilation(false); // disable recompilation for this method
          optimizationPlan->setOptLevelDowngraded(false);
          }
       }


### PR DESCRIPTION
Full speed debug compilations, implemented
using MimicInterpreterFrameShape, must use
the no-opt optimization level. Therefore,
they do not support recompilations.

This change disables recompilations for
any methods compiled in such a configuration.