### PR TITLE
Remove unused functions from Z CodeGenerator

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1318,12 +1318,6 @@ OMR::Z::CodeGenerator::isAddMemoryUpdate(TR::Node * node, TR::Node * valueChild)
    }
 
 bool
-OMR::Z::CodeGenerator::inlinePackedLongConversion()
-   {
-   return !self()->comp()->getOptions()->getOption(TR_DisablePackedLongConversion);
-   }
-
-bool
 OMR::Z::CodeGenerator::isUsing32BitEvaluator(TR::Node *node)
    {
    if ((node->getOpCodeValue() == TR::sadd || node->getOpCodeValue() == TR::ssub) &&
@@ -2508,8 +2502,6 @@ bool OMR::Z::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
 
    return ((value >= smallestPos) || (value <= largestNeg));
    }
-
-bool OMR::Z::CodeGenerator::supportsNamedVirtualRegisters() { return false; } // TODO : Identitiy needs folding
 
 // This method it mostly for safely moving register spills outside of loops
 // Within a loop after each instruction we must keep track of what happened to registers

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -362,7 +362,6 @@ public:
    void setNodeAddressOfCachedStaticTree(TR::Node *n) { _nodeAddressOfCachedStatic=n; }
    TR::Node *getNodeAddressOfCachedStatic() { return _nodeAddressOfCachedStatic; }
 
-   bool supportsNamedVirtualRegisters(); // no virt, default
    TR::SparseBitVector & getBucketPlusIndexRegisters()  { return _bucketPlusIndexRegisters; }
 
    // For hanging multiple loads from register symbols onto one common DEPEND
@@ -767,7 +766,6 @@ public:
    void ensure64BitRegister(TR::Register *reg);
 
    virtual bool isAddMemoryUpdate(TR::Node * node, TR::Node * valueChild);
-   bool inlinePackedLongConversion();
 
    bool globalAccessRegistersSupported();
 


### PR DESCRIPTION
- Removed unused functions `inlinePackedLongConversion` and `supportsNamedVirtualRegisters` from `compiler/z/codegen/OMRCodeGenerator.cpp` and `compiler/z/codegen/OMRCodeGenerator.hpp`

Closes: #2062, #2059

Signed-off-by: Arwin Neil Baichoo <arwinneil@gmail.com>