### PR TITLE
Remove asARMMemoryReference virtual from MemoryReference

### DIFF
--- a/compiler/codegen/OMRMemoryReference.hpp
+++ b/compiler/codegen/OMRMemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,6 @@ namespace OMR { typedef OMR::MemoryReference MemoryReferenceConnector; }
 #include "infra/Annotations.hpp"  // for OMR_EXTENSIBLE
 
 namespace TR { class MemoryReference; }
-class TR_ARMMemoryReference;
 
 namespace OMR
 {
@@ -47,8 +46,6 @@ class OMR_EXTENSIBLE MemoryReference
    TR_ALLOC(TR_Memory::MemoryReference)
 
    TR::MemoryReference *self();
-
-   virtual TR_ARMMemoryReference  *asARMMemoryReference()  { return 0; }
 
    protected:
    MemoryReference() {};


### PR DESCRIPTION
The function is not used and doesn't belong in the base class.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>