### PR TITLE
Remove tracking of instruction selection phase from OMR::Z::CodeGenerator

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1472,10 +1472,7 @@ OMR::Z::CodeGenerator::endInstructionSelection()
 void
 OMR::Z::CodeGenerator::doInstructionSelection()
    {
-   self()->setDoingInstructionSelection(true);
    OMR::CodeGenerator::doInstructionSelection();
-   self()->setDoingInstructionSelection(false);
-
    if (_returnTypeInfoInstruction != NULL)
       {
       _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(self()->comp()->getReturnInfo()));

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1220,7 +1220,7 @@ protected:
       {
       // Available                       = 0x00000001,
       S390CG_extCodeBaseRegisterIsFree   = 0x00000002,
-      S390CG_doingInstructionSelection   = 0x00000004,
+      // Available                       = 0x00000004,
       S390CG_addStorageReferenceHints    = 0x00000008,
       S390CG_isOutOfLineHotPath          = 0x00000010,
       S390CG_literalPoolOnDemandOnRun    = 0x00000020,

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -956,10 +956,6 @@ public:
    // Snippet Data functions
    void addDataConstantSnippet(TR::S390ConstantDataSnippet * snippet);
 
-   // Identify the Inst selection phase
-   bool getDoingInstructionSelection() { return _cgFlags.testAny(S390CG_doingInstructionSelection); }
-   void setDoingInstructionSelection(bool b) { _cgFlags.set(S390CG_doingInstructionSelection, b); }
-
    // Target Address List functions
    int32_t setEstimatedOffsetForTargetAddressSnippets();
    int32_t setEstimatedLocationsForTargetAddressSnippetLabels(int32_t estimatedSnippetStart);

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -136,7 +136,7 @@ void OMR::Z::MemoryReference::addToTemporaryNegativeOffset(TR::Node *node, int32
 void OMR::Z::MemoryReference::setupCheckForLongDispFlag(TR::CodeGenerator *cg)
    {
    // Enable a check for the long disp slot in generateBin phase
-   if (cg->getDoingInstructionSelection())
+   if (cg->getCodeGeneratorPhase() == TR::CodeGenPhase::InstructionSelectionPhase)
       {
       self()->setCheckForLongDispSlot();
       }


### PR DESCRIPTION
Remove instruction selection phase tracking in OMR::Z::CodeGenerator and use getCodeGeneratorPhase() instead

Closes #2065
Signed-off-by: Shivam Mittal <shivammittal99@gmail.com>