### PR TITLE
Restore CMAKE_ prefix on CXX_EXTENSIONS support var

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -25,7 +25,7 @@ project(comptest LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_compile_options(-pthread)
 


### PR DESCRIPTION
Somehow the CMAKE_ prefix was lost on the CMAKE_CXX_EXTENSIONS variable,
and subsequently CMake defaulted to extensions on, rather than off.

Thanks to @dnakamura for spotting this. 