### PR TITLE
Small corrections to Tril

### DIFF
--- a/fvtest/compilertriltest/ILValidatorTest.cpp
+++ b/fvtest/compilertriltest/ILValidatorTest.cpp
@@ -139,7 +139,7 @@ TEST_P(CommoningTest, CommoningWithinBlock)
    ASSERT_EQ(1, entry_point(std::get<0>(param), std::get<1>(param)));
    }
 
-INSTANTIATE_TEST_CASE_P(CommingValidationTest, CommoningTest,
+INSTANTIATE_TEST_CASE_P(CommoningValidationTest, CommoningTest,
   ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()));
 
 class CommoningDeathTest : public TRTest::JitTest {};

--- a/fvtest/tril/tril/tril.l
+++ b/fvtest/tril/tril/tril.l
@@ -38,12 +38,12 @@
                        };
 
 [-]?[0-9]+      {
-                yylval.integer = strtoul(yytext, NULL, 10);
+                yylval.integer = strtoull(yytext, NULL, 10);
                 return INTEGER;
             };
 
 [-]?0x[0-9a-fA-F]+      {
-                yylval.integer = strtoul(yytext, NULL, 16);
+                yylval.integer = strtoull(yytext, NULL, 16);
                 return INTEGER;
             }
 


### PR DESCRIPTION
* Correct parsing function so that it will work on a 32 bit platform that has `unsigned long` be 32 bits.
* Correct typo in test case name. 