### PR TITLE
Remove deprecated isAddressOfStaticSymRef from Linkage

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1583,13 +1583,6 @@ OMR::CodeGenerator::nodeMatches(TR::Node *addr1, TR::Node *addr2, bool addresses
       {
       foundMatch = true;
       }
-   else if (addr1->getOpCodeValue() == TR::aload && addr2->getOpCodeValue() == TR::aload &&
-            self()->getLinkage()->isAddressOfStaticSymRef(addr1->getSymbolReference()) &&
-            self()->getLinkage()->isAddressOfStaticSymRef(addr2->getSymbolReference()) &&
-            addr1->getSymbolReference() == addr2->getSymbolReference())
-      {
-      foundMatch = true;
-      }
    else if (addressesUnderSameTreeTop &&
             addr1->getOpCodeValue() == TR::i2a && addr2->getOpCodeValue() == TR::i2a &&
             addr1->getFirstChild()->getOpCode().isLoadVarDirect() &&

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -98,8 +98,6 @@ class OMR_EXTENSIBLE Linkage
       {
       return NULL;
       }
-
-   virtual bool isAddressOfStaticSymRef(TR::SymbolReference *) { return false; }
 
    virtual bool mapPreservedRegistersToStackOffsets(int32_t *mapRegsToStack, int32_t &numPreserved, TR_BitVector *&) { return false; }
    virtual TR::Instruction *savePreservedRegister(TR::Instruction *cursor, int32_t regIndex, int32_t offset)    {return NULL; }

--- a/compiler/codegen/StorageInfo.cpp
+++ b/compiler/codegen/StorageInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -125,14 +125,6 @@ TR_StorageInfo::populateAddress(TR::Node *address)
             {
             _class = TR_DirectMappedStatic;
             _offset += _symRef->getOffset();
-            }
-         }
-      else if (_address->getOpCodeValue() == TR::aload && _symRef->getOffset() == 0)
-         {
-         if (comp()->cg()->getLinkage()->isAddressOfStaticSymRef(_symRef))
-            {
-            // the base address of the static area has been cached in _symRef and is being loaded here with an aload
-            _class = TR_StaticBaseAddress;
             }
          }
       }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2166,12 +2166,6 @@ refCanBeKilled(TR::Node *node, TR::Compilation *comp)
       return false;
       }
 
-   if (node->getOpCodeValue() == TR::aload &&
-       comp->cg()->getLinkage()->isAddressOfStaticSymRef(node->getSymbolReference()))
-      {
-      return false;
-      }
-
    if (node->getOpCode().isLoadConst() && !node->anchorConstChildren())
       {
       return false;
@@ -4755,7 +4749,7 @@ OMR::Node::setArrayComponentClassInNode(TR_OpaqueClassBlock *c)
 TR::ILOpCodes
 OMR::Node::setOverflowCheckOperation(TR::ILOpCodes op)
    {
-   TR_ASSERT(self()->getOpCode().isOverflowCheck(), 
+   TR_ASSERT(self()->getOpCode().isOverflowCheck(),
              "set OverflowCHK operation info for no OverflowCHK node");
    return _unionBase._extension.getExtensionPtr()->setElem<TR::ILOpCodes>(3, op);
    }
@@ -4763,7 +4757,7 @@ OMR::Node::setOverflowCheckOperation(TR::ILOpCodes op)
 TR::ILOpCodes
 OMR::Node::getOverflowCheckOperation()
    {
-   TR_ASSERT(self()->getOpCode().isOverflowCheck(), 
+   TR_ASSERT(self()->getOpCode().isOverflowCheck(),
    	     "get OverflowCHK operation info for no OverflowCHK node");
    return _unionBase._extension.getExtensionPtr()->getElem<TR::ILOpCodes>(3);
    }
@@ -7517,7 +7511,7 @@ bool
 OMR::Node::isNopableInlineGuard()
    {
    TR::Compilation * c = TR::comp();
-   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() && 
+   return self()->isTheVirtualGuardForAGuardedInlinedCall() && !self()->isProfiledGuard() &&
       !(self()->isBreakpointGuard() && c->getOption(TR_DisableNopBreakpointGuard));
    }
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1653,8 +1653,8 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
       // makes these for us
       if (failedArgs.size() > 0)
          {
-         RematTools::walkTreeTopsCalculatingRematFailureAlternatives(comp(), 
-            block1->getFirstRealTreeTop(), 
+         RematTools::walkTreeTopsCalculatingRematFailureAlternatives(comp(),
+            block1->getFirstRealTreeTop(),
             tif.getParameterMapper().firstTempTreeTop()->getNextTreeTop(),
             failedArgs, scanTargets, argSafetyInfo, tracer()->debugLevel());
 
@@ -1678,8 +1678,8 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
       TR::SparseBitVector unsafeSymRefs(comp()->allocator());
       if (!scanTargets.IsZero())
          {
-         RematTools::walkTreesCalculatingRematSafety(comp(), block1->getFirstRealTreeTop(), 
-            tif.getParameterMapper().lastTempTreeTop()->getNextTreeTop(), 
+         RematTools::walkTreesCalculatingRematSafety(comp(), block1->getFirstRealTreeTop(),
+            tif.getParameterMapper().lastTempTreeTop()->getNextTreeTop(),
             scanTargets, unsafeSymRefs, tracer()->debugLevel());
          }
 
@@ -3103,10 +3103,6 @@ TR_HandleInjectedBasicBlock::createTemps(bool replaceAllReferences)
          {
          ref->_isConst = true;
          }
-      else if (opcode.getOpCodeValue() == TR::aload && comp()->cg()->getLinkage()->isAddressOfStaticSymRef(ref->_node->getSymbolReference()))
-         {
-         ref->_isConst = true;
-         }
       else
          {
          TR::SymbolReference * symRef = 0;
@@ -3138,7 +3134,7 @@ TR_HandleInjectedBasicBlock::createTemps(bool replaceAllReferences)
             if (tt->getNode()->getOpCode().isBranch() || tt->getNode()->getOpCode().isSwitch())
                tt = tt->getPrevTreeTop();
 
-            // If this treetop is an OSR point, a store cannot be placed between it and the 
+            // If this treetop is an OSR point, a store cannot be placed between it and the
             // transition treetop in postExecutionOSR
             if (comp()->isPotentialOSRPoint(tt->getNode()))
                tt = comp()->getMethodSymbol()->getOSRTransitionTreeTop(tt);
@@ -5124,7 +5120,7 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
        && (tif->resultNode() == NULL || tif->resultNode()->getReferenceCount() == 0))
       {
       /**
-       * In OSR, we need to split block even for cases without virtual guard. This is 
+       * In OSR, we need to split block even for cases without virtual guard. This is
        * because in OSR a block with OSR point must have an exception edge to the osrCatchBlock
        * of correct callerIndex. Split the block here so that the OSR points from callee
        * and from caller are separated.

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -576,7 +576,6 @@ OMR::Optimization::nodeIsOrderDependent(TR::Node *node, uint32_t depth, bool has
    // should only be used as a heuristic for optimizations.
    bool constNeedsAnchor = node->getOpCode().isLoadConst() && node->anchorConstChildren();
    return ((node->getOpCode().isLoad() && node->getOpCode().hasSymbolReference() &&
-            !(cachedStaticReg && node->getOpCodeValue() == TR::aload && linkage->isAddressOfStaticSymRef(node->getSymbolReference())) &&
             ((node->getReferenceCount() > 1) || hasCommonedAncestor)) ||
            ((!node->getOpCode().isLoadConst() || constNeedsAnchor) && depth >= MAX_DEPTH_FOR_SMART_ANCHORING));
 }

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -288,7 +288,7 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
 
    //  traceMsg(comp(), "Growing useDefInfo to %d\n",getNumUseNodes());
    _useDefInfo.resize(getNumUseNodes(), TR_UseDefInfo::BitVector(comp()->allocator(allocatorName)));
-   //   for (i = getNumUseNodes()-1; i >= 0; --i)        
+   //   for (i = getNumUseNodes()-1; i >= 0; --i)
    //      _useDefInfo[i].GrowTo(getNumDefNodes());
    _isUseDefInfoValid = true;
 
@@ -723,8 +723,7 @@ bool TR_UseDefInfo::isValidAutoOrParm(TR::SymbolReference *symRef)
    symRef->getUseonlyAliases().getAliases(useOnlyAliases);
 
    return  (useDefAliases.PopulationCount() == 1 &&
-            useOnlyAliases.PopulationCount() == 1 &&
-            !comp()->cg()->getLinkage()->isAddressOfStaticSymRef(symRef));
+            useOnlyAliases.PopulationCount() == 1);
    }
 
 bool TR_UseDefInfo::excludedGlobals(TR::Symbol *sym)


### PR DESCRIPTION
Remove the function definition and uses and fold surrounding code
assuming it always returns false.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>