### PR TITLE
Remove FrontEnd implementation of reserveNTrampolines

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -406,9 +406,3 @@ TR_FrontEnd::needsMethodTrampolines()
    return 0;
    }
 
-
-void
-TR_FrontEnd::reserveNTrampolines(TR::Compilation *, int32_t n, bool inBinaryEncoding)
-   {
-   notImplemented("reserveNTrampolines");
-   }

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -228,7 +228,6 @@ public:
    virtual void unreserveCodeCache(TR::CodeCache *codeCache) { TR_ASSERT(0, "This method needs to be implemented"); }
    virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation* comp); // MCT
    virtual void reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);
-   virtual void reserveNTrampolines(TR::Compilation *, int32_t n, bool inBinaryEncoding);
    virtual intptrj_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void * callSite);
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void * callSite); // No TR::Compilation parameter so this can be called from runtime code
    virtual bool needsMethodTrampolines();


### PR DESCRIPTION
Subsumed by the CodeGenerator implementation.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>