### PR TITLE
Modify makefile rules for zOS

### DIFF
--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -36,7 +36,6 @@ endif
 
 # Enable Debugging Symbols
 ifeq ($(OMR_DEBUG),1)
-  GLOBAL_FLAGS+=-Wc,g9
 endif
 
 # Enable Optimizations
@@ -70,9 +69,7 @@ GLOBAL_CPPFLAGS+=-DJ9ZOS390 -DLONGLONG -DJ9VM_TIERED_CODE_CACHE -D_ALL_SOURCE -D
 # a,goff   Assemble into GOFF object files
 # NOANSIALIAS Do not generate ALIAS binder control statements
 # TARGET   Generate code for the target operating system
-# list     Generate assembly listing
-# offset   In assembly listing, show addresses as offsets of function entry points
-GLOBAL_FLAGS+=-Wc,xplink,convlit\(ISO8859-1\),rostring,FLOAT\(IEEE,FOLD,AFP\),enum\(4\) -Wa,goff -Wc,NOANSIALIAS -Wc,TARGET\(zOSV1R13\) -W "c,list,offset"
+GLOBAL_FLAGS+=-Wc,xplink,convlit\(ISO8859-1\),rostring,FLOAT\(IEEE,FOLD,AFP\),enum\(4\) -Wa,goff -Wc,NOANSIALIAS -Wc,TARGET\(zOSV1R13\)
 
 ifeq (1,$(OMR_ENV_DATA64))
   GLOBAL_CPPFLAGS+=-DJ9ZOS39064
@@ -114,17 +111,6 @@ ifeq (1,$(DO_LINK))
     GLOBAL_SHARED_LIBS+=j9a2e
   endif
 endif
-
-
-# compilation for C files.
-define COMPILE_C_COMMAND
-$(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) $(GLOBAL_CFLAGS) $(MODULE_CFLAGS) $(CFLAGS) -c $< -o $@ > $*.asmlist
-endef
-
-# compilation for C++ files.
-define COMPILE_CXX_COMMAND
-$(CXX) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) $(GLOBAL_CXXFLAGS) $(MODULE_CXXFLAGS) $(CXXFLAGS) -c $< -o $@ > $*.asmlist
-endef
 
 # compilation for metal-C files.
 ifeq (1,$(OMR_ENV_DATA64))


### PR DESCRIPTION
Currently the OMR zOS makefiles require that a user sets a few 
evnironment variables that control the placement of compile
options. This change uses the default placement of compile options
so that the environment variables are not required.

Remove the LIST option since we do not need to generate the 
assembly listing to stdout.

This change also removes the -g9 option that was added for
generating debug information since it is not valid.

[ci skip] - on zOS changes

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>