### PR TITLE
Change to remove unused armAllocate

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -528,8 +528,6 @@ class OMR_EXTENSIBLE CodeGenerator
    // allocate is used by the main compilation class to get a code
    // generator for the current compilation.
    //
-   static TR::CodeGenerator *armAllocate(TR::Compilation *comp);
-
    TR::Recompilation *allocateRecompilationInfo() { return NULL; }
 
    // --------------------------------------------------------------------------


### PR DESCRIPTION
This change removes the unused armAllocate from
CodeGenerator in issue #1884

Fixes: #1884
Signed-off-by: Srinath Karanam <srinathk@in.ibm.com>