### PR TITLE
Enable optimizations with JProfiling

### DIFF
--- a/compiler/optimizer/AsyncCheckInsertion.cpp
+++ b/compiler/optimizer/AsyncCheckInsertion.cpp
@@ -120,7 +120,7 @@ bool TR_AsyncCheckInsertion::shouldPerform()
    {
    // Don't run when profiling
    //
-   if (comp()->isProfilingCompilation() || comp()->generateArraylets())
+   if (comp()->getProfilingMode() == JitProfiling || comp()->generateArraylets())
       return false;
 
    // It is not safe to add an asynccheck under involuntary OSR

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1590,7 +1590,7 @@ void TR_InlinerBase::rematerializeCallArguments(TR_TransformInlinedFunction & ti
    block1 = block1->startOfExtendedBlock();
    static char *disableProfiledGuardRemat = feGetEnv("TR_DisableProfiledGuardRemat");
 
-   bool suitableForRemat = !comp()->getOption(TR_DisableGuardedCallArgumentRemat) && !comp()->isProfilingCompilation();
+   bool suitableForRemat = !comp()->getOption(TR_DisableGuardedCallArgumentRemat) && comp()->getProfilingMode() != JitProfiling;
    if (suitableForRemat)
       {
       if (guard->_kind == TR_NoGuard)

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -3323,7 +3323,7 @@ int32_t TR_EliminateRedundantGotos::process(TR::TreeTop *startTree, TR::TreeTop 
    if (cfg == NULL)
       return false;
 
-   if (comp()->isProfilingCompilation())
+   if (comp()->getProfilingMode() == JitProfiling)
       return 0;
 
    bool gotosWereEliminated = false;
@@ -3732,7 +3732,7 @@ void TR_CleanseTrees::prePerformOnBlocks()
 
 int32_t TR_CleanseTrees::process(TR::TreeTop *startTree, TR::TreeTop *endTreeTop)
    {
-   if (comp()->isProfilingCompilation())
+   if (comp()->getProfilingMode() == JitProfiling)
       return 0;
 
    TR_Structure *rootStructure = comp()->getFlowGraph()->getStructure();
@@ -6840,7 +6840,7 @@ bool TR_BlockSplitter::isExitEdge(TR::Block *mergeNode, TR::Block *successor)
 bool TR_BlockSplitter::hasIVUpdate(TR::Block *block)
    {
    TR_RegionStructure *parent = getParentStructure(block);
-   if (getLastRun() || comp()->isProfilingCompilation() || !parent || !parent->isNaturalLoop())
+   if (getLastRun() || comp()->getProfilingMode() == JitProfiling || !parent || !parent->isNaturalLoop())
       return false;
 
    if (trace())
@@ -6872,7 +6872,7 @@ bool TR_BlockSplitter::hasIVUpdate(TR::Block *block)
 bool TR_BlockSplitter::hasLoopAsyncCheck(TR::Block *block)
    {
    TR_RegionStructure *parent = getParentStructure(block);
-   if (getLastRun() || comp()->isProfilingCompilation() || !parent || !parent->isNaturalLoop())
+   if (getLastRun() || comp()->getProfilingMode() == JitProfiling || !parent || !parent->isNaturalLoop())
       return false;
 
    if (trace())

--- a/compiler/optimizer/LoopReplicator.cpp
+++ b/compiler/optimizer/LoopReplicator.cpp
@@ -86,7 +86,7 @@ int32_t TR_LoopReplicator::perform()
        optimizer()->optsThatCanCreateLoopsDisabled())
       return 0;
 
-   if (comp()->isProfilingCompilation())
+   if (comp()->getProfilingMode() == JitProfiling)
       return 0;
 
    _cfg = comp()->getFlowGraph();

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4213,7 +4213,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
             _canPredictIters = false;
          }
 
-      if (!refineAliases() && _canPredictIters && !comp()->isProfilingCompilation() &&
+      if (!refineAliases() && _canPredictIters && comp()->getProfilingMode() != JitProfiling &&
           performTransformation(comp(), "%s Creating test outside loop for deciding if async check is required\n", OPT_DETAILS_LOOP_VERSIONER))
          {
          TR::Node *lowerBound = _loopTestTree->getNode()->getFirstChild()->duplicateTreeForCodeMotion();

--- a/compiler/optimizer/OMROptimizer.hpp
+++ b/compiler/optimizer/OMROptimizer.hpp
@@ -97,6 +97,7 @@ enum
    IfNoLoops,
    IfProfiling,
    IfNotProfiling,
+   IfNotJitProfiling,
    IfNews,
    IfEnabledAndOptServer,
    IfOptServer,
@@ -107,6 +108,7 @@ enum
    IfNoLoopsOREnabledAndLoops, // ie. do this opt if no loops; if loops, it must be enabled
    IfEnabledAndProfiling,
    IfEnabledAndNotProfiling,
+   IfEnabledAndNotJitProfiling,
    IfLoopsAndNotProfiling,
    MustBeDone,
    IfEnabled,

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -15249,7 +15249,7 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       node->getBlock()->getNumber(),
       block->getNumber());
 
-   if (s->comp()->isProfilingCompilation())
+   if (s->comp()->getProfilingMode() == JitProfiling)
       return node;
 
    // See if this block has a single successor by looking at the CFG

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -1027,7 +1027,7 @@ bool TR_OrderBlocks::peepHoleGotoToFollowing(TR::CFG *cfg, TR::Block *block, TR:
 bool TR_OrderBlocks::peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, char *title,
                                         TR::BitVector &skippedGotoBlocks)
    {
-   if (comp()->isProfilingCompilation())
+   if (comp()->getProfilingMode() == JitProfiling)
       return false;
 
    if (destOfGoto->isGotoBlock(comp(),true)
@@ -1068,7 +1068,7 @@ bool TR_OrderBlocks::peepHoleGotoToGoto(TR::CFG *cfg, TR::Block *block, TR::Node
 // returns TRUE if the pattern was found and replaced
 bool TR_OrderBlocks::peepHoleGotoToEmpty(TR::CFG *cfg, TR::Block *block, TR::Node *gotoNode, TR::Block *destOfGoto, char *title)
    {
-   if (comp()->isProfilingCompilation())
+   if (comp()->getProfilingMode() == JitProfiling)
       return false;
 
    if (destOfGoto->isEmptyBlock() && !(destOfGoto->getStructureOf() && destOfGoto->getStructureOf()->isLoopInvariantBlock()) &&
@@ -1494,7 +1494,7 @@ bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
    TR::CFG *cfg             = comp()->getFlowGraph();
 
    // pattern: block has nothing in it and no exceptional predecessors (can redirect edges around it and remove it)
-   if ((block->isEmptyBlock() && (block->hasExceptionPredecessors() == false) && !comp()->isProfilingCompilation()
+   if ((block->isEmptyBlock() && (block->hasExceptionPredecessors() == false) && comp()->getProfilingMode() != JitProfiling
        && !(block->getStructureOf() && block->getStructureOf()->isLoopInvariantBlock()))
        && (block->isTargetOfJumpWhoseTargetCanBeChanged(comp())))
        //TODO enable for PLX, currently disabled because we cannot re-direct edges for ASM flows
@@ -1536,7 +1536,8 @@ bool TR_OrderBlocks::doPeepHoleBlockCorrections(TR::Block *block, char *title)
             madeAChange = true;
 
          // if we made either of the above changes, then prevBlock might be empty now (remove it if it is)
-         if (madeAChange && prevBlock->isEmptyBlock() && (prevBlock->hasExceptionPredecessors() == false) && !comp()->isProfilingCompilation() && prevBlock->isTargetOfJumpWhoseTargetCanBeChanged(comp()))
+         if (madeAChange && prevBlock->isEmptyBlock() && (prevBlock->hasExceptionPredecessors() == false) && comp()->getProfilingMode() != JitProfiling &&
+             prevBlock->isTargetOfJumpWhoseTargetCanBeChanged(comp()))
             {
             removeEmptyBlock(cfg, prevBlock, title);
             }

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -227,7 +227,7 @@ int32_t TR_PartialRedundancy::perform()
    // PRE is too expensive when profiling with HCR on, due to the number
    // of blocks and temps this configuration creates. Disabling it
    // won't affect performance if there are no profilings allowed.
-   if (comp()->isProfilingCompilation() && comp()->getHCRMode() != TR::none && _numProfilingsAllowed == 0)
+   if (comp()->getProfilingMode() == JitProfiling && comp()->getHCRMode() != TR::none && _numProfilingsAllowed == 0)
       return 0;
 
    TR::StackMemoryRegion stackMemoryRegion(*trMemory());

--- a/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
+++ b/compiler/optimizer/RedundantAsyncCheckRemoval.cpp
@@ -106,7 +106,7 @@ bool TR_RedundantAsyncCheckRemoval::shouldPerform()
    {
    // Don't run when profiling
    //
-   if (comp()->isProfilingCompilation() || comp()->generateArraylets())
+   if (comp()->getProfilingMode() == JitProfiling || comp()->generateArraylets())
       return false;
 
 

--- a/compiler/optimizer/ShrinkWrapping.cpp
+++ b/compiler/optimizer/ShrinkWrapping.cpp
@@ -83,11 +83,6 @@ int32_t TR_ShrinkWrap::perform()
    if (_traceSW)
       traceMsg(comp(), "Going to start shrink wrapping of registers\n");
 
-   // dont bother with profiling compiles
-   //
-   if (0 && comp()->isProfilingCompilation())
-      return 0;
-
    // no shrink wrapping on CFG with internal cycles, as the
    // analysis is going to be conservative anyway
    //


### PR DESCRIPTION
This change enables various optimizations
that were disabled under JitProfiling due
to issues with the duplication it performed,
such as the increased node count or its
limitations on asyncchecks.