### PR TITLE
Fix OSR on guard failure during late inlining

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2043,7 +2043,12 @@ TR_InlinerBase::addGuardForVirtual(
            createdHCRGuard ||
            (osrForNonHCRGuards && shouldAttemptOSR)))
          {
-         TR::TreeTop *induceTree = callerSymbol->genInduceOSRCall(guardedCallNodeTreeTop, callNode->getByteCodeInfo().getCallerIndex(), (callNode->getNumChildren() - callNode->getFirstArgumentIndex()), false, false, callerSymbol->getFlowGraph());
+         // Late inlining may result in callerSymbol not being the resolved method that actually calls the inlined method
+         // This is problematic for linking OSR blocks
+         TR::ResolvedMethodSymbol *callingMethod = callNode->getByteCodeInfo().getCallerIndex() == -1 ?
+            comp()->getMethodSymbol() : comp()->getInlinedResolvedMethodSymbol(callNode->getByteCodeInfo().getCallerIndex());
+
+         TR::TreeTop *induceTree = callingMethod->genInduceOSRCall(guardedCallNodeTreeTop, callNode->getByteCodeInfo().getCallerIndex(), (callNode->getNumChildren() - callNode->getFirstArgumentIndex()), false, false, callerSymbol->getFlowGraph());
          if (induceOSRCallTree)
             *induceOSRCallTree = induceTree;
          }


### PR DESCRIPTION
OSR on guard failure will use an OSR transition
in place of a virtual call. This can occur
during late inlining. For bookkeeping to be
correctly updated, the OSR blocks for the
caller must be linked with the callee's.
However, the incorrect resolved method
symbol was being used during late inlining,
resulting in a crash.