### PR TITLE
Correct spelling of createCoDependententTemporary

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1814,7 +1814,7 @@ OMR::SymbolReferenceTable::createTemporary(TR::ResolvedMethodSymbol * owningMeth
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createCoDependententTemporary(TR::ResolvedMethodSymbol *owningMethodSymbol, TR::DataType type, bool isInternalPointer, size_t size, TR::Symbol *coDependent, int32_t offset)
+OMR::SymbolReferenceTable::createCoDependentTemporary(TR::ResolvedMethodSymbol *owningMethodSymbol, TR::DataType type, bool isInternalPointer, size_t size, TR::Symbol *coDependent, int32_t offset)
    {
    TR::SymbolReference *tempSymRef = findOrCreateAutoSymbol(owningMethodSymbol, offset, type, true, isInternalPointer, false, false, size);
    return tempSymRef;

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -275,7 +275,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,
          bool isInternalPointer = false, bool reuseAuto = true, bool isAdjunct = false, size_t size = 0);
    TR::SymbolReference * createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer = false, size_t size = 0);
-   TR::SymbolReference * createCoDependententTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer, size_t size,
+   TR::SymbolReference * createCoDependentTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer, size_t size,
          TR::Symbol *coDependent, int32_t offset);
    TR::SymbolReference * findStaticSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataType);
 

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -1529,7 +1529,7 @@ void TR_FieldPrivatizer::privatizeElementCandidates()
             continue;
             }
 
-         tempSymRef = comp()->getSymRefTab()->createCoDependententTemporary(comp()->getMethodSymbol(),candidate.node->getDataType(),false,candidate.node->getSize(),candidate.node->getSymbol(),0);
+         tempSymRef = comp()->getSymRefTab()->createCoDependentTemporary(comp()->getMethodSymbol(),candidate.node->getDataType(),false,candidate.node->getSize(),candidate.node->getSymbol(),0);
 
          tempMap.Add(candidate.valueNum,tempSymRef);
          }


### PR DESCRIPTION
- Corrected the spelling of `createCoDependententTemporary` to `createCoDependententTemporary` in `compile/OMRSymbolReferenceTable.cpp`,  and in all references of this function (2 references) .

- Updated copyright year of ` compiler/compile/OMRSymbolReferenceTable.hpp` to current year as per contribution guidelines.

Closes : #2104

Signed-off-by: Arwin Neil Baichoo <arwinneil@gmail.com>