### PR TITLE
Add a query for targeted inlining

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -5422,17 +5422,11 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
    updateCallersFlags(callerSymbol, calleeSymbol, _optimizer);
 
 
-   if (calleeSymbol->getMethod()->isArchetypeSpecimen() || calleeSymbol->hasMethodHandleInvokes())
+   if (getUtil()->needTargetedInlining(calleeSymbol))
       {
-      // Trees from archetype specimens may not match the archetype method's bytecodes,
-      // so there may be some calls things that inliner missed.
-      //
-      // Tactically, we also inline again based on hasMethodHandleInvokes because EstimateCodeSize
-      // doesn't yet cope with invokeHandle, invokeHandleGeneric, and invokeDynamic (but it should).
-      //
       _optimizer->setRequestOptimization(OMR::methodHandleInvokeInliningGroup);
       if (comp()->trace(OMR::inlining))
-         heuristicTrace(tracer(),"Requesting another pass of MethodHandle invoke inlining due to %s\n", tracer()->traceSignature(calleeSymbol));
+         heuristicTrace(tracer(),"Requesting another pass of targeted inlining due to %s\n", tracer()->traceSignature(calleeSymbol));
       }
 
    // Append the callee's catch block to the end of the caller
@@ -6374,6 +6368,12 @@ TR_PrexArgInfo *
 OMR_InlinerUtil::computePrexInfo(TR_CallTarget *target)
    {
    return NULL;
+   }
+
+bool
+OMR_InlinerUtil::needTargetedInlining(TR::ResolvedMethodSymbol *callee)
+   {
+   return false;
    }
 
 void

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -538,6 +538,30 @@ class OMR_InlinerUtil : public TR::OptimizationUtil, public OMR_InlinerHelper
       virtual void adjustMethodByteCodeSizeThreshold(TR::ResolvedMethodSymbol *callSymbol, int &methodByteCodeSizeThreshold){ return; }
       virtual TR_PrexArgInfo *computePrexInfo(TR_CallTarget *target);
       virtual void collectCalleeMethodClassInfo(TR_ResolvedMethod *calleeMethod);
+
+      /**
+       * \brief
+       *    Check if another pass of targeted inlining is needed if the given method is inlined.
+       *
+       * \parm callee
+       *    The method symbol of the callee.
+       *
+       * \return
+       *    True if another pass of targeted inlining is needed, otherwise false.
+       *
+       * \note
+       *    Targeted inlining is meant to deal with method call chains where the receiver of current call stores the information
+       *    of the next call, which is usually the receiver or the method of the next call. Knowing the receiver of the first call
+       *    means we can devirtualize all the calls along the chain.
+       *
+       *    Each method except the last one in the chain usually contains simple code that manipulates the arguments for the next
+       *    call. The last method in the chain is usually the most important one, it does the real job and can contain arbitrary
+       *    code.
+       *
+       *    The goal of targeted inlining is to inline along the call chain to get the most important method inlined, which is the
+       *    last one in the chain. It does not care about other callsites.
+       */
+      virtual bool needTargetedInlining(TR::ResolvedMethodSymbol *callee);
    protected:
       virtual bool validateInterfaceImplementation(TR_ResolvedMethod *interfaceMethod);
       virtual void refineColdness (TR::Node* node, bool& isCold);


### PR DESCRIPTION
Add an extension point in InlinerUtil to answer whether targeted
inlining is needed for a method after it is inlined.

Signed-off-by: liqunl <liqunl@ca.ibm.com>