### PR TITLE
Allow restoring default Google Test output

### DIFF
--- a/fvtest/omrGtestGlue/omrTest.h
+++ b/fvtest/omrGtestGlue/omrTest.h
@@ -122,6 +122,7 @@ public:
 	}
 
 	static void setDefaultTestListener(bool showTestCases = true, bool showTests = false, bool showSuccess = false, bool showFailures = true) {
+            if (!getenv("OMR_VERBOSE_TEST")) {
 		TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
 		TestEventListener* default_printer = listeners.Release(listeners.default_result_printer());
 		OMREventListener *listener = new OMREventListener(default_printer);
@@ -130,6 +131,7 @@ public:
 		listener->_showSuccess = showSuccess;
 		listener->_showFailures = showFailures;
 		listeners.Append(listener);
+            }
 	}
 };
 


### PR DESCRIPTION
Sometimes when debugging a test case it's extremely valuable to see
the complete Google Test output. This change allows restoring that
behaviour under an environment variable OMR_VERBOSE_TEST.
