### PR TITLE
Disable redefinition of 'remove' for z/TPF Platform

### DIFF
--- a/compiler/infra/Checklist.hpp
+++ b/compiler/infra/Checklist.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,10 @@
 
 #ifndef OMR_CHECKLIST_INCL
 #define OMR_CHECKLIST_INCL
+
+#ifdef OMRZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
 
 class TR_BitVector;
 

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -19,6 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
+#ifdef OMRZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
+
 #include "optimizer/RegisterCandidate.hpp"
 
 #include <algorithm>                           // for std::max, etc

--- a/compiler/runtime/CodeCacheTypes.hpp
+++ b/compiler/runtime/CodeCacheTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,10 @@
 
 #ifndef CODECACHETYPES_INCL
 #define CODECACHETYPES_INCL
+
+#ifdef OMRZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
 
 #include <stddef.h>                            // for size_t
 #include <stdint.h>                            // for uint8_t, int32_t, etc

--- a/gc/base/PacketList.hpp
+++ b/gc/base/PacketList.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,10 @@
 
 #if !defined(PACKETLIST_HPP_)
 #define PACKETLIST_HPP_
+
+#ifdef OMRZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
 
 #include "omrcfg.h"
 #include "omr.h"


### PR DESCRIPTION
z/TPF builds runtimes with an intermediary character
translation library which uses intercepting headers
to redefine system functions which require translation
from ascii to ebcdic. However, for some scenarios
translations is not desired. The 'remove' member function
is one of those instances where we don't want to
redefine to do translations.

Signed-off-by: jjohnst-us <jjohnst@us.ibm.com>