### PR TITLE
Make getParmValues virtual

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -863,7 +863,7 @@ class ValuePropagation : public TR::Optimization
    void invalidateUseDefInfo()       {_invalidateUseDefInfo = true;}
    void invalidateValueNumberInfo()  {_invalidateValueNumberInfo = true;}
    void setCurrentParent(TR::Node *n) {_currentParent = n;}
-   void getParmValues();
+   virtual void getParmValues();
    bool isParmInvariant(TR::Symbol *sym);
    bool computeDivRangeWhenDivisorCanBeZero(TR::Node *node)
       {


### PR DESCRIPTION
This function in `OMRValuePropagation` only applies to OpenJ9 (non-J9
runtimes return almost immediately).  Prepare to relocate this code to
OpenJ9 by first marking it virtual.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>