### PR TITLE
Fix OSR liveness to include parms

### DIFF
--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -1305,7 +1305,9 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
 
    if (node->getOpCode().isStoreDirect())
       {
-      TR::AutomaticSymbol *local = node->getSymbolReference()->getSymbol()->getAutoSymbol();
+      TR::RegisterMappedSymbol *local = node->getSymbolReference()->getSymbol()->getAutoSymbol();
+      if (!local)
+         local = node->getSymbolReference()->getSymbol()->getParmSymbol();
       if (local && !local->isLiveLocalIndexUninitialized())
          {
          int32_t localIndex = local->getLiveLocalIndex();
@@ -1326,7 +1328,10 @@ void TR_OSRLiveRangeAnalysis::maintainLiveness(TR::Node *node,
       }
    else if (node->getOpCode().isLoadVarDirect() || node->getOpCodeValue() == TR::loadaddr)
       {
-      TR::AutomaticSymbol *local = node->getSymbolReference()->getSymbol()->getAutoSymbol();
+      TR::RegisterMappedSymbol *local = node->getSymbolReference()->getSymbol()->getAutoSymbol();
+      if (!local)
+         local = node->getSymbolReference()->getSymbol()->getParmSymbol();
+ 
       if (local && !local->isLiveLocalIndexUninitialized())
          {
          int32_t localIndex = local->getLiveLocalIndex();


### PR DESCRIPTION
When finding the killing or gening symbols, the maintainLiveness
function should get the parm symbols in addition to auto symbols.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>