### PR TITLE
Fix code synchronization issue

### DIFF
--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -1884,6 +1884,8 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 #if defined(AIXPPC)
 
 			*((unsigned int *)memPtr) = (unsigned int)0x4e800020; /* blr instruction (equivalent to RET on x86)*/
+			__lwsync();
+			__isync();
 
 			struct fDesc {
 				uintptr_t func_addr;


### PR DESCRIPTION
In some cases, the store to establish the dynamically synthesized
function (i.e. create the return instruction) can still be within the
CPU core store queue. So, a stale instruction can be fetched and
executed from the iCache. This can cause an IOT/Abort trap. __lwsync()
and __isync() are used to synchronize the iCache. This prevents the
IOT/Abort trap. 

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>