### PR TITLE
Remove default value for `objectAllocationFlags`

### DIFF
--- a/gc/include/omrgc.h
+++ b/gc/include/omrgc.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 /* Allocation description will be initialized in call */
-omrobjectptr_t OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, uintptr_t allocationCategory, uintptr_t requiredSizeInBytes, uintptr_t objectAllocationFlags = 0);
+omrobjectptr_t OMR_GC_AllocateObject(OMR_VMThread * omrVMThread, uintptr_t allocationCategory, uintptr_t requiredSizeInBytes, uintptr_t objectAllocationFlags);
 
 omr_error_t OMR_GC_SystemCollect(OMR_VMThread* omrVMThread, uint32_t gcCode);
 


### PR DESCRIPTION
Remove default value for `objectAllocationFlags` in `OMR_GC_AllocateObject`.

Default values for function parameters are a C++ feature and don't exist
in C.

Signed-off-by: Paavo Parkkinen <pparkkin@gmail.com>