### PR TITLE
Removed unused function armAllocate

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -522,14 +522,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
 
 
-   // --------------------------------------------------------------------------
-   // Constructor
-   //
-   // allocate is used by the main compilation class to get a code
-   // generator for the current compilation.
-   //
-   static TR::CodeGenerator *armAllocate(TR::Compilation *comp);
-
    TR::Recompilation *allocateRecompilationInfo() { return NULL; }
 
    // --------------------------------------------------------------------------


### PR DESCRIPTION
Removed unused and non-implemented declared function armAllocate
from CodeGenerator.

Closes: #1884
Signed-off-by: Kabir Islam <kaislam1@in.ibm.com>