### PR TITLE
Deprecate unused instruction properties in Z codegen

### DIFF
--- a/compiler/z/codegen/ArchInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/ArchInstOpCodeProperties.hpp
@@ -26,7 +26,7 @@
 
 
       // BAD
-   0,
+   S390OpProp_None,
 
       // A
    S390OpProp_Is32Bit |
@@ -54,7 +54,6 @@
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
    S390OpProp_SetsSignFlag |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // AEB
@@ -76,7 +75,6 @@
    S390OpProp_SetsOverflowFlag |
    S390OpProp_UsesTarget |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate |
    S390OpProp_SetsOperand1,
 
       // AG
@@ -103,7 +101,6 @@
    S390OpProp_SetsOverflowFlag |
    S390OpProp_UsesTarget |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate |
    S390OpProp_SetsOperand1,
 
       // AGFR
@@ -191,7 +188,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsCC,
 
@@ -201,7 +197,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_TargetHW |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate |
    S390OpProp_SetsOperand1,
 
       // AL
@@ -210,7 +205,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALC
@@ -220,7 +214,6 @@
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALCG
@@ -230,7 +223,6 @@
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALCGR
@@ -238,7 +230,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALCR
@@ -246,7 +237,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALFI
@@ -254,7 +244,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALG
@@ -263,7 +252,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALGF
@@ -272,7 +260,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALGFI
@@ -280,20 +267,17 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALGFR
    S390OpProp_Is32To64Bit |
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALGHSIK
    S390OpProp_Is64Bit |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_IsExtendedImmediate |
    S390OpProp_SetsOperand1,
 
@@ -301,19 +285,16 @@
    S390OpProp_Is64Bit |
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALGRK
    S390OpProp_Is64Bit |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALHHHR
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_TargetHW |
    S390OpProp_SrcHW |
    S390OpProp_Src2HW |
@@ -322,7 +303,6 @@
       // ALHHLR
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_TargetHW |
    S390OpProp_SrcHW |
    S390OpProp_Src2LW |
@@ -331,7 +311,6 @@
       // ALHSIK
    S390OpProp_Is32Bit |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_IsExtendedImmediate |
    S390OpProp_SetsOperand1,
 
@@ -339,19 +318,16 @@
    S390OpProp_Is32Bit |
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALRK
    S390OpProp_Is32Bit |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // ALSIH
    S390OpProp_SetsZeroFlag |
    S390OpProp_UsesTarget |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_IsExtendedImmediate |
    S390OpProp_TargetHW |
    S390OpProp_SetsOperand1,
@@ -368,8 +344,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // AR
@@ -389,7 +363,6 @@
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
    S390OpProp_SetsSignFlag |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1,
@@ -401,7 +374,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // BAL
@@ -463,10 +435,10 @@
    S390OpProp_SetsOperand1,
 
       // BPP
-   S390OpProp_IsExecutionHint,
+   S390OpProp_None,
 
       // BPRP
-   S390OpProp_IsExecutionHint,
+   S390OpProp_None,
 
       // BRAS
    S390OpProp_BranchOp |
@@ -590,7 +562,6 @@
       // CDGTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // CDLFBR
@@ -683,8 +654,7 @@
    S390OpProp_Is32Bit |
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
-   S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate,
+   S390OpProp_IsExtendedImmediate,
 
       // CG
    S390OpProp_Is64Bit |
@@ -706,7 +676,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_SetsSignFlag |
    S390OpProp_SetsOverflowFlag |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // CGEBR
@@ -727,8 +696,7 @@
    S390OpProp_Is32To64Bit |
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
-   S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate,
+   S390OpProp_IsExtendedImmediate,
 
       // CGFR
    S390OpProp_Is32To64Bit |
@@ -800,7 +768,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_SetsSignFlag |
    S390OpProp_SetsOverflowFlag |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_SetsOperand1,
 
@@ -840,8 +807,7 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // CIB
    S390OpProp_Is32Bit |
@@ -852,8 +818,7 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_TargetHW |
-   S390OpProp_IsSignedImmediate,
+   S390OpProp_TargetHW,
 
       // CIJ
    S390OpProp_Is32Bit |
@@ -878,16 +843,12 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_SSSchedulingCandidate |
-   S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefTwoIsLoad,
+   S390OpProp_HasTwoMemoryReferences,
 
       // CLCL
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_SetsOperand1 |
@@ -898,7 +859,6 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_SetsOperand1 |
@@ -909,7 +869,6 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_SetsOperand1 |
@@ -1067,8 +1026,7 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // CLI
    S390OpProp_IsCompare |
@@ -1112,8 +1070,7 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // CLR
    S390OpProp_Is32Bit |
@@ -1148,7 +1105,6 @@
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_UsesTarget,
 
       // CPYA
@@ -1195,7 +1151,6 @@
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_UsesTarget |
    S390OpProp_SetsOperand3 |
@@ -1255,7 +1210,6 @@
       // CXGTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1,
@@ -1285,8 +1239,7 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // D
    S390OpProp_Is32Bit |
@@ -1314,7 +1267,6 @@
       // DDTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsFPC |
    S390OpProp_SetsOperand1,
 
@@ -1404,7 +1356,6 @@
       // DXTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsFPC |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
@@ -1414,7 +1365,7 @@
    S390OpProp_SetsOperand1,
 
       // ECAG
-   0,
+   S390OpProp_None,
 
       // EEDTR
    S390OpProp_DoubleFP |
@@ -1448,7 +1399,7 @@
    S390OpProp_SetsOperand1,
 
       // ETND
-   0,
+   S390OpProp_None,
 
       // EX
    S390OpProp_IsStore |
@@ -1510,7 +1461,6 @@
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_UsesTarget,
 
@@ -1518,7 +1468,6 @@
    S390OpProp_TargetLW |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_UsesTarget,
 
@@ -1579,9 +1528,7 @@
       // KIMD
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1590,9 +1537,7 @@
       // KLMD
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1601,9 +1546,7 @@
       // KM
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1612,9 +1555,7 @@
       // KMAC
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1623,9 +1564,7 @@
       // KMC
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1634,9 +1573,7 @@
       // KMCTR
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1645,9 +1582,7 @@
       // KMF
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1656,9 +1591,7 @@
       // KMO
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -1707,7 +1640,6 @@
    S390OpProp_IsLoad |
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand1,
 
@@ -1716,22 +1648,18 @@
    S390OpProp_IsLoad |
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand1,
 
       // LAM
    S390OpProp_IsLoad |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
 
       // LAMY
    S390OpProp_IsLoad |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
 
@@ -1801,7 +1729,6 @@
 
       // LAY
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LB
@@ -1880,7 +1807,6 @@
    S390OpProp_DoubleFP |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // LDGR
@@ -1896,7 +1822,6 @@
       // LDY
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LE
@@ -1911,7 +1836,6 @@
       // LEDTR
    S390OpProp_SingleFP |
    S390OpProp_DoubleFP |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // LER
@@ -1921,7 +1845,6 @@
       // LEY
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LFH
@@ -1976,7 +1899,6 @@
       // LGFI
    S390OpProp_Is32To64Bit |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate |
    S390OpProp_SetsOperand1,
 
       // LGFR
@@ -2042,7 +1964,6 @@
    S390OpProp_Is32Bit |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LLC
@@ -2166,7 +2087,6 @@
       // LM
    S390OpProp_IsLoad |
    S390OpProp_Is32Bit |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand1 |
@@ -2175,7 +2095,6 @@
       // LMG
    S390OpProp_IsLoad |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand1 |
@@ -2184,10 +2103,8 @@
       // LMY
    S390OpProp_IsLoad |
    S390OpProp_Is32Bit |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegRangeForTarget |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
 
@@ -2284,11 +2201,8 @@
    S390OpProp_Is32Bit |
    S390OpProp_IsLoad |
    S390OpProp_UsesRegPairForTarget |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
    S390OpProp_SetsCC |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // LPDBR
@@ -2305,11 +2219,8 @@
    S390OpProp_Is64Bit |
    S390OpProp_IsLoad |
    S390OpProp_UsesRegPairForTarget |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
    S390OpProp_SetsCC |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // LPEBR
@@ -2455,7 +2366,6 @@
    S390OpProp_IsLoad |
    S390OpProp_Is32Bit |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LZDR
@@ -2491,7 +2401,6 @@
    S390OpProp_IsLoad |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // MADB
@@ -2530,7 +2439,6 @@
       // MDTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // MEEB
@@ -2560,7 +2468,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // MHI
@@ -2609,7 +2516,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // MSDB
@@ -2666,18 +2572,13 @@
       // MVC
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVCL
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -2701,13 +2602,11 @@
       // MVIY
    S390OpProp_IsStore |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // MXTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1,
@@ -2725,11 +2624,7 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // NG
@@ -2760,7 +2655,7 @@
    S390OpProp_SetsOperand1,
 
       // NIAI
-   S390OpProp_IsExecutionHint,
+   S390OpProp_None,
 
       // NIHF
    S390OpProp_TargetHW |
@@ -2806,7 +2701,6 @@
    S390OpProp_IsStore |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // NR
@@ -2831,7 +2725,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // O
@@ -2847,11 +2740,7 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // OG
@@ -2925,7 +2814,6 @@
    S390OpProp_IsStore |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // OR
@@ -2945,7 +2833,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // PFD
@@ -2962,20 +2849,17 @@
    S390OpProp_SetsOperand1,
 
       // PPA
-   S390OpProp_IsExecutionHint |
    S390OpProp_UsesTarget,
 
       // QADTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsFPC |
    S390OpProp_SetsOperand1,
 
       // QAXTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsFPC |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
@@ -3034,13 +2918,11 @@
       // RRDTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // RRXTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1,
@@ -3080,7 +2962,6 @@
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
    S390OpProp_SetsSignFlag |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_SetsOperand1,
 
       // SEB
@@ -3174,7 +3055,6 @@
    S390OpProp_SetsOverflowFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // SL
@@ -3183,8 +3063,7 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsOperand1 |
-   S390OpProp_SetsCarryFlag,
+   S390OpProp_SetsOperand1,
 
       // SLA
    S390OpProp_Is32Bit |
@@ -3214,7 +3093,6 @@
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLBG
@@ -3224,7 +3102,6 @@
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLBGR
@@ -3232,7 +3109,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLBR
@@ -3240,7 +3116,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
    S390OpProp_ReadsCC |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLDA
@@ -3272,7 +3147,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLG
@@ -3281,7 +3155,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLGF
@@ -3290,7 +3163,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLGFI
@@ -3298,27 +3170,23 @@
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLGFR
    S390OpProp_Is32To64Bit |
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLGR
    S390OpProp_Is64Bit |
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLGRK
    S390OpProp_Is64Bit |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLHHHR
@@ -3326,7 +3194,6 @@
    S390OpProp_TargetHW |
    S390OpProp_SrcHW |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLHHLR
@@ -3334,7 +3201,6 @@
    S390OpProp_TargetHW |
    S390OpProp_SrcLW |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLL
@@ -3356,13 +3222,11 @@
    S390OpProp_Is32Bit |
    S390OpProp_UsesTarget |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLRK
    S390OpProp_Is32Bit |
    S390OpProp_SetsZeroFlag |
-   S390OpProp_SetsCarryFlag |
    S390OpProp_SetsOperand1,
 
       // SLY
@@ -3371,8 +3235,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsCarryFlag |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // SQDB
@@ -3463,7 +3325,6 @@
       // SRST
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
    S390OpProp_UsesTarget |
@@ -3472,7 +3333,6 @@
       // SRSTU
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
    S390OpProp_UsesTarget |
@@ -3480,8 +3340,7 @@
 
       // SRNMT
    S390OpProp_DoubleFP |
-   S390OpProp_Is64Bit |
-   S390OpProp_SetsDFPRoundingMode,
+   S390OpProp_Is64Bit,
 
       // ST
    S390OpProp_IsStore |
@@ -3491,15 +3350,12 @@
 
       // STAM
    S390OpProp_IsStore |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand3,
 
       // STAMY
    S390OpProp_IsStore |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand3,
 
       // STC
@@ -3545,14 +3401,12 @@
    S390OpProp_Is32Bit |
    S390OpProp_IsStore |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand3,
 
       // STCY
    S390OpProp_Is32Bit |
    S390OpProp_IsStore |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand2,
 
       // STD
@@ -3562,8 +3416,7 @@
 
       // STDY
    S390OpProp_IsStore |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // STE
    S390OpProp_IsStore |
@@ -3572,8 +3425,7 @@
 
       // STEY
    S390OpProp_IsStore |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // STFH
    S390OpProp_IsStore |
@@ -3605,13 +3457,11 @@
    S390OpProp_Is32Bit |
    S390OpProp_IsStore |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand2,
 
       // STM
    S390OpProp_IsStore |
    S390OpProp_Is32Bit |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand3,
@@ -3619,7 +3469,6 @@
       // STMG
    S390OpProp_IsStore |
    S390OpProp_Is64Bit |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand3,
@@ -3627,10 +3476,8 @@
       // STMY
    S390OpProp_IsStore |
    S390OpProp_Is32Bit |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegRangeForTarget |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand3,
 
       // STOC
@@ -3684,14 +3531,12 @@
    S390OpProp_IsStore |
    S390OpProp_Is32Bit |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand2,
 
       // SXTR
    S390OpProp_DoubleFP |
    S390OpProp_Is64Bit |
    S390OpProp_SetsSignFlag |
-   S390OpProp_ReadsDFPRoundingMode |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1,
@@ -3703,7 +3548,6 @@
    S390OpProp_SetsOverflowFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // TABORT
@@ -3786,27 +3630,20 @@
       // TMY
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
       // TR
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // TRE
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1,
 
@@ -3818,9 +3655,7 @@
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_ImplicitlyUsesGPR1 |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
@@ -3831,9 +3666,7 @@
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_ImplicitlyUsesGPR1 |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
@@ -3843,20 +3676,15 @@
    S390OpProp_ImplicitlySetsGPR2 |
    S390OpProp_ImplicitlySetsGPR1 |
    S390OpProp_SetsCC |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_IsLoad |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefTwoIsLoad,
+   S390OpProp_IsLoad,
 
       // TRTO
    S390OpProp_UsesTarget |
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_ImplicitlyUsesGPR1 |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
@@ -3867,9 +3695,7 @@
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_ImplicitlyUsesGPR1 |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
@@ -3880,7 +3706,6 @@
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_ImplicitlyUsesGPR1 |
    S390OpProp_SetsOperand1,
 
@@ -3889,7 +3714,6 @@
    S390OpProp_SetsCC |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_ImplicitlyUsesGPR1 |
    S390OpProp_SetsOperand1,
 
@@ -3912,11 +3736,7 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // XG
@@ -3966,7 +3786,6 @@
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // XR
@@ -3986,7 +3805,6 @@
    S390OpProp_SetsZeroFlag |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // ASI
@@ -4154,14 +3972,12 @@
    S390OpProp_Is32Bit |
    S390OpProp_UsesTarget |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate |
    S390OpProp_SetsOperand1,
 
       // MSGFI
    S390OpProp_Is64Bit |
    S390OpProp_UsesTarget |
    S390OpProp_IsExtendedImmediate |
-   S390OpProp_IsSignedImmediate |
    S390OpProp_SetsOperand1,
 
       // AP
@@ -4170,11 +3986,7 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // BASSM
@@ -4214,7 +4026,6 @@
    S390OpProp_LongDispSupported |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_UsesRegPairForSource |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_UsesTarget |
    S390OpProp_SetsOperand3 |
@@ -4244,7 +4055,6 @@
    S390OpProp_SetsCC |
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
@@ -4252,7 +4062,6 @@
       // CKSM
    S390OpProp_UsesRegPairForSource |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_SetsCC |
    S390OpProp_SetsOperand1,
 
@@ -4260,10 +4069,7 @@
    S390OpProp_IsCompare |
    S390OpProp_SetsCompareFlag |
    S390OpProp_IsLoad |
-   S390OpProp_SSSchedulingCandidate |
-   S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefTwoIsLoad,
+   S390OpProp_HasTwoMemoryReferences,
 
       // CPSDR
    S390OpProp_SingleFP |
@@ -4275,9 +4081,7 @@
 
       // CUUTF
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsCC |
@@ -4286,9 +4090,7 @@
 
       // CUTFU
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsCC |
@@ -4297,36 +4099,28 @@
 
       // CU14
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsCC,
 
       // CU24
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsCC,
 
       // CU41
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsCC,
 
       // CU42
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsCC,
@@ -4334,7 +4128,6 @@
       // CUSE
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2 |
    S390OpProp_ImplicitlyUsesGPR0 |
@@ -4348,7 +4141,6 @@
       // CVBY
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // CVBG
@@ -4360,11 +4152,7 @@
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_UsesTarget |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // ED
@@ -4372,11 +4160,7 @@
    S390OpProp_IsStore |
    S390OpProp_UsesTarget |
    S390OpProp_SetsCC |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // EDMK
@@ -4385,11 +4169,7 @@
    S390OpProp_IsStore |
    S390OpProp_UsesTarget |
    S390OpProp_SetsCC |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // ESAR
@@ -4400,14 +4180,12 @@
 
       // EREG
    S390OpProp_Is32Bit |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
 
       // EREGG
    S390OpProp_Is64Bit |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
@@ -4433,12 +4211,10 @@
 
       // IVSK
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_SetsOperand1,
 
       // ISKE
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_SetsOperand1,
 
       // LAE
@@ -4447,7 +4223,6 @@
 
       // LAEY
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LCBB
@@ -4501,17 +4276,14 @@
       // LRAY
    S390OpProp_LongDispSupported |
    S390OpProp_SetsCC |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1,
 
       // LURA
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_SetsOperand1,
 
       // LURAG
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_SetsOperand1,
 
       // MC
@@ -4521,11 +4293,7 @@
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_UsesTarget |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MSCH
@@ -4541,8 +4309,6 @@
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVCSK
@@ -4551,8 +4317,6 @@
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVCK
@@ -4560,16 +4324,12 @@
    S390OpProp_IsStore |
    S390OpProp_SetsCC |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVCLU
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -4579,9 +4339,7 @@
       // MVCLE
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_UsesRegPairForSource |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
@@ -4593,8 +4351,6 @@
    S390OpProp_IsStore |
    S390OpProp_SetsCC |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVCS
@@ -4602,46 +4358,30 @@
    S390OpProp_IsStore |
    S390OpProp_SetsCC |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVN
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVO
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVZ
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // MVST
    S390OpProp_IsLoad |
    S390OpProp_UsesTarget |
-   S390OpProp_IsImplicitLoad |
    S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore |
    S390OpProp_SetsCC |
    S390OpProp_ImplicitlyUsesGPR0 |
    S390OpProp_SetsOperand1 |
@@ -4650,14 +4390,11 @@
       // PACK
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // PALB
-   0,
+   S390OpProp_None,
 
       // PC
    S390OpProp_ImplicitlySetsGPR3 |
@@ -4678,29 +4415,23 @@
       // PKA
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // PKU
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // PR
-   0,
+   S390OpProp_None,
 
       // PT
-   0,
+   S390OpProp_None,
 
       // PFDRL
-   0,
+   S390OpProp_None,
 
       // RCHP
    S390OpProp_SetsCC |
@@ -4711,7 +4442,7 @@
    S390OpProp_ImplicitlyUsesGPR1,
 
       // SAC
-   0,
+   S390OpProp_None,
 
       // SAL
    S390OpProp_ImplicitlyUsesGPR1,
@@ -4729,7 +4460,7 @@
    S390OpProp_IsLoad,
 
       // SIGP
-   S390OpProp_MayUseRegPairForTarget |
+   S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1,
 
       // SP
@@ -4738,15 +4469,11 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // SPKA
-   0,
+   S390OpProp_None,
 
       // SPM
    S390OpProp_SetsCC,
@@ -4761,17 +4488,14 @@
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefOneIsStore |
    S390OpProp_SetsOperand1,
 
       // SRNM
-   0,
+   S390OpProp_None,
 
       // SSAR
-   0,
+   S390OpProp_None,
 
       // SSCH
    S390OpProp_SetsCC |
@@ -4821,7 +4545,6 @@
 
       // STMH
    S390OpProp_IsStore |
-   S390OpProp_SetsMultipleRegs |
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand3,
 
@@ -4845,8 +4568,6 @@
    S390OpProp_IsStore |
    S390OpProp_Is64Bit |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // STSCH
@@ -4856,15 +4577,13 @@
    S390OpProp_SetsOperand1,
 
       // STURA
-   S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore,
+   S390OpProp_IsStore,
 
       // STURG
-   S390OpProp_IsStore |
-   S390OpProp_IsImplicitStore,
+   S390OpProp_IsStore,
 
       // SVC
-   0,
+   S390OpProp_None,
 
       // TAR
    S390OpProp_SetsCC,
@@ -4893,10 +4612,7 @@
    S390OpProp_SetsCC |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
-   S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsLoad |
-   S390OpProp_MemRefTwoIsLoad,
+   S390OpProp_HasTwoMemoryReferences,
 
       // TPROT
    S390OpProp_IsLoad |
@@ -4912,30 +4628,21 @@
       // UNPK
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // UNPKA
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_SetsCC |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // UNPKU
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
    S390OpProp_SetsCC |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // UPT
@@ -4954,10 +4661,7 @@
    S390OpProp_SetsSignFlag |
    S390OpProp_IsLoad |
    S390OpProp_IsStore |
-   S390OpProp_SSSchedulingCandidate |
    S390OpProp_HasTwoMemoryReferences |
-   S390OpProp_MemRefOneIsStore |
-   S390OpProp_MemRefTwoIsLoad |
    S390OpProp_SetsOperand1,
 
       // AXBR
@@ -5738,16 +5442,16 @@
    S390OpProp_SetsOperand1,
 
       // SAM24
-   0,
+   S390OpProp_None,
 
       // SAM31
-   0,
+   S390OpProp_None,
 
       // SAM64
-   0,
+   S390OpProp_None,
 
       // TAM
-   0,
+   S390OpProp_None,
 
       // CDZT
    S390OpProp_DoubleFP |
@@ -6040,7 +5744,6 @@
 
       // VLM
    S390OpProp_IsLoad |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_UsesRegRangeForTarget |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOperand2,
@@ -6121,7 +5824,6 @@
 
       // VSTM
    S390OpProp_IsStore |
-   S390OpProp_ReadsMultipleRegs |
    S390OpProp_UsesRegRangeForTarget,
 
       // VSTL
@@ -6440,55 +6142,55 @@
    S390OpProp_SetsCC,
 
       // RINEXT
-   0,
+   S390OpProp_None,
 
       // ASSOCREGS
-   0,
+   S390OpProp_None,
 
       // DEPEND
-   0,
+   S390OpProp_None,
 
       // DS
-   0,
+   S390OpProp_None,
 
       // FENCE
-   0,
+   S390OpProp_None,
 
       // SCHEDFENCE
-   0,
+   S390OpProp_None,
 
       // PROC
-   0,
+   S390OpProp_None,
 
       // RET
-   0,
+   S390OpProp_None,
 
       // DIRECTIVE
-   0,
+   S390OpProp_None,
 
       // WRTBAR
-   0,
+   S390OpProp_None,
 
       // XPCALLDESC
-   0,
+   S390OpProp_None,
 
       // DC
-   0,
+   S390OpProp_None,
 
       // DC2
-   0,
+   S390OpProp_None,
 
       // VGNOP
-   0,
+   S390OpProp_None,
 
       // NOP
-   0,
+   S390OpProp_None,
 
       // ASM
-   0,
+   S390OpProp_None,
 
       // LABEL
-   0,
+   S390OpProp_None,
 
       // TAILCALL
    S390OpProp_IsCall,
@@ -6617,7 +6319,7 @@
    S390OpProp_SetsCC,
 
    // PRNO
-   0,
+   S390OpProp_None,
 
    // LGG
    S390OpProp_IsLoad |
@@ -6657,7 +6359,6 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsCC,
 
@@ -6665,16 +6366,14 @@
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
    S390OpProp_BranchOp |
-   S390OpProp_ReadsCC |
-   S390OpProp_IsYForm,
+   S390OpProp_ReadsCC,
 
    // MG
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_UsesRegPairForTarget |
    S390OpProp_SetsOperand1 |
-   S390OpProp_LongDispSupported |
-   S390OpProp_IsYForm,
+   S390OpProp_LongDispSupported,
 
    // MGRK
    S390OpProp_UsesRegPairForTarget |
@@ -6684,8 +6383,7 @@
    S390OpProp_UsesTarget |
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
-   S390OpProp_SetsOperand1 |
-   S390OpProp_IsYForm,
+   S390OpProp_SetsOperand1,
 
    // MSC
    S390OpProp_Is32Bit |
@@ -6694,8 +6392,7 @@
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOverflowFlag |
-   S390OpProp_SetsCC |
-   S390OpProp_IsYForm,
+   S390OpProp_SetsCC,
 
    // MSRKC
    S390OpProp_Is32Bit |
@@ -6710,8 +6407,7 @@
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOperand1 |
    S390OpProp_SetsOverflowFlag |
-   S390OpProp_SetsCC |
-   S390OpProp_IsYForm,
+   S390OpProp_SetsCC,
 
    // MSGRKC
    S390OpProp_Is64Bit |
@@ -6725,5 +6421,4 @@
    S390OpProp_IsLoad |
    S390OpProp_LongDispSupported |
    S390OpProp_SetsOverflowFlag |
-   S390OpProp_SetsCC |
-   S390OpProp_IsYForm,
+   S390OpProp_SetsCC,

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -400,19 +400,20 @@ namespace Z
 #define   VSI_FORMAT    59
 
 /* Instruction Properties (One hot encoding) */
+#define S390OpProp_None                   static_cast<uint64_t>(0x0000000000000000ull)
 #define S390OpProp_UsesTarget             static_cast<uint64_t>(0x0000000000000001ull)
 #define S390OpProp_SingleFP               static_cast<uint64_t>(0x0000000000000002ull)
 #define S390OpProp_DoubleFP               static_cast<uint64_t>(0x0000000000000004ull)
 #define S390OpProp_SetsZeroFlag           static_cast<uint64_t>(0x0000000000000008ull)
 #define S390OpProp_SetsSignFlag           static_cast<uint64_t>(0x0000000000000010ull)
-#define S390OpProp_SetsCarryFlag          static_cast<uint64_t>(0x0000000000000020ull)
+// Available                              static_cast<uint64_t>(0x0000000000000020ull)
 #define S390OpProp_SetsOverflowFlag       static_cast<uint64_t>(0x0000000000000040ull)
 #define S390OpProp_BranchOp               static_cast<uint64_t>(0x0000000000000080ull)
 #define S390OpProp_IsLoad                 static_cast<uint64_t>(0x0000000000000100ull)
 #define S390OpProp_IsStore                static_cast<uint64_t>(0x0000000000000200ull)
-#define S390OpProp_IsSync                 static_cast<uint64_t>(0x0000000000000400ull)
-#define S390OpProp_ReadsMultipleRegs      static_cast<uint64_t>(0x0000000000000800ull)
-#define S390OpProp_SetsMultipleRegs       static_cast<uint64_t>(0x0000000000001000ull)
+// Available                              static_cast<uint64_t>(0x0000000000000400ull)
+// Available                              static_cast<uint64_t>(0x0000000000000800ull)
+// Available                              static_cast<uint64_t>(0x0000000000001000ull)
 #define S390OpProp_Is64Bit                static_cast<uint64_t>(0x0000000000002000ull)
 #define S390OpProp_Is32Bit                static_cast<uint64_t>(0x0000000000004000ull)
 #define S390OpProp_Is32To64Bit            static_cast<uint64_t>(0x0000000000008000ull)
@@ -427,11 +428,11 @@ namespace Z
 #define S390OpProp_UsesRegRangeForTarget  static_cast<uint64_t>(0x0000000001000000ull)
 #define S390OpProp_IsRegCopy              static_cast<uint64_t>(0x0000000002000000ull)
 #define S390OpProp_Trap                   static_cast<uint64_t>(0x0000000004000000ull)
-#define S390OpProp_ReadsDFPRoundingMode   static_cast<uint64_t>(0x0000000008000000ull)
-#define S390OpProp_SetsDFPRoundingMode    static_cast<uint64_t>(0x0000000010000000ull)
+// Available                              static_cast<uint64_t>(0x0000000008000000ull)
+// Available                              static_cast<uint64_t>(0x0000000010000000ull)
 #define S390OpProp_ReadsFPC               static_cast<uint64_t>(0x0000000020000000ull)
 #define S390OpProp_SetsFPC                static_cast<uint64_t>(0x0000000040000000ull)
-#define S390OpProp_UsesImplicitRegisters  static_cast<uint64_t>(0x0000000080000000ull)
+// Available                              static_cast<uint64_t>(0x0000000080000000ull)
 #define S390OpProp_TargetHW               static_cast<uint64_t>(0x0000000100000000ull)
 #define S390OpProp_TargetLW               static_cast<uint64_t>(0x0000000200000000ull)
 #define S390OpProp_SrcHW                  static_cast<uint64_t>(0x0000000400000000ull)
@@ -446,16 +447,16 @@ namespace Z
 #define S390OpProp_ImplicitlySetsGPR1     static_cast<uint64_t>(0x0000080000000000ull)
 #define S390OpProp_ImplicitlySetsGPR2     static_cast<uint64_t>(0x0000100000000000ull)
 #define S390OpProp_IsCompare              static_cast<uint64_t>(0x0000200000000000ull)
-#define S390OpProp_MayUseRegPairForTarget static_cast<uint64_t>(0x0000400000000000ull)
-#define S390OpProp_IsYForm                static_cast<uint64_t>(0x0000800000000000ull)
-#define S390OpProp_IsImplicitLoad         static_cast<uint64_t>(0x0001000000000000ull)
-#define S390OpProp_IsImplicitStore        static_cast<uint64_t>(0x0002000000000000ull)
-#define S390OpProp_MemRefOneIsStore       static_cast<uint64_t>(0x0004000000000000ull)
-#define S390OpProp_MemRefOneIsLoad        static_cast<uint64_t>(0x0008000000000000ull)
-#define S390OpProp_MemRefTwoIsStore       static_cast<uint64_t>(0x0010000000000000ull)
-#define S390OpProp_MemRefTwoIsLoad        static_cast<uint64_t>(0x0020000000000000ull)
-#define S390OpProp_SSSchedulingCandidate  static_cast<uint64_t>(0x0040000000000000ull)
-#define S390OpProp_IsExecutionHint        static_cast<uint64_t>(0x0080000000000000ull)
+// Available                              static_cast<uint64_t>(0x0000400000000000ull)
+// Available                              static_cast<uint64_t>(0x0000800000000000ull)
+// Available                              static_cast<uint64_t>(0x0001000000000000ull)
+// Available                              static_cast<uint64_t>(0x0002000000000000ull)
+// Available                              static_cast<uint64_t>(0x0004000000000000ull)
+// Available                              static_cast<uint64_t>(0x0008000000000000ull)
+// Available                              static_cast<uint64_t>(0x0010000000000000ull)
+// Available                              static_cast<uint64_t>(0x0020000000000000ull)
+// Available                              static_cast<uint64_t>(0x0040000000000000ull)
+// Available                              static_cast<uint64_t>(0x0080000000000000ull)
 #define S390OpProp_SetsOperand1           static_cast<uint64_t>(0x0100000000000000ull)
 #define S390OpProp_SetsOperand2           static_cast<uint64_t>(0x0200000000000000ull)
 #define S390OpProp_SetsOperand3           static_cast<uint64_t>(0x0400000000000000ull)
@@ -463,7 +464,7 @@ namespace Z
 #define S390OpProp_ImplicitlySetsGPR3     static_cast<uint64_t>(0x1000000000000000ull)
 #define S390OpProp_ImplicitlySetsGPR4     static_cast<uint64_t>(0x2000000000000000ull)
 #define S390OpProp_ImplicitlySetsGPR5     static_cast<uint64_t>(0x4000000000000000ull)
-#define S390OpProp_IsSignedImmediate      static_cast<uint64_t>(0x8000000000000000ull)
+// Available                              static_cast<uint64_t>(0x8000000000000000ull)
 
 /* Instruction Properties 2 (One hot encoding) */
 #define S390OpProp2_UsesM3                static_cast<uint64_t>(0x0000000000000001ull)
@@ -618,7 +619,6 @@ class InstOpCode: public OMR::InstOpCode
    uint64_t isCall() {return properties[_mnemonic] & S390OpProp_IsCall;}
    uint64_t isCompare() {return properties[_mnemonic] & S390OpProp_IsCompare;}
    uint64_t isExtendedImmediate() {return properties[_mnemonic] & S390OpProp_IsExtendedImmediate;}
-   uint64_t isSignedImmediate() {return properties[_mnemonic] & S390OpProp_IsSignedImmediate;}
    uint64_t isTargetHW() {return properties[_mnemonic] & S390OpProp_TargetHW;}
    uint64_t isTargetLW() {return properties[_mnemonic] & S390OpProp_TargetLW;}
    uint64_t isSrcHW() {return properties[_mnemonic] & S390OpProp_SrcHW;}
@@ -631,13 +631,11 @@ class InstOpCode: public OMR::InstOpCode
    uint64_t is32bit() {return properties[_mnemonic] & S390OpProp_Is32Bit;}
    uint64_t is32to64bit() {return properties[_mnemonic] & S390OpProp_Is32To64Bit;}
 
-   uint64_t usesImplicitRegisters() { return properties[_mnemonic] & S390OpProp_UsesImplicitRegisters;}
    uint64_t hasLongDispSupport() {return properties[_mnemonic] & S390OpProp_LongDispSupported;}
    uint64_t usesRegPairForTarget() {return properties[_mnemonic] & S390OpProp_UsesRegPairForTarget; }
-   uint64_t mayUseRegPairForTarget() { return properties[_mnemonic] & S390OpProp_MayUseRegPairForTarget; }
    uint64_t usesRegPairForSource() {return properties[_mnemonic] & S390OpProp_UsesRegPairForSource; }
    uint64_t usesRegRangeForTarget(){return properties[_mnemonic] & S390OpProp_UsesRegRangeForTarget; }
-   uint64_t canUseRegPairForTarget() {return usesRegPairForTarget() || usesRegRangeForTarget() || mayUseRegPairForTarget(); }
+   uint64_t canUseRegPairForTarget() {return usesRegPairForTarget() || usesRegRangeForTarget(); }
    uint64_t shouldUseRegPairForTarget() {return usesRegPairForTarget(); }
 
    uint64_t implicitlyUsesGPR0() { return properties[_mnemonic] & S390OpProp_ImplicitlyUsesGPR0; }
@@ -659,32 +657,17 @@ class InstOpCode: public OMR::InstOpCode
    uint64_t setsCC() {return (setsZeroFlag() || setsSignFlag() || setsOverflowFlag() || setsCompareFlag() || setsCarryFlag() || (properties[_mnemonic] & S390OpProp_SetsCC));}
    uint64_t readsCC() {return properties[_mnemonic] & S390OpProp_ReadsCC;}
 
-   uint64_t readsMultipleRegs() {return properties[_mnemonic] & S390OpProp_ReadsMultipleRegs;}
-   uint64_t setsMultipleRegs() {return properties[_mnemonic] & S390OpProp_SetsMultipleRegs;}
    uint64_t setsZeroFlag() {return properties[_mnemonic] & S390OpProp_SetsZeroFlag;}
    uint64_t setsSignFlag() {return properties[_mnemonic] & S390OpProp_SetsSignFlag;}
-   uint64_t setsCarryFlag() {return properties[_mnemonic] & S390OpProp_SetsCarryFlag;}
    uint64_t setsOverflowFlag() {return properties[_mnemonic] & S390OpProp_SetsOverflowFlag;}
    uint64_t setsCompareFlag() {return properties[_mnemonic] & S390OpProp_SetsCompareFlag;}
+   uint64_t setsCarryFlag() { return setsZeroFlag(); }
 
    uint64_t isRegCopy() {return properties[_mnemonic] & S390OpProp_IsRegCopy; }
    uint64_t hasTwoMemoryReferences() {return properties[_mnemonic] & S390OpProp_HasTwoMemoryReferences;}
 
-   uint64_t readsDFPRoundingMode() {return properties[_mnemonic] & S390OpProp_ReadsDFPRoundingMode; }
-   uint64_t setsDFPRoundingMode() {return properties[_mnemonic] & S390OpProp_SetsDFPRoundingMode; }
-
    uint64_t readsFPC() {return properties[_mnemonic] & S390OpProp_ReadsFPC; }
    uint64_t setsFPC() {return properties[_mnemonic] & S390OpProp_SetsFPC; }
-
-   uint64_t mr1IsStore()   {return properties[_mnemonic] & S390OpProp_MemRefOneIsStore;}
-   uint64_t mr1IsLoad()    {return properties[_mnemonic] & S390OpProp_MemRefOneIsLoad;}
-   uint64_t mr2IsStore()   {return properties[_mnemonic] & S390OpProp_MemRefTwoIsStore;}
-   uint64_t mr2IsLoad()    {return properties[_mnemonic] & S390OpProp_MemRefTwoIsLoad;}
-
-   uint64_t isSSSchedulingCandidate()  {return properties[_mnemonic] & S390OpProp_SSSchedulingCandidate;}
-   uint64_t isYForm() {return properties[_mnemonic] & S390OpProp_IsYForm; }
-   uint64_t isImplicitLoad()  {return properties[_mnemonic] & S390OpProp_IsImplicitLoad; }   // like CLCL R1,R2
-   uint64_t isImplicitStore() {return properties[_mnemonic] & S390OpProp_IsImplicitStore; }  // like MVCL R1,R2
 
    uint64_t isLabel() {return _mnemonic == LABEL;}
    uint64_t isBeginBlock() {return _mnemonic == LABEL;}

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -194,8 +194,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    virtual bool isLoad()              { return _opcode.isLoad() > 0; }
    virtual bool isStore()             { return _opcode.isStore() > 0; }
-   virtual bool isImplicitLoad()      { return _opcode.isImplicitLoad() > 0; }
-   virtual bool isImplicitStore()     { return _opcode.isImplicitStore() > 0; }
    virtual bool isBranchOp()          { return _opcode.isBranchOp() > 0; }
    virtual bool isTrap()              { return _opcode.isTrap() > 0; }
    virtual bool isLabel()             { return _opcode.isLabel() > 0; }
@@ -216,12 +214,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual bool implicitlySetsGPR0() { return _opcode.implicitlySetsGPR0() > 0; }
    virtual bool implicitlySetsGPR1() { return _opcode.implicitlySetsGPR1() > 0; }
    virtual bool implicitlySetsGPR2() { return _opcode.implicitlySetsGPR2() > 0; }
-
-   bool mr1IsStore() { return _opcode.mr1IsStore() > 0; }
-   bool mr2IsStore() { return _opcode.mr2IsStore() > 0; }
-
-   bool mr1IsLoad() { return _opcode.mr1IsLoad() > 0; }
-   bool mr2IsLoad() { return _opcode.mr2IsLoad() > 0; }
 
    bool isCompare() { return _opcode.isCompare() > 0; }
    bool fprOp()     { return _opcode.fprOp() > 0; }


### PR DESCRIPTION
Some instruction properties in the Z codegen are not used and are
slated for deprecation. We currently do not envision any of the removed
properties to be used by any downstream projects now or in the future
thus eliminating stale properties allows us to minimize the size of the
instruction opcode tables and consolidate properties and properties2
static fields.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>