### PR TITLE
CMake: Organize targets into folders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ project(omr VERSION ${OMR_VERSION} LANGUAGES CXX C)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 
+set_property(GLOBAL PROPERTY USE_FOLDERS TRUE)
+
 include(OmrAssert)
 include(OmrFindFiles)
 include(OmrHookgen)

--- a/cmake/modules/OmrTracegen.cmake
+++ b/cmake/modules/OmrTracegen.cmake
@@ -25,6 +25,7 @@ endif()
 set(OMR_TRACEGEN_ 1)
 
 add_custom_target(run_tracegen)
+set_property(TARGET run_tracegen PROPERTY FOLDER tracegen)
 
 # Setup a default trace root if one has not alreay been set
 if(NOT DEFINED OMR_TRACE_ROOT)
@@ -70,6 +71,7 @@ function(omr_add_tracegen input)
 	)
 	add_custom_target("trc_${base_name}" DEPENDS "${generated_filename}.c")
 	add_dependencies(run_tracegen "trc_${base_name}")
+	set_property(TARGET "trc_${base_name}" PROPERTY FOLDER tracegen)
 endfunction(omr_add_tracegen)
 
 macro(add_tracegen)
@@ -88,3 +90,4 @@ add_custom_command(OUTPUT tracemerge.stamp
 add_custom_target(run_tracemerge
 	DEPENDS tracemerge.stamp
 )
+set_property(TARGET run_tracemerge PROPERTY FOLDER tracegen)

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -66,4 +66,6 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omralgotest j9a2e)
 endif()
 
+set_property(TARGET omralgotest PROPERTY FOLDER fvtest)
+
 add_test(NAME algotest COMMAND omralgotest -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -113,4 +113,6 @@ target_link_libraries(compilertest
 	${CMAKE_DL_LIBS}
 )
 
+set_property(TARGET compilertest PROPERTY FOLDER fvtest)
+
 add_test(NAME CompilerTest COMMAND compilertest)

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -49,6 +49,8 @@ target_link_libraries(comptest
 	tril
 )
 
+set_property(TARGET comptest PROPERTY FOLDER fvtest)
+
 add_test(
 	NAME comptest
 	COMMAND comptest --gtest_color=yes

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -59,6 +59,7 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omrgctest j9a2e)
 endif()
 
+set_property(TARGET omrgctest PROPERTY FOLDER fvtest)
 
 add_test(NAME gctest
 	COMMAND omrgctest "--gtest_filter=gcFunctionalTest*"

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -40,4 +40,6 @@ target_link_libraries(jitbuildertest
 	${CMAKE_DL_LIBS}
 )
 
+set_property(TARGET jitbuildertest PROPERTY FOLDER fvtest)
+
 add_test(NAME JitBuilderTest COMMAND jitbuildertest)

--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -48,3 +48,5 @@ if(NOT OMR_HOST_OS STREQUAL "win")
 	endif()
 endif()
 #target_link_libraries(omrGtest INTERFACE omrGtestGlue)
+
+set_property(TARGET omrGtest PROPERTY FOLDER fvtest)

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -100,6 +100,8 @@ target_compile_options(sltestlib
 		${OMR_PLATFORM_SHARED_COMPILE_OPTIONS}
 )
 
+set_target_properties(omrporttest sltestlib PROPERTIES FOLDER fvtest)
+
 add_test(NAME porttest COMMAND omrporttest)
 
 if(OMR_OPT_CUDA)

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -85,4 +85,6 @@ endif()
 	#MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
 #endif
 
+set_property(TARGET omrsigtest PROPERTY FOLDER fvtest)
+
 add_test(NAME sigtest COMMAND omrsigtest)

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -43,4 +43,6 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omrthreadextendedtest j9a2e)
 endif()
 
+set_property(TARGET omrthreadextendedtest PROPERTY FOLDER fvtest)
+
 add_test(NAME threadextendedtest COMMAND omrthreadextendedtest)

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -93,6 +93,8 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omrthreadtest j9a2e)
 endif()
 
+set_property(TARGET omrthreadtest PROPERTY FOLDER fvtest)
+
 add_test(NAME threadtest COMMAND omrthreadtest)
 add_test(NAME threadSetAttrThreadWeightTest COMMAND omrthreadtest --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
 if(OMR_HOST_OS STREQUAL "linux")

--- a/fvtest/tril/examples/incordec/CMakeLists.txt
+++ b/fvtest/tril/examples/incordec/CMakeLists.txt
@@ -34,3 +34,5 @@ add_executable(incordec
 target_link_libraries(incordec
 	tril
 )
+
+set_property(TARGET incordec PROPERTY FOLDER fvtest/tril/examples)

--- a/fvtest/tril/examples/mandelbrot/CMakeLists.txt
+++ b/fvtest/tril/examples/mandelbrot/CMakeLists.txt
@@ -34,3 +34,5 @@ add_executable(mandelbrot
 target_link_libraries(mandelbrot
 	tril
 )
+
+set_property(TARGET mandelbrot PROPERTY FOLDER fvtest/tril/examples)

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -43,6 +43,8 @@ target_link_libraries(triltest
 	omrGtest
 )
 
+set_property(TARGET triltest PROPERTY FOLDER fvtest/tril)
+
 add_test(
 	NAME triltest
 	COMMAND triltest

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -71,3 +71,5 @@ target_link_libraries(tril_compiler tril)
 #install(FILES ast.h ilgen.hpp DESTINATION include)
 #install(TARGETS tril EXPORT tril-targets ARCHIVE DESTINATION lib)
 #install(EXPORT tril-targets FILE tril-config.cmake DESTINATION lib/cmake/tril)
+
+set_target_properties(tril tril_dumper tril_compiler PROPERTIES FOLDER fvtest/tril)

--- a/fvtest/util/CMakeLists.txt
+++ b/fvtest/util/CMakeLists.txt
@@ -32,3 +32,5 @@ if(OMR_ENHANCED_WARNINGS)
 endif()
 
 target_include_directories(omrtestutil PUBLIC .)
+
+set_property(TARGET omrtestutil PROPERTY FOLDER fvtest)

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -38,4 +38,6 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(omrutiltest j9a2e)
 endif()
 
+set_property(TARGET omrutiltest PROPERTY FOLDER fvtest)
+
 add_test(NAME utiltest COMMAND omrutiltest)

--- a/fvtest/vmtest/CMakeLists.txt
+++ b/fvtest/vmtest/CMakeLists.txt
@@ -42,4 +42,6 @@ target_link_libraries(omrvmtest
 
 )
 
+set_property(TARGET omrvmtest PROPERTY FOLDER fvtest)
+
 add_test(NAME vmtest COMMAND omrvmtest)

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -306,3 +306,5 @@ target_link_libraries(omrgc
 		${OMR_TRACE_LIB}
 		${OMR_THREAD_LIB}
 )
+
+set_target_properties(omrgc omrgc_hookgen omrgc_tracegen PROPERTIES FOLDER gc)

--- a/tools/hookgen/CMakeLists.txt
+++ b/tools/hookgen/CMakeLists.txt
@@ -35,3 +35,5 @@ install(TARGETS hookgen
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	COMPONENT tooling
 )
+
+set_property(TARGET hookgen PROPERTY FOLDER tools)

--- a/tools/tracegen/CMakeLists.txt
+++ b/tools/tracegen/CMakeLists.txt
@@ -53,6 +53,8 @@ if(OMR_HOST_OS STREQUAL "zos")
 	target_link_libraries(trace j9a2e)
 endif()
 
+set_target_properties(trace tracegen PROPERTIES FOLDER tools)
+
 install(TARGETS tracegen
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	COMPONENT tooling

--- a/tools/tracemerge/CMakeLists.txt
+++ b/tools/tracemerge/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(tracemerge
 		trace # static
 )
 
+set_property(TARGET tracemerge PROPERTY FOLDER util)
+
 install(TARGETS tracemerge
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	COMPONENT tooling

--- a/util/a2e/CMakeLists.txt
+++ b/util/a2e/CMakeLists.txt
@@ -49,3 +49,5 @@ add_custom_command(TARGET j9a2e
 	COMMAND mv j9a2e.x ${CMAKE_BINARY_DIR}/j9a2e.x
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+set_property(TARGET j9a2e PROPERTY FOLDER util)

--- a/util/avl/CMakeLists.txt
+++ b/util/avl/CMakeLists.txt
@@ -41,3 +41,5 @@ target_include_directories(j9avl
 	PUBLIC
 		.
 )
+
+set_property(TARGET j9avl PROPERTY FOLDER util)

--- a/util/hashtable/CMakeLists.txt
+++ b/util/hashtable/CMakeLists.txt
@@ -55,3 +55,5 @@ target_link_libraries(j9hashtable
 		j9pool
 		omrutil
 )
+
+set_property(TARGET j9hashtable PROPERTY FOLDER util)

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -55,3 +55,5 @@ target_link_libraries(j9hookstatic PUBLIC
 	omrport
 )
 add_tracegen(j9hook.tdf)
+
+set_target_properties(j9hook_obj j9hookstatic PROPERTIES FOLDER util)

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -158,3 +158,5 @@ target_link_libraries(omrutil PUBLIC
 	j9hashtable
 	${OMR_UTIL_GLUE_TARGET}
 )
+
+set_target_properties(omrutil_obj omrutil PROPERTIES FOLDER util)

--- a/util/pool/CMakeLists.txt
+++ b/util/pool/CMakeLists.txt
@@ -37,3 +37,5 @@ endif()
 if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(j9pool PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
+
+set_property(TARGET j9pool PROPERTY FOLDER util)


### PR DESCRIPTION
Organize the various targets into folders when using a generator with
folder support.

See
https://cmake.org/cmake/help/v3.2/prop_gbl/USE_FOLDERS.html
https://cmake.org/cmake/help/v3.2/prop_tgt/FOLDER.html

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>