### PR TITLE
Improve the code cache allocation process on Linux

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -369,6 +369,13 @@ typedef struct J9PortVmemParams {
 	 *  		- enabled for Linux only,
 	 *  		- If not set, search memory in linear scan method
 	 *  		- If set, scan memory in a quick way, using memory information in file /proc/self/maps. (still use linear search if failed)
+	 * \arg OMRPORT_VMEM_ADDRESS_HINT
+	 *		- enabled for Linux and default pages only,
+	 *		- If not set, search memory page by page until address is within desired range
+	 *		- If set, return whatever mmap gives us
+	 *		- this option is based on the observation that mmap would take the preferred address as a hint about where to place the mapping
+	 *		- therefore instead of trying page after page to allocate in the desired region, we stop after the first attempt and return whatever default_pageSize_reserver_memory() gives us as it might give us an address that's good enough
+	 *
 	 */
 	uintptr_t options;
 
@@ -399,6 +406,7 @@ typedef enum J9VMemMemoryQuery {
 #define OMRPORT_VMEM_ZOS_USE2TO32G_AREA 16
 #define OMRPORT_VMEM_ALLOC_QUICK 		32
 #define OMRPORT_VMEM_ZTPF_USE_31BIT_MALLOC 64
+#define OMRPORT_VMEM_ADDRESS_HINT 128
 
 /**
  * @name Virtual Memory Address


### PR DESCRIPTION
On the OMR side: add a new Virtual Memory Option called OMRPORT_VMEM_ADDRESS_HINT
Change the method getMemoryInRangeForDefaultPages() to do the following:
	- when OMRPORT_VMEM_ADDRESS_HINT is used, instead of trying page by page to allocate in the desired region, we stop after the first attempt and return whatever default_pageSize_reserve_memory() gives us
	- when doing OMRPORT_VMEM_ALLOC_QUICK, do not try the slow search with mmap if the fast search with smaps failed
	- when doing OMRPORT_VMEM_ALLOC_QUICK, avoid doing the range check when OMRPORT_VMEM_ADDRESS_STRICT is not set

On the OpenJ9 side: change the JIT to do the following during code cache allocation
	- try to allocate memory providing a desired address and setting OMRPORT_VMEM_ADDRESS_HINT
	- if the address returned by the OS is not within (2GB - 24MB) of the JIT dll, then try again by setting OMRPORT_VMEM_ALLOC_QUICK and a much larger address range(the full 2GB - 24MB from JIT dll address range), but not setting OMRPORT_VMEM_STRICT_ADDRESS and accept whatever we get back
	- refactor redundant code into functions and change the order of operation inside J9::CodeCacheManager::allocateCodeCacheSegment to make the code cleaner

The OpenJ9 side change is dependent on the OMR side change, therefore pull in the OMR side change first.
See issue 270 in OpenJ9 for more detail.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>