### PR TITLE
Support building OMR with Runtime Sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include(OmrFindFiles)
 include(OmrHookgen)
 include(OmrPlatform)
 include(OmrTracegen)
+include(OmrSanitizerSupport)
 
 ###
 ### Set up the global platform configuration

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -141,3 +141,5 @@ set(OMR_ENV_GCC OFF CACHE BOOL "TODO: Document")
 
 
 set(OMR_OPT_CUDA OFF CACHE BOOL "TODO: Document")
+
+set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GNU or Clang") 

--- a/cmake/modules/OmrSanitizerSupport.cmake
+++ b/cmake/modules/OmrSanitizerSupport.cmake
@@ -1,0 +1,40 @@
+###############################################################################
+# Copyright (c) 2017, 2017 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+###############################################################################
+
+include(OmrUtility)
+
+set(OMR_SANITIZER OFF CACHE STRING "-fsanitize parameter")
+set_property(
+	CACHE OMR_SANITIZER
+	PROPERTY STRINGS OFF undefined address thread
+	)
+
+# GNU style sanitizers 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU") 
+	if (OMR_SANITIZER) 
+		message(STATUS "${OMR_SANITIZER} Sanitizer is enabled")
+		# Extra options for the sanitizers, often documented to improve output
+		set(ADDITIONAL_SANITIZER_FLAGS "-fno-omit-frame-pointer")
+		omr_append_flags(CMAKE_CXX_FLAGS ${ADDITIONAL_SANITIZER_FLAGS} "-fsanitize=${OMR_SANITIZER}")
+		omr_append_flags(CMAKE_C_FLAGS   ${ADDITIONAL_SANITIZER_FLAGS} "-fsanitize=${OMR_SANITIZER}")
+	endif() 
+endif()

--- a/doc/BuildingWithCMake.md
+++ b/doc/BuildingWithCMake.md
@@ -108,6 +108,16 @@ Cross compiling OMR is done in two steps:
    cmake --build .
    ```
 
+## Extra Feature Flags
+
+*  OMR_SANITIZER={address,thread,undefined} turns on one: [Address Sanitizer
+   (ASan)][asan], [Undefined Behaviour Sanitizer (UBSan)][ubsan] or [Thread
+   Sanitizer (TSan)][tsan]. This only has an effect with GCC or Clang. 
+
+[ubsan]: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+[asan]: https://github.com/google/sanitizers/wiki/AddressSanitizer
+[tsan]: https://clang.llvm.org/docs/ThreadSanitizer.html 
+
 ## What's next?
 
 The work here is ongoing. We are tracking development with github issue


### PR DESCRIPTION
Some compiler systems (gcc and clang) support the notion of Runtime
Sanitizers. These are builds that are instrumented to flag bugs at
runtime. Sanitizers are nice because they typically have a very low
false positive rate, and as such, when an issue is flagged, it typically
can be relied on.
