### PR TITLE
Remove deprecated warm instruction and block properties

### DIFF
--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,13 +81,6 @@ class OMR_EXTENSIBLE Instruction
    virtual bool isVirtualGuardNOPInstruction() { return false; }
 
    virtual TR::LabelSymbol *getLabelSymbol() { return NULL; }
-
-   /*
-    * Instruction properties.
-    */
-   bool isLastWarmInstruction() { return (_index & TO_MASK(LastWarmInstruction)) != 0; }
-   void setLastWarmInstruction(bool v) { v ? _index |= TO_MASK(LastWarmInstruction) : _index &= ~TO_MASK(LastWarmInstruction); }
-
 
    typedef uint32_t TIndex;
    TR_ALLOC(TR_Memory::Instruction)
@@ -279,7 +272,7 @@ class OMR_EXTENSIBLE Instruction
    TR::Node *_node;
    TR::CodeGenerator *_cg;
 
-   protected: 
+   protected:
    TR_BitVector *_liveLocals;
    TR_BitVector *_liveMonitors;
    int32_t _registerSaveDescription;
@@ -290,9 +283,9 @@ class OMR_EXTENSIBLE Instruction
       TR_GCStackMap *_GCMap;
       TR_GCInfo()
          {
-         _GCRegisterMask = 0; 
+         _GCRegisterMask = 0;
          _GCMap = 0;
-         } 
+         }
       } _gc;
 
 

--- a/compiler/codegen/OMRInstructionFlagEnum.hpp
+++ b/compiler/codegen/OMRInstructionFlagEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,6 @@
  * This file will be included within an enum.  Only comments and enumerator
  * definitions are permitted.
  */
-
-// Instruction flag delimiting the last instruction in the warm area of
-// a method.
-//
-LastWarmInstruction,
 
 // Instruction requires a GC map
 //

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -388,9 +388,6 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    void setIsSuperCold(bool v = true);
    bool isSuperCold();
 
-   void setIsLastWarmBlock(bool b = true)             { _flags.set(_isLastWarmBlock, b); }
-   bool isLastWarmBlock()                             { return _flags.testAny(_isLastWarmBlock); }
-
    void setDoNotProfile()                             { _flags.set(_doNotProfile); }
    bool doNotProfile()                                { return _flags.testAny(_doNotProfile); }
 
@@ -509,7 +506,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       _isExtensionOfPreviousBlock           = 0x00000001,
       _isCold                               = 0x00000002,
       _isSuperCold                          = 0x00040000,  // User specified cold/hotness by pragma or @ASSERT for PLX
-      _isLastWarmBlock                      = 0x00000080,
+      // AVAILABLE                          = 0x00000080,
       _doNotProfile                         = 0x00000004,
       _specializedDesyncCatchBlock          = 0x00000008,
       _firstBlockInLoop                     = 0x00000020,

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3554,7 +3554,6 @@ OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp(uint8_t *curso
             nbytes += currInstr->getOpCode().getInstructionLength();
             }
          currInstr->setNext(nextInstr);
-         //May need to copy some attributes of instr into currInstr e.g. lastWarm etc.
          }
       else if (TR::Compiler->target.is64Bit())
          {


### PR DESCRIPTION
* Remove LastWarmInstruction property from `OMR::Instruction`
* Remove LastWarmBlock property from `OMR::Block`

Both are deprecated and no longer used.

Closes: #2119

Signed-off-by: Daryl Maier <maier@ca.ibm.com>