### PR TITLE
Prepare to relocate ValuePropagation functions to OpenJ9

### DIFF
--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7260,8 +7260,7 @@ void OMR::ValuePropagation::doDelayedTransformations()
    for (converterCallTree = convIt.getFirst();
 		   converterCallTree; converterCallTree = convIt.getNext())
       {
-
-      transformConverterCall(converterCallTree);
+      static_cast<TR::ValuePropagation *>(this)->transformConverterCall(converterCallTree);
       }
    _converterCalls.deleteAll();
 
@@ -7272,7 +7271,7 @@ void OMR::ValuePropagation::doDelayedTransformations()
       ObjCloneInfo *cloneInfo = objCloneTypeIt.getFirst();
       while (callTree && cloneInfo)
          {
-         transformObjectCloneCall(callTree, cloneInfo);
+         static_cast<TR::ValuePropagation *>(this)->transformObjectCloneCall(callTree, cloneInfo);
          callTree = objCloneIt.getNext();
          cloneInfo = objCloneTypeIt.getNext();
          }
@@ -7287,7 +7286,7 @@ void OMR::ValuePropagation::doDelayedTransformations()
       TR_OpaqueClassBlock *clazz = arrayCloneTypeIt.getFirst();
       while (callTree && clazz)
          {
-         transformArrayCloneCall(callTree, clazz);
+         static_cast<TR::ValuePropagation *>(this)->transformArrayCloneCall(callTree, clazz);
          callTree = arrayCloneIt.getNext();
          clazz = arrayCloneTypeIt.getNext();
          }
@@ -7328,7 +7327,7 @@ void OMR::ValuePropagation::doDelayedTransformations()
       tt.set(&_needMultiLeafArrayCopy);
       for (rtArrayCopyTree = tt.getFirst(); rtArrayCopyTree; rtArrayCopyTree = tt.getNext())
          {
-         transformRTMultiLeafArrayCopy(rtArrayCopyTree);
+         static_cast<TR::ValuePropagation *>(this)->transformRTMultiLeafArrayCopy(rtArrayCopyTree);
          }
       _needMultiLeafArrayCopy.deleteAll();
       }

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -764,32 +764,6 @@ bool OMR::ValuePropagation::canTransformArrayCopyCallForSmall(TR::Node *node, in
       return false;
       }
    }
-
-
-#ifdef J9_PROJECT_SPECIFIC
-static
-TR_ResolvedMethod * findResolvedClassMethod(TR::Compilation * comp, char * className, char * methodName, char * methodSig)
-   {
-   TR_OpaqueClassBlock * classHandle = comp->fe()->getClassFromSignature(className, strlen(className), comp->getCurrentMethod());
-
-   if (classHandle)
-      {
-      TR_ScratchList<TR_ResolvedMethod> classMethods(comp->trMemory());
-      comp->fej9()->getResolvedMethods(comp->trMemory(), classHandle, &classMethods);
-
-      ListIterator<TR_ResolvedMethod> it(&classMethods);
-      TR_ResolvedMethod *method;
-      int methodNameLen = strlen(methodName);
-      int methodSigLen  = strlen(methodSig);
-      for (method = it.getCurrent(); method; method = it.getNext())
-         {
-         if (!strncmp(method->nameChars(), methodName, methodNameLen) && !strncmp(method->signatureChars(), methodSig, methodSigLen))
-            return method;
-         }
-      }
-   return NULL;
-   }
-#endif
 
 
 void OMR::ValuePropagation::removeArrayCopyNode(TR::TreeTop *arraycopyTree)


### PR DESCRIPTION
Functions that are wholly guarded with J9_PROJECT_SPECIFIC macros will
be relocated to the OpenJ9 project.  The code that calls them, however,
is guarded with J9_PROJECT_SPECIFIC macros but is nested within functions
that are not.  To enable relocation, these calls need to have their
receiver object (i.e., `this`) downcast to `TR::ValuePropagation`.

Functions affected:

```
transformRTMultiLeafArrayCopy
transformObjectCloneCall
transformArrayCloneCall
transformConverterCall
```

Signed-off-by: Daryl Maier <maier@ca.ibm.com>