### PR TITLE
Exclude nodes marked with NeedsSignExt flag in Load Extensions

### DIFF
--- a/compiler/optimizer/LoadExtensions.hpp
+++ b/compiler/optimizer/LoadExtensions.hpp
@@ -45,6 +45,11 @@ private:
    TR_BitVector *_signExtensionFlags;
    TR_UseDefInfo *_useDefInfo;
 
+   /* \brief
+    *    Keeps track of all nodes which should be excluded from consideration in this optimization.
+    */
+   TR::SparseBitVector _excludedNodes;
+
    enum overrideFlags
       {
       narrowOverride  = 0x01,


### PR DESCRIPTION
Load Extensions is a local optimization is that it is unaware of and
does not respect global sign extension decisions. GRA in particular can
set the NeedsSignExt flag on iRegStores signifying that a sign
extension should be emitted during the evaluation of the global
register store. This directly conflicts with the Load Extensions
optimization.

We introduce an excluded nodes list and prevent the local optimization
on any load that feeds into a store marked with the NeedsSignExt flag.

Closes: #2187
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>