### PR TITLE
Eliminate and fold allowDSEOfVolatiles

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1597,7 +1597,6 @@ class OMR_EXTENSIBLE CodeGenerator
    void setInlinedGetCurrentThreadMethod() {_flags3.set(InlinedGetCurrentThreadMethod);}
 
    bool disableCommoningOfVolatiles() {return false; }
-   bool allowDSEOfVolatiles() {return true; }
 
    bool considerAllAutosAsTacticalGlobalRegisterCandidates()    {return _flags1.testAny(ConsiderAllAutosAsTacticalGlobalRegisterCandidates);}
    void setConsiderAllAutosAsTacticalGlobalRegisterCandidates() {_flags1.set(ConsiderAllAutosAsTacticalGlobalRegisterCandidates);}

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -509,7 +509,7 @@ bool TR_IsolatedStoreElimination::canRemoveStoreNode(TR::Node *node)
    // operation that we do not want to remove.
    //
 
-   if (!comp()->cg()->allowDSEOfVolatiles() && node->getSymbolReference()->getSymbol()->isVolatile())
+   if (node->getSymbolReference()->getSymbol()->isVolatile())
       return false;
 
    if (node->dontEliminateStores())

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1043,7 +1043,6 @@ public:
    bool mulDecompositionCostIsJustified(int32_t numOfOperations, char bitPosition[], char operationType[], int64_t value);
 
    bool disableCommoningOfVolatiles() { return false; } // TODO : Identitiy needs folding
-   bool allowDSEOfVolatiles() { return true; } // TODO : Identitiy needs folding
 
    bool canUseGoldenEagleImmediateInstruction( int32_t value )
      {


### PR DESCRIPTION
Eliminates and folds the query allowDSEOfVolatiles that always returned true.