### PR TITLE
Fix C interface issues in omrgc.h

### DIFF
--- a/gc/include/omrgc.h
+++ b/gc/include/omrgc.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,21 +32,25 @@
 #include "omrcomp.h"
 #include "j9nongenerated.h"
 
-class MM_AllocateInitialization;
-
+/* Runtime API (C) */
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Runtime API */
-
-/* Caller is expected to initialize the allocation description (MM_AllocateInitialization::getAllocateDescription()) prior to call */
-omrobjectptr_t OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, MM_AllocateInitialization *allocator);
+/* Allocation description will be initialized in call */
+omrobjectptr_t OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, uintptr_t allocationCategory, uintptr_t requiredSizeInBytes, uintptr_t objectAllocationFlags = 0);
 
 omr_error_t OMR_GC_SystemCollect(OMR_VMThread* omrVMThread, uint32_t gcCode);
 
 #ifdef __cplusplus
 } /* extern "C" { */
+#endif
+
+/* Runtime API (C++) */
+#ifdef __cplusplus
+class MM_AllocateInitialization;
+/* Caller is expected to initialize the allocation description (MM_AllocateInitialization::getAllocateDescription()) prior to call */
+omrobjectptr_t OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, MM_AllocateInitialization *allocator);
 #endif
 
 #endif /* MM_OMRGCAPI_HPP_ */

--- a/gc/startup/omrgcalloc.cpp
+++ b/gc/startup/omrgcalloc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,6 +44,13 @@ OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, MM_AllocateInitialization *all
 	}
 
 	return allocator->allocateAndInitializeObject(omrVMThread);
+}
+
+omrobjectptr_t
+OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, uintptr_t allocationCategory, uintptr_t requiredSizeInBytes, uintptr_t allocationFlags)
+{
+	MM_AllocateInitialization allocator(MM_EnvironmentBase::getEnvironment(omrVMThread), allocationCategory, requiredSizeInBytes, allocationFlags);
+	return OMR_GC_AllocateObject(omrVMThread, &allocator);
 }
 
 omr_error_t


### PR DESCRIPTION
C interface as presented included a C++ artifact in a function parameter
list. The C++ function is now wrapped in a method that has an acceptable
C parameter list.

omrgc.h is a C header file and should not have included the forward
class declaration or included it in a function parameter list (my bad). 
However, I have left it in the omrgc.h header file, enclosed with `#ifdef 
__cplusplus` for backwards compatibility. AFAIK only GCConfigTest.cpp
uses the C++ interface for this method, within OMR.

Issue: #1957
Signed-off-by: Kim Briggs <briggs@ca.ibm.com>