### PR TITLE
Correct JitBuilder's optimizer strategy selection

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(comptest
 	VectorTest.cpp
 	CallTest.cpp
 	LongAndAsRotateTest.cpp
+	MockStrategyTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/SharedVerifiers.hpp
+++ b/fvtest/compilertriltest/SharedVerifiers.hpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+
+/**
+ * This Verifier checks if an AND operation exists. 
+ *
+ * Compilation is stopped by returning a non-zero return code.
+ */
+class NoAndIlVerifier : public TR::IlVerifier
+   {
+   public:
+   int32_t verifyNode(TR::Node *node)
+      {
+      if (node->getOpCode().isAnd()) 
+         {
+         return 1;
+         }
+      return 0;
+      }
+
+   int32_t verify(TR::ResolvedMethodSymbol *sym)
+      {
+      for(TR::PreorderNodeIterator iter(sym->getFirstTreeTop(), sym->comp()); iter.currentTree(); ++iter)
+         {
+         int32_t rtn = verifyNode(iter.currentNode());
+         if(rtn)
+            return rtn;
+         }
+
+      return 0;
+      }
+   };

--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -170,13 +170,13 @@ Optimizer::Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymb
    self()->setRequestOptimization(OMR::cheapTacticalGlobalRegisterAllocatorGroup, true);
    self()->setRequestOptimization(OMR::tacticalGlobalRegisterAllocatorGroup, true);
    self()->setRequestOptimization(OMR::tacticalGlobalRegisterAllocator, true);
-   }
 
-const OptimizationStrategy *
-Optimizer::optimizationStrategy(TR::Compilation *c)
-   {
-   // force warm strategy for now
-   return JBwarmStrategyOpts;
+
+   omrCompilationStrategies[noOpt] = JBwarmStrategyOpts;
+   omrCompilationStrategies[cold]  = JBwarmStrategyOpts;
+   omrCompilationStrategies[warm]  = JBwarmStrategyOpts;
+   omrCompilationStrategies[hot]   = JBwarmStrategyOpts;
+
    }
 
 inline

--- a/jitbuilder/optimizer/JBOptimizer.hpp
+++ b/jitbuilder/optimizer/JBOptimizer.hpp
@@ -52,8 +52,6 @@ class Optimizer : public OMR::OptimizerConnector
    Optimizer(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymbol, bool isIlGen,
          const OptimizationStrategy *strategy = NULL, uint16_t VNType = 0);
 
-   static const OptimizationStrategy *optimizationStrategy( TR::Compilation *c);
-
    private:
    TR::Optimizer *self();
    };


### PR DESCRIPTION
Previously by providing it's own optimizer strategy selection, JitBuilder ended up bypassing the mock optimizer support. 

This PR changes the way the JitBuilder chooses it's strategies, and adds a test for Mock optimization strategy support.