### PR TITLE
Add runtime assumption with multiple patch sites

### DIFF
--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -264,6 +264,7 @@ const char * objectName[] =
    "TR_IPCCNode",
    "IPHashedCallSite",
    "Assumptions",
+   "PatchSites",
 
    "TR_ZHWProfiler",
    "TR_PPCHWProfiler",

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -412,6 +412,7 @@ public:
       IPCCNode,
       IPHashedCallSite,
       Assumption,
+      PatchSites,
 
       ZHWProfiler,
       PPCHWProfiler,

--- a/compiler/runtime/OMRRuntimeAssumptions.cpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.cpp
@@ -40,3 +40,107 @@ void TR::PatchNOPedGuardSite::compensate(bool isSMP, uint8_t *location, uint8_t 
    {
    _patchVirtualGuard(location, destination, isSMP);
    }
+
+TR::PatchSites::PatchSites(TR_PersistentMemory *pm, size_t maxSize) :
+    _maxSize(maxSize),
+    _size(0),
+    _refCount(0),
+    _patchPoints(NULL),
+    _firstLocation(NULL),
+    _lastLocation(NULL)
+   {
+   size_t bytes = sizeof(uint8_t*) * 2 * maxSize;
+   TR_ASSERT(maxSize == bytes/(sizeof(uint8_t*) * 2),  "Requested number of patch sites %d exceeds supported size\n", maxSize);
+   _patchPoints = (uint8_t**) pm->jitPersistentAlloc(bytes);
+   }
+
+/**
+ * Add a patch site to the collection.
+ */
+void TR::PatchSites::add(uint8_t *location, uint8_t *destination)
+   {
+   TR_ASSERT_FATAL(_size < _maxSize, "Cannot add more patch sites, max size is %d", _maxSize);
+   _patchPoints[_size * 2] = location;
+   _patchPoints[_size * 2 + 1] = destination;
+   _size++;
+
+   if (_firstLocation == NULL || location < _firstLocation)
+      _firstLocation = location;
+   if (_lastLocation == NULL || location > _lastLocation)
+      _lastLocation = location;
+   }
+
+/**
+ * Compare this collection with another.
+ * Will return true if both will patch the same locations, in the same order.
+ * Duplicate locations are also respected.
+ */
+bool TR::PatchSites::equals(PatchSites *other)
+   {
+   if (other->getSize() != _size)
+      return false;
+
+   if (_firstLocation != other->getFirstLocation() || _lastLocation != other->getLastLocation())
+      return false;
+
+   for (size_t i = 0; i < _size; ++i)
+      {
+      if (getLocation(i) != other->getLocation(i))
+         return false;
+      }
+   return true;
+   }
+
+/**
+ * Check if a location is contained within this collection.
+ */
+bool TR::PatchSites::containsLocation(uint8_t *location)
+   {
+   if (_firstLocation > location || _lastLocation < location)
+      return false;
+   return internalContainsLocation(location);
+   }
+
+bool TR::PatchSites::internalContainsLocation(uint8_t *location)
+   {
+   for (size_t i = 0; i < _size; ++i) 
+      {
+      if (getLocation(i) == location)
+         return true;
+      }
+   return false;
+   } 
+
+uint8_t *TR::PatchSites::getLocation(size_t index)
+   {
+   TR_ASSERT(index < _size, "Invalid index for patch site %d but size %d", index, _size);
+   return _patchPoints[index * 2];
+   }
+uint8_t *TR::PatchSites::getDestination(size_t index)
+   {
+   TR_ASSERT(index < _size, "Invalid index for patch site %d but size %d", index, _size);
+   return _patchPoints[index * 2 + 1];
+   }
+
+/**
+ * Functions to maintain reference counts from runtime assumptions.
+ * Each new runtime assumption using the list should call addReferences
+ * and should then call reclaim when the runtime assumption is being removed.
+ */
+void TR::PatchSites::addReference()
+   {
+   _refCount++;
+   TR_ASSERT(_refCount > 0, "Reference count overflow");
+   }
+
+void TR::PatchSites::reclaim(PatchSites *sites)
+   {
+   TR_ASSERT(sites->_refCount > 0, "Attempt to reclaim patch sites without a reference");
+   sites->_refCount--;
+
+   if (sites->_refCount == 0)
+      {
+      TR_PersistentMemory::jitPersistentFree(sites->_patchPoints);
+      TR_PersistentMemory::jitPersistentFree(sites);
+      }
+   }


### PR DESCRIPTION
Runtime assumptions incur a persistent memory
and runtime overhead. It is possible for assumptions
to require several patch sites in a method for the same
event. It is also possible for several events to require
the same set of patch sites.

This adds a runtime assumption capable of representing
such a situation with reduced overhead, by creating
a shared collection of patch sites.