### PR TITLE
Remove OpenJ9-specific CodeGenerator function

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -593,10 +593,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    uint8_t getSizeOfCombinedBuffer() {return 0;} // no virt, default
 
-   // The number of nodes we want between a monexit and the next monent before transforming a monitored region with
-   // transactional lock elision.
-   int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 15; } // no virt, default
-
    bool doRematerialization() {return false;} // no virt, default
 
    // --------------------------------------------------------------------------

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -727,13 +727,6 @@ public:
 
    bool doRematerialization() {return true;}
 
-   /**
-    * The number of nodes we want between a monexit and the next monent before transforming a monitored region with
-    * transactional lock elision.  On Z, we require 25-30 cycles between transactions, or else the latter transaction will
-    * be aborted (with significant penalty).  The 45 is an estimate based on CPI of 1.5-2, and average of 1 instruction per node.
-    */
-   int32_t getMinimumNumberOfNodesBetweenMonitorsForTLE() { return 45; }
-
    void dumpDataSnippets(TR::FILE *outFile);
    void dumpTargetAddressSnippets(TR::FILE *outFile);
 


### PR DESCRIPTION
`OMR::CodeGenerator` function `getMinimumNumberOfNodesBetweenMonitorsForTLE`
has been relocated to the OpenJ9 project.  Delete it from OMR.

Closes: #2061 

Signed-off-by: Daryl Maier <maier@ca.ibm.com>