### PR TITLE
Add hasSlotSharingOrDeadSlotsInfo to OSRMethodData

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -779,6 +779,13 @@ TR_OSRMethodData::getArgInfo(int32_t byteCodeIndex)
    return args;
    }
 
+
+bool
+TR_OSRMethodData::hasSlotSharingOrDeadSlotsInfo()
+   {
+   return !bcInfoHashTab.IsEmpty();
+   }
+
 /*
  * Add pending push live range info for a BCI.
  *

--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -278,6 +278,7 @@ class TR_OSRMethodData
    void addSlotSharingInfo(int32_t byteCodeIndex,
                            int32_t slot, int32_t symRefNum, int32_t symRefOrder, int32_t symSize, bool takesTwoSlots);
    void ensureSlotSharingInfoAt(int32_t byteCodeIndex);
+   bool hasSlotSharingOrDeadSlotsInfo();
    void addInstruction(int32_t instructionPC, int32_t byteCodeIndex);
 
    int32_t getHeaderSize() const;


### PR DESCRIPTION
Add this API to query whether there is information about slots sharing or dead slots stored in OSRMethodData