### PR TITLE
Remove calls to `getMnemonicName` in `z` codegen

### DIFF
--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -85,7 +85,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", TR::InstOpCode::getMnemonicName(op));
+   TR_ASSERT(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", cg->getDebug()? cg->getDebug()->getOpCodeName(&_opcode) : "(unknown)");
 
    self()->initialize();
    }
@@ -95,7 +95,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedin
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", TR::InstOpCode::getMnemonicName(op));
+   TR_ASSERT(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", cg->getDebug()? cg->getDebug()->getOpCodeName(&_opcode) : "(unknown)");
 
    self()->initialize(precedingInstruction, true);
    }


### PR DESCRIPTION
There are a couple of Assertions in OMRInstruction.cpp
which make calls to `OMR::InstOpCode::getMnemonicName`.
However, `getMnemonicName` is yet to be implemented on `Z`
and therefore these calls generate compile time failures.

This commit replaces the said calls by using an alternate API.

Closes: #2144

Signed-off-by: Rwitaban (Ray) Banerjee rayb@ca.ibm.com