### PR TITLE
Fix unresolved case in duplicate check

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1849,7 +1849,7 @@ OMR::Node::isUnsafeToDuplicateAndExecuteAgain(int32_t *nodeVisitBudget)
          // Unresolved symrefs need to be evaluated in their original location,
          // under the ResolveCHK.
          //
-         return false;
+         return true;
          }
       else if (self()->getOpCodeValue() == TR::loadaddr)
          {


### PR DESCRIPTION
The method `isUnsafeToDuplicateAndExecuteAgain` on
nodes will determine whether its safe to duplicate
a node and its children. However, unresolved
symbol references were treated as safe for duplication,
even though they should remain under their resolve
checks.