### PR TITLE
WIP : Remove _compressedRefs from  OMR::CodeGenerator

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -248,7 +248,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _simulatedNodeStates(NULL),
      _availableSpillTemps(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),
      _counterBlocks(getTypedAllocator<TR::Block*>(TR::comp()->allocator())),
-     _compressedRefs(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _liveReferenceList(getTypedAllocator<TR_LiveReference*>(TR::comp()->allocator())),
      _snippetList(getTypedAllocator<TR::Snippet*>(TR::comp()->allocator())),
      _registerArray(self()->comp()->trMemory()),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1940,9 +1940,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> _jniCallSites; // list of instrutions representing direct jni call sites
 
    TR_Array<void *> _monitorMapping;
-
-   TR::list<TR::Node*> _compressedRefs;
-
    int32_t _lowestSavedReg;
 
    uint32_t _vmThreadLiveCount;


### PR DESCRIPTION
OMR part of the fix for 1896.

Issue: #1896
Signed-off-by: Swathi Kalahastri <swkalaha@in.ibm.com>