### PR TITLE
Implement write barriers for arraycopy for ARM

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -935,10 +935,6 @@ TR::Register *OMR::ARM::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
    FILE *outFile;
 
    bool isSimpleCopy = (node->getNumChildren() == 3);
-   if(!isSimpleCopy)
-      {
-      TR_ASSERT(0,"Only simple array copies currently implemented on arm");
-      }
 
    if (isSimpleCopy)
       {
@@ -949,14 +945,13 @@ TR::Register *OMR::ARM::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
       lengthNode = node->getChild(2);
       }
    else
-     {
-      TR_ASSERT(0,"Only simple array copies implemented for arm");
+      {
       srcObjNode = node->getChild(0);
       dstObjNode = node->getChild(1);
       srcAddrNode = node->getChild(2);
       dstAddrNode = node->getChild(3);
       lengthNode = node->getChild(4);
-     }
+      }
 
    stopUsingCopyReg1 = stopUsingCopyReg(srcObjNode, srcObjReg, cg);
    stopUsingCopyReg2 = stopUsingCopyReg(dstObjNode, dstObjReg, cg);
@@ -985,6 +980,13 @@ TR::Register *OMR::ARM::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
                                    node, (uintptr_t)arrayCopyHelper->getMethodAddress(),
                                    deps,
                                    arrayCopyHelper);
+
+#ifdef J9_PROJECT_SPECIFIC
+   if (!isSimpleCopy)
+      {
+      TR::TreeEvaluator::genWrtbarForArrayCopy(node, srcObjReg, dstObjReg, cg);
+      }
+#endif
 
    if (srcObjNode != NULL)
       cg->decReferenceCount(srcObjNode);


### PR DESCRIPTION
OMR::ARM::TreeEvaluator::arraycopyEvaluator() asserts when passed
a non-simple arraycopy node.
This implements new functions genWrtbarForArrayCopy() and
VMCardCheckEvaluator() for handling non-simple arraycopy nodes.

Closes: #1996

Signed-off-by: knn-k <konno@jp.ibm.com>