### PR TITLE
Improve locking

### DIFF
--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -70,20 +70,16 @@ omrthread_spinlock_acquire(omrthread_t self, omrthread_monitor_t monitor)
 	uintptr_t spinCount2Init = monitor->spinCount2;
 	uintptr_t spinCount1Init = monitor->spinCount1;
 
+	uintptr_t spinCount3 = spinCount3Init;
+	uintptr_t spinCount2 = spinCount2Init;
+
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
-	BOOLEAN spinning = TRUE;
  	if (monitor->spinThreads < lib->maxSpinThreads) {
  		VM_AtomicSupport::add(&monitor->spinThreads, 1);
  	} else {
- 		spinCount1Init = 1;
- 		spinCount2Init = 1;
- 		spinCount3Init = 1;
- 		spinning = FALSE;
+ 		goto exit;
  	}
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
-
-	uintptr_t spinCount3 = spinCount3Init;
-	uintptr_t spinCount2 = spinCount2Init;
 
 	for (; spinCount3 > 0; spinCount3--) {
 		for (spinCount2 = spinCount2Init; spinCount2 > 0; spinCount2--) {
@@ -134,11 +130,10 @@ update_jlm:
 #endif /* OMR_THR_JLM */
 
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
-	if (spinning) {
-		VM_AtomicSupport::subtract(&monitor->spinThreads, 1);
-	}
-#endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
+	VM_AtomicSupport::subtract(&monitor->spinThreads, 1);
 
+exit:
+#endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
 	return result;
 }
 


### PR DESCRIPTION
Currently, there is a limit (spin_thread_limit) on how many threads can
spin at a time on a monitor/lock. Over this spin_thread_limit, threads
don't spin but try to acquire the lock once before waiting. This can
cause high CPU utilization if there are large number of threads that try
to acquire a monitor/lock.

Now onwards, threads over the spin_thread_limit will immediately wait
instead of trying to acquire the monitor/lock once. This will help avoid
high CPU utilization.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>