### PR TITLE
Implement software read barrier for concurrent scavenger testing

### DIFF
--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -112,6 +112,11 @@ class ObjectModel
    */
    bool shouldGenerateReadBarriersForFieldLoads() { return false; };
 
+   /**
+   * @brief: Returns true if option for software read barriers is enabled in the VM's GC
+   */
+   bool shouldReplaceGuardedLoadWithSoftwareReadBarrier() { return false; };
+
    };
 }
 

--- a/compiler/env/OMRVMEnv.hpp
+++ b/compiler/env/OMRVMEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,6 +107,33 @@ public:
    uintptrj_t OSRFrameSizeInBytes(TR::Compilation *comp, TR_OpaqueMethodBlock* method) { return 0; }
    bool ensureOSRBufferSize(TR::Compilation *comp, uintptrj_t osrFrameSizeInBytes, uintptrj_t osrScratchBufferSizeInBytes, uintptrj_t osrStackFrameSizeInBytes) { return false; }
    uintptrj_t thisThreadGetOSRReturnAddressOffset(TR::Compilation *comp) { return 0; }
+
+   /**
+    * @brief Returns offset from the current thread to the intermediate result field.
+    * The field contains intermediate result from the latest guarded load during concurrent scavenge.
+    */
+   uintptrj_t thisThreadGetGSIntermediateResultOffset(TR::Compilation *comp) { return 0; }
+   /**
+    * @brief Returns offset from the current thread to the flags to check if concurrent scavenge is active
+    */
+   uintptrj_t thisThreadGetConcurrentScavengeActiveByteAddressOffset(TR::Compilation *comp) { return 0; }
+   /**
+    * @brief Returns offset from the current thread to the field with the base address of the evacuate memory region
+    */
+   uintptrj_t thisThreadGetEvacuateBaseAddressOffset(TR::Compilation *comp) { return 0; }
+   /**
+    * @brief Returns offset from the current thread to the field with the top address of the evacuate memory region
+    */
+   uintptrj_t thisThreadGetEvacuateTopAddressOffset(TR::Compilation *comp) { return 0; }
+   /**
+    * @brief Returns offset from the current thread to the operand address field.
+    * It contains data from the most recent guarded load during concurrent scavenge
+    */
+   uintptrj_t thisThreadGetGSOperandAddressOffset(TR::Compilation *comp) { return 0; }
+   /**
+    * @brief Returns offset from the current thread to the filed with the read barrier handler address
+    */
+   uintptrj_t thisThreadGetGSHandlerAddressOffset(TR::Compilation *comp) { return 0; }
 
    };
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1162,6 +1162,7 @@ private:
    bool LGFRReduction();
    bool AGIReduction();
    bool ICMReduction();
+   bool replaceGuardedLoadWithSoftwareReadBarrier();
    bool LAReduction();
    bool NILHReduction();
    bool duplicateNILHReduction();

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13510,8 +13510,8 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
       TR_ASSERT_FATAL(TR::Compiler->target.is64Bit(),
                  "GSCS: Guarded Load OOL Path only defined in 64 bit mode");
       TR::Register *vmReg = cg->getMethodMetaDataRealRegister();
-      int32_t offsetOfConcurrentScavengerActiveByte = offsetof(J9VMThread, privateFlags) + 5;
-      TR::MemoryReference *privFlagMR = generateS390MemoryReference(vmReg, offsetOfConcurrentScavengerActiveByte, cg);
+      TR::MemoryReference *privFlagMR = generateS390MemoryReference(vmReg,
+            TR::Compiler->vm.thisThreadGetConcurrentScavengeActiveByteAddressOffset(cg->comp()), cg);
       generateSIInstruction(cg, TR::InstOpCode::TM, node, privFlagMR, 0x00000002);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_CC3, node, slowPathLabel);
 

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -420,6 +420,7 @@ public:
 	bool scavengerEnabled;
 	bool scavengerRsoScanUnsafe;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	bool softwareEvacuateReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS */
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
 	bool concurrentScavengerForced; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
 	uintptr_t concurrentScavengerBackgroundThreads; /**< number of background GC threads during concurrent phase of Scavenge */
@@ -812,6 +813,16 @@ public:
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
 	
+   MMINLINE bool
+   isSoftwareEvacuateReadBarrierEnabled()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+      return softwareEvacuateReadBarrier;
+#else
+      return false;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }
+
 	bool isConcurrentScavengerInProgress();
 	
 	MMINLINE bool
@@ -1339,6 +1350,7 @@ public:
 		, scvTenureStrategyHistory(true)
 		, scavengerEnabled(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		, softwareEvacuateReadBarrier(false)
 		, concurrentScavenger(false)
 		, concurrentScavengerForced(false)
 		, concurrentScavengerBackgroundThreads(1)


### PR DESCRIPTION
Add ability to run concurrent scavenger with JIT enabled on s390
hardware that doesn't support guarded storage.

Signed-off-by: Evgenia Badyanova evgeniab@ca.ibm.com