### PR TITLE
Relocate notYetRunMeansCold to OpenJ9

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2082,62 +2082,10 @@ void OMR::Compilation::registerResolvedMethodSymbolReference(TR::SymbolReference
    }
 
 
-bool OMR::Compilation::notYetRunMeansCold()
+bool
+OMR::Compilation::notYetRunMeansCold()
    {
-   if (_optimizer && !((TR::Optimizer*)_optimizer)->isIlGenOpt())
-      return false;
-
-   TR_ResolvedMethod *currentMethod = self()->getJittedMethodSymbol()->getResolvedMethod();
-
-   intptrj_t initialCount = currentMethod->hasBackwardBranches() ?
-                             self()->getOptions()->getInitialBCount() :
-                             self()->getOptions()->getInitialCount();
-
-   if (currentMethod->convertToMethod()->isBigDecimalMethod() ||
-       currentMethod->convertToMethod()->isBigDecimalConvertersMethod())
-       initialCount = 0;
-
-#ifdef J9_PROJECT_SPECIFIC
-    switch (currentMethod->getRecognizedMethod())
-      {
-      case TR::com_ibm_jit_DecimalFormatHelper_formatAsDouble:
-      case TR::com_ibm_jit_DecimalFormatHelper_formatAsFloat:
-         initialCount = 0;
-         break;
-      default:
-      	break;
-      }
-
-    if (currentMethod->containingClass() == self()->getStringClassPointer())
-       {
-       if (currentMethod->isConstructor())
-          {
-          char *sig = currentMethod->signatureChars();
-          if (!strncmp(sig, "([CIIII)", 8) ||
-              !strncmp(sig, "([CIICII)", 9) ||
-              !strncmp(sig, "(II[C)", 6))
-             initialCount = 0;
-          }
-       else
-          {
-          char *sig = "isRepeatedCharCacheHit";
-          if (strncmp(currentMethod->nameChars(), sig, strlen(sig)) == 0)
-             initialCount = 0;
-          }
-       }
-#endif
-
-   if (
-      self()->isDLT()
-      || (initialCount < TR_UNRESOLVED_IMPLIES_COLD_COUNT)
-      || ((self()->getOption(TR_UnresolvedAreNotColdAtCold) && self()->getMethodHotness() == cold) || self()->getMethodHotness() < cold)
-      || currentMethod->convertToMethod()->isArchetypeSpecimen()
-      || (  self()->getCurrentMethod()
-         && self()->getCurrentMethod()->convertToMethod()->isArchetypeSpecimen())
-      )
-      return false;
-   else
-      return true;
+   return false;
    }
 
 

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -939,7 +939,15 @@ public:
    // To TransformUtil
    void setStartTree(TR::TreeTop * tt);
 
-
+   /**
+    * \brief
+    *    Answers whether the fact that a method has not been executed yet implies
+    *    that the method is cold.
+    *
+    * \return
+    *    true if the fact that a method has not been executed implies it is cold;
+    *    false otherwise
+    */
    bool notYetRunMeansCold();
 
    TR::Region &aliasRegion();


### PR DESCRIPTION
The bulk of this `OMR::Compilation` function applies to OpenJ9.  Move
the functionality to the OpenJ9 project and replace the OMR version
with a sensible default (returning `false`).

Signed-off-by: Daryl Maier <maier@ca.ibm.com>