### PR TITLE
Remove unused code from obselete ENABLE_STRUCTS experiment

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5585,12 +5585,6 @@ TR::Node *indirectLoadSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
 
 TR::Node *indirectStoreSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
-#ifdef ENABLE_STRUCTS
-   if (node->getSymbolReference()->isPacked() && node->getOpCodeValue() != TR::astorei)
-      {
-      removeStructObjectCreation(node, s);
-      }
-#endif
    if (node->getOpCode().isStoreIndirect())
       node->getFirstChild()->setIsNonNegative(true);
 


### PR DESCRIPTION
As noted in Issue #1856, this ENABLE_STRUCTS code was part of a now
removed experiment, and can in turn be removed

Issue: #1856
Signed-off-by: William Smith <will.smith@uk.ibm.com>