### PR TITLE
Improve compile time performance of copy propagation

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -444,6 +444,9 @@ int32_t TR_CopyPropagation::perform()
          }
       }
 
+   // Pre-compute and cache usedef information for compile time performance
+   useDefInfo->buildDefUseInfo();
+
    // Required beyond the scope of the stack memory region
    bool donePropagation = false;
 


### PR DESCRIPTION
Copy propagation is exclusively enabled by default in the warm strategy
on IBM Z targets. It is quite a compile time hungry optimization. One
of the reasons as to why can be attributed to its use of use-def
analysis.

The optimization calls `getUsesFromDef` quite frequently which ends up
boiling down to a call to `TR_UseDefInfo::getUsesFromDef_ref`. In this
function we would always take the `else` path because the use-def
information has not been computed. This is an expensive task.

An optimization we can make here is the pre-compute the use-def info
ahead of time and avoid the expensive on-demand computation.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>