### PR TITLE
Add support for detecting docker container

### DIFF
--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -261,7 +261,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_cgroup_get_enabled_subsystems, /* sysinfo_cgroup_get_enabled_subsystems */
 	omrsysinfo_cgroup_enable_subsystems, /* sysinfo_cgroup_enable_subsystems */
 	omrsysinfo_cgroup_are_subsystems_enabled, /* sysinfo_cgroup_are_subsystems_enabled */
-	omrsysinfo_cgroup_get_memlimit, /* sysinfo_cgroup_get_memlimit */	
+	omrsysinfo_cgroup_get_memlimit, /* sysinfo_cgroup_get_memlimit */
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -902,6 +902,7 @@ omrsysinfo_cgroup_are_subsystems_enabled(struct OMRPortLibrary *portLibrary, uin
  * omrsysinfo_cgroup_enable_limits() before calling this function.
  * When the fuction returns OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM,
  * value of *limits is unspecified.
+ * Note that 'limit' parameter must not be NULL.
  *
  * @param[in] portLibrary pointer to OMRPortLibrary
  * @param[out] limit pointer to uint64_t which successful return contains memory limit imposed by cgroup


### PR DESCRIPTION
Add support in port library for detecting if we are running in
docker container or not.
This is required for cgroup related APIs in port library,
such as `omrsysinfo_cgroup_get_memlimit`, to work properly.
This is because when running in a docker container,
the cgroups listed in `/proc/self/cgroup` do not match the cgroups
of the process in the container. `/proc/self/cgroup` actually
shows the cgroups as seen from the host.

Eg if a process is running in a docker container,
its `/proc/PID/cgroup` on docker will show something like:
```
$ cat /proc/8364/cgroup
11:cpuset:/docker/<container id>
10:perf_event:/docker/<container id>
9:memory:/dockera/<container id>
...
```

but the actual cgroup of the process would be "/".

Once we figure out that we are running in docker container,
then cgroup APIs in port library should use "/" as cgroup name
for reading resource limits.

Note that as and when docker containers start supporting
cgroup namespace, then above mentioned mismatch would also be fixed.
Following issues and PRs are related to adding support for
cgroup namespace in docker container:
https://github.com/opencontainers/runc/pull/1184
https://github.com/opencontainers/runtime-spec/issues/62
https://github.com/opencontainers/runtime-spec/issues/66

There is no direct mechanism to detect if we are running in
docker container.
Most reliable mechanism that I have come across is
by checking the cgroup for PID 1 (by reading `/proc/1/cgroup` file)
for all subsystems. If all cgroups are "/", then it indicates the
process is running on host system.
Else we conclude it to be running in a docker container.
Note that this mechanism will break when docker containers start
supporting cgroup namespace.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>