### PR TITLE
Zero out dead slots at OSR transition for FSD

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1213,6 +1213,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceOSRGuardInsertion",           "L\ttrace HCR guard insertion",                    TR::Options::traceOptimization, osrGuardInsertion, 0, "P"},
    {"traceOSRGuardRemoval",             "L\ttrace HCR guard removal",                      TR::Options::traceOptimization, osrGuardRemoval, 0, "P"},
 #endif
+   {"traceOSRLiveRangeAnalysis",        "L\ttrace OSR live range analysis",                TR::Options::traceOptimization, osrLiveRangeAnalysis, 0, "P"},
    {"tracePartialInlining",             "L\ttrace partial inlining heuristics",            SET_OPTION_BIT(TR_TracePartialInlining), "P" },
    {"tracePostBinaryEncoding",          "L\tdump instructions (code cache addresses, real registers) after binary encoding", SET_TRACECG_BIT(TR_TraceCGPostBinaryEncoding), "P"},
    {"tracePostInstructionSelection",    "L\tdump instructions (virtual registers) after instruction selection", SET_TRACECG_BIT(TR_TraceCGPostInstructionSelection), "P"},

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -2256,6 +2256,7 @@ OMR::ResolvedMethodSymbol::detectInternalCycles(TR::CFG *cfg, TR::Compilation *c
                      gotoBlock->setIsCold();
                      clonedCatch->setFrequency(CATCH_COLD_BLOCK_COUNT);
                      gotoBlock->setFrequency(CATCH_COLD_BLOCK_COUNT);
+
                      break;
                      }
                   }

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -546,7 +546,7 @@ static const OptimizationStrategy ilgenStrategyOpts[] =
    { coldBlockMarker                               },
    { allocationSinking,             IfNews         },
    { invariantArgumentPreexistence, IfNotClassLoadPhaseAndNotProfiling }, // Should not run if a recompilation is possible
-   { osrLiveRangeAnalysis,          IfVoluntaryOSR   },
+   { osrLiveRangeAnalysis,          IfOSR   },
    { osrDefAnalysis,                IfInvoluntaryOSR },
 #endif
    { endOpts },

--- a/compiler/optimizer/OSRDefAnalysis.hpp
+++ b/compiler/optimizer/OSRDefAnalysis.hpp
@@ -90,10 +90,14 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    int32_t partialAnalysis();
 
    void buildOSRLiveRangeInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
-      int32_t *liveLocalIndexToSymRefNumberMap, int32_t numBits, TR_OSRMethodData *osrMethodData);
+      int32_t *liveLocalIndexToSymRefNumberMap, int32_t numBits, TR_OSRMethodData *osrMethodData, bool containsPendingPushes);
    void buildOSRSlotSharingInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
       int32_t *liveLocalIndexToSymRefNumberMap, TR_BitVector *slotSharingVars);
 
+   void buildDeadSlotsInfo(TR::Node *node, TR_BitVector *liveVars, TR_OSRPoint *osrPoint,
+      int32_t *liveLocalIndexToSymRefNumberMap, bool containsPendingPush);
+
+   void buildDeadPendingPushSlotsInfo(TR::Node *node, TR_BitVector *livePendingPushSymRefs, TR_OSRPoint *osrPoint);
    void pendingPushLiveRangeInfo(TR::Node *node, TR_BitVector *liveSymRefs,
       TR_BitVector *allPendingPushSymRefs, TR_OSRPoint *osrPoint, TR_OSRMethodData *osrMethodData);
    void pendingPushSlotSharingInfo(TR::Node *node, TR_BitVector *liveSymRefs,
@@ -102,11 +106,14 @@ class TR_OSRLiveRangeAnalysis : public TR::Optimization
    void maintainLiveness(TR::Node *node, TR::Node *parent, int32_t childNum, vcount_t  visitCount,
        TR_Liveness *liveLocals, TR_BitVector *liveVars, TR::Block *block);
    TR::TreeTop *collectPendingPush(TR_ByteCodeInfo bci, TR::TreeTop *pps, TR_BitVector *liveVars);
+   void intersectWithExistingDeadSlots (TR_OSRPoint *osrPoint, TR_BitVector *deadPPSSlots, TR_BitVector *deadAutoSlots, bool containsPendingPush);
 
    TR_BitVector *_liveVars;
    TR_BitVector *_pendingPushSymRefs;
    TR_BitVector *_sharedSymRefs;
    TR_BitVector *_workBitVector;
+   TR_BitVector *_workDeadSymRefs;
+   TR_BitVector *_visitedBCI;    
    };
 
 class TR_OSRExceptionEdgeRemoval : public TR::Optimization


### PR DESCRIPTION
In debugging mode, the debugger may dereference an object slot even
after it's gone dead and we must make sure such dead slots are zeroed
out at OSR transition to avoid program crashing.

VoluntaryOSR could zero out the dead slots at induceOSR in trees
because there is one induceOSR for each osrPoint. However, under
involuntarOSR, which debbuging mode runs with, multiple osrPoints
would transit to the same code block and therefore the zero stores
can not be expressed in trees shared between all the different
osrPoints.

This changeset adds the infrastructure to bookkeep deadslots while
compiling the Java code. At OSR transition at runtime, the prepareForOSR
helper reads the data and decide which slots to zero out.