### PR TITLE
Give DefiningMap a const key

### DIFF
--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -91,9 +91,9 @@ namespace TR
       };
    }
 
-typedef TR::typed_allocator<std::pair<int32_t , TR_BitVector*>, TR::Region&> DefiningMapAllocator;
+typedef TR::typed_allocator<std::pair<const int32_t, TR_BitVector*>, TR::Region&> DefiningMapAllocator;
 typedef std::less<int32_t> DefiningMapComparator;
-typedef std::map<int32_t, TR_BitVector*, DefiningMapComparator, DefiningMapAllocator> DefiningMap;
+typedef std::map<const int32_t, TR_BitVector*, DefiningMapComparator, DefiningMapAllocator> DefiningMap;
 
 typedef TR::vector<DefiningMap *, TR::Region&> DefiningMaps;
 


### PR DESCRIPTION
std::map uses require a const key or else recent version of XCode (more
recent than used on our build machines apparently) will not match the
template classes properly. This commit simply makes the key const.

Fixes: #2192

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>