### PR TITLE
Remove deprecated OMR::Compilation::nodeNeeds2Regs()

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -179,11 +179,6 @@ OMR::Compilation::getHotnessName(TR_Hotness h)
    return pHotnessNames[h];
    }
 
-bool OMR::Compilation::nodeNeeds2Regs(TR::Node*node)
-   {
-   return node->requiresRegisterPair(self());
-   }
-
 
 static TR::CodeGenerator * allocateCodeGenerator(TR::Compilation * comp)
    {
@@ -636,7 +631,7 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNo
    if (self()->isOSRTransitionTarget(TR::postExecutionOSR))
       {
       if (node->getOpCodeValue() == TR::treetop || node->getOpCode().isCheck())
-         node = node->getFirstChild(); 
+         node = node->getFirstChild();
 
       if (_osrInfrastructureRemoved && !ignoreInfra)
          potentialOSRPoint = false;
@@ -769,7 +764,7 @@ OMR::Compilation::getOSRInductionOffset(TR::Node *node)
    // If no induction after the OSR point, offset must be 0
    if (!self()->isOSRTransitionTarget(TR::postExecutionOSR))
       return 0;
-   
+
    TR::Node *osrNode;
    if (!self()->isPotentialOSRPoint(node, &osrNode))
       {
@@ -2289,7 +2284,7 @@ OMR::Compilation::getOSRCallSiteRematSize(uint32_t callSiteIndex)
    }
 
 /*
- * Get the pending push symbol reference and the corresponding load, to later remat the pending push 
+ * Get the pending push symbol reference and the corresponding load, to later remat the pending push
  * within OSR code blocks inside the callee. To get a mapping, the call site index for the callee and
  * the caller's pending push slot should be provided.
  */

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -31,7 +31,7 @@ namespace OMR { class Compilation; }
 namespace OMR { typedef OMR::Compilation CompilationConnector; }
 #endif
 
-/** 
+/**
  * \file OMRCompilation.hpp
  * \brief Header for OMR::Compilation, root of the Compilation extensible class hierarchy.
  */
@@ -158,10 +158,10 @@ enum CompilationReturnCodes
 #endif
 
 /**
- * \def performTransformation(comp, msg, ...) 
+ * \def performTransformation(comp, msg, ...)
  *
  * \brief Macro that is used to guard optional steps in compilation in order to
- *        aid debuggability  
+ *        aid debuggability
  *
  *
  * Ostensibly, the purpose of performTransformation is to allow code
@@ -169,37 +169,37 @@ enum CompilationReturnCodes
  * isolate a buggy optimization. But this description fails to capture the
  * important effect that performTransformation has on the maintainability of
  * Testarossa’s code base.
- * 
+ *
  * Calls to performTransformation can (and should) be placed around any part of
  * the code that is optional; in an optimizer, that’s a lot of code. Tons of
  * Testarossa code is there only to improve performance–not for correctness–and
  * can therefore be guarded by performTransformation.
- * 
+ *
  * A call in a hypothetical dead code elimination might look like this:
- * 
+ *
  *     if (performTransformation2c(comp(),
  *           "%sDeleting dead candidate [%p]\n", OPT_DETAILS, candidate->_node))
  *        {
- *        // Logic to delete some dead code. 
+ *        // Logic to delete some dead code.
  *        }
- * 
+ *
  * When this opt runs on a method that is being logged, all calls to
  * performTransformation will be assigned a unique number. Running the test
  * case with lastOptTransformationIndex=n will prevent subsequent
  * transformations from occurring. By adjusting n and observing when the test
  * passes and fails, it is possible to narrow down the failing transformation
  * using a binary-search approach.
- * 
+ *
  * But beyond just allowing this opt to be enabled and disabled, this idiom
  * also does the following:
- * 
+ *
  *  -  It describes what the code does without needing a comment
  *  -  It reports the transformation in the log
  *  -  It gives people unfamiliar with the opt a way to locate the code that
  *     caused a particular transformation
  *  -  Combined with countOptTransformations, it allows you to locate methods
  *     in which this opt is occurring
- * 
+ *
  * Most importantly, it identifies exactly the code that should be skipped if
  * someone wanted to prevent this opt from occurring in certain cases. Even if
  * you know nothing about an optimization, you can locate its
@@ -208,7 +208,7 @@ enum CompilationReturnCodes
  * the optimization in some undefined state. The author of the optimization
  * has identified this code as “skippable”, so you can be fairly certain that
  * skipping it will do just what you want.
- * 
+ *
  * If you are developing code that has optional parts, it is strongly
  * recommended to guard them with performTransformation. It is likely to help
  * you debug your code immediately, and will certainly help people after you to
@@ -502,8 +502,6 @@ public:
    // ==========================================================================
    // Should be in Code Generator
    //
-   bool nodeNeeds2Regs(TR::Node * node);
-
    // J9
    int32_t getNumReservedIPICTrampolines() const { return _numReservedIPICTrampolines; }
    void setNumReservedIPICTrampolines(int32_t n) { _numReservedIPICTrampolines = n; }
@@ -722,7 +720,7 @@ public:
    bool isRecompilationEnabled() { return false; }
 
    int32_t getOptLevel();
- 
+
    TR_Hotness getNextOptLevel() { return _nextOptLevel; }
    void setNextOptLevel(TR_Hotness nextOptLevel) { _nextOptLevel = nextOptLevel; }
    TR_Hotness getMethodHotness();


### PR DESCRIPTION
This function was deprecated by e6d4b6e3c4d4d1d6e7fd5c4e708c195b24026212 and
cleaned up in all known downstream projects.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>