### PR TITLE
Disable *Death*Tests for OS X CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,6 @@ before_install:
 env:
   global:
     - GTEST_COLOR=1
-    - GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
-    # Disable the core dump tests as container based builds don't allow setting
-    # core_pattern and don't have apport installed.  This can be removed when
-    # apport is available in apt whitelist
     - BUILD_JOBS=2
   matrix:
     - BUILD_WITH_CMAKE=yes CMAKE_GENERATOR="Unix Makefiles"

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -23,12 +23,25 @@
 
 set -evx
 
+if test "x$TRAVIS_OS_NAME" = "xosx"; then
+  export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:*DeathTest*
+else
+  # Disable the core dump tests as container based builds don't allow setting
+  # core_pattern and don't have apport installed.  This can be removed when
+  # apport is available in apt whitelist
+  export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
+fi
+
 if test "x$BUILD_WITH_CMAKE" = "xyes"; then
+
   if test "x$CMAKE_GENERATOR" = "x"; then
     export CMAKE_GENERATOR="Ninja"
   fi
-  if test "x$TRAVIS_OS_NAME" = "xosx" && test "x$CMAKE_GENERATOR" = "xNinja"; then
-    brew install ninja
+  
+  if test "x$TRAVIS_OS_NAME" = "xosx"; then
+    if test "x$CMAKE_GENERATOR" = "xNinja"; then
+      brew install ninja
+    fi
   fi
 
   mkdir build


### PR DESCRIPTION
These tests take up to 10s of minutes when running on the OS X CI
machines which causes the tests to fail. When running locally
these tests on take seconds. This disables the tests from the
OS X CI until we can resolve the issue.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>