### PR TITLE
WIP: Create the opcode breturn

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -72,7 +72,7 @@ TR::Register *OMR::ARM::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeGen
    return NULL;
    }
 
-// also handles areturn
+/* Also handles areturn and breturn. */
 TR::Register *OMR::ARM::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *returnRegister = cg->evaluate(node->getFirstChild());
@@ -81,7 +81,17 @@ TR::Register *OMR::ARM::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::Code
    addDependency(deps, returnRegister, cg->getProperties().getIntegerReturnRegister(), TR_GPR, cg);
 
    generateAdminInstruction(cg, ARMOp_ret, node, deps);
-   cg->comp()->setReturnInfo(TR_IntReturn);
+   switch (node->getDataType())
+     {
+     case TR::Int8:
+       cg->comp()->setReturnInfo(TR_ByteReturn);
+       break;
+     case TR::Int64:
+       cg->comp()->setReturnInfo(TR_IntReturn);
+       break;
+     default:
+       TR_ASSERT(false, "The ireturnEvaluator in arm should only be used when the data being returned is of type TR::Int8 || TR::Int32");
+     }
    return NULL;
    }
 
@@ -100,7 +110,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::Code
    return NULL;
    }
 
-// areturn handled by ireturnEvaluator
+// breturn and areturn handled by ireturnEvaluator
 
 TR::Register *OMR::ARM::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/arm/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/TreeEvaluatorTable.hpp
@@ -70,6 +70,7 @@
    TR::TreeEvaluator::sstoreEvaluator,      // TR::sstorei
    TR::TreeEvaluator::istoreEvaluator,      // TR::istorei
    TR::TreeEvaluator::gotoEvaluator,        // TR::Goto
+   TR::TreeEvaluator::ireturnEvaluator,     // TR::breturn
    TR::TreeEvaluator::ireturnEvaluator,     // TR::ireturn
    TR::TreeEvaluator::lreturnEvaluator,     // TR::lreturn
    TR::TreeEvaluator::freturnEvaluator,     // TR::freturn

--- a/compiler/compile/CompilationTypes.hpp
+++ b/compiler/compile/CompilationTypes.hpp
@@ -81,21 +81,22 @@ enum TR_CallingContext {
 
 
 
-// function return type flags for word preceding the entry point in any
+// function return types for word preceding the entry point in any
 // linkage that needs to be callable from interpreted.  Also used in pic
 // for use when dispatching methods that are interpreted in megamorphic send
 // case
 enum TR_ReturnInfo
    {
-   TR_VoidReturn        = 0,
-   TR_IntReturn         = 1,
-   TR_LongReturn        = 2,
-   TR_FloatReturn       = 3,
-   TR_DoubleReturn      = 4,
-   TR_ObjectReturn      = 5, // Currently 64-bit platforms only
-   TR_FloatXMMReturn    = 6, // IA32 and AMD64 only
-   TR_DoubleXMMReturn   = 7, // IA32 and AMD64 only
-   TR_ConstructorReturn = 8  // Return from constructor
+   TR_VoidReturn,
+   TR_ByteReturn,
+   TR_IntReturn,
+   TR_LongReturn,
+   TR_FloatReturn,
+   TR_DoubleReturn,
+   TR_ObjectReturn,     // Currently 64-bit platforms only
+   TR_FloatXMMReturn,   // IA32 and AMD64 only
+   TR_DoubleXMMReturn,  // IA32 and AMD64 only
+   TR_ConstructorReturn // Return from constructor
    };
 
 

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -649,6 +649,22 @@
    },
 
    {
+   /* .opcode               = */ TR::breturn,
+   /* .name                 = */ "breturn",
+   /* .properties1          = */ ILProp1::Return | ILProp1::TreeTop,
+   /* .properties2          = */ ILProp2::MayUseSystemStack,
+   /* .properties3          = */ 0,
+   /* .properties4          = */ 0,
+   /* .dataType             = */ TR::Int8,
+   /* .typeProperties       = */ ILTypeProp::Size_1 | ILTypeProp::Integer,
+   /* .childProperties      = */ ONE_CHILD(TR::Int8),
+   /* .swapChildrenOpCode   = */ TR::BadILOp,
+   /* .reverseBranchOpCode  = */ TR::BadILOp,
+   /* .booleanCompareOpCode = */ TR::BadILOp,
+   /* .ifCompareOpCode      = */ TR::BadILOp,
+   },
+
+   {
    /* .opcode               = */ TR::ireturn,
    /* .name                 = */ "ireturn",
    /* .properties1          = */ ILProp1::Return | ILProp1::TreeTop,
@@ -657,7 +673,7 @@
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int32,
    /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer,
-   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), // ireturn is used to return all types smaller than Int32
+   /* .childProperties      = */ ONE_CHILD(ILChildProp::UnspecifiedChildType), // ireturn is used to return both TR::Int16 and TR::Int32
    /* .swapChildrenOpCode   = */ TR::BadILOp,
    /* .reverseBranchOpCode  = */ TR::BadILOp,
    /* .booleanCompareOpCode = */ TR::BadILOp,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -86,6 +86,7 @@
    sstorei,  // store indirect short integer          (child1 a, child2 s)
    istorei,  // store indirect integer                (child1 a, child2 i)
    Goto,     // goto label address
+   breturn,  // return a byte
    ireturn,  // return an integer
    lreturn,  // return a long integer
    freturn,  // return a float

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1191,7 +1191,7 @@ public:
       {
       switch(type)
          {
-         case TR::Int8:     return TR::ireturn;
+         case TR::Int8:     return TR::breturn;
          case TR::Int16:    return TR::ireturn;
          case TR::Int32:    return TR::ireturn;
          case TR::Int64:    return TR::lreturn;

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3150,8 +3150,9 @@ OMR::Node::getReturnCode(bool isReason)
       return NULL;
 
    // just return code
-   else if (self()->getOpCodeValue() == TR::ireturn &&
-            self()->getNumChildren() == 1)
+   else if (self()->getNumChildren() == 1 &&
+            (self()->getOpCodeValue() == TR::ireturn ||
+             self()->getOpCodeValue() == TR::breturn))
       codeChild = self()->getChild(0);
 
    // return code and return reason

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -61,6 +61,7 @@
    indirectStoreSimplifier, // TR::sstorei
    indirectStoreSimplifier, // TR::istorei
    gotoSimplifier,          // TR::Goto
+   dftSimplifier,           // TR::breturn
    dftSimplifier,           // TR::ireturn
    dftSimplifier,           // TR::lreturn
    dftSimplifier,           // TR::freturn

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -201,6 +201,7 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainStore,           // TR::sstorei
    constrainStore,           // TR::istorei
    constrainGoto,            // TR::Goto
+   constrainReturn,          // TR::breturn
    constrainReturn,          // TR::ireturn
    constrainReturn,          // TR::lreturn
    constrainReturn,          // TR::freturn

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -792,6 +792,7 @@ TR_ReturnInfo OMR::Power::Linkage::getReturnInfoFromReturnType(TR::DataType retu
       case TR::NoType:
          return TR_VoidReturn;
       case TR::Int8:
+         return TR_ByteReturn;
       case TR::Int16:
       case TR::Int32:
          return TR_IntReturn;

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -85,6 +85,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *ilstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *astoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);  // ibm@59591
    static TR::Register *gotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *breturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ireturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *freturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -62,6 +62,7 @@
    TR::TreeEvaluator::sstoreEvaluator,                  // TR::sstorei
    TR::TreeEvaluator::istoreEvaluator,                  // TR::istorei
    TR::TreeEvaluator::gotoEvaluator,                    // TR::Goto
+   TR::TreeEvaluator::breturnEvaluator,                 // TR::breturn
    TR::TreeEvaluator::ireturnEvaluator,                 // TR::ireturn
    TR::TreeEvaluator::lreturnEvaluator,                 // TR::lreturn
    TR::TreeEvaluator::freturnEvaluator,                 // TR::freturn

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2340,6 +2340,7 @@ int32_t childTypes[] =
    TR::Int16 | (TR::Address<<8),   // TR::sstorei
    TR::Int32 | (TR::Address<<8),   // TR::istorei
    TR::NoType,                     // TR::Goto
+   TR::Int8,                      // TR::breturn
    TR::Int32,                     // TR::ireturn
    TR::Int64,                     // TR::lreturn
    TR::Float,                      // TR::freturn

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -63,6 +63,7 @@
    TR::TreeEvaluator::sstoreEvaluator,                  // TR::sstorei
    TR::TreeEvaluator::istoreEvaluator,                  // TR::istorei
    TR::TreeEvaluator::gotoEvaluator,                    // TR::Goto
+   TR::TreeEvaluator::integerReturnEvaluator,           // TR::breturn
    TR::TreeEvaluator::integerReturnEvaluator,           // TR::ireturn
    TR::TreeEvaluator::integerReturnEvaluator,           // TR::lreturn
    TR::TreeEvaluator::fpReturnEvaluator,                // TR::freturn

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1214,6 +1214,9 @@ TR::Register *OMR::X86::TreeEvaluator::integerReturnEvaluator(TR::Node *node, TR
             default:
                TR_ASSERT(0, "Unrecognized return type");
                // fall through
+            case TR::Int8:
+               returnInfo = TR_ByteReturn;
+               break;
             case TR::Int32:
                returnInfo = TR_IntReturn;
                break;
@@ -1228,7 +1231,18 @@ TR::Register *OMR::X86::TreeEvaluator::integerReturnEvaluator(TR::Node *node, TR
          }
       else
          {
-         comp->setReturnInfo(TR_IntReturn);
+         switch (node->getDataType())
+            {
+            default:
+              TR_ASSERT(0, "On non-64bit target platforms, the only supported return types are TR::Int8 and TR::Int32");
+              // fall through
+            case TR::Int8:
+              comp->setReturnInfo(TR_ByteReturn);
+              break;
+            case TR::Int32:
+              comp->setReturnInfo(TR_IntReturn);
+              break;
+            }
          }
       }
 

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -63,6 +63,7 @@
    TR::TreeEvaluator::sstoreEvaluator,                  // TR::sstorei
    TR::TreeEvaluator::istoreEvaluator,                  // TR::istorei
    TR::TreeEvaluator::gotoEvaluator,                    // TR::Goto
+   TR::TreeEvaluator::integerReturnEvaluator,           // TR::breturn
    TR::TreeEvaluator::integerReturnEvaluator,           // TR::ireturn
    TR::TreeEvaluator::integerPairReturnEvaluator,      // TR::lreturn
    TR::TreeEvaluator::fpReturnEvaluator,                // TR::freturn

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1077,7 +1077,7 @@ OMR::Z::TreeEvaluator::igotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * Handles all types of return opcodes
- * (return, areturn, ireturn, lreturn, freturn, dreturn, iureturn, lureturn, oreturn)
+ * (return, areturn, breturn, ireturn, lreturn, freturn, dreturn, iureturn, lureturn, oreturn)
  */
 TR::Register *
 OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -1148,6 +1148,24 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       case TR::areturn:
          comp->setReturnInfo(TR_ObjectReturn);
          dependencies->addPostCondition(returnValRegister, linkage->getIntegerReturnRegister());
+         break;
+      case TR::breturn:
+         dependencies->addPostCondition(returnValRegister, linkage->getIntegerReturnRegister());
+         comp->setReturnInfo(TR_ByteReturn);
+         if (linkage->isNeedsWidening())
+            {
+            /* LGBR equiv to {Operands R_1,R_2 : Load Byte (64<-8)} */
+            new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LGBR,
+                                                           node, returnValRegister,
+                                                           returnValRegister, cg);
+            }
+         else
+            {
+            /* LBR equiv to {Operands R_1, R_2 : Load Byte (32<-8)} */
+            new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LBR,
+                                                           node, returnValRegister,
+                                                           returnValRegister, cg);
+            }
          break;
       case TR::ireturn:
          dependencies->addPostCondition(returnValRegister, linkage->getIntegerReturnRegister());

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -63,6 +63,7 @@
    TR::TreeEvaluator::sstoreEvaluator,      // TR::sstorei
    TR::TreeEvaluator::istoreEvaluator,      // TR::istorei
    TR::TreeEvaluator::gotoEvaluator,        // TR::Goto
+   TR::TreeEvaluator::returnEvaluator,      // TR::breturn
    TR::TreeEvaluator::returnEvaluator,      // TR::ireturn
    TR::TreeEvaluator::returnEvaluator,      // TR::lreturn
    TR::TreeEvaluator::returnEvaluator,      // TR::freturn

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -180,7 +180,7 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 (block (ireturn (b2i (%s (bconst %d) (iconst %d)) ))))", param.opcode.c_str(), param.lhs, param.rhs);
+    std::snprintf(inputTrees, 120, "(method return=Int8 (block (breturn (%s (bconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -197,7 +197,7 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (b2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
+    std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (breturn (%s (bload parm=0) (iload parm=1)) )))", param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);


### PR DESCRIPTION
Add `breturn` to the list of available  `ILOpCode`s and implement the required
codegen support on `X`, `P`, `Z`  and `arm`. 


This is part of an effort to raise `TR::Int8` to a first class citizen.

Please see https://github.com/eclipse/omr/issues/1901 for the relevant discussion. 

Fixes Issue: #1887 (NOTE: Does not address the `bureturn` aspect of it)

Signed-off-by: Rwitaban (Ray) Banerjee rayb@ca.ibm.com