### PR TITLE
Remove unused Linkage function

### DIFF
--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,8 +82,6 @@ class OMR_EXTENSIBLE Linkage
    virtual TR_RegisterKinds argumentRegisterKind(TR::Node *argumentNode);
 
    virtual bool useCachedStaticAreaAddresses(TR::Compilation *c) { return false; }
-
-   virtual bool isPointerToPrivateStaticAddress(TR::SymbolReference *ref) { return false; }
 
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
       {


### PR DESCRIPTION
Member function `isPointerToPrivateStaticAddress` is not overridden or used
in any known project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>