### PR TITLE
Introducing Atomic Compare And Swap Support to X86

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -220,7 +220,7 @@ class SymbolReferenceTable
        *  This symbol represents an intrinsic call of the following format:
        *
        *  \code
-       *    icall <atomicAddSymbol>
+       *    icall/lcall <atomicAddSymbol>
        *      <address>
        *      <value>
        *  \endcode
@@ -241,7 +241,7 @@ class SymbolReferenceTable
        *  This symbol represents an intrinsic call of the following format:
        *
        *  \code
-       *    icall <atomicFetchAndAddSymbol>
+       *    icall/lcall <atomicFetchAndAddSymbol>
        *      <address>
        *      <value>
        *  \endcode
@@ -265,7 +265,7 @@ class SymbolReferenceTable
        *  This symbol represents an intrinsic call of the following format:
        *
        *  \code
-       *    icall <atomicSwapSymbol>
+       *    icall/lcall <atomicSwapSymbol>
        *      <address>
        *      <value>
        *  \endcode
@@ -283,7 +283,56 @@ class SymbolReferenceTable
       atomicSwapSymbol,
       atomicSwap32BitSymbol,
       atomicSwap64BitSymbol,
-      atomicCompareAndSwapSymbol,
+
+      /** \brief
+       *
+       *  This symbol represents an intrinsic call of the following format:
+       *
+       *  \code
+       *    icall <atomicCompareAndSwapReturnStatusSymbol>
+       *      <address>
+       *      <old value>
+       *      <new value>
+       *  \endcode
+       *
+       *  Which performs the following operation atomically:
+       *
+       *  \code
+       *    temp = [address]
+       *    if (temp == <old value>)
+       *      [address] = <new value>
+       *      return true
+       *    else
+       *      return false
+       *  \endcode
+       *
+       *  The data type of \c <old value> indicates the width of the operation.
+       */
+      atomicCompareAndSwapReturnStatusSymbol,
+
+      /** \brief
+       *
+       *  This symbol represents an intrinsic call of the following format:
+       *
+       *  \code
+       *    icall/lcall <atomicCompareAndSwapReturnValueSymbol>
+       *      <address>
+       *      <old value>
+       *      <new value>
+       *  \endcode
+       *
+       *  Which performs the following operation atomically:
+       *
+       *  \code
+       *    temp = [address]
+       *    if (temp == <old value>)
+       *      [address] = <new value>
+       *    return temp
+       *  \endcode
+       *
+       *  The data type of \c <old value> indicates the width of the operation.
+       */
+      atomicCompareAndSwapReturnValueSymbol,
 
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1645,8 +1645,10 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<atomicSwap32Bit>";
          case TR::SymbolReferenceTable::atomicSwap64BitSymbol:
              return "<atomicSwap64Bit>";
-         case TR::SymbolReferenceTable::atomicCompareAndSwapSymbol:
-             return "<atomicCompareAndSwap>";
+         case TR::SymbolReferenceTable::atomicCompareAndSwapReturnStatusSymbol:
+             return "<atomicCompareAndSwapReturnStatus>";
+         case TR::SymbolReferenceTable::atomicCompareAndSwapReturnValueSymbol:
+             return "<atomicCompareAndSwapReturnValue>";
          case TR::SymbolReferenceTable::potentialOSRPointHelperSymbol:
              return "<potentialOSRPointHelper>";
          case TR::SymbolReferenceTable::osrFearPointHelperSymbol:
@@ -2096,14 +2098,15 @@ static const char *commonNonhelperSymbolNames[] =
    "<startPCLinkageInfo>",
    "<instanceShapeFromROMClass>",
    "<synchronizedFieldLoad>",
-   "<atomicAdd32Bit>",
-   "<atomicAdd64Bit>",
+   "<atomicAdd>",
+   "<atomicFetchAndAdd>",
    "<atomicFetchAndAdd32Bit>",
    "<atomicFetchAndAdd64Bit>",
+   "<atomicSwap>",
    "<atomicSwap32Bit>",
    "<atomicSwap64Bit>",
-   "<atomicCompareAndSwap32Bit>",
-   "<atomicCompareAndSwap64Bit>"
+   "<atomicCompareAndSwapReturnStatus>",
+   "<atomicCompareAndSwapReturnValue>",
    };
 
 const char *

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1076,21 +1076,17 @@ OMR::X86::CodeGenerator::supportsMergingGuards()
 bool
 OMR::X86::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
    {
-   bool result;
-
    switch (symbol)
       {
       case TR::SymbolReferenceTable::atomicAddSymbol:
       case TR::SymbolReferenceTable::atomicFetchAndAddSymbol:
       case TR::SymbolReferenceTable::atomicSwapSymbol:
-         result = true;
-         break;
+      case TR::SymbolReferenceTable::atomicCompareAndSwapReturnStatusSymbol:
+      case TR::SymbolReferenceTable::atomicCompareAndSwapReturnValueSymbol:
+         return true;
       default:
-         result = false;
-         break;
+         return false;
       }
-
-   return result;
    }
 
 TR::RealRegister *

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3033,6 +3033,96 @@ static TR::Register* inlineAtomicMemoryUpdate(TR::Node* node, TR_X86OpCodes op, 
    return value;
    }
 
+/** \brief
+ *    Generate instructions to do atomic compare and 64-bit memory update on X86-32.
+ *
+ *  \param node
+ *     The tree node
+ *
+ *  \param returnValue
+ *     Indicate whether the result is the old memory value or the status of memory update
+ *
+ *  \param cg
+ *     The code generator
+ */
+static TR::Register* inline64BitAtomicCompareAndMemoryUpdateOn32Bit(TR::Node* node, bool returnValue, TR::CodeGenerator* cg)
+   {
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "32-bit only");
+   TR::Register* address  = cg->evaluate(node->getChild(0));
+   TR::Register* oldvalue = cg->longClobberEvaluate(node->getChild(1));
+   TR::Register* newvalue = cg->evaluate(node->getChild(2));
+
+   TR::RegisterDependencyConditions* deps = generateRegisterDependencyConditions((uint8_t)4, (uint8_t)4, cg);
+   deps->addPreCondition(oldvalue->getLowOrder(),  TR::RealRegister::eax, cg);
+   deps->addPreCondition(oldvalue->getHighOrder(), TR::RealRegister::edx, cg);
+   deps->addPreCondition(newvalue->getLowOrder(),  TR::RealRegister::ebx, cg);
+   deps->addPreCondition(newvalue->getHighOrder(), TR::RealRegister::ecx, cg);
+   deps->addPostCondition(oldvalue->getLowOrder(),  TR::RealRegister::eax, cg);
+   deps->addPostCondition(oldvalue->getHighOrder(), TR::RealRegister::edx, cg);
+   deps->addPostCondition(newvalue->getLowOrder(),  TR::RealRegister::ebx, cg);
+   deps->addPostCondition(newvalue->getHighOrder(), TR::RealRegister::ecx, cg);
+
+   generateMemInstruction(LCMPXCHG8BMem, node, generateX86MemoryReference(address, 0, cg), deps, cg);
+   if (!returnValue)
+      {
+      cg->stopUsingRegister(oldvalue->getHighOrder());
+      oldvalue = oldvalue->getLowOrder();
+      generateRegInstruction(SETE1Reg, node, oldvalue, cg);
+      generateRegRegInstruction(MOVZXReg4Reg1, node, oldvalue, oldvalue, cg);
+      }
+
+   node->setRegister(oldvalue);
+   cg->decReferenceCount(node->getChild(0));
+   cg->decReferenceCount(node->getChild(1));
+   cg->decReferenceCount(node->getChild(2));
+   return oldvalue;
+   }
+
+/** \brief
+ *    Generate instructions to do atomic compare and memory update.
+ *
+ *  \param node
+ *     The tree node
+ *
+ *  \param op
+ *     The instruction op code to perform the memory update
+ *
+ *  \param returnValue
+ *     Indicate whether the result is the old memory value or the status of memory update
+ *
+ *  \param cg
+ *     The code generator
+ */
+static TR::Register* inlineAtomicCompareAndMemoryUpdate(TR::Node* node, bool returnValue, TR::CodeGenerator* cg)
+   {
+   bool isNode64Bit = node->getChild(1)->getDataType().isInt64();
+   if (TR::Compiler->target.is32Bit() && isNode64Bit)
+      {
+      return inline64BitAtomicCompareAndMemoryUpdateOn32Bit(node, returnValue, cg);
+      }
+
+   TR::Register* address  = cg->evaluate(node->getChild(0));
+   TR::Register* oldvalue = cg->gprClobberEvaluate(node->getChild(1), MOVRegReg());
+   TR::Register* newvalue = cg->evaluate(node->getChild(2));
+
+   TR::RegisterDependencyConditions* deps = generateRegisterDependencyConditions((uint8_t)1, (uint8_t)1, cg);
+   deps->addPreCondition(oldvalue, TR::RealRegister::eax, cg);
+   deps->addPostCondition(oldvalue, TR::RealRegister::eax, cg);
+
+   generateMemRegInstruction(LCMPXCHGMemReg(isNode64Bit), node, generateX86MemoryReference(address, 0, cg), newvalue, deps, cg);
+   if (!returnValue)
+      {
+      generateRegInstruction(SETE1Reg, node, oldvalue, cg);
+      generateRegRegInstruction(MOVZXReg4Reg1, node, oldvalue, oldvalue, cg);
+      }
+
+   node->setRegister(oldvalue);
+   cg->decReferenceCount(node->getChild(0));
+   cg->decReferenceCount(node->getChild(1));
+   cg->decReferenceCount(node->getChild(2));
+   return oldvalue;
+   }
+
 // TR::icall, TR::acall, TR::lcall, TR::fcall, TR::dcall, TR::call handled by directCallEvaluator
 TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -3080,6 +3170,14 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
       if (op != BADIA32Op)
          {
          return inlineAtomicMemoryUpdate(node, op, cg);
+         }
+      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicCompareAndSwapReturnStatusSymbol))
+         {
+         return inlineAtomicCompareAndMemoryUpdate(node, false, cg);
+         }
+      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicCompareAndSwapReturnValueSymbol))
+         {
+         return inlineAtomicCompareAndMemoryUpdate(node, true, cg);
          }
       }
 


### PR DESCRIPTION
X86 CG now supports Atomic Compare And Swap.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>