### PR TITLE
Move reserveNTrampolines to x86 CodeGenerator

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -674,7 +674,7 @@ static bool willNotInlineCompareAndSwapNative(TR::Node *node,
 #endif
    }
 
-   
+
 /** @brief Identify methods which are not transformed into inline assembly.
 
     Some recognized methods are transformed into very simple hardcoded
@@ -1948,7 +1948,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       int32_t numTrampolinesToReserve = self()->getPicSlotCount() - self()->comp()->getNumReservedIPICTrampolines();
       TR_ASSERT(numTrampolinesToReserve >= 0, "Discrepancy with number of IPIC trampolines to reserve getPicSlotCount()=%d getNumReservedIPICTrampolines()=%d",
          self()->getPicSlotCount(), self()->comp()->getNumReservedIPICTrampolines());
-      self()->comp()->fe()->reserveNTrampolines(self()->comp(), numTrampolinesToReserve, true);
+      self()->reserveNTrampolines(numTrampolinesToReserve);
       }
 
    self()->setBinaryBufferStart(temp);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -361,6 +361,15 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    int32_t branchDisplacementToHelperOrTrampoline(uint8_t *nextInstructionAddress, TR::SymbolReference *helper);
 
+   /*
+    * \brief Reserve space in the code cache for a specified number of trampolines.
+    *
+    * \param[in] numTrampolines : number of trampolines to reserve
+    *
+    * \return : none
+    */
+   void reserveNTrampolines(int32_t numTrampolines) { return; }
+
    // Note: This leaves the code aligned in the specified manner.
    TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
 


### PR DESCRIPTION
Migrate the function from the FrontEnd to the x86 CodeGenerator and
simplify its API.

Also, modify the one use of `reserveNTrampolines` to use the CodeGenerator
version.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>