### PR TITLE
Remove genericCallHash from OMRSymbolReferenceTable

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -132,8 +132,6 @@ OMR::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation
       baseArray.element(i) = 0;
    _size_hint = sizeHint;
 
-   _genericCallHash  = new (trHeapMemory()) TR_HashTab(comp->trMemory(), heapAlloc, 60);
-
    }
 
 

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -73,7 +73,6 @@
 #include "infra/BitVector.hpp"                 // for TR_BitVector, etc
 #include "infra/Cfg.hpp"                       // for CFG, TR_SuccessorIterator, etc
 #include "infra/Flags.hpp"                     // for flags8_t
-#include "infra/HashTab.hpp"                   // for TR_HashTab, TR_HashId
 #include "infra/Link.hpp"                      // for TR_LinkHead, TR_Pair
 #include "infra/List.hpp"                      // for List, ListIterator, etc
 #include "infra/CfgEdge.hpp"                   // for CFGEdge

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -31,7 +31,6 @@ namespace OMR { class SymbolReferenceTable; }
 namespace OMR { typedef OMR::SymbolReferenceTable SymbolReferenceTableConnector; }
 #endif
 
-#include "infra/HashTab.hpp"
 #include "il/symbol/ResolvedMethodSymbol.hpp"
 
 #include <map>                                 // for std::map

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -488,8 +488,6 @@ class SymbolReferenceTable
 
    size_t                              _size_hint;
 
-   TR_HashTab *_genericCallHash;
-
    typedef CS2::CompoundHashKey<mcount_t, const char *> OwningMethodAndString;
    typedef CS2::HashTable<OwningMethodAndString, TR::SymbolReference *, TR::Allocator> SymrefsByOwningMethodAndString;
 

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -45,6 +45,7 @@
 #include "infra/Assert.hpp"
 #include "infra/Monitor.hpp"                 // for createCounter race conditions
 #include "infra/CriticalSection.hpp"         // for createCounter race conditions
+#include "infra/Bit.hpp"
 
 #if defined(_MSC_VER)
 #include <malloc.h> // alloca on Windows


### PR DESCRIPTION
 - Removed `_genericCallHash` and all references from OMR::SymbolReferenceTable.

Closes: #2129

Signed-off-by: Arwin Neil Baichoo <arwinneil@gmail.com>