### PR TITLE
Reset lastFreeEntry

### DIFF
--- a/gc/base/MemoryPoolAddressOrderedList.cpp
+++ b/gc/base/MemoryPoolAddressOrderedList.cpp
@@ -706,6 +706,7 @@ MM_MemoryPoolAddressOrderedList::reset(Cause cause)
 	clearHints();
 	_heapFreeList = (MM_HeapLinkedFreeHeader *)NULL;
 
+	_lastFreeEntry = NULL;
 	resetFreeEntryAllocateStats(_largeObjectAllocateStats);
 	resetLargeObjectAllocateStats();
 }

--- a/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
@@ -334,6 +334,7 @@ MM_MemoryPoolSplitAddressOrderedListBase::reset(Cause cause)
 		/* initialize frequent allocates for each free list based on cummulative large object stats for the pool */
 		resetFreeEntryAllocateStats(&_largeObjectAllocateStatsForFreeList[i]);
 	}
+	_lastFreeEntry = NULL;
 	resetFreeEntryAllocateStats(_largeObjectAllocateStats);
 	resetLargeObjectAllocateStats();
 }


### PR DESCRIPTION
On Global GCs reset _lastFreeEntry (to point to NULL) when AOL pool is
reset. The only user of this info is aborted GC handling in Concurrent
Scavenger, which will always be set this through compaction step that is
done as a part of Percolate GGC (in CS world). Still, for cleanness and
for future changes (if/when compaction is made an optional part of
Percolate GGC), this is correct to reset.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>