### PR TITLE
Fix Compare and Branch helper for unsigned comparisons

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3380,7 +3380,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
             case TR::Int16:
             case TR::Int8:
                constValue32 = getIntegralValue(constNode);
-               compareOpCode = TR::InstOpCode::C;
+               compareOpCode = isUnsignedCmp ? TR::InstOpCode::CL : TR::InstOpCode::C;
                break;
             default:
                TR_ASSERT(0, "generateS390CompareOps: Unexpected Type\n");


### PR DESCRIPTION
Unsigned comparison nodes such as ifbucmpgt can be
evaluated incorrectly if the data type of the second
child is LoadConstant and 8 or 16 bits. We generate a
signed comparison instruction instead of an unsigned
instruction. This commit fixes that by correctly generating
an unsigned comparison instruction if the comparison node
is also unsigned.

Closes: #1943
Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>