### PR TITLE
WIP: Feedback: Stateful Method Compilation.

### DIFF
--- a/compiler/control/CMakeLists.txt
+++ b/compiler/control/CMakeLists.txt
@@ -25,4 +25,5 @@ compiler_library(control
 	${CMAKE_CURRENT_SOURCE_DIR}/OMRRecompilation.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/CompilationController.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/CompileMethod.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/CompilationStateManager.cpp
 )

--- a/compiler/control/CompilationStateManager.cpp
+++ b/compiler/control/CompilationStateManager.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+*
+* (c) Copyright IBM Corp. 2017, 2017
+*
+*  This program and the accompanying materials are made available
+*  under the terms of the Eclipse Public License v1.0 and
+*  Apache License v2.0 which accompanies this distribution.
+*
+*      The Eclipse Public License is available at
+*      http://www.eclipse.org/legal/epl-v10.html
+*
+*      The Apache License v2.0 is available at
+*      http://www.opensource.org/licenses/apache2.0.php
+*
+* Contributors:
+*    Multiple authors (IBM Corp.) - initial implementation and documentation
+******************************************************************************/
+
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"          // for TR_ResolvedMethod
+#include "control/CompilationStateManager.hpp"
+#include "control/CompileMethod.hpp" 
+#include "control/OptimizationPlan.hpp"        // for TR_OptimizationPlan, etc
+#include "control/Options.hpp"
+#include "control/Options_inlines.hpp"         // for TR::Options, etc
+#include "env/SystemSegmentProvider.hpp"
+#include "env/TRMemory.hpp"                    // for TR_Memory, etc
+#include "env/jittypes.h"                      // for uintptrj_t
+#include "ilgen/IlGenRequest.hpp"              // for CompileIlGenRequest
+#include "ilgen/IlGeneratorMethodDetails.hpp"
+#include "infra/Assert.hpp"                    // for TR_ASSERT
+
+CompilationStateManager::CompilationStateManager(OMR_VMThread *omrVMThread,
+                                                 TR::IlGeneratorMethodDetails & details,
+                                                 TR_Hotness hotness) :
+   state(INITIALIZING),
+   plan(TR_OptimizationPlan::alloc(hotness,false,false)),
+   filterInfo(NULL),
+   startPC(NULL),
+   return_code(COMPILATION_REQUESTED),
+   fe(OMR::FrontEnd::singleton()),
+   rawAllocator(),
+   scratchSegmentProvider(1 << 16, rawAllocator),
+   dispatchRegion(scratchSegmentProvider, rawAllocator),
+   trMemory(*fe.persistentMemory(), dispatchRegion),
+   compilee(*((TR_ResolvedMethod *)details.getMethod())),
+   options(NULL),
+   request(details)
+   {
+   if (!methodCanBeCompiled(&fe, compilee, filterInfo, &trMemory))
+      {
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompileExclude))
+         {
+         TR_VerboseLog::write("<JIT: %s cannot be translated>\n",
+                              compilee.signature(&trMemory));
+         }
+      changeState(COMPLETED); 
+      return; 
+      }
+
+   if (!plan)
+      {
+      if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCompileExclude))
+         {
+         TR_VerboseLog::write("<JIT: %s out-of-memory allocating optimization plan>\n",
+                              compilee.signature(&trMemory));
+         }
+      changeState(COMPLETED); 
+      return; 
+      }
+   
+   int32_t optionSetIndex = filterInfo ? filterInfo->getOptionSet() : 0;
+   int32_t lineNumber = filterInfo ? filterInfo->getLineNumber() : 0;
+   options= new (trMemory.trHeapMemory()) TR::Options(
+                                                      &trMemory,
+                                                      optionSetIndex,
+                                                      lineNumber,
+                                                      &compilee,
+                                                      0,
+                                                      plan,
+                                                      false);
+    
+   TR_ASSERT(TR::comp() == NULL, "there seems to be a current TLS TR::Compilation object %p for this thread. At this point there should be no current TR::Compilation object", TR::comp());
+   compiler = new (trMemory.trHeapMemory()) TR::Compilation(0, omrVMThread, &fe, &compilee, request, *options, dispatchRegion, &trMemory, plan);
+   TR_ASSERT(TR::comp() == compiler, "the TLS TR::Compilation object %p for this thread does not match the one %p just created.", TR::comp(), compiler);
+
+   changeState(INITIALIZED);
+   }
+
+/**
+ * Transition between states. Will assert on an invalid state transition.
+ */
+void
+CompilationStateManager::changeState(State s) 
+   {
+   const bool ALLOWED_STATE_TRANSITIONS[LAST_COMPILATION_STATE][LAST_COMPILATION_STATE] = {
+      // INITIALIZING,  INITIALIZED,    COMPILING,      COMPLETED,
+         0,             1,              0,              1, // INITIALIZING
+         0,             0,              1,              1, // INITIALIZED
+         0,             0,              0,              1, // COMPILING
+         0,             0,              0,              0, // COMPLETED
+   }; 
+
+   TR_ASSERT_FATAL(ALLOWED_STATE_TRANSITIONS[state][s],
+                   "Can't transition from state %d to %d", (int)state, (int)s);
+
+   state = s; 
+   }
+
+
+/**
+ * Compile the method
+ */
+void CompilationStateManager::compile() { 
+   changeState(COMPILING); 
+
+   uint64_t translationTime = TR::Compiler->vm.getUSecClock();
+   startPC = tryAndCompileCompilation(*compiler, compilee, options, trMemory, scratchSegmentProvider, translationTime, return_code); 
+
+   changeState(COMPLETED); 
+}
+
+/**
+ * Destroy a compilation state manager
+ */
+CompilationStateManager::~CompilationStateManager() 
+   {
+   if (NULL != plan)
+      {
+      TR_OptimizationPlan::freeOptimizationPlan(plan);
+      }
+
+   if (NULL != compiler) 
+      {
+      //delete compiler; // Cannot delete yet; need a better story for destruction here.
+      compiler->~Compilation();
+      compiler = NULL; 
+      }
+   }

--- a/compiler/control/CompilationStateManager.hpp
+++ b/compiler/control/CompilationStateManager.hpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *
+ * (c) Copyright IBM Corp. 2017, 2017
+ *
+ *  This program and the accompanying materials are made available
+ *  under the terms of the Eclipse Public License v1.0 and
+ *  Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * Contributors:
+ *    Multiple authors (IBM Corp.) - initial implementation and documentation
+ ******************************************************************************/
+
+
+#ifndef OMR_COMPILATION_STATE_MANAGER 
+#define OMR_COMPILATION_STATE_MANAGER
+
+
+#include "compile/CompilationTypes.hpp"  // for TR_Hotness
+#include "control/OptimizationPlan.hpp"  // for TR_OptimizationPlan, etc
+#include "env/SystemSegmentProvider.hpp"
+#include "env/ConcreteFE.hpp"            // for FrontEnd
+#include "ilgen/IlGenRequest.hpp"        // for CompileIlGenRequest
+
+// Not extensible yet, though could be made extensible if necessary.
+
+
+namespace TR { class IlGeneratorMethodDetails; }
+namespace TR { class Options; } 
+class TR_FilterBST;
+
+/**
+ * A stateful object responsible for managing compilation. The intention is that
+ * this can be passed around to drive compilation at various points (and allow 
+ * initialization and compilation to happen under different locking contexts!) 
+ *
+ * There are four states worth considering here 
+ * - Initializing: Pre-compilation initialization.  
+ * - Initialized: At this point the manaager is prepared to compile, and has 
+ *                all the information required to compile a method. 
+ * - Compiling:   When compilation is requested to begin
+ * - Completed:   When the compilation is completed (or has been declined), 
+ *                the state manager enters the completed state. 
+ *
+ * Huh. Maybe this is more of a compilation promise? 
+ *
+ * A note on threading: this object must be created and processed on the same 
+ * thread, as it will set the thread-local compilation global during construction. 
+ */
+class CompilationStateManager { 
+public:
+   enum State { 
+      INITIALIZING = 0,
+      INITIALIZED, 
+      COMPILING,
+      COMPLETED,
+      LAST_COMPILATION_STATE
+   }; 
+
+   CompilationStateManager(OMR_VMThread *,
+                           TR::IlGeneratorMethodDetails&,
+                           TR_Hotness); 
+   ~CompilationStateManager(); 
+
+   State getState() { return state; } 
+
+   int32_t getReturnCode()
+      { 
+      TR_ASSERT_FATAL(state == COMPLETED, "Asking for a return code before it's available -- call compile()");
+      return return_code; 
+      }
+
+   uint8_t* getStartPC()
+      {
+      TR_ASSERT_FATAL(state == COMPLETED, "Asking for a PC  before it's available -- call compile()");
+      return startPC; 
+      }
+
+   void compile(); 
+
+private:
+   void changeState(State);
+
+   State state; 
+   TR_OptimizationPlan *plan;
+   TR_FilterBST *filterInfo;
+   uint8_t* startPC; 
+
+   int32_t return_code; 
+   OMR::FrontEnd &fe;
+   TR::RawAllocator rawAllocator;
+   TR::SystemSegmentProvider scratchSegmentProvider;
+   TR::Region dispatchRegion;
+   TR_Memory trMemory;
+   TR_ResolvedMethod &compilee;
+
+   TR::Options* options;
+   TR::CompileIlGenRequest request;
+   TR::Compilation* compiler; 
+};
+#endif

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -201,7 +201,7 @@ int32_t init_options(TR::JitConfig *jitConfig, char *cmdLineOptions)
    return 0;
    }
 
-static bool methodCanBeCompiled(OMR::FrontEnd *fe, TR_ResolvedMethod &method, TR_FilterBST *&filter, TR_Memory *trMemory)
+bool methodCanBeCompiled(OMR::FrontEnd *fe, TR_ResolvedMethod &method, TR_FilterBST *&filter, TR_Memory *trMemory)
    {
    if (!method.isCompilable(trMemory))
       return false;

--- a/compiler/control/CompileMethod.hpp
+++ b/compiler/control/CompileMethod.hpp
@@ -22,9 +22,11 @@
 #include <stdint.h>                      // for int32_t, uint8_t
 #include "compile/CompilationTypes.hpp"  // for TR_Hotness
 #include "env/ConcreteFE.hpp"            // for FrontEnd
+#include "env/SystemSegmentProvider.hpp"
 
 struct OMR_VMThread;
 class TR_ResolvedMethod;
+class TR_FilterBST;
 namespace TR { class IlGeneratorMethodDetails; }
 namespace TR { class JitConfig; }
 
@@ -32,3 +34,30 @@ int32_t init_options(TR::JitConfig *jitConfig, char * cmdLineOptions);
 int32_t commonJitInit(OMR::FrontEnd &fe, char * cmdLineOptions);
 uint8_t *compileMethod(OMR_VMThread *omrVMThread, TR_ResolvedMethod &compilee, TR_Hotness hotness, int32_t &rc);
 uint8_t *compileMethodFromDetails(OMR_VMThread *omrVMThread, TR::IlGeneratorMethodDetails &details, TR_Hotness hotness, int32_t &rc);
+
+
+/** 
+ * If anyone objects to the compilation of this method, 
+ * let them speak now or forever hold their peace. 
+ *
+ * @returns true iff the method can be compiled. 
+ */
+bool methodCanBeCompiled(OMR::FrontEnd *fe,
+                         TR_ResolvedMethod &method,
+                         TR_FilterBST *&filter,
+                         TR_Memory *trMemory);
+
+/**
+ * Try and compile a method. 
+ *
+ * If successfull, the address of the start of the method will be returned, otherwise,
+ * the return-code will indicate the failure reason. 
+ */
+uint8_t*
+tryAndCompileCompilation(TR::Compilation& compiler,
+                         TR_ResolvedMethod& compilee,
+                         TR::Options* options,
+                         TR_Memory& trMemory,
+                         TR::SegmentAllocator &scratchSegmentProvider,
+                         uint64_t translationStartTime,
+                         int32_t& rc);

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -26,6 +26,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/control/OMROptions.cpp \
     $(JIT_OMR_DIRTY_DIR)/control/OptimizationPlan.cpp \
     $(JIT_OMR_DIRTY_DIR)/control/OMRRecompilation.cpp  \
+    $(JIT_OMR_DIRTY_DIR)/control/CompilationStateManager.cpp  \
     $(JIT_OMR_DIRTY_DIR)/env/ExceptionTable.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/Assert.cpp \
     $(JIT_OMR_DIRTY_DIR)/infra/BitVector.cpp \

--- a/fvtest/compilertest/control/TestJit.cpp
+++ b/fvtest/compilertest/control/TestJit.cpp
@@ -23,6 +23,7 @@
 #include "codegen/CodeGenerator.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "control/CompileMethod.hpp"
+#include "control/CompilationStateManager.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/FrontEnd.hpp"
 #include "env/IO.hpp"
@@ -212,7 +213,10 @@ extern "C"
 uint8_t *
 compileMethod(TR::IlGeneratorMethodDetails & details, TR_Hotness hotness, int32_t &rc)
    {
-   return compileMethodFromDetails(NULL, details, hotness, rc);
+   CompilationStateManager sm(NULL, details, hotness); 
+   sm.compile(); 
+   rc = sm.getReturnCode(); 
+   return sm.getStartPC();  
    }
 
 extern "C"

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -28,6 +28,7 @@
 #include "compile/CompilationTypes.hpp"
 #include "compile/Method.hpp"
 #include "control/CompileMethod.hpp"
+#include "control/CompilationStateManager.hpp"
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"
 #include "ilgen.hpp"
@@ -70,11 +71,11 @@ int32_t Tril::SimpleCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
        methodDetails.setIlVerifier(verifier);
        }
 
-    int32_t rc = 0;
-    auto entry_point = compileMethodFromDetails(NULL, methodDetails, warm, rc);
-
+    CompilationStateManager sm(NULL, methodDetails, warm); 
+    sm.compile(); 
+    auto rc = sm.getReturnCode(); 
     // if compilation was successful, set the entry point for the compiled body
-    if (rc == 0) setEntryPoint(entry_point);
+    if (rc == 0) setEntryPoint(sm.getStartPC());
 
     // return the return code for the compilation
     return rc;


### PR DESCRIPTION
The CompilationStateManager is a stateful object responsible for managing the environement of compilation. 

The intention is that this can be passed around to drive compilation, while allowing initialization and
compilation to happen under different locking contexts, a useful property for asynchronous compilation. 

This is one potential answer to issues [raised here](https://github.com/eclipse/omr/pull/1961#issuecomment-342514686), as this could be enhanced to provide callbacks and inspection of compiler objects between state changes. 

Opening the PR for feedback, though this preliminary version doesn't have feedback hooks built in allowing inspection and manipulation of things like the compilation objects.

