### PR TITLE
Extend memory region profiler

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -71,6 +71,7 @@
 #include "optimizer/StructuralAnalysis.hpp"
 #include "ras/Debug.hpp"                              // for TR_DebugBase, etc
 #include "runtime/Runtime.hpp"                        // for setDllSlip
+#include "env/RegionProfiler.hpp"
 
 #include <map>
 #include <utility>
@@ -127,6 +128,8 @@ OMR::CodeGenPhase::performAll()
    for(; i < TR::CodeGenPhase::getListSize(); i++)
       {
       PhaseValue phaseToDo = PhaseList[i];
+      TR::RegionProfiler rp(_cg->comp()->trMemory()->heapMemoryRegion(), *_cg->comp(), "codegen/%s/%s",
+         _cg->comp()->getHotnessName(_cg->comp()->getMethodHotness()), self()->getName(phaseToDo));
       _phaseToFunctionTable[phaseToDo](_cg, self());
       }
    }

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -99,7 +99,7 @@
 #include "control/Recompilation.hpp"           // for TR_Recompilation, etc
 #include "runtime/CodeCacheExceptions.hpp"
 #include "ilgen/IlGen.hpp"                     // for TR_IlGenerator
-
+#include "env/RegionProfiler.hpp"              // for TR::RegionProfiler
 // this ratio defines how full the alias memory region is allowed to become before
 // it is recreated after an optimization finishes
 #define ALIAS_REGION_LOAD_FACTOR 0.75
@@ -993,6 +993,7 @@ int32_t OMR::Compilation::compile()
       _recompilationInfo->startOfCompilation();
 
    {
+     TR::RegionProfiler rpIlgen(self()->trMemory()->heapMemoryRegion(), *self(), "comp/ilgen");
      if (printCodegenTime) genILTime.startTiming(self());
      _ilGenSuccess = _methodSymbol->genIL(self()->fe(), self(), self()->getSymRefTab(), _ilGenRequest);
      if (printCodegenTime) genILTime.stopTiming(self());
@@ -1049,7 +1050,10 @@ int32_t OMR::Compilation::compile()
       TR_DebuggingCounters::initializeCompilation();
       if (printCodegenTime) optTime.startTiming(self());
 
-      self()->performOptimizations();
+         {
+         TR::RegionProfiler rpOpt(self()->trMemory()->heapMemoryRegion(), *self(), "comp/opt");
+         self()->performOptimizations();
+         }
 
       if (printCodegenTime) optTime.stopTiming(self());
 
@@ -1085,6 +1089,8 @@ int32_t OMR::Compilation::compile()
          _recompilationInfo->beforeCodeGen();
 
         {
+        TR::RegionProfiler rpCodegen(self()->trMemory()->heapMemoryRegion(), *self(), "comp/codegen");
+
         if (printCodegenTime)
            codegenTime.startTiming(self());
 

--- a/compiler/env/RegionProfiler.hpp
+++ b/compiler/env/RegionProfiler.hpp
@@ -48,13 +48,21 @@ namespace TR {
 class RegionProfiler
    {
 public:
-   RegionProfiler(TR::Region &region, TR::Compilation &compilation, const char *identifier) :
+   RegionProfiler(TR::Region &region, TR::Compilation &compilation, const char *format, ...) :
       _region(region),
       _initialRegionSize(_region.bytesAllocated()),
       _initialSegmentProviderSize(_region._segmentProvider.bytesAllocated()),
-      _compilation(compilation),
-      _identifier(identifier ? identifier : "[ANONYMOUS]")
+      _compilation(compilation)
       {
+      if (_compilation.getOption(TR_ProfileMemoryRegions))
+         {
+         va_list args;
+         va_start(args, format);
+         int len = vsnprintf(_identifier, sizeof(_identifier), format, args);
+         TR_ASSERT(len < sizeof(_identifier), "Region profiler identifier truncated as it exceeded max length %d", sizeof(_identifier));
+         _identifier[sizeof(_identifier) - 1] = '\0';
+         va_end(args);
+         }
       }
 
    ~RegionProfiler()
@@ -65,9 +73,8 @@ public:
             &_compilation,
             TR::DebugCounter::debugCounterName(
                &_compilation,
-               "kbytesAllocated.details/%s/%s",
-               _identifier,
-               _compilation.getHotnessName(_compilation.getMethodHotness())
+               "kbytesAllocated.details/%s",
+               _identifier
                ),
             (_region.bytesAllocated() - _initialRegionSize) / 1024
             );
@@ -75,9 +82,8 @@ public:
             &_compilation,
             TR::DebugCounter::debugCounterName(
                &_compilation,
-               "segmentAllocation.details/%s/%s",
-                _identifier,
-                _compilation.getHotnessName(_compilation.getMethodHotness())
+               "segmentAllocation.details/%s",
+                _identifier
                 ),
             (_region._segmentProvider.bytesAllocated() - _initialSegmentProviderSize) / 1024
             );
@@ -89,7 +95,7 @@ private:
    size_t const _initialRegionSize;
    size_t const _initialSegmentProviderSize;
    TR::Compilation &_compilation;
-   const char * const _identifier;
+   char _identifier[256];
    };
 
 }

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1247,11 +1247,6 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
    {
    OMR::Optimizations optNum = optimization->_num;
    TR::OptimizationManager *manager = getOptimization(optNum);
-   char description[256];
-   snprintf(description, sizeof(description), "performOptimization - %s", getOptimizationName(optNum));
-   description[255] = '\0';
-   TR::RegionProfiler heapMemoryProfiler(comp()->trMemory()->heapMemoryRegion(), *comp(), description);
-
    TR_ASSERT(manager != NULL, "Optimization manager should have been initialized for %s.",
       getOptimizationName(optNum));
 
@@ -1625,6 +1620,8 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
    //
    // This is a real optimization.
    //
+   TR::RegionProfiler rp(comp()->trMemory()->heapMemoryRegion(), *comp(), "opt/%s/%s", comp()->getHotnessName(comp()->getMethodHotness()),
+      getOptimizationName(optNum));
 
    if (comp()->isOutermostMethod())
       comp()->incOptIndex(); // Note that we count the opt even if we're not doing it, to keep the opt indexes more stable


### PR DESCRIPTION
This change simplifies use of the memory region
profiler and extends its use to codegen and the
general compilation strategy.