### PR TITLE
Resynchronize data flow kinds enum with names table

### DIFF
--- a/compiler/optimizer/DataFlowAnalysis.enum
+++ b/compiler/optimizer/DataFlowAnalysis.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,13 +44,12 @@ BackwardUnionDFSetAnalysis            = 13,
 BackwardIntersectionDFSetAnalysis     = 14,
 ExceptionCheckMotion                  = 15,
 RedundantExpressionAdjustment         = 16,
-//Available New DataFlowAnalysis      = 17,
-FlowSensitiveEscapeAnalysis           = 18,
-LiveOnAllPaths                        = 19,
-ReachingBlocks                        = 20,
-RegisterAnticipatability              = 21,
-RegisterAvailability                  = 22,
-DSALiveness                           = 24,
-GPRLiveness                           = 25,
+FlowSensitiveEscapeAnalysis           = 17,
+LiveOnAllPaths                        = 18,
+ReachingBlocks                        = 19,
+RegisterAnticipatability              = 20,
+RegisterAvailability                  = 21,
+DSALiveness                           = 22,
+GPRLiveness                           = 23,
 
 #endif


### PR DESCRIPTION
The data flow analysis kinds enum in `compiler/optimizer/DataFlowAnalysis.enum`
is out of sync with the names table in `compiler/optimizer/DataFlowAnalysis.cpp`.
Fix the enum numbering.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>