### PR TITLE
Adding new Test cases to Tril

### DIFF
--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(comptest
 	CallTest.cpp
 	LongAndAsRotateTest.cpp
 	MockStrategyTest.cpp
+	LogicalTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/LogicalTest.cpp
+++ b/fvtest/compilertriltest/LogicalTest.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+
+#include "OpCodeTest.hpp"
+#include "default_compiler.hpp"
+
+int32_t ineg(int32_t l) {
+    return -l;
+}
+
+class Int32Logical : public TRTest::UnaryOpTest<int32_t> {}; 
+
+TEST_P(Int32Logical, UsingConst) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int32 (block (ireturn (%s (iconst %d) ) )))", param.opcode.c_str(), param.value);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)()>();
+    volatile auto exp = param.oracle(param.value);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
+}
+
+
+INSTANTIATE_TEST_CASE_P(LogicalTest, Int32Logical, ::testing::Combine(
+    ::testing::ValuesIn(TRTest::const_values<int32_t>()),
+    ::testing::Values(
+        std::make_tuple("ineg", ineg)
+        )));

--- a/fvtest/compilertriltest/LogicalTest.cpp
+++ b/fvtest/compilertriltest/LogicalTest.cpp
@@ -27,6 +27,13 @@ int32_t ineg(int32_t l) {
     return -l;
 }
 
+int32_t iabs(int32_t l) { 
+   if (l >= 0) 
+      return l;
+   else 
+      return -1 * l; 
+}
+
 class Int32Logical : public TRTest::UnaryOpTest<int32_t> {}; 
 
 TEST_P(Int32Logical, UsingConst) {
@@ -52,5 +59,6 @@ TEST_P(Int32Logical, UsingConst) {
 INSTANTIATE_TEST_CASE_P(LogicalTest, Int32Logical, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_values<int32_t>()),
     ::testing::Values(
-        std::make_tuple("ineg", ineg)
+        std::make_tuple("ineg", ineg),
+        std::make_tuple("iabs", iabs)
         )));

--- a/fvtest/compilertriltest/OpCodeTest.hpp
+++ b/fvtest/compilertriltest/OpCodeTest.hpp
@@ -43,6 +43,27 @@ struct BinaryOpParamStruct {
         Ret (*oracle)(Left, Right);
 };
 
+// C++11 upgrade (Issue #1916).
+template <typename Ret, typename T>
+struct UnaryOpParamStruct {
+        T value;
+        std::string opcode;
+        Ret (*oracle)(T);
+};
+
+
+/**
+ * @brief Given an instance of UnaryOpParamType, returns an equivalent instance
+ *    of UnaryOpParamStruct
+ */
+template <typename Ret, typename T>
+UnaryOpParamStruct<Ret, T> to_struct(std::tuple<T , std::tuple<std::string, Ret (*)(T)>> param) {
+    UnaryOpParamStruct<Ret, T> s;
+    s.value  = std::get<0>(param);
+    s.opcode = std::get<0>(std::get<1>(param));
+    s.oracle = std::get<1>(std::get<1>(param));
+    return s;
+}
 /**
  * @brief Given an instance of BinaryOpParamType, returns an equivalent instance
  *    of BinaryOpParamStruct
@@ -64,6 +85,10 @@ class OpCodeTest : public JitTest, public ::testing::WithParamInterface< std::tu
 
 template <typename T>
 class BinaryOpTest : public JitTest, public ::testing::WithParamInterface< std::tuple< std::tuple<T,T>, std::tuple<std::string, T (*)(T,T)>> > {};
+
+template <typename T>
+class UnaryOpTest : public JitTest, public ::testing::WithParamInterface< std::tuple< T , std::tuple<std::string, T (*)(T)>> > {};
+
 
 } // namespace CompTest
 


### PR DESCRIPTION
New test cases for unary opcodes `iabs` and `ineg`. 