### PR TITLE
Remove obsolete RegisterSymbols

### DIFF
--- a/compiler/codegen/Analyser.cpp
+++ b/compiler/codegen/Analyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,7 +60,6 @@ void TR_Analyser::setInputs(TR::Node     *firstChild,
    if (  firstChild->getOpCode().isMemoryReference()
       && firstChild->getSymbolReference() != vftPointerSymRef
       && firstChild->getReferenceCount() == 1
-      && !firstChild->getSymbol()->isRegisterSymbol()
       && !lockedIntoRegister1)
       {
       setMem1();
@@ -69,7 +68,6 @@ void TR_Analyser::setInputs(TR::Node     *firstChild,
    if (  secondChild->getOpCode().isMemoryReference()
       && secondChild->getSymbolReference() != vftPointerSymRef
       && secondChild->getReferenceCount() == 1
-      && !secondChild->getSymbol()->isRegisterSymbol()
       && !lockedIntoRegister2)
       {
       setMem2();

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -427,16 +427,6 @@ class SymbolReferenceTable
    bool                 isRefinedArrayShadow(TR::SymbolReference *symRef);
    bool                 isImmutableArrayShadow(TR::SymbolReference *symRef);
 
-
-   // A RegisterSymbol is a pseudo memory location that represents some machine
-   // register or a value we would like the register allocator to map to a register.
-   // Such a RegisterSymbol belongs to a method as its conceptual life span is the
-   // life of a procedure. A set of hardware registers is pre-created for each method.
-   //
-   void initRegisterSymbols(TR::ResolvedMethodSymbol *);
-   TR::SymbolReference * createRegisterSymbol(TR::ResolvedMethodSymbol *, TR_RegisterKinds, TR::DataType, TR_GlobalRegisterNumber grn);
-   TR::SymbolReference * getRegisterSymbol(TR_GlobalRegisterNumber grn);
-
    /*
     * --------------------------------------------------------------------------
     */
@@ -450,7 +440,7 @@ class SymbolReferenceTable
     * For union type support
     */
 
-   // Mark two symbol references as shared aliases of each other 
+   // Mark two symbol references as shared aliases of each other
    void makeSharedAliases(TR::SymbolReference *sr1, TR::SymbolReference *sr2);
    // Retrieve shared aliases bitvector for a given symbol reference
    TR_BitVector *getSharedAliases(TR::SymbolReference *sr);
@@ -486,7 +476,6 @@ class SymbolReferenceTable
    List<TR::SymbolReference>            _currentThreadDebugEventDataSymbolRefs;
 
    uint32_t                            _nextRegShadowIndex;
-   TR_Array<TR::SymbolReference *>      *_registerSymbolRefs;
 
    CS2::HashTable<uint32_t, TR::Symbol *, TR::Allocator> _aggregateShadowSymbolMap;
    CS2::HashTable<TR::SparseBitVector *, TR::SymbolReference *, TR::Allocator> _aggregateShadowSymbolReferenceMap;

--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -238,16 +238,6 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(AllocatorType m, const 
    }
 
 template <typename AllocatorType>
-TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(AllocatorType m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe)
-   {
-   TR::AutomaticSymbol * sym = new (m) TR::AutomaticSymbol(d,s);
-   sym->_regKind = regKind;
-   sym->_globalRegisterNumber = globalRegNum;
-   sym->setIsRegisterSymbol();
-   return sym;
-   }
-
-template <typename AllocatorType>
 TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(AllocatorType m, int32_t arrayType, TR::DataType d, uint32_t s, TR_FrontEnd * fe)
    {
    TR::AutomaticSymbol * sym   = new (m) TR::AutomaticSymbol(d, s);
@@ -320,7 +310,6 @@ TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(AllocatorType m,
 
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(TR_HeapMemory m, const char * name) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(TR_HeapMemory m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe) ;
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_HeapMemory m, int32_t arrayType, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_HeapMemory m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_HeapMemory m, TR::AutomaticSymbol *pinningArrayPointer);
@@ -329,7 +318,6 @@ template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_He
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(TR_HeapMemory m, uint32_t s);
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(TR_StackMemory m, const char * name) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(TR_StackMemory m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe) ;
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_StackMemory m, int32_t arrayType, TR::DataType   d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(TR_StackMemory m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_StackMemory m, TR::AutomaticSymbol *pinningArrayPointer);
@@ -338,7 +326,6 @@ template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(TR_St
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createVariableSized(TR_StackMemory m, uint32_t s);
 
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createMarker(PERSISTENT_NEW_DECLARE m, const char * name) ;
-template TR::AutomaticSymbol * OMR::AutomaticSymbol::createRegisterSymbol(PERSISTENT_NEW_DECLARE m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe) ;
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(PERSISTENT_NEW_DECLARE m, int32_t arrayType, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createLocalObject(PERSISTENT_NEW_DECLARE m, TR::ILOpCodes kind, TR::SymbolReference * classSymRef, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
 template TR::AutomaticSymbol * OMR::AutomaticSymbol::createInternalPointer(PERSISTENT_NEW_DECLARE m, TR::AutomaticSymbol *pinningArrayPointer);

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,38 +112,6 @@ public:
    template <typename AllocatorType>
    static TR::AutomaticSymbol * createMarker(AllocatorType m, const char * name);
 
-/** @} */
-
-public:
-/**
- * The class formerly known as TR_RegisterSymbol
- *
- * The following is to be used by register allocation. We have Hardware and
- * Symbolic register auto temps.
- *
- *  - A Hardware register auto means that a load/store from this register auto
- *  maps directly to the register it describes.
- *  - A symbolic register auto is left open and instruction level register
- *  allocation is free to choose any register for it as well as it can choose
- *  to map this register auto to a spill location.
- *
- * \todo Verify the above comment is correct, or at least remap the terms to something recognizable.
- *
- *
- */
-   template <typename AllocatorType>
-   static TR::AutomaticSymbol * createRegisterSymbol(AllocatorType m, TR_RegisterKinds regKind, uint32_t globalRegNum, TR::DataType d, uint32_t s, TR_FrontEnd * fe);
-
-   TR_RegisterKinds  getRegisterKind() const                { return _regKind;                        }
-   void              setGlobalRegisterNumber(uint32_t grn)  { _globalRegisterNumber = grn;            }
-   uint32_t          getGlobalRegisterNumber() const        { return _globalRegisterNumber;           }
-   void              setRealRegister()                      { return (_flags2.set(RealRegister));     }
-   bool              isRealRegister()                       { return (_flags2.testAny(RealRegister)); }
-
-private:
-
-   TR_RegisterKinds _regKind;
-   int32_t _globalRegisterNumber;
 /** @} */
 
 /**

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,7 +147,6 @@ public:
    inline TR::AutomaticSymbol                        *getVariableSizeSymbol();
    inline TR::StaticSymbol                           *getCallSiteTableEntrySymbol();
    inline TR::StaticSymbol                           *getMethodTypeTableEntrySymbol();
-   inline TR::AutomaticSymbol                        *getRegisterSymbol();
 
    // These methods perform an explicit (debug) assume that the symbol is a correct type
    // and then return the symbol explicitly cast to the type.
@@ -165,7 +164,6 @@ public:
    inline TR::RegisterMappedSymbol            *castToMethodMetaDataSymbol();
    inline TR::LabelSymbol                     *castToLabelSymbol();
    inline TR::ResolvedMethodSymbol            *castToJittedMethodSymbol();
-   inline TR::AutomaticSymbol                 *castToRegisterSymbol();
 
    inline TR::StaticSymbol                    *castToStaticSymbol();
    inline TR::StaticSymbol                    *castToNamedStaticSymbol();
@@ -290,9 +288,6 @@ public:
 
    inline void setPinningArrayPointer();
    inline bool isPinningArrayPointer();
-
-   inline bool isRegisterSymbol();
-   inline void setIsRegisterSymbol();
 
    inline void setAutoAddressTaken();
    inline bool isAutoAddressTaken();
@@ -492,7 +487,7 @@ public:
                                               ///< to behave as regular locals to
                                               ///< preserve floating point semantics
       PinningArrayPointer       = 0x10000000,
-      RegisterAuto              = 0x00020000, ///< Symbol to be translated to register at instruction selection
+      // Available              = 0x00020000,
       AutoAddressTaken          = 0x04000000, ///< a loadaddr of this auto exists
       SpillTempLoaded           = 0x04000000, ///< share bit with loadaddr because spill temps will never have their address taken. Used to remove store to spill if never loaded
       AutoMarkerSymbol          = 0x02000000, ///< dummy symbol marking some auto boundary
@@ -562,7 +557,7 @@ public:
       HasAddrTaken              = 0x00000010, // used to denote that we have a loadaddr of this symbol
       MethodTypeTableEntry      = 0x00000020, // JSR292
       NotDataAddress            = 0x00000040, // isStatic only: AOT
-      RealRegister              = 0x00000080, // RegisterSymbol is machine real register
+      // Available              = 0x00000080,
       UnsafeShadow              = 0x00000100,
       NamedShadow               = 0x00000200,
       ImmutableField            = 0x00000400,

--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -134,12 +134,6 @@ TR::StaticSymbol *OMR::Symbol::castToMethodTypeTableEntrySymbol()
    }
 
 
-TR::AutomaticSymbol *OMR::Symbol::castToRegisterSymbol()
-   {
-   TR_ASSERT(self()->isRegisterSymbol(), "OMR::Symbol::castToRegisterSymbol expected a register symbol");
-   return (TR::AutomaticSymbol*)this;
-   }
-
 TR::AutomaticSymbol * OMR::Symbol::castToAutoMarkerSymbol()
    {
    TR_ASSERT(self()->isAutoMarkerSymbol(), "OMR::Symbol::castToAutoMarkerSymbol, symbol is not a auto marker symbol");
@@ -224,18 +218,6 @@ bool
 OMR::Symbol::isPinningArrayPointer()
    {
    return self()->isAuto() && _flags.testAny(PinningArrayPointer);
-   }
-
-bool
-OMR::Symbol::isRegisterSymbol()
-   {
-   return self()->isAuto() && _flags.testAny(RegisterAuto);
-   }
-
-void
-OMR::Symbol::setIsRegisterSymbol()
-   {
-   _flags.set(RegisterAuto);
    }
 
 void
@@ -888,12 +870,6 @@ TR::Symbol *
 OMR::Symbol::getNamedShadowSymbol()
    {
    return self()->isNamedShadowSymbol() ? (TR::Symbol *)this : 0;
-   }
-
-TR::AutomaticSymbol *
-OMR::Symbol::getRegisterSymbol()
-   {
-   return self()->isRegisterSymbol() ? (TR::AutomaticSymbol *)this : 0;
    }
 
 TR::StaticSymbol *

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1786,16 +1786,7 @@ TR_Debug::getAutoName(TR::SymbolReference * symRef)
 
    name[0]=0;  //initialize to empty string
 
-
-   if (symRef->getSymbol()->isRegisterSymbol())
-     {
-     TR::AutomaticSymbol *symReg=symRef->getSymbol()->castToRegisterSymbol();
-     if(symReg->isRealRegister())
-       sprintf(name,"<GlobalReg%d %s>",symReg->getGlobalRegisterNumber(),getGlobalRegisterName(symReg->getGlobalRegisterNumber()));
-     else
-       sprintf(name,"<GlobalReg%d>",symReg->getGlobalRegisterNumber());
-     }
-   else if (symRef->getSymbol()->isSpillTempAuto())
+   if (symRef->getSymbol()->isSpillTempAuto())
       {
       char * symName = (char *)_comp->trMemory()->allocateHeapMemory(20);
       if (symRef->getSymbol()->getDataType() == TR::Float || symRef->getSymbol()->getDataType() == TR::Double)

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1467,7 +1467,6 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
       }
    else if ( secondChild->getRegister()==NULL && secondChild->getReferenceCount()==1 &&
              secondChild->getOpCode().isMemoryReference() &&
-             !secondChild->getSymbolReference()->getSymbol()->isRegisterSymbol() &&
              !needCheck)
       {
       sourceMR = generateS390MemoryReference(secondChild, cg);
@@ -1648,15 +1647,15 @@ genericLongShiftSingle(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::
                {
                srcReg = cg->evaluate(firstChild->getFirstChild());
                auto mnemonic = cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12) ? TR::InstOpCode::RISBGN : TR::InstOpCode::RISBG;
-               
+
                generateRIEInstruction(cg, mnemonic, node, trgReg, srcReg, (int8_t)(32-value), (int8_t)((63-value)|0x80), (int8_t)value);
-               
+
                node->setRegister(trgReg);
-               
+
                cg->decReferenceCount(firstChild->getFirstChild());
                cg->decReferenceCount(firstChild);
                cg->decReferenceCount(secondChild);
-               
+
                return trgReg;
                }
             }
@@ -2485,7 +2484,7 @@ OMR::Z::TreeEvaluator::tryToReplaceLongAndWithRotateInstruction(TR::Node * node,
          int32_t tOnes  = trailingZeroes(~longConstValue);
          int32_t lOnes  = leadingZeroes(~longConstValue);
          int32_t popCnt = populationCount(longConstValue);
- 
+
          // if the population count is 0 then the result of the AND will also be 0,
          // because a popCnt=0 means there are no overlapping bits between the two AND
          // operands. We cannot generate a RISBG for this case as RISBG cannot be
@@ -2528,7 +2527,7 @@ OMR::Z::TreeEvaluator::tryToReplaceLongAndWithRotateInstruction(TR::Node * node,
             //
             // "firstChild->getReferenceCount() > 1"
             //    If the firstChild's refCount>1, we will need to clobber evaluate this case
-            //    because we cannot destroy the value. In such a case we're better off with 
+            //    because we cannot destroy the value. In such a case we're better off with
             //    RISBG because RISBG won't clobber anything and hence can do the operation
             //    faster.
             //
@@ -2588,7 +2587,7 @@ OMR::Z::TreeEvaluator::tryToReplaceLongAndWithRotateInstruction(TR::Node * node,
 
                // if possible then use the instruction that doesn't set the CC as it's faster
                TR::InstOpCode::Mnemonic opCode = cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12) ? TR::InstOpCode::RISBGN : TR::InstOpCode::RISBG;
- 
+
                // this instruction sets the rotation factor to 0 and sets the zero bit(0x80).
                // So it's effectively zeroing out every bit except the inclusive range of lsBit to msBit
                // The bits in that range are preserved as is
@@ -3736,7 +3735,7 @@ OMR::Z::TreeEvaluator::mulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool isUnsigned = (node->getOpCodeValue() == TR::iumulh);
    PRINT_ME("imulh", node, cg);
    TR::Node * firstChild = node->getFirstChild();
-   TR::Node * secondChild = node->getSecondChild();   
+   TR::Node * secondChild = node->getSecondChild();
    TR::Register * firstRegister = cg->gprClobberEvaluate(firstChild);
    TR::Register * targetRegister = cg->allocateRegister();
    TR::Instruction * cursor = NULL;

--- a/compiler/z/codegen/CompareAnalyser.cpp
+++ b/compiler/z/codegen/CompareAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,7 +139,6 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
          {
          if (secondChild->getReferenceCount() == 1 &&
             secondChild->getRegister() == NULL &&
-             !(secondChild->getOpCode().hasSymbolReference() && secondChild->getSymbolReference()->getSymbol()->isRegisterSymbol()) &&
             (secondChild->getOpCodeValue() == TR::lload || (secondChild->getOpCodeValue() == TR::iload && secondIU2L)))
             {
             lowSecondMR = generateS390MemoryReference(secondChild, _cg);
@@ -159,7 +158,6 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
          {
          if (firstChild->getReferenceCount() == 1 &&
             firstChild->getRegister() == NULL &&
-             !(firstChild->getOpCode().hasSymbolReference() && firstChild->getSymbolReference()->getSymbol()->isRegisterSymbol()) &&
             (firstChild->getOpCodeValue() == TR::lload || (firstChild->getOpCodeValue() == TR::iload && firstIU2L)))
             {
             lowFirstMR = generateS390MemoryReference(firstChild, _cg);

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -316,12 +316,12 @@ generateExtendedFloatConstantReg(TR::Node *node, TR::CodeGenerator *cg, int64_t 
       mrHi->stopUsingMemRefRegister(cg);
       mrLo->stopUsingMemRefRegister(cg);
       }
-      
+
    if (cg->isLiteralPoolOnDemandOn())
       {
       cg->stopUsingRegister(litBase);
       }
-      
+
    return trgReg;
    }
 
@@ -755,7 +755,7 @@ commonLong2FloatEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          if (two_pow_64_lo)
             two_pow_64_lo->stopUsingMemRefRegister(cg);
          }
-         
+
       if (cg->isLiteralPoolOnDemandOn())
          {
          cg->stopUsingRegister(litBase);
@@ -885,41 +885,26 @@ OMR::Z::TreeEvaluator::dconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::floadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-
-   //traceMsg(comp,"In fload evaluator for Node %p. isRegisterSymbol = %d\n",node,node->getSymbolReference()->getSymbol()->isRegisterSymbol());
-
-   if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return TR::TreeEvaluator::fRegLoadEvaluator(node, cg);
-   else
-     return floadHelper(node, cg, NULL);
+   return floadHelper(node, cg, NULL);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::dloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     return TR::TreeEvaluator::dRegLoadEvaluator(node, cg);
-   else
-     return dloadHelper(node, cg, NULL);
+   return dloadHelper(node, cg, NULL);
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::fstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     TR::TreeEvaluator::fRegStoreEvaluator(node, cg);
-   else
-     fstoreHelper(node, cg);
+   fstoreHelper(node, cg);
    return NULL;
    }
 
 TR::Register *
 OMR::Z::TreeEvaluator::dstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     TR::TreeEvaluator::dRegStoreEvaluator(node, cg);
-   else
-     dstoreHelper(node, cg);
+   dstoreHelper(node, cg);
    return NULL;
    }
 
@@ -1062,7 +1047,7 @@ OMR::Z::TreeEvaluator::ddivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /** \brief Generates code for a % b for both float and double values
  *  \details
- *  The code uses divide-to-integer instructions DIxBR to get remainder of two double/float values. 
+ *  The code uses divide-to-integer instructions DIxBR to get remainder of two double/float values.
  *  In rare cases when result of DIxBR is not exact it calls out to double/float remainder helper which
  *  calls fmod to get remainder and uses System linkage.
  */
@@ -1125,7 +1110,7 @@ OMR::Z::TreeEvaluator::floatRemHelper(TR::Node * node, TR::CodeGenerator * cg)
    TR_S390OutOfLineCodeSection *outlinedSlowPath = new (cg->trHeapMemory()) TR_S390OutOfLineCodeSection(labelNotExact,labelOK,cg);
    cg->getS390OutOfLineCodeSectionList().push_front(outlinedSlowPath);
    outlinedSlowPath->swapInstructionListsWithCompilation();
-   
+
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelNotExact);
    callNode->setChild(0, node->getFirstChild());
    callNode->setChild(1, node->getSecondChild());
@@ -1133,14 +1118,14 @@ OMR::Z::TreeEvaluator::floatRemHelper(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register *helperReturnRegister = linkage->buildSystemLinkageDispatch(callNode);
    generateRRInstruction(cg, node->getDataType() == TR::Float ? TR::InstOpCode::LER : TR::InstOpCode::LDR, node,  targetRegister, helperReturnRegister);
 
-   // buildSystemLinkageDispatch sets a helperReturnRegister to callNode. 
-   // Artificially setting reference count of callNode to 1 and decreasing it makes sure that this register is no longer live in the method. 
+   // buildSystemLinkageDispatch sets a helperReturnRegister to callNode.
+   // Artificially setting reference count of callNode to 1 and decreasing it makes sure that this register is no longer live in the method.
    callNode->setReferenceCount(1);
    cg->decReferenceCount(callNode);
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, labelOK);
    outlinedSlowPath->swapInstructionListsWithCompilation();
 
-   TR::RegisterDependencyConditions * postDeps = generateRegisterDependencyConditions(0, 4, cg);   
+   TR::RegisterDependencyConditions * postDeps = generateRegisterDependencyConditions(0, 4, cg);
    postDeps->addPostCondition(targetRegister, TR::RealRegister::AssignAny);
    postDeps->addPostCondition(firstRegister, TR::RealRegister::AssignAny);
    postDeps->addPostCondition(secondRegister, TR::RealRegister::AssignAny);
@@ -1293,12 +1278,12 @@ OMR::Z::TreeEvaluator::fbits2iEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    cg->decReferenceCount(node->getFirstChild());
    if (node->getNumChildren() == 2)
       cg->decReferenceCount(node->getSecondChild());
-      
+
    if (cg->isLiteralPoolOnDemandOn())
       {
       cg->stopUsingRegister(litBase);
       }
-      
+
    return targetReg;
    }
 
@@ -1543,12 +1528,12 @@ OMR::Z::TreeEvaluator::dbits2lEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          }
       cg->decReferenceCount(firstChild);
       }
-      
+
    if (cg->isLiteralPoolOnDemandOn())
       {
       cg->stopUsingRegister(litBase);
       }
-      
+
    return targetReg;
    }
 
@@ -2313,13 +2298,7 @@ OMR::Z::TreeEvaluator::fRegLoadEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
    if(globalReg == NULL)
      {
-      if (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-        {
-        TR::AutomaticSymbol *regSym=node->getSymbolReference()->getSymbol()->castToRegisterSymbol();
-        globalRegNum = regSym->getGlobalRegisterNumber();
-        }
-      else
-        globalRegNum = node->getGlobalRegisterNumber();
+     globalRegNum = node->getGlobalRegisterNumber();
      }
 
    if (globalReg == NULL)
@@ -2339,13 +2318,7 @@ OMR::Z::TreeEvaluator::dRegLoadEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
    if(globalReg == NULL)
      {
-      if (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-        {
-        TR::AutomaticSymbol *regSym=node->getSymbolReference()->getSymbol()->castToRegisterSymbol();
-        globalRegNum = regSym->getGlobalRegisterNumber();
-        }
-      else
-        globalRegNum = node->getGlobalRegisterNumber();
+     globalRegNum = node->getGlobalRegisterNumber();
      }
 
    if (globalReg == NULL)
@@ -2363,14 +2336,7 @@ OMR::Z::TreeEvaluator::fRegStoreEvaluator(TR::Node * node, TR::CodeGenerator * c
    TR::Node * child = node->getFirstChild();
 
    TR::Register * globalReg=NULL;
-   TR_GlobalRegisterNumber globalRegNum;
-   if (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     {
-     TR::AutomaticSymbol *regSym=node->getSymbolReference()->getSymbol()->castToRegisterSymbol();
-     globalRegNum = regSym->getGlobalRegisterNumber();
-     }
-   else
-     globalRegNum = node->getGlobalRegisterNumber();
+   TR_GlobalRegisterNumber globalRegNum = node->getGlobalRegisterNumber();
 
    globalReg = cg->evaluate(child);
 
@@ -2384,14 +2350,7 @@ OMR::Z::TreeEvaluator::dRegStoreEvaluator(TR::Node * node, TR::CodeGenerator * c
    TR::Node * child = node->getFirstChild();
 
    TR::Register * globalReg=NULL;
-   TR_GlobalRegisterNumber globalRegNum;
-   if (node->getOpCode().hasSymbolReference() && node->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     {
-     TR::AutomaticSymbol *regSym=node->getSymbolReference()->getSymbol()->castToRegisterSymbol();
-     globalRegNum = regSym->getGlobalRegisterNumber();
-     }
-   else
-     globalRegNum = node->getGlobalRegisterNumber();
+   TR_GlobalRegisterNumber globalRegNum = node->getGlobalRegisterNumber();
 
    globalReg = cg->evaluate(child);
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -594,7 +594,6 @@ public:
    void setRealRegisterAssociation(TR::Register     *reg,
                                    TR::RealRegister::RegNum realNum);
    bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt);
-   void registerSymbolSetup();
 
    // Used to model register liveness without Future Use Count.
    virtual bool isInternalControlFlowReg(TR::Register *reg);

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1494,8 +1494,6 @@ OMR::Z::MemoryReference::populateShiftLeftTree(TR::Node * subTree, TR::CodeGener
       {
       TR::Node *firstChild=subTree->getFirstChild();
       TR::Register *firstRegister = firstChild->getRegister();
-      if(firstRegister == NULL && firstChild->getOpCode().hasSymbolReference() && firstChild->getSymbolReference()->getSymbol()->isRegisterSymbol())
-        firstRegister = cg->evaluate(firstChild);
       if (firstRegister && !_baseRegister && !_indexRegister)
          {
          strengthReducedShift = true;
@@ -1643,8 +1641,6 @@ bool OMR::Z::MemoryReference::tryBaseIndexDispl(TR::CodeGenerator* cg, TR::Node*
    if (!loadStore->getOpCode().isLoadVar() &&
        !loadStore->getOpCode().isStore())
       return false;
-   if (topAdd->getRegister() == NULL && topAdd->getOpCode().hasSymbolReference() && topAdd->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     cg->evaluate(topAdd);
    if (topAdd->getRegister() != NULL) return false;
    if (integerChild->getOpCode().isLoadConst()) return false;
 
@@ -1694,12 +1690,8 @@ bool OMR::Z::MemoryReference::tryBaseIndexDispl(TR::CodeGenerator* cg, TR::Node*
 
    if (!cg->isDispInRange(offset)) return false;
    breg = base->getRegister();
-   if (breg == NULL && base->getOpCode().hasSymbolReference() && base->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     breg = cg->evaluate(base);
    if (breg == NULL && base->getReferenceCount() <= 1) return false;
    ireg = index->getRegister();
-   if (ireg == NULL && index->getOpCode().hasSymbolReference() && index->getSymbolReference()->getSymbol()->isRegisterSymbol())
-     ireg = cg->evaluate(index);
    if (ireg == NULL && index->getReferenceCount() <= 1) return false;
    if (breg == NULL)
       breg = cg->evaluate(base);


### PR DESCRIPTION
`TR::RegisterSymbol`s are a remnant from an old register allocator and
do not have relevance in the OMR project.  These symbols are unused by
any known downstream project.

Remove references to `TR::RegisterSymbol`s and fold code around symbol
identity checks assuming register symbols never exist.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>