### PR TITLE
The std::map value pairs have const keys

### DIFF
--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -199,7 +199,7 @@ bool collectSymbolReferencesInNode(TR::Node *node,
    return true;
    }
 
-typedef std::pair<TR::Node*, int32_t> LPEntry;
+typedef std::pair<TR::Node* const, int32_t> LPEntry;
 typedef TR::typed_allocator<LPEntry, TR::Region&> LPAlloc;
 typedef std::map<TR::Node*, int32_t, std::less<TR::Node*>, LPAlloc> LongestPathMap;
 

--- a/compiler/optimizer/Structure.cpp
+++ b/compiler/optimizer/Structure.cpp
@@ -214,7 +214,7 @@ class TR_RegionStructure::ExitExtraction
    typedef TR::typed_allocator<TR::CFGEdge*, TR::Region&> EdgeVecAlloc;
    typedef std::vector<TR::CFGEdge*, EdgeVecAlloc> EdgeVec;
 
-   typedef std::pair<TR_RegionStructure*, TR_BitVector> RcEntry;
+   typedef std::pair<TR_RegionStructure* const, TR_BitVector> RcEntry;
    typedef TR::typed_allocator<RcEntry, TR::Region&> RcAlloc;
    typedef std::less<TR_RegionStructure*> RcCmp;
    typedef std::map<TR_RegionStructure*, TR_BitVector, RcCmp, RcAlloc> RegionContents;


### PR DESCRIPTION
Update two places where we're creating an allocator that allocates the wrong type. On recent mac OS versions, this fixes a compilation failure.

Signed-off-by: Robert Young <rwy0717@gmail.com>