### PR TITLE
Remove references to libaux library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Product: OMR
 
-Copyright (c) 1991, 2016 IBM Corp. and others
+Copyright (c) 1991, 2017 IBM Corp. and others
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2
 which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ or the Apache 
@@ -19,8 +19,7 @@ Subject to the following notices:
 
 1.	Google Test is provided under the Google Test license below.
 2.	Pugixml is provided under the pugixml license below.
-3.	Libauxv is provided under the libauxv license below.
-4.	config.sub and config.guess are provided under the GPL v3.0 with the
+3.	config.sub and config.guess are provided under the GPL v3.0 with the
 	Autoconf exception (see below).
 
 You may distribute this program and materials under either the
@@ -543,32 +542,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
-E.	libauxv
-Redistribution and use in source and binary forms, with or without
-     modification, are permitted provided that the following conditions are met:
-	 * Redistributions of source code must retain the above copyright
-	   notice, this list of conditions and the following disclaimer.
-	 * Redistributions in binary form must reproduce the above copyright
-	   notice, this list of conditions and the following disclaimer in the
-	   documentation and/or other materials provided with the distribution.
-	 * Neither the name of the IBM Corporation nor the names of its
-	   contributors may be used to endorse or promote products derived from
-	   this software without specific prior written permission.
-
-     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-     ARE DISCLAIMED. IN NO EVENT SHALL IBM CORPORATION BE LIABLE FOR ANY
-     DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-     SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-     OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-     DAMAGE.
-
-
-F.	config.sub and config.guess
+E.	config.sub and config.guess
 
 This file is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by

--- a/longabout.html
+++ b/longabout.html
@@ -93,36 +93,6 @@ THE SOFTWARE.
 The source is available at <a href="http://pugixml.org/2014/11/27/pugixml-1.5-release.html">http://pugixml.org/2014/11/27/pugixml-1.5-release.html</a>.
 </p>
 
-<h4>libauxv</h4>
-<p>
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:</p>
-<p class="list">* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.</p>
-<p class="list">* Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.</p>
-<p class="list">* Neither the name of the IBM Corporation nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.</p>
-
-<p>
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL IBM CORPORATION BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-</p>
-<p>
-The source is available at <a href="https://github.com/Libauxv/libauxv">https://github.com/Libauxv/libauxv</a>.
-</p>
-
 <h4>config.sub and config.guess</h4>
 <p>
 This file is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The initial OMR contribution included a library called "auxv" as part of
the port library (port/unix/auxv.[ch]). This library was written by IBM
and incorporated into the OMR code base (then the J9 JVM) long before
this code was separately released as an open source library called
libauxv. The code in OMR is, in fact, unrelated to that open source
library.

A mistake was made referencing libauxv in our license materials, however:
our LICENSE and longabout.html files reference libauxv as if it has a
different license than the rest of OMR and even mention the open source
project. This commit removes these references because they are wrong.

[ci skip] since this update does not affect the code

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>