### PR TITLE
WIP Define JitBuilder client API

### DIFF
--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -91,9 +91,9 @@ namespace TR
       };
    }
 
-typedef TR::typed_allocator<std::pair<int32_t , TR_BitVector*>, TR::Region&> DefiningMapAllocator;
+typedef TR::typed_allocator<std::pair<const int32_t, TR_BitVector*>, TR::Region&> DefiningMapAllocator;
 typedef std::less<int32_t> DefiningMapComparator;
-typedef std::map<int32_t, TR_BitVector*, DefiningMapComparator, DefiningMapAllocator> DefiningMap;
+typedef std::map<const int32_t, TR_BitVector*, DefiningMapComparator, DefiningMapAllocator> DefiningMap;
 
 typedef TR::vector<DefiningMap *, TR::Region&> DefiningMaps;
 

--- a/compiler/ilgen/BytecodeBuilder.cpp
+++ b/compiler/ilgen/BytecodeBuilder.cpp
@@ -19,124 +19,48 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "compile/Compilation.hpp"
-#include "compile/Method.hpp"
-#include "env/FrontEnd.hpp"
-#include "infra/List.hpp"
-#include "il/Block.hpp"
 #include "ilgen/VirtualMachineState.hpp"
 #include "ilgen/IlBuilder.hpp"
 #include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
 #include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/BytecodeBuilderImpl.hpp"
 #include "ilgen/TypeDictionary.hpp"
-
-// should really move into IlInjector.hpp
-#define TraceEnabled    (comp()->getOption(TR_TraceILGen))
-#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
+#include "ilgen/TypeDictionaryImpl.hpp"
 
 
-OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
-                                      int32_t bcIndex,
-                                      char *name)
-   : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary()),
-   _fallThroughBuilder(0),
-   _bcIndex(bcIndex),
-   _name(name),
-   _initialVMState(0),
-   _vmState(0)
+OMR::BytecodeBuilder::BytecodeBuilder(TR::BytecodeBuilderImpl *impl, TR::MethodBuilder *mb, TR::TypeDictionary *types)
+   : TR::IlBuilder(impl, mb, types)
+   { }
+
+TR::BytecodeBuilderImpl *
+OMR::BytecodeBuilder::impl()
    {
-   _successorBuilders = new (PERSISTENT_NEW) List<TR::BytecodeBuilder>(_types->trMemory());
-   initialize(methodBuilder->details(), methodBuilder->methodSymbol(),
-              methodBuilder->fe(), methodBuilder->symRefTab());
-   initSequence();
+   return static_cast<TR::BytecodeBuilderImpl *>(_impl);
    }
 
-/**
- * Call this function at the top of your bytecode iteration loop so that all services called
- * while this bytecode builder is being translated will mark their IL nodes as having this
- * BytecodeBuilder's _bcIndex (very handy when looking at compiler logs).
- * Note: *all* generated nodes will be marked with this builder's _bcIndex until another
- *       BytecodeBuilder's SetCurrentIlGenerator() is called.
- */
-void
-OMR::BytecodeBuilder::SetCurrentIlGenerator()
+int32_t
+OMR::BytecodeBuilder::bcIndex()
    {
-   comp()->setCurrentIlGenerator((TR_IlGenerator *)this);
+   return impl()->bcIndex();
    }
 
-void
-TR::BytecodeBuilder::initialize(TR::IlGeneratorMethodDetails * details,
-                                TR::ResolvedMethodSymbol     * methodSymbol,
-                                TR::FrontEnd                 * fe,
-                                TR::SymbolReferenceTable     * symRefTab)
-    {
-    this->OMR::IlInjector::initialize(details, methodSymbol, fe, symRefTab);
-
-    //addBytecodeBuilderToList relies on _comp and it won't be ready until now
-    _methodBuilder->addToAllBytecodeBuildersList(this);
-    }
-
-void
-OMR::BytecodeBuilder::appendBlock(TR::Block *block, bool addEdge)
+OMR::VirtualMachineState *
+OMR::BytecodeBuilder::initialVMState()
    {
-   if (block == NULL)
-      {
-      block = emptyBlock();
-      }
-
-   block->setByteCodeIndex(_bcIndex, _comp);
-   return TR::IlBuilder::appendBlock(block, addEdge);
+   return impl()->initialVMState();
    }
 
-uint32_t
-OMR::BytecodeBuilder::countBlocks()
+char *
+OMR::BytecodeBuilder::name()
    {
-   // only count each block once
-   if (_count > -1)
-      return _count;
-
-   TraceIL("[ %p ] TR::BytecodeBuilder::countBlocks 0\n", this);
-
-   _count = TR::IlBuilder::countBlocks();
-
-   if (NULL != _fallThroughBuilder)
-      _methodBuilder->addToBlockCountingWorklist(_fallThroughBuilder);
-
-   ListIterator<TR::BytecodeBuilder> iter(_successorBuilders);
-   for (TR::BytecodeBuilder *builder = iter.getFirst(); !iter.atEnd(); builder = iter.getNext())
-      if (builder->_count < 0)
-         _methodBuilder->addToBlockCountingWorklist(builder);
-
-   TraceIL("[ %p ] TR::BytecodeBuilder::countBlocks %d\n", this, _count);
-
-   return _count;
+   return impl()->name();
    }
 
-bool
-OMR::BytecodeBuilder::connectTrees()
+OMR::VirtualMachineState *
+OMR::BytecodeBuilder::vmState()
    {
-   if (!_connectedTrees)
-      {
-      TraceIL("[ %p ] TR::BytecodeBuilder::connectTrees\n", this);
-      bool rc = TR::IlBuilder::connectTrees();
-      addAllSuccessorBuildersToWorklist();
-      return rc;
-      }
-
-   return true;
-   }
-
-
-void
-OMR::BytecodeBuilder::addAllSuccessorBuildersToWorklist()
-   {
-   if (NULL != _fallThroughBuilder)
-      _methodBuilder->addToTreeConnectingWorklist(_fallThroughBuilder);
-
-   // iterate over _successorBuilders
-   ListIterator<TR::BytecodeBuilder> iter(_successorBuilders);
-   for (TR::BytecodeBuilder *builder = iter.getFirst(); !iter.atEnd(); builder = iter.getNext())
-      _methodBuilder->addToTreeConnectingWorklist(builder);
+   return impl()->vmState();
    }
 
 // Must be called *after* all code has been added to the bytecode builder
@@ -144,21 +68,7 @@ OMR::BytecodeBuilder::addAllSuccessorBuildersToWorklist()
 void
 OMR::BytecodeBuilder::AddFallThroughBuilder(TR::BytecodeBuilder *ftb)
    {
-   TR_ASSERT(comesBack(), "builder does not appear to have a fall through path");
-
-   TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", this, ftb);
-
-   TR::BytecodeBuilder *b = ftb;
-   transferVMState(&b);    // may change what b points at!
-
-   if (b != ftb)
-      TraceIL("IlBuilder[ %p ]:: fallThrough successor changed to [ %p ]\n", this, b);
-   _fallThroughBuilder = b;
-    _methodBuilder->addBytecodeBuilderToWorklist(ftb);
-
-   // add explicit goto and register the actual fall-through block
-   TR::IlBuilder *tgtb = b;
-   TR::IlBuilder::Goto(&tgtb);
+   impl()->AddFallThroughBuilder(ftb->impl());
    }
 
 // AddSuccessorBuilders() should be called with a list of TR::BytecodeBuilder ** pointers.
@@ -176,69 +86,18 @@ OMR::BytecodeBuilder::AddSuccessorBuilders(uint32_t numExits, ...)
    for (int32_t e=0;e < numExits;e++)
       {
       TR::BytecodeBuilder **builder = (TR::BytecodeBuilder **) va_arg(exits, TR::BytecodeBuilder **);
-      if ((*builder)->_bcIndex < _bcIndex) //If the successor has a bcIndex < than the current bcIndex this may be a loop
-         _methodSymbol->setMayHaveLoops(true);
-      transferVMState(builder);            // may change what builder points at!
-      _successorBuilders->add(*builder);   // must be the bytecode builder that comes back from transferVMState()
-      _methodBuilder->addBytecodeBuilderToWorklist(*builder);
-      TraceIL("IlBuilder[ %p ]:: successor [ %p ]\n", this, *builder);
+      TR::BytecodeBuilderImpl *bbi = (*builder)->impl();
+      impl()->AddSuccessorBuilder(&bbi);
+      *builder = bbi->client();
       }
    va_end(exits);
-   }
-
-void
-OMR::BytecodeBuilder::setHandlerInfo(uint32_t catchType)
-   {
-   TR::Block *catchBlock = getEntry();
-   catchBlock->setIsCold();
-   catchBlock->setHandlerInfo(catchType, comp()->getInlineDepth(), -1, _methodSymbol->getResolvedMethod(), comp());
-   }
-
-void
-OMR::BytecodeBuilder::propagateVMState(OMR::VirtualMachineState *fromVMState)
-   {
-   _initialVMState = (OMR::VirtualMachineState *) fromVMState->MakeCopy();
-   _vmState = (OMR::VirtualMachineState *) fromVMState->MakeCopy();
-   }
-
-// transferVMState needs to be called before the actual transfer operation (Goto, IfCmp,
-// etc.) is created because we may need to insert a builder object along that control
-// flow edge to synchronize the vm state at the target (in the case of a merge point).
-// On return, the object pointed at by the "b" parameter may have changed. The caller
-// should direct control for this edge to whatever the parameter passed to "b" is
-// pointing at on return
-void
-OMR::BytecodeBuilder::transferVMState(TR::BytecodeBuilder **b)
-   {
-   TR_ASSERT(_vmState != NULL, "asked to transfer a NULL vmState from builder %p [ bci %d ]", this, _bcIndex);
-   if ((*b)->initialVMState())
-      {
-      // there is already a vm state at the target builder
-      // so we need to synchronize this builder's vm state with the target builder's vm state
-      // for example, the local variables holding the elements on the operand stack may not match
-      // create an intermediate builder object to do that work
-      TR::BytecodeBuilder *intermediateBuilder = _methodBuilder->OrphanBytecodeBuilder((*b)->_bcIndex, (*b)->_name);
-
-      _vmState->MergeInto((*b)->initialVMState(), intermediateBuilder);
-      TraceIL("IlBuilder[ %p ]:: transferVMState merged vm state on way to [ %p ] using [ %p ]\n", this, *b, intermediateBuilder);
-
-      TR::IlBuilder *tgtb = *b;
-      intermediateBuilder->IlBuilder::Goto(&tgtb);
-      intermediateBuilder->_fallThroughBuilder = *b;
-      TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", intermediateBuilder, *b);
-      *b = intermediateBuilder; // branches should direct towards intermediateBuilder not original *b
-      }
-   else
-      {
-      (*b)->propagateVMState(_vmState);
-      }
    }
 
 void
 OMR::BytecodeBuilder::Goto(TR::BytecodeBuilder **dest)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    Goto(*dest);
    }
 
@@ -246,21 +105,20 @@ void
 OMR::BytecodeBuilder::Goto(TR::BytecodeBuilder *dest)
    {
    AddSuccessorBuilder(&dest);
-   OMR::IlBuilder::Goto(dest);
+   this->OMR::IlBuilder::Goto(dest);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpEqual(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpEqual(dest, v1, v2);
    }
@@ -269,14 +127,13 @@ void
 OMR::BytecodeBuilder::IfCmpEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpEqualZero(*dest, c);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpEqualZero(dest, c);
    }
@@ -285,14 +142,13 @@ void
 OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpNotEqual(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpNotEqual(dest, v1, v2);
    }
@@ -301,14 +157,13 @@ void
 OMR::BytecodeBuilder::IfCmpNotEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpNotEqualZero(*dest, c);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpNotEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpNotEqualZero(dest, c);
    }
@@ -317,14 +172,13 @@ void
 OMR::BytecodeBuilder::IfCmpLessThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpLessThan(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpLessThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpLessThan(dest, v1, v2);
    }
@@ -333,14 +187,13 @@ void
 OMR::BytecodeBuilder::IfCmpUnsignedLessThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpUnsignedLessThan(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpUnsignedLessThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedLessThan(dest, v1, v2);
    }
@@ -349,14 +202,13 @@ void
 OMR::BytecodeBuilder::IfCmpLessOrEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpLessOrEqual(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpLessOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpLessOrEqual(dest, v1, v2);
    }
@@ -365,14 +217,13 @@ void
 OMR::BytecodeBuilder::IfCmpUnsignedLessOrEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpUnsignedLessOrEqual(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpUnsignedLessOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedLessOrEqual(dest, v1, v2);
    }
@@ -381,14 +232,13 @@ void
 OMR::BytecodeBuilder::IfCmpGreaterThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpGreaterThan(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpGreaterThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpGreaterThan(dest, v1, v2);
    }
@@ -397,14 +247,13 @@ void
 OMR::BytecodeBuilder::IfCmpUnsignedGreaterThan(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpUnsignedGreaterThan(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpUnsignedGreaterThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedGreaterThan(dest, v1, v2);
    }
@@ -413,14 +262,13 @@ void
 OMR::BytecodeBuilder::IfCmpGreaterOrEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpGreaterOrEqual(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpGreaterOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpGreaterOrEqual(dest, v1, v2);
    }
@@ -428,14 +276,13 @@ void
 OMR::BytecodeBuilder::IfCmpUnsignedGreaterOrEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR::IlValue *v2)
    {
    if (*dest == NULL)
-      *dest = _methodBuilder->OrphanBytecodeBuilder(_bcIndex, _name);
+      *dest = methodBuilder()->OrphanBytecodeBuilder(impl()->bcIndex(), impl()->name());
    IfCmpUnsignedGreaterOrEqual(*dest, v1, v2);
    }
 
 void
 OMR::BytecodeBuilder::IfCmpUnsignedGreaterOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedGreaterOrEqual(dest, v1, v2);
    }

--- a/compiler/ilgen/BytecodeBuilderImpl.cpp
+++ b/compiler/ilgen/BytecodeBuilderImpl.cpp
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "env/FrontEnd.hpp"
+#include "infra/List.hpp"
+#include "il/Block.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+#include "ilgen/IlInjector.hpp"
+#include "ilgen/IlBuilderImpl.hpp"
+#include "ilgen/IlValueImpl.hpp"
+#include "ilgen/IlTypeImpl.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/BytecodeBuilderImpl.hpp"
+#include "ilgen/TypeDictionaryImpl.hpp"
+
+
+OMR::BytecodeBuilderImpl::BytecodeBuilderImpl(TR::MethodBuilderImpl *methodBuilder,
+                                              int32_t bcIndex,
+                                              char *name)
+   : TR::IlBuilderImpl(methodBuilder, methodBuilder->typeDictionary()),
+   _bcIndex(bcIndex),
+   _name(name),
+   _fallThroughBuilder(0),
+   _initialVMState(0),
+   _vmState(0)
+   {
+   _successorBuilders = new (PERSISTENT_NEW) List<TR::BytecodeBuilderImpl>(_types->trMemory());
+   initialize(methodBuilder->details(), methodBuilder->methodSymbol(),
+              methodBuilder->fe(), methodBuilder->symRefTab());
+   initSequence();
+   }
+
+TR::BytecodeBuilder *
+OMR::BytecodeBuilderImpl::client()
+   {
+   return static_cast<TR::BytecodeBuilder *>(_clientBuilder);
+   }
+
+void
+OMR::BytecodeBuilderImpl::initialize(TR::IlGeneratorMethodDetails * details,
+                                    TR::ResolvedMethodSymbol     * methodSymbol,
+                                    TR::FrontEnd                 * fe,
+                                    TR::SymbolReferenceTable     * symRefTab)
+    {
+    this->OMR::IlInjector::initialize(details, methodSymbol, fe, symRefTab);
+
+    //addBytecodeBuilderToList relies on _comp and it won't be ready until now
+    _methodBuilder->addToAllBytecodeBuildersList(static_cast<TR::BytecodeBuilderImpl *>(this));
+    }
+
+void
+OMR::BytecodeBuilderImpl::appendBlock(TR::Block *block, bool addEdge)
+   {
+   if (block == NULL)
+      {
+      block = emptyBlock();
+      }
+
+   block->setByteCodeIndex(bcIndex(), _comp);
+   return TR::IlBuilderImpl::appendBlock(block, addEdge);
+   }
+
+uint32_t
+OMR::BytecodeBuilderImpl::countBlocks()
+   {
+   // only count each block once
+   if (_count > -1)
+      return _count;
+
+   TraceIL("[ %p ] TR::BytecodeBuilderImpl::countBlocks 0\n", this);
+
+   _count = TR::IlBuilderImpl::countBlocks();
+
+   if (NULL != _fallThroughBuilder)
+      _methodBuilder->addToBlockCountingWorklist(_fallThroughBuilder);
+
+   ListIterator<TR::BytecodeBuilderImpl> iter(_successorBuilders);
+   for (TR::BytecodeBuilderImpl *builder = iter.getFirst(); !iter.atEnd(); builder = iter.getNext())
+      if (builder->_count < 0)
+         _methodBuilder->addToBlockCountingWorklist(builder);
+
+   TraceIL("[ %p ] TR::BytecodeBuilderImpl::countBlocks %d\n", this, _count);
+
+   return _count;
+   }
+
+bool
+OMR::BytecodeBuilderImpl::connectTrees()
+   {
+   if (!_connectedTrees)
+      {
+      TraceIL("[ %p ] TR::BytecodeBuilderImpl::connectTrees\n", this);
+      bool rc = TR::IlBuilderImpl::connectTrees();
+      addAllSuccessorBuildersToWorklist();
+      return rc;
+      }
+
+   return true;
+   }
+
+
+void
+OMR::BytecodeBuilderImpl::addAllSuccessorBuildersToWorklist()
+   {
+   if (NULL != _fallThroughBuilder)
+      _methodBuilder->addToTreeConnectingWorklist(_fallThroughBuilder);
+
+   // iterate over _successorBuilders
+   ListIterator<TR::BytecodeBuilderImpl> iter(_successorBuilders);
+   for (TR::BytecodeBuilderImpl *builder = iter.getFirst(); !iter.atEnd(); builder = iter.getNext())
+      _methodBuilder->addToTreeConnectingWorklist(builder);
+   }
+
+// Must be called *after* all code has been added to the bytecode builder
+// Also, current VM state is assumed to be what should propagate to the fallthrough builder
+void
+OMR::BytecodeBuilderImpl::AddFallThroughBuilder(TR::BytecodeBuilderImpl *ftb)
+   {
+   TR_ASSERT(comesBack(), "builder does not appear to have a fall through path");
+
+   TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", this, ftb);
+
+   TR::BytecodeBuilderImpl *b = ftb;
+   transferVMState(&b);    // may change what b points at!
+
+   if (b != ftb)
+      TraceIL("IlBuilder[ %p ]:: fallThrough successor changed to [ %p ]\n", this, b);
+
+   _fallThroughBuilder = b;
+   _methodBuilder->addBytecodeBuilderToWorklist(ftb);
+
+   // add explicit goto and register the actual fall-through block
+   TR::IlBuilderImpl *tgtb = b;
+   TR::IlBuilderImpl::Goto(&tgtb);
+   }
+
+// AddSuccessorBuilders() should be called with a list of TR::BytecodeBuilderImpl ** pointers.
+// Each one of these pointers could be changed by AddSuccessorBuilders() in the case where
+// some operations need to be inserted along the control flow edges to synchronize the
+// vm state from "this" builder to the target BytecodeBuilderImpl. For this reason, the actual
+// control flow edges should be created (i.e. with Goto, IfCmp*, etc.) *after* calling
+// AddSuccessorBuilders, and the target used when creating those flow edges should take
+// into account that AddSuccessorBuilders may change the builder object provided.
+void
+OMR::BytecodeBuilderImpl::AddSuccessorBuilder(TR::BytecodeBuilderImpl **builder)
+   {
+   if ((*builder)->bcIndex() < bcIndex()) //If the successor has a bcIndex < than the current bcIndex this may be a loop
+      _methodSymbol->setMayHaveLoops(true);
+   transferVMState(builder);            // may change what builder points at!
+   _successorBuilders->add(*builder);   // must be the bytecode builder that comes back from transferVMState()
+   _methodBuilder->addBytecodeBuilderToWorklist(*builder);
+   TraceIL("IlBuilder[ %p ]:: successor [ %p ]\n", this, *builder);
+   }
+
+/* TODO: why isn't this in IlBuilderImpl? */
+void
+OMR::BytecodeBuilderImpl::setHandlerInfo(uint32_t catchType)
+   {
+   TR::Block *catchBlock = getEntry();
+   catchBlock->setIsCold();
+   catchBlock->setHandlerInfo(catchType, comp()->getInlineDepth(), -1, _methodSymbol->getResolvedMethod(), comp());
+   }
+
+void
+OMR::BytecodeBuilderImpl::propagateVMState(OMR::VirtualMachineState *fromVMState)
+   {
+   _initialVMState = (OMR::VirtualMachineState *) fromVMState->MakeCopy();
+   _vmState = (OMR::VirtualMachineState *) fromVMState->MakeCopy();
+   }
+
+// transferVMState needs to be called before the actual transfer operation (Goto, IfCmp,
+// etc.) is created because we may need to insert a builder object along that control
+// flow edge to synchronize the vm state at the target (in the case of a merge point).
+// On return, the object pointed at by the "b" parameter may have changed. The caller
+// should direct control for this edge to whatever the parameter passed to "b" is
+// pointing at on return
+void
+OMR::BytecodeBuilderImpl::transferVMState(TR::BytecodeBuilderImpl **b)
+   {
+   TR_ASSERT(_vmState != NULL, "asked to transfer a NULL vmState from builder %p [ bci %d ]", this, bcIndex());
+   if ((*b)->initialVMState())
+      {
+      // there is already a vm state at the target builder
+      // so we need to synchronize this builder's vm state with the target builder's vm state
+      // for example, the local variables holding the elements on the operand stack may not match
+      // create an intermediate builder object to do that work
+      TR::BytecodeBuilderImpl *intermediateBuilder = _methodBuilder->orphanBytecodeBuilderImpl((*b)->bcIndex(), (*b)->_name);
+
+      _vmState->MergeInto((*b)->initialVMState(), intermediateBuilder->client());
+      TraceIL("IlBuilder[ %p ]:: transferVMState merged vm state on way to [ %p ] using [ %p ]\n", this, *b, intermediateBuilder);
+
+      TR::IlBuilderImpl *tgtb = *b;
+      intermediateBuilder->IlBuilderImpl::Goto(&tgtb);
+      intermediateBuilder->_fallThroughBuilder = *b;
+      TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", intermediateBuilder, *b);
+      *b = intermediateBuilder; // branches should direct towards intermediateBuilder not original *b
+      }
+   else
+      {
+      (*b)->propagateVMState(_vmState);
+      }
+   }

--- a/compiler/ilgen/BytecodeBuilderImpl.hpp
+++ b/compiler/ilgen/BytecodeBuilderImpl.hpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_BYTECODEBUILDER_IMPL_INCL
+#define OMR_BYTECODEBUILDER_IMPL_INCL
+
+#ifndef TR_BYTECODEBUILDER_IMPL_DEFINED
+#define TR_BYTECODEBUILDER_IMPL_DEFINED
+#define PUT_OMR_BYTECODEBUILDER_IMPL_INTO_TR
+#endif // !defined(TR_BYTECODEBUILDER_IMPL_DEFINED)
+
+#include "ilgen/IlBuilderImpl.hpp"
+
+namespace OMR { class VirtualMachineState; }
+namespace TR { class BytecodeBuilder; }
+namespace TR { class BytecodeBuilderImpl; }
+namespace TR { class MethodBuilderImpl; }
+
+namespace OMR
+{
+
+class BytecodeBuilderImpl : public TR::IlBuilderImpl
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   BytecodeBuilderImpl(TR::MethodBuilderImpl *methodBuilder, int32_t bcIndex, char *name=NULL);
+   virtual ~BytecodeBuilderImpl()
+      { }
+
+   void operator delete(void * ptr)
+      { }
+
+   /**
+    * Support for BytecodeBuilder public API
+    */
+   void AddFallThroughBuilder(TR::BytecodeBuilderImpl *ftb);
+   void AddSuccessorBuilder(TR::BytecodeBuilderImpl **b);
+
+   int32_t bcIndex()
+      { return _bcIndex; }
+
+   OMR::VirtualMachineState *initialVMState()
+      { return _initialVMState; }
+
+   char *name()
+      { return _name; }
+
+   OMR::VirtualMachineState *vmState()
+      { return _vmState; }
+
+   /**
+    * Public API for other JitBuilder classes
+    */
+
+   virtual void initialize(TR::IlGeneratorMethodDetails * details,
+                           TR::ResolvedMethodSymbol     * methodSymbol,
+                           TR::FrontEnd                 * fe,
+                           TR::SymbolReferenceTable     * symRefTab);
+
+   virtual int32_t currentByteCodeIndex()
+      { return _bcIndex; }
+
+   virtual uint32_t countBlocks();
+
+   virtual bool isBytecodeBuilderImpl() { return true; } // TODO: eliminate
+
+   void propagateVMState(OMR::VirtualMachineState *fromVMState);
+
+   void setVMState(OMR::VirtualMachineState *vmState)
+      { _vmState = vmState; }
+
+   TR::BytecodeBuilder *client();
+
+protected:
+   int32_t                         _bcIndex;
+   char                          * _name;
+   TR::BytecodeBuilderImpl       * _fallThroughBuilder;
+   List<TR::BytecodeBuilderImpl> * _successorBuilders;
+   OMR::VirtualMachineState      * _initialVMState;
+   OMR::VirtualMachineState      * _vmState;
+
+   virtual void appendBlock(TR::Block *block = 0, bool addEdge=true);
+   void addAllSuccessorBuildersToWorklist();
+   bool connectTrees();
+   virtual void setHandlerInfo(uint32_t catchType);
+   void transferVMState(TR::BytecodeBuilderImpl **b);
+   };
+
+} // namespace OMR
+
+
+#if defined(PUT_OMR_BYTECODEBUILDER_IMPL_INTO_TR)
+
+namespace TR
+{
+   class BytecodeBuilderImpl : public OMR::BytecodeBuilderImpl
+      {
+      public:
+         BytecodeBuilderImpl(TR::MethodBuilderImpl *methodBuilder, int32_t bcIndex, char *name=NULL)
+            : OMR::BytecodeBuilderImpl(methodBuilder, bcIndex, name)
+            { }
+      };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_BYTECODEBUILDER_IMPL_INTO_TR)
+
+#endif // !defined(OMR_BYTECODEBUILDER_IMPL_INCL)

--- a/compiler/ilgen/CMakeLists.txt
+++ b/compiler/ilgen/CMakeLists.txt
@@ -22,11 +22,19 @@
 compiler_library(ilgen
 	${CMAKE_CURRENT_SOURCE_DIR}/IlGenRequest.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/IlBuilder.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/IlTypeImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/IlValue.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/IlValueImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/IlInjector.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/MethodBuilder.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/MethodBuilderImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/BytecodeBuilder.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/BytecodeBuilderImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/TypeDictionary.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/TypeDictionaryImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ThunkBuilder.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/ThunkBuilderImpl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/VirtualMachineOperandArray.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/VirtualMachineOperandStack.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/VirtualMachineRegister.cpp
 )

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -154,21 +154,6 @@ IlBuilder::setupForBuildIL()
    _exitBlock = emptyBlock();
    }
 
-
-#if 0
-char *
-IlBuilder::getName()
-   {
-   if (!_haveReplayName)
-      {
-      sprintf(_replayName, "B_%p", this);
-      _haveReplayName = true;
-      }
-   return _replayName;
-   }
-#endif
-
-
 void
 IlBuilder::print(const char *title, bool recurse)
    {

--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,1751 +19,408 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include "ilgen/IlBuilder.hpp"
-
 #include <stdint.h>
-#include <stdarg.h>
-#include <string.h>
-#include "codegen/CodeGenerator.hpp"
-#include "compile/Compilation.hpp"
-#include "compile/Method.hpp"
-#include "compile/SymbolReferenceTable.hpp"
-#include "control/Recompilation.hpp"
-#include "env/CompilerEnv.hpp"
-#include "env/FrontEnd.hpp"
-#include "il/Block.hpp"
-#include "il/SymbolReference.hpp"
-#include "il/ILOps.hpp"
-#include "il/Node.hpp"
-#include "il/Node_inlines.hpp"
-#include "il/TreeTop.hpp"
-#include "il/TreeTop_inlines.hpp"
-#include "il/symbol/AutomaticSymbol.hpp"
-#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
-#include "ilgen/TypeDictionary.hpp"
-#include "ilgen/IlInjector.hpp"
+#include "ilgen/IlType.hpp"
+#include "ilgen/IlValue.hpp"
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/IlBuilderImpl.hpp"
 #include "ilgen/MethodBuilder.hpp"
-#include "ilgen/BytecodeBuilder.hpp"
-#include "infra/Cfg.hpp"
-#include "infra/List.hpp"
-
-#define OPT_DETAILS "O^O ILBLD: "
-
-#define TraceEnabled    (comp()->getOption(TR_TraceILGen))
-#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
+#include "ilgen/TypeDictionary.hpp"
 
 
-// IlBuilder is a class designed to help build Testarossa IL quickly without
-// a lot of knowledge of the intricacies of commoned references, symbols,
-// symbol references, or blocks. You can add operations to an IlBuilder via
-// a set of services, for example: Add, Sub, Load, Store. These services
-// operate on TR::IlValues, which currently correspond to SymbolReferences.
-// However, IlBuilders also incorporate a notion of "symbols" that are
-// identified by strings (i.e. arbitrary symbolic names).
-//
-// So Load("a") returns a TR::IlValue. Load("b") returns a different
-// TR::IlValue. The value of a+b can be computed by Add(Load("a"),Load("b")),
-// and that value can be stored into c by Store("c", Add(Load("a"),Load("b"))).
-//
-// More complicated services exist to construct control flow by linking
-// together sets of IlBuilder objects. A simple if-then construct, for
-// example, can be built with the following code:
-//    TR::IlValue *condition = NotEqualToZero(Load("a"));
-//    TR::IlBuilder *then = NULL;
-//    IfThen(&then, condition);
-//    then->Return(then->ConstInt32(0));
-//
-//
-// An IlBuilder is really a sequence of Blocks and other IlBuilders, but an
-// IlBuilder is also a sequence of TreeTops connecting together a set of
-// Blocks that are arranged in the CFG. Another way to think of an IlBuilder
-// is as representing the code needed to execute a particular code path
-// (which may itself have sub control flow handled by embedded IlBuilders).
-// All IlBuilders exist within the single control flow graph, but the full
-// control flow graph will not be connected together until all IlBuilder
-// objects have had injectIL() called.
+OMR::IlBuilder::IlBuilder(TR::MethodBuilder *mb, TR::TypeDictionary *types)
+   : _mb(mb),
+     _impl(TR::IlBuilderImpl::allocate(mb->impl(), types->impl())),
+     NoType(types->NoType),
+     Int8(types->Int8),
+     Int16(types->Int16),
+     Int32(types->Int32),
+     Int64(types->Int64),
+     Word(types->Word),
+     Float(types->Float),
+     Double(types->Double),
+     Address(types->Address),
+     VectorInt8(types->VectorInt8),
+     VectorInt16(types->VectorInt16),
+     VectorInt32(types->VectorInt32),
+     VectorInt64(types->VectorInt64),
+     VectorFloat(types->VectorFloat),
+     VectorDouble(types->VectorDouble)
+   {
+   _impl->setClient(static_cast<TR::IlBuilder *>(this));
+   }
 
-
-namespace OMR
-{
-
-IlBuilder::IlBuilder(TR::IlBuilder *source)
-   : TR::IlInjector(source),
-   _methodBuilder(source->_methodBuilder),
-   _sequence(0),
-   _sequenceAppender(0),
-   _entryBlock(0),
-   _exitBlock(0),
-   _count(-1),
-   _partOfSequence(false),
-   _connectedTrees(false),
-   _comesBack(true)
+OMR::IlBuilder::IlBuilder(TR::IlBuilderImpl *impl, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
+   : _mb(methodBuilder),
+     _impl(impl),
+     NoType(types->NoType),
+     Int8(types->Int8),
+     Int16(types->Int16),
+     Int32(types->Int32),
+     Int64(types->Int64),
+     Word(types->Word),
+     Float(types->Float),
+     Double(types->Double),
+     Address(types->Address),
+     VectorInt8(types->VectorInt8),
+     VectorInt16(types->VectorInt16),
+     VectorInt32(types->VectorInt32),
+     VectorInt64(types->VectorInt64),
+     VectorFloat(types->VectorFloat),
+     VectorDouble(types->VectorDouble)
    {
    }
 
-bool
-IlBuilder::TraceEnabled_log(){
-    bool traceEnabled = _comp->getOption(TR_TraceILGen);
-    return traceEnabled;
-}
-
-void
-IlBuilder::TraceIL_log(const char* s, ...){
-    va_list argp;
-    va_start (argp, s);
-    traceMsgVarArgs(_comp, s, argp);
-    va_end(argp);
-}
-
-void
-IlBuilder::initSequence()
+OMR::IlBuilder::~IlBuilder()
    {
-   _sequence = new (_comp->trMemory()->trHeapMemory()) List<SequenceEntry>(_comp->trMemory());
-   _sequenceAppender = new (_comp->trMemory()->trHeapMemory()) ListAppender<SequenceEntry>(_sequence);
-   }
-
-bool
-IlBuilder::injectIL()
-   {
-   TraceIL("Inside injectIL()\n");
-   TraceIL("original entry %p\n", cfg()->getStart());
-   TraceIL("original exit %p\n", cfg()->getEnd());
-
-   setupForBuildIL();
-
-   bool rc = buildIL();
-   TraceIL("buildIL() returned %d\n", rc);
-   if (!rc)
-      return false;
-
-   rc = connectTrees();
-   if (TraceEnabled)
-      comp()->dumpMethodTrees("after connectTrees");
-   cfg()->removeUnreachableBlocks();
-   if (TraceEnabled)
-      comp()->dumpMethodTrees("after removing unreachable blocks");
-   return rc;
-   }
-
-void
-IlBuilder::setupForBuildIL()
-   {
-   initSequence();
-   appendBlock(NULL, false);
-   _entryBlock = _currentBlock;
-   _exitBlock = emptyBlock();
-   }
-
-void
-IlBuilder::print(const char *title, bool recurse)
-   {
-   if (!TraceEnabled)
-      return;
-
-   if (title != NULL)
-      TraceIL("[ %p ] %s\n", this, title);
-   TraceIL("[ %p ] _methodBuilder %p\n", this, _methodBuilder);
-   TraceIL("[ %p ] _entryBlock %p\n", this, _entryBlock);
-   TraceIL("[ %p ] _exitBlock %p\n", this, _exitBlock);
-   TraceIL("[ %p ] _connectedBlocks %d\n", this, _connectedTrees);
-   TraceIL("[ %p ] _comesBack %d\n", this, _comesBack);
-   TraceIL("[ %p ] Sequence:\n", this);
-   ListIterator<SequenceEntry> iter(_sequence);
-   for (SequenceEntry *entry = iter.getFirst(); !iter.atEnd(); entry = iter.getNext())
+   if (_impl)
       {
-      if (entry->_isBlock)
-         {
-         printBlock(entry->_block);
-         }
-      else
-         {
-         if (recurse)
-            {
-            TraceIL("[ %p ] Inner builder %p", this, entry->_builder);
-            entry->_builder->print(NULL, recurse);
-            }
-         else
-            {
-            TraceIL("[ %p ] Builder %p\n", this, entry->_builder);
-            }
-         }
+      //delete impl();
       }
-   }
-
-void
-IlBuilder::printBlock(TR::Block *block)
-   {
-   if (!TraceEnabled)
-      return;
-
-   TraceIL("[ %p ] Block %p\n", this, block);
-   TR::TreeTop *tt = block->getEntry();
-   while (tt != block->getExit())
-      {
-      comp()->getDebug()->print(comp()->getOutFile(), tt);
-      tt = tt->getNextTreeTop();
-      }
-   comp()->getDebug()->print(comp()->getOutFile(), tt);
-   }
-
-TR::SymbolReference *
-IlBuilder::lookupSymbol(const char *name)
-   {
-   TR_ASSERT(_methodBuilder, "cannot look up symbols in an IlBuilder that has no MethodBuilder");
-   return _methodBuilder->lookupSymbol(name);
-   }
-
-void
-IlBuilder::defineSymbol(const char *name, TR::SymbolReference *symRef)
-   {
-   TR_ASSERT(_methodBuilder, "cannot define symbols in an IlBuilder that has no MethodBuilder");
-   _methodBuilder->defineSymbol(name, symRef);
-   }
-
-void
-IlBuilder::defineValue(const char *name, TR::IlType *type)
-   {
-   TR::DataType dt = type->getPrimitiveType();
-   TR::SymbolReference *newSymRef = symRefTab()->createTemporary(methodSymbol(), dt);
-   newSymRef->getSymbol()->setNotCollected();
-   defineSymbol(name, newSymRef);
    }
 
 TR::IlValue *
-IlBuilder::newValue(TR::DataType dt, TR::Node *n)
+OMR::IlBuilder::Copy(TR::IlValue *value)
    {
-   // make sure TreeTop is well formed
-   TR::Node *ttNode = n;
-   if (!ttNode->getOpCode().isTreeTop())
-      ttNode = TR::Node::create(TR::treetop, 1, n);
+   return impl()->Copy(value->impl());
+   }
 
-   TR::TreeTop *tt = TR::TreeTop::create(_comp, ttNode);
-   _currentBlock->append(tt);
-   TR::IlValue *value = new (_comp->trHeapMemory()) TR::IlValue(n, tt, _currentBlock, _methodBuilder);
+TR::IlBuilder *
+OMR::IlBuilder::OrphanBuilder()
+   {
+   TR::IlBuilderImpl *bi = impl()->OrphanBuilderImpl();
+   return orphanBuilder(bi);
+   }
+
+TR::IlBuilder *
+OMR::IlBuilder::orphanBuilder(TR::IlBuilderImpl *bi)
+   {
+   TR::TypeDictionary *types = _mb->_types;
+   TR::IlBuilder *b = new TR::IlBuilder(bi, _mb, types);
+   bi->setClient(b);
+   _mb->newBuilder(b);
+   return b;
+   }
+
+/**
+ * Constants
+**/
+
+TR::IlValue *
+OMR::IlBuilder::NullAddress()
+   {
+   return impl()->NullAddress();
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstInt8(int8_t value)
+   {
+   return impl()->ConstInt8(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstInt16(int16_t value)
+   {
+   return impl()->ConstInt16(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstInt32(int32_t value)
+   {
+   return impl()->ConstInt32(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstInt64(int64_t value)
+   {
+   return impl()->ConstInt64(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstFloat(float value)
+   {
+   return impl()->ConstFloat(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstDouble(double value)
+   {
+   return impl()->ConstDouble(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstAddress(const void * const value)
+   {
+   return impl()->ConstAddress(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstString(const char * const value)
+   {
+   return impl()->ConstString(value);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConstInteger(TR::IlType *intType, int64_t value)
+   {
+   return impl()->ConstInteger(intType->impl(), value);
+   }
+
+
+   // arithmetic
+TR::IlValue *
+OMR::IlBuilder::Add(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->Add(left->impl(), right->impl());
+   }
+
+#define ILBUILDER_PARM_SETUP(ptrImpl, ptrArg, parmArg) \
+   TR::IlBuilderImpl *ptrImpl = NULL;                  \
+   TR::IlBuilderImpl **ptrArg = NULL;                  \
+   if (parmArg)                                        \
+      {                                                \
+      ptrArg = &ptrImpl;                               \
+      if (*parmArg)                                    \
+         ptrImpl = (*parmArg)->impl();                  \
+      }
+
+#define ILBUILDER_PARM_RETURN(ptrImpl, parmArg) \
+   if (parmArg)                                 \
+      *parmArg = ptrImpl->client();
+   
+TR::IlValue *
+OMR::IlBuilder::AddWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(handlerImpl, handlerArg, handler);
+   TR::IlValue *value = impl()->AddWithOverflow(handlerArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(handlerImpl, handler);
    return value;
    }
 
 TR::IlValue *
-IlBuilder::newValue(TR::IlType *dt, TR::Node *n)
+OMR::IlBuilder::AddWithUnsignedOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
    {
-   return newValue(dt->getPrimitiveType(), n);
+   ILBUILDER_PARM_SETUP(handlerImpl, handlerArg, handler);
+   TR::IlValue *value = impl()->AddWithUnsignedOverflow(handlerArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(handlerImpl, handler);
+   return value;
    }
 
 TR::IlValue *
-IlBuilder::NewValue(TR::IlType *dt)
+OMR::IlBuilder::Sub(TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT_FATAL(0, "should not create a value without a TR::Node");
+   return impl()->Sub(left->impl(), right->impl());
    }
 
 TR::IlValue *
-IlBuilder::Copy(TR::IlValue *value)
+OMR::IlBuilder::SubWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
    {
-   TR::DataType dt = value->getDataType();
-   TR::SymbolReference *newSymRef = symRefTab()->createTemporary(_methodSymbol, dt);
-   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
-   sprintf(name, "_T%u", newSymRef->getCPIndex());
-   newSymRef->getSymbol()->getAutoSymbol()->setName(name);
-   newSymRef->getSymbol()->setNotCollected();
-   _methodBuilder->defineSymbol(name, newSymRef);
-
-   storeToTemp(newSymRef, loadValue(value));
-
-   TR::IlValue *newVal = newValue(newSymRef->getSymbol()->getDataType(), loadTemp(newSymRef));
-
-   TraceIL("IlBuilder[ %p ]::Copy value (%d) dataType (%d) to newVal (%d) at cpIndex (%d)\n", this, value->getID(), dt, newVal->getID(), newSymRef->getCPIndex());
-
-   return newVal;
-   }
-
-TR::TreeTop *
-IlBuilder::getFirstTree()
-   {
-   TR_ASSERT(_blocks, "_blocks not created yet");
-   TR_ASSERT(_blocks[0], "_blocks[0] not created yet");
-   return _blocks[0]->getEntry();
-   }
-
-TR::TreeTop *
-IlBuilder::getLastTree()
-   {
-   TR_ASSERT(_blocks, "_blocks not created yet");
-   TR_ASSERT(_blocks[_numBlocks], "_blocks[0] not created yet");
-   return _blocks[_numBlocks]->getExit();
-   }
-
-uint32_t
-IlBuilder::countBlocks()
-   {
-   // only count each block once
-   if (_count > -1)
-      return _count;
-
-   TraceIL("[ %p ] TR::IlBuilder::countBlocks 0 at entry\n", this);
-
-   _count = 0; // prevent recursive counting; will be updated to real value before returning
-
-   uint32_t count=0;
-   ListIterator<SequenceEntry> iter(_sequence);
-   for (SequenceEntry *entry = iter.getFirst(); !iter.atEnd(); entry = iter.getNext())
-      {
-      if (entry->_isBlock)
-         count++;
-      else
-         count += entry->_builder->countBlocks();
-      }
-
-   if (this != _methodBuilder)
-      {
-      // exit block isn't in the sequence except for method builders
-      //            gets tacked in late by connectTrees
-      count++;
-      }
-
-   TraceIL("[ %p ] TR::IlBuilder::countBlocks %d\n", this, count);
-
-   _count = count;
-   return count;
-   }
-
-void
-IlBuilder::pullInBuilderTrees(TR::IlBuilder *builder,
-                              uint32_t *currentBlock,
-                              TR::TreeTop **firstTree,
-                              TR::TreeTop **newLastTree)
-   {
-   TraceIL("\n[ %p ] Calling connectTrees on inner builder %p\n", this, builder);
-   builder->connectTrees();
-   TraceIL("\n[ %p ] Returned from connectTrees on %p\n", this, builder);
-
-   TR::Block **innerBlocks = builder->blocks();
-   uint32_t innerNumBlocks = builder->numBlocks();
-
-   uint32_t copyBlock = *currentBlock;
-   for (uint32_t i=0;i < innerNumBlocks;i++, copyBlock++)
-      {
-      if (TraceEnabled)
-         {
-         TraceIL("[ %p ] copying inner block B%d to B%d\n", this, i, copyBlock);
-         printBlock(innerBlocks[i]);
-         }
-      _blocks[copyBlock] = innerBlocks[i];
-      }
-
-   *currentBlock += innerNumBlocks;
-   *firstTree = innerBlocks[0]->getEntry();
-   *newLastTree = innerBlocks[innerNumBlocks-1]->getExit();
-   }
-
-bool
-IlBuilder::connectTrees()
-   {
-   // don't do this more than once per builder object
-   if (_connectedTrees)
-      return true;
-
-   _connectedTrees = true;
-
-   TraceIL("[ %p ] TR::IlBuilder::connectTrees():\n", this);
-
-   // figure out how many blocks we need
-   uint32_t numBlocks = countBlocks();
-   TraceIL("[ %p ] Total %d blocks\n", this, numBlocks);
-
-   allocateBlocks(numBlocks);
-   TraceIL("[ %p ] Allocated _blocks %p\n", this, _blocks);
-
-   // now add all the blocks from the sequence into the _blocks array
-   // and connect the trees into a single sequence
-   uint32_t currentBlock = 0;
-   TR::Block **blocks = _blocks;
-   TR::TreeTop *lastTree = NULL;
-
-   TraceIL("[ %p ] Connecting trees one entry at a time:\n", this);
-   ListIterator<SequenceEntry> iter(_sequence);
-   for (SequenceEntry *entry = iter.getFirst(); !iter.atEnd(); entry = iter.getNext())
-      {
-      TraceIL("[ %p ] currentBlock = %d\n", this, currentBlock);
-      TraceIL("[ %p ] lastTree = %p\n", this, lastTree);
-      TR::TreeTop *firstTree = NULL;
-      TR::TreeTop *newLastTree = NULL;
-      if (entry->_isBlock)
-         {
-         if (TraceEnabled)
-            {
-            TraceIL("[ %p ] Block entry %p becomes block B%d\n", this, entry->_block, currentBlock);
-            printBlock(entry->_block);
-            }
-         blocks[currentBlock++] = entry->_block;
-         firstTree = entry->_block->getEntry();
-         newLastTree = entry->_block->getExit();
-         }
-      else
-         {
-         TR::IlBuilder *builder = entry->_builder;
-         pullInBuilderTrees(builder, &currentBlock, &firstTree, &newLastTree);
-         }
-
-      TraceIL("[ %p ] First tree is %p [ node %p ]\n", this, firstTree, firstTree->getNode());
-      TraceIL("[ %p ] Last tree will be %p [ node %p ]\n", this, newLastTree, newLastTree->getNode());
-
-      // connect the trees
-      if (lastTree)
-         {
-         TraceIL("[ %p ] Connecting tree %p [ node %p ] to new tree %p [ node %p ]\n", this, lastTree, lastTree->getNode(), firstTree, firstTree->getNode());
-         lastTree->join(firstTree);
-         }
-
-      lastTree = newLastTree;
-      }
-
-   if (_methodBuilder != this)
-      {
-      // non-method builders need to append the "EXIT" block trees
-      // (method builders have EXIT as the special block 1)
-      TraceIL("[ %p ] Connecting last tree %p [ node %p ] to exit block entry %p [ node %p ]\n", this, lastTree, lastTree->getNode(), _exitBlock->getEntry(), _exitBlock->getEntry()->getNode());
-      lastTree->join(_exitBlock->getEntry());
-
-      // also add exit block to blocks array and add an edge from last block to EXIT if the builder comes back (i.e. doesn't return or branch off somewhere)
-      if (comesBack())
-         cfg()->addEdge(blocks[currentBlock-1], getExit());
-
-      blocks[currentBlock++] = _exitBlock;
-      TraceIL("[ %p ] exit block %d is %p (%p -> %p)\n", this, _exitBlock->getNumber(), _exitBlock->getEntry(), _exitBlock->getExit());
-      lastTree = _exitBlock->getExit();
-
-      _numBlocks = currentBlock;
-      }
-
-   TraceIL("[ %p ] last tree %p [ node %p ]\n", this, lastTree, lastTree->getNode());
-   lastTree->setNextTreeTop(NULL);
-   TraceIL("[ %p ] blocks[%d] exit tree is %p\n", this, currentBlock-1, blocks[currentBlock-1]->getExit());
-
-   return true;
-   }
-
-TR::Node *
-IlBuilder::zero(TR::DataType dt)
-   {
-   switch (dt)
-      {
-      case TR::Int8 :  return TR::Node::bconst(0);
-      case TR::Int16 : return TR::Node::sconst(0);
-      case TR::Int32 : return TR::Node::iconst(0);
-      case TR::Int64 : return TR::Node::lconst(0);
-      default :        return TR::Node::create(TR::ILOpCode::constOpCode(dt), 0, 0);
-      }
-   TR_ASSERT(0, "should not reach here");
-   }
-
-TR::Node *
-IlBuilder::zero(TR::IlType *dt)
-   {
-   return zero(dt->getPrimitiveType());
-   }
-
-TR::Node *
-IlBuilder::zeroNodeForValue(TR::IlValue *v)
-   {
-   return zero(v->getDataType());
+   ILBUILDER_PARM_SETUP(handlerImpl, handlerArg, handler);
+   TR::IlValue *value = impl()->SubWithOverflow(handlerArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(handlerImpl, handler);
+   return value;
    }
 
 TR::IlValue *
-IlBuilder::zeroForValue(TR::IlValue *v)
+OMR::IlBuilder::SubWithUnsignedOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
    {
-   TR::IlValue *returnValue = newValue(v->getDataType(), zeroNodeForValue(v));
-   return returnValue;
-   }
-
-
-TR::IlBuilder *
-IlBuilder::OrphanBuilder()
-   {
-   TR::IlBuilder *orphan = new (comp()->trHeapMemory()) TR::IlBuilder(_methodBuilder, _types);
-   orphan->initialize(_details, _methodSymbol, _fe, _symRefTab);
-   orphan->setupForBuildIL();
-   return orphan;
-   }
-
-TR::Block *
-IlBuilder::emptyBlock()
-   {
-   TR::Block *empty = TR::Block::createEmptyBlock(NULL, _comp);
-   cfg()->addNode(empty);
-   return empty;
-   }
-
-
-TR::IlBuilder *
-IlBuilder::createBuilderIfNeeded(TR::IlBuilder *builder)
-   {
-   if (builder == NULL)
-      builder = OrphanBuilder();
-   return builder;
-   }
-
-IlBuilder::SequenceEntry *
-IlBuilder::blockEntry(TR::Block *block)
-   {
-   return new (_comp->trMemory()->trHeapMemory()) IlBuilder::SequenceEntry(block);
-   }
-
-IlBuilder::SequenceEntry *
-IlBuilder::builderEntry(TR::IlBuilder *builder)
-   {
-   return new (_comp->trMemory()->trHeapMemory()) IlBuilder::SequenceEntry(builder);
-   }
-
-void
-IlBuilder::appendBlock(TR::Block *newBlock, bool addEdge)
-   {
-   if (newBlock == NULL)
-      {
-      newBlock = emptyBlock();
-      }
-
-   _sequenceAppender->add(blockEntry(newBlock));
-
-   if (_currentBlock && addEdge)
-      {
-      // if current block does not fall through to new block, use appendNoFallThroughBlock() rather than appendBlock()
-      cfg()->addEdge(_currentBlock, newBlock);
-      }
-
-   // subsequent IL should generate to appended block
-   _currentBlock = newBlock;
-   }
-
-void
-IlBuilder::AppendBuilder(TR::IlBuilder *builder)
-   {
-   TR_ASSERT(builder->_partOfSequence == false, "builder cannot be in two places");
-
-   builder->_partOfSequence = true;
-   _sequenceAppender->add(builderEntry(builder));
-   if (_currentBlock != NULL)
-      {
-      cfg()->addEdge(_currentBlock, builder->getEntry());
-      _currentBlock = NULL;
-      }
-
-   TraceIL("IlBuilder[ %p ]::AppendBuilder %p\n", this, builder);
-
-   // when trees are connected, exit block will swing down to become last trees in builder, so it can fall through to this block we're about to create
-   // need to add edge explicitly because of this exit block sleight of hand
-   appendNoFallThroughBlock();
-   cfg()->addEdge(builder->getExit(), _currentBlock);
-   }
-
-TR::Node *
-IlBuilder::loadValue(TR::IlValue *v)
-   {
-   return v->load(_currentBlock);
-   }
-
-void
-IlBuilder::storeNode(TR::SymbolReference *symRef, TR::Node *v)
-   {
-   genTreeTop(TR::Node::createStore(symRef, v));
-   }
-
-void
-IlBuilder::indirectStoreNode(TR::Node *addr, TR::Node *v)
-   {
-   TR::DataType dt = v->getDataType();
-   TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(dt, addr);
-   TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectArrayStore(dt);
-   genTreeTop(TR::Node::createWithSymRef(storeOp, 2, addr, v, 0, storeSymRef));
+   ILBUILDER_PARM_SETUP(handlerImpl, handlerArg, handler);
+   TR::IlValue *value = impl()->SubWithUnsignedOverflow(handlerArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(handlerImpl, handler);
+   return value;
    }
 
 TR::IlValue *
-IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad)
+OMR::IlBuilder::Mul(TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(dt->isPointer(), "indirectLoadNode must apply to pointer type");
-   TR::IlType * baseType = dt->baseType();
-   TR::DataType primType = baseType->getPrimitiveType();
-   TR_ASSERT(primType != TR::NoType, "Dereferencing an untyped pointer.");
-   TR::DataType symRefType = primType;
-   if (isVectorLoad)
-      symRefType = symRefType.scalarToVector();
-
-   TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(symRefType, addr);
-
-   TR::ILOpCodes loadOp = comp()->il.opCodeForIndirectArrayLoad(primType);
-   if (isVectorLoad)
-      {
-      loadOp = TR::ILOpCode::convertScalarToVector(loadOp);
-      baseType = _types->PrimitiveType(symRefType);
-      }
-
-   TR::Node *loadNode = TR::Node::createWithSymRef(loadOp, 1, 1, addr, storeSymRef);
-
-   TR::IlValue *loadValue = newValue(baseType, loadNode);
-   return loadValue;
-   }
-
-/**
- * @brief Store an IlValue into a named local variable
- * @param varName the name of the local variable to be stored into. If the name has not been used before, this local variable will
- *                take the same data type as the value being written to it.
- * @param value IlValue that should be written to the local variable, which should be the same data type
- */
-void
-IlBuilder::Store(const char *varName, TR::IlValue *value)
-   {
-   if (!_methodBuilder->symbolDefined(varName))
-      _methodBuilder->defineValue(varName, _types->PrimitiveType(value->getDataType()));
-   TR::SymbolReference *symRef = lookupSymbol(varName);
-
-   TraceIL("IlBuilder[ %p ]::Store %s %d gets %d\n", this, varName, symRef->getCPIndex(), value->getID());
-   storeNode(symRef, loadValue(value));
-   }
-
-/**
- * @brief Store an IlValue into the same local value as another IlValue
- * @param dest IlValue that should now hold the same value as "value"
- * @param value IlValue that should overwrite "dest"
- */
-void
-IlBuilder::StoreOver(TR::IlValue *dest, TR::IlValue *value)
-   {
-   dest->storeOver(value, _currentBlock);
-   }
-
-/**
- * @brief Store a vector IlValue into a named local variable
- * @param varName the name of the local variable to be vector stored into. if the name has not been used before, this local variable will
- *                take the same data type as the value being written to it. The width of this data will be determined by the vector
- *                data type of IlValue.
- * @param value IlValue with the vector data that should be written to the local variable, and should have the same data type
- */
-void
-IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
-   {
-   TR::Node *valueNode = loadValue(value);
-   TR::DataType dt = valueNode->getDataType();
-   if (!dt.isVector())
-      {
-      valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
-      dt = dt.scalarToVector();
-      }
-
-   if (!_methodBuilder->symbolDefined(varName))
-      _methodBuilder->defineValue(varName, _types->PrimitiveType(dt));
-   TR::SymbolReference *symRef = lookupSymbol(varName);
-
-   TraceIL("IlBuilder[ %p ]::VectorStore %s %d gets %d\n", this, varName, symRef->getCPIndex(), value->getID());
-   storeNode(symRef, loadValue(value));
-   }
-
-/**
- * @brief Store an IlValue through a pointer
- * @param address the pointer address through which the value will be written
- * @param value IlValue that should be written at "address"
- */
-void
-IlBuilder::StoreAt(TR::IlValue *address, TR::IlValue *value)
-   {
-   TR_ASSERT(address->getDataType() == TR::Address, "StoreAt needs an address operand");
-
-   TraceIL("IlBuilder[ %p ]::StoreAt address %d gets %d\n", this, address->getID(), value->getID());
-   indirectStoreNode(loadValue(address), loadValue(value));
-   }
-
-/**
- * @brief Store a vector IlValue through a pointer
- * @param address the pointer address through which the vector value will be written. The width of the store will be determined
- *                by the vector data type of IlValue.
- * @param value IlValue with the vector data that should be written  at "address"
- */
-void
-IlBuilder::VectorStoreAt(TR::IlValue *address, TR::IlValue *value)
-   {
-   TR_ASSERT(address->getDataType() == TR::Address, "VectorStoreAt needs an address operand");
-
-   TraceIL("IlBuilder[ %p ]::VectorStoreAt address %d gets %d\n", this, address->getID(), value->getID());
-
-   TR::Node *valueNode = loadValue(value);
-
-   if (!valueNode->getDataType().isVector())
-      valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
-
-   indirectStoreNode(loadValue(address), valueNode);
+   return impl()->Mul(left->impl(), right->impl());
    }
 
 TR::IlValue *
-IlBuilder::CreateLocalArray(int32_t numElements, TR::IlType *elementType)
+OMR::IlBuilder::MulWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
    {
-   uint32_t size = numElements * elementType->getSize();
-   TR::SymbolReference *localArraySymRef = symRefTab()->createLocalPrimArray(size,
-                                                                             methodSymbol(),
-                                                                             8 /*FIXME: JVM-specific - byte*/);
-   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
-   sprintf(name, "_T%u", localArraySymRef->getCPIndex());
-   localArraySymRef->getSymbol()->getAutoSymbol()->setName(name);
-   localArraySymRef->setStackAllocatedArrayAccess();
-   _methodBuilder->defineSymbol(name, localArraySymRef);
+   ILBUILDER_PARM_SETUP(handlerImpl, handlerArg, handler);
+   TR::IlValue *value = impl()->MulWithOverflow(handlerArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(handlerImpl, handler);
+   return value;
+   }
 
-   TR::Node *arrayAddress = TR::Node::createWithSymRef(TR::loadaddr, 0, localArraySymRef);
-   TR::IlValue *arrayAddressValue = newValue(TR::Address, arrayAddress);
-
-   TraceIL("IlBuilder[ %p ]::CreateLocalArray array allocated %d bytes, address in %d\n", this, size, arrayAddressValue->getID());
-   return arrayAddressValue;
-
+/* TODO: should have a WithZeroCheck variant here */
+TR::IlValue *
+OMR::IlBuilder::Div(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->Div(left->impl(), right->impl());
    }
 
 TR::IlValue *
-IlBuilder::CreateLocalStruct(TR::IlType *structType)
+OMR::IlBuilder::And(TR::IlValue *left, TR::IlValue *right)
    {
-   //similar to CreateLocalArray except writing a method in StructType to get the struct size
-   uint32_t size = structType->getSize();
-   TR::SymbolReference *localStructSymRef = symRefTab()->createLocalPrimArray(size,
-                                                                             methodSymbol(),
-                                                                             8 /*FIXME: JVM-specific - byte*/);
-   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
-   sprintf(name, "_T%u", localStructSymRef->getCPIndex());
-   localStructSymRef->getSymbol()->getAutoSymbol()->setName(name);
-   localStructSymRef->setStackAllocatedArrayAccess();
-   _methodBuilder->defineSymbol(name, localStructSymRef);
-
-   TR::Node *structAddress = TR::Node::createWithSymRef(TR::loadaddr, 0, localStructSymRef);
-   TR::IlValue *structAddressValue = newValue(TR::Address, structAddress);
-
-   TraceIL("IlBuilder[ %p ]::CreateLocalStruct struct allocated %d bytes, address in %d\n", this, size, structAddressValue->getID());
-   return structAddressValue;
+   return impl()->And(left->impl(), right->impl());
    }
 
-void
-IlBuilder::StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value)
+TR::IlValue *
+OMR::IlBuilder::Or(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->Or(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::Xor(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->Xor(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ShiftL(TR::IlValue *v, TR::IlValue *amount)
+   {
+   return impl()->ShiftL(v->impl(), amount->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ShiftR(TR::IlValue *v, TR::IlValue *amount)
+   {
+   return impl()->ShiftR(v->impl(), amount->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::UnsignedShiftR(TR::IlValue *v, TR::IlValue *amount)
+   {
+   return impl()->UnsignedShiftR(v->impl(), amount->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::NotEqualTo(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->NotEqualTo(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::EqualTo(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->EqualTo(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::LessThan(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->LessThan(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::UnsignedLessThan(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->UnsignedLessThan(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::LessOrEqualTo(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->LessOrEqualTo(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::UnsignedLessOrEqualTo(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->UnsignedLessOrEqualTo(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::GreaterThan(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->GreaterThan(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::UnsignedGreaterThan(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->UnsignedGreaterThan(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::GreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->GreaterOrEqualTo(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::UnsignedGreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right)
+   {
+   return impl()->UnsignedGreaterOrEqualTo(left->impl(), right->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)
+   {
+   return impl()->ConvertTo(t->impl(), v->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::UnsignedConvertTo(TR::IlType *t, TR::IlValue *v)
+   {
+   return impl()->UnsignedConvertTo(t->impl(), v->impl());
+   }
+
+
+// memory operations
+TR::IlValue *
+OMR::IlBuilder::CreateLocalArray(int32_t numElements, TR::IlType *elementType)
   {
-  TR::SymbolReference *symRef = (TR::SymbolReference*)_types->FieldReference(type, field);
-  TR::DataType fieldType = symRef->getSymbol()->getDataType();
-  TraceIL("IlBuilder[ %p ]::StoreIndirect %s.%s (%d) into (%d)\n", this, type, field, value->getID(), object->getID());
-  TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectStore(fieldType);
-  genTreeTop(TR::Node::createWithSymRef(storeOp, 2, loadValue(object), loadValue(value), 0, symRef));
+  return impl()->CreateLocalArray(numElements, elementType->impl());
   }
 
 TR::IlValue *
-IlBuilder::Load(const char *name)
-   {
-   TR::SymbolReference *symRef = lookupSymbol(name);
-   TR::Node *valueNode = TR::Node::createLoad(symRef);
-   TR::IlValue *returnValue = newValue(symRef->getSymbol()->getDataType(), valueNode);
-   return returnValue;
-   }
+OMR::IlBuilder::CreateLocalStruct(TR::IlType *structType)
+  {
+  return impl()->CreateLocalStruct(structType->impl());
+  }
 
 TR::IlValue *
-IlBuilder::VectorLoad(const char *name)
-   {
-   TR::SymbolReference *nameSymRef = lookupSymbol(name);
-   TR::DataType returnType = nameSymRef->getSymbol()->getDataType();
-   TR_ASSERT(returnType.isVector(), "VectorLoad must load symbol with a vector type");
+OMR::IlBuilder::Load(const char *name)
+  {
+  return impl()->Load(name);
+  }
 
-   TR::Node *loadNode = TR::Node::createWithSymRef(0, TR::comp()->il.opCodeForDirectLoad(returnType), 0, nameSymRef);
-   TR::IlValue *returnValue = newValue(returnType, loadNode);
-   TraceIL("IlBuilder[ %p ]::%d is VectorLoad %s (%d)\n", this, returnValue->getID(), name, nameSymRef->getCPIndex());
-
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::LoadIndirect(const char *type, const char *field, TR::IlValue *object)
-   {
-   TR::SymbolReference *symRef = (TR::SymbolReference *)_types->FieldReference(type, field);
-   TR::DataType fieldType = symRef->getSymbol()->getDataType();
-   TR::IlValue *returnValue = newValue(fieldType, TR::Node::createWithSymRef(comp()->il.opCodeForIndirectLoad(fieldType), 1, loadValue(object), 0, symRef));
-   TraceIL("IlBuilder[ %p ]::%d is LoadIndirect %s.%s from (%d)\n", this, returnValue->getID(), type, field, object->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::LoadAt(TR::IlType *dt, TR::IlValue *address)
-   {
-   TR_ASSERT(address->getDataType() == TR::Address, "LoadAt needs an address operand");
-   TR::IlValue *returnValue = indirectLoadNode(dt, loadValue(address));
-   TraceIL("IlBuilder[ %p ]::%d is LoadAt type %d address %d\n", this, returnValue->getID(), dt->getPrimitiveType(), address->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::VectorLoadAt(TR::IlType *dt, TR::IlValue *address)
-   {
-   TR_ASSERT(address->getDataType() == TR::Address, "LoadAt needs an address operand");
-   TR::IlValue *returnValue = indirectLoadNode(dt, loadValue(address), true);
-   TraceIL("IlBuilder[ %p ]::%d is VectorLoadAt type %d address %d\n", this, returnValue->getID(), dt->getPrimitiveType(), address->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
-   {
-   TR::IlType *elemType = dt->baseType();
-   TR_ASSERT(base->getDataType() == TR::Address, "IndexAt must be called with a pointer base");
-   TR_ASSERT(elemType != NULL, "IndexAt should be called with pointer type");
-   TR_ASSERT(elemType->getPrimitiveType() != TR::NoType, "Cannot use IndexAt with pointer to NoType.");
-   TR::Node *baseNode = loadValue(base);
-   TR::Node *indexNode = loadValue(index);
-   TR::Node *elemSizeNode;
-   TR::ILOpCodes addOp, mulOp;
-   TR::DataType indexType = indexNode->getDataType();
-   if (TR::Compiler->target.is64Bit())
-      {
-      if (indexType != TR::Int64)
-         {
-         TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, TR::Int64);
-         indexNode = TR::Node::create(op, 1, indexNode);
-         }
-      elemSizeNode = TR::Node::lconst(elemType->getSize());
-      addOp = TR::aladd;
-      mulOp = TR::lmul;
-      }
-   else
-      {
-      TR::DataType targetType = TR::Int32;
-      if (indexType != targetType)
-         {
-         TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, targetType);
-         indexNode = TR::Node::create(op, 1, indexNode);
-         }
-      elemSizeNode = TR::Node::iconst(elemType->getSize());
-      addOp = TR::aiadd;
-      mulOp = TR::imul;
-      }
-
-   TR::Node *offsetNode = TR::Node::create(mulOp, 2, indexNode, elemSizeNode);
-   TR::Node *addrNode = TR::Node::create(addOp, 2, baseNode, offsetNode);
-
-   TR::IlValue *address = newValue(Address, addrNode);
-
-   TraceIL("IlBuilder[ %p ]::%d is IndexAt(%s) base %d index %d\n", this, address->getID(), dt->getName(), base->getID(), index->getID());
-
-   return address;
-   }
-
-/**
- * @brief Generate IL to load the address of a struct field.
- *
- * The address of the field is calculated by adding the field's offset to the
- * base address of the struct. The address is also converted (type casted) to
- * a pointer to the type of the field.
- */
-TR::IlValue *
-IlBuilder::StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue* obj) {
-   auto offset = typeDictionary()->OffsetOf(structName, fieldName);
-   auto ptype = typeDictionary()->PointerTo(typeDictionary()->GetFieldType(structName, fieldName));
-   TR::IlValue* offsetValue = NULL;
-   if (TR::Compiler->target.is64Bit())
-      {
-      offsetValue = ConstInt64(offset);
-      }
-   else
-      {
-      offsetValue = ConstInt32(offset);
-      }
-   auto addr = Add(obj, offsetValue);
-   return ConvertTo(ptype, addr);
-}
-
-/**
- * @brief Generate IL to load the address of a union field.
- *
- * The address of the field is simply the base address of the union, since the
- * offset of all union fields is zero.
- */
-TR::IlValue *
-IlBuilder::UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValue* obj) {
-   auto ptype = typeDictionary()->PointerTo(typeDictionary()->UnionFieldType(unionName, fieldName));
-   return ConvertTo(ptype, obj);
-}
-
-TR::IlValue *
-IlBuilder::NullAddress()
-   {
-   TR::IlValue *returnValue = newValue(Address, TR::Node::aconst(0));
-   TraceIL("IlBuilder[ %p ]::%d is NullAddress\n", this, returnValue->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstInt8(int8_t value)
-   {
-   TR::IlValue *returnValue = newValue(Int8, TR::Node::bconst(value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstInt8 %d\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstInt16(int16_t value)
-   {
-   TR::IlValue *returnValue = newValue(Int16, TR::Node::sconst(value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstInt16 %d\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstInt32(int32_t value)
-   {
-   TR::IlValue *returnValue = newValue(Int32, TR::Node::iconst(value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstInt32 %d\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstInt64(int64_t value)
-   {
-   TR::IlValue *returnValue = newValue(Int64, TR::Node::lconst(value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstInt64 %d\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstFloat(float value)
-   {
-   TR::Node *fconstNode = TR::Node::create(0, TR::fconst, 0);
-   fconstNode->setFloat(value);
-   TR::IlValue *returnValue = newValue(Float, fconstNode);
-   TraceIL("IlBuilder[ %p ]::%d is ConstFloat %f\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstDouble(double value)
-   {
-   TR::Node *dconstNode = TR::Node::create(0, TR::dconst, 0);
-   dconstNode->setDouble(value);
-   TR::IlValue *returnValue = newValue(Double, dconstNode);
-   TraceIL("IlBuilder[ %p ]::%d is ConstDouble %lf\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstString(const char * const value)
-   {
-   TR::IlValue *returnValue = newValue(Address, TR::Node::aconst((uintptrj_t)value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstString %p\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstAddress(const void * const value)
-   {
-   TR::IlValue *returnValue = newValue(Address, TR::Node::aconst((uintptrj_t)value));
-   TraceIL("IlBuilder[ %p ]::%d is ConstAddress %p\n", this, returnValue->getID(), value);
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ConstInteger(TR::IlType *intType, int64_t value)
-   {
-   if      (intType == Int8)  return ConstInt8 ((int8_t)  value);
-   else if (intType == Int16) return ConstInt16((int16_t) value);
-   else if (intType == Int32) return ConstInt32((int32_t) value);
-   else if (intType == Int64) return ConstInt64(          value);
-
-   TR_ASSERT(0, "unknown integer type");
-   return NULL;
-   }
-
-TR::IlValue *
-IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)
-   {
-   TR::DataType typeFrom = v->getDataType();
-   TR::DataType typeTo = t->getPrimitiveType();
-   if (typeFrom == typeTo)
-      {
-      TraceIL("IlBuilder[ %p ]::%d is ConvertTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
-      return v;
-      }
-   TR::IlValue *convertedValue = convertTo(t, v, false);
-   TraceIL("IlBuilder[ %p ]::%d is ConvertTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
-   return convertedValue;
-   }
-
-TR::IlValue *
-IlBuilder::UnsignedConvertTo(TR::IlType *t, TR::IlValue *v)
-   {
-   TR::DataType typeFrom = v->getDataType();
-   TR::DataType typeTo = t->getPrimitiveType();
-   if (typeFrom == typeTo)
-      {
-      TraceIL("IlBuilder[ %p ]::%d is UnsignedConvertTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
-      return v;
-      }
-   TR::IlValue *convertedValue = convertTo(t, v, true);
-   TraceIL("IlBuilder[ %p ]::%d is UnsignedConvertTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
-   return convertedValue;
-   }
-
-TR::IlValue *
-IlBuilder::convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned)
-   {
-   TR::DataType typeFrom = v->getDataType();
-   TR::DataType typeTo = t->getPrimitiveType();
-
-   TR::ILOpCodes convertOp = ILOpCode::getProperConversion(typeFrom, typeTo, needUnsigned);
-   TR_ASSERT(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d (TR::DataType %d) to type %s", this, v->getID(), (int)typeFrom, t->getName());
-
-   TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
-   TR::IlValue *convertedValue = newValue(t, result);
-   return convertedValue;
-   }
-
-TR::IlValue *
-IlBuilder::unaryOp(TR::ILOpCodes op, TR::IlValue *v)
-   {
-   TR::Node *valueNode = loadValue(v);
-   TR::Node *result = TR::Node::create(op, 1, valueNode);
-
-   TR::IlValue *returnValue = newValue(v->getDataType(), result);
-   return returnValue;
-   }
+void 
+OMR::IlBuilder::Store(const char *name, TR::IlValue *value)
+  {
+  impl()->Store(name, value->impl());
+  }
 
 void
-IlBuilder::doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr)
-   {
-   TR::Node *    left  = *leftPtr;
-   TR::DataType lType = left->getDataType();
-
-   TR::Node *    right = *rightPtr;
-   TR::DataType rType = right->getDataType();
-
-   if (lType.isVector() && !rType.isVector())
-      *rightPtr = TR::Node::create(TR::vsplats, 1, right);
-
-   if (!lType.isVector() && rType.isVector())
-      *leftPtr = TR::Node::create(TR::vsplats, 1, left);
-   }
-
-TR::Node*
-IlBuilder::binaryOpNodeFromNodes(TR::ILOpCodes op,
-                                 TR::Node *leftNode,
-                                 TR::Node *rightNode) 
-   {
-   TR::DataType leftType = leftNode->getDataType();
-   TR::DataType rightType = rightNode->getDataType();
-   bool isAddressBump = ((leftType == TR::Address) &&
-                            (rightType == TR::Int32 || rightType == TR::Int64));
-   bool isRevAddressBump = ((rightType == TR::Address) &&
-                               (leftType == TR::Int32 || leftType == TR::Int64));
-   TR_ASSERT(leftType == rightType || isAddressBump || isRevAddressBump, "binaryOp requires both left and right operands to have same type or one is address and other is Int32/64");
-
-   if (isRevAddressBump) // swap them
-      {
-      TR::Node *save = leftNode;
-      leftNode = rightNode;
-      rightNode = save;
-      }
-   
-   return TR::Node::create(op, 2, leftNode, rightNode);
-   }
+OMR::IlBuilder::StoreOver(TR::IlValue *dest, TR::IlValue *value)
+  {
+  impl()->StoreOver(dest->impl(), value->impl());
+  }
 
 TR::IlValue *
-IlBuilder::binaryOpFromNodes(TR::ILOpCodes op,
-                             TR::Node *leftNode,
-                             TR::Node *rightNode) 
-   {
-   TR::Node *result = binaryOpNodeFromNodes(op, leftNode, rightNode);
-   TR::IlValue *returnValue = newValue(result->getDataType(), result);
-   return returnValue;
-   } 
+OMR::IlBuilder::LoadAt(TR::IlType *dt, TR::IlValue *address)
+  {
+  return impl()->LoadAt(dt->impl(), address->impl());
+  }
+
+void 
+OMR::IlBuilder::StoreAt(TR::IlValue *address, TR::IlValue *value)
+  {
+  impl()->StoreAt(address->impl(), value->impl());
+  }
 
 TR::IlValue *
-IlBuilder::binaryOpFromOpMap(OpCodeMapper mapOp,
-                             TR::IlValue *left,
-                             TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
+OMR::IlBuilder::LoadIndirect(const char *type, const char *field, TR::IlValue *object)
+  {
+  return impl()->LoadIndirect(type, field, object->impl());
+  }
 
-   doVectorConversions(&leftNode, &rightNode);
-
-   TR::DataType leftType = leftNode->getDataType();
-   return binaryOpFromNodes(mapOp(leftType), leftNode, rightNode);
-   }
+void 
+OMR::IlBuilder::StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value)
+  {
+  impl()->StoreIndirect(type, field, object->impl(), value->impl());
+  }
 
 TR::IlValue *
-IlBuilder::binaryOpFromOpCode(TR::ILOpCodes op,
-                              TR::IlValue *left,
-                              TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   //doVectorConversions(&left, &right);
-   return binaryOpFromNodes(op, leftNode, rightNode);
-   }
-
-TR::IlValue *
-IlBuilder::compareOp(TR_ComparisonTypes ct,
-                     bool needUnsigned,
-                     TR::IlValue *left,
-                     TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::ILOpCodes op = TR::ILOpCode::compareOpCode(leftNode->getDataType(), ct, needUnsigned);
-   return binaryOpFromOpCode(op, left, right);
-   }
-
-TR::IlValue *
-IlBuilder::NotEqualTo(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=compareOp(TR_cmpNE, false, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is NotEqualTo %d != %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-void
-IlBuilder::Goto(TR::IlBuilder **dest)
-   {
-   *dest = createBuilderIfNeeded(*dest);
-   Goto(*dest);
-   }
-
-void
-IlBuilder::Goto(TR::IlBuilder *dest)
-   {
-   TR_ASSERT(dest != NULL, "This goto implementation requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::Goto %p\n", this, dest);
-   appendGoto(dest->getEntry());
-   setDoesNotComeBack();
-   }
-
-void
-IlBuilder::Return()
-   {
-   TraceIL("IlBuilder[ %p ]::Return\n", this);
-   TR::Node *returnNode = TR::Node::create(TR::ILOpCode::returnOpCode(TR::NoType));
-   genTreeTop(returnNode);
-   cfg()->addEdge(_currentBlock, cfg()->getEnd());
-   setDoesNotComeBack();
-   }
-
-void
-IlBuilder::Return(TR::IlValue *value)
-   {
-   TraceIL("IlBuilder[ %p ]::Return %d\n", this, value->getID());
-   TR::Node *returnNode = TR::Node::create(TR::ILOpCode::returnOpCode(value->getDataType()), 1, loadValue(value));
-   genTreeTop(returnNode);
-   cfg()->addEdge(_currentBlock, cfg()->getEnd());
-   setDoesNotComeBack();
-   }
-
-TR::IlValue *
-IlBuilder::Sub(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue = NULL;
-   if (left->getDataType() == TR::Address)
-      {
-      if (right->getDataType() == TR::Int32)
-         returnValue = binaryOpFromNodes(TR::aiadd, loadValue(left), loadValue(Sub(ConstInt32(0), right)));
-      else if (right->getDataType() == TR::Int64)
-         returnValue = binaryOpFromNodes(TR::aladd, loadValue(left), loadValue(Sub(ConstInt64(0), right)));
-      }
-   if (returnValue == NULL)
-      returnValue=binaryOpFromOpMap(TR::ILOpCode::subtractOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is Sub %d - %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-static TR::ILOpCodes addOpCode(TR::DataType type)
-   {
-   return TR::ILOpCode::addOpCode(type, TR::Compiler->target.is64Bit());
-   }
-
-static TR::ILOpCodes unsignedAddOpCode(TR::DataType type)
-   {
-   return TR::ILOpCode::unsignedAddOpCode(type, TR::Compiler->target.is64Bit());
-   }
-
-TR::IlValue *
-IlBuilder::Add(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue = NULL;
-   if (left->getDataType() == TR::Address)
-      {
-      if (right->getDataType() == TR::Int32)
-         returnValue = binaryOpFromNodes(TR::aiadd, loadValue(left), loadValue(right));
-      else if (right->getDataType() == TR::Int64)
-         returnValue = binaryOpFromNodes(TR::aladd, loadValue(left), loadValue(right));
-      }
-   if (returnValue == NULL)
-      returnValue = binaryOpFromOpMap(addOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is Add %d + %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-/*
- * blockThrowsException:
- * ....
- * goto blockAfterExceptionHandler 
- * Handler:
- * ....
- * goto blockAfterExceptionHandler 
- * blockAfterExceptionHandler:
- */
-void
-IlBuilder::appendExceptionHandler(TR::Block *blockThrowsException, TR::IlBuilder **handler, uint32_t catchType)
-   {
-   //split block after overflowCHK, and add an goto to blockAfterExceptionHandler
-   appendBlock();
-   TR::Block *blockWithGoto = _currentBlock;
-   TR::Node *gotoNode = TR::Node::create(NULL, TR::Goto);
-   genTreeTop(gotoNode);
-   _currentBlock = NULL;
-   _currentBlockNumber = -1;
- 
-   //append handler, add exception edge and merge edge
-   *handler = createBuilderIfNeeded(*handler);
-   TR_ASSERT(*handler != NULL, "exception handler cannot be NULL\n");
-   (*handler)->_isHandler = true;
-   cfg()->addExceptionEdge(blockThrowsException, (*handler)->getEntry());
-   AppendBuilder(*handler);
-   (*handler)->setHandlerInfo(catchType);
-
-   TR::Block *blockAfterExceptionHandler = _currentBlock;
-   TraceIL("blockAfterExceptionHandler block_%d, blockWithGoto block_%d \n", blockAfterExceptionHandler->getNumber(), blockWithGoto->getNumber());
-   gotoNode->setBranchDestination(blockAfterExceptionHandler->getEntry());
-   cfg()->addEdge(blockWithGoto, blockAfterExceptionHandler);
-   }
-
-void
-IlBuilder::setHandlerInfo(uint32_t catchType)
-   {
-   TR::Block *catchBlock = getEntry();
-   catchBlock->setIsCold();
-   catchBlock->setHandlerInfoWithOutBCInfo(catchType, comp()->getInlineDepth(), -1, _methodSymbol->getResolvedMethod(), comp());
-   }
-
-TR::Node*
-IlBuilder::genOverflowCHKTreeTop(TR::Node *operationNode, TR::ILOpCodes overflow)
-   {
-   TR::Node *overflowChkNode = TR::Node::createWithRoomForOneMore(overflow, 3, symRefTab()->findOrCreateOverflowCheckSymbolRef(_methodSymbol), operationNode, operationNode->getFirstChild(), operationNode->getSecondChild());
-   overflowChkNode->setOverflowCheckOperation(operationNode->getOpCodeValue());
-   genTreeTop(overflowChkNode);
-   return overflowChkNode;
-   }
-
-TR::IlValue *
-IlBuilder::genOperationWithOverflowCHK(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode, TR::IlBuilder **handler, TR::ILOpCodes overflow)
-   {
-   /*
-    * BB1:
-    *    overflowCHK
-    *       operation(add/sub/mul)
-    *          child1
-    *          child2
-    *       =>child1
-    *       =>child2
-    *    store
-    *       => operation
-    * BB2:
-    *    goto BB3 
-    * Handler:
-    *    ...
-    * BB3:
-    *    continue
-    */
-   TR::Node *operationNode = binaryOpNodeFromNodes(op, leftNode, rightNode);
-   TR::Node *overflowChkNode = genOverflowCHKTreeTop(operationNode, overflow);
-
-   TR::Block *blockWithOverflowCHK = _currentBlock;
-   TR::IlValue *resultValue = newValue(operationNode->getDataType(), operationNode);
-   genTreeTop(TR::Node::createStore(resultValue->getSymbolReference(), operationNode));
-
-   appendExceptionHandler(blockWithOverflowCHK, handler, TR::Block::CanCatchOverflowCheck);
-   return resultValue;
-   }
-
-// This function takes 4 arguments and generate the addValue.
-// This function is called by AddWithOverflow and AddWithUnsignedOverflow.
-TR::ILOpCodes 
-IlBuilder::getOpCode(TR::IlValue *leftValue, TR::IlValue *rightValue)
-   {
-   TR::ILOpCodes op;
-   if (leftValue->getDataType() == TR::Address)
-      {
-      if (rightValue->getDataType() == TR::Int32)
-         op = TR::aiadd;
-      else if (rightValue->getDataType() == TR::Int64)
-         op = TR::aladd;
-      else 
-         TR_ASSERT(0, "the right child type must be either TR::Int32 or TR::Int64 when the left child of Add is TR::Address\n");
-      }    
-   else 
-      {
-      op = addOpCode(leftValue->getDataType());
-      }
-   return op; 
-   }
-
-TR::IlValue *
-IlBuilder::AddWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::ILOpCodes opcode = getOpCode(left, right);
-   TR::IlValue *addValue = genOperationWithOverflowCHK(opcode, leftNode, rightNode, handler, TR::OverflowCHK);
-   TraceIL("IlBuilder[ %p ]::%d is AddWithOverflow %d + %d\n", this, addValue->getID(), left->getID(), right->getID());
-   return addValue;
-   }
-
-TR::IlValue *
-IlBuilder::AddWithUnsignedOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::ILOpCodes opcode = getOpCode(left, right);
-   TR::IlValue *addValue = genOperationWithOverflowCHK(opcode, leftNode, rightNode, handler, TR::UnsignedOverflowCHK);
-   TraceIL("IlBuilder[ %p ]::%d is AddWithUnsignedOverflow %d + %d\n", this, addValue->getID(), left->getID(), right->getID());
-   return addValue;
-   }
-
-TR::IlValue *
-IlBuilder::SubWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::IlValue *subValue = genOperationWithOverflowCHK(TR::ILOpCode::subtractOpCode(leftNode->getDataType()), leftNode, rightNode, handler, TR::OverflowCHK);
-   TraceIL("IlBuilder[ %p ]::%d is SubWithOverflow %d + %d\n", this, subValue->getID(), left->getID(), right->getID());
-   return subValue;
-   }
-
-TR::IlValue *
-IlBuilder::SubWithUnsignedOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::IlValue *unsignedSubValue = genOperationWithOverflowCHK(TR::ILOpCode::subtractOpCode(leftNode->getDataType()), leftNode, rightNode, handler, TR::UnsignedOverflowCHK);
-   TraceIL("IlBuilder[ %p ]::%d is UnsignedSubWithOverflow %d + %d\n", this, unsignedSubValue->getID(), left->getID(), right->getID());
-   return unsignedSubValue;
-   }
-
-TR::IlValue *
-IlBuilder::MulWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::IlValue *mulValue = genOperationWithOverflowCHK(TR::ILOpCode::multiplyOpCode(leftNode->getDataType()), leftNode, rightNode, handler, TR::OverflowCHK);
-   TraceIL("IlBuilder[ %p ]::%d is MulWithOverflow %d + %d\n", this, mulValue->getID(), left->getID(), right->getID());
-   return mulValue;
-   }
-
-TR::IlValue *
-IlBuilder::Mul(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::multiplyOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is Mul %d * %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::Div(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::divideOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is Div %d / %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::And(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::andOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is And %d & %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::Or(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::orOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is Or %d | %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::Xor(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=binaryOpFromOpMap(TR::ILOpCode::xorOpCode, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is Xor %d ^ %d\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::Node*
-IlBuilder::shiftOpNodeFromNodes(TR::ILOpCodes op,
-                                TR::Node *leftNode,
-                                TR::Node *rightNode) 
-   {
-   TR::DataType leftType = leftNode->getDataType();
-   TR::DataType rightType = rightNode->getDataType();
-   TR_ASSERT(leftType.isIntegral() && rightType.isInt32(), "shift operation first operand must be an integer, and shift amount must be 32-bit integer");
-
-   return TR::Node::create(op, 2, leftNode, rightNode);
-   }
-
-TR::IlValue *
-IlBuilder::shiftOpFromNodes(TR::ILOpCodes op,
-                            TR::Node *leftNode,
-                            TR::Node *rightNode) 
-   {
-   TR::Node *result = shiftOpNodeFromNodes(op, leftNode, rightNode);
-   TR::IlValue *returnValue = newValue(result->getDataType(), result);
-   return returnValue;
-   } 
-
-TR::IlValue *
-IlBuilder::shiftOpFromOpMap(OpCodeMapper mapOp,
-                            TR::IlValue *left,
-                            TR::IlValue *right)
-   {
-   TR::Node *leftNode = loadValue(left);
-   TR::DataType leftType = leftNode->getDataType();
-   TR_ASSERT(leftType.isIntegral(), "left operand of shift must be integer type");
-
-   TR::Node *rightNode = loadValue(right);
-   if (!rightNode->getDataType().isInt32())
-      right = ConvertTo(Int32, right);
-
-   doVectorConversions(&leftNode, &rightNode);
-
-   return shiftOpFromNodes(mapOp(leftType), leftNode, rightNode);
-   }
-
-TR::IlValue *
-IlBuilder::ShiftL(TR::IlValue *v, TR::IlValue *amount)
-   {
-   TR::IlValue *returnValue=shiftOpFromOpMap(TR::ILOpCode::shiftLeftOpCode, v, amount);
-   TraceIL("IlBuilder[ %p ]::%d is shr %d << %d\n", this, returnValue->getID(), v->getID(), amount->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::ShiftR(TR::IlValue *v, TR::IlValue *amount)
-   {
-   TR::IlValue *returnValue=shiftOpFromOpMap(TR::ILOpCode::shiftRightOpCode, v, amount);
-   TraceIL("IlBuilder[ %p ]::%d is shr %d >> %d\n", this, returnValue->getID(), v->getID(), amount->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::UnsignedShiftR(TR::IlValue *v, TR::IlValue *amount)
-   {
-   TR::IlValue *returnValue=shiftOpFromOpMap(TR::ILOpCode::unsignedShiftRightOpCode, v, amount);
-   TraceIL("IlBuilder[ %p ]::%d is unsigned shr %d >> %d\n", this, returnValue->getID(), v->getID(), amount->getID());
-   return returnValue;
-   }
-
-/*
- * @brief IfAnd service for constructing short circuit AND conditional nests (like the && operator)
- * @param allTrueBuilder builder containing operations to execute if all conditional tests evaluate to true
- * @param anyFalseBuilder builder containing operations to execute if any conditional test is false
- * @param numTerms the number of conditional terms
- * @param ... for each term, provide a TR::IlBuilder object and a TR::IlValue object that evaluates a condition (builder is where all the operations to evaluate the condition go, the value is the final result of the condition)
- *
- * Example:
- * TR::IlBuilder *cond1Builder = OrphanBuilder();
- * TR::IlValue *cond1 = cond1Builder->GreaterOrEqual(
- *                      cond1Builder->   Load("x"),
- *                      cond1Builder->   Load("lower"));
- * TR::IlBuilder *cond2Builder = OrphanBuilder();
- * TR::IlValue *cond2 = cond2Builder->LessThan(
- *                      cond2Builder->   Load("x"),
- *                      cond2Builder->   Load("upper"));
- * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
- * IfAnd(&inRange, &outOfRange, 2, cond1Builder, cond1, cond2Builder, cond2);
- */
-void
-IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ...)
-   {
-   TR::IlBuilder *mergePoint = OrphanBuilder();
-   *allTrueBuilder = createBuilderIfNeeded(*allTrueBuilder);
-   *anyFalseBuilder = createBuilderIfNeeded(*anyFalseBuilder);
-
-   va_list terms;
-   va_start(terms, numTerms);
-   for (int32_t t=0;t < numTerms;t++)
-      {
-      TR::IlBuilder *condBuilder = va_arg(terms, TR::IlBuilder*);
-      TR::IlValue *condValue = va_arg(terms, TR::IlValue*);
-      AppendBuilder(condBuilder);
-      condBuilder->IfCmpEqualZero(anyFalseBuilder, condValue);
-      // otherwise fall through to test next term
-      }
-   va_end(terms);
-
-   // if control gets here, all the provided terms were true
-   AppendBuilder(*allTrueBuilder);
-   Goto(mergePoint);
-
-   // also need to handle the false case
-   AppendBuilder(*anyFalseBuilder);
-   Goto(mergePoint);
-
-   AppendBuilder(mergePoint);
-
-   // return state for "this" can get confused by the Goto's in this service
-   setComesBack();
-   }
-
-/*
- * @brief IfOr service for constructing short circuit OR conditional nests (like the || operator)
- * @param anyTrueBuilder builder containing operations to execute if any conditional test evaluates to true
- * @param allFalseBuilder builder containing operations to execute if all conditional tests are false
- * @param numTerms the number of conditional terms
- * @param ... for each term, provide a TR::IlBuilder object and a TR::IlValue object that evaluates a condition (builder is where all the operations to evaluate the condition go, the value is the final result of the condition)
- *
- * Example:
- * TR::IlBuilder *cond1Builder = OrphanBuilder();
- * TR::IlValue *cond1 = cond1Builder->LessThan(
- *                      cond1Builder->   Load("x"),
- *                      cond1Builder->   Load("lower"));
- * TR::IlBuilder *cond2Builder = OrphanBuilder();
- * TR::IlValue *cond2 = cond2Builder->GreaterOrEqual(
- *                      cond2Builder->   Load("x"),
- *                      cond2Builder->   Load("upper"));
- * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
- * IfOr(&outOfRange, &inRange, 2, cond1Builder, cond1, cond2Builder, cond2);
- */
-void
-IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ...)
-   {
-   TR::IlBuilder *mergePoint = OrphanBuilder();
-   *anyTrueBuilder = createBuilderIfNeeded(*anyTrueBuilder);
-   *allFalseBuilder = createBuilderIfNeeded(*allFalseBuilder);
-
-   va_list terms;
-   va_start(terms, numTerms);
-   for (int32_t t=0;t < numTerms-1;t++)
-      {
-      TR::IlBuilder *condBuilder = va_arg(terms, TR::IlBuilder*);
-      TR::IlValue *condValue = va_arg(terms, TR::IlValue*);
-      AppendBuilder(condBuilder);
-      condBuilder->IfCmpNotEqualZero(anyTrueBuilder, condValue);
-      // otherwise fall through to test next term
-      }
-
-   // reverse condition on last term so that it can fall through to anyTrueBuilder
-   TR::IlBuilder *condBuilder = va_arg(terms, TR::IlBuilder*);
-   TR::IlValue *condValue = va_arg(terms, TR::IlValue*);
-   AppendBuilder(condBuilder);
-   condBuilder->IfCmpEqualZero(allFalseBuilder, condValue);
-   va_end(terms);
-
-   // any true term will end up here
-   AppendBuilder(*anyTrueBuilder);
-   Goto(mergePoint);
-
-   // if control gets here, all the provided terms were false
-   AppendBuilder(*allFalseBuilder);
-   Goto(mergePoint);
-
-   AppendBuilder(mergePoint);
-
-   // return state for "this" can get confused by the Goto's in this service
-   setComesBack();
-   }
-
-TR::IlValue *
-IlBuilder::EqualTo(TR::IlValue *left, TR::IlValue *right)
-   {
-   TR::IlValue *returnValue=compareOp(TR_cmpEQ, false, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is EqualTo %d == %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-void
-IlBuilder::integerizeAddresses(TR::IlValue **leftPtr, TR::IlValue **rightPtr)
-   {
-   TR::IlValue *left = *leftPtr;
-   if (left->getDataType() == TR::Address)
-      *leftPtr = ConvertTo(Word, left);
-
-   TR::IlValue *right = *rightPtr;
-   if (right->getDataType() == TR::Address)
-      *rightPtr = ConvertTo(Word, right);
-   }
-
-TR::IlValue *
-IlBuilder::LessThan(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpLT, false, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is LessThan %d < %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::UnsignedLessThan(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpLT, true, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is UnsignedLessThan %d < %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::LessOrEqualTo(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpLE, false, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is LessOrEqualTo %d <= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::UnsignedLessOrEqualTo(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpLE, true, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is UnsignedLessOrEqualTo %d <= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::GreaterThan(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpGT, false, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is GreaterThan %d > %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::UnsignedGreaterThan(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpGT, true, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is UnsignedGreaterThan %d > %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::GreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpGE, false, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is GreaterOrEqualTo %d >= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue *
-IlBuilder::UnsignedGreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right)
-   {
-   integerizeAddresses(&left, &right);
-   TR::IlValue *returnValue=compareOp(TR_cmpGE, true, left, right);
-   TraceIL("IlBuilder[ %p ]::%d is UnsignedGreaterOrEqualTo %d >= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
-   return returnValue;
-   }
-
-TR::IlValue** 
-IlBuilder::processCallArgs(TR::Compilation *comp, int numArgs, va_list args)
-   {
-   TR::IlValue ** argValues = (TR::IlValue **) comp->trMemory()->allocateHeapMemory(numArgs * sizeof(TR::IlValue *));
-   for (int32_t a=0;a < numArgs;a++)
-      {
-      argValues[a] = va_arg(args, TR::IlValue*);
-      }
-   return argValues;
-   }
-
-/*
- * \param numArgs 
- *    Number of actual arguments for the method  plus 1 
- * \param ... 
- *    The list is a computed address followed by the actual arguments
- */
-TR::IlValue *
-IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, ...)
-   {
-   TraceIL("IlBuilder[ %p ]::ComputedCall %s\n", this, functionName);
-   va_list args;
-   va_start(args, numArgs);
-   TR::IlValue **argValues = processCallArgs(_comp, numArgs, args);
-   va_end(args);
-   TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
-      resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
-
-   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
-   return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
-   }
-
-/*
- * \param numArgs 
- *    Number of actual arguments for the method  plus 1 
- * \param argValues
- *    the computed address followed by the actual arguments
- */
-TR::IlValue *
-IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, TR::IlValue **argValues)
-   {
-   TraceIL("IlBuilder[ %p ]::ComputedCall %s\n", this, functionName);
-   TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
-      resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
-
-   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
-   return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
-   }
-
-TR::IlValue *
-IlBuilder::Call(const char *functionName, int32_t numArgs, ...)
-   {
-   TraceIL("IlBuilder[ %p ]::Call %s\n", this, functionName);
-   va_list args;
-   va_start(args, numArgs);
-   TR::IlValue **argValues = processCallArgs(_comp, numArgs, args);
-   va_end(args);
-   TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
-      resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
-
-   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
-   return genCall(methodSymRef, numArgs, argValues);
-   }
-
-TR::IlValue *
-IlBuilder::Call(const char *functionName, int32_t numArgs, TR::IlValue ** argValues)
-   {
-   TraceIL("IlBuilder[ %p ]::Call %s\n", this, functionName);
-   TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
-      resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
-
-   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
-   return genCall(methodSymRef, numArgs, argValues);
-   }
-
-TR::IlValue *
-IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlValue ** argValues, bool isDirectCall /* true by default*/)
-   {
-   TR::DataType returnType = methodSymRef->getSymbol()->castToMethodSymbol()->getMethod()->returnType();
-   TR::Node *callNode = TR::Node::createWithSymRef(isDirectCall? TR::ILOpCode::getDirectCall(returnType): TR::ILOpCode::getIndirectCall(returnType), numArgs, methodSymRef);
-
-   // TODO: should really verify argument types here
-   int32_t childIndex = 0;
-   for (int32_t a=0;a < numArgs;a++)
-      {
-      TR::IlValue *arg = argValues[a];
-      if (arg->getDataType() == TR::Int8 || arg->getDataType() == TR::Int16 || (Word == Int64 && arg->getDataType() == TR::Int32))
-         arg = ConvertTo(Word, arg);
-      callNode->setAndIncChild(childIndex++, loadValue(arg));
-      }
-
-   // callNode must be anchored by itself
-   genTreeTop(callNode);
-
-   if (returnType != TR::NoType)
-      {
-      TR::IlValue *returnValue = newValue(callNode->getDataType(), callNode);
-      return returnValue;
-      }
-
-   return NULL;
-   }
-
+OMR::IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
+  {
+  return impl()->IndexAt(dt->impl(), base->impl(), index->impl());
+  }
 
 /** \brief
  *     The service is used to atomically increase memory location \p baseAddress by amount of \p value. 
@@ -1777,28 +434,12 @@ IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlVal
  *  \return
  *     The old value at the location \p baseAddress.
  */
+
 TR::IlValue *
-IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
-   {
-   TR_ASSERT(comp()->cg()->supportsAtomicAdd(), "this platform doesn't support AtomicAdd() yet");
-   TR_ASSERT(baseAddress->getDataType() == TR::Address, "baseAddress must be TR::Address");
-
-   //Determine the implementation type and returnType by detecting "value"'s type
-   TR::DataType returnType = value->getDataType();
-   TR_ASSERT(returnType == TR::Int32 || (returnType == TR::Int64 && TR::Compiler->target.is64Bit()), "AtomicAdd currently only supports Int32/64 values");
-   TraceIL("IlBuilder[ %p ]::AtomicAdd(%d, %d)\n", this, baseAddress->getID(), value->getID());
-
-   OMR::SymbolReferenceTable::CommonNonhelperSymbol atomicBitSymbol = returnType == TR::Int32 ? TR::SymbolReferenceTable::atomicAdd32BitSymbol : TR::SymbolReferenceTable::atomicAdd64BitSymbol;//lock add
-   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(atomicBitSymbol); 
-   TR::Node *callNode;
-   callNode = TR::Node::createWithSymRef(TR::ILOpCode::getDirectCall(returnType), 2, methodSymRef);
-   callNode->setAndIncChild(0, loadValue(baseAddress));
-   callNode->setAndIncChild(1, loadValue(value));
-
-   TR::IlValue *returnValue = newValue(callNode->getDataType(), callNode);
-   return returnValue; 
-   }
-
+OMR::IlBuilder::AtomicAdd(TR::IlValue *baseAddress, TR::IlValue * value)
+  {
+  return impl()->AtomicAdd(baseAddress->impl(), value->impl());
+  }
 
 /**
  * \brief
@@ -1870,603 +511,488 @@ IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
  *              |   transactionBuilder
  *              |-->persistentFailurie
  */
+void 
+OMR::IlBuilder::Transaction(TR::IlBuilder **persistentFailureBuilder,
+                            TR::IlBuilder **transientFailureBuilder,
+                            TR::IlBuilder **fallThroughBuilder)
+  {
+   ILBUILDER_PARM_SETUP(persistentFailureBuilderImpl, persistentFailureBuilderArg, persistentFailureBuilder);
+   ILBUILDER_PARM_SETUP(transientFailureBuilderImpl, transientFailureBuilderArg, transientFailureBuilder);
+   ILBUILDER_PARM_SETUP(fallThroughBuilderImpl, fallThroughBuilderArg, fallThroughBuilder);
+   impl()->Transaction(persistentFailureBuilderArg, transientFailureBuilderArg, fallThroughBuilderArg);
+   ILBUILDER_PARM_RETURN(persistentFailureBuilderImpl, persistentFailureBuilder);
+   ILBUILDER_PARM_RETURN(transientFailureBuilderImpl, transientFailureBuilder);
+   ILBUILDER_PARM_RETURN(fallThroughBuilderImpl, fallThroughBuilder);
+  }
+
+void 
+OMR::IlBuilder::TransactionAbort()
+  {
+  impl()->TransactionAbort();
+  }
+
+
+TR::IlValue *
+OMR::IlBuilder::StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue* obj)
+  {
+  return impl()->StructFieldInstanceAddress(structName, fieldName, obj->impl());
+  }
+
+TR::IlValue *
+OMR::IlBuilder::UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValue* obj)
+  {
+  return impl()->UnionFieldInstanceAddress(unionName, fieldName, obj->impl());
+  }
+
+// vector memory
+TR::IlValue *
+OMR::IlBuilder::VectorLoad(const char *name)
+   {
+   return impl()->VectorLoad(name);
+   }
+
+TR::IlValue *
+OMR::IlBuilder::VectorLoadAt(TR::IlType *dt, TR::IlValue *address)
+   {
+   return impl()->VectorLoadAt(dt->impl(), address->impl());
+   }
+
 void
-IlBuilder::Transaction(TR::IlBuilder **persistentFailureBuilder, TR::IlBuilder **transientFailureBuilder, TR::IlBuilder **transactionBuilder)
-   {   
-   //This assertion is to rule out platforms which don't have tstart evaluator yet. 
-   TR_ASSERT(comp()->cg()->hasTMEvaluator(), "this platform doesn't support tstart or tfinish evaluator yet");   
-    
-   TraceIL("IlBuilder[ %p ]::transactionBegin %p, %p, %p, %p)\n", this, *persistentFailureBuilder, *transientFailureBuilder, *transactionBuilder);
+OMR::IlBuilder::VectorStore(const char *name, TR::IlValue *value)
+   {
+   impl()->VectorStore(name, value->impl());
+   }
 
-   appendBlock();
+void
+OMR::IlBuilder::VectorStoreAt(TR::IlValue *address, TR::IlValue *value)
+   {
+   impl()->VectorStoreAt(address->impl(), value->impl());
+   }
 
-   TR::Block *mergeBlock = emptyBlock();
-   *persistentFailureBuilder = createBuilderIfNeeded(*persistentFailureBuilder);
-   *transientFailureBuilder = createBuilderIfNeeded(*transientFailureBuilder);
-   *transactionBuilder = createBuilderIfNeeded(*transactionBuilder);
 
-   if (!comp()->cg()->getSupportsTM())
+// control
+void
+OMR::IlBuilder::AppendBuilder(TR::IlBuilder *builder)
+   {
+   impl()->AppendBuilder(builder->impl());
+   }
+
+TR::IlValue *
+OMR::IlBuilder::Call(const char *name, int32_t numArgs, ...)
+   {
+   va_list args;
+   va_start(args, numArgs);
+   TR::IlValue ** argValues = new TR::IlValue *[numArgs];
+   for (int32_t a=0;a < numArgs;a++)
       {
-      //if user's processor doesn't support TM.
-      //we will walk around transaction and transientFailure paths
-
-      Goto(persistentFailureBuilder);
-
-      AppendBuilder(*transactionBuilder);
-      AppendBuilder(*transientFailureBuilder);
-
-      AppendBuilder(*persistentFailureBuilder);
-      appendBlock(mergeBlock);
-      return;
+      argValues[a] = va_arg(args, TR::IlValue *);
       }
-
-   TR::Node *persistentFailureNode = TR::Node::create(TR::branch, 0, (*persistentFailureBuilder)->getEntry()->getEntry());
-   TR::Node *transientFailureNode = TR::Node::create(TR::branch, 0, (*transientFailureBuilder)->getEntry()->getEntry());
-   TR::Node *transactionNode = TR::Node::create(TR::branch, 0, (*transactionBuilder)->getEntry()->getEntry());
-
-   TR::Node *tStartNode = TR::Node::create(TR::tstart, 3, persistentFailureNode, transientFailureNode, transactionNode);   
-   tStartNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionEntrySymbolRef(comp()->getMethodSymbol()));
-   
-   genTreeTop(tStartNode);
-
-   //connecting the block having tstart with persistentFailure's and transaction's blocks 
-   cfg()->addEdge(_currentBlock, (*persistentFailureBuilder)->getEntry());
-   cfg()->addEdge(_currentBlock, (*transientFailureBuilder)->getEntry());
-   cfg()->addEdge(_currentBlock, (*transactionBuilder)->getEntry());
-
-   appendNoFallThroughBlock();
-   AppendBuilder(*transientFailureBuilder);
-   gotoBlock(mergeBlock);
-
-   AppendBuilder(*persistentFailureBuilder);
-   gotoBlock(mergeBlock);
-
-   AppendBuilder(*transactionBuilder);
-    
-   //ending the transaction at the end of transactionBuilder
-   appendBlock();
-   TR::Node *tEndNode=TR::Node::create(TR::tfinish,0);
-   tEndNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionExitSymbolRef(comp()->getMethodSymbol()));
-   genTreeTop(tEndNode);
-
-   //Three IlBuilders above merged here
-   appendBlock(mergeBlock);
-   }  
-
-
-/**
- * Generate XABORT instruction to abort transaction
- */
-void
-IlBuilder::TransactionAbort()
-   {
-   TraceIL("IlBuilder[ %p ]::transactionAbort", this);
-   TR::Node *tAbortNode = TR::Node::create(TR::tabort, 0);
-   tAbortNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionAbortSymbolRef(comp()->getMethodSymbol()));
-   genTreeTop(tAbortNode);
+   va_end(args);
+   TR::IlValue *value = Call(name, numArgs, argValues);
+   delete[] argValues;
+   return value;
    }
 
-void
-IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
+TR::IlValue *
+OMR::IlBuilder::Call(const char *name, int32_t numArgs, TR::IlValue **argValues)
    {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpNotEqualZero(*target, condition);
+   return impl()->Call(name, numArgs, reinterpret_cast<TR::IlValueImpl **>(argValues));
    }
 
-void
-IlBuilder::IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
+TR::IlValue *
+OMR::IlBuilder::ComputedCall(const char *name, int32_t numArgs, ...)
    {
-   TR_ASSERT(target != NULL, "This IfCmpNotEqualZero requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpNotEqualZero %d? -> [ %p ] B%d\n", this, condition->getID(), target, target->getEntry()->getNumber());
-   ifCmpNotEqualZero(condition, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpNotEqual(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpNotEqual requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpNotEqual %d == %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpNE, false, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpEqualZero(*target, condition);
-   }
-
-void
-IlBuilder::IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpEqualZero requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpEqualZero %d == 0? -> [ %p ] B%d\n", this, condition->getID(), target, target->getEntry()->getNumber());
-   ifCmpEqualZero(condition, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpEqual(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpEqual requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpEqual %d == %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpEQ, false, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpLessThan(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpLessThan requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpLessThan %d < %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpLT, false, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpUnsignedLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpUnsignedLessThan(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpUnsignedLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpUnsignedLessThan requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpUnsignedLessThan %d < %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpLT, true, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpLessOrEqual(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpLessOrEqual requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpLessOrEqual %d <= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpLE, false, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpUnsignedLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpUnsignedLessOrEqual(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpUnsignedLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TR_ASSERT(target != NULL, "This IfCmpUnsignedLessOrEqual requires a non-NULL builder object");
-   TraceIL("IlBuilder[ %p ]::IfCmpUnsignedLessOrEqual %d <= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpLE, true, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpGreaterThan(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TraceIL("IlBuilder[ %p ]::IfCmpGreaterThan %d > %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpGT, false, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpUnsignedGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpUnsignedGreaterThan(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpUnsignedGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TraceIL("IlBuilder[ %p ]::IfCmpUnsignedGreaterThan %d > %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpGT, true, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpGreaterOrEqual(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TraceIL("IlBuilder[ %p ]::IfCmpGreaterOrEqual %d >= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpGE, false, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::IfCmpUnsignedGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
-   {
-   *target = createBuilderIfNeeded(*target);
-   IfCmpUnsignedGreaterOrEqual(*target, left, right);
-   }
-
-void
-IlBuilder::IfCmpUnsignedGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
-   {
-   TraceIL("IlBuilder[ %p ]::IfCmpUnsignedGreaterOrEqual %d >= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
-   ifCmpCondition(TR_cmpGE, true, left, right, target->getEntry());
-   }
-
-void
-IlBuilder::ifCmpCondition(TR_ComparisonTypes ct, bool isUnsignedCmp, TR::IlValue *left, TR::IlValue *right, TR::Block *target)
-   {
-   integerizeAddresses(&left, &right);
-   TR::Node *leftNode = loadValue(left);
-   TR::Node *rightNode = loadValue(right);
-   TR::ILOpCode cmpOpCode(TR::ILOpCode::compareOpCode(leftNode->getDataType(), ct, isUnsignedCmp));
-   ifjump(cmpOpCode.convertCmpToIfCmp(),
-          leftNode,
-          rightNode,
-          target);
-   appendBlock();
-   }
-
-void
-IlBuilder::ifCmpNotEqualZero(TR::IlValue *condition, TR::Block *target)
-   {
-   ifCmpCondition(TR_cmpNE, false, condition, zeroForValue(condition), target);
-   }
-
-void
-IlBuilder::ifCmpEqualZero(TR::IlValue *condition, TR::Block *target)
-   {
-   ifCmpCondition(TR_cmpEQ, false, condition, zeroForValue(condition), target);
-   }
-
-void
-IlBuilder::appendGoto(TR::Block *destBlock)
-   {
-   gotoBlock(destBlock);
-   appendBlock();
-   }
-
-/* Flexible builder for if...then...else structures
- * Basically 3 ways to call it:
- *    1) with then and else paths
- *    2) only a then path
- *    3) only an else path
- * #2 and #3 are similar: the existing path is appended and the proper condition causes branch around to the merge point
- * #1: then path exists "out of line", else path falls through from If and then jumps to merge, followed by then path which
- *     falls through to the merge point
- */
-void
-IlBuilder::IfThenElse(TR::IlBuilder **thenPath, TR::IlBuilder **elsePath, TR::IlValue *condition)
-   {
-   TR_ASSERT(thenPath != NULL || elsePath != NULL, "IfThenElse needs at least one conditional path");
-
-   TR::Block *thenEntry = NULL;
-   TR::Block *elseEntry = NULL;
-
-   if (thenPath)
+   va_list args;
+   va_start(args, numArgs);
+   TR::IlValue ** argValues = new TR::IlValue *[numArgs];
+   for (int32_t a=0;a < numArgs;a++)
       {
-      *thenPath = createBuilderIfNeeded(*thenPath);
-      thenEntry = (*thenPath)->getEntry();
+      argValues[a] = va_arg(args, TR::IlValue *);
       }
+   va_end(args);
+   TR::IlValue *value = ComputedCall(name, numArgs, argValues);
+   delete[] argValues;
+   return value;
+   }
 
-   if (elsePath)
-      {
-      *elsePath = createBuilderIfNeeded(*elsePath);
-      elseEntry = (*elsePath)->getEntry();
-      }
-
-   TR::Block *mergeBlock = emptyBlock();
-
-   TraceIL("IlBuilder[ %p ]::IfThenElse %d", this, condition->getID());
-   if (thenEntry)
-      TraceIL(" then B%d", thenEntry->getNumber());
-   if (elseEntry)
-      TraceIL(" else B%d", elseEntry->getNumber());
-   TraceIL(" merge B%d\n", mergeBlock->getNumber());
-
-   if (thenPath == NULL) // case #3
-      {
-      ifCmpNotEqualZero(condition, mergeBlock);
-      if ((*elsePath)->_partOfSequence)
-         gotoBlock(elseEntry);
-      else
-         AppendBuilder(*elsePath);
-      }
-   else if (elsePath == NULL) // case #2
-      {
-      ifCmpEqualZero(condition, mergeBlock);
-      if ((*thenPath)->_partOfSequence)
-         gotoBlock(thenEntry);
-      else
-         AppendBuilder(*thenPath);
-      }
-   else // case #1
-      {
-      ifCmpNotEqualZero(condition, thenEntry);
-      if ((*elsePath)->_partOfSequence)
-         {
-         gotoBlock(elseEntry);
-         }
-      else
-         {
-         AppendBuilder(*elsePath);
-         appendGoto(mergeBlock);
-         }
-      if (!(*thenPath)->_partOfSequence)
-         AppendBuilder(*thenPath);
-      // if then path exists elsewhere already,
-      //  then IfCmpNotEqual above already brances to it
-      }
-
-   // all paths possibly merge back here
-   appendBlock(mergeBlock);
+TR::IlValue *
+OMR::IlBuilder::ComputedCall(const char *name, int32_t numArgs, TR::IlValue **args)
+   {
+   return impl()->ComputedCall(name, numArgs, reinterpret_cast<TR::IlValueImpl **>(args));
    }
 
 void
-IlBuilder::Switch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  uint32_t numCases,
-                  int32_t *caseValues,
-                  TR::IlBuilder **caseBuilders,
-                  bool *caseFallsThrough)
+OMR::IlBuilder::Goto(TR::IlBuilder **dest)
    {
-   TR::IlValue *selectorValue = Load(selectionVar);
-   TR_ASSERT(selectorValue->getDataType() == TR::Int32, "Switch only supports selector having type Int32");
-   *defaultBuilder = createBuilderIfNeeded(*defaultBuilder);
-
-   TR::Node *defaultNode = TR::Node::createCase(0, (*defaultBuilder)->getEntry()->getEntry());
-   TR::Node *lookupNode = TR::Node::create(TR::lookup, numCases + 2, loadValue(selectorValue), defaultNode);
-
-   // get the lookup tree into this builder, even though we haven't completely filled it in yet
-   genTreeTop(lookupNode);
-   TR::Block *switchBlock = _currentBlock;
-
-   // make sure no fall through edge created from the lookup
-   appendNoFallThroughBlock();
-
-   TR::IlBuilder *breakBuilder = OrphanBuilder();
-
-   // each case handler is a sequence of two builder objects: first the one passed in via caseBuilder (or will be passed
-   //   back via caseBuilders, and second a builder that branches to the breakBuilder (unless this case falls through)
-   for (int32_t c=0;c < numCases;c++)
-      {
-      int32_t value = caseValues[c];
-      TR::IlBuilder *handler = NULL;
-      if (!caseFallsThrough[c])
-         {
-         handler = OrphanBuilder();
-
-         caseBuilders[c] = createBuilderIfNeeded(caseBuilders[c]);
-         handler->AppendBuilder(caseBuilders[c]);
-
-         // handle "break" with a separate builder so user can add whatever they want into caseBuilders[c]
-         TR::IlBuilder *branchToBreak = OrphanBuilder();
-         branchToBreak->Goto(&breakBuilder);
-         handler->AppendBuilder(branchToBreak);
-         }
-      else
-         {
-         caseBuilders[c] = createBuilderIfNeeded(caseBuilders[c]);
-         handler = caseBuilders[c];
-         }
-
-      TR::Block *caseBlock = handler->getEntry();
-      cfg()->addEdge(switchBlock, caseBlock);
-      AppendBuilder(handler);
-
-      TR::Node *caseNode = TR::Node::createCase(0, caseBlock->getEntry(), value);
-      lookupNode->setAndIncChild(c+2, caseNode);
-      }
-
-   cfg()->addEdge(switchBlock, (*defaultBuilder)->getEntry());
-   AppendBuilder(*defaultBuilder);
-
-   AppendBuilder(breakBuilder);
+   ILBUILDER_PARM_SETUP(destImpl, destArg, dest);
+   impl()->Goto(destArg);
+   ILBUILDER_PARM_RETURN(destImpl, dest);
    }
 
 void
-IlBuilder::Switch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  uint32_t numCases,
-                  ...)
+OMR::IlBuilder::Goto(TR::IlBuilder *dest)
    {
-   int32_t *caseValues = (int32_t *) _comp->trMemory()->allocateHeapMemory(numCases * sizeof(int32_t));
-   TR_ASSERT(0 != caseValues, "out of memory");
+   impl()->Goto(dest->impl());
+   }
 
-   TR::IlBuilder **caseBuilders = (TR::IlBuilder **) _comp->trMemory()->allocateHeapMemory(numCases * sizeof(TR::IlBuilder *));
-   TR_ASSERT(0 != caseBuilders, "out of memory");
+void
+OMR::IlBuilder::Return()
+   {
+   impl()->Return();
+   }
 
-   bool *caseFallsThrough = (bool *) _comp->trMemory()->allocateHeapMemory(numCases * sizeof(bool));
-   TR_ASSERT(0 != caseFallsThrough, "out of memory");
+void
+OMR::IlBuilder::Return(TR::IlValue *value)
+   {
+   impl()->Return(value->impl());
+   }
+
+void
+OMR::IlBuilder::ForLoop(bool countsUp,
+                        const char *indVar,
+                        TR::IlBuilder **body,
+                        TR::IlBuilder **breakBuilder,
+                        TR::IlBuilder **continueBuilder,
+                        TR::IlValue *initial,
+                        TR::IlValue *iterateWhile,
+                        TR::IlValue *increment)
+   {
+   ILBUILDER_PARM_SETUP(bodyImpl, bodyArg, body);
+   ILBUILDER_PARM_SETUP(breakBuilderImpl, breakBuilderArg, breakBuilder);
+   ILBUILDER_PARM_SETUP(continueBuilderImpl, continueBuilderArg, continueBuilder);
+   impl()->ForLoop(countsUp, indVar, bodyArg, breakBuilderArg, continueBuilderArg, initial->impl(), iterateWhile->impl(), increment->impl());
+   ILBUILDER_PARM_RETURN(bodyImpl, body);
+   ILBUILDER_PARM_RETURN(breakBuilderImpl, breakBuilder);
+   ILBUILDER_PARM_RETURN(continueBuilderImpl, continueBuilder);
+   }
+
+void
+OMR::IlBuilder::WhileDoLoop(const char *exitCondition,
+                            TR::IlBuilder **body,
+                            TR::IlBuilder **breakBuilder,
+                            TR::IlBuilder **continueBuilder)
+   {
+   ILBUILDER_PARM_SETUP(bodyImpl, bodyArg, body);
+   ILBUILDER_PARM_SETUP(breakBuilderImpl, breakBuilderArg, breakBuilder);
+   ILBUILDER_PARM_SETUP(continueBuilderImpl, continueBuilderArg, continueBuilder);
+   impl()->WhileDoLoop(exitCondition, bodyArg, breakBuilderArg, continueBuilderArg);
+   ILBUILDER_PARM_RETURN(bodyImpl, body);
+   ILBUILDER_PARM_RETURN(breakBuilderImpl, breakBuilder);
+   ILBUILDER_PARM_RETURN(continueBuilderImpl, continueBuilder);
+   }
+
+void
+OMR::IlBuilder::DoWhileLoop(const char *exitCondition,
+                            TR::IlBuilder **body,
+                            TR::IlBuilder **breakBuilder,
+                            TR::IlBuilder **continueBuilder)
+   {
+   ILBUILDER_PARM_SETUP(bodyImpl, bodyArg, body);
+   ILBUILDER_PARM_SETUP(breakBuilderImpl, breakBuilderArg, breakBuilder);
+   ILBUILDER_PARM_SETUP(continueBuilderImpl, continueBuilderArg, continueBuilder);
+   impl()->DoWhileLoop(exitCondition, bodyArg, breakBuilderArg, continueBuilderArg);
+   ILBUILDER_PARM_RETURN(bodyImpl, body);
+   ILBUILDER_PARM_RETURN(breakBuilderImpl, breakBuilder);
+   ILBUILDER_PARM_RETURN(continueBuilderImpl, continueBuilder);
+   }
+
+void
+OMR::IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpNotEqualZero(targetArg, condition->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
+   {
+   impl()->IfCmpNotEqualZero(target->impl(), condition->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpNotEqual(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpNotEqual(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpEqualZero(targetArg, condition->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
+   {
+   impl()->IfCmpEqualZero(target->impl(), condition->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpEqual(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpEqual(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpLessThan(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpLessThan(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpUnsignedLessThan(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpUnsignedLessThan(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpLessOrEqual(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpLessOrEqual(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpUnsignedLessOrEqual(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpUnsignedLessOrEqual(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpGreaterThan(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpGreaterThan(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpUnsignedGreaterThan(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpUnsignedGreaterThan(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpGreaterOrEqual(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpGreaterOrEqual(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right)
+   {
+   ILBUILDER_PARM_SETUP(targetImpl, targetArg, target);
+   impl()->IfCmpUnsignedGreaterOrEqual(targetArg, left->impl(), right->impl());
+   ILBUILDER_PARM_RETURN(targetImpl, target);
+   }
+
+void
+OMR::IlBuilder::IfCmpUnsignedGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
+   {
+   impl()->IfCmpUnsignedGreaterOrEqual(target->impl(), left->impl(), right->impl());
+   }
+
+void
+OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ... )
+   {
+   ILBUILDER_PARM_SETUP(allTrueBuilderImpl, allTrueBuilderArg, allTrueBuilder);
+   ILBUILDER_PARM_SETUP(anyFalseBuilderImpl, anyFalseBuilderArg, anyFalseBuilder);
+
+   va_list terms;
+   va_start(terms, numTerms);
+   TR::IlBuilderImpl ** termBuilders = new TR::IlBuilderImpl *[numTerms >> 1];
+   TR::IlValueImpl ** termValues = new TR::IlValueImpl *[numTerms >> 1];
+   for (int32_t t=0;t < numTerms;t++)
+      {
+      termBuilders[t] = (va_arg(terms, TR::IlBuilder *))->impl();
+      termValues[t] = (va_arg(terms, TR::IlValue *))->impl();
+      }
+   va_end(terms);
+
+   impl()->IfAnd(allTrueBuilderArg, anyFalseBuilderArg, numTerms, termBuilders, termValues);
+
+   delete[] termBuilders;
+   delete[] termValues;
+
+   ILBUILDER_PARM_RETURN(allTrueBuilderImpl, allTrueBuilder);
+   ILBUILDER_PARM_RETURN(anyFalseBuilderImpl, anyFalseBuilder);
+   }
+
+void
+OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ... )
+   {
+   ILBUILDER_PARM_SETUP(anyTrueBuilderImpl, anyTrueBuilderArg, anyTrueBuilder);
+   ILBUILDER_PARM_SETUP(allFalseBuilderImpl, allFalseBuilderArg, allFalseBuilder);
+
+   va_list terms;
+   va_start(terms, numTerms);
+   TR::IlBuilderImpl ** termBuilders = new TR::IlBuilderImpl *[numTerms >> 1];
+   TR::IlValueImpl ** termValues = new TR::IlValueImpl *[numTerms >> 1];
+   for (int32_t t=0;t < numTerms;t++)
+      {
+      termBuilders[t] = (va_arg(terms, TR::IlBuilder *))->impl();
+      termValues[t] = (va_arg(terms, TR::IlValue *))->impl();
+      }
+   va_end(terms);
+
+   impl()->IfOr(anyTrueBuilderArg, allFalseBuilderArg, numTerms, termBuilders, termValues);
+
+   delete[] termBuilders;
+   delete[] termValues;
+
+   ILBUILDER_PARM_RETURN(anyTrueBuilderImpl, anyTrueBuilder);
+   ILBUILDER_PARM_RETURN(allFalseBuilderImpl, allFalseBuilder);
+   }
+
+void
+OMR::IlBuilder::IfThenElse(TR::IlBuilder **thenPath,
+                           TR::IlBuilder **elsePath,
+                           TR::IlValue *condition)
+   {
+   ILBUILDER_PARM_SETUP(thenPathImpl, thenPathArg, thenPath);
+   ILBUILDER_PARM_SETUP(elsePathImpl, elsePathArg, elsePath);
+   impl()->IfThenElse(thenPathArg, elsePathArg, condition->impl());
+   ILBUILDER_PARM_RETURN(thenPathImpl, thenPath);
+   ILBUILDER_PARM_RETURN(elsePathImpl, elsePath);
+   }
+
+void
+OMR::IlBuilder::Switch(const char *selectionVar,
+                       TR::IlBuilder **defaultBuilder,
+                       uint32_t numCases,
+                       ...)
+   {
+   int32_t *caseValues = new int32_t[numCases];
+
+   // caseBuilders remembers the double pointers passed in, so we don't have to do another va_list iteration afterwards
+   TR::IlBuilder ***caseBuilders = new TR::IlBuilder **[numCases];
+
+   TR::IlBuilder **caseBuilderArray = new TR::IlBuilder *[numCases];
+   bool *caseFallsThrough = new bool[numCases];
 
    va_list cases;
    va_start(cases, numCases);
    for (int32_t c=0;c < numCases;c++)
       {
-      caseValues[c] = (int32_t) va_arg(cases, int);
-      caseBuilders[c] = *(TR::IlBuilder **) va_arg(cases, TR::IlBuilder **);
-      caseFallsThrough[c] = (bool) va_arg(cases, int);
+      caseValues[c] = va_arg(cases, int32_t);
+      caseBuilders[c] = va_arg(cases, TR::IlBuilder **);
+
+      caseBuilderArray[c] = *caseBuilders[c];
+      caseFallsThrough[c] = (va_arg(cases, int32_t) != 0);
       }
    va_end(cases);
 
-   Switch(selectionVar, defaultBuilder, numCases, caseValues, caseBuilders, caseFallsThrough);
+   Switch(selectionVar, defaultBuilder, numCases, caseValues, caseBuilderArray, caseFallsThrough);
 
-   // if Switch created any new builders, we need to put those back into the arguments passed into this Switch call
-   va_start(cases, numCases);
+   // if any of the entries in caseBuilderArray changed, update the corresponding parameter
    for (int32_t c=0;c < numCases;c++)
       {
-      int throwawayValue = va_arg(cases, int);
-      TR::IlBuilder **caseBuilder = va_arg(cases, TR::IlBuilder **);
-      (*caseBuilder) = caseBuilders[c];
-      int throwAwayFallsThrough = va_arg(cases, int);
-      }
-   va_end(cases);
-   }
-
-
-void
-IlBuilder::ForLoop(bool countsUp,
-                   const char *indVar,
-                   TR::IlBuilder **loopCode,
-                   TR::IlBuilder **breakBuilder,
-                   TR::IlBuilder **continueBuilder,
-                   TR::IlValue *initial,
-                   TR::IlValue *end,
-                   TR::IlValue *increment)
-   {
-   methodSymbol()->setMayHaveLoops(true);
-   TR_ASSERT(loopCode != NULL, "ForLoop needs to have loopCode builder");
-   *loopCode = createBuilderIfNeeded(*loopCode);
-
-   TraceIL("IlBuilder[ %p ]::ForLoop ind %s initial %d end %d increment %d loopCode %p countsUp %d\n", this, indVar, initial->getID(), end->getID(), increment->getID(), *loopCode, countsUp);
-
-   Store(indVar, initial);
-
-   TR::IlValue *loopCondition;
-   TR::IlBuilder *loopBody = OrphanBuilder();
-   loopCondition = countsUp ? LessThan(Load(indVar), end) : GreaterThan(Load(indVar), end);
-   IfThen(&loopBody, loopCondition);
-   loopBody->AppendBuilder(*loopCode);
-   TR::IlBuilder *loopContinue = OrphanBuilder();
-   loopBody->AppendBuilder(loopContinue);
-
-   if (breakBuilder)
-      {
-      TR_ASSERT(*breakBuilder == NULL, "ForLoop returns breakBuilder, cannot provide breakBuilder as input");
-      *breakBuilder = OrphanBuilder();
-      AppendBuilder(*breakBuilder);
+      *(caseBuilders[c]) = caseBuilderArray[c];
       }
 
-   if (continueBuilder)
-      {
-      TR_ASSERT(*continueBuilder == NULL, "ForLoop returns continueBuilder, cannot provide continueBuilder as input");
-      *continueBuilder = loopContinue;
-      }
-
-   if (countsUp)
-      {
-      loopContinue->Store(indVar,
-      loopContinue->   Add(
-      loopContinue->      Load(indVar),
-                          increment));
-      loopContinue->IfCmpLessThan(&loopBody,
-      loopContinue->   Load(indVar),
-                       end);
-      }
-   else
-      {
-      loopContinue->Store(indVar,
-      loopContinue->   Sub(
-      loopContinue->      Load(indVar),
-                          increment));
-      loopContinue->IfCmpGreaterThan(&loopBody,
-      loopContinue->   Load(indVar),
-                       end);
-      }
-
-   // make sure any subsequent operations go into their own block *after* the loop
-   appendBlock();
+   delete[] caseFallsThrough;
+   delete[] caseBuilders;
+   delete[] caseValues;
    }
 
 void
-IlBuilder::DoWhileLoop(const char *whileCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder, TR::IlBuilder **continueBuilder)
+OMR::IlBuilder::Switch(const char *selectionVar,
+                       TR::IlBuilder **defaultBuilder,
+                       uint32_t numCases,
+                       int32_t *caseValues,
+                       TR::IlBuilder **caseBuilders,
+                       bool *caseFallsThrough)
    {
-   methodSymbol()->setMayHaveLoops(true);
-   TR_ASSERT(body != NULL, "doWhileLoop needs to have a body");
-
-   if (!_methodBuilder->symbolDefined(whileCondition))
-      _methodBuilder->defineValue(whileCondition, Int32);
-
-   *body = createBuilderIfNeeded(*body);
-   TraceIL("IlBuilder[ %p ]::DoWhileLoop do body B%d while %s\n", this, (*body)->getEntry()->getNumber(), whileCondition);
-
-   AppendBuilder(*body);
-   TR::IlBuilder *loopContinue = NULL;
-
-   if (continueBuilder)
+   ILBUILDER_PARM_SETUP(defaultBuilderImpl, defaultBuilderArg, defaultBuilder);
+   TR::IlBuilderImpl **  caseBuilderImpls = new TR::IlBuilderImpl *[numCases];
+   for (int32_t c=0;c < numCases;c++)
       {
-      TR_ASSERT(*continueBuilder == NULL, "DoWhileLoop returns continueBuilder, cannot provide continueBuilder as input");
-      loopContinue = *continueBuilder = OrphanBuilder();
-      }
-   else
-      loopContinue = OrphanBuilder();
-
-   AppendBuilder(loopContinue);
-   loopContinue->IfCmpNotEqualZero(body,
-   loopContinue->   Load(whileCondition));
-
-   if (breakBuilder)
-      {
-      TR_ASSERT(*breakBuilder == NULL, "DoWhileLoop returns breakBuilder, cannot provide breakBuilder as input");
-      *breakBuilder = OrphanBuilder();
-      AppendBuilder(*breakBuilder);
+      if (caseBuilders[c] == NULL)
+         caseBuilderImpls[c] = NULL;
+      else
+         caseBuilderImpls[c] = caseBuilders[c]->impl();
       }
 
-   // make sure any subsequent operations go into their own block *after* the loop
-   appendBlock();
+   impl()->Switch(selectionVar, defaultBuilderArg, numCases, caseValues, caseBuilderImpls, caseFallsThrough);
+
+   // if any builders were changed, update their clients in caseBuilders
+   for (int32_t c=0;c < numCases;c++)
+      {
+      caseBuilders[c] = caseBuilderImpls[c]->client();
+      }
+
+   delete[] caseBuilderImpls;
+   ILBUILDER_PARM_RETURN(defaultBuilderImpl, defaultBuilder);
    }
-
-void
-IlBuilder::WhileDoLoop(const char *whileCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder, TR::IlBuilder **continueBuilder)
-   {
-   methodSymbol()->setMayHaveLoops(true);
-   TR_ASSERT(body != NULL, "WhileDo needs to have a body");
-   TraceIL("IlBuilder[ %p ]::WhileDoLoop while %s do body %p\n", this, whileCondition, *body);
-
-   TR::IlBuilder *done = OrphanBuilder();
-   if (breakBuilder)
-      {
-      TR_ASSERT(*breakBuilder == NULL, "WhileDoLoop returns breakBuilder, cannot provide breakBuilder as input");
-      *breakBuilder = done;
-      }
-
-   TR::IlBuilder *loopContinue = OrphanBuilder();
-   if (continueBuilder)
-      {
-      TR_ASSERT(*continueBuilder == NULL, "WhileDoLoop returns continueBuilder, cannot provide continueBuilder as input");
-      *continueBuilder = loopContinue;
-      }
-
-   AppendBuilder(loopContinue);
-   loopContinue->IfCmpEqualZero(&done,
-   loopContinue->   Load(whileCondition));
-
-   *body = createBuilderIfNeeded(*body);
-   AppendBuilder(*body);
-
-   Goto(&loopContinue);
-   setComesBack(); // this goto is on one particular flow path, doesn't mean every path does a goto
-
-   AppendBuilder(done);
-   }
-
-} // namespace OMR

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -154,7 +154,6 @@ public:
    TR::IlValue *ConstDouble(double value);
    TR::IlValue *ConstAddress(const void * const value);
    TR::IlValue *ConstString(const char * const value);
-   TR::IlValue *ConstzeroValueForValue(TR::IlValue *v);
 
    TR::IlValue *Const(int8_t value)             { return ConstInt8(value); }
    TR::IlValue *Const(int16_t value)            { return ConstInt16(value); }

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -27,188 +27,145 @@
 #define PUT_OMR_ILBUILDER_INTO_TR
 #endif // !defined(TR_ILBUILDER_DEFINED)
 
-#include <fstream>
-#include <stdarg.h>
-#include <string.h>
-#include "ilgen/IlInjector.hpp"
-#include "il/ILHelpers.hpp"
+#include <cstddef>
+#include <stdint.h>
 
-#include "ilgen/IlValue.hpp" // must go after IlInjector.hpp or TR_ALLOC isn't cleaned up
+#define TOSTR(x)     #x
+#define LINETOSTR(x) TOSTR(x)
 
-namespace OMR { class MethodBuilder; }
+namespace OMR { class IlBuilderImpl; }
 
-namespace TR { class Block; }
-namespace TR { class IlGeneratorMethodDetails; }
 namespace TR { class IlBuilder; }
-namespace TR { class ResolvedMethodSymbol; } 
-namespace TR { class SymbolReference; }
-namespace TR { class SymbolReferenceTable; }
-
+namespace TR { class IlBuilderImpl; }
 namespace TR { class IlType; }
+namespace TR { class IlValue; }
+namespace TR { class MethodBuilder; }
 namespace TR { class TypeDictionary; }
-
-template <class T> class List;
-template <class T> class ListAppender;
+namespace TR { class VirtualMachineRegisterInStruct; }
 
 namespace OMR
 {
 
-typedef TR::ILOpCodes (*OpCodeMapper)(TR::DataType);
+/*
+ * IlBuilder Client API
+ * TODO: put class documentation here
+ * Constructors/Destructors at the top, other API grouped in categories, alphabetical in each category
+ * All implementations, with the exception of constructors, are simply
+ * delegations to the IlBuilderImpl object stored in _impl . There
+ * is a 1-1 relationship between IlBuilder and IlBuilderImpl objects.
+ * All IlBuilder objects are associated with their containing MethodBuilder
+ * object and will be deleted when the MethodBuilder object is destructed.
+ * IlBuilder objects should be allocated via OrphanBuilder(), so there are
+ * no public constructors for this class.
+ */
 
-
-class IlBuilder : public TR::IlInjector
+class IlBuilder
    {
+   friend class MethodBuilder;
+   friend class OMR::IlBuilderImpl;
+   friend class VirtualMachineRegisterInStruct;
 
-protected:
-   struct SequenceEntry
-      {
-      TR_ALLOC(TR_Memory::IlGenerator)
+   public:
+   /*
+    * @brief public constructor to be used by client subclasses of IlBuilder
+    * Normally OrphanBuilder() is used to allocate IlBuilder objects.
+    */
+   IlBuilder(TR::MethodBuilder *mb, TR::TypeDictionary *types);
 
-      SequenceEntry(TR::Block *block)
-         {
-         _isBlock = true;
-         _block = block;
-         }
-      SequenceEntry(TR::IlBuilder *builder)
-         {
-         _isBlock = false;
-         _builder = builder;
-         }
+   protected:
+   /*
+    * @brief constructor used by other JitBuilder classes (e.g. MethodBuilder)
+    */
+   IlBuilder(TR::IlBuilderImpl *impl, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types);
 
-      bool _isBlock;
-      union
-         {
-         TR::Block *_block;
-         TR::IlBuilder *_builder;
-         };
-      };
+   public:
+   virtual ~IlBuilder();
 
-   SequenceEntry *blockEntry(TR::Block *block);
-   SequenceEntry *builderEntry(TR::IlBuilder *builder);
+   virtual bool buildIl()
+      { return false; }
 
-public:
-   TR_ALLOC(TR_Memory::IlGenerator)
-
-   friend class OMR::MethodBuilder;
-
-   IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
-      : TR::IlInjector(types),
-      _methodBuilder(methodBuilder),
-      _sequence(0),
-      _sequenceAppender(0),
-      _entryBlock(0),
-      _exitBlock(0),
-      _count(-1),
-      _partOfSequence(false),
-      _connectedTrees(false),
-      _comesBack(true),
-      _isHandler(false)
-      {
-      }
-   IlBuilder(TR::IlBuilder *source);
-   virtual ~IlBuilder() { }
-
-   void initSequence();
-
-   virtual bool injectIL();
-   virtual void setupForBuildIL();
-
-   virtual bool isMethodBuilder()               { return false; }
-   virtual TR::MethodBuilder *asMethodBuilder() { return NULL; }
-
-   virtual bool isBytecodeBuilder()             { return false; }
-
-   //char *getName();
-
-   void print(const char *title, bool recurse=false);
-   void printBlock(TR::Block *block);
-
-   TR::TreeTop *getFirstTree();
-   TR::TreeTop *getLastTree();
-   TR::Block *getEntry() { return _entryBlock; }
-   TR::Block *getExit()  { return _exitBlock; }
-
-   void setDoesNotComeBack() { _comesBack = false; }
-   void setComesBack()       { _comesBack = true; }
-   bool comesBack()          { return _comesBack; }
-
-   bool blocksHaveBeenCounted() { return _count > -1; }
-
-   TR::IlBuilder *createBuilderIfNeeded(TR::IlBuilder *builder);
-   TR::IlBuilder *OrphanBuilder();
-   bool TraceEnabled_log();
-   void TraceIL_log(const char *s, ...);
-
-   // create a new local value (temporary variable)
-   TR::IlValue *NewValue(TR::IlType *dt);
-
+   // misc
    TR::IlValue *Copy(TR::IlValue *value);
+   TR::IlBuilder *OrphanBuilder();
 
    // constants
-   TR::IlValue *NullAddress();
+   TR::IlValue *ConstAddress(const void * const value);
+   TR::IlValue *ConstDouble(double value);
+   TR::IlValue *ConstFloat(float value);
+   TR::IlValue *ConstInteger(TR::IlType *intType, int64_t value);
    TR::IlValue *ConstInt8(int8_t value);
    TR::IlValue *ConstInt16(int16_t value);
    TR::IlValue *ConstInt32(int32_t value);
    TR::IlValue *ConstInt64(int64_t value);
-   TR::IlValue *ConstFloat(float value);
-   TR::IlValue *ConstDouble(double value);
-   TR::IlValue *ConstAddress(const void * const value);
    TR::IlValue *ConstString(const char * const value);
 
-   TR::IlValue *Const(int8_t value)             { return ConstInt8(value); }
-   TR::IlValue *Const(int16_t value)            { return ConstInt16(value); }
-   TR::IlValue *Const(int32_t value)            { return ConstInt32(value); }
-   TR::IlValue *Const(int64_t value)            { return ConstInt64(value); }
-   TR::IlValue *Const(float value)              { return ConstFloat(value); }
-   TR::IlValue *Const(double value)             { return ConstDouble(value); }
-   TR::IlValue *Const(const void * const value) { return ConstAddress(value); }
-
-   TR::IlValue *ConstInteger(TR::IlType *intType, int64_t value);
+   TR::IlValue *Const(const void * const value)
+      { return ConstAddress(value); }
+   TR::IlValue *Const(double value)
+      { return ConstDouble(value); }
+   TR::IlValue *Const(float value)
+      { return ConstFloat(value); }
+   TR::IlValue *Const(int8_t value)
+      { return ConstInt8(value); }
+   TR::IlValue *Const(int16_t value)
+      { return ConstInt16(value); }
+   TR::IlValue *Const(int32_t value)
+      { return ConstInt32(value); }
+   TR::IlValue *Const(int64_t value)
+      { return ConstInt64(value); }
+   TR::IlValue *NullAddress();
 
    // arithmetic
    TR::IlValue *Add(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *AddWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *AddWithUnsignedOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *And(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *Div(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
+   TR::IlValue *Mul(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *MulWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *Or(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *ShiftL(TR::IlValue *v, TR::IlValue *amount);
+   TR::IlValue *ShiftL(TR::IlValue *v, int8_t amount)
+      { return ShiftL(v, ConstInt8(amount)); }
+   TR::IlValue *ShiftR(TR::IlValue *v, TR::IlValue *amount);
+   TR::IlValue *ShiftR(TR::IlValue *v, int8_t amount)
+      { return ShiftR(v, ConstInt8(amount)); }
    TR::IlValue *Sub(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *SubWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *SubWithUnsignedOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *Mul(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *MulWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *Div(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *And(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *Or(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *Xor(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *ShiftL(TR::IlValue *v, TR::IlValue *amount);
-   TR::IlValue *ShiftL(TR::IlValue *v, int8_t amount)                { return ShiftL(v, ConstInt8(amount)); }
-   TR::IlValue *ShiftR(TR::IlValue *v, TR::IlValue *amount);
-   TR::IlValue *ShiftR(TR::IlValue *v, int8_t amount)                { return ShiftR(v, ConstInt8(amount)); }
    TR::IlValue *UnsignedShiftR(TR::IlValue *v, TR::IlValue *amount);
-   TR::IlValue *UnsignedShiftR(TR::IlValue *v, int8_t amount)        { return UnsignedShiftR(v, ConstInt8(amount)); }
-   TR::IlValue *NotEqualTo(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *UnsignedShiftR(TR::IlValue *v, int8_t amount)
+      { return UnsignedShiftR(v, ConstInt8(amount)); }
+   TR::IlValue *Xor(TR::IlValue *left, TR::IlValue *right);
+
+   // compares
    TR::IlValue *EqualTo(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *LessThan(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *UnsignedLessThan(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *LessOrEqualTo(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *UnsignedLessOrEqualTo(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *GreaterThan(TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *UnsignedGreaterThan(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *LessThan(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *GreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *GreaterThan(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *NotEqualTo(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *UnsignedLessOrEqualTo(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *UnsignedLessThan(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *UnsignedGreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *UnsignedGreaterThan(TR::IlValue *left, TR::IlValue *right);
+
+   // conversions
    TR::IlValue *ConvertTo(TR::IlType *t, TR::IlValue *v);
    TR::IlValue *UnsignedConvertTo(TR::IlType *t, TR::IlValue *v);
 
    // memory
+   TR::IlValue *AtomicAdd(TR::IlValue *baseAddress, TR::IlValue  *value);
    TR::IlValue *CreateLocalArray(int32_t numElements, TR::IlType *elementType);
    TR::IlValue *CreateLocalStruct(TR::IlType *structType);
    TR::IlValue *Load(const char *name);
-   void Store(const char *name, TR::IlValue *value);
-   void StoreOver(TR::IlValue *dest, TR::IlValue *value);
    TR::IlValue *LoadAt(TR::IlType *dt, TR::IlValue *address);
-   void StoreAt(TR::IlValue *address, TR::IlValue *value);
    TR::IlValue *LoadIndirect(const char *type, const char *field, TR::IlValue *object);
+   void Store(const char *name, TR::IlValue *value);
+   void StoreAt(TR::IlValue *address, TR::IlValue *value);
    void StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value);
-   TR::IlValue *IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
-   TR::IlValue *AtomicAdd(TR::IlValue *baseAddress, TR::IlValue * value);
+   void StoreOver(TR::IlValue *dest, TR::IlValue *value);
    void Transaction(TR::IlBuilder **persistentFailureBuilder, TR::IlBuilder **transientFailureBuilder, TR::IlBuilder **fallThroughBuilder);
    void TransactionAbort();
 
@@ -220,8 +177,8 @@ public:
     * is to use the field's address instead. This is not an elegent solution and
     * should be revisited.
     */
-   TR::IlValue *StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue* obj);
-   TR::IlValue *UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValue* obj);
+   TR::IlValue *StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValue *obj);
+   TR::IlValue *UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValue *obj);
 
    // vector memory
    TR::IlValue *VectorLoad(const char *name);
@@ -235,12 +192,54 @@ public:
    TR::IlValue *Call(const char *name, int32_t numArgs, TR::IlValue **argValues);
    TR::IlValue *ComputedCall(const char *name, int32_t numArgs, ...);
    TR::IlValue *ComputedCall(const char *name, int32_t numArgs, TR::IlValue **args);
-   TR::IlValue *genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlValue ** paramValues, bool isDirectCall = true);
+   void DoWhileLoop(const char *exitCondition,
+                    TR::IlBuilder **body,
+                    TR::IlBuilder **breakBuilder = NULL,
+                    TR::IlBuilder **continueBuilder = NULL);
+   void DoWhileLoopWithBreak(const char *exitCondition,
+                             TR::IlBuilder **body,
+                             TR::IlBuilder **breakBuilder)
+      { DoWhileLoop(exitCondition, body, breakBuilder); }
+   void DoWhileLoopWithContinue(const char *exitCondition,
+                                TR::IlBuilder **body,
+                                TR::IlBuilder **continueBuilder)
+      { DoWhileLoop(exitCondition, body, NULL, continueBuilder); }
    void Goto(TR::IlBuilder **dest);
    void Goto(TR::IlBuilder *dest);
-   void Return();
-   void Return(TR::IlValue *value);
-   virtual void ForLoop(bool countsUp,
+   /* @brief creates an AND nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
+   void IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ... );
+   void IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
+   void IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition);
+   void IfCmpLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
+   void IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition);
+   void IfCmpUnsignedLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
+   void IfCmpUnsignedGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
+   /* @brief creates an OR nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
+   void IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ... );
+   virtual void IfThen(TR::IlBuilder **thenPath, TR::IlValue *condition)
+      { IfThenElse(thenPath, NULL, condition); }
+   void IfThenElse(TR::IlBuilder **thenPath,
+                   TR::IlBuilder **elsePath,
+                   TR::IlValue *condition);
+   void ForLoop(bool countsUp,
                 const char *indVar,
                 TR::IlBuilder **body,
                 TR::IlBuilder **breakBuilder,
@@ -248,25 +247,18 @@ public:
                 TR::IlValue *initial,
                 TR::IlValue *iterateWhile,
                 TR::IlValue *increment);
-
-   void ForLoopUp(const char *indVar,
-                  TR::IlBuilder **body,
-                  TR::IlValue *initial,
-                  TR::IlValue *iterateWhile,
-                  TR::IlValue *increment)
-      {
-      ForLoop(true, indVar, body, NULL, NULL, initial, iterateWhile, increment);
-      }
-
    void ForLoopDown(const char *indVar,
                     TR::IlBuilder **body,
                     TR::IlValue *initial,
                     TR::IlValue *iterateWhile,
                     TR::IlValue *increment)
-      {
-      ForLoop(false, indVar, body, NULL, NULL, initial, iterateWhile, increment);
-      }
-
+      { ForLoop(false, indVar, body, NULL, NULL, initial, iterateWhile, increment); }
+   void ForLoopUp(const char *indVar,
+                  TR::IlBuilder **body,
+                  TR::IlValue *initial,
+                  TR::IlValue *iterateWhile,
+                  TR::IlValue *increment)
+      { ForLoop(true, indVar, body, NULL, NULL, initial, iterateWhile, increment); }
    void ForLoopWithBreak(bool countsUp,
                          const char *indVar,
                          TR::IlBuilder **body,
@@ -274,10 +266,7 @@ public:
                          TR::IlValue *initial,
                          TR::IlValue *iterateWhile,
                          TR::IlValue *increment)
-      {
-      ForLoop(countsUp, indVar, body, breakBody, NULL, initial, iterateWhile, increment);
-      }
-
+      { ForLoop(countsUp, indVar, body, breakBody, NULL, initial, iterateWhile, increment); }
    void ForLoopWithContinue(bool countsUp,
                             const char *indVar,
                             TR::IlBuilder **body,
@@ -285,68 +274,9 @@ public:
                             TR::IlValue *initial,
                             TR::IlValue *iterateWhile,
                             TR::IlValue *increment)
-      {
-      ForLoop(countsUp, indVar, body, NULL, continueBody, initial, iterateWhile, increment);
-      }
-
-   virtual void WhileDoLoop(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder = NULL, TR::IlBuilder **continueBuilder = NULL);
-   void WhileDoLoopWithBreak(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder)
-      {
-      WhileDoLoop(exitCondition, body, breakBuilder);
-      }
-
-   void WhileDoLoopWithContinue(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **continueBuilder)
-      {
-      WhileDoLoop(exitCondition, body, NULL, continueBuilder);
-      }
-
-   virtual void DoWhileLoop(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder = NULL, TR::IlBuilder **continueBuilder = NULL);
-   void DoWhileLoopWithBreak(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder)
-      {
-      DoWhileLoop(exitCondition, body, breakBuilder);
-      }
-   void DoWhileLoopWithContinue(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **continueBuilder)
-      {
-      DoWhileLoop(exitCondition, body, NULL, continueBuilder);
-      }
-
-   /* @brief creates an AND nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
-   void IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ... );
-   /* @brief creates an OR nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
-   void IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ... );
-
-   void IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
-   void IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition);
-   void IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
-   void IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition);
-   void IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedGreaterThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedGreaterThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedGreaterOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValue *right);
-   void IfCmpUnsignedGreaterOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right);
-
-   void IfThenElse(TR::IlBuilder **thenPath,
-                   TR::IlBuilder **elsePath,
-                   TR::IlValue *condition);
-   virtual void IfThen(TR::IlBuilder **thenPath, TR::IlValue *condition)
-      {
-      IfThenElse(thenPath, NULL, condition);
-      }
+      { ForLoop(countsUp, indVar, body, NULL, continueBody, initial, iterateWhile, increment); }
+   void Return();
+   void Return(TR::IlValue *value);
    void Switch(const char *selectionVar,
                TR::IlBuilder **defaultBuilder,
                uint32_t numCases,
@@ -357,123 +287,70 @@ public:
                TR::IlBuilder **defaultBuilder,
                uint32_t numCases,
                ...);
+   void WhileDoLoop(const char *exitCondition,
+                    TR::IlBuilder **body,
+                    TR::IlBuilder **breakBuilder = NULL,
+                    TR::IlBuilder **continueBuilder = NULL);
+   void WhileDoLoopWithBreak(const char *exitCondition,
+                             TR::IlBuilder **body,
+                             TR::IlBuilder **breakBuilder)
+      { WhileDoLoop(exitCondition, body, breakBuilder); }
+   void WhileDoLoopWithContinue(const char *exitCondition,
+                                TR::IlBuilder **body,
+                                TR::IlBuilder **continueBuilder)
+      { WhileDoLoop(exitCondition, body, NULL, continueBuilder); }
 
-protected:
-
-   /**
-    * @brief MethodBuilder parent for this IlBuilder object
-    */
-   TR::MethodBuilder           * _methodBuilder;
-
-   /**
-    * @brief sequence of TR::Blocks and other TR::IlBuilder objects that should execute when control reaches this IlBuilder
-    */
-   List<SequenceEntry>         * _sequence;
-
-   /**
-    * @brief used to track the end of the current sequence
-    */
-   ListAppender<SequenceEntry> * _sequenceAppender;
+   protected:
 
    /**
-    * @brief each IlBuilder object is like a mini-CFG, with its own unique entry block
+    * @brief Access to this IlBuilder's implementation object.
+    *  Subclasses will implement impl() but return more derived types,
+    *  so impl() is purposefully not virtual.
     */
-   TR::Block                   * _entryBlock;
+   TR::IlBuilderImpl *impl()
+      { return _impl; }
 
    /**
-    * @brief each IlBuilder object is like a mini-CFG, with its own unique exit block
+    * @brief return MethodBuilder that owns this IlBuilder object
     */
-   TR::Block                   * _exitBlock;
+   TR::MethodBuilder *methodBuilder()
+      { return _mb; }
 
    /**
-    * @brief counter for how many TR::Blocks are needed to represent everything inside this IlBuilder object
+    * @brief creates an IlBuilder object to wrap an implementation object
     */
-   int32_t                       _count;
+   TR::IlBuilder *orphanBuilder(TR::IlBuilderImpl *bi);
+
+   /*
+    * @brief MethodBuilder client object that "owns" this IlBuilder object
+    * Used primarily to track IlBuilder object allocations at the MethodBuilder
+    */
+   TR::MethodBuilder *_mb;
+
+   /*
+    * @brief implementation object corresponding to this client object (1-1 mapping)
+    */
+   TR::IlBuilderImpl *_impl;
 
    /**
-    * @brief has this IlBuilder object been made part of some other builder's sequence
+    * @brief Convenience pointers for referring to primitive types
     */
-   bool                          _partOfSequence;
+   TR::IlType * NoType;
+   TR::IlType * Int8;
+   TR::IlType * Int16;
+   TR::IlType * Int32;
+   TR::IlType * Int64;
+   TR::IlType * Word;
+   TR::IlType * Float;
+   TR::IlType * Double;
+   TR::IlType * Address;
+   TR::IlType * VectorInt8;
+   TR::IlType * VectorInt16;
+   TR::IlType * VectorInt32;
+   TR::IlType * VectorInt64;
+   TR::IlType * VectorFloat;
+   TR::IlType * VectorDouble;
 
-   /**
-    * @brief has connectTrees been run on this IlBuilder object yet
-    */
-   bool                          _connectedTrees;
-
-   /**
-    * @brief returns true if there is a control edge to this IlBuilder's exit block
-    */
-   bool                          _comesBack;
-
-   /**
-    * @brief returns true if this IlBuilder object is a handler for an exception edge
-    */
-   bool                          _isHandler;
-
-   virtual bool buildIL() { return true; }
-
-   TR::SymbolReference *lookupSymbol(const char *name);
-   void defineSymbol(const char *name, TR::SymbolReference *v);
-   TR::IlValue *newValue(TR::IlType *dt, TR::Node *n=NULL);
-   TR::IlValue *newValue(TR::DataType dt, TR::Node *n=NULL);
-   void defineValue(const char *name, TR::IlType *dt);
-
-   TR::Node *loadValue(TR::IlValue *v);
-   void storeNode(TR::SymbolReference *symRef, TR::Node *v);
-   void indirectStoreNode(TR::Node *addr, TR::Node *v);
-   TR::IlValue *indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad=false);
-
-   TR::Node *zero(TR::DataType dt);
-   TR::Node *zero(TR::IlType *dt);
-   TR::Node *zeroNodeForValue(TR::IlValue *v);
-   TR::IlValue *zeroForValue(TR::IlValue *v);
-
-   TR::IlValue *unaryOp(TR::ILOpCodes op, TR::IlValue *v);
-   void doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr);
-   TR::IlValue *binaryOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
-   TR::Node *binaryOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
-   TR::IlValue *binaryOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *binaryOpFromOpCode(TR::ILOpCodes op, TR::IlValue *left, TR::IlValue *right);
-   TR::Node *shiftOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
-   TR::IlValue *shiftOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
-   TR::IlValue *shiftOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *compareOp(TR_ComparisonTypes ct, bool needUnsigned, TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned);
-
-   void ifCmpCondition(TR_ComparisonTypes ct, bool isUnsignedCmp, TR::IlValue *left, TR::IlValue *right, TR::Block *target);
-   void ifCmpNotEqualZero(TR::IlValue *condition, TR::Block *target);
-   void ifCmpEqualZero(TR::IlValue *condition, TR::Block *target);
-
-   void integerizeAddresses(TR::IlValue **leftPtr, TR::IlValue **rightPtr);
-
-   void appendGoto(TR::Block *destBlock);
-
-   virtual void appendBlock(TR::Block *block = 0, bool addEdge=true);
-   void appendNoFallThroughBlock(TR::Block *block = 0)
-      {
-      appendBlock(block, false);
-      }
-
-   TR::Block *emptyBlock();
-   
-   virtual uint32_t countBlocks();
-
-   void pullInBuilderTrees(TR::IlBuilder *builder,
-                           uint32_t *currentBlock,
-                           TR::TreeTop **firstTree,
-                           TR::TreeTop **newLastTree);
-
-   // BytecodeBuilder needs this interface, but IlBuilders doesn't so just ignore the parameter
-   virtual bool connectTrees(uint32_t *currentBlock) { return connectTrees(); }
-
-   virtual bool connectTrees();
-
-   TR::Node *genOverflowCHKTreeTop(TR::Node *operationNode, TR::ILOpCodes overflow);
-   TR::ILOpCodes getOpCode(TR::IlValue *leftValue, TR::IlValue *rightValue);
-   void appendExceptionHandler(TR::Block *blockThrowsException, TR::IlBuilder **builder, uint32_t catchType);
-   TR::IlValue *genOperationWithOverflowCHK(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode, TR::IlBuilder **handler, TR::ILOpCodes overflow);
-   virtual void setHandlerInfo(uint32_t catchType);
-   TR::IlValue **processCallArgs(TR::Compilation *comp, int numArgs, va_list args);
    };
 
 } // namespace OMR
@@ -491,8 +368,8 @@ namespace TR
             : OMR::IlBuilder(methodBuilder, types)
             { }
 
-         IlBuilder(TR::IlBuilder *source)
-            : OMR::IlBuilder(source)
+         IlBuilder(TR::IlBuilderImpl *impl, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
+            : OMR::IlBuilder(impl, methodBuilder, types)
             { }
       };
 

--- a/compiler/ilgen/IlBuilderImpl.cpp
+++ b/compiler/ilgen/IlBuilderImpl.cpp
@@ -1,0 +1,2528 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Recompilation.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/FrontEnd.hpp"
+#include "il/Block.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/List.hpp"
+#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "ilgen/BytecodeBuilderImpl.hpp"
+#include "ilgen/IlBuilderImpl.hpp"
+#include "ilgen/IlInjector.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
+#include "ilgen/TypeDictionaryImpl.hpp"
+
+#define OPT_DETAILS "O^O ILBLD: "
+
+
+// TODO: Move this description to the client API
+// IlBuilderImpl is a class designed to help build Testarossa IL quickly without
+// a lot of knowledge of the intricacies of commoned references, symbols,
+// symbol references, or blocks. You can add operations to an IlBuilderImpl via
+// a set of services, for example: Add, Sub, Load, Store. These services
+// operate on TR::IlValues, which currently correspond to SymbolReferences.
+// However, IlBuilderImpls also incorporate a notion of "symbols" that are
+// identified by strings (i.e. arbitrary symbolic names).
+//
+// So Load("a") returns a TR::IlValue. Load("b") returns a different
+// TR::IlValue. The value of a+b can be computed by Add(Load("a"),Load("b")),
+// and that value can be stored into c by Store("c", Add(Load("a"),Load("b"))).
+//
+// More complicated services exist to construct control flow by linking
+// together sets of IlBuilderImpl objects. A simple if-then construct, for
+// example, can be built with the following code:
+//    TR::IlValue *condition = NotEqualToZero(Load("a"));
+//    TR::IlBuilderImpl *then = NULL;
+//    IfThen(&then, condition);
+//    then->Return(then->ConstInt32(0));
+//
+//
+// Leave this here, improve relevance
+// An IlBuilderImpl is really a sequence of Blocks and other IlBuilderImpls, but an
+// IlBuilderImpl is also a sequence of TreeTops connecting together a set of
+// Blocks that are arranged in the CFG. Another way to think of an IlBuilderImpl
+// is as representing the code needed to execute a particular code path
+// (which may itself have sub control flow handled by embedded IlBuilderImpls).
+// All IlBuilderImpls exist within the single control flow graph, but the full
+// control flow graph will not be connected together until all IlBuilderImpl
+// objects have had injectIL() called.
+
+
+OMR::IlBuilderImpl::IlBuilderImpl(TR::MethodBuilderImpl *methodBuilder, TR::TypeDictionaryImpl *types)
+   : TR::IlInjector(types),
+   _clientBuilder(0),             // setClient() must be used to set this later
+   _methodBuilder(methodBuilder),
+   _sequence(0),
+   _sequenceAppender(0),
+   _entryBlock(0),
+   _exitBlock(0),
+   _count(-1),
+   _partOfSequence(false),
+   _connectedTrees(false),
+   _comesBack(true),
+   _isHandler(false)
+   {
+   }
+
+OMR::IlBuilderImpl::IlBuilderImpl(TR::IlBuilderImpl *source)
+   : TR::IlInjector(source),
+   _methodBuilder(source->_methodBuilder),
+   _sequence(0),
+   _sequenceAppender(0),
+   _entryBlock(0),
+   _exitBlock(0),
+   _count(-1),
+   _partOfSequence(false),
+   _connectedTrees(false),
+   _comesBack(true)
+   {
+   }
+
+
+bool
+OMR::IlBuilderImpl::TraceEnabled_log()
+   {
+   bool traceEnabled = _comp->getOption(TR_TraceILGen);
+   return traceEnabled;
+   }
+
+void
+OMR::IlBuilderImpl::TraceIL_log(const char* s, ...)
+   {
+   va_list argp;
+   va_start (argp, s);
+   traceMsgVarArgs(_comp, s, argp);
+   va_end(argp);
+   }
+
+void
+OMR::IlBuilderImpl::initSequence()
+   {
+   _sequence = new (_comp->trMemory()->trHeapMemory()) List<SequenceEntry>(_comp->trMemory());
+   _sequenceAppender = new (_comp->trMemory()->trHeapMemory()) ListAppender<SequenceEntry>(_sequence);
+   }
+
+bool
+OMR::IlBuilderImpl::injectIL()
+   {
+   TraceIL("Inside injectIL()\n");
+   TraceIL("original entry %p\n", cfg()->getStart());
+   TraceIL("original exit %p\n", cfg()->getEnd());
+
+   setupForBuildIL();
+
+   bool rc = buildIL();
+   TraceIL("buildIL() returned %d\n", rc);
+   if (!rc)
+      return false;
+
+   rc = connectTrees();
+   if (TraceEnabled)
+      comp()->dumpMethodTrees("after connectTrees");
+   cfg()->removeUnreachableBlocks();
+   if (TraceEnabled)
+      comp()->dumpMethodTrees("after removing unreachable blocks");
+   return rc;
+   }
+
+void
+OMR::IlBuilderImpl::setupForBuildIL()
+   {
+   initSequence();
+   appendBlock(NULL, false);
+   _entryBlock = _currentBlock;
+   _exitBlock = emptyBlock();
+   }
+
+void
+OMR::IlBuilderImpl::print(const char *title, bool recurse)
+   {
+   if (!TraceEnabled)
+      return;
+
+   if (title != NULL)
+      TraceIL("[ %p ] %s\n", this, title);
+   TraceIL("[ %p ] _methodBuilder %p\n", this, _methodBuilder);
+   TraceIL("[ %p ] _entryBlock %p\n", this, _entryBlock);
+   TraceIL("[ %p ] _exitBlock %p\n", this, _exitBlock);
+   TraceIL("[ %p ] _connectedBlocks %d\n", this, _connectedTrees);
+   TraceIL("[ %p ] _comesBack %d\n", this, _comesBack);
+   TraceIL("[ %p ] Sequence:\n", this);
+   ListIterator<SequenceEntry> iter(_sequence);
+   for (SequenceEntry *entry = iter.getFirst(); !iter.atEnd(); entry = iter.getNext())
+      {
+      if (entry->_isBlock)
+         {
+         printBlock(entry->_block);
+         }
+      else
+         {
+         if (recurse)
+            {
+            TraceIL("[ %p ] Inner builder %p", this, entry->_builder);
+            entry->_builder->print(NULL, recurse);
+            }
+         else
+            {
+            TraceIL("[ %p ] Builder %p\n", this, entry->_builder);
+            }
+         }
+      }
+   }
+
+void
+OMR::IlBuilderImpl::printBlock(TR::Block *block)
+   {
+   if (!TraceEnabled)
+      return;
+
+   TraceIL("[ %p ] Block %p\n", this, block);
+   TR::TreeTop *tt = block->getEntry();
+   while (tt != block->getExit())
+      {
+      comp()->getDebug()->print(comp()->getOutFile(), tt);
+      tt = tt->getNextTreeTop();
+      }
+   comp()->getDebug()->print(comp()->getOutFile(), tt);
+   }
+
+TR::SymbolReference *
+OMR::IlBuilderImpl::lookupSymbol(const char *name)
+   {
+   TR_ASSERT(_methodBuilder, "cannot look up symbols in an IlBuilderImpl that has no MethodBuilderImpl");
+   return _methodBuilder->lookupSymbol(name);
+   }
+
+void
+OMR::IlBuilderImpl::defineSymbol(const char *name, TR::SymbolReference *symRef)
+   {
+   TR_ASSERT(_methodBuilder, "cannot define symbols in an IlBuilderImpl that has no MethodBuilderImpl");
+   _methodBuilder->defineSymbol(name, symRef);
+   }
+
+void
+OMR::IlBuilderImpl::defineValue(const char *name, TR::IlTypeImpl *type)
+   {
+   TR::DataType dt = type->getRealPrimitiveType();
+   TR::SymbolReference *newSymRef = symRefTab()->createTemporary(methodSymbol(), dt);
+   newSymRef->getSymbol()->setNotCollected();
+   defineSymbol(name, newSymRef);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::newValue(TR::DataType dt, TR::Node *n)
+   {
+   // make sure TreeTop is well formed
+   TR::Node *ttNode = n;
+   if (!ttNode->getOpCode().isTreeTop())
+      ttNode = TR::Node::create(TR::treetop, 1, n);
+
+   TR::TreeTop *tt = TR::TreeTop::create(_comp, ttNode);
+   _currentBlock->append(tt);
+   TR::IlValueImpl *value = new (_comp->trHeapMemory()) TR::IlValueImpl(n, tt, _currentBlock, _methodBuilder);
+   return value;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::newValue(TR::IlTypeImpl *dt, TR::Node *n)
+   {
+   return newValue(dt->getRealPrimitiveType(), n);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Copy(TR::IlValueImpl *value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::DataType dt = value->getDataType();
+   TR::SymbolReference *newSymRef = symRefTab()->createTemporary(_methodSymbol, dt);
+   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+   sprintf(name, "_T%u", newSymRef->getCPIndex());
+   newSymRef->getSymbol()->getAutoSymbol()->setName(name);
+   newSymRef->getSymbol()->setNotCollected();
+
+   storeToTemp(newSymRef, loadValue(value));
+
+   TR::IlValueImpl *newVal = newValue(newSymRef->getSymbol()->getDataType(), loadTemp(newSymRef));
+
+   TraceIL("IlBuilderImpl[ %p ]::Copy value (%d) dataType (%d) to newVal (%d) at cpIndex (%d)\n", this, value->getID(), dt, newVal->getID(), newSymRef->getCPIndex());
+
+   return newVal;
+   }
+
+TR::TreeTop *
+OMR::IlBuilderImpl::getFirstTree()
+   {
+   TR_ASSERT(_blocks, "_blocks not created yet");
+   TR_ASSERT(_blocks[0], "_blocks[0] not created yet");
+   return _blocks[0]->getEntry();
+   }
+
+TR::TreeTop *
+OMR::IlBuilderImpl::getLastTree()
+   {
+   TR_ASSERT(_blocks, "_blocks not created yet");
+   TR_ASSERT(_blocks[_numBlocks], "_blocks[0] not created yet");
+   return _blocks[_numBlocks]->getExit();
+   }
+
+uint32_t
+OMR::IlBuilderImpl::countBlocks()
+   {
+   // only count each block once
+   if (_count > -1)
+      return _count;
+
+   TraceIL("[ %p ] TR::IlBuilderImpl::countBlocks 0 at entry\n", this);
+
+   _count = 0; // prevent recursive counting; will be updated to real value before returning
+
+   uint32_t count=0;
+   ListIterator<SequenceEntry> iter(_sequence);
+   for (SequenceEntry *entry = iter.getFirst(); !iter.atEnd(); entry = iter.getNext())
+      {
+      if (entry->_isBlock)
+         count++;
+      else
+         count += entry->_builder->countBlocks();
+      }
+
+   if (this != _methodBuilder)
+      {
+      // exit block isn't in the sequence except for method builders
+      //            gets tacked in late by connectTrees
+      count++;
+      }
+
+   TraceIL("[ %p ] TR::IlBuilderImpl::countBlocks %d\n", this, count);
+
+   _count = count;
+   return count;
+   }
+
+void
+OMR::IlBuilderImpl::pullInBuilderTrees(TR::IlBuilderImpl *builder,
+                              uint32_t *currentBlock,
+                              TR::TreeTop **firstTree,
+                              TR::TreeTop **newLastTree)
+   {
+   TraceIL("\n[ %p ] Calling connectTrees on inner builder %p\n", this, builder);
+   builder->connectTrees();
+   TraceIL("\n[ %p ] Returned from connectTrees on %p\n", this, builder);
+
+   TR::Block **innerBlocks = builder->blocks();
+   uint32_t innerNumBlocks = builder->numBlocks();
+
+   uint32_t copyBlock = *currentBlock;
+   for (uint32_t i=0;i < innerNumBlocks;i++, copyBlock++)
+      {
+      if (TraceEnabled)
+         {
+         TraceIL("[ %p ] copying inner block B%d to B%d\n", this, i, copyBlock);
+         printBlock(innerBlocks[i]);
+         }
+      _blocks[copyBlock] = innerBlocks[i];
+      }
+
+   *currentBlock += innerNumBlocks;
+   *firstTree = innerBlocks[0]->getEntry();
+   *newLastTree = innerBlocks[innerNumBlocks-1]->getExit();
+   }
+
+bool
+OMR::IlBuilderImpl::connectTrees()
+   {
+   // don't do this more than once per builder object
+   if (_connectedTrees)
+      return true;
+
+   _connectedTrees = true;
+
+   TraceIL("[ %p ] TR::IlBuilderImpl::connectTrees():\n", this);
+
+   // figure out how many blocks we need
+   uint32_t numBlocks = countBlocks();
+   TraceIL("[ %p ] Total %d blocks\n", this, numBlocks);
+
+   allocateBlocks(numBlocks);
+   TraceIL("[ %p ] Allocated _blocks %p\n", this, _blocks);
+
+   // now add all the blocks from the sequence into the _blocks array
+   // and connect the trees into a single sequence
+   uint32_t currentBlock = 0;
+   TR::Block **blocks = _blocks;
+   TR::TreeTop *lastTree = NULL;
+
+   TraceIL("[ %p ] Connecting trees one entry at a time:\n", this);
+   ListIterator<SequenceEntry> iter(_sequence);
+   for (SequenceEntry *entry = iter.getFirst(); !iter.atEnd(); entry = iter.getNext())
+      {
+      TraceIL("[ %p ] currentBlock = %d\n", this, currentBlock);
+      TraceIL("[ %p ] lastTree = %p\n", this, lastTree);
+      TR::TreeTop *firstTree = NULL;
+      TR::TreeTop *newLastTree = NULL;
+      if (entry->_isBlock)
+         {
+         if (TraceEnabled)
+            {
+            TraceIL("[ %p ] Block entry %p becomes block B%d\n", this, entry->_block, currentBlock);
+            printBlock(entry->_block);
+            }
+         blocks[currentBlock++] = entry->_block;
+         firstTree = entry->_block->getEntry();
+         newLastTree = entry->_block->getExit();
+         }
+      else
+         {
+         TR::IlBuilderImpl *builder = entry->_builder;
+         pullInBuilderTrees(builder, &currentBlock, &firstTree, &newLastTree);
+         }
+
+      TraceIL("[ %p ] First tree is %p [ node %p ]\n", this, firstTree, firstTree->getNode());
+      TraceIL("[ %p ] Last tree will be %p [ node %p ]\n", this, newLastTree, newLastTree->getNode());
+
+      // connect the trees
+      if (lastTree)
+         {
+         TraceIL("[ %p ] Connecting tree %p [ node %p ] to new tree %p [ node %p ]\n", this, lastTree, lastTree->getNode(), firstTree, firstTree->getNode());
+         lastTree->join(firstTree);
+         }
+
+      lastTree = newLastTree;
+      }
+
+   if (_methodBuilder != this)
+      {
+      // non-method builders need to append the "EXIT" block trees
+      // (method builders have EXIT as the special block 1)
+      TraceIL("[ %p ] Connecting last tree %p [ node %p ] to exit block entry %p [ node %p ]\n", this, lastTree, lastTree->getNode(), _exitBlock->getEntry(), _exitBlock->getEntry()->getNode());
+      lastTree->join(_exitBlock->getEntry());
+
+      // also add exit block to blocks array and add an edge from last block to EXIT if the builder comes back (i.e. doesn't return or branch off somewhere)
+      if (comesBack())
+         cfg()->addEdge(blocks[currentBlock-1], getExit());
+
+      blocks[currentBlock++] = _exitBlock;
+      TraceIL("[ %p ] exit block %d is %p (%p -> %p)\n", this, _exitBlock->getNumber(), _exitBlock->getEntry(), _exitBlock->getExit());
+      lastTree = _exitBlock->getExit();
+
+      _numBlocks = currentBlock;
+      }
+
+   TraceIL("[ %p ] last tree %p [ node %p ]\n", this, lastTree, lastTree->getNode());
+   lastTree->setNextTreeTop(NULL);
+   TraceIL("[ %p ] blocks[%d] exit tree is %p\n", this, currentBlock-1, blocks[currentBlock-1]->getExit());
+
+   return true;
+   }
+
+TR::Node *
+OMR::IlBuilderImpl::zero(TR::DataType dt)
+   {
+   switch (dt)
+      {
+      case TR::Int8 :  return TR::Node::bconst(0);
+      case TR::Int16 : return TR::Node::sconst(0);
+      case TR::Int32 : return TR::Node::iconst(0);
+      case TR::Int64 : return TR::Node::lconst(0);
+      default :        return TR::Node::create(TR::ILOpCode::constOpCode(dt), 0, 0);
+      }
+   TR_ASSERT(0, "should not reach here");
+   }
+
+TR::Node *
+OMR::IlBuilderImpl::zero(TR::IlTypeImpl *dt)
+   {
+   return zero(dt->getRealPrimitiveType());
+   }
+
+TR::Node *
+OMR::IlBuilderImpl::zeroNodeForValue(TR::IlValueImpl *v)
+   {
+   return zero(v->getDataType());
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::zeroForValue(TR::IlValueImpl *v)
+   {
+   TR::IlValueImpl *returnValue = newValue(v->getDataType(), zeroNodeForValue(v));
+   return returnValue;
+   }
+
+
+TR::IlBuilderImpl *
+OMR::IlBuilderImpl::allocate(TR::MethodBuilderImpl *mb, TR::TypeDictionaryImpl *types)
+   {
+   TR::IlBuilderImpl *orphan = new (TR::comp()->trHeapMemory()) TR::IlBuilderImpl(mb, types);
+   orphan->initialize(mb->details(), mb->methodSymbol(), mb->fe(), mb->symRefTab());
+   orphan->setupForBuildIL();
+   return orphan;
+   }
+
+TR::IlBuilderImpl *
+OMR::IlBuilderImpl::OrphanBuilderImpl()
+   {
+   TR::IlBuilderImpl *orphan = allocate(_methodBuilder, _types);
+   return orphan;
+   }
+
+TR::IlBuilderImpl *
+OMR::IlBuilderImpl::orphanBuilderImpl()
+   {
+   return client()->OrphanBuilder()->impl();
+   }
+
+TR::Block *
+OMR::IlBuilderImpl::emptyBlock()
+   {
+   TR::Block *empty = TR::Block::createEmptyBlock(NULL, _comp);
+   cfg()->addNode(empty);
+   return empty;
+   }
+
+
+TR::IlBuilderImpl *
+OMR::IlBuilderImpl::createBuilderIfNeeded(TR::IlBuilderImpl *builder)
+   {
+   if (builder == NULL)
+      builder = orphanBuilderImpl();
+   return builder;
+   }
+
+OMR::IlBuilderImpl::SequenceEntry *
+OMR::IlBuilderImpl::blockEntry(TR::Block *block)
+   {
+   return new (_comp->trMemory()->trHeapMemory()) IlBuilderImpl::SequenceEntry(block);
+   }
+
+OMR::IlBuilderImpl::SequenceEntry *
+OMR::IlBuilderImpl::builderEntry(TR::IlBuilderImpl *builder)
+   {
+   return new (_comp->trMemory()->trHeapMemory()) IlBuilderImpl::SequenceEntry(builder);
+   }
+
+void
+OMR::IlBuilderImpl::appendBlock(TR::Block *newBlock, bool addEdge)
+   {
+   if (newBlock == NULL)
+      {
+      newBlock = emptyBlock();
+      }
+
+   _sequenceAppender->add(blockEntry(newBlock));
+
+   if (_currentBlock && addEdge)
+      {
+      // if current block does not fall through to new block, use appendNoFallThroughBlock() rather than appendBlock()
+      cfg()->addEdge(_currentBlock, newBlock);
+      }
+
+   // subsequent IL should generate to appended block
+   _currentBlock = newBlock;
+   }
+
+void
+OMR::IlBuilderImpl::AppendBuilder(TR::IlBuilderImpl *builder)
+   {
+   TR_ASSERT(builder->_partOfSequence == false, "builder cannot be in two places");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   builder->_partOfSequence = true;
+   _sequenceAppender->add(builderEntry(builder));
+   if (_currentBlock != NULL)
+      {
+      cfg()->addEdge(_currentBlock, builder->getEntry());
+      _currentBlock = NULL;
+      }
+
+   TraceIL("IlBuilderImpl[ %p ]::AppendBuilder %p\n", this, builder);
+
+   // when trees are connected, exit block will swing down to become last trees in builder, so it can fall through to this block we're about to create
+   // need to add edge explicitly because of this exit block sleight of hand
+   appendNoFallThroughBlock();
+   cfg()->addEdge(builder->getExit(), _currentBlock);
+   }
+
+TR::Node *
+OMR::IlBuilderImpl::loadValue(TR::IlValueImpl *v)
+   {
+   return v->load(_currentBlock);
+   }
+
+void
+OMR::IlBuilderImpl::storeNode(TR::SymbolReference *symRef, TR::Node *v)
+   {
+   genTreeTop(TR::Node::createStore(symRef, v));
+   }
+
+void
+OMR::IlBuilderImpl::indirectStoreNode(TR::Node *addr, TR::Node *v)
+   {
+   TR::DataType dt = v->getDataType();
+   TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(dt, addr);
+   TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectArrayStore(dt);
+   genTreeTop(TR::Node::createWithSymRef(storeOp, 2, addr, v, 0, storeSymRef));
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::indirectLoadNode(TR::IlTypeImpl *dt, TR::Node *addr, bool isVectorLoad)
+   {
+   TR_ASSERT(dt->isPointer(), "indirectLoadNode must apply to pointer type");
+   TR::IlTypeImpl * baseType = dt->baseType()->impl();
+   TR::DataType primType = baseType->getRealPrimitiveType();
+   TR_ASSERT(primType != TR::NoType, "Dereferencing an untyped pointer.");
+   TR::DataType symRefType = primType;
+   if (isVectorLoad)
+      symRefType = symRefType.scalarToVector();
+
+   TR::SymbolReference *storeSymRef = symRefTab()->findOrCreateArrayShadowSymbolRef(symRefType, addr);
+
+   TR::ILOpCodes loadOp = comp()->il.opCodeForIndirectArrayLoad(primType);
+   if (isVectorLoad)
+      {
+      loadOp = TR::ILOpCode::convertScalarToVector(loadOp);
+      baseType = _types->PrimitiveType(symRefType);
+      }
+
+   TR::Node *loadNode = TR::Node::createWithSymRef(loadOp, 1, 1, addr, storeSymRef);
+
+   TR::IlValueImpl *loadValue = newValue(baseType, loadNode);
+   return loadValue;
+   }
+
+/**
+ * @brief Store an IlValueImpl into a named local variable
+ * @param varName the name of the local variable to be stored into. If the name has not been used before, this local variable will
+ *                take the same data type as the value being written to it.
+ * @param value IlValueImpl that should be written to the local variable, which should be the same data type
+ */
+void
+OMR::IlBuilderImpl::Store(const char *varName, TR::IlValueImpl *value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   if (!_methodBuilder->symbolDefined(varName))
+      _methodBuilder->defineValue(varName, _types->PrimitiveType(value->getDataType()));
+   TR::SymbolReference *symRef = lookupSymbol(varName);
+
+   TraceIL("IlBuilderImpl[ %p ]::Store %s %d gets %d\n", this, varName, symRef->getCPIndex(), value->getID());
+   storeNode(symRef, loadValue(value));
+   }
+
+/**
+ * @brief Store an IlValueImpl into the same local value as another IlValueImpl
+ * @param dest IlValueImpl that should now hold the same value as "value"
+ * @param value IlValueImpl that should overwrite "dest"
+ */
+void
+OMR::IlBuilderImpl::StoreOver(TR::IlValueImpl *dest, TR::IlValueImpl *value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   dest->storeOver(value, _currentBlock);
+   }
+
+/**
+ * @brief Store a vector IlValueImpl into a named local variable
+ * @param varName the name of the local variable to be vector stored into. if the name has not been used before, this local variable will
+ *                take the same data type as the value being written to it. The width of this data will be determined by the vector
+ *                data type of IlValueImpl.
+ * @param value IlValueImpl with the vector data that should be written to the local variable, and should have the same data type
+ */
+void
+OMR::IlBuilderImpl::VectorStore(const char *varName, TR::IlValueImpl *value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *valueNode = loadValue(value);
+   TR::DataType dt = valueNode->getDataType();
+   if (!dt.isVector())
+      {
+      valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
+      dt = dt.scalarToVector();
+      }
+
+   if (!_methodBuilder->symbolDefined(varName))
+      _methodBuilder->defineValue(varName, _types->PrimitiveType(dt));
+   TR::SymbolReference *symRef = lookupSymbol(varName);
+
+   TraceIL("IlBuilderImpl[ %p ]::VectorStore %s %d gets %d\n", this, varName, symRef->getCPIndex(), value->getID());
+   storeNode(symRef, loadValue(value));
+   }
+
+/**
+ * @brief Store an IlValueImpl through a pointer
+ * @param address the pointer address through which the value will be written
+ * @param value IlValueImpl that should be written at "address"
+ */
+void
+OMR::IlBuilderImpl::StoreAt(TR::IlValueImpl *address, TR::IlValueImpl *value)
+   {
+   TR_ASSERT(address->getDataType() == TR::Address, "StoreAt needs an address operand");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TraceIL("IlBuilderImpl[ %p ]::StoreAt address %d gets %d\n", this, address->getID(), value->getID());
+   indirectStoreNode(loadValue(address), loadValue(value));
+   }
+
+/**
+ * @brief Store a vector IlValueImpl through a pointer
+ * @param address the pointer address through which the vector value will be written. The width of the store will be determined
+ *                by the vector data type of IlValueImpl.
+ * @param value IlValueImpl with the vector data that should be written  at "address"
+ */
+void
+OMR::IlBuilderImpl::VectorStoreAt(TR::IlValueImpl *address, TR::IlValueImpl *value)
+   {
+   TR_ASSERT(address->getDataType() == TR::Address, "VectorStoreAt needs an address operand");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TraceIL("IlBuilderImpl[ %p ]::VectorStoreAt address %d gets %d\n", this, address->getID(), value->getID());
+
+   TR::Node *valueNode = loadValue(value);
+
+   if (!valueNode->getDataType().isVector())
+      valueNode = TR::Node::create(TR::vsplats, 1, valueNode);
+
+   indirectStoreNode(loadValue(address), valueNode);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::CreateLocalArray(int32_t numElements, TR::IlTypeImpl *elementType)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   uint32_t size = numElements * elementType->getSize();
+   TR::SymbolReference *localArraySymRef = symRefTab()->createLocalPrimArray(size,
+                                                                             methodSymbol(),
+                                                                             8 /*FIXME: JVM-specific - byte*/);
+   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+   sprintf(name, "_T%u", localArraySymRef->getCPIndex());
+   localArraySymRef->getSymbol()->getAutoSymbol()->setName(name);
+   localArraySymRef->setStackAllocatedArrayAccess();
+
+   TR::Node *arrayAddress = TR::Node::createWithSymRef(TR::loadaddr, 0, localArraySymRef);
+   TR::IlValueImpl *arrayAddressValue = newValue(TR::Address, arrayAddress);
+
+   TraceIL("IlBuilderImpl[ %p ]::CreateLocalArray array allocated %d bytes, address in %d\n", this, size, arrayAddressValue->getID());
+   return arrayAddressValue;
+
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::CreateLocalStruct(TR::IlTypeImpl *structType)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   uint32_t size = structType->getSize();
+   TR::SymbolReference *localStructSymRef = symRefTab()->createLocalPrimArray(size,
+                                                                             methodSymbol(),
+                                                                             8 /*FIXME: JVM-specific - byte*/);
+   char *name = (char *) _comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+   sprintf(name, "_T%u", localStructSymRef->getCPIndex());
+   localStructSymRef->getSymbol()->getAutoSymbol()->setName(name);
+   localStructSymRef->setStackAllocatedArrayAccess();
+
+   TR::Node *structAddress = TR::Node::createWithSymRef(TR::loadaddr, 0, localStructSymRef);
+   TR::IlValueImpl *structAddressValue = newValue(TR::Address, structAddress);
+
+   TraceIL("IlBuilderImpl[ %p ]::CreateLocalStruct struct allocated %d bytes, address in %d\n", this, size, structAddressValue->getID());
+   return structAddressValue;
+   }
+
+void
+OMR::IlBuilderImpl::StoreIndirect(const char *type, const char *field, TR::IlValueImpl *object, TR::IlValueImpl *value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::SymbolReference *symRef = (TR::SymbolReference*)_types->FieldReference(type, field);
+   TR::DataType fieldType = symRef->getSymbol()->getDataType();
+   TraceIL("IlBuilderImpl[ %p ]::StoreIndirect %s.%s (%d) into (%d)\n", this, type, field, value->getID(), object->getID());
+   TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectStore(fieldType);
+   genTreeTop(TR::Node::createWithSymRef(storeOp, 2, loadValue(object), loadValue(value), 0, symRef));
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Load(const char *name)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::SymbolReference *symRef = lookupSymbol(name);
+   TR::Node *valueNode = TR::Node::createLoad(symRef);
+   TR::IlValueImpl *returnValue = newValue(symRef->getSymbol()->getDataType(), valueNode);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Load %s (%d)\n", this, returnValue->getID(), name, symRef->getCPIndex());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::VectorLoad(const char *name)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::SymbolReference *nameSymRef = lookupSymbol(name);
+   TR::DataType returnType = nameSymRef->getSymbol()->getDataType();
+   TR_ASSERT(returnType.isVector(), "VectorLoad must load symbol with a vector type");
+
+   TR::Node *loadNode = TR::Node::createWithSymRef(0, TR::comp()->il.opCodeForDirectLoad(returnType), 0, nameSymRef);
+   TR::IlValueImpl *returnValue = newValue(returnType, loadNode);
+   TraceIL("IlBuilderImpl[ %p ]::%d is VectorLoad %s (%d)\n", this, returnValue->getID(), name, nameSymRef->getCPIndex());
+
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::LoadIndirect(const char *type, const char *field, TR::IlValueImpl *object)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::SymbolReference *symRef = (TR::SymbolReference *)_types->FieldReference(type, field);
+   TR::DataType fieldType = symRef->getSymbol()->getDataType();
+   TR::IlValueImpl *returnValue = newValue(fieldType, TR::Node::createWithSymRef(comp()->il.opCodeForIndirectLoad(fieldType), 1, loadValue(object), 0, symRef));
+   TraceIL("IlBuilderImpl[ %p ]::%d is LoadIndirect %s.%s from (%d)\n", this, returnValue->getID(), type, field, object->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::LoadAt(TR::IlTypeImpl *dt, TR::IlValueImpl *address)
+   {
+   TR_ASSERT(address->getDataType() == TR::Address, "LoadAt needs an address operand");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = indirectLoadNode(dt, loadValue(address));
+   TraceIL("IlBuilderImpl[ %p ]::%d is LoadAt type %d address %d\n", this, returnValue->getID(), dt->getRealPrimitiveType(), address->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::VectorLoadAt(TR::IlTypeImpl *dt, TR::IlValueImpl *address)
+   {
+   TR_ASSERT(address->getDataType() == TR::Address, "LoadAt needs an address operand");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = indirectLoadNode(dt, loadValue(address), true);
+   TraceIL("IlBuilderImpl[ %p ]::%d is VectorLoadAt type %d address %d\n", this, returnValue->getID(), dt->getRealPrimitiveType(), address->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::IndexAt(TR::IlTypeImpl *dt, TR::IlValueImpl *base, TR::IlValueImpl *index)
+   {
+   TR::IlTypeImpl *elemType = dt->baseType()->impl();
+   TR_ASSERT(base->getDataType() == TR::Address, "IndexAt must be called with a pointer base");
+   TR_ASSERT(elemType != NULL, "IndexAt should be called with pointer type");
+   TR_ASSERT(elemType->getRealPrimitiveType() != TR::NoType, "Cannot use IndexAt with pointer to NoType.");
+
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TR::Node *baseNode = loadValue(base);
+   TR::Node *indexNode = loadValue(index);
+   TR::Node *elemSizeNode;
+   TR::ILOpCodes addOp, mulOp;
+   TR::DataType indexType = indexNode->getDataType();
+   if (TR::Compiler->target.is64Bit())
+      {
+      if (indexType != TR::Int64)
+         {
+         TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, TR::Int64);
+         indexNode = TR::Node::create(op, 1, indexNode);
+         }
+      elemSizeNode = TR::Node::lconst(elemType->getSize());
+      addOp = TR::aladd;
+      mulOp = TR::lmul;
+      }
+   else
+      {
+      TR::DataType targetType = TR::Int32;
+      if (indexType != targetType)
+         {
+         TR::ILOpCodes op = TR::DataType::getDataTypeConversion(indexType, targetType);
+         indexNode = TR::Node::create(op, 1, indexNode);
+         }
+      elemSizeNode = TR::Node::iconst(elemType->getSize());
+      addOp = TR::aiadd;
+      mulOp = TR::imul;
+      }
+
+   TR::Node *offsetNode = TR::Node::create(mulOp, 2, indexNode, elemSizeNode);
+   TR::Node *addrNode = TR::Node::create(addOp, 2, baseNode, offsetNode);
+
+   TR::IlValueImpl *address = newValue(Address, addrNode);
+
+   TraceIL("IlBuilderImpl[ %p ]::%d is IndexAt(%s) base %d index %d\n", this, address->getID(), dt->getName(), base->getID(), index->getID());
+
+   return address;
+   }
+
+/**
+ * @brief Generate IL to load the address of a struct field.
+ *
+ * The address of the field is calculated by adding the field's offset to the
+ * base address of the struct. The address is also converted (type casted) to
+ * a pointer to the type of the field.
+ */
+TR::IlValueImpl *
+OMR::IlBuilderImpl::StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValueImpl* obj) {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   auto offset = typeDictionary()->OffsetOf(structName, fieldName);
+   auto ptype = typeDictionary()->PointerTo(typeDictionary()->GetFieldType(structName, fieldName));
+   TR::IlValueImpl* offsetValue = NULL;
+   if (TR::Compiler->target.is64Bit())
+      {
+      offsetValue = ConstInt64(offset);
+      }
+   else
+      {
+      offsetValue = ConstInt32(offset);
+      }
+   auto addr = Add(obj, offsetValue);
+   return ConvertTo(ptype, addr);
+}
+
+/**
+ * @brief Generate IL to load the address of a union field.
+ *
+ * The address of the field is simply the base address of the union, since the
+ * offset of all union fields is zero.
+ */
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValueImpl* obj) {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   auto ptype = typeDictionary()->PointerTo(typeDictionary()->UnionFieldType(unionName, fieldName));
+   return ConvertTo(ptype, obj);
+}
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::NullAddress()
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Address, TR::Node::aconst(0));
+   TraceIL("IlBuilderImpl[ %p ]::%d is NullAddress\n", this, returnValue->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstInt8(int8_t value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Int8, TR::Node::bconst(value));
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstInt8 %d\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstInt16(int16_t value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Int16, TR::Node::sconst(value));
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstInt16 %d\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstInt32(int32_t value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Int32, TR::Node::iconst(value));
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstInt32 %d\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstInt64(int64_t value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Int64, TR::Node::lconst(value));
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstInt64 %d\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstFloat(float value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *fconstNode = TR::Node::create(0, TR::fconst, 0);
+   fconstNode->setFloat(value);
+   TR::IlValueImpl *returnValue = newValue(Float, fconstNode);
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstFloat %f\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstDouble(double value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *dconstNode = TR::Node::create(0, TR::dconst, 0);
+   dconstNode->setDouble(value);
+   TR::IlValueImpl *returnValue = newValue(Double, dconstNode);
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstDouble %lf\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstString(const char * const value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Address, TR::Node::aconst((uintptrj_t)value));
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstString %p\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstAddress(const void * const value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = newValue(Address, TR::Node::aconst((uintptrj_t)value));
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConstAddress %p\n", this, returnValue->getID(), value);
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConstInteger(TR::IlTypeImpl *intType, int64_t value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   if      (intType == Int8)  return ConstInt8 ((int8_t)  value);
+   else if (intType == Int16) return ConstInt16((int16_t) value);
+   else if (intType == Int32) return ConstInt32((int32_t) value);
+   else if (intType == Int64) return ConstInt64(          value);
+
+   TR_ASSERT(0, "unknown integer type");
+   return NULL;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ConvertTo(TR::IlTypeImpl *t, TR::IlValueImpl *v)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::DataType typeFrom = v->getDataType();
+   TR::DataType typeTo = t->getRealPrimitiveType();
+   if (typeFrom == typeTo)
+      {
+      TraceIL("IlBuilderImpl[ %p ]::%d is ConvertTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
+      return v;
+      }
+   TR::IlValueImpl *convertedValue = convertTo(t, v, false);
+   TraceIL("IlBuilderImpl[ %p ]::%d is ConvertTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
+   return convertedValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnsignedConvertTo(TR::IlTypeImpl *t, TR::IlValueImpl *v)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::DataType typeFrom = v->getDataType();
+   TR::DataType typeTo = t->getRealPrimitiveType();
+   if (typeFrom == typeTo)
+      {
+      TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedConvertTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
+      return v;
+      }
+   TR::IlValueImpl *convertedValue = convertTo(t, v, true);
+   TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedConvertTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
+   return convertedValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::convertTo(TR::IlTypeImpl *t, TR::IlValueImpl *v, bool needUnsigned)
+   {
+   TR::DataType typeFrom = v->getDataType();
+   TR::DataType typeTo = t->getRealPrimitiveType();
+
+   TR::ILOpCodes convertOp = ILOpCode::getProperConversion(typeFrom, typeTo, needUnsigned);
+   TR_ASSERT(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d (TR::DataType %d) to type %s", this, v->getID(), (int)typeFrom, t->getName());
+
+   TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
+   TR::IlValueImpl *convertedValue = newValue(t, result);
+   return convertedValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::unaryOp(TR::ILOpCodes op, TR::IlValueImpl *v)
+   {
+   TR::Node *valueNode = loadValue(v);
+   TR::Node *result = TR::Node::create(op, 1, valueNode);
+
+   TR::IlValueImpl *returnValue = newValue(v->getDataType(), result);
+   return returnValue;
+   }
+
+void
+OMR::IlBuilderImpl::doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr)
+   {
+   TR::Node *    left  = *leftPtr;
+   TR::DataType lType = left->getDataType();
+
+   TR::Node *    right = *rightPtr;
+   TR::DataType rType = right->getDataType();
+
+   if (lType.isVector() && !rType.isVector())
+      *rightPtr = TR::Node::create(TR::vsplats, 1, right);
+
+   if (!lType.isVector() && rType.isVector())
+      *leftPtr = TR::Node::create(TR::vsplats, 1, left);
+   }
+
+TR::Node*
+OMR::IlBuilderImpl::binaryOpNodeFromNodes(TR::ILOpCodes op,
+                                 TR::Node *leftNode,
+                                 TR::Node *rightNode) 
+   {
+   TR::DataType leftType = leftNode->getDataType();
+   TR::DataType rightType = rightNode->getDataType();
+   bool isAddressBump = ((leftType == TR::Address) &&
+                            (rightType == TR::Int32 || rightType == TR::Int64));
+   bool isRevAddressBump = ((rightType == TR::Address) &&
+                               (leftType == TR::Int32 || leftType == TR::Int64));
+   TR_ASSERT(leftType == rightType || isAddressBump || isRevAddressBump, "binaryOp requires both left and right operands to have same type or one is address and other is Int32/64");
+
+   if (isRevAddressBump) // swap them
+      {
+      TR::Node *save = leftNode;
+      leftNode = rightNode;
+      rightNode = save;
+      }
+   
+   return TR::Node::create(op, 2, leftNode, rightNode);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::binaryOpFromNodes(TR::ILOpCodes op,
+                             TR::Node *leftNode,
+                             TR::Node *rightNode) 
+   {
+   TR::Node *result = binaryOpNodeFromNodes(op, leftNode, rightNode);
+   TR::IlValueImpl *returnValue = newValue(result->getDataType(), result);
+   return returnValue;
+   } 
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::binaryOpFromOpMap(OpCodeMapper mapOp,
+                             TR::IlValueImpl *left,
+                             TR::IlValueImpl *right)
+   {
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+
+   doVectorConversions(&leftNode, &rightNode);
+
+   TR::DataType leftType = leftNode->getDataType();
+   return binaryOpFromNodes(mapOp(leftType), leftNode, rightNode);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::binaryOpFromOpCode(TR::ILOpCodes op,
+                              TR::IlValueImpl *left,
+                              TR::IlValueImpl *right)
+   {
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   //doVectorConversions(&left, &right);
+   return binaryOpFromNodes(op, leftNode, rightNode);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::compareOp(TR_ComparisonTypes ct,
+                     bool needUnsigned,
+                     TR::IlValueImpl *left,
+                     TR::IlValueImpl *right)
+   {
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::ILOpCodes op = TR::ILOpCode::compareOpCode(leftNode->getDataType(), ct, needUnsigned);
+   return binaryOpFromOpCode(op, left, right);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::NotEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpNE, false, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is NotEqualTo %d != %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+void
+OMR::IlBuilderImpl::Goto(TR::IlBuilderImpl **dest)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *dest = createBuilderIfNeeded(*dest);
+   Goto(*dest);
+   }
+
+void
+OMR::IlBuilderImpl::Goto(TR::IlBuilderImpl *dest)
+   {
+   TR_ASSERT(dest != NULL, "This goto implementation requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::Goto %p\n", this, dest);
+   appendGoto(dest->getEntry());
+   setDoesNotComeBack();
+   }
+
+void
+OMR::IlBuilderImpl::Return()
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::Return\n", this);
+   TR::Node *returnNode = TR::Node::create(TR::ILOpCode::returnOpCode(TR::NoType));
+   genTreeTop(returnNode);
+   cfg()->addEdge(_currentBlock, cfg()->getEnd());
+   setDoesNotComeBack();
+   }
+
+void
+OMR::IlBuilderImpl::Return(TR::IlValueImpl *value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::Return %d\n", this, value->getID());
+   TR::Node *returnNode = TR::Node::create(TR::ILOpCode::returnOpCode(value->getDataType()), 1, loadValue(value));
+   genTreeTop(returnNode);
+   cfg()->addEdge(_currentBlock, cfg()->getEnd());
+   setDoesNotComeBack();
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Sub(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = NULL;
+   if (left->getDataType() == TR::Address)
+      {
+      if (right->getDataType() == TR::Int32)
+         returnValue = binaryOpFromNodes(TR::aiadd, loadValue(left), loadValue(Sub(ConstInt32(0), right)));
+      else if (right->getDataType() == TR::Int64)
+         returnValue = binaryOpFromNodes(TR::aladd, loadValue(left), loadValue(Sub(ConstInt64(0), right)));
+      }
+   if (returnValue == NULL)
+      returnValue=binaryOpFromOpMap(TR::ILOpCode::subtractOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Sub %d - %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+static TR::ILOpCodes addOpCode(TR::DataType type)
+   {
+   return TR::ILOpCode::addOpCode(type, TR::Compiler->target.is64Bit());
+   }
+
+static TR::ILOpCodes unsignedAddOpCode(TR::DataType type)
+   {
+   return TR::ILOpCode::unsignedAddOpCode(type, TR::Compiler->target.is64Bit());
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Add(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue = NULL;
+   if (left->getDataType() == TR::Address)
+      {
+      if (right->getDataType() == TR::Int32)
+         returnValue = binaryOpFromNodes(TR::aiadd, loadValue(left), loadValue(right));
+      else if (right->getDataType() == TR::Int64)
+         returnValue = binaryOpFromNodes(TR::aladd, loadValue(left), loadValue(right));
+      }
+   if (returnValue == NULL)
+      returnValue = binaryOpFromOpMap(addOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Add %d + %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+/*
+ * blockThrowsException:
+ * ....
+ * goto blockAfterExceptionHandler 
+ * Handler:
+ * ....
+ * goto blockAfterExceptionHandler 
+ * blockAfterExceptionHandler:
+ */
+void
+OMR::IlBuilderImpl::appendExceptionHandler(TR::Block *blockThrowsException, TR::IlBuilderImpl **handler, uint32_t catchType)
+   {
+   //split block after overflowCHK, and add an goto to blockAfterExceptionHandler
+   appendBlock();
+   TR::Block *blockWithGoto = _currentBlock;
+   TR::Node *gotoNode = TR::Node::create(NULL, TR::Goto);
+   genTreeTop(gotoNode);
+   _currentBlock = NULL;
+   _currentBlockNumber = -1;
+ 
+   //append handler, add exception edge and merge edge
+   *handler = createBuilderIfNeeded(*handler);
+   TR_ASSERT(*handler != NULL, "exception handler cannot be NULL\n");
+   (*handler)->_isHandler = true;
+   cfg()->addExceptionEdge(blockThrowsException, (*handler)->getEntry());
+   AppendBuilder(*handler);
+   (*handler)->setHandlerInfo(catchType);
+
+   TR::Block *blockAfterExceptionHandler = _currentBlock;
+   TraceIL("blockAfterExceptionHandler block_%d, blockWithGoto block_%d \n", blockAfterExceptionHandler->getNumber(), blockWithGoto->getNumber());
+   gotoNode->setBranchDestination(blockAfterExceptionHandler->getEntry());
+   cfg()->addEdge(blockWithGoto, blockAfterExceptionHandler);
+   }
+
+void
+OMR::IlBuilderImpl::setHandlerInfo(uint32_t catchType)
+   {
+   TR::Block *catchBlock = getEntry();
+   catchBlock->setIsCold();
+   catchBlock->setHandlerInfoWithOutBCInfo(catchType, comp()->getInlineDepth(), -1, _methodSymbol->getResolvedMethod(), comp());
+   }
+
+TR::Node*
+OMR::IlBuilderImpl::genOverflowCHKTreeTop(TR::Node *operationNode, TR::ILOpCodes overflow)
+   {
+   TR::Node *overflowChkNode = TR::Node::createWithRoomForOneMore(overflow, 3, symRefTab()->findOrCreateOverflowCheckSymbolRef(_methodSymbol), operationNode, operationNode->getFirstChild(), operationNode->getSecondChild());
+   overflowChkNode->setOverflowCheckOperation(operationNode->getOpCodeValue());
+   genTreeTop(overflowChkNode);
+   return overflowChkNode;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::genOperationWithOverflowCHK(TR::ILOpCodes op,
+                                                TR::Node *leftNode,
+                                                TR::Node *rightNode,
+                                                TR::IlBuilderImpl **handler,
+                                                TR::ILOpCodes overflow)
+   {
+   /*
+    * BB1:
+    *    overflowCHK
+    *       operation(add/sub/mul)
+    *          child1
+    *          child2
+    *       =>child1
+    *       =>child2
+    *    store
+    *       => operation
+    * BB2:
+    *    goto BB3 
+    * Handler:
+    *    ...
+    * BB3:
+    *    continue
+    */
+   TR::Node *operationNode = binaryOpNodeFromNodes(op, leftNode, rightNode);
+   TR::Node *overflowChkNode = genOverflowCHKTreeTop(operationNode, overflow);
+
+   TR::Block *blockWithOverflowCHK = _currentBlock;
+   TR::IlValueImpl *resultValue = newValue(operationNode->getDataType(), operationNode);
+   genTreeTop(TR::Node::createStore(resultValue->getSymbolReference(), operationNode));
+
+   appendExceptionHandler(blockWithOverflowCHK, handler, TR::Block::CanCatchOverflowCheck);
+   return resultValue;
+   }
+
+// This function takes 4 arguments and generate the addValue.
+// This function is called by AddWithOverflow and AddWithUnsignedOverflow.
+TR::ILOpCodes 
+OMR::IlBuilderImpl::getOpCode(TR::IlValueImpl *leftValue, TR::IlValueImpl *rightValue)
+   {
+   TR::ILOpCodes op;
+   if (leftValue->getDataType() == TR::Address)
+      {
+      if (rightValue->getDataType() == TR::Int32)
+         op = TR::aiadd;
+      else if (rightValue->getDataType() == TR::Int64)
+         op = TR::aladd;
+      else 
+         TR_ASSERT(0, "the right child type must be either TR::Int32 or TR::Int64 when the left child of Add is TR::Address\n");
+      }    
+   else 
+      {
+      op = addOpCode(leftValue->getDataType());
+      }
+   return op; 
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::AddWithOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::ILOpCodes opcode = getOpCode(left, right);
+   TR::IlValueImpl *addValue = genOperationWithOverflowCHK(opcode, leftNode, rightNode, handler, TR::OverflowCHK);
+   TraceIL("IlBuilderImpl[ %p ]::%d is AddWithOverflow %d + %d\n", this, addValue->getID(), left->getID(), right->getID());
+   return addValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::AddWithUnsignedOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::ILOpCodes opcode = getOpCode(left, right);
+   TR::IlValueImpl *addValue = genOperationWithOverflowCHK(opcode, leftNode, rightNode, handler, TR::UnsignedOverflowCHK);
+   TraceIL("IlBuilderImpl[ %p ]::%d is AddWithUnsignedOverflow %d + %d\n", this, addValue->getID(), left->getID(), right->getID());
+   return addValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::SubWithOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::IlValueImpl *subValue = genOperationWithOverflowCHK(TR::ILOpCode::subtractOpCode(leftNode->getDataType()), leftNode, rightNode, handler, TR::OverflowCHK);
+   TraceIL("IlBuilderImpl[ %p ]::%d is SubWithOverflow %d + %d\n", this, subValue->getID(), left->getID(), right->getID());
+   return subValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::SubWithUnsignedOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::IlValueImpl *unsignedSubValue = genOperationWithOverflowCHK(TR::ILOpCode::subtractOpCode(leftNode->getDataType()), leftNode, rightNode, handler, TR::UnsignedOverflowCHK);
+   TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedSubWithOverflow %d + %d\n", this, unsignedSubValue->getID(), left->getID(), right->getID());
+   return unsignedSubValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::MulWithOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::IlValueImpl *mulValue = genOperationWithOverflowCHK(TR::ILOpCode::multiplyOpCode(leftNode->getDataType()), leftNode, rightNode, handler, TR::OverflowCHK);
+   TraceIL("IlBuilderImpl[ %p ]::%d is MulWithOverflow %d + %d\n", this, mulValue->getID(), left->getID(), right->getID());
+   return mulValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Mul(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=binaryOpFromOpMap(TR::ILOpCode::multiplyOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Mul %d * %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Div(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=binaryOpFromOpMap(TR::ILOpCode::divideOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Div %d / %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::And(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=binaryOpFromOpMap(TR::ILOpCode::andOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is And %d & %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Or(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=binaryOpFromOpMap(TR::ILOpCode::orOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Or %d | %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Xor(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=binaryOpFromOpMap(TR::ILOpCode::xorOpCode, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is Xor %d ^ %d\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::Node*
+OMR::IlBuilderImpl::shiftOpNodeFromNodes(TR::ILOpCodes op,
+                                TR::Node *leftNode,
+                                TR::Node *rightNode) 
+   {
+   TR::DataType leftType = leftNode->getDataType();
+   TR::DataType rightType = rightNode->getDataType();
+   TR_ASSERT(leftType.isIntegral() && rightType.isInt32(), "shift operation first operand must be an integer, and shift amount must be 32-bit integer");
+
+   return TR::Node::create(op, 2, leftNode, rightNode);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::shiftOpFromNodes(TR::ILOpCodes op,
+                            TR::Node *leftNode,
+                            TR::Node *rightNode) 
+   {
+   TR::Node *result = shiftOpNodeFromNodes(op, leftNode, rightNode);
+   TR::IlValueImpl *returnValue = newValue(result->getDataType(), result);
+   return returnValue;
+   } 
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::shiftOpFromOpMap(OpCodeMapper mapOp,
+                            TR::IlValueImpl *left,
+                            TR::IlValueImpl *right)
+   {
+   TR::Node *leftNode = loadValue(left);
+   TR::DataType leftType = leftNode->getDataType();
+   TR_ASSERT(leftType.isIntegral(), "left operand of shift must be integer type");
+
+   TR::Node *rightNode = loadValue(right);
+   if (!rightNode->getDataType().isInt32())
+      right = ConvertTo(Int32, right);
+
+   doVectorConversions(&leftNode, &rightNode);
+
+   return shiftOpFromNodes(mapOp(leftType), leftNode, rightNode);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ShiftL(TR::IlValueImpl *v, TR::IlValueImpl *amount)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=shiftOpFromOpMap(TR::ILOpCode::shiftLeftOpCode, v, amount);
+   TraceIL("IlBuilderImpl[ %p ]::%d is shr %d << %d\n", this, returnValue->getID(), v->getID(), amount->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ShiftR(TR::IlValueImpl *v, TR::IlValueImpl *amount)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=shiftOpFromOpMap(TR::ILOpCode::shiftRightOpCode, v, amount);
+   TraceIL("IlBuilderImpl[ %p ]::%d is shr %d >> %d\n", this, returnValue->getID(), v->getID(), amount->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnsignedShiftR(TR::IlValueImpl *v, TR::IlValueImpl *amount)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=shiftOpFromOpMap(TR::ILOpCode::unsignedShiftRightOpCode, v, amount);
+   TraceIL("IlBuilderImpl[ %p ]::%d is unsigned shr %d >> %d\n", this, returnValue->getID(), v->getID(), amount->getID());
+   return returnValue;
+   }
+
+/*
+ * @brief IfAnd service for constructing short circuit AND conditional nests (like the && operator)
+ * @param allTrueBuilder builder containing operations to execute if all conditional tests evaluate to true
+ * @param anyFalseBuilder builder containing operations to execute if any conditional test is false
+ * @param numTerms the number of conditional terms
+ * @param ... for each term, provide a TR::IlBuilderImpl object and a TR::IlValueImpl object that evaluates a condition (builder is where all the operations to evaluate the condition go, the value is the final result of the condition)
+ *
+ * Example:
+ * TR::IlBuilder *cond1Builder = OrphanBuilder();
+ * TR::IlValue *cond1 = cond1Builder->GreaterOrEqual(
+ *                      cond1Builder->   Load("x"),
+ *                      cond1Builder->   Load("lower"));
+ * TR::IlBuilder *cond2Builder = OrphanBuilder();
+ * TR::IlValue *cond2 = cond2Builder->LessThan(
+ *                      cond2Builder->   Load("x"),
+ *                      cond2Builder->   Load("upper"));
+ * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
+ * IfAnd(&inRange, &outOfRange, 2, cond1Builder, cond1, cond2Builder, cond2);
+ */
+void
+OMR::IlBuilderImpl::IfAnd(TR::IlBuilderImpl **allTrueBuilder, TR::IlBuilderImpl **anyFalseBuilder, int32_t numTerms, TR::IlBuilderImpl **caseBuilders, TR::IlValueImpl **caseValues)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlBuilderImpl *mergePoint = orphanBuilderImpl();
+   *allTrueBuilder = createBuilderIfNeeded(*allTrueBuilder);
+   *anyFalseBuilder = createBuilderIfNeeded(*anyFalseBuilder);
+
+   for (int32_t t=0;t < numTerms;t++)
+      {
+      TR::IlBuilderImpl *condBuilder = caseBuilders[t];
+      TR::IlValueImpl *condValue = caseValues[t];
+      AppendBuilder(condBuilder);
+      condBuilder->IfCmpEqualZero(anyFalseBuilder, condValue);
+      // otherwise fall through to test next term
+      }
+
+   // if control gets here, all the provided terms were true
+   AppendBuilder(*allTrueBuilder);
+   Goto(mergePoint);
+
+   // also need to handle the false case
+   AppendBuilder(*anyFalseBuilder);
+   Goto(mergePoint);
+
+   AppendBuilder(mergePoint);
+
+   // return state for "this" can get confused by the Goto's in this service
+   setComesBack();
+   }
+
+/*
+ * @brief IfOr service for constructing short circuit OR conditional nests (like the || operator)
+ * @param anyTrueBuilder builder containing operations to execute if any conditional test evaluates to true
+ * @param allFalseBuilder builder containing operations to execute if all conditional tests are false
+ * @param numTerms the number of conditional terms
+ * @param ... for each term, provide a TR::IlBuilderImpl object and a TR::IlValueImpl object that evaluates a condition (builder is where all the operations to evaluate the condition go, the value is the final result of the condition)
+ *
+ * Example:
+ * TR::IlBuilder *cond1Builder = OrphanBuilder();
+ * TR::IlValue *cond1 = cond1Builder->LessThan(
+ *                      cond1Builder->   Load("x"),
+ *                      cond1Builder->   Load("lower"));
+ * TR::IlBuilder *cond2Builder = OrphanBuilder();
+ * TR::IlValue *cond2 = cond2Builder->GreaterOrEqual(
+ *                      cond2Builder->   Load("x"),
+ *                      cond2Builder->   Load("upper"));
+ * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
+ * IfOr(&outOfRange, &inRange, 2, cond1Builder, cond1, cond2Builder, cond2);
+ */
+void
+OMR::IlBuilderImpl::IfOr(TR::IlBuilderImpl **anyTrueBuilder, TR::IlBuilderImpl **allFalseBuilder, int32_t numTerms, TR::IlBuilderImpl **caseBuilders, TR::IlValueImpl **caseValues)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlBuilderImpl *mergePoint = orphanBuilderImpl();
+   *anyTrueBuilder = createBuilderIfNeeded(*anyTrueBuilder);
+   *allFalseBuilder = createBuilderIfNeeded(*allFalseBuilder);
+
+   for (int32_t t=0;t < numTerms-1;t++)
+      {
+      TR::IlBuilderImpl *condBuilder = caseBuilders[t];
+      TR::IlValueImpl *condValue = caseValues[t];
+      AppendBuilder(condBuilder);
+      condBuilder->IfCmpNotEqualZero(anyTrueBuilder, condValue);
+      // otherwise fall through to test next term
+      }
+
+   // reverse condition on last term so that it can fall through to anyTrueBuilder
+   TR::IlBuilderImpl *condBuilder = caseBuilders[numTerms-1];
+   TR::IlValueImpl *condValue = caseValues[numTerms-1];
+   AppendBuilder(condBuilder);
+   condBuilder->IfCmpEqualZero(allFalseBuilder, condValue);
+
+   // any true term will end up here
+   AppendBuilder(*anyTrueBuilder);
+   Goto(mergePoint);
+
+   // if control gets here, all the provided terms were false
+   AppendBuilder(*allFalseBuilder);
+   Goto(mergePoint);
+
+   AppendBuilder(mergePoint);
+
+   // return state for "this" can get confused by the Goto's in this service
+   setComesBack();
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::EqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpEQ, false, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is EqualTo %d == %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+void
+OMR::IlBuilderImpl::integerizeAddresses(TR::IlValueImpl **leftPtr, TR::IlValueImpl **rightPtr)
+   {
+   TR::IlValueImpl *left = *leftPtr;
+   if (left->getDataType() == TR::Address)
+      *leftPtr = ConvertTo(Word, left);
+
+   TR::IlValueImpl *right = *rightPtr;
+   if (right->getDataType() == TR::Address)
+      *rightPtr = ConvertTo(Word, right);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::LessThan(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpLT, false, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is LessThan %d < %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnsignedLessThan(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpLT, true, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedLessThan %d < %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::LessOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpLE, false, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is LessOrEqualTo %d <= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnsignedLessOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpLE, true, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedLessOrEqualTo %d <= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::GreaterThan(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpGT, false, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is GreaterThan %d > %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnsignedGreaterThan(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpGT, true, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedGreaterThan %d > %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::GreaterOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpGE, false, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is GreaterOrEqualTo %d >= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::UnsignedGreaterOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   integerizeAddresses(&left, &right);
+   TR::IlValueImpl *returnValue=compareOp(TR_cmpGE, true, left, right);
+   TraceIL("IlBuilderImpl[ %p ]::%d is UnsignedGreaterOrEqualTo %d >= %d?\n", this, returnValue->getID(), left->getID(), right->getID());
+   return returnValue;
+   }
+
+TR::IlValueImpl** 
+OMR::IlBuilderImpl::processCallArgs(TR::Compilation *comp, int numArgs, va_list args)
+   {
+   TR::IlValueImpl ** argValues = (TR::IlValueImpl **) comp->trMemory()->allocateHeapMemory(numArgs * sizeof(TR::IlValueImpl *));
+   for (int32_t a=0;a < numArgs;a++)
+      {
+      argValues[a] = va_arg(args, TR::IlValueImpl*);
+      }
+   return argValues;
+   }
+
+/*
+ * \param numArgs 
+ *    Number of actual arguments for the method  plus 1 
+ * \param argValues
+ *    the computed address followed by the actual arguments
+ */
+TR::IlValueImpl *
+OMR::IlBuilderImpl::ComputedCall(const char *functionName, int32_t numArgs, TR::IlValueImpl **argValues)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::ComputedCall %s\n", this, functionName);
+   TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
+      resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
+   return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::Call(const char *functionName, int32_t numArgs, TR::IlValueImpl **argValues)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::Call %s\n", this, functionName);
+   TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
+      resolvedMethod = _methodBuilder->lookupFunction(functionName);
+   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
+   return genCall(methodSymRef, numArgs, argValues);
+   }
+
+TR::IlValueImpl *
+OMR::IlBuilderImpl::genCall(TR::SymbolReference *methodSymRef,
+                            int32_t numArgs,
+                            TR::IlValueImpl ** argValues,
+                            bool isDirectCall /* true by default*/)
+   {
+   TR::DataType returnType = methodSymRef->getSymbol()->castToMethodSymbol()->getMethod()->returnType();
+   TR::Node *callNode = TR::Node::createWithSymRef(isDirectCall? TR::ILOpCode::getDirectCall(returnType): TR::ILOpCode::getIndirectCall(returnType), numArgs, methodSymRef);
+
+   // TODO: should really verify argument types here
+   int32_t childIndex = 0;
+   for (int32_t a=0;a < numArgs;a++)
+      {
+      TR::IlValueImpl *arg = argValues[a];
+
+      // widen narrow integer arguments to a machine word
+      // if client relies on this implicit behaviour, then gets *signed* extension
+      if (arg->getDataType() == TR::Int8 || arg->getDataType() == TR::Int16 || (Word == Int64 && arg->getDataType() == TR::Int32))
+         arg = ConvertTo(Word, arg);
+      callNode->setAndIncChild(childIndex++, loadValue(arg));
+      }
+
+   // callNode must be anchored by itself
+   genTreeTop(callNode);
+
+   if (returnType != TR::NoType)
+      {
+      TR::IlValueImpl *returnValue = newValue(callNode->getDataType(), callNode);
+      return returnValue;
+      }
+
+   return NULL;
+   }
+
+/** \brief
+ *     The service is used to atomically increase memory location \p baseAddress by amount of \p value. 
+ *
+ *  \param value
+ *     The amount to increase for the memory location.
+ *
+ *  \note
+ *     This service currently only supports Int32/Int64. 
+ *
+ *  \return
+ *     The old value at the location \p baseAddress.
+ */
+TR::IlValueImpl *
+OMR::IlBuilderImpl::AtomicAdd(TR::IlValueImpl * baseAddress, TR::IlValueImpl * value)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TR_ASSERT(comp()->cg()->supportsAtomicAdd(), "this platform doesn't support AtomicAdd() yet");
+   TR_ASSERT(baseAddress->getDataType() == TR::Address, "baseAddress must be TR::Address");
+
+   //Determine the implementation type and returnType by detecting "value"'s type
+   TR::DataType returnType = value->getDataType();
+   TR_ASSERT(returnType == TR::Int32 || (returnType == TR::Int64 && TR::Compiler->target.is64Bit()), "AtomicAdd currently only supports Int32/64 values");
+   TraceIL("IlBuilder[ %p ]::AtomicAdd(%d, %d)\n", this, baseAddress->getID(), value->getID());
+
+   OMR::SymbolReferenceTable::CommonNonhelperSymbol atomicBitSymbol = returnType == TR::Int32 ? TR::SymbolReferenceTable::atomicAdd32BitSymbol : TR::SymbolReferenceTable::atomicAdd64BitSymbol;//lock add
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(atomicBitSymbol); 
+   TR::Node *callNode;
+   callNode = TR::Node::createWithSymRef(TR::ILOpCode::getDirectCall(returnType), 2, methodSymRef);
+   callNode->setAndIncChild(0, loadValue(baseAddress));
+   callNode->setAndIncChild(1, loadValue(value));
+
+   TR::IlValueImpl *returnValue = newValue(callNode->getDataType(), callNode);
+   return returnValue; 
+   }
+
+
+/**
+ * \brief
+ *  The service is for generating a treetop for transaction begin when the user needs to use transactional memory.
+ *  At the end of transaction path, service will automatically generate transaction end instruction.
+ *
+ * \verbatim
+ *   
+ *    +---------------------------------+
+ *    |<block_$tstart>                  |
+ *    |==============                   |
+ *    | TSTART                          |
+ *    |    |                            |
+ *    |    |_ <block_$persistentFailure>|
+ *    |    |_ <block_$transientFailure> |
+ *    |    |_ <block_$transaction>      |+------------------------+----------------------------------+
+ *    |                                 |                         |                                  |
+ *    +---------------------------------+                         |                                  |
+ *                       |                                        |                                  |
+ *                       v                                        V                                  V
+ *    +-----------------------------------------+   +-------------------------------+    +-------------------------+     
+ *    |<block_$transaction>                     |   |<block_$persistentFailure>     |    |<block_$transientFailure>|      
+ *    |====================                     |   |===========================    |    |=========================|
+ *    |     add (For illustration, we take add  |   |AtomicAdd (For illustration, we|    |   ...                   |
+ *    |     ... as an example. User could       |   |...       take atomicAdd as an |    |   ...                   |
+ *    |     ... replace it with other non-atomic|   |...       example. User could  |    |   ...                   |
+ *    |     ... operations.)                    |   |...       replace it with other|    |   ...                   |
+ *    |     ...                                 |   |...       atomic operations.)  |    |   ...                   |
+ *    |     TEND                                |   |...                            |    |   ...                   |
+ *    |goto --> block_$merge                    |   |goto->block_$merge             |    |goto->block_$merge       |
+ *    +----------------------------------------+    +-------------------------------+    +-------------------------+
+ *                      |                                          |                                 |
+ *                      |                                          |                                 |
+ *                      |------------------------------------------+---------------------------------+
+ *                      |
+ *                      v             
+ *              +----------------+     
+ *              | block_$merge   |     
+ *              | ============== |   
+ *              |      ...       |
+ *              +----------------+   
+ *
+ * \endverbatim 
+ *
+ * \structure & \param value
+ *     tstart
+ *       |
+ *       ----persistentFailure // This is a permanent failure, try atomic way to do it instead
+ *       |
+ *       ----transientFailure // Temporary failure, user can retry 
+ *       |
+ *       ----transaction // Success, use general(non-atomic) way to do it
+ *                |
+ *                ---- non-atomic operations
+ *                |
+ *                ---- ...
+ *                |
+ *                ---- tend
+ *
+ * \note
+ *      If user's platform doesn't support TM, go to persistentFailure path directly/
+ *      In this case, current IlBuilderImpl walks around transientFailureBuilder and transactionBuilder
+ *      and goes to persistentFailureBuilder.
+ *      
+ *      _currentBuilder
+ *          |
+ *          ->Goto()
+ *              |   transientFailureBuilder 
+ *              |   transactionBuilder
+ *              |-->persistentFailurie
+ */
+void
+OMR::IlBuilderImpl::Transaction(TR::IlBuilderImpl **persistentFailureBuilder,
+                                TR::IlBuilderImpl **transientFailureBuilder,
+                                TR::IlBuilderImpl **transactionBuilder)
+   {   
+   // This assertion is to rule out platforms which don't have HTM support
+   TR_ASSERT(comp()->cg()->hasTMEvaluator(), "this platform doesn't support tstart or tfinish evaluator yet");
+    
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TraceIL("IlBuilderImpl[ %p ]::transactionBegin %p, %p, %p, %p)\n", this, *persistentFailureBuilder, *transientFailureBuilder, *transactionBuilder);
+
+   appendBlock();
+
+   TR::Block *mergeBlock = emptyBlock();
+   *persistentFailureBuilder = createBuilderIfNeeded(*persistentFailureBuilder);
+   *transientFailureBuilder = createBuilderIfNeeded(*transientFailureBuilder);
+   *transactionBuilder = createBuilderIfNeeded(*transactionBuilder);
+
+   if (!comp()->cg()->getSupportsTM())
+      {
+      // if user's processor doesn't support TM.
+      // we will walk around transaction and transientFailure paths
+
+      Goto(persistentFailureBuilder);
+
+      AppendBuilder(*transactionBuilder);
+      AppendBuilder(*transientFailureBuilder);
+
+      AppendBuilder(*persistentFailureBuilder);
+      appendBlock(mergeBlock);
+      return;
+      }
+
+   TR::Node *persistentFailureNode = TR::Node::create(TR::branch, 0, (*persistentFailureBuilder)->getEntry()->getEntry());
+   TR::Node *transientFailureNode = TR::Node::create(TR::branch, 0, (*transientFailureBuilder)->getEntry()->getEntry());
+   TR::Node *transactionNode = TR::Node::create(TR::branch, 0, (*transactionBuilder)->getEntry()->getEntry());
+
+   TR::Node *tStartNode = TR::Node::create(TR::tstart, 3, persistentFailureNode, transientFailureNode, transactionNode);   
+   tStartNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionEntrySymbolRef(comp()->getMethodSymbol()));
+   
+   genTreeTop(tStartNode);
+
+   // connecting the block having tstart with persistentFailure's and transaction's blocks 
+   cfg()->addEdge(_currentBlock, (*persistentFailureBuilder)->getEntry());
+   cfg()->addEdge(_currentBlock, (*transientFailureBuilder)->getEntry());
+   cfg()->addEdge(_currentBlock, (*transactionBuilder)->getEntry());
+
+   appendNoFallThroughBlock();
+   AppendBuilder(*transientFailureBuilder);
+   gotoBlock(mergeBlock);
+
+   AppendBuilder(*persistentFailureBuilder);
+   gotoBlock(mergeBlock);
+
+   AppendBuilder(*transactionBuilder);
+    
+   // ending the transaction at the end of transactionBuilder
+   appendBlock();
+   TR::Node *tEndNode=TR::Node::create(TR::tfinish,0);
+   tEndNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionExitSymbolRef(comp()->getMethodSymbol()));
+   genTreeTop(tEndNode);
+
+   // Three IlBuilderImpls above merged here
+   appendBlock(mergeBlock);
+   }  
+
+
+/**
+ * Generate XABORT instruction to abort transaction
+ */
+void
+OMR::IlBuilderImpl::TransactionAbort()
+   {
+   // This assertion is to rule out platforms which don't have HTM support
+   TR_ASSERT(comp()->cg()->hasTMEvaluator(), "this platform doesn't support tstart or tfinish evaluator yet");
+   // Should really verify we're in a transaction here
+
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::transactionAbort", this);
+   TR::Node *tAbortNode = TR::Node::create(TR::tabort, 0);
+   tAbortNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionAbortSymbolRef(comp()->getMethodSymbol()));
+   genTreeTop(tAbortNode);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpNotEqualZero(TR::IlBuilderImpl **target, TR::IlValueImpl *condition)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpNotEqualZero(*target, condition);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpNotEqualZero(TR::IlBuilderImpl *target, TR::IlValueImpl *condition)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpNotEqualZero requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpNotEqualZero %d? -> [ %p ] B%d\n", this, condition->getID(), target, target->getEntry()->getNumber());
+   ifCmpNotEqualZero(condition, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpNotEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpNotEqual(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpNotEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpNotEqual requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpNotEqual %d == %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpNE, false, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpEqualZero(TR::IlBuilderImpl **target, TR::IlValueImpl *condition)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpEqualZero(*target, condition);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpEqualZero(TR::IlBuilderImpl *target, TR::IlValueImpl *condition)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpEqualZero requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpEqualZero %d == 0? -> [ %p ] B%d\n", this, condition->getID(), target, target->getEntry()->getNumber());
+   ifCmpEqualZero(condition, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpEqual(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpEqual requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpEqual %d == %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpEQ, false, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpLessThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpLessThan(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpLessThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpLessThan requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpLessThan %d < %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpLT, false, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedLessThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpUnsignedLessThan(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedLessThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpUnsignedLessThan requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpUnsignedLessThan %d < %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpLT, true, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpLessOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpLessOrEqual(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpLessOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpLessOrEqual requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpLessOrEqual %d <= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpLE, false, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedLessOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpUnsignedLessOrEqual(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedLessOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpUnsignedLessOrEqual requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpUnsignedLessOrEqual %d <= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpLE, true, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpGreaterThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpGreaterThan(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpGreaterThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpGreaterThan requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpGreaterThan %d > %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpGT, false, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedGreaterThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpUnsignedGreaterThan(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedGreaterThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpUnsignedGreaterThan requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpUnsignedGreaterThan %d > %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpGT, true, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpGreaterOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpGreaterOrEqual(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpGreaterOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpGreaterOrEqual requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpGreaterOrEqual %d >= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpGE, false, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedGreaterOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   *target = createBuilderIfNeeded(*target);
+   IfCmpUnsignedGreaterOrEqual(*target, left, right);
+   }
+
+void
+OMR::IlBuilderImpl::IfCmpUnsignedGreaterOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right)
+   {
+   TR_ASSERT(target != NULL, "This IfCmpUnsignedGreaterOrEqual requires a non-NULL builder object");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+   TraceIL("IlBuilderImpl[ %p ]::IfCmpUnsignedGreaterOrEqual %d >= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
+   ifCmpCondition(TR_cmpGE, true, left, right, target->getEntry());
+   }
+
+void
+OMR::IlBuilderImpl::ifCmpCondition(TR_ComparisonTypes ct, bool isUnsignedCmp, TR::IlValueImpl *left, TR::IlValueImpl *right, TR::Block *target)
+   {
+   integerizeAddresses(&left, &right);
+   TR::Node *leftNode = loadValue(left);
+   TR::Node *rightNode = loadValue(right);
+   TR::ILOpCode cmpOpCode(TR::ILOpCode::compareOpCode(leftNode->getDataType(), ct, isUnsignedCmp));
+   ifjump(cmpOpCode.convertCmpToIfCmp(),
+          leftNode,
+          rightNode,
+          target);
+   appendBlock();
+   }
+
+void
+OMR::IlBuilderImpl::ifCmpNotEqualZero(TR::IlValueImpl *condition, TR::Block *target)
+   {
+   ifCmpCondition(TR_cmpNE, false, condition, zeroForValue(condition), target);
+   }
+
+void
+OMR::IlBuilderImpl::ifCmpEqualZero(TR::IlValueImpl *condition, TR::Block *target)
+   {
+   ifCmpCondition(TR_cmpEQ, false, condition, zeroForValue(condition), target);
+   }
+
+void
+OMR::IlBuilderImpl::appendGoto(TR::Block *destBlock)
+   {
+   gotoBlock(destBlock);
+   appendBlock();
+   }
+
+/* Flexible builder for if...then...else structures
+ * Basically 3 ways to call it:
+ *    1) with then and else paths
+ *    2) only a then path
+ *    3) only an else path
+ * #2 and #3 are similar: the existing path is appended and the proper condition causes branch around to the merge point
+ * #1: then path exists "out of line", else path falls through from If and then jumps to merge, followed by then path which
+ *     falls through to the merge point
+ */
+void
+OMR::IlBuilderImpl::IfThenElse(TR::IlBuilderImpl **thenPath, TR::IlBuilderImpl **elsePath, TR::IlValueImpl *condition)
+   {
+   TR_ASSERT(thenPath != NULL || elsePath != NULL, "IfThenElse needs at least one conditional path");
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TR::Block *thenEntry = NULL;
+   TR::Block *elseEntry = NULL;
+
+   if (thenPath)
+      {
+      *thenPath = createBuilderIfNeeded(*thenPath);
+      thenEntry = (*thenPath)->getEntry();
+      }
+
+   if (elsePath)
+      {
+      *elsePath = createBuilderIfNeeded(*elsePath);
+      elseEntry = (*elsePath)->getEntry();
+      }
+
+   TR::Block *mergeBlock = emptyBlock();
+
+   TraceIL("IlBuilderImpl[ %p ]::IfThenElse %d", this, condition->getID());
+   if (thenEntry)
+      TraceIL(" then B%d", thenEntry->getNumber());
+   if (elseEntry)
+      TraceIL(" else B%d", elseEntry->getNumber());
+   TraceIL(" merge B%d\n", mergeBlock->getNumber());
+
+   if (thenPath == NULL) // case #3
+      {
+      ifCmpNotEqualZero(condition, mergeBlock);
+      if ((*elsePath)->_partOfSequence)
+         gotoBlock(elseEntry);
+      else
+         AppendBuilder(*elsePath);
+      }
+   else if (elsePath == NULL) // case #2
+      {
+      ifCmpEqualZero(condition, mergeBlock);
+      if ((*thenPath)->_partOfSequence)
+         gotoBlock(thenEntry);
+      else
+         AppendBuilder(*thenPath);
+      }
+   else // case #1
+      {
+      ifCmpNotEqualZero(condition, thenEntry);
+      if ((*elsePath)->_partOfSequence)
+         {
+         gotoBlock(elseEntry);
+         }
+      else
+         {
+         AppendBuilder(*elsePath);
+         appendGoto(mergeBlock);
+         }
+      if (!(*thenPath)->_partOfSequence)
+         AppendBuilder(*thenPath);
+      // if then path exists elsewhere already,
+      //  then IfCmpNotEqual above already brances to it
+      }
+
+   // all paths possibly merge back here
+   appendBlock(mergeBlock);
+   }
+
+void
+OMR::IlBuilderImpl::Switch(const char *selectionVar,
+                           TR::IlBuilderImpl **defaultBuilder,
+                           uint32_t numCases,
+                           int32_t *caseValues,
+                           TR::IlBuilderImpl **caseBuilders,
+                           bool *caseFallsThrough)
+   {
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TR::IlValueImpl *selectorValue = Load(selectionVar);
+   TR_ASSERT(selectorValue->getDataType() == TR::Int32, "Switch only supports selector having type Int32");
+
+   *defaultBuilder = createBuilderIfNeeded(*defaultBuilder);
+
+   TR::Node *defaultNode = TR::Node::createCase(0, (*defaultBuilder)->getEntry()->getEntry());
+   TR::Node *lookupNode = TR::Node::create(TR::lookup, numCases + 2, loadValue(selectorValue), defaultNode);
+
+   // get the lookup tree into this builder, even though we haven't completely filled it in yet
+   genTreeTop(lookupNode);
+   TR::Block *switchBlock = _currentBlock;
+
+   // make sure no fall through edge created from the lookup
+   appendNoFallThroughBlock();
+
+   TR::IlBuilderImpl *breakBuilder = orphanBuilderImpl();
+
+   // each case handler is a sequence of two builder objects: first the one passed in via caseBuilder (or will be passed
+   //   back via caseBuilders, and second a builder that branches to the breakBuilder (unless this case falls through)
+   for (int32_t c=0;c < numCases;c++)
+      {
+      int32_t value = caseValues[c];
+      caseBuilders[c] = createBuilderIfNeeded(caseBuilders[c]);
+
+      TR::IlBuilderImpl *handler = NULL;
+      if (!caseFallsThrough[c])
+         {
+         handler = orphanBuilderImpl();
+         handler->AppendBuilder(caseBuilders[c]);
+         handler->Goto(&breakBuilder);
+         }
+      else
+         {
+         handler = caseBuilders[c];
+         }
+
+      TR::Block *caseBlock = handler->getEntry();
+      cfg()->addEdge(switchBlock, caseBlock);
+      AppendBuilder(handler);
+
+      TR::Node *caseNode = TR::Node::createCase(0, caseBlock->getEntry(), value);
+      lookupNode->setAndIncChild(c+2, caseNode);
+      }
+
+   cfg()->addEdge(switchBlock, (*defaultBuilder)->getEntry());
+   AppendBuilder(*defaultBuilder);
+
+   AppendBuilder(breakBuilder);
+   }
+
+void
+OMR::IlBuilderImpl::ForLoop(bool countsUp,
+                            const char *indVar,
+                            TR::IlBuilderImpl **loopCode,
+                            TR::IlBuilderImpl **breakBuilder,
+                            TR::IlBuilderImpl **continueBuilder,
+                            TR::IlValueImpl *initial,
+                            TR::IlValueImpl *end,
+                            TR::IlValueImpl *increment)
+   {
+   methodSymbol()->setMayHaveLoops(true);
+   TR_ASSERT(loopCode != NULL, "ForLoop needs to have loopCode builder");
+
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   *loopCode = createBuilderIfNeeded(*loopCode);
+
+   TraceIL("IlBuilderImpl[ %p ]::ForLoop ind %s initial %d end %d increment %d loopCode %p countsUp %d\n", this, indVar, initial->getID(), end->getID(), increment->getID(), *loopCode, countsUp);
+
+   Store(indVar, initial);
+
+   TR::IlValueImpl *loopCondition;
+   TR::IlBuilderImpl *loopBody = orphanBuilderImpl();
+   loopCondition = countsUp ? LessThan(Load(indVar), end) : GreaterThan(Load(indVar), end);
+   IfThenElse(&loopBody, NULL, loopCondition); // if-then without else
+   loopBody->AppendBuilder(*loopCode);
+   TR::IlBuilderImpl *loopContinue = orphanBuilderImpl();
+   loopBody->AppendBuilder(loopContinue);
+
+   if (breakBuilder)
+      {
+      TR_ASSERT(*breakBuilder == NULL, "ForLoop returns breakBuilder, cannot provide breakBuilder as input");
+      *breakBuilder = orphanBuilderImpl();
+      AppendBuilder(*breakBuilder);
+      }
+
+   if (continueBuilder)
+      {
+      TR_ASSERT(*continueBuilder == NULL, "ForLoop returns continueBuilder, cannot provide continueBuilder as input");
+      *continueBuilder = loopContinue;
+      }
+
+   if (countsUp)
+      {
+      loopContinue->Store(indVar,
+      loopContinue->   Add(
+      loopContinue->      Load(indVar),
+                          increment));
+      loopContinue->IfCmpLessThan(&loopBody,
+      loopContinue->   Load(indVar),
+                       end);
+      }
+   else
+      {
+      loopContinue->Store(indVar,
+      loopContinue->   Sub(
+      loopContinue->      Load(indVar),
+                          increment));
+      loopContinue->IfCmpGreaterThan(&loopBody,
+      loopContinue->   Load(indVar),
+                       end);
+      }
+
+   // make sure any subsequent operations go into their own block *after* the loop
+   appendBlock();
+   }
+
+void
+OMR::IlBuilderImpl::DoWhileLoop(const char *whileCondition,
+                                TR::IlBuilderImpl **body,
+                                TR::IlBuilderImpl **breakBuilder,
+                                TR::IlBuilderImpl **continueBuilder)
+   {
+   methodSymbol()->setMayHaveLoops(true);
+   TR_ASSERT(body != NULL, "doWhileLoop needs to have a body");
+
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   if (!_methodBuilder->symbolDefined(whileCondition))
+      _methodBuilder->defineValue(whileCondition, Int32);
+
+   *body = createBuilderIfNeeded(*body);
+   TraceIL("IlBuilderImpl[ %p ]::DoWhileLoop do body B%d while %s\n", this, (*body)->getEntry()->getNumber(), whileCondition);
+
+   AppendBuilder(*body);
+   TR::IlBuilderImpl *loopContinue = NULL;
+
+   if (continueBuilder)
+      {
+      TR_ASSERT(*continueBuilder == NULL, "DoWhileLoop returns continueBuilder, cannot provide continueBuilder as input");
+      loopContinue = *continueBuilder = orphanBuilderImpl();
+      }
+   else
+      loopContinue = orphanBuilderImpl();
+
+   AppendBuilder(loopContinue);
+   loopContinue->IfCmpNotEqualZero(body,
+   loopContinue->   Load(whileCondition));
+
+   if (breakBuilder)
+      {
+      TR_ASSERT(*breakBuilder == NULL, "DoWhileLoop returns breakBuilder, cannot provide breakBuilder as input");
+      *breakBuilder = orphanBuilderImpl();
+      AppendBuilder(*breakBuilder);
+      }
+
+   // make sure any subsequent operations go into their own block *after* the loop
+   appendBlock();
+   }
+
+void
+OMR::IlBuilderImpl::WhileDoLoop(const char *whileCondition,
+                                TR::IlBuilderImpl **body,
+                                TR::IlBuilderImpl **breakBuilder,
+                                TR::IlBuilderImpl **continueBuilder)
+   {
+   methodSymbol()->setMayHaveLoops(true);
+   TR_ASSERT(body != NULL, "WhileDo needs to have a body");
+
+   comp()->setCurrentIlGenerator(static_cast<TR_IlGenerator *>(this));
+
+   TraceIL("IlBuilderImpl[ %p ]::WhileDoLoop while %s do body %p\n", this, whileCondition, *body);
+
+   TR::IlBuilderImpl *done = orphanBuilderImpl();
+   if (breakBuilder)
+      {
+      TR_ASSERT(*breakBuilder == NULL, "WhileDoLoop returns breakBuilder, cannot provide breakBuilder as input");
+      *breakBuilder = done;
+      }
+
+   TR::IlBuilderImpl *loopContinue = orphanBuilderImpl();
+   if (continueBuilder)
+      {
+      TR_ASSERT(*continueBuilder == NULL, "WhileDoLoop returns continueBuilder, cannot provide continueBuilder as input");
+      *continueBuilder = loopContinue;
+      }
+
+   AppendBuilder(loopContinue);
+   loopContinue->IfCmpEqualZero(&done,
+   loopContinue->   Load(whileCondition));
+
+   *body = createBuilderIfNeeded(*body);
+   AppendBuilder(*body);
+
+   Goto(&loopContinue);
+   setComesBack(); // this goto is on one particular flow path, doesn't mean every path does a goto
+
+   AppendBuilder(done);
+   }

--- a/compiler/ilgen/IlBuilderImpl.hpp
+++ b/compiler/ilgen/IlBuilderImpl.hpp
@@ -1,0 +1,458 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_ILBUILDER_IMPL_INCL
+#define OMR_ILBUILDER_IMPL_INCL
+
+#ifndef TR_ILBUILDER_IMPL_DEFINED
+#define TR_ILBUILDER_IMPL_DEFINED
+#define PUT_OMR_ILBUILDER_IMPL_INTO_TR
+#endif // !defined(TR_ILBUILDER_IMPL_DEFINED)
+
+#include <fstream>
+#include <stdarg.h>
+#include <string.h>
+#include "ilgen/IlInjector.hpp"
+#include "il/ILHelpers.hpp"
+
+#include "ilgen/IlValueImpl.hpp" // must go after IlInjector.hpp or TR_ALLOC isn't cleaned up
+
+namespace OMR { class MethodBuilderImpl; }
+
+namespace TR { class Block; }
+namespace TR { class IlGeneratorMethodDetails; }
+namespace TR { class ResolvedMethodSymbol; } 
+namespace TR { class SymbolReference; }
+namespace TR { class SymbolReferenceTable; }
+
+namespace TR { class IlBuilder; }
+namespace TR { class IlBuilderImpl; }
+namespace TR { class IlTypeImplImpl; }
+namespace TR { class TypeDictionaryImpl; }
+
+template <class T> class List;
+template <class T> class ListAppender;
+
+namespace OMR
+{
+
+typedef TR::ILOpCodes (*OpCodeMapper)(TR::DataType);
+
+
+class IlBuilderImpl : public TR::IlInjector
+   {
+
+protected:
+   struct SequenceEntry
+      {
+      TR_ALLOC(TR_Memory::IlGenerator)
+
+      SequenceEntry(TR::Block *block)
+         {
+         _isBlock = true;
+         _block = block;
+         }
+      SequenceEntry(TR::IlBuilderImpl *builder)
+         {
+         _isBlock = false;
+         _builder = builder;
+         }
+
+      bool _isBlock;
+      union
+         {
+         TR::Block *_block;
+         TR::IlBuilderImpl *_builder;
+         };
+      };
+
+   SequenceEntry *blockEntry(TR::Block *block);
+   SequenceEntry *builderEntry(TR::IlBuilderImpl *builder);
+
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   friend class OMR::MethodBuilderImpl;
+
+   IlBuilderImpl(TR::MethodBuilderImpl *methodBuilder, TR::TypeDictionaryImpl *types);
+   IlBuilderImpl(TR::IlBuilderImpl *source);
+   virtual ~IlBuilderImpl()
+      { }
+   void operator delete(void * ptr)
+      { }
+
+   /*
+    * Client API support for IlBuilder, in alphabetical order within categories
+    */
+
+   // create a new local value (temporary variable)
+   TR::IlValueImpl *Copy(TR::IlValueImpl *value);
+   TR::IlBuilderImpl *OrphanBuilderImpl();
+
+   // constants
+   TR::IlValueImpl *NullAddress();
+   TR::IlValueImpl *ConstInt8(int8_t value);
+   TR::IlValueImpl *ConstInt16(int16_t value);
+   TR::IlValueImpl *ConstInt32(int32_t value);
+   TR::IlValueImpl *ConstInt64(int64_t value);
+   TR::IlValueImpl *ConstFloat(float value);
+   TR::IlValueImpl *ConstDouble(double value);
+   TR::IlValueImpl *ConstAddress(const void * const value);
+   TR::IlValueImpl *ConstString(const char * const value);
+   TR::IlValueImpl *ConstZeroValueForValue(TR::IlValueImpl *v);
+   TR::IlValueImpl *ConstInteger(TR::IlTypeImpl *intType, int64_t value);
+
+   // arithmetic
+   TR::IlValueImpl *Add(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *AddWithOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *AddWithUnsignedOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *And(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *Div(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *IndexAt(TR::IlTypeImpl *dt, TR::IlValueImpl *base, TR::IlValueImpl *index);
+   TR::IlValueImpl *Mul(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *MulWithOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *Or(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *ShiftL(TR::IlValueImpl *v, TR::IlValueImpl *amount);
+   TR::IlValueImpl *ShiftR(TR::IlValueImpl *v, TR::IlValueImpl *amount);
+   TR::IlValueImpl *Sub(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *SubWithOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *SubWithUnsignedOverflow(TR::IlBuilderImpl **handler, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *UnsignedShiftR(TR::IlValueImpl *v, TR::IlValueImpl *amount);
+   TR::IlValueImpl *Xor(TR::IlValueImpl *left, TR::IlValueImpl *right);
+
+   // comparisons
+   TR::IlValueImpl *EqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *GreaterOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *GreaterThan(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *LessOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *LessThan(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *NotEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *UnsignedGreaterOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *UnsignedGreaterThan(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *UnsignedLessOrEqualTo(TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *UnsignedLessThan(TR::IlValueImpl *left, TR::IlValueImpl *right);
+
+   // conversions
+   TR::IlValueImpl *ConvertTo(TR::IlTypeImpl *t, TR::IlValueImpl *v);
+   TR::IlValueImpl *UnsignedConvertTo(TR::IlTypeImpl *t, TR::IlValueImpl *v);
+
+   // memory
+   TR::IlValueImpl *AtomicAdd(TR::IlValueImpl *baseAddress, TR::IlValueImpl * value);
+   TR::IlValueImpl *CreateLocalArray(int32_t numElements, TR::IlTypeImpl *elementType);
+   TR::IlValueImpl *CreateLocalStruct(TR::IlTypeImpl *structType);
+   TR::IlValueImpl *Load(const char *name);
+   TR::IlValueImpl *LoadAt(TR::IlTypeImpl *dt, TR::IlValueImpl *address);
+   TR::IlValueImpl *LoadIndirect(const char *type, const char *field, TR::IlValueImpl *object);
+   void Store(const char *name, TR::IlValueImpl *value);
+   void StoreAt(TR::IlValueImpl *address, TR::IlValueImpl *value);
+   void StoreOver(TR::IlValueImpl *dest, TR::IlValueImpl *value);
+   void StoreIndirect(const char *type, const char *field, TR::IlValueImpl *object, TR::IlValueImpl *value);
+   void Transaction(TR::IlBuilderImpl **persistentFailureBuilder, TR::IlBuilderImpl **transientFailureBuilder, TR::IlBuilderImpl **fallThroughBuilder);
+   void TransactionAbort();
+
+   /**
+    * `StructFieldAddress` and `UnionFieldAddress` are two functions that
+    * provide a workaround for a limitation in JitBuilder. Becuase `TR::IlValueImpl`
+    * cannot represent an object type (only pointers to objects), there is no
+    * way to generate a load for a field that is itself an object. The workaround
+    * is to use the field's address instead. This is not an elegent solution and
+    * should be revisited.
+    */
+   TR::IlValueImpl *StructFieldInstanceAddress(const char* structName, const char* fieldName, TR::IlValueImpl* obj);
+   TR::IlValueImpl *UnionFieldInstanceAddress(const char* unionName, const char* fieldName, TR::IlValueImpl* obj);
+
+   // vector memory
+   TR::IlValueImpl *VectorLoad(const char *name);
+   TR::IlValueImpl *VectorLoadAt(TR::IlTypeImpl *dt, TR::IlValueImpl *address);
+   void VectorStore(const char *name, TR::IlValueImpl *value);
+   void VectorStoreAt(TR::IlValueImpl *address, TR::IlValueImpl *value);
+
+   // control
+   void AppendBuilder(TR::IlBuilderImpl *builder);
+   TR::IlValueImpl *Call(const char *name, int32_t numArgs, TR::IlValueImpl **argValues);
+   TR::IlValueImpl *ComputedCall(const char *name, int32_t numArgs, TR::IlValueImpl **args);
+   void Goto(TR::IlBuilderImpl **dest);
+   void Goto(TR::IlBuilderImpl *dest);
+   void Return();
+   void Return(TR::IlValueImpl *value);
+   virtual void ForLoop(bool countsUp,
+                const char *indVar,
+                TR::IlBuilderImpl **body,
+                TR::IlBuilderImpl **breakBuilder,
+                TR::IlBuilderImpl **continueBuilder,
+                TR::IlValueImpl *initial,
+                TR::IlValueImpl *iterateWhile,
+                TR::IlValueImpl *increment);
+   void WhileDoLoop(const char *exitCondition,
+                    TR::IlBuilderImpl **body,
+                    TR::IlBuilderImpl **breakBuilder = NULL,
+                    TR::IlBuilderImpl **continueBuilder = NULL);
+   void DoWhileLoop(const char *exitCondition,
+                    TR::IlBuilderImpl **body,
+                    TR::IlBuilderImpl **breakBuilder = NULL,
+                    TR::IlBuilderImpl **continueBuilder = NULL);
+   /* @brief creates an AND nest of short-circuited conditions, */
+   /*        for each term pass an IlBuilderImpl containing the condition */
+   /*        and the IlValueImpl that computes the condition */
+   void IfAnd(TR::IlBuilderImpl **allTrueBuilder,
+              TR::IlBuilderImpl **anyFalseBuilder,
+              int32_t numTerms,
+              TR::IlBuilderImpl **caseBuilders,
+              TR::IlValueImpl **caseValues);
+   void IfCmpEqualZero(TR::IlBuilderImpl **target, TR::IlValueImpl *condition);
+   void IfCmpEqualZero(TR::IlBuilderImpl *target, TR::IlValueImpl *condition);
+   void IfCmpEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpLessOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpLessOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpLessThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpLessThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpGreaterOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpGreaterOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpGreaterThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpGreaterThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpNotEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpNotEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpNotEqualZero(TR::IlBuilderImpl **target, TR::IlValueImpl *condition);
+   void IfCmpNotEqualZero(TR::IlBuilderImpl *target, TR::IlValueImpl *condition);
+   void IfCmpUnsignedGreaterOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedGreaterOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedGreaterThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedGreaterThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedLessOrEqual(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedLessOrEqual(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedLessThan(TR::IlBuilderImpl **target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   void IfCmpUnsignedLessThan(TR::IlBuilderImpl *target, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   /* @brief creates an OR nest of short-circuited conditions, */
+   /*       for each term pass an IlBuilderImpl containing the condition */
+   /*       and the IlValueImpl that computes the condition */
+   void IfOr(TR::IlBuilderImpl **anyTrueBuilder,
+             TR::IlBuilderImpl **allFalseBuilder,
+             int32_t numTerms,
+             TR::IlBuilderImpl **caseBuilders,
+             TR::IlValueImpl **caseValues);
+   void IfThenElse(TR::IlBuilderImpl **thenPath,
+                   TR::IlBuilderImpl **elsePath,
+                   TR::IlValueImpl *condition);
+   void Switch(const char *selectionVar,
+               TR::IlBuilderImpl **defaultBuilder,
+               uint32_t numCases,
+               int32_t *caseValues,
+               TR::IlBuilderImpl **caseBuilders,
+               bool *caseFallsThrough);
+
+
+   /*
+    * Public API for *Impl classes
+    */
+
+   static TR::IlBuilderImpl *allocate(TR::MethodBuilderImpl *mb, TR::TypeDictionaryImpl *types);
+
+   void setClient(TR::IlBuilder *b)
+      { _clientBuilder = b; }
+
+   TR::IlBuilder *client()
+      { return _clientBuilder; }
+
+   TR::IlBuilderImpl *orphanBuilderImpl();
+
+   void initSequence();
+
+   virtual bool injectIL();
+   virtual void setupForBuildIL();
+
+   virtual bool isMethodBuilder()                   { return false; }
+   virtual TR::MethodBuilderImpl *asMethodBuilder() { return NULL; }
+
+   virtual bool isBytecodeBuilder()                 { return false; }
+
+   void print(const char *title, bool recurse=false);
+   void printBlock(TR::Block *block);
+
+   TR::TreeTop *getFirstTree();
+   TR::TreeTop *getLastTree();
+   TR::Block *getEntry() { return _entryBlock; }
+   TR::Block *getExit()  { return _exitBlock; }
+
+   void setDoesNotComeBack() { _comesBack = false; }
+   void setComesBack()       { _comesBack = true; }
+   bool comesBack()          { return _comesBack; }
+
+   bool blocksHaveBeenCounted() { return _count > -1; }
+
+   TR::IlBuilderImpl *createBuilderIfNeeded(TR::IlBuilderImpl *builder);
+   bool TraceEnabled_log();
+   void TraceIL_log(const char *s, ...);
+
+   TR::IlValueImpl *genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlValueImpl ** paramValues, bool isDirectCall = true);
+
+protected:
+
+   /**
+    * @brief corresponding IlBuilder (client API) object (must be 1-1 relationship)
+    */
+   TR::IlBuilder               * _clientBuilder;
+
+   /**
+    * @brief MethodBuilderImpl parent for this IlBuilderImpl object
+    */
+   TR::MethodBuilderImpl       * _methodBuilder;
+
+   /**
+    * @brief sequence of TR::Blocks and other TR::IlBuilderImpl objects that should execute when control reaches this IlBuilderImpl
+    */
+   List<SequenceEntry>         * _sequence;
+
+   /**
+    * @brief used to track the end of the current sequence
+    */
+   ListAppender<SequenceEntry> * _sequenceAppender;
+
+   /**
+    * @brief each IlBuilderImpl object is like a mini-CFG, with its own unique entry block
+    */
+   TR::Block                   * _entryBlock;
+
+   /**
+    * @brief each IlBuilderImpl object is like a mini-CFG, with its own unique exit block
+    */
+   TR::Block                   * _exitBlock;
+
+   /**
+    * @brief counter for how many TR::Blocks are needed to represent everything inside this IlBuilderImpl object
+    */
+   int32_t                       _count;
+
+   /**
+    * @brief has this IlBuilderImpl object been made part of some other builder's sequence
+    */
+   bool                          _partOfSequence;
+
+   /**
+    * @brief has connectTrees been run on this IlBuilderImpl object yet
+    */
+   bool                          _connectedTrees;
+
+   /**
+    * @brief returns true if there is a control edge to this IlBuilderImpl's exit block
+    */
+   bool                          _comesBack;
+
+   /**
+    * @brief returns true if this IlBuilderImpl object is a handler for an exception edge
+    */
+   bool                          _isHandler;
+
+   virtual bool buildIL() { return true; }
+
+   TR::SymbolReference *lookupSymbol(const char *name);
+   void defineSymbol(const char *name, TR::SymbolReference *v);
+   TR::IlValueImpl *newValue(TR::IlTypeImpl *dt, TR::Node *n=NULL);
+   TR::IlValueImpl *newValue(TR::DataType dt, TR::Node *n=NULL);
+   void defineValue(const char *name, TR::IlTypeImpl *dt);
+
+   TR::Node *loadValue(TR::IlValueImpl *v);
+   void storeNode(TR::SymbolReference *symRef, TR::Node *v);
+   void indirectStoreNode(TR::Node *addr, TR::Node *v);
+   TR::IlValueImpl *indirectLoadNode(TR::IlTypeImpl *dt, TR::Node *addr, bool isVectorLoad=false);
+
+   TR::Node *zero(TR::DataType dt);
+   TR::Node *zero(TR::IlTypeImpl *dt);
+   TR::Node *zeroNodeForValue(TR::IlValueImpl *v);
+   TR::IlValueImpl *zeroForValue(TR::IlValueImpl *v);
+
+   TR::IlValueImpl *unaryOp(TR::ILOpCodes op, TR::IlValueImpl *v);
+   void doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr);
+   TR::IlValueImpl *binaryOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
+   TR::Node *binaryOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
+   TR::IlValueImpl *binaryOpFromOpMap(OpCodeMapper mapOp, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *binaryOpFromOpCode(TR::ILOpCodes op, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::Node *shiftOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
+   TR::IlValueImpl *shiftOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
+   TR::IlValueImpl *shiftOpFromOpMap(OpCodeMapper mapOp, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *compareOp(TR_ComparisonTypes ct, bool needUnsigned, TR::IlValueImpl *left, TR::IlValueImpl *right);
+   TR::IlValueImpl *convertTo(TR::IlTypeImpl *t, TR::IlValueImpl *v, bool needUnsigned);
+
+   void ifCmpCondition(TR_ComparisonTypes ct, bool isUnsignedCmp, TR::IlValueImpl *left, TR::IlValueImpl *right, TR::Block *target);
+   void ifCmpNotEqualZero(TR::IlValueImpl *condition, TR::Block *target);
+   void ifCmpEqualZero(TR::IlValueImpl *condition, TR::Block *target);
+
+   void integerizeAddresses(TR::IlValueImpl **leftPtr, TR::IlValueImpl **rightPtr);
+
+   void appendGoto(TR::Block *destBlock);
+
+   virtual void appendBlock(TR::Block *block = 0, bool addEdge=true);
+   void appendNoFallThroughBlock(TR::Block *block = 0)
+      {
+      appendBlock(block, false);
+      }
+
+   TR::Block *emptyBlock();
+   
+   virtual uint32_t countBlocks();
+
+   void pullInBuilderTrees(TR::IlBuilderImpl *builder,
+                           uint32_t *currentBlock,
+                           TR::TreeTop **firstTree,
+                           TR::TreeTop **newLastTree);
+
+   // BytecodeBuilderImpl needs this interface (with currentBlock), but IlBuilderImpl doesn't so just ignore the parameter
+   virtual bool connectTrees(uint32_t *currentBlock) { return connectTrees(); }
+
+   virtual bool connectTrees();
+
+   TR::Node *genOverflowCHKTreeTop(TR::Node *operationNode, TR::ILOpCodes overflow);
+   TR::ILOpCodes getOpCode(TR::IlValueImpl *leftValue, TR::IlValueImpl *rightValue);
+   void appendExceptionHandler(TR::Block *blockThrowsException, TR::IlBuilderImpl **builder, uint32_t catchType);
+   TR::IlValueImpl *genOperationWithOverflowCHK(TR::ILOpCodes op,
+                                                TR::Node *leftNode,
+                                                TR::Node *rightNode,
+                                                TR::IlBuilderImpl **handler,
+                                                TR::ILOpCodes overflow);
+   virtual void setHandlerInfo(uint32_t catchType);
+   TR::IlValueImpl **processCallArgs(TR::Compilation *comp, int numArgs, va_list args);
+   };
+
+} // namespace OMR
+
+
+
+#if defined(PUT_OMR_ILBUILDER_IMPL_INTO_TR)
+
+namespace TR
+{
+   class IlBuilderImpl : public OMR::IlBuilderImpl
+      {
+      public:
+         IlBuilderImpl(TR::MethodBuilderImpl *methodBuilder, TR::TypeDictionaryImpl *types)
+            : OMR::IlBuilderImpl(methodBuilder, types)
+            { }
+
+         IlBuilderImpl(TR::IlBuilderImpl *source)
+            : OMR::IlBuilderImpl(source)
+            { }
+      };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_ILBUILDER_IMPL_INTO_TR)
+
+#endif // !defined(OMR_ILBUILDER_IMPL_INCL)

--- a/compiler/ilgen/IlType.cpp
+++ b/compiler/ilgen/IlType.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2016 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,12 +19,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdint.h>
-#include "ilgen/IlInjector.hpp"
-#include "ilgen/IlValueImpl.hpp"
+#include "il/DataTypes.hpp"
+#include "env/Region.hpp"
+#include "env/SystemSegmentProvider.hpp"
+#include "env/TRMemory.hpp"
+#include "ilgen/IlTypeImpl.hpp"
+#include "ilgen/TypeDictionary.hpp"
 
-TR::IlValueImpl *
-OMR::IlValue::impl()
+
+TR::IlTypeImpl *
+OMR::IlType::impl()
    {
-   return static_cast<TR::IlValueImpl *>(this);
+   return static_cast<TR::IlTypeImpl *>(this);
+   }
+
+TR::IlType *
+OMR::IlType::getPrimitiveType()
+   {
+   return _dict->NoType;
    }

--- a/compiler/ilgen/IlType.hpp
+++ b/compiler/ilgen/IlType.hpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_ILTYPE_INCL
+#define OMR_ILTYPE_INCL
+
+
+#ifndef TR_ILTYPE_DEFINED
+#define TR_ILTYPE_DEFINED
+#define PUT_OMR_ILTYPE_INTO_TR
+#endif
+
+#include <stddef.h>
+
+namespace JitBuilder { class ResolvedMethod; }
+namespace TR { class IlBuilderImpl; }
+namespace TR { class IlType; }
+namespace TR { class IlTypeImpl; }
+namespace TR { class TypeDictionary; }
+
+namespace OMR
+{
+
+class IlType
+   {
+   friend class IlBuilder;
+   friend class IlBuilderImpl;
+   friend class MethodBuilder;
+   friend class ThunkBuilder;
+   friend class TypeDictionary;
+   friend class TypeDictionaryImpl;
+   friend class VirtualMachineRegister;
+   friend class ::JitBuilder::ResolvedMethod;
+
+public:
+   /* there should be no public constructors */
+
+   virtual TR::IlType *baseType()
+      { return 0; }
+
+   const char *getName()     // TODO: rename to GetName()
+      { return _name; }
+
+   virtual TR::IlType *getPrimitiveType(); // TODO: change to PrimitiveType()
+
+   virtual size_t getSize()  // TODO: change to Size()
+      { return -1; }
+
+   virtual bool isArray()
+      { return false; }
+
+   virtual bool isPointer()
+      { return false; }
+
+   virtual bool isStruct()
+      {return false; }
+
+   virtual bool isUnion()
+      { return false; }
+
+protected:
+   IlType(const char *name, TR::TypeDictionary *dict) :
+      _dict(dict),
+      _name(name)
+      { }
+   IlType() :
+      _name(0)
+      { }
+   virtual ~IlType()
+      { }
+
+   TR::IlTypeImpl *impl();
+
+   TR::TypeDictionary * _dict;
+   const char         * _name;
+   };
+
+} // namespace OMR
+
+
+#if defined(PUT_OMR_ILTYPE_INTO_TR)
+namespace TR
+{
+class IlType : public OMR::IlType
+   {
+   /* there should be no public constructors */
+
+   protected:
+      IlType(const char *name, TR::TypeDictionary *dict)
+         : OMR::IlType(name, dict)
+         { }
+      IlType()
+         : OMR::IlType()
+         { }
+   };
+} // namespace TR
+#endif // defined(PUT_OMR_ILTYPE_INTO_TR)
+
+
+#endif // !defined(OMR_ILTYPE_INCL)

--- a/compiler/ilgen/IlTypeImpl.cpp
+++ b/compiler/ilgen/IlTypeImpl.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2016 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,12 +19,41 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdint.h>
-#include "ilgen/IlInjector.hpp"
-#include "ilgen/IlValueImpl.hpp"
+#include <stdlib.h>
 
-TR::IlValueImpl *
-OMR::IlValue::impl()
+#include "env/Region.hpp"
+#include "env/SystemSegmentProvider.hpp"
+#include "env/TRMemory.hpp"
+#include "il/DataTypes.hpp"
+#include "ilgen/IlTypeImpl.hpp"
+
+
+
+const char *OMR::IlTypeImpl::_signatureNameForType[] =
    {
-   return static_cast<TR::IlValueImpl *>(this);
+   "V",  // NoType
+   "B",  // Int8
+   "C",  // Int16
+   "I",  // Int32
+   "J",  // Int64
+   "F",  // Float
+   "D",  // Double
+   "L",  // Address
+   // TODO: vector types!
+   };
+
+char *
+OMR::IlTypeImpl::getSignatureName()
+   {
+   TR::DataType dt = getRealPrimitiveType();
+   if (dt == TR::Address)
+      return (char *)_name;
+   return (char *) _signatureNameForType[dt];
+   }
+
+size_t
+OMR::IlTypeImpl::getSize()
+   {
+   TR_ASSERT(0, "The input type does not have a defined size\n");
+   return 0;
    }

--- a/compiler/ilgen/IlTypeImpl.hpp
+++ b/compiler/ilgen/IlTypeImpl.hpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_ILTYPE_IMPL_INCL
+#define OMR_ILTYPE_IMPL_INCL
+
+
+#ifndef TR_ILTYPE_IMPL_DEFINED
+#define TR_ILTYPE_IMPL_DEFINED
+#define PUT_OMR_ILTYPE_IMPL_INTO_TR
+#endif
+
+#include "il/DataTypes.hpp"
+#include "ilgen/IlType.hpp"
+
+namespace OMR
+{
+
+class IlTypeImpl : public TR::IlType
+   {
+public:
+   IlTypeImpl(const char *name, TR::TypeDictionary *dict) :
+      TR::IlType(name, dict)
+      { }
+   //IlTypeImpl() :
+   //   TR::IlType()
+   //   { }
+   virtual ~IlTypeImpl()
+      { }
+
+   virtual TR::IlType *baseType()
+      { return NULL; }
+   virtual char *getSignatureName();       // TODO: change to signatureName()
+   virtual size_t getSize();               // TODO: change to size()
+   virtual bool isArray()
+      { return false; }
+   virtual bool isPointer()
+      { return false; }
+   virtual bool isStruct()
+      {return false; }
+   virtual bool isUnion()
+      { return false; }
+
+   static const char *_signatureNameForType[];
+
+   virtual TR::DataType getRealPrimitiveType()
+      { return TR::NoType; }
+
+   TR::TypeDictionary *dict()
+      { return _dict; }
+   };
+
+} // namespace OMR
+
+
+#if defined(PUT_OMR_ILTYPE_IMPL_INTO_TR)
+namespace TR
+{
+class IlTypeImpl : public OMR::IlTypeImpl
+   {
+   /* there should be no public constructors */
+
+   protected:
+      IlTypeImpl(const char *name, TR::TypeDictionary *dict)
+         : OMR::IlTypeImpl(name, dict)
+         { }
+      //IlTypeImpl()
+      //   : OMR::IlTypeImpl()
+      //   { }
+   };
+} // namespace TR
+#endif // defined(PUT_OMR_ILTYPE_IMPL_INTO_TR)
+
+
+#endif // !defined(OMR_ILTYPE_IMPL_INCL)

--- a/compiler/ilgen/IlValue.hpp
+++ b/compiler/ilgen/IlValue.hpp
@@ -27,93 +27,55 @@
 #define PUT_OMR_ILVALUE_INTO_TR
 #endif // !defined(TR_ILVALUE_DEFINED)
 
-#include "il/DataTypes.hpp" // for TR::DataType
 
-namespace TR { class Node; }
-namespace TR { class TreeTop; }
-namespace TR { class Block; }
-namespace TR { class Symbol; }
-namespace TR { class SymbolReference; }
+namespace OMR { class IlBuilder; }
+namespace TR { class IlValueImpl; }
 namespace TR { class MethodBuilder; }
-namespace TR { class IlValue; }
+
 
 namespace OMR
 {
 
 class IlValue
    {
+   friend class OMR::IlBuilder;
+
+protected:
+   IlValue(TR::MethodBuilder *mb, int32_t id)
+      : _methodBuilder(mb), _id(id)
+      { }
+
 public:
-   TR_ALLOC(TR_Memory::IlGenerator)
 
    /**
-    * @brief initial state assumes value will only be used locally
+    * TR::IlValue has no public constructor because JitBuilder clients should not create their own IlValues
     */
-   IlValue(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilder *methodBuilder);
-
-   /**
-    * @brief return a TR::Node that computes this value, either directly if in same block or by loading a local variable if not
-    * @param block TR::Block for the load point so it can be compared to the TR::Block where value is computed
-    */
-   TR::Node *load(TR::Block *block);
-
-   /**
-    * @brief ensures that the provided value replaces the current value, but only affects subsequent loads
-    * @param value the new value that should be returned whenever the current value is loaded
-    * @param block TR::Block for the replacement point, so that either the node pointer is changed or what's stored in the symbol reference
-    */
-   void storeOver(TR::IlValue *value, TR::Block *block);
-
-   /**
-    * @brief return the data type of this value
-    */
-   TR::DataType getDataType();
-
-   /**
-    * @brief returns the TR::SymbolReference holding the value, or NULL if willBeUsedInAnotherBlock() has not yet been called
-    * Caller should ensure the current block is different than the block that computes the value; if the current block is the
-    * same then it is better to use the value as a node pointer via GetNodePointerIfLegal().
-    */
-   TR::SymbolReference *getSymbolReference()
-      {
-      return _symRefThatCanBeUsedInOtherBlocks;
-      }
 
    /**
     * @brief returns a unique identifier for this IlValue object within its MethodBuilder
     * Note that IlValues from different MethodBuilders can have the same ID.
     */
-   int32_t getID()
+   int32_t getID() // TODO: capitalize for consistency in public API
       {
       return _id;
       }
 
+   /**
+    * @brief returns the TR::MethodBuilder object that owns this IlValue
+    */
+   TR::MethodBuilder *methodBuilder()
+      {
+      return _methodBuilder;
+      }
+
 protected:
    /**
-    * @brief ensures this value is accessible via an auto symbol, but only generates store if hasn't already been stored
+    * @brief returns the TR::IlBuilderImpl object corresponding to this IlValue
+    * Currently, IlValueImpl is a superclass so only need to static_cast this
     */
-   void storeToAuto();
+   TR::IlValueImpl *impl();
 
 private:
-
-   /**
-    * @brief identifying number for values guaranteed to be unique per MethodBuilder
-    */
-   int32_t               _id;
-
-   /**
-    * @brief TR::Node pointer that computes the actual value
-    */
-   TR::Node            * _nodeThatComputesValue;
-
-   /**
-    * @brief TR::TreeTop that anchors this node (though not necessarily directly)
-    */
-   TR::TreeTop         * _treeTopThatAnchorsValue;
-
-   /**
-    * @brief TR::Block where the value is computed
-    */
-   TR::Block           * _blockThatComputesValue;
 
    /**
     * @brief Method builder object where value is computed
@@ -121,9 +83,10 @@ private:
    TR::MethodBuilder   * _methodBuilder;
 
    /**
-    * @brief TR::SymbolReference for temp holding value if it needs to be used outside basic block that computes it
+    * @brief identifying number for values guaranteed to be unique per MethodBuilder
     */
-   TR::SymbolReference * _symRefThatCanBeUsedInOtherBlocks;
+   int32_t               _id;
+
    };
 
 } // namespace OMR
@@ -137,8 +100,8 @@ namespace TR
    class IlValue : public OMR::IlValue
       {
       public:
-         IlValue(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilder *methodBuilder)
-            : OMR::IlValue(node, treeTop, block, methodBuilder)
+         IlValue(TR::MethodBuilder *mb, int32_t id)
+            : OMR::IlValue(mb, id)
             { }
       };
 

--- a/compiler/ilgen/IlValueImpl.cpp
+++ b/compiler/ilgen/IlValueImpl.cpp
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include "compile/Compilation.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/Symbol.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "il/SymbolReference.hpp"
+#include "ilgen/IlValueImpl.hpp" // must follow include for compile/Compilation.hpp for TR_Memory
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
+
+
+OMR::IlValueImpl::IlValueImpl(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilderImpl *methodBuilder)
+   : TR::IlValue(methodBuilder->client(), methodBuilder->getNextValueID()),
+     _nodeThatComputesValue(node),
+     _treeTopThatAnchorsValue(treeTop),
+     _blockThatComputesValue(block),
+     _symRefThatCanBeUsedInOtherBlocks(0)
+   {
+   if (methodBuilder == NULL)
+      printf("IlValueImpl::IlValueImpl NULL MethodBuilder\n");
+   }
+
+TR::DataType
+OMR::IlValueImpl::getDataType()
+   {
+   return _nodeThatComputesValue->getDataType();
+   }
+
+void
+OMR::IlValueImpl::storeToAuto()
+   {
+   if (_symRefThatCanBeUsedInOtherBlocks == NULL)
+      {
+      TR::Compilation *comp = TR::comp();
+
+      // first use from another block, need to create symref and insert store tree where node  was computed
+      TR::MethodBuilderImpl *mbImpl = methodBuilder()->impl();
+      TR::SymbolReference *symRef = comp->getSymRefTab()->createTemporary(mbImpl->methodSymbol(), _nodeThatComputesValue->getDataType());
+      symRef->getSymbol()->setNotCollected();
+      char *name = (char *) comp->trMemory()->allocateHeapMemory((2+10+1) * sizeof(char)); // 2 ("_T") + max 10 digits + trailing zero
+      sprintf(name, "_T%u", symRef->getCPIndex());
+      symRef->getSymbol()->getAutoSymbol()->setName(name);
+
+      // create store and its treetop
+      TR::Node *storeNode = TR::Node::createStore(symRef, _nodeThatComputesValue);
+      TR::TreeTop *prevTreeTop = _treeTopThatAnchorsValue->getPrevTreeTop();
+      TR::TreeTop *newTree = TR::TreeTop::create(comp, storeNode);
+      newTree->insertNewTreeTop(prevTreeTop, _treeTopThatAnchorsValue);
+
+      _treeTopThatAnchorsValue->unlink(true);
+
+      _treeTopThatAnchorsValue = newTree;
+      _symRefThatCanBeUsedInOtherBlocks = symRef;
+      }
+   }
+
+TR::Node *
+OMR::IlValueImpl::load(TR::Block *block)
+   {
+   if (_blockThatComputesValue == block)
+      return _nodeThatComputesValue;
+
+   storeToAuto();
+   return TR::Node::createLoad(_symRefThatCanBeUsedInOtherBlocks);
+   }
+
+void
+OMR::IlValueImpl::storeOver(TR::IlValueImpl *value, TR::Block *block)
+   {
+   TR_ASSERT(getDataType() == value->getDataType(), "invalid StoreOver operation: type mismatch");
+
+   if (value->_blockThatComputesValue == block && _blockThatComputesValue == block)
+      {
+      // probably not very common scenario, but if both values are in the same block as current
+      // then storeOver just needs to update node pointer
+      _nodeThatComputesValue = value->_nodeThatComputesValue;
+      }
+   else
+      {
+      // more commonly, if any value is in another block or this use will be in a different block, first ensure this value is
+      // stored to an auto symbol
+      // NOTE this may mean that nodes will be stored to more than one auto, but that's ok
+      storeToAuto();
+
+      // on the off chance that value was computed in this block, we can use its node pointer directly here
+      TR::Node *sourceValue = value->_nodeThatComputesValue;
+
+      // if, however, value was computed in a different block, make sure it's stored to an auto and then load it from that auto
+      if (value->_blockThatComputesValue != block)
+         {
+         value->storeToAuto();
+         sourceValue = value->load(block);
+         }
+
+      // finally store sourceValue into our own auto symbol (which we know exists because we called storeToAuto())
+      TR::Node *store = TR::Node::createStore(_symRefThatCanBeUsedInOtherBlocks, sourceValue);
+      TR::TreeTop *tt = TR::TreeTop::create(TR::comp(), store);
+      block->append(tt);
+
+      // any downstream use of "this" IlValueImpl will now load the value computed by "value"
+      }
+   }

--- a/compiler/ilgen/IlValueImpl.hpp
+++ b/compiler/ilgen/IlValueImpl.hpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2017 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_ILVALUE_IMPL_INCL
+#define OMR_ILVALUE_IMPL_INCL
+
+#ifndef TR_ILVALUE_IMPL_DEFINED
+#define TR_ILVALUE_IMPL_DEFINED
+#define PUT_OMR_ILVALUE_IMPL_INTO_TR
+#endif // !defined(TR_ILVALUE_IMPL_DEFINED)
+
+#include "ilgen/IlValue.hpp"
+
+#include "il/DataTypes.hpp" // for TR::DataType
+
+namespace TR { class Node; }
+namespace TR { class TreeTop; }
+namespace TR { class Block; }
+namespace TR { class Symbol; }
+namespace TR { class SymbolReference; }
+
+namespace TR { class IlValueImpl; }
+namespace TR { class MethodBuilderImpl; }
+
+namespace OMR
+{
+
+class IlValueImpl : public TR::IlValue
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   /**
+    * @brief initial state assumes value will only be used locally
+    */
+   IlValueImpl(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilderImpl *methodBuilder);
+
+   /**
+    * @brief return a TR::Node that computes this value, either directly if in same block or by loading a local variable if not
+    * @param block TR::Block for the load point so it can be compared to the TR::Block where value is computed
+    */
+   TR::Node *load(TR::Block *block);
+
+   /**
+    * @brief ensures that the provided value replaces the current value, but only affects subsequent loads
+    * @param value the new value that should be returned whenever the current value is loaded
+    * @param block TR::Block for the replacement point, so that either the node pointer is changed or what's stored in the symbol reference
+    */
+   void storeOver(TR::IlValueImpl *value, TR::Block *block);
+
+   /**
+    * @brief return the data type of this value
+    */
+   TR::DataType getDataType();
+
+   /**
+    * @brief returns the TR::SymbolReference holding the value, or NULL if willBeUsedInAnotherBlock() has not yet been called
+    * Caller should ensure the current block is different than the block that computes the value; if the current block is the
+    * same then it is better to use the value as a node pointer via GetNodePointerIfLegal().
+    */
+   TR::SymbolReference *getSymbolReference()
+      {
+      return _symRefThatCanBeUsedInOtherBlocks;
+      }
+
+protected:
+   /**
+    * @brief ensures this value is accessible via an auto symbol, but only generates store if hasn't already been stored
+    */
+   void storeToAuto();
+
+private:
+
+   /**
+    * @brief TR::Node pointer that computes the actual value
+    */
+   TR::Node            * _nodeThatComputesValue;
+
+   /**
+    * @brief TR::TreeTop that anchors this node (though not necessarily directly)
+    */
+   TR::TreeTop         * _treeTopThatAnchorsValue;
+
+   /**
+    * @brief TR::Block where the value is computed
+    */
+   TR::Block           * _blockThatComputesValue;
+
+   /**
+    * @brief TR::SymbolReference for temp holding value if it needs to be used outside basic block that computes it
+    */
+   TR::SymbolReference * _symRefThatCanBeUsedInOtherBlocks;
+   };
+
+} // namespace OMR
+
+
+
+#if defined(PUT_OMR_ILVALUE_IMPL_INTO_TR)
+
+namespace TR
+{
+   class IlValueImpl : public OMR::IlValueImpl
+      {
+      public:
+         IlValueImpl(TR::Node *node, TR::TreeTop *treeTop, TR::Block *block, TR::MethodBuilderImpl *methodBuilder)
+            : OMR::IlValueImpl(node, treeTop, block, methodBuilder)
+            { }
+      };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_ILVALUE_IMPL_INTO_TR)
+
+#endif // !defined(OMR_ILVALUE_IMPL_INCL)

--- a/compiler/ilgen/MethodBuilder.cpp
+++ b/compiler/ilgen/MethodBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,595 +19,192 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <iostream>
-#include <fstream>
-
-#include <stdint.h>
-#include "compile/Method.hpp"
-#include "env/FrontEnd.hpp"
-#include "env/Region.hpp"
-#include "env/SystemSegmentProvider.hpp"
-#include "env/TRMemory.hpp"
-#include "il/Block.hpp"
-#include "il/Node.hpp"
-#include "il/Node_inlines.hpp"
-#include "il/TreeTop.hpp"
-#include "il/TreeTop_inlines.hpp"
-#include "il/symbol/AutomaticSymbol.hpp"
-#include "codegen/CodeGenerator.hpp"
-#include "compile/Compilation.hpp"
-#include "compile/SymbolReferenceTable.hpp"
-#include "control/Recompilation.hpp"
-#include "infra/Assert.hpp"
-#include "infra/Cfg.hpp"
-#include "infra/STLUtils.hpp"
-#include "infra/List.hpp"
-#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
-#include "ilgen/IlInjector.hpp"
-#include "ilgen/IlBuilder.hpp"
-#include "ilgen/MethodBuilder.hpp"
 #include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/BytecodeBuilderImpl.hpp"
+#include "ilgen/IlType.hpp"
+#include "ilgen/IlBuilderImpl.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
 #include "ilgen/TypeDictionary.hpp"
-#include "ilgen/VirtualMachineState.hpp"
-
-#define OPT_DETAILS "O^O ILBLD: "
-
-// Size of MethodBuilder memory segments
-#define MEM_SEGMENT_SIZE 1 << 16   // i.e. 65536 bytes (~64KB)
-
-#define TraceEnabled    (comp()->getOption(TR_TraceILGen))
-#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
 
 
-// MethodBuilder is an IlBuilder object representing an entire method /
-// function, so it conceptually has an entry point (though multiple entry
-// method builders are entirely possible). Typically there is a single
-// MethodBuilder created for each particular method compilation unit and
-// multiple methods would require multiple MethodBuilder objects.
-//
-// A MethodBuilder is also an IlBuilder whose control flow path starts when
-// the method is called. Returning from the method must be explicitly built
-// into the builder.
-//
-
-namespace OMR
-{
-
-MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState *vmState)
-   : TR::IlBuilder(asMethodBuilder(), types),
-   // Note: _memoryRegion and the corresponding TR::SegmentProvider and TR::Memory instances are stored as pointers within MethodBuilder
-   // in order to avoid increasing the number of header files needed to compile against the JitBuilder library. Because we are storing
-   // them as pointers, we cannot rely on the default C++ destruction semantic to destruct and deallocate the memory region, but rather
-   // have to do it explicitly in the MethodBuilder destructor. And since C++ destroys the other members *after* executing the user defined
-   // destructor, we need to make sure that any members (and their contents) that are allocated in _memoryRegion are explicitly destroyed
-   // and deallocated *before* _memoryRegion in the MethodBuilder destructor.
-   _segmentProvider(new(TR::Compiler->persistentAllocator()) TR::SystemSegmentProvider(MEM_SEGMENT_SIZE, TR::Compiler->rawAllocator)),
-   _memoryRegion(new(TR::Compiler->persistentAllocator()) TR::Region(*_segmentProvider, TR::Compiler->rawAllocator)),
-   _trMemory(new(TR::Compiler->persistentAllocator()) TR_Memory(*::trPersistentMemory, *_memoryRegion)),
-   _methodName("NoName"),
-   _returnType(NoType),
-   _numParameters(0),
-   _symbols(str_comparator, *_memoryRegion),
-   _parameterSlot(str_comparator, *_memoryRegion),
-   _symbolTypes(str_comparator, *_memoryRegion),
-   _symbolNameFromSlot(std::less<int32_t>(), *_memoryRegion),
-   _symbolIsArray(str_comparator, *_memoryRegion),
-   _memoryLocations(str_comparator, *_memoryRegion),
-   _functions(str_comparator, *_memoryRegion),
-   _cachedParameterTypes(0),
-   _definingFile(""),
-   _newSymbolsAreTemps(false),
-   _nextValueID(0),
-   _useBytecodeBuilders(false),
-   _countBlocksWorklist(0),
-   _connectTreesWorklist(0),
-   _allBytecodeBuilders(0),
-   _vmState(vmState),
-   _bytecodeWorklist(NULL),
-   _bytecodeHasBeenInWorklist(NULL)
+TR::MethodBuilderImpl *
+OMR::MethodBuilder::impl()
    {
-
-   _definingLine[0] = '\0';
+   // unfortunately, cannot use a static_cast here without including MethodBuilderImpl.hpp
+   // which pulls in more compiler headers we don't want
+   return (TR::MethodBuilderImpl *)_impl;
    }
 
-MethodBuilder::~MethodBuilder()
+OMR::MethodBuilder::MethodBuilder(TR::IlBuilderImpl *impl, TR::TypeDictionary *types, OMR::VirtualMachineState *vmState)
+   : TR::IlBuilder(impl, static_cast<TR::MethodBuilder *>(this), types)
+   { }
+
+OMR::MethodBuilder::MethodBuilder(TR::TypeDictionary *types, OMR::VirtualMachineState *vmState)
+   : TR::IlBuilder(TR::MethodBuilderImpl::allocate(static_cast<TR::MethodBuilder *>(this), types->impl(), vmState),
+                   static_cast<TR::MethodBuilder *>(this),
+                   types),
+   _types(types)
+   { }
+
+OMR::MethodBuilder::~MethodBuilder()
    {
-   // Cleanup allocations in _memoryRegion *before* its destroyed below (see note in constructor)
-   _symbols.clear();
-   _parameterSlot.clear();
-   _symbolTypes.clear();
-   _symbolNameFromSlot.clear();
-   _symbolIsArray.clear();
-   _memoryLocations.clear();
-   _functions.clear();
-
-   _trMemory->~TR_Memory();
-   ::operator delete(_trMemory, TR::Compiler->persistentAllocator());
-   _memoryRegion->~Region();
-   ::operator delete(_memoryRegion, TR::Compiler->persistentAllocator());
-   static_cast<TR::SystemSegmentProvider *>(_segmentProvider)->~SystemSegmentProvider();
-   ::operator delete(_segmentProvider, TR::Compiler->persistentAllocator());
-   }
-
-TR::MethodBuilder *
-MethodBuilder::asMethodBuilder()
-   {
-   return static_cast<TR::MethodBuilder *>(this);
-   }
-
-void
-MethodBuilder::setupForBuildIL()
-   {
-   initSequence();
-
-   _entryBlock = cfg()->getStart()->asBlock();
-   _exitBlock = cfg()->getEnd()->asBlock();
-
-   TraceIL("\tEntry = %p\n", _entryBlock);
-   TraceIL("\tExit  = %p\n", _exitBlock);
-
-   // initial "real" block 2 flowing from Entry
-   appendBlock(NULL, false);
-
-   // Method's first tree is from Entry block
-   _methodSymbol->setFirstTreeTop(_currentBlock->getEntry());
-
-   // set up initial CFG
-   cfg()->addEdge(_entryBlock, _currentBlock);
-   }
-
-bool
-MethodBuilder::injectIL()
-   {
-   bool rc = IlBuilder::injectIL();
-   return rc;
-   }
-
-
-uint32_t
-MethodBuilder::countBlocks()
-   {
-   if (_count > -1)
-      return _count;
-
-   TraceIL("[ %p ] TR::MethodBuilder::countBlocks 0 at entry\n", this);
-
-   uint32_t numBlocks = this->TR::IlBuilder::countBlocks();
-
-   _numBlocksBeforeWorklist = numBlocks;
-
-   TraceIL("[ %p ] TR::MethodBuilder::countBlocks %d before worklist\n", this, numBlocks);
-
-   // if not using bytecode builders, numBlocks is the real count
-   if (!_useBytecodeBuilders)
-      return numBlocks;
-
-   TraceIL("[ %p ] TR::MethodBuilder::countBlocks iterating over worklist\n", this);
-   // also need to visit any bytecode builders that have been added to the count worklist
-   while (!_countBlocksWorklist->isEmpty())
+   for(std::vector<TR::IlBuilder *>::iterator it = _ownedBuilderObjects.begin(); it != _ownedBuilderObjects.end(); ++it)
       {
-
-      while (!_countBlocksWorklist->isEmpty())
-         {
-         TR::BytecodeBuilder *builder = _countBlocksWorklist->popHead();
-         TraceIL("[ %p ] TR::MethodBuilder::countBlocks visiting [ %p ]\n", this, builder);
-         numBlocks += builder->countBlocks();
-         TraceIL("[ %p ] numBlocks is %d\n", this, numBlocks);
-         }
-
-      ListIterator<TR::BytecodeBuilder> iter(_allBytecodeBuilders);
-      for (TR::BytecodeBuilder *builder=iter.getFirst();
-           !iter.atEnd();
-           builder = iter.getNext())
-         {
-         // any BytecodeBuilders that have not yet been connected are actually unreachable
-         // but unreachable code analysis will assert if their trees aren't in the method
-         // we could iterate through the trees to remove this builder's blocks from the CFG
-         // but it's probably easier to just connect the trees and let them be ripped out later
-         // but here: need to count their blocks
-         if (builder->_count < 0)
-            {
-            TraceIL("[ %p ] Adding unreachable BytecodeBuilder %p to counting worklist\n", this, builder);
-            _countBlocksWorklist->add(builder);
-            }
-         }
+      //delete *it;
       }
 
-   _count = numBlocks;
-   return numBlocks;
-   }
-
-bool
-MethodBuilder::connectTrees()
-   {
-   TraceIL("[ %p ] TR::MethodBuilder::connectTrees entry\n", this);
-   if (_useBytecodeBuilders)
+   if (_impl)
       {
-      // allocate worklists up front
-
-      _countBlocksWorklist = new (comp()->trHeapMemory()) List<TR::BytecodeBuilder>(comp()->trMemory());
-      _connectTreesWorklist = new (comp()->trHeapMemory()) List<TR::BytecodeBuilder>(comp()->trMemory());
-
-      // this will go count everything up front
-      _count = countBlocks();
+      //delete impl();
+      _impl = NULL; // ensure superclasses do not also delete _impl
       }
-
-   TraceIL("[ %p ] TR::MethodBuilder::connectTrees total blocks %d\n", this, _count);
-
-   bool rc = TR::IlBuilder::connectTrees();
-
-   if (!_useBytecodeBuilders || !rc)
-      return rc;
-
-   // call to IlBuilder::connectTrees only filled in blocks for this method builder
-   // and the first bytecode builder, but there could still be a worklist of
-   // bytecode builders to process
-
-   TR::Block **blocks = _blocks;
-
-   uint32_t currentBlock = _numBlocksBeforeWorklist;
-
-   TR::TreeTop *lastTree = blocks[currentBlock-1]->getExit();
-
-   do
-      {
-
-      // iterate on the worklist pulling trees and blocks into this builder
-      while (!_connectTreesWorklist->isEmpty())
-         {
-         TR::BytecodeBuilder *builder = _connectTreesWorklist->popHead();
-         if (!builder->_connectedTrees)
-            {
-            TraceIL("[ %p ] connectTrees visiting next builder from worklist [ %p ]\n", this, builder);
-
-            TR::TreeTop *firstTree = NULL;
-            TR::TreeTop *newLastTree = NULL;
-
-            pullInBuilderTrees(builder, &currentBlock, &firstTree, &newLastTree);
-
-            TraceIL("[ %p ] First tree is %p [ node %p ]\n", this, firstTree, firstTree->getNode());
-            TraceIL("[ %p ] Last tree will be %p [ node %p ]\n", this, newLastTree, newLastTree->getNode());
-
-            // connect the trees
-            if (lastTree)
-               {
-               TraceIL("[ %p ] Connecting tree %p [ node %p ] to new tree %p [ node %p ]\n", this, lastTree, lastTree->getNode(), firstTree, firstTree->getNode());
-               lastTree->join(firstTree);
-               }
-
-            lastTree = newLastTree;
-            }
-         }
-
-      ListIterator<TR::BytecodeBuilder> iter(_allBytecodeBuilders);
-      for (TR::BytecodeBuilder *builder=iter.getFirst();
-           !iter.atEnd();
-           builder = iter.getNext())
-         {
-         // any BytecodeBuilders that have not yet been connected are actually unreachable
-         // but unreachable code analysis will assert if their trees aren't in the method
-         // we could iterate through the trees to remove this builder's blocks from the CFG
-         // but it's probably easier to just connect the trees and let them be ripped out later
-         if (!builder->_connectedTrees)
-            {
-            TraceIL("[ %p ] Adding unreachable BytecodeBuilder %p to connection worklist\n", this, builder);
-            _connectTreesWorklist->add(builder);
-            }
-         }
-      } while (!_connectTreesWorklist->isEmpty());
-
-   return true;
-   }
-
-bool
-MethodBuilder::symbolDefined(const char *name)
-   {
-   // _symbols not good enough because symbol can be defined even if it has
-   // never been stored to, but _symbolTypes will contain all symbols, even
-   // if they have never been used. See ::DefineLocal, for example, which can
-   // be called in a MethodBuilder contructor. In contrast, ::DefineSymbol
-   // which inserts into _symbols, can only be called from within a MethodBuilder's
-   // ::buildIL() method ).
-   return _symbolTypes.find(name) != _symbolTypes.end();
    }
 
 void
-MethodBuilder::defineSymbol(const char *name, TR::SymbolReference *symRef)
+OMR::MethodBuilder::AllLocalsHaveBeenDefined()
    {
-   TR_ASSERT_FATAL(_symbols.find(name) == _symbols.end(), "Symbol '%s' already defined", name);
-
-   _symbols.insert(std::make_pair(name, symRef));
-   _symbolNameFromSlot.insert(std::make_pair(symRef->getCPIndex(), name));
-   
-   TR::IlType *type = typeDictionary()->PrimitiveType(symRef->getSymbol()->getDataType());
-   _symbolTypes.insert(std::make_pair(name, type));
-
-   if (!_newSymbolsAreTemps)
-      _methodSymbol->setFirstJitTempIndex(_methodSymbol->getTempIndex());
-   }
-
-TR::SymbolReference *
-MethodBuilder::lookupSymbol(const char *name)
-   {
-   TR::SymbolReference *symRef;
-
-   SymbolMap::iterator symbolsIterator = _symbols.find(name);
-   if (symbolsIterator != _symbols.end())  // Found
-      {
-      symRef = symbolsIterator->second;
-      return symRef;
-      }
-
-   SymbolTypeMap::iterator symTypesIterator =  _symbolTypes.find(name);
-
-   TR_ASSERT_FATAL(symTypesIterator != _symbolTypes.end(), "Symbol '%s' doesn't exist", name);
-
-   TR::IlType *symbolType = symTypesIterator->second;
-   TR::DataType primitiveType = symbolType->getPrimitiveType();
-
-   ParameterMap::iterator paramSlotsIterator = _parameterSlot.find(name);
-   if (paramSlotsIterator != _parameterSlot.end())
-      {
-      int32_t slot = paramSlotsIterator->second;
-      symRef = symRefTab()->findOrCreateAutoSymbol(_methodSymbol,
-                                                   slot,
-                                                   primitiveType,
-                                                   true, false, true);
-      }
-   else
-      {
-      symRef = symRefTab()->createTemporary(_methodSymbol, primitiveType);
-      symRef->getSymbol()->getAutoSymbol()->setName(name);
-      _symbolNameFromSlot.insert(std::make_pair(symRef->getCPIndex(), name));
-      }
-   symRef->getSymbol()->setNotCollected();
-
-   _symbols.insert(std::make_pair(name, symRef));
-
-   return symRef;
-   }
-
-TR::ResolvedMethod *
-MethodBuilder::lookupFunction(const char *name)
-   {
-   FunctionMap::iterator it = _functions.find(name);
-
-   if (it == _functions.end())  // Not found
-      {
-      size_t len = strlen(name);
-      if (len == strlen(_methodName) && strncmp(_methodName, name, len) == 0)
-         return static_cast<TR::ResolvedMethod *>(_methodSymbol->getResolvedMethod());
-      return NULL;
-      }
-
-   TR::ResolvedMethod *method = it->second;
-   return method;
-   }
-
-bool
-MethodBuilder::isSymbolAnArray(const char *name)
-   {
-   return _symbolIsArray.find(name) != _symbolIsArray.end();
-   }
-
-TR::BytecodeBuilder *
-MethodBuilder::OrphanBytecodeBuilder(int32_t bcIndex, char *name)
-   {
-   TR::BytecodeBuilder *orphan = new (comp()->trHeapMemory()) TR::BytecodeBuilder(_methodBuilder, bcIndex, name);
-   orphan->initialize(_details, _methodSymbol, _fe, _symRefTab);
-   orphan->setupForBuildIL();
-   return orphan;
+   impl()->AllLocalsHaveBeenDefined();
    }
 
 void
-MethodBuilder::AppendBuilder(TR::BytecodeBuilder *bb)
+OMR::MethodBuilder::AppendBuilder(TR::BytecodeBuilder *bb)
    {
-   this->OMR::IlBuilder::AppendBuilder(bb);
-   if (_vmState)
-      bb->propagateVMState(_vmState);
-   addBytecodeBuilderToWorklist(bb);
+   impl()->AppendBuilder(bb->impl());
    }
 
 void
-MethodBuilder::DefineName(const char *name)
+OMR::MethodBuilder::AppendBuilder(TR::IlBuilder *b)
    {
-   _methodName = name;
+   impl()->AppendBuilder(b->impl());
    }
 
 void
-MethodBuilder::DefineLocal(const char *name, TR::IlType *dt)
+OMR::MethodBuilder::AppendBytecodeBuilder(TR::BytecodeBuilder *bb)
    {
-   TR_ASSERT_FATAL(_symbolTypes.find(name) == _symbolTypes.end(), "Symbol '%s' already defined", name);
-   _symbolTypes.insert(std::make_pair(name, dt));
+   impl()->AppendBytecodeBuilder(bb->impl());
    }
 
 void
-MethodBuilder::DefineMemory(const char *name, TR::IlType *dt, void *location)
+OMR::MethodBuilder::DefineArrayParameter(const char *name, TR::IlType *dt)
    {
-   TR_ASSERT_FATAL(_memoryLocations.find(name) == _memoryLocations.end(), "Memory '%s' already defined", name);
-
-   _symbolTypes.insert(std::make_pair(name, dt));
-   _memoryLocations.insert(std::make_pair(name, location));
+   impl()->DefineArrayParameter(name, dt->impl());
    }
 
 void
-MethodBuilder::DefineParameter(const char *name, TR::IlType *dt)
+OMR::MethodBuilder::DefineFile(const char *fileName)
    {
-   TR_ASSERT_FATAL(_parameterSlot.find(name) == _parameterSlot.end(), "Parameter '%s' already defined", name);
-
-   _parameterSlot.insert(std::make_pair(name, _numParameters));
-   _symbolNameFromSlot.insert(std::make_pair(_numParameters, name));
-   _symbolTypes.insert(std::make_pair(name, dt));
-
-   _numParameters++;
+   impl()->DefineFile(fileName);
    }
 
 void
-MethodBuilder::DefineArrayParameter(const char *name, TR::IlType *elementType)
+OMR::MethodBuilder::DefineFunction(const char* const name,
+                                   const char* const fileName,
+                                   const char* const lineNumber,
+                                   void            * entryPoint,
+                                   TR::IlType      * returnType,
+                                   int32_t           numParms,
+                                   ...)
    {
-   DefineParameter(name, elementType);
+   TR::IlTypeImpl **parmTypeImpls = new TR::IlTypeImpl*[numParms];
 
-   _symbolIsArray.insert(name);
-   }
-
-void
-MethodBuilder::DefineReturnType(TR::IlType *dt)
-   {
-   _returnType = dt;
-   }
-
-void
-MethodBuilder::DefineFunction(const char* const name,
-                              const char* const fileName,
-                              const char* const lineNumber,
-                              void           * entryPoint,
-                              TR::IlType     * returnType,
-                              int32_t          numParms,
-                              ...)
-   {
-   TR::IlType **parmTypes = (TR::IlType **) malloc(numParms * sizeof(TR::IlType *));
    va_list parms;
    va_start(parms, numParms);
    for (int32_t p=0;p < numParms;p++)
       {
-      parmTypes[p] = (TR::IlType *) va_arg(parms, TR::IlType *);
+      parmTypeImpls[p] = va_arg(parms, TR::IlType *)->impl();
       }
    va_end(parms);
 
-   DefineFunction(name, fileName, lineNumber, entryPoint, returnType, numParms, parmTypes);
+   impl()->DefineFunction(name, fileName, lineNumber, entryPoint, returnType->impl(), numParms, parmTypeImpls);
+   // parmTypeImpls array now owned by impl() object
    }
 
 void
-MethodBuilder::DefineFunction(const char* const name,
-                              const char* const fileName,
-                              const char* const lineNumber,
-                              void           * entryPoint,
-                              TR::IlType     * returnType,
-                              int32_t          numParms,
-                              TR::IlType     ** parmTypes)
-   {   
-   TR_ASSERT_FATAL(_functions.find(name) == _functions.end(), "Function '%s' already defined", name);
-   TR::ResolvedMethod *method = new (*_memoryRegion) TR::ResolvedMethod((char*)fileName,
-                                                                        (char*)lineNumber,
-                                                                        (char*)name,
-                                                                        numParms,
-                                                                        parmTypes,
-                                                                        returnType,
-                                                                        entryPoint,
-                                                                        0);
-
-   _functions.insert(std::make_pair(name, method));
-   }
-
-const char *
-MethodBuilder::getSymbolName(int32_t slot)
+OMR::MethodBuilder::DefineFunction(const char* const name,
+                                   const char* const fileName,
+                                   const char* const lineNumber,
+                                   void            * entryPoint,
+                                   TR::IlType      * returnType,
+                                   int32_t           numParms,
+                                   TR::IlType     ** parmTypes)
    {
-   // Sometimes the code generators will manufacture a symbol reference themselves with no way
-   // to properly assign a cpIndex, that these symbol references show up here with slot == -1
-   // when JIT logging. One specific case is when the code generate converts an indirect store to
-   // a known stack allocated object using a constant offset to a store with a different offset
-   // based of the stack pointer (because it knows exactly which stack slot is being referenced),
-   // but there could be other cases. This escape clause doesn't feel like a great solution to this
-   // problem, but since the assertions only really catch while create JIT logs (names are only
-   // needed when generating logs), it's actually more useful to allow the compilation to continue
-   // so that the full log can be generated rather than aborting.
-   if (slot == -1)
-      return "Unknown";
-
-   SlotToSymNameMap::iterator it = _symbolNameFromSlot.find(slot);
-   TR_ASSERT_FATAL(it != _symbolNameFromSlot.end(), "No symbol found in slot %d", slot);
-
-   const char *symbolName = it->second;
-   return symbolName;
-   }
-
-TR::IlType **
-MethodBuilder::getParameterTypes()
-   {
-   if (_cachedParameterTypes)
-      return _cachedParameterTypes;
-
-   TR_ASSERT(_numParameters < 10, "too many parameters for parameter types array");
-   TR::IlType **paramTypesArray = _cachedParameterTypesArray;
-   for (int32_t p=0;p < _numParameters;p++)
+   TR::IlTypeImpl **parmTypeImpls = new TR::IlTypeImpl*[numParms];
+   for (int32_t p=0;p < numParms;p++)
       {
-      SlotToSymNameMap::iterator symNamesIterator = _symbolNameFromSlot.find(p);
-      TR_ASSERT_FATAL(symNamesIterator != _symbolNameFromSlot.end(), "No symbol found in slot %d", p);
-      const char *name = symNamesIterator->second;
-
-      std::map<const char *, TR::IlType *, StrComparator>::iterator symTypesIterator = _symbolTypes.find(name);
-      TR_ASSERT_FATAL(symTypesIterator != _symbolTypes.end(), "No matching symbol type for parameter '%s'", name);
-      paramTypesArray[p] = symTypesIterator->second;
+      parmTypeImpls[p] = parmTypes[p]->impl();
       }
 
-   _cachedParameterTypes = paramTypesArray;
-   return paramTypesArray;
+   impl()->DefineFunction(name, fileName, lineNumber, entryPoint, returnType->impl(), numParms, parmTypeImpls);
+   // parmTypeImpls array now owned by impl() object
    }
 
 void
-MethodBuilder::addToBlockCountingWorklist(TR::BytecodeBuilder *builder)
+OMR::MethodBuilder::DefineLine(const char *line)
    {
-   TraceIL("[ %p ] TR::MethodBuilder::addToBlockCountingWorklist %p\n", this, builder);
-   _countBlocksWorklist->add(builder);
+   impl()->DefineLine(line);
    }
 
 void
-MethodBuilder::addToTreeConnectingWorklist(TR::BytecodeBuilder *builder)
+OMR::MethodBuilder::DefineLine(int line)
    {
-   if (!builder->_connectedTrees)
-      {
-      TraceIL("[ %p ] TR::MethodBuilder::addToTreeConnectingWorklist %p\n", this, builder);
-      _connectTreesWorklist->add(builder);
-      }
+   impl()->DefineLine(line);
    }
 
 void
-MethodBuilder::addToAllBytecodeBuildersList(TR::BytecodeBuilder* bcBuilder)
+OMR::MethodBuilder::DefineLocal(const char *name, TR::IlType *dt)
    {
-   if (NULL == _allBytecodeBuilders)
-      {
-      _allBytecodeBuilders = new (comp()->trHeapMemory()) List<TR::BytecodeBuilder>(comp()->trMemory());
-      //if we're allocating this list, then this method builder uses bytecode builders
-      setUseBytecodeBuilders();
-      }
-   _allBytecodeBuilders->add(bcBuilder);
+   impl()->DefineLocal(name, dt->impl());
    }
 
 void
-MethodBuilder::AppendBytecodeBuilder(TR::BytecodeBuilder *builder)
+OMR::MethodBuilder::DefineMemory(const char *name, TR::IlType *dt, void *location)
    {
-   IlBuilder::AppendBuilder(builder);
-   
+   impl()->DefineMemory(name, dt->impl(), location);
    }
 
 void
-MethodBuilder::addBytecodeBuilderToWorklist(TR::BytecodeBuilder *builder)
+OMR::MethodBuilder::DefineName(const char *name)
    {
-   if (_bytecodeWorklist == NULL)
-      {
-      _bytecodeWorklist = new (comp()->trHeapMemory()) TR_BitVector(32, comp()->trMemory());
-      _bytecodeHasBeenInWorklist = new (comp()->trHeapMemory()) TR_BitVector(32, comp()->trMemory());
-      }
+   impl()->DefineName(name);
+   }
 
-   int32_t b_bci = builder->bcIndex();
-   if (!_bytecodeHasBeenInWorklist->get(b_bci))
-      {
-      _bytecodeWorklist->set(b_bci);
-      _bytecodeHasBeenInWorklist->set(b_bci);
-      }
+void
+OMR::MethodBuilder::DefineParameter(const char *name, TR::IlType *type)
+   {
+   impl()->DefineParameter(name, type->impl());
+   }
+
+void
+OMR::MethodBuilder::DefineReturnType(TR::IlType *dt)
+   {
+   impl()->DefineReturnType(dt->impl());
    }
 
 int32_t
-MethodBuilder::GetNextBytecodeFromWorklist()
+OMR::MethodBuilder::GetNextBytecodeFromWorklist()
    {
-   if (_bytecodeWorklist == NULL || _bytecodeWorklist->isEmpty())
-      return -1;
-
-   TR_BitVectorIterator it(*_bytecodeWorklist);
-   int32_t bci=it.getFirstElement();
-   if (bci > -1)
-      _bytecodeWorklist->reset(bci);
-   return bci;
+   return impl()->GetNextBytecodeFromWorklist();
    }
 
-} // namespace OMR
+TR::BytecodeBuilder *
+OMR::MethodBuilder::OrphanBytecodeBuilder(int32_t bcIndex, char *name)
+   {
+   TR::BytecodeBuilderImpl *bbi = impl()->OrphanBytecodeBuilderImpl(bcIndex, name);
+   TR::BytecodeBuilder *bcb = new TR::BytecodeBuilder(bbi, static_cast<TR::MethodBuilder *>(this), _types);
+   bbi->setClient(bcb);
+   newBuilder(bcb);
+   return bcb;
+   }
+
+void
+OMR::MethodBuilder::setVMState(OMR::VirtualMachineState *vmState)
+   {
+   impl()->SetVMState(vmState);
+   }
+
+void
+OMR::MethodBuilder::newBuilder(TR::IlBuilder *b)
+   {
+   _ownedBuilderObjects.push_back(b);
+   }

--- a/compiler/ilgen/MethodBuilderImpl.cpp
+++ b/compiler/ilgen/MethodBuilderImpl.cpp
@@ -1,0 +1,637 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include <iostream>
+#include <fstream>
+
+#include <stdint.h>
+#include "compile/Method.hpp"
+#include "env/FrontEnd.hpp"
+#include "env/Region.hpp"
+#include "env/SystemSegmentProvider.hpp"
+#include "env/TRMemory.hpp"
+#include "il/Block.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Recompilation.hpp"
+#include "infra/Assert.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/STLUtils.hpp"
+#include "infra/List.hpp"
+#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "ilgen/IlInjector.hpp"
+#include "ilgen/IlBuilderImpl.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/BytecodeBuilderImpl.hpp"
+#include "ilgen/TypeDictionaryImpl.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+
+#define OPT_DETAILS "O^O ILBLD: "
+
+// Size of MethodBuilderImpl memory segments
+#define MEM_SEGMENT_SIZE 1 << 16   // i.e. 65536 bytes (~64KB)
+
+// MethodBuilderImpl is an IlBuilderImpl object representing an entire method /
+// function, so it conceptually has an entry point (though multiple entry
+// method builders are entirely possible). Typically there is a single
+// MethodBuilderImpl created for each particular method compilation unit and
+// multiple methods would require multiple MethodBuilderImpl objects.
+//
+// A MethodBuilderImpl is also an IlBuilderImpl whose control flow path starts when
+// the method is called. Returning from the method must be explicitly built
+// into the builder.
+//
+
+OMR::MethodBuilderImpl::MethodBuilderImpl(TR::MethodBuilder *clientBuilder, TR::TypeDictionaryImpl *types, OMR::VirtualMachineState *vmState)
+   : TR::IlBuilderImpl(static_cast<TR::MethodBuilderImpl *>(this), types),
+   // Note: _memoryRegion and the corresponding TR::SegmentProvider and TR::Memory instances are stored as pointers within MethodBuilderImpl
+   // in order to avoid increasing the number of header files needed to compile against the JitBuilder library. Because we are storing
+   // them as pointers, we cannot rely on the default C++ destruction semantic to destruct and deallocate the memory region, but rather
+   // have to do it explicitly in the MethodBuilderImpl destructor. And since C++ destroys the other members *after* executing the user defined
+   // destructor, we need to make sure that any members (and their contents) that are allocated in _memoryRegion are explicitly destroyed
+   // and deallocated *before* _memoryRegion in the MethodBuilderImpl destructor.
+   _segmentProvider(new(TR::Compiler->persistentAllocator()) TR::SystemSegmentProvider(MEM_SEGMENT_SIZE, TR::Compiler->rawAllocator)),
+   _memoryRegion(new(TR::Compiler->persistentAllocator()) TR::Region(*_segmentProvider, TR::Compiler->rawAllocator)),
+   _trMemory(new(TR::Compiler->persistentAllocator()) TR_Memory(*::trPersistentMemory, *_memoryRegion)),
+   _methodName("NoName"),
+   _returnType(NoType),
+   _numParameters(0),
+   _symbols(str_comparator, *_memoryRegion),
+   _parameterSlot(str_comparator, *_memoryRegion),
+   _symbolTypes(str_comparator, *_memoryRegion),
+   _symbolNameFromSlot(std::less<int32_t>(), *_memoryRegion),
+   _symbolIsArray(str_comparator, *_memoryRegion),
+   _memoryLocations(str_comparator, *_memoryRegion),
+   _functions(str_comparator, *_memoryRegion),
+   _cachedParameterTypes(0),
+   _definingFile(""),
+   _newSymbolsAreTemps(false),
+   _nextValueID(0),
+   _useBytecodeBuilders(false),
+   _countBlocksWorklist(0),
+   _connectTreesWorklist(0),
+   _allBytecodeBuilders(0),
+   _vmState(vmState),
+   _bytecodeWorklist(NULL),
+   _bytecodeHasBeenInWorklist(NULL)
+   {
+   _definingLine[0] = '\0';
+   setClient(clientBuilder);
+   }
+
+OMR::MethodBuilderImpl::~MethodBuilderImpl()
+   {
+   // Cleanup allocations in _memoryRegion *before* its destroyed below (see note in constructor)
+   _symbols.clear();
+   _parameterSlot.clear();
+   _symbolTypes.clear();
+   _symbolNameFromSlot.clear();
+   _symbolIsArray.clear();
+   _memoryLocations.clear();
+   _functions.clear();
+
+   _trMemory->~TR_Memory();
+   ::operator delete(_trMemory, TR::Compiler->persistentAllocator());
+   _memoryRegion->~Region();
+   ::operator delete(_memoryRegion, TR::Compiler->persistentAllocator());
+   static_cast<TR::SystemSegmentProvider *>(_segmentProvider)->~SystemSegmentProvider();
+   ::operator delete(_segmentProvider, TR::Compiler->persistentAllocator());
+   }
+
+TR::MethodBuilder *
+OMR::MethodBuilderImpl::client()
+   {
+   return static_cast<TR::MethodBuilder *>(_clientBuilder);
+   }
+
+TR::MethodBuilderImpl *
+OMR::MethodBuilderImpl::asMethodBuilder()
+   {
+   return static_cast<TR::MethodBuilderImpl *>(this);
+   }
+
+bool
+OMR::MethodBuilderImpl::buildIL()
+   {
+   AllLocalsHaveBeenDefined();
+   return client()->buildIL();
+   }
+
+void
+OMR::MethodBuilderImpl::setupForBuildIL()
+   {
+   initSequence();
+
+   _entryBlock = cfg()->getStart()->asBlock();
+   _exitBlock = cfg()->getEnd()->asBlock();
+
+   TraceIL("\tEntry = %p\n", _entryBlock);
+   TraceIL("\tExit  = %p\n", _exitBlock);
+
+   // initial "real" block 2 flowing from Entry
+   appendBlock(NULL, false);
+
+   // Method's first tree is from Entry block
+   _methodSymbol->setFirstTreeTop(_currentBlock->getEntry());
+
+   // set up initial CFG
+   cfg()->addEdge(_entryBlock, _currentBlock);
+   }
+
+bool
+OMR::MethodBuilderImpl::injectIL()
+   {
+   bool rc = IlBuilderImpl::injectIL();
+   return rc;
+   }
+
+
+uint32_t
+OMR::MethodBuilderImpl::countBlocks()
+   {
+   if (_count > -1)
+      return _count;
+
+   TraceIL("[ %p ] TR::MethodBuilderImpl::countBlocks 0 at entry\n", this);
+
+   uint32_t numBlocks = this->TR::IlBuilderImpl::countBlocks();
+
+   _numBlocksBeforeWorklist = numBlocks;
+
+   TraceIL("[ %p ] TR::MethodBuilderImpl::countBlocks %d before worklist\n", this, numBlocks);
+
+   // if not using bytecode builders, numBlocks is the real count
+   if (!_useBytecodeBuilders)
+      return numBlocks;
+
+   TraceIL("[ %p ] TR::MethodBuilderImpl::countBlocks iterating over worklist\n", this);
+   // also need to visit any bytecode builders that have been added to the count worklist
+   while (!_countBlocksWorklist->isEmpty())
+      {
+
+      while (!_countBlocksWorklist->isEmpty())
+         {
+         TR::BytecodeBuilderImpl *builder = _countBlocksWorklist->popHead();
+         TraceIL("[ %p ] TR::MethodBuilderImpl::countBlocks visiting [ %p ]\n", this, builder);
+         numBlocks += builder->countBlocks();
+         TraceIL("[ %p ] numBlocks is %d\n", this, numBlocks);
+         }
+
+      ListIterator<TR::BytecodeBuilderImpl> iter(_allBytecodeBuilders);
+      for (TR::BytecodeBuilderImpl *builder=iter.getFirst();
+           !iter.atEnd();
+           builder = iter.getNext())
+         {
+         // any BytecodeBuilderImpls that have not yet been connected are actually unreachable
+         // but unreachable code analysis will assert if their trees aren't in the method
+         // we could iterate through the trees to remove this builder's blocks from the CFG
+         // but it's probably easier to just connect the trees and let them be ripped out later
+         // but here: need to count their blocks
+         if (builder->_count < 0)
+            {
+            TraceIL("[ %p ] Adding unreachable BytecodeBuilderImpl %p to counting worklist\n", this, builder);
+            _countBlocksWorklist->add(builder);
+            }
+         }
+      }
+
+   _count = numBlocks;
+   return numBlocks;
+   }
+
+bool
+OMR::MethodBuilderImpl::connectTrees()
+   {
+   TraceIL("[ %p ] TR::MethodBuilderImpl::connectTrees entry\n", this);
+   if (_useBytecodeBuilders)
+      {
+      // allocate worklists up front
+
+      _countBlocksWorklist = new (comp()->trHeapMemory()) List<TR::BytecodeBuilderImpl>(comp()->trMemory());
+      _connectTreesWorklist = new (comp()->trHeapMemory()) List<TR::BytecodeBuilderImpl>(comp()->trMemory());
+
+      // this will go count everything up front
+      _count = countBlocks();
+      }
+
+   TraceIL("[ %p ] TR::MethodBuilderImpl::connectTrees total blocks %d\n", this, _count);
+
+   bool rc = TR::IlBuilderImpl::connectTrees();
+
+   if (!_useBytecodeBuilders || !rc)
+      return rc;
+
+   // call to IlBuilderImpl::connectTrees only filled in blocks for this method builder
+   // and the first bytecode builder, but there could still be a worklist of
+   // bytecode builders to process
+
+   TR::Block **blocks = _blocks;
+
+   uint32_t currentBlock = _numBlocksBeforeWorklist;
+
+   TR::TreeTop *lastTree = blocks[currentBlock-1]->getExit();
+
+   do
+      {
+
+      // iterate on the worklist pulling trees and blocks into this builder
+      while (!_connectTreesWorklist->isEmpty())
+         {
+         TR::BytecodeBuilderImpl *builder = _connectTreesWorklist->popHead();
+         if (!builder->_connectedTrees)
+            {
+            TraceIL("[ %p ] connectTrees visiting next builder from worklist [ %p ]\n", this, builder);
+
+            TR::TreeTop *firstTree = NULL;
+            TR::TreeTop *newLastTree = NULL;
+
+            pullInBuilderTrees(builder, &currentBlock, &firstTree, &newLastTree);
+
+            TraceIL("[ %p ] First tree is %p [ node %p ]\n", this, firstTree, firstTree->getNode());
+            TraceIL("[ %p ] Last tree will be %p [ node %p ]\n", this, newLastTree, newLastTree->getNode());
+
+            // connect the trees
+            if (lastTree)
+               {
+               TraceIL("[ %p ] Connecting tree %p [ node %p ] to new tree %p [ node %p ]\n", this, lastTree, lastTree->getNode(), firstTree, firstTree->getNode());
+               lastTree->join(firstTree);
+               }
+
+            lastTree = newLastTree;
+            }
+         }
+
+      ListIterator<TR::BytecodeBuilderImpl> iter(_allBytecodeBuilders);
+      for (TR::BytecodeBuilderImpl *builder=iter.getFirst();
+           !iter.atEnd();
+           builder = iter.getNext())
+         {
+         // any BytecodeBuilderImpls that have not yet been connected are actually unreachable
+         // but unreachable code analysis will assert if their trees aren't in the method
+         // we could iterate through the trees to remove this builder's blocks from the CFG
+         // but it's probably easier to just connect the trees and let them be ripped out later
+         if (!builder->_connectedTrees)
+            {
+            TraceIL("[ %p ] Adding unreachable BytecodeBuilderImpl %p to connection worklist\n", this, builder);
+            _connectTreesWorklist->add(builder);
+            }
+         }
+      } while (!_connectTreesWorklist->isEmpty());
+
+   return true;
+   }
+
+bool
+OMR::MethodBuilderImpl::symbolDefined(const char *name)
+   {
+   // _symbols not good enough because symbol can be defined even if it has
+   // never been stored to, but _symbolTypes will contain all symbols, even
+   // if they have never been used. See ::DefineLocal, for example, which can
+   // be called in a MethodBuilderImpl contructor. In contrast, ::DefineSymbol
+   // which inserts into _symbols, can only be called from within a MethodBuilderImpl's
+   // ::buildIL() method ).
+   return _symbolTypes.find(name) != _symbolTypes.end();
+   }
+
+void
+OMR::MethodBuilderImpl::defineSymbol(const char *name, TR::SymbolReference *symRef)
+   {
+   TR_ASSERT_FATAL(_symbols.find(name) == _symbols.end(), "Symbol '%s' already defined", name);
+
+   _symbols.insert(std::make_pair(name, symRef));
+   _symbolNameFromSlot.insert(std::make_pair(symRef->getCPIndex(), name));
+   
+   TR::IlTypeImpl *type = typeDictionary()->PrimitiveType(symRef->getSymbol()->getDataType());
+   _symbolTypes.insert(std::make_pair(name, type));
+
+   if (!_newSymbolsAreTemps)
+      _methodSymbol->setFirstJitTempIndex(_methodSymbol->getTempIndex());
+   }
+
+TR::SymbolReference *
+OMR::MethodBuilderImpl::lookupSymbol(const char *name)
+   {
+   TR::SymbolReference *symRef;
+
+   SymbolMap::iterator symbolsIterator = _symbols.find(name);
+   if (symbolsIterator != _symbols.end())  // Found
+      {
+      symRef = symbolsIterator->second;
+      return symRef;
+      }
+
+   SymbolTypeMap::iterator symTypesIterator =  _symbolTypes.find(name);
+
+   TR_ASSERT_FATAL(symTypesIterator != _symbolTypes.end(), "Symbol '%s' doesn't exist", name);
+
+   TR::IlTypeImpl *symbolType = symTypesIterator->second;
+   TR::DataType primitiveType = symbolType->getRealPrimitiveType();
+
+   ParameterMap::iterator paramSlotsIterator = _parameterSlot.find(name);
+   if (paramSlotsIterator != _parameterSlot.end())
+      {
+      int32_t slot = paramSlotsIterator->second;
+      symRef = symRefTab()->findOrCreateAutoSymbol(_methodSymbol,
+                                                   slot,
+                                                   primitiveType,
+                                                   true, false, true);
+      }
+   else
+      {
+      symRef = symRefTab()->createTemporary(_methodSymbol, primitiveType);
+      symRef->getSymbol()->getAutoSymbol()->setName(name);
+      _symbolNameFromSlot.insert(std::make_pair(symRef->getCPIndex(), name));
+      }
+   symRef->getSymbol()->setNotCollected();
+
+   _symbols.insert(std::make_pair(name, symRef));
+
+   return symRef;
+   }
+
+TR::ResolvedMethod *
+OMR::MethodBuilderImpl::lookupFunction(const char *name)
+   {
+   FunctionMap::iterator it = _functions.find(name);
+
+   if (it == _functions.end())  // Not found
+      {
+      size_t len = strlen(name);
+      if (len == strlen(_methodName) && strncmp(_methodName, name, len) == 0)
+         return static_cast<TR::ResolvedMethod *>(_methodSymbol->getResolvedMethod());
+      return NULL;
+      }
+
+   TR::ResolvedMethod *method = it->second;
+   return method;
+   }
+
+bool
+OMR::MethodBuilderImpl::isSymbolAnArray(const char *name)
+   {
+   return _symbolIsArray.find(name) != _symbolIsArray.end();
+   }
+
+TR::BytecodeBuilderImpl *
+OMR::MethodBuilderImpl::OrphanBytecodeBuilderImpl(int32_t bcIndex, char *name)
+   {
+   TR::BytecodeBuilderImpl *orphan = new (comp()->trHeapMemory()) TR::BytecodeBuilderImpl(_methodBuilder, bcIndex, name);
+   orphan->initialize(_details, _methodSymbol, _fe, _symRefTab);
+   orphan->setupForBuildIL();
+   return orphan;
+   }
+
+TR::BytecodeBuilderImpl *
+OMR::MethodBuilderImpl::orphanBytecodeBuilderImpl(int32_t bcIndex, char *name)
+   {
+   return client()->OrphanBytecodeBuilder(bcIndex, name)->impl();
+   }
+
+void
+OMR::MethodBuilderImpl::AppendBuilder(TR::BytecodeBuilderImpl *bb)
+   {
+   this->OMR::IlBuilderImpl::AppendBuilder(bb);
+   if (_vmState)
+      bb->propagateVMState(_vmState);
+   addBytecodeBuilderToWorklist(bb);
+   }
+
+void
+OMR::MethodBuilderImpl::DefineName(const char *name)
+   {
+   _methodName = name;
+   }
+
+void
+OMR::MethodBuilderImpl::DefineLocal(const char *name, TR::IlTypeImpl *dt)
+   {
+   TR_ASSERT_FATAL(_symbolTypes.find(name) == _symbolTypes.end(), "Symbol '%s' already defined", name);
+   _symbolTypes.insert(std::make_pair(name, dt));
+   }
+
+void
+OMR::MethodBuilderImpl::DefineMemory(const char *name, TR::IlTypeImpl *dt, void *location)
+   {
+   TR_ASSERT_FATAL(_memoryLocations.find(name) == _memoryLocations.end(), "Memory '%s' already defined", name);
+
+   _symbolTypes.insert(std::make_pair(name, dt));
+   _memoryLocations.insert(std::make_pair(name, location));
+   }
+
+void
+OMR::MethodBuilderImpl::DefineParameter(const char *name, TR::IlTypeImpl *dt)
+   {
+   TR_ASSERT_FATAL(_parameterSlot.find(name) == _parameterSlot.end(), "Parameter '%s' already defined", name);
+
+   _parameterSlot.insert(std::make_pair(name, _numParameters));
+   _symbolNameFromSlot.insert(std::make_pair(_numParameters, name));
+   _symbolTypes.insert(std::make_pair(name, dt));
+
+   _numParameters++;
+   }
+
+void
+OMR::MethodBuilderImpl::DefineArrayParameter(const char *name, TR::IlTypeImpl *elementType)
+   {
+   DefineParameter(name, elementType);
+
+   _symbolIsArray.insert(name);
+   }
+
+void
+OMR::MethodBuilderImpl::DefineReturnType(TR::IlTypeImpl *dt)
+   {
+   _returnType = dt;
+   }
+
+void
+OMR::MethodBuilderImpl::DefineFunction(const char * const    name,
+                                       const char * const    fileName,
+                                       const char * const    lineNumber,
+                                       void                * entryPoint,
+                                       TR::IlTypeImpl      * returnType,
+                                       int32_t               numParms,
+                                       ...)
+   {
+   TR::IlTypeImpl **parmTypes = (TR::IlTypeImpl **) TR::comp()->trMemory()->allocateHeapMemory(numParms * sizeof(TR::IlTypeImpl *));
+   va_list parms;
+   va_start(parms, numParms);
+   for (int32_t p=0;p < numParms;p++)
+      {
+      parmTypes[p] = (TR::IlTypeImpl *) va_arg(parms, TR::IlTypeImpl *);
+      }
+   va_end(parms);
+
+   DefineFunction(name, fileName, lineNumber, entryPoint, returnType, numParms, parmTypes);
+   }
+
+void
+OMR::MethodBuilderImpl::DefineFunction(const char * const    name,
+                                       const char * const    fileName,
+                                       const char * const    lineNumber,
+                                       void                * entryPoint,
+                                       TR::IlTypeImpl      * returnType,
+                                       int32_t               numParms,
+                                       TR::IlTypeImpl     ** parmTypes)
+   {   
+   TR_ASSERT_FATAL(_functions.find(name) == _functions.end(), "Function '%s' already defined", name);
+   TR::ResolvedMethod *method = new (*_memoryRegion) TR::ResolvedMethod((char*)fileName,
+                                                                        (char*)lineNumber,
+                                                                        (char*)name,
+                                                                        numParms,
+                                                                        parmTypes,
+                                                                        returnType,
+                                                                        entryPoint,
+                                                                        0);
+
+   _functions.insert(std::make_pair(name, method));
+   }
+
+const char *
+OMR::MethodBuilderImpl::getSymbolName(int32_t slot)
+   {
+   // Sometimes the code generators will manufacture a symbol reference themselves with no way
+   // to properly assign a cpIndex, that these symbol references show up here with slot == -1
+   // when JIT logging. One specific case is when the code generate converts an indirect store to
+   // a known stack allocated object using a constant offset to a store with a different offset
+   // based of the stack pointer (because it knows exactly which stack slot is being referenced),
+   // but there could be other cases. This escape clause doesn't feel like a great solution to this
+   // problem, but since the assertions only really catch while create JIT logs (names are only
+   // needed when generating logs), it's actually more useful to allow the compilation to continue
+   // so that the full log can be generated rather than aborting.
+   if (slot == -1)
+      return "Unknown";
+
+   SlotToSymNameMap::iterator it = _symbolNameFromSlot.find(slot);
+   TR_ASSERT_FATAL(it != _symbolNameFromSlot.end(), "No symbol found in slot %d", slot);
+
+   const char *symbolName = it->second;
+   return symbolName;
+   }
+
+TR::IlTypeImpl **
+OMR::MethodBuilderImpl::getParameterTypes()
+   {
+   if (_cachedParameterTypes)
+      return _cachedParameterTypes;
+
+   TR_ASSERT(_numParameters < 10, "too many parameters for parameter types array");
+   TR::IlTypeImpl **paramTypesArray = _cachedParameterTypesArray;
+   for (int32_t p=0;p < _numParameters;p++)
+      {
+      SlotToSymNameMap::iterator symNamesIterator = _symbolNameFromSlot.find(p);
+      TR_ASSERT_FATAL(symNamesIterator != _symbolNameFromSlot.end(), "No symbol found in slot %d", p);
+      const char *name = symNamesIterator->second;
+
+      std::map<const char *, TR::IlTypeImpl *, StrComparator>::iterator symTypesIterator = _symbolTypes.find(name);
+      TR_ASSERT_FATAL(symTypesIterator != _symbolTypes.end(), "No matching symbol type for parameter '%s'", name);
+      paramTypesArray[p] = symTypesIterator->second;
+      }
+
+   _cachedParameterTypes = paramTypesArray;
+   return paramTypesArray;
+   }
+
+void
+OMR::MethodBuilderImpl::addToBlockCountingWorklist(TR::BytecodeBuilderImpl *builder)
+   {
+   TraceIL("[ %p ] TR::MethodBuilderImpl::addToBlockCountingWorklist %p\n", this, builder);
+   _countBlocksWorklist->add(builder);
+   }
+
+void
+OMR::MethodBuilderImpl::addToTreeConnectingWorklist(TR::BytecodeBuilderImpl *builder)
+   {
+   if (!builder->_connectedTrees)
+      {
+      TraceIL("[ %p ] TR::MethodBuilderImpl::addToTreeConnectingWorklist %p\n", this, builder);
+      _connectTreesWorklist->add(builder);
+      }
+   }
+
+void
+OMR::MethodBuilderImpl::addToAllBytecodeBuildersList(TR::BytecodeBuilderImpl* bcBuilder)
+   {
+   if (NULL == _allBytecodeBuilders)
+      {
+      _allBytecodeBuilders = new (comp()->trHeapMemory()) List<TR::BytecodeBuilderImpl>(comp()->trMemory());
+      //if we're allocating this list, then this method builder uses bytecode builders
+      setUseBytecodeBuilders();
+      }
+   _allBytecodeBuilders->add(bcBuilder);
+   }
+
+void
+OMR::MethodBuilderImpl::AppendBytecodeBuilder(TR::BytecodeBuilderImpl *builder)
+   {
+   this->IlBuilderImpl::AppendBuilder(builder);
+   }
+
+void
+OMR::MethodBuilderImpl::addBytecodeBuilderToWorklist(TR::BytecodeBuilderImpl *builder)
+   {
+   if (_bytecodeWorklist == NULL)
+      {
+      _bytecodeWorklist = new (comp()->trHeapMemory()) TR_BitVector(32, comp()->trMemory());
+      _bytecodeHasBeenInWorklist = new (comp()->trHeapMemory()) TR_BitVector(32, comp()->trMemory());
+      }
+
+   int32_t b_bci = builder->bcIndex();
+   if (!_bytecodeHasBeenInWorklist->get(b_bci))
+      {
+      _bytecodeWorklist->set(b_bci);
+      _bytecodeHasBeenInWorklist->set(b_bci);
+      }
+   }
+
+int32_t
+OMR::MethodBuilderImpl::GetNextBytecodeFromWorklist()
+   {
+   if (_bytecodeWorklist == NULL || _bytecodeWorklist->isEmpty())
+      return -1;
+
+   TR_BitVectorIterator it(*_bytecodeWorklist);
+   int32_t bci=it.getFirstElement();
+   if (bci > -1)
+      _bytecodeWorklist->reset(bci);
+   return bci;
+   }
+
+TR::MethodBuilderImpl *
+OMR::MethodBuilderImpl::allocate(TR::MethodBuilder *client, TR::TypeDictionaryImpl *types, OMR::VirtualMachineState *vmState)
+   {
+   //LEAK: unfortunately must allocate in persistent memory because compilation hasn't begun when MethodBuilder object is created
+   return new (PERSISTENT_NEW) TR::MethodBuilderImpl(client, types, vmState);
+   }
+
+bool
+OMR::MethodBuilderImpl::RequestFunction(const char *name)
+   {
+   return client()->RequestFunction(name);
+   }

--- a/compiler/ilgen/MethodBuilderImpl.hpp
+++ b/compiler/ilgen/MethodBuilderImpl.hpp
@@ -1,0 +1,287 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_METHODBUILDER_IMPL_INCL
+#define OMR_METHODBUILDER_IMPL_INCL
+
+
+#ifndef TR_METHODBUILDER_IMPL_DEFINED
+#define TR_METHODBUILDER_IMPL_DEFINED
+#define PUT_OMR_METHODBUILDER_IMPL_INTO_TR
+#endif
+
+
+#include <map>
+#include <set>
+#include <fstream>
+#include "ilgen/IlBuilderImpl.hpp"
+#include "env/TypedAllocator.hpp"
+
+// Maximum length of _definingLine string (including null terminator)
+#define MAX_LINE_NUM_LEN 7
+
+class TR_BitVector;
+namespace TR { class BytecodeBuilder; }
+namespace TR { class ResolvedMethod; }
+namespace TR { class SymbolReference; }
+namespace OMR { class VirtualMachineState; }
+
+namespace TR { class SegmentProvider; }
+namespace TR { class Region; }
+class TR_Memory;
+
+namespace TR { class BytecodeBuilderImpl; }
+namespace TR { class IlType; }
+namespace TR { class IlTypeImpl; }
+namespace TR { class MethodBuilder; }
+namespace TR { class MethodBuilderImpl; }
+namespace TR { class TypeDictionaryImpl; }
+
+namespace OMR
+{
+
+class MethodBuilderImpl : public TR::IlBuilderImpl
+   {
+   public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   MethodBuilderImpl(TR::MethodBuilder *clientBuilder, TR::TypeDictionaryImpl *types, OMR::VirtualMachineState *vmState = NULL);
+   MethodBuilderImpl(TR::MethodBuilder *clientBuilder, const MethodBuilderImpl &src);
+   virtual ~MethodBuilderImpl();
+
+   void operator delete(void * ptr)
+      { }
+
+   virtual bool buildIL();
+
+   virtual TR::MethodBuilderImpl * asMethodBuilder();
+
+   /*
+    * Client API support for MethodBuilder, in alphabetical order
+    */
+   void AllLocalsHaveBeenDefined()
+      {
+      _newSymbolsAreTemps = true;
+      }
+   void AppendBuilder(TR::BytecodeBuilderImpl *bb);
+   void AppendBytecodeBuilder(TR::BytecodeBuilderImpl *builder);
+   void DefineArrayParameter(const char *name, TR::IlTypeImpl *dt);
+   void DefineFile(const char *file)
+      {
+      _definingFile = file;
+      }
+   void DefineFunction(const char* const name,
+                               const char* const fileName,
+                               const char* const lineNumber,
+                               void           * entryPoint,
+                               TR::IlTypeImpl * returnType,
+                               int32_t          numParms,
+                               ...);
+   void DefineFunction(const char* const name,
+                               const char* const fileName,
+                               const char* const lineNumber,
+                               void           * entryPoint,
+                               TR::IlTypeImpl * returnType,
+                               int32_t          numParms,
+                               TR::IlTypeImpl ** parmTypes);
+   void DefineLine(const char *line)
+      {
+      snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%s", line);
+      }
+   void DefineLine(int line)
+      {
+      snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%d", line);
+      }
+   void DefineLocal(const char *name, TR::IlTypeImpl *dt);
+   void DefineMemory(const char *name, TR::IlTypeImpl *dt, void *location);
+   void DefineName(const char *name);
+   void DefineParameter(const char *name, TR::IlTypeImpl *type);
+   void DefineReturnType(TR::IlTypeImpl *dt);
+   int32_t GetNextBytecodeFromWorklist();
+   TR::BytecodeBuilderImpl *OrphanBytecodeBuilderImpl(int32_t bcIndex=0, char *name=NULL);
+   bool RequestFunction(const char *name);
+   void SetVMState(OMR::VirtualMachineState *vmState)
+      {
+      _vmState = vmState;
+      }
+
+
+
+   /*
+    * Client API support for IlBuilder, in alphabetical order
+    */
+   void AppendBuilder(TR::IlBuilderImpl *b)
+      {
+      this->OMR::IlBuilderImpl::AppendBuilder(b);
+      }
+
+
+   /*
+    * Public API for *Impl classes
+    */
+
+   static TR::MethodBuilderImpl *allocate(TR::MethodBuilder *client, TR::TypeDictionaryImpl *types, OMR::VirtualMachineState *vmState);
+
+   TR::BytecodeBuilderImpl *orphanBytecodeBuilderImpl(int32_t bcIndex=0, char *name=NULL);
+
+   virtual void setupForBuildIL();
+   virtual bool injectIL();
+
+   int32_t getNextValueID()                                  { return _nextValueID++; }
+   bool usesBytecodeBuilders()                               { return _useBytecodeBuilders; }
+   void setUseBytecodeBuilders()                             { _useBytecodeBuilders = true; }
+
+   void addToAllBytecodeBuildersList(TR::BytecodeBuilderImpl *bcBuilder);
+   void addToTreeConnectingWorklist(TR::BytecodeBuilderImpl *builder);
+   void addToBlockCountingWorklist(TR::BytecodeBuilderImpl *builder);
+
+   virtual bool isMethodBuilder()                            { return true; }
+
+   OMR::VirtualMachineState *vmState()
+      {
+      return _vmState;
+      }
+
+   const char *getDefiningFile()                             { return _definingFile; }
+   const char *getDefiningLine()                             { return _definingLine; }
+
+   const char *getMethodName()                               { return _methodName; }
+
+   TR::IlTypeImpl *getReturnType()                           { return _returnType; }
+   int32_t getNumParameters()                                { return _numParameters; }
+   const char *getSymbolName(int32_t slot);
+
+   TR::IlTypeImpl **getParameterTypes();
+   char *getSignature(int32_t numParams, TR::IlTypeImpl **paramTypeArray);
+   char *getSignature(TR::IlTypeImpl **paramTypeArray)
+      {
+      return getSignature(_numParameters, paramTypeArray);
+      }
+
+   TR::SymbolReference *lookupSymbol(const char *name);
+   void defineSymbol(const char *name, TR::SymbolReference *v);
+   bool symbolDefined(const char *name);
+   bool isSymbolAnArray(const char * name);
+
+   TR::ResolvedMethod *lookupFunction(const char *name);
+
+   /**
+    * @brief add a bytecode builder to the worklist
+    * @param bcBuilder is the bytecode builder whose bytecode index will be added to the worklist
+    */
+   void addBytecodeBuilderToWorklist(TR::BytecodeBuilderImpl *bcBuilder);
+
+   /**
+    * @brief return the client object associated with this MethodBuilderImpl object
+    */
+   TR::MethodBuilder *client();
+
+   protected:
+
+   virtual uint32_t countBlocks();
+   virtual bool connectTrees();
+
+   private:
+   TR::SegmentProvider *_segmentProvider;
+   TR::Region *_memoryRegion;
+   TR_Memory *_trMemory;
+
+   // These values are typically defined outside of a compilation
+   const char                    * _methodName;
+   TR::IlTypeImpl                * _returnType;
+   int32_t                         _numParameters;
+
+   typedef bool (*StrComparator)(const char *, const char*);
+
+   typedef TR::typed_allocator<std::pair<const char * const, TR::SymbolReference *>, TR::Region &> SymbolMapAllocator;
+   typedef std::map<const char *, TR::SymbolReference *, StrComparator, SymbolMapAllocator> SymbolMap;
+
+   // This map should only be accessed inside a compilation via lookupSymbol
+   SymbolMap                       _symbols;
+
+   typedef TR::typed_allocator<std::pair<const char * const, int32_t>, TR::Region &> ParameterMapAllocator;
+   typedef std::map<const char *, int32_t, StrComparator, ParameterMapAllocator> ParameterMap;
+   ParameterMap                    _parameterSlot;
+
+   typedef TR::typed_allocator<std::pair<const char * const, TR::IlTypeImpl *>, TR::Region &> SymbolTypeMapAllocator;
+   typedef std::map<const char *, TR::IlTypeImpl *, StrComparator, SymbolTypeMapAllocator> SymbolTypeMap;
+   SymbolTypeMap                   _symbolTypes;
+
+   typedef TR::typed_allocator<std::pair<int32_t const, const char *>, TR::Region &> SlotToSymNameMapAllocator;
+   typedef std::map<int32_t, const char *, std::less<int32_t>, SlotToSymNameMapAllocator> SlotToSymNameMap;
+   SlotToSymNameMap                _symbolNameFromSlot;
+   
+   typedef TR::typed_allocator<const char *, TR::Region &> StringSetAllocator;
+   typedef std::set<const char *, StrComparator, StringSetAllocator> ArrayIdentifierSet;
+
+   // This set acts as an identifier for symbols which correspond to arrays
+   ArrayIdentifierSet              _symbolIsArray;
+
+   typedef TR::typed_allocator<std::pair<const char * const, void *>, TR::Region &> MemoryLocationMapAllocator;
+   typedef std::map<const char *, void *, StrComparator, MemoryLocationMapAllocator> MemoryLocationMap;
+   MemoryLocationMap               _memoryLocations;
+
+   typedef TR::typed_allocator<std::pair<const char * const, TR::ResolvedMethod *>, TR::Region &> FunctionMapAllocator;
+   typedef std::map<const char *, TR::ResolvedMethod *, StrComparator, FunctionMapAllocator> FunctionMap;
+   FunctionMap                     _functions;
+
+   TR::IlTypeImpl               ** _cachedParameterTypes;
+   const char                    * _definingFile;
+   char                            _definingLine[MAX_LINE_NUM_LEN];
+   TR::IlTypeImpl                * _cachedParameterTypesArray[10];
+
+   bool                            _newSymbolsAreTemps;
+   int32_t                         _nextValueID;
+
+   bool                            _useBytecodeBuilders;
+   uint32_t                        _numBlocksBeforeWorklist;
+   List<TR::BytecodeBuilderImpl> * _countBlocksWorklist;
+   List<TR::BytecodeBuilderImpl> * _connectTreesWorklist;
+   List<TR::BytecodeBuilderImpl> * _allBytecodeBuilders;
+   OMR::VirtualMachineState      * _vmState;
+
+   TR_BitVector                  * _bytecodeWorklist;
+   TR_BitVector                  * _bytecodeHasBeenInWorklist;
+   };
+
+} // namespace OMR
+
+
+#if defined(PUT_OMR_METHODBUILDER_IMPL_INTO_TR)
+
+namespace TR
+{
+   class MethodBuilderImpl : public OMR::MethodBuilderImpl
+      {
+      public:
+         MethodBuilderImpl(TR::MethodBuilder *clientBuilder, TR::TypeDictionaryImpl *types)
+            : OMR::MethodBuilderImpl(clientBuilder, types)
+            { }
+         MethodBuilderImpl(TR::MethodBuilder *clientBuilder, TR::TypeDictionaryImpl *types, OMR::VirtualMachineState *vmState)
+            : OMR::MethodBuilderImpl(clientBuilder, types, vmState)
+            { }
+      };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_METHODBUILDER_IMPL_INTO_TR)
+
+#endif // !defined(OMR_METHODBUILDER_IMPL_INCL)

--- a/compiler/ilgen/ThunkBuilderImpl.cpp
+++ b/compiler/ilgen/ThunkBuilderImpl.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include <stdint.h>
+#include "compile/Compilation.hpp"
+#include "ilgen/IlBuilderImpl.hpp"
+#include "ilgen/IlInjector.hpp"
+#include "ilgen/IlTypeImpl.hpp"
+#include "ilgen/IlValueImpl.hpp"
+#include "ilgen/ThunkBuilder.hpp"
+#include "ilgen/ThunkBuilderImpl.hpp"
+#include "ilgen/TypeDictionaryImpl.hpp"
+
+#define OPT_DETAILS "O^O THUNKBUILDER: "
+
+/**
+ * ThunkBuilderImpl is a MethodBuilder object representing a thunk for
+ * calling native functions with a particular signature (kind of like
+ * libffi). It is designed to take a target address and an array of
+ * Word-sized arguments and to call that target address with the
+ * provided arguments (after converting to the appropriate parameter
+ * types). The types of the parameters and return type are provided at
+ * construction time so that different ThunkBuilder instances can use
+ * different method signatures.
+ */
+
+OMR::ThunkBuilderImpl::ThunkBuilderImpl(TR::ThunkBuilder *client,
+                                        TR::TypeDictionaryImpl *types,
+                                        uint32_t numCalleeParams,
+                                        TR::IlTypeImpl **calleeParamTypes)
+   : TR::MethodBuilderImpl(client, types),
+   _numCalleeParams(numCalleeParams),
+   _calleeParamTypes(calleeParamTypes)
+   {
+   // NOTE: this object now has responsibility to delete[] _calleeParamTypes
+   }
+
+OMR::ThunkBuilderImpl::~ThunkBuilderImpl()
+   {
+   delete[] _calleeParamTypes;
+   _calleeParamTypes = NULL;
+   }
+
+bool
+OMR::ThunkBuilderImpl::buildIL()
+   {
+   TR::IlTypeImpl *pWord = typeDictionary()->PointerTo(Word);
+
+   uint32_t numArgs = _numCalleeParams+1;
+   TR::IlValueImpl **args = (TR::IlValueImpl **) comp()->trMemory()->allocateHeapMemory(numArgs * sizeof(TR::IlValueImpl *));
+
+   // first argument is the target address
+   args[0] = Load("target");
+
+   // followed by the actual arguments
+   for (uint32_t p=0; p < _numCalleeParams; p++)
+      {
+      uint32_t a=p+1;
+      args[a] = ConvertTo(_calleeParamTypes[p],
+                   LoadAt(pWord,
+                      IndexAt(pWord,
+                         Load("args"),
+                         ConstInt32(p))));
+      }
+
+   TR::IlValueImpl *retValue = ComputedCall("thunkTarget", numArgs, args);
+
+   if (getReturnType() != NoType)
+      Return(retValue);
+   else
+      Return();
+
+   return true;
+   }
+
+TR::ThunkBuilderImpl *
+OMR::ThunkBuilderImpl::allocate(TR::ThunkBuilder *client,
+                                TR::TypeDictionaryImpl *types,
+                                uint32_t numCalleeParams,
+                                TR::IlTypeImpl **calleeParamTypes)
+   {
+   return new (PERSISTENT_NEW) TR::ThunkBuilderImpl(client, types, numCalleeParams, calleeParamTypes);
+   }

--- a/compiler/ilgen/ThunkBuilderImpl.hpp
+++ b/compiler/ilgen/ThunkBuilderImpl.hpp
@@ -19,19 +19,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#ifndef OMR_THUNKBUILDER_INCL
-#define OMR_THUNKBUILDER_INCL
+#ifndef OMR_THUNKBUILDER_IMPL_INCL
+#define OMR_THUNKBUILDER_IMPL_INCL
 
 
-#ifndef TR_THUNKBUILDER_DEFINED
-#define TR_THUNKBUILDER_DEFINED
-#define PUT_OMR_THUNKBUILDER_INTO_TR
+#ifndef TR_THUNKBUILDER_IMPL_DEFINED
+#define TR_THUNKBUILDER_IMPL_DEFINED
+#define PUT_OMR_THUNKBUILDER_IMPL_INTO_TR
 #endif
 
 
-#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/MethodBuilderImpl.hpp"
 
-namespace TR { class ThunkBuilderImpl; }
 
 namespace OMR
 {
@@ -56,44 +55,53 @@ namespace OMR
  * calls the given function, and will return the return value as expected.
  */
 
-class ThunkBuilder : public TR::MethodBuilder
+class ThunkBuilderImpl : public TR::MethodBuilderImpl
    {
-   public:
+   friend OMR::ThunkBuilder;
+
+   protected:
+   TR_ALLOC(TR_Memory::IlGenerator)
 
    /**
-    * @brief construct a ThunkBuilder for a particular signature
-    * @param types TypeDictionary object that will be used by the ThunkBuilder object
-    * @param name primarily used for debug purposes and will appear in the compilation log
-    * @param returnType return type for the thunk's signature
+    * @brief construct a ThunkBuilderImpl for a particular signature
+    * @param client ThunkBUilder client object corresponding to this ThunkBuilderImpl object
     * @param numCalleeParams number of parameters in the thunk's signature
     * @param calleeParamTypes array of parameter types in the thunk's signature, must have numCalleeParams elements
     */
-   ThunkBuilder(TR::TypeDictionary *types, const char *name, TR::IlType *returnType,
-                uint32_t numCalleeParams, TR::IlType **calleeParamTypes);
-   virtual ~ThunkBuilder();
+   ThunkBuilderImpl(TR::ThunkBuilder *client, TR::TypeDictionaryImpl *types, uint32_t numCalleeParams, TR::IlTypeImpl **calleeParamTypes);
+   virtual ~ThunkBuilderImpl();
 
-   protected:
-   TR::ThunkBuilderImpl *impl();
+   virtual bool buildIL();
+
+   private:
+   TR::ThunkBuilder *client();
+
+   static TR::ThunkBuilderImpl *allocate(TR::ThunkBuilder *client, TR::TypeDictionaryImpl *types, uint32_t numCalleeParams, TR::IlTypeImpl **calleeParamTypes);
+
+   uint32_t          _numCalleeParams;
+   TR::IlTypeImpl ** _calleeParamTypes;
    };
 
 } // namespace OMR
 
 
-#if defined(PUT_OMR_THUNKBUILDER_INTO_TR)
+#if defined(PUT_OMR_THUNKBUILDER_IMPL_INTO_TR)
 
 namespace TR
 {
-   class ThunkBuilder : public OMR::ThunkBuilder
+   class ThunkBuilderImpl : public OMR::ThunkBuilderImpl
       {
       public:
-         ThunkBuilder(TR::TypeDictionary *types, const char *name, TR::IlType *returnType,
-                      uint32_t numCalleeParams, TR::IlType **calleeParamTypes)
-            : OMR::ThunkBuilder(types, name, returnType, numCalleeParams, calleeParamTypes)
+         ThunkBuilderImpl(TR::ThunkBuilder *client,
+                          TR::TypeDictionaryImpl *types,
+                          uint32_t numCalleeParams,
+                          TR::IlTypeImpl **calleeParamTypes)
+            : OMR::ThunkBuilderImpl(client, types, numCalleeParams, calleeParamTypes)
             { }
       };
 
 } // namespace TR
 
-#endif // defined(PUT_OMR_THUNKBUILDER_INTO_TR)
+#endif // defined(PUT_OMR_THUNKBUILDER_IMPL_INTO_TR)
 
-#endif // !defined(OMR_THUNKBUILDER_INCL)
+#endif // !defined(OMR_THUNKBUILDER_IMPL_INCL)

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -19,683 +19,149 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdlib.h>
-
-#include "il/DataTypes.hpp"
-#include "il/SymbolReference.hpp"
-#include "compile/SymbolReferenceTable.hpp"
-#include "compile/Compilation.hpp"
-#include "env/FrontEnd.hpp"
+#include "ilgen/IlType.hpp"
+#include "ilgen/IlTypeImpl.hpp"
 #include "ilgen/TypeDictionary.hpp"
-#include "env/Region.hpp"
-#include "env/SystemSegmentProvider.hpp"
-#include "env/TRMemory.hpp"
-#include "infra/Assert.hpp"
-#include "infra/BitVector.hpp"
-#include "infra/STLUtils.hpp"
+#include "ilgen/TypeDictionaryImpl.hpp"
 
 
-namespace OMR
-{
-
-static const char *signatureNameForType[] =
-   {
-   "V",  // NoType
-   "B",  // Int8
-   "C",  // Int16
-   "I",  // Int32
-   "J",  // Int64
-   "F",  // Float
-   "D",  // Double
-   "L",  // Address
-   // TODO: vector types!
-   };
-
-char *
-IlType::getSignatureName()
-   {
-   TR::DataType dt = getPrimitiveType();
-   if (dt == TR::Address)
-      return (char *)_name;
-   return (char *) signatureNameForType[dt];
-   }
-
-size_t
-IlType::getSize()
-   {
-   TR_ASSERT(0, "The input type does not have a defined size\n");
-   return 0;
-   }
-
-const uint8_t primitiveTypeAlignment[TR::NumOMRTypes] =
-   {
-   1,  // NoType
-   1,  // Int8
-   2,  // Int16
-   4,  // Int32
-   8,  // Int64
-   4,  // Float
-   8,  // Double
-#if TR_TARGET_64BIT // HOST?
-   4,  // Address/Word
-#else
-   8,  // Address/Word
-#endif
-   16, // VectorInt8
-   16, // VectorInt16
-   16, // VectorInt32
-   16, // VectorInt64
-   16, // VectorFloat
-   16  // VectorDouble
-   };
-
-
-class PrimitiveType : public TR::IlType
-   {
-public:
-   TR_ALLOC(TR_Memory::IlGenerator)
-
-   PrimitiveType(const char * name, TR::DataType type) :
-      TR::IlType(name),
-      _type(type)
-      { }
-   virtual ~PrimitiveType()
-      { }
-
-   virtual TR::DataType getPrimitiveType()
-      {
-      return _type;
-      }
-
-   virtual char *getSignatureName() { return (char *) signatureNameForType[_type]; }
-
-   virtual size_t getSize() { return TR::DataType::getSize(_type); }
-
-protected:
-   TR::DataType _type;
-   };
-
-
-class FieldInfo
-   {
-public:
-   TR_ALLOC(TR_Memory::IlGenerator)
-
-   FieldInfo(const char *name, size_t offset, TR::IlType *type) :
-      _next(0),
-      _name(name),
-      _offset(offset),
-      _type(type),
-      _symRef(0)
-      {
-      }
-
-   void cacheSymRef(TR::SymbolReference *symRef) { _symRef = symRef; }
-   TR::SymbolReference *getSymRef()              { return _symRef; }
-   void clearSymRef()                            { _symRef = NULL; }
-
-   TR::IlType *getType()                         { return _type; }
-
-   TR::DataType getPrimitiveType()               { return _type->getPrimitiveType(); }
-
-   size_t getOffset()                            { return _offset; }
-
-   FieldInfo *getNext()                          { return _next; }
-   void setNext(FieldInfo *next)                 { _next = next; }
-
-//private:
-   FieldInfo           * _next;
-   const char          * _name;
-   size_t                _offset;
-   TR::IlType          * _type;
-   TR::SymbolReference * _symRef;
-   };
-
-
-class StructType : public TR::IlType
-   {
-public:
-   TR_ALLOC(TR_Memory::IlGenerator)
-
-   StructType(const char *name) :
-      TR::IlType(name),
-      _firstField(0),
-      _lastField(0),
-      _size(0),
-      _closed(false)
-      { }
-   virtual ~StructType()
-      { }
-
-   TR::DataType getPrimitiveType()                 { return TR::Address; }
-   void Close(size_t finalSize)                      { TR_ASSERT(_size <= finalSize, "Final size %d of struct %s is less than its current size %d\n", finalSize, _name, _size); _size = finalSize; _closed = true; };
-   void Close()                                      { _closed = true; };
-
-   void AddField(const char *name, TR::IlType *fieldType, size_t offset);
-   void AddField(const char *name, TR::IlType *fieldType);
-   TR::IlType * getFieldType(const char *fieldName);
-   size_t getFieldOffset(const char *fieldName);
-
-   TR::SymbolReference *getFieldSymRef(const char *name);
-   bool isStruct() { return true; }
-   virtual size_t getSize() { return _size; }
-
-   void clearSymRefs();
-
-protected:
-   FieldInfo * findField(const char *fieldName);
-
-   FieldInfo * _firstField;
-   FieldInfo * _lastField;
-   size_t      _size;
-   bool        _closed;
-   };
-
-void
-StructType::AddField(const char *name, TR::IlType *typeInfo, size_t offset)
-   {
-   if (_closed)
-      return;
-
-   TR_ASSERT(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
-
-   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, offset, typeInfo);
-   if (0 != _lastField)
-      _lastField->setNext(fieldInfo);
-   else
-      _firstField = fieldInfo;
-   _lastField = fieldInfo;
-   _size = offset + typeInfo->getSize();
-   }
-
-void
-StructType::AddField(const char *name, TR::IlType *typeInfo)
-   {
-   if (_closed)
-      return;
-
-   TR::DataType primitiveType = typeInfo->getPrimitiveType();
-   uint32_t align = primitiveTypeAlignment[primitiveType] - 1;
-   _size = (_size + align) & (~align);
-
-   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, _size, typeInfo);
-   if (0 != _lastField)
-      _lastField->setNext(fieldInfo);
-   else
-      _firstField = fieldInfo;
-   _lastField = fieldInfo;
-   _size += typeInfo->getSize();
-   }
-
-FieldInfo *
-StructType::findField(const char *fieldName)
-   {
-   FieldInfo *info = _firstField;
-   while (NULL != info)
-      {
-      if (strncmp(info->_name, fieldName, strlen(fieldName)) == 0)
-         return info;
-      info = info->_next;
-      }
-   return NULL;
-   }
-
-TR::IlType *
-StructType::getFieldType(const char *fieldName)
-   {
-   FieldInfo *info = findField(fieldName);
-   if (NULL == info)
-      return NULL;
-   return info->_type;
-   }
-
-size_t
-StructType::getFieldOffset(const char *fieldName)
-   {
-   FieldInfo *info = findField(fieldName);
-   if (NULL == info)
-      return -1;
-   return info->getOffset();
-   }
-
-TR::IlReference *
-StructType::getFieldSymRef(const char *fieldName)
-   {
-   FieldInfo *info = findField(fieldName);
-   if (NULL == info)
-      return NULL;
-
-   TR::SymbolReference *symRef = info->getSymRef();
-   if (NULL == symRef)
-      {
-      TR::Compilation *comp = TR::comp();
-
-      TR::DataType type = info->getPrimitiveType();
-
-      char *fullName = (char *) comp->trMemory()->allocateHeapMemory((strlen(info->_name) + 1 + strlen(_name) + 1) * sizeof(char));
-      sprintf(fullName, "%s.%s", _name, info->_name);
-      TR::Symbol *symbol = TR::Symbol::createNamedShadow(comp->trHeapMemory(), type, info->_type->getSize(), fullName);
-
-      // TBD: should we create a dynamic "constant" pool for accesses made by the method being compiled?
-      symRef = new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);
-      symRef->setOffset(info->getOffset());
-
-      // conservative aliasing
-      int32_t refNum = symRef->getReferenceNumber();
-      if (type == TR::Address)
-         comp->getSymRefTab()->aliasBuilder.addressShadowSymRefs().set(refNum);
-      else if (type == TR::Int32)
-         comp->getSymRefTab()->aliasBuilder.intShadowSymRefs().set(refNum);
-      else
-         comp->getSymRefTab()->aliasBuilder.nonIntPrimitiveShadowSymRefs().set(refNum);
-
-      info->cacheSymRef(symRef);
-      }
-
-   return (TR::IlReference *)symRef;
-   }
-
-void
-StructType::clearSymRefs()
-   {
-   FieldInfo *field = _firstField;
-   while (field)
-      {
-      field->clearSymRef();
-      field = field->_next;
-      }
-   }
-
-
-class UnionType : public TR::IlType
-   {
-public:
-   TR_ALLOC(TR_Memory::IlGenerator)
-
-   UnionType(const char *name, TR_Memory* trMemory) :
-      TR::IlType(name),
-      _firstField(0),
-      _lastField(0),
-      _size(0),
-      _closed(false),
-      _symRefBV(4, trMemory),
-      _trMemory(trMemory)
-      { }
-   virtual ~UnionType()
-      { }
-
-   TR::DataType getPrimitiveType()                 { return TR::Address; }
-   void Close();
-
-   void AddField(const char *name, TR::IlType *fieldType);
-   TR::IlType * getFieldType(const char *fieldName);
-
-   TR::SymbolReference *getFieldSymRef(const char *name);
-   virtual bool isUnion() { return true; }
-   virtual size_t getSize() { return _size; }
-
-   void clearSymRefs();
-
-protected:
-   FieldInfo * findField(const char *fieldName);
-
-   FieldInfo * _firstField;
-   FieldInfo * _lastField;
-   size_t      _size;
-   bool        _closed;
-   TR_BitVector _symRefBV;
-   TR_Memory* _trMemory;
-   };
-
-void
-UnionType::AddField(const char *name, TR::IlType *typeInfo)
-   {
-   if (_closed)
-      return;
-
-   auto fieldSize = typeInfo->getSize();
-   if (fieldSize > _size) _size = fieldSize;
-
-   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, 0 /* no offset */, typeInfo);
-   if (0 != _lastField)
-      _lastField->setNext(fieldInfo);
-   else
-      _firstField = fieldInfo;
-   _lastField = fieldInfo;
-   }
-
-void
-UnionType::Close()
-   {
-   _closed = true;
-   }
-
-FieldInfo *
-UnionType::findField(const char *fieldName)
-   {
-   FieldInfo *info = _firstField;
-   while (NULL != info)
-      {
-      if (strncmp(info->_name, fieldName, strlen(fieldName)) == 0)
-         return info;
-      info = info->_next;
-      }
-   return NULL;
-   }
-
-TR::IlType *
-UnionType::getFieldType(const char *fieldName)
-   {
-   FieldInfo *info = findField(fieldName);
-   if (NULL == info)
-      return NULL;
-   return info->_type;
-   }
-
-TR::IlReference *
-UnionType::getFieldSymRef(const char *fieldName)
-   {
-   FieldInfo *info = findField(fieldName);
-   TR_ASSERT(info, "Struct %s has no field with name %s\n", getName(), fieldName);
-
-   TR::SymbolReference *symRef = info->getSymRef();
-   if (NULL == symRef)
-      {
-      // create a symref for the new field and set its bitvector
-      TR::Compilation *comp = TR::comp();
-      auto symRefTab = comp->getSymRefTab();
-      TR::DataType type = info->getPrimitiveType();
-
-      char *fullName = (char *) comp->trMemory()->allocateHeapMemory((strlen(info->_name) + 1 + strlen(_name) + 1) * sizeof(char));
-      sprintf(fullName, "%s.%s", _name, info->_name);
-      TR::Symbol *symbol = TR::Symbol::createNamedShadow(comp->trHeapMemory(), type, info->_type->getSize(), fullName);
-      symRef = new (comp->trHeapMemory()) TR::SymbolReference(symRefTab, symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);
-      symRef->setOffset(0);
-      symRef->setReallySharesSymbol();
-
-      TR_SymRefIterator sit(_symRefBV, symRefTab);
-      for (TR::SymbolReference *sr = sit.getNext(); sr; sr = sit.getNext())
-          {
-          symRefTab->makeSharedAliases(symRef, sr);
-          }
-
-      _symRefBV.set(symRef->getReferenceNumber());
-
-      info->cacheSymRef(symRef);
-      }
-
-   return static_cast<TR::IlReference *>(symRef);
-   }
-
-void
-UnionType::clearSymRefs()
-   {
-   FieldInfo *field = _firstField;
-   while (field)
-      {
-      field->clearSymRef();
-      field = field->_next;
-      }
-   _symRefBV.init(4, _trMemory);
-   }
-
-
-class PointerType : public TR::IlType
-   {
-public:
-   TR_ALLOC(TR_Memory::IlGenerator)
-
-   PointerType(TR::IlType *baseType) :
-      TR::IlType(_nameArray),
-      _baseType(baseType)
-      {
-      char *baseName = (char *)_baseType->getName();
-      TR_ASSERT(strlen(baseName) < 45, "cannot store name of pointer type");
-      sprintf(_nameArray, "L%s;", baseName);
-      }
-   virtual bool isPointer() { return true; }
-
-   virtual TR::IlType *baseType() { return _baseType; }
-
-   virtual const char *getName() { return _name; }
-
-   virtual TR::DataType getPrimitiveType() { return TR::Address; }
-
-   virtual size_t getSize() { return TR::DataType::getSize(TR::Address); }
-
-protected:
-   TR::IlType          * _baseType;
-   char                  _nameArray[48];
-   };
-
-
-TypeDictionary::TypeDictionary() :
-   // Note: _memoryRegion and the corresponding TR::SegmentProvider and TR::Memory instances are stored as pointers within TypeDictionary
-   // in order to avoid increasing the number of header files needed to compile against the JitBuilder library. Because we are storing
-   // them as pointers, we cannot rely on the default C++ destruction semantic to destruct and deallocate the memory region, but rather
-   // have to do it explicitly in the TypeDictionary destructor. And since C++ destroys the other members *after* executing the user defined
-   // destructor, we need to make sure that any members (and their contents) that are allocated in _memoryRegion are explicitly destroyed
-   // and deallocated *before* _memoryRegion in the TypeDictionary destructor.
-   _segmentProvider( new(TR::Compiler->persistentAllocator()) TR::SystemSegmentProvider(1 << 16, TR::Compiler->rawAllocator) ),
-   _memoryRegion( new(TR::Compiler->persistentAllocator()) TR::Region(*_segmentProvider, TR::Compiler->rawAllocator) ),
-   _trMemory( new(TR::Compiler->persistentAllocator()) TR_Memory(*::trPersistentMemory, *_memoryRegion) ),
-   _structsByName(str_comparator, _trMemory->heapMemoryRegion()),
-   _unionsByName(str_comparator, _trMemory->heapMemoryRegion())
+OMR::TypeDictionary::TypeDictionary()
+   : _impl(TR::TypeDictionaryImpl::allocate(static_cast<TR::TypeDictionary *>(this)))
    {
    // primitive types
-   NoType       = _primitiveType[TR::NoType]                = new (PERSISTENT_NEW) OMR::PrimitiveType("NoType", TR::NoType);
-   Int8         = _primitiveType[TR::Int8]                  = new (PERSISTENT_NEW) OMR::PrimitiveType("Int8", TR::Int8);
-   Int16        = _primitiveType[TR::Int16]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Int16", TR::Int16);
-   Int32        = _primitiveType[TR::Int32]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Int32", TR::Int32);
-   Int64        = _primitiveType[TR::Int64]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Int64", TR::Int64);
-   Float        = _primitiveType[TR::Float]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Float", TR::Float);
-   Double       = _primitiveType[TR::Double]                = new (PERSISTENT_NEW) OMR::PrimitiveType("Double", TR::Double);
-   Address      = _primitiveType[TR::Address]               = new (PERSISTENT_NEW) OMR::PrimitiveType("Address", TR::Address);
-   VectorInt8   = _primitiveType[TR::VectorInt8]            = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt8", TR::VectorInt8);
-   VectorInt16  = _primitiveType[TR::VectorInt16]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt16", TR::VectorInt16);
-   VectorInt32  = _primitiveType[TR::VectorInt32]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt32", TR::VectorInt32);
-   VectorInt64  = _primitiveType[TR::VectorInt64]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt64", TR::VectorInt64);
-   VectorFloat  = _primitiveType[TR::VectorFloat]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorFloat", TR::VectorFloat);
-   VectorDouble = _primitiveType[TR::VectorDouble]          = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorDouble", TR::VectorDouble);
+   NoType       = impl()->NoType;
+   Int8         = impl()->Int8;
+   Int16        = impl()->Int16;
+   Int32        = impl()->Int32;
+   Int64        = impl()->Int64;
+   Float        = impl()->Float;
+   Double       = impl()->Double;
+   Address      = impl()->Address;
+   VectorInt8   = impl()->VectorInt8;
+   VectorInt16  = impl()->VectorInt16;
+   VectorInt32  = impl()->VectorInt32;
+   VectorInt64  = impl()->VectorInt64;
+   VectorFloat  = impl()->VectorFloat;
+   VectorDouble = impl()->VectorDouble;
 
    // pointer to primitive types
-   pNoType       = _pointerToPrimitiveType[TR::NoType]       = new (PERSISTENT_NEW) PointerType(NoType);
-   pInt8         = _pointerToPrimitiveType[TR::Int8]         = new (PERSISTENT_NEW) PointerType(Int8);
-   pInt16        = _pointerToPrimitiveType[TR::Int16]        = new (PERSISTENT_NEW) PointerType(Int16);
-   pInt32        = _pointerToPrimitiveType[TR::Int32]        = new (PERSISTENT_NEW) PointerType(Int32);
-   pInt64        = _pointerToPrimitiveType[TR::Int64]        = new (PERSISTENT_NEW) PointerType(Int64);
-   pFloat        = _pointerToPrimitiveType[TR::Float]        = new (PERSISTENT_NEW) PointerType(Float);
-   pDouble       = _pointerToPrimitiveType[TR::Double]       = new (PERSISTENT_NEW) PointerType(Double);
-   pAddress      = _pointerToPrimitiveType[TR::Address]      = new (PERSISTENT_NEW) PointerType(Address);
-   pVectorInt8   = _pointerToPrimitiveType[TR::VectorInt8]   = new (PERSISTENT_NEW) PointerType(VectorInt8);
-   pVectorInt16  = _pointerToPrimitiveType[TR::VectorInt16]  = new (PERSISTENT_NEW) PointerType(VectorInt16);
-   pVectorInt32  = _pointerToPrimitiveType[TR::VectorInt32]  = new (PERSISTENT_NEW) PointerType(VectorInt32);
-   pVectorInt64  = _pointerToPrimitiveType[TR::VectorInt64]  = new (PERSISTENT_NEW) PointerType(VectorInt64);
-   pVectorFloat  = _pointerToPrimitiveType[TR::VectorFloat]  = new (PERSISTENT_NEW) PointerType(VectorFloat);
-   pVectorDouble = _pointerToPrimitiveType[TR::VectorDouble] = new (PERSISTENT_NEW) PointerType(VectorDouble);
+   pNoType       = impl()->pNoType;
+   pInt8         = impl()->pInt8;
+   pInt16        = impl()->pInt16;
+   pInt32        = impl()->pInt32;
+   pInt64        = impl()->pInt64;
+   pFloat        = impl()->pFloat;
+   pDouble       = impl()->pDouble;
+   pAddress      = impl()->pAddress;
+   pVectorInt8   = impl()->pVectorInt8;
+   pVectorInt16  = impl()->pVectorInt16;
+   pVectorInt32  = impl()->pVectorInt32;
+   pVectorInt64  = impl()->pVectorInt64;
+   pVectorFloat  = impl()->pVectorFloat;
+   pVectorDouble = impl()->pVectorDouble;
 
-   if (TR::Compiler->target.is64Bit())
-      {
-      Word =  _primitiveType[TR::Int64]; 
-      pWord =  _pointerToPrimitiveType[TR::Int64];
-      }
-   else
-      {
-      Word =  _primitiveType[TR::Int32];
-      pWord =  _pointerToPrimitiveType[TR::Int32];
-      }
-   }
-
-TypeDictionary::~TypeDictionary() throw()
-   {
-   // Cleanup allocations in _memoryRegion *before* its destroyed below (see note in constructor)
-   _structsByName.clear();
-   _unionsByName.clear();
-
-   _trMemory->~TR_Memory();
-   ::operator delete(_trMemory, TR::Compiler->persistentAllocator());
-   _memoryRegion->~Region();
-   ::operator delete(_memoryRegion, TR::Compiler->persistentAllocator());
-   static_cast<TR::SystemSegmentProvider *>(_segmentProvider)->~SystemSegmentProvider();
-   ::operator delete(_segmentProvider, TR::Compiler->persistentAllocator());
+   Word         = impl()->Word;
+   pWord        = impl()->pWord;
    }
 
 TR::IlType *
-TypeDictionary::LookupStruct(const char *structName)
+OMR::TypeDictionary::PointerTo(TR::DataType baseType)
    {
-   return getStruct(structName);
+   return impl()->PointerTo(baseType);
    }
 
 TR::IlType *
-TypeDictionary::LookupUnion(const char *unionName)
+OMR::TypeDictionary::PrimitiveType(TR::DataType primitiveType)
    {
-   return getUnion(unionName);
-   }
-
-TR::IlType *
-TypeDictionary::DefineStruct(const char *structName)
-   {
-   TR_ASSERT_FATAL(_structsByName.find(structName) == _structsByName.end(), "Struct '%s' already exists", structName);
-
-   StructType *newType = new (PERSISTENT_NEW) StructType(structName);
-   _structsByName.insert(std::make_pair(structName, newType));
-
-   return newType;
+   return impl()->PrimitiveType(primitiveType);
    }
 
 void
-TypeDictionary::DefineField(const char *structName, const char *fieldName, TR::IlType *type, size_t offset)
+OMR::TypeDictionary::CloseStruct(const char *structName)
    {
-   getStruct(structName)->AddField(fieldName, type, offset);
+   impl()->CloseStruct(structName);
    }
 
 void
-TypeDictionary::DefineField(const char *structName, const char *fieldName, TR::IlType *type)
+OMR::TypeDictionary::CloseStruct(const char *structName, size_t finalSize)
    {
-   getStruct(structName)->AddField(fieldName, type);
+   impl()->CloseStruct(structName, finalSize);
+   }
+
+void
+OMR::TypeDictionary::CloseUnion(const char *unionName)
+   {
+   impl()->CloseUnion(unionName);
+   }
+
+void
+OMR::TypeDictionary::DefineField(const char *structName, const char *fieldName, TR::IlType *type, size_t offset)
+   {
+   impl()->DefineField(structName, fieldName, type->impl(), offset);
+   }
+
+void
+OMR::TypeDictionary::DefineField(const char *structName, const char *fieldName, TR::IlType *type)
+   {
+   impl()->DefineField(structName, fieldName, type->impl());
    }
 
 TR::IlType *
-TypeDictionary::GetFieldType(const char *structName, const char *fieldName)
+OMR::TypeDictionary::DefineStruct(const char *structName)
    {
-   return getStruct(structName)->getFieldType(fieldName);
+   return impl()->DefineStruct(structName);
+   }
+
+TR::IlType *
+OMR::TypeDictionary::DefineUnion(const char *unionName)
+   {
+   return impl()->DefineUnion(unionName);
+   }
+
+TR::IlType *
+OMR::TypeDictionary::GetFieldType(const char *structName, const char *fieldName)
+   {
+   return impl()->GetFieldType(structName, fieldName);
+   }
+
+TR::IlType *
+OMR::TypeDictionary::LookupStruct(const char *structName)
+   {
+   return impl()->LookupStruct(structName);
+   }
+
+TR::IlType *
+OMR::TypeDictionary::LookupUnion(const char *unionName)
+   {
+   return impl()->LookupUnion(unionName);
    }
 
 size_t
-TypeDictionary::OffsetOf(const char *structName, const char *fieldName)
+OMR::TypeDictionary::OffsetOf(const char *structName, const char *fieldName)
    {
-   return getStruct(structName)->getFieldOffset(fieldName);
-   }
-
-void
-TypeDictionary::CloseStruct(const char *structName, size_t finalSize)
-   {
-   getStruct(structName)->Close(finalSize);
-   }
-
-void
-TypeDictionary::CloseStruct(const char *structName)
-   {
-   getStruct(structName)->Close();
+   return impl()->OffsetOf(structName, fieldName);
    }
 
 TR::IlType *
-TypeDictionary::DefineUnion(const char *unionName)
+OMR::TypeDictionary::PointerTo(const char *structName)
    {
-   TR_ASSERT_FATAL(_unionsByName.find(unionName) == _unionsByName.end(), "Union '%s' already exists", unionName);
-   
-   UnionType *newType = new (PERSISTENT_NEW) UnionType(unionName, _trMemory);
-   _unionsByName.insert(std::make_pair(unionName, newType));
-
-   return newType;
-   }
-
-void
-TypeDictionary::UnionField(const char *unionName, const char *fieldName, TR::IlType *type)
-   {
-   getUnion(unionName)->AddField(fieldName, type);
-   }
-
-void
-TypeDictionary::CloseUnion(const char *unionName)
-   {
-   getUnion(unionName)->Close();
+   return impl()->PointerTo(structName);
    }
 
 TR::IlType *
-TypeDictionary::UnionFieldType(const char *unionName, const char *fieldName)
+OMR::TypeDictionary::PointerTo(TR::IlType *baseType)
    {
-   return getUnion(unionName)->getFieldType(fieldName);
-   }
-
-TR::IlType *
-TypeDictionary::PointerTo(const char *structName)
-   {
-   return PointerTo(LookupStruct(structName));
-   }
-
-TR::IlType *
-TypeDictionary::PointerTo(TR::IlType *baseType)
-   {
-   return new (PERSISTENT_NEW) PointerType(baseType);
-   }
-
-TR::IlReference *
-TypeDictionary::FieldReference(const char *typeName, const char *fieldName)
-   {
-   StructMap::iterator structIterator = _structsByName.find(typeName);
-   if (structIterator != _structsByName.end())
-      {
-      StructType *theStruct = structIterator->second;
-      return theStruct->getFieldSymRef(fieldName);
-      }
-
-   UnionMap::iterator unionIterator = _unionsByName.find(typeName);
-   if (unionIterator != _unionsByName.end())
-      {
-      UnionType *theUnion = unionIterator->second;
-      return theUnion->getFieldSymRef(fieldName);
-      }
-
-   TR_ASSERT_FATAL(false, "No type with name '%s'", typeName);
-   return NULL;
+   return impl()->PointerTo(baseType->impl());
    }
 
 void
-TypeDictionary::NotifyCompilationDone()
+OMR::TypeDictionary::UnionField(const char *unionName, const char *fieldName, TR::IlType *type)
    {
-   // clear all symbol references for fields
-   for (StructMap::iterator it = _structsByName.begin(); it != _structsByName.end(); it++)
-      {
-      StructType *aStruct = it->second;
-      aStruct->clearSymRefs();
-      }
-
-   // clear all symbol references for union fields
-   for (UnionMap::iterator it = _unionsByName.begin(); it != _unionsByName.end(); it++)
-      {
-      UnionType *aUnion = it->second;
-      aUnion->clearSymRefs();
-      }
+   impl()->UnionField(unionName, fieldName, type->impl());
    }
 
-OMR::StructType *
-TypeDictionary::getStruct(const char *structName)
+TR::IlType *
+OMR::TypeDictionary::UnionFieldType(const char *unionName, const char *fieldName)
    {
-   StructMap::iterator it = _structsByName.find(structName);
-   TR_ASSERT_FATAL(it != _structsByName.end(), "No struct named '%s'", structName);
-
-   StructType *theStruct = it->second;
-   return theStruct;
+   return impl()->UnionFieldType(unionName, fieldName);
    }
-
-OMR::UnionType *
-TypeDictionary::getUnion(const char *unionName)
-   {
-   UnionMap::iterator it = _unionsByName.find(unionName);
-   TR_ASSERT_FATAL(it != _unionsByName.end(), "No union named '%s'", unionName);
-
-   UnionType *theUnion = it->second;
-   return theUnion;
-   }
-} // namespace OMR

--- a/compiler/ilgen/TypeDictionaryImpl.cpp
+++ b/compiler/ilgen/TypeDictionaryImpl.cpp
@@ -1,0 +1,506 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#include <stdlib.h>
+
+#include "il/DataTypes.hpp"
+#include "il/SymbolReference.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "compile/Compilation.hpp"
+#include "env/FrontEnd.hpp"
+#include "ilgen/TypeDictionaryImpl.hpp"
+#include "env/Region.hpp"
+#include "env/SystemSegmentProvider.hpp"
+#include "env/TRMemory.hpp"
+#include "infra/Assert.hpp"
+#include "infra/BitVector.hpp"
+#include "infra/STLUtils.hpp"
+
+
+const uint8_t primitiveTypeAlignment[TR::NumOMRTypes] =
+   {
+   1,  // NoType
+   1,  // Int8
+   2,  // Int16
+   4,  // Int32
+   8,  // Int64
+   4,  // Float
+   8,  // Double
+#if TR_TARGET_64BIT
+   4,  // Address/Word
+#else
+   8,  // Address/Word
+#endif
+   16, // VectorInt8
+   16, // VectorInt16
+   16, // VectorInt32
+   16, // VectorInt64
+   16, // VectorFloat
+   16  // VectorDouble
+   };
+
+
+void
+OMR::StructType::AddField(const char *name, TR::IlTypeImpl *typeInfo, size_t offset)
+   {
+   if (_closed)
+      return;
+
+   TR_ASSERT(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
+
+   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, offset, typeInfo);
+   if (0 != _lastField)
+      _lastField->setNext(fieldInfo);
+   else
+      _firstField = fieldInfo;
+   _lastField = fieldInfo;
+   _size = offset + typeInfo->getSize();
+   }
+
+void
+OMR::StructType::AddField(const char *name, TR::IlTypeImpl *typeInfo)
+   {
+   if (_closed)
+      return;
+
+   TR::DataType primitiveType = typeInfo->getRealPrimitiveType();
+   uint32_t align = primitiveTypeAlignment[primitiveType] - 1;
+   _size = (_size + align) & (~align);
+
+   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, _size, typeInfo);
+   if (0 != _lastField)
+      _lastField->setNext(fieldInfo);
+   else
+      _firstField = fieldInfo;
+   _lastField = fieldInfo;
+   _size += typeInfo->getSize();
+   } 
+
+OMR::FieldInfo *
+OMR::StructType::findField(const char *fieldName)
+   {
+   FieldInfo *info = _firstField;
+   while (NULL != info)
+      {
+      if (strncmp(info->_name, fieldName, strlen(fieldName)) == 0)
+         return info;
+      info = info->_next;
+      }
+   return NULL;
+   }
+
+TR::IlTypeImpl *
+OMR::StructType::getFieldType(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return NULL;
+   return info->_type;
+   }
+
+size_t
+OMR::StructType::getFieldOffset(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return -1;
+   return info->getOffset();
+   }
+
+TR::IlReference *
+OMR::StructType::getFieldSymRef(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return NULL;
+
+   TR::SymbolReference *symRef = info->getSymRef();
+   if (NULL == symRef)
+      {
+      TR::Compilation *comp = TR::comp();
+
+      TR::DataType type = info->getPrimitiveType();
+
+      char *fullName = (char *) comp->trMemory()->allocateHeapMemory((strlen(info->_name) + 1 + strlen(_name) + 1) * sizeof(char));
+      sprintf(fullName, "%s.%s", _name, info->_name);
+      TR::Symbol *symbol = TR::Symbol::createNamedShadow(comp->trHeapMemory(), type, info->_type->getSize(), fullName);
+
+      // TBD: should we create a dynamic "constant" pool for accesses made by the method being compiled?
+      symRef = new (comp->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab(), symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);
+      symRef->setOffset(info->getOffset());
+
+      // conservative aliasing
+      int32_t refNum = symRef->getReferenceNumber();
+      if (type == TR::Address)
+         comp->getSymRefTab()->aliasBuilder.addressShadowSymRefs().set(refNum);
+      else if (type == TR::Int32)
+         comp->getSymRefTab()->aliasBuilder.intShadowSymRefs().set(refNum);
+      else
+         comp->getSymRefTab()->aliasBuilder.nonIntPrimitiveShadowSymRefs().set(refNum);
+
+      info->cacheSymRef(symRef);
+      }
+
+   return (TR::IlReference *)symRef;
+   }
+
+void
+OMR::StructType::clearSymRefs()
+   {
+   FieldInfo *field = _firstField;
+   while (field)
+      {
+      field->clearSymRef();
+      field = field->_next;
+      }
+   }
+
+
+void
+OMR::UnionType::AddField(const char *name, TR::IlTypeImpl *typeInfo)
+   {
+   if (_closed)
+      return;
+
+   auto fieldSize = typeInfo->getSize();
+   if (fieldSize > _size) _size = fieldSize;
+
+   FieldInfo *fieldInfo = new (PERSISTENT_NEW) FieldInfo(name, 0 /* no offset */, typeInfo);
+   if (0 != _lastField)
+      _lastField->setNext(fieldInfo);
+   else
+      _firstField = fieldInfo;
+   _lastField = fieldInfo;
+   }
+
+void
+OMR::UnionType::Close()
+   {
+   _closed = true;
+   }
+
+OMR::FieldInfo *
+OMR::UnionType::findField(const char *fieldName)
+   {
+   FieldInfo *info = _firstField;
+   while (NULL != info)
+      {
+      if (strncmp(info->_name, fieldName, strlen(fieldName)) == 0)
+         return info;
+      info = info->_next;
+      }
+   return NULL;
+   }
+
+TR::IlTypeImpl *
+OMR::UnionType::getFieldType(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   if (NULL == info)
+      return NULL;
+   return info->_type;
+   }
+
+TR::IlReference *
+OMR::UnionType::getFieldSymRef(const char *fieldName)
+   {
+   FieldInfo *info = findField(fieldName);
+   TR_ASSERT(info, "Struct %s has no field with name %s\n", getName(), fieldName);
+
+   TR::SymbolReference *symRef = info->getSymRef();
+   if (NULL == symRef)
+      {
+      // create a symref for the new field and set its bitvector
+      TR::Compilation *comp = TR::comp();
+      auto symRefTab = comp->getSymRefTab();
+      TR::DataType type = info->getPrimitiveType();
+
+      char *fullName = (char *) comp->trMemory()->allocateHeapMemory((strlen(info->_name) + 1 + strlen(_name) + 1) * sizeof(char));
+      sprintf(fullName, "%s.%s", _name, info->_name);
+      TR::Symbol *symbol = TR::Symbol::createNamedShadow(comp->trHeapMemory(), type, info->_type->getSize(), fullName);
+      symRef = new (comp->trHeapMemory()) TR::SymbolReference(symRefTab, symbol, comp->getMethodSymbol()->getResolvedMethodIndex(), -1);
+      symRef->setOffset(0);
+      symRef->setReallySharesSymbol();
+
+      TR_SymRefIterator sit(_symRefBV, symRefTab);
+      for (TR::SymbolReference *sr = sit.getNext(); sr; sr = sit.getNext())
+          {
+          symRefTab->makeSharedAliases(symRef, sr);
+          }
+
+      _symRefBV.set(symRef->getReferenceNumber());
+
+      info->cacheSymRef(symRef);
+      }
+
+   return static_cast<TR::IlReference *>(symRef);
+   }
+
+void
+OMR::UnionType::clearSymRefs()
+   {
+   FieldInfo *field = _firstField;
+   while (field)
+      {
+      field->clearSymRef();
+      field = field->_next;
+      }
+   _symRefBV.init(4, _trMemory);
+   }
+
+
+TR::TypeDictionaryImpl *
+OMR::TypeDictionaryImpl::allocate(TR::TypeDictionary *client)
+   {
+   return new (PERSISTENT_NEW) TR::TypeDictionaryImpl(client);
+   }
+
+OMR::TypeDictionaryImpl::TypeDictionaryImpl(TR::TypeDictionary *client) :
+
+   // Note: _memoryRegion and the corresponding TR::SegmentProvider and TR::Memory instances are stored as pointers within TypeDictionaryImpl
+   // in order to avoid increasing the number of header files needed to compile against the JitBuilder library. Because we are storing
+   // them as pointers, we cannot rely on the default C++ destruction semantic to destruct and deallocate the memory region, but rather
+   // have to do it explicitly in the TypeDictionaryImpl destructor. And since C++ destroys the other members *after* executing the user defined
+   // destructor, we need to make sure that any members (and their contents) that are allocated in _memoryRegion are explicitly destroyed
+   // and deallocated *before* _memoryRegion in the TypeDictionaryImpl destructor.
+   _segmentProvider( new(TR::Compiler->persistentAllocator()) TR::SystemSegmentProvider(1 << 16, TR::Compiler->rawAllocator) ),
+   _memoryRegion( new(TR::Compiler->persistentAllocator()) TR::Region(*_segmentProvider, TR::Compiler->rawAllocator) ),
+   _client(client),
+   _trMemory( new(TR::Compiler->persistentAllocator()) TR_Memory(*::trPersistentMemory, *_memoryRegion) ),
+   _structsByName(str_comparator, _trMemory->heapMemoryRegion()),
+   _unionsByName(str_comparator, _trMemory->heapMemoryRegion())
+   {
+   // primitive types
+   NoType       = _primitiveType[TR::NoType]                = new (PERSISTENT_NEW) OMR::PrimitiveType("NoType", TR::NoType, client);
+   Int8         = _primitiveType[TR::Int8]                  = new (PERSISTENT_NEW) OMR::PrimitiveType("Int8", TR::Int8, client);
+   Int16        = _primitiveType[TR::Int16]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Int16", TR::Int16, client);
+   Int32        = _primitiveType[TR::Int32]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Int32", TR::Int32, client);
+   Int64        = _primitiveType[TR::Int64]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Int64", TR::Int64, client);
+   Float        = _primitiveType[TR::Float]                 = new (PERSISTENT_NEW) OMR::PrimitiveType("Float", TR::Float, client);
+   Double       = _primitiveType[TR::Double]                = new (PERSISTENT_NEW) OMR::PrimitiveType("Double", TR::Double, client);
+   Address      = _primitiveType[TR::Address]               = new (PERSISTENT_NEW) OMR::PrimitiveType("Address", TR::Address, client);
+   VectorInt8   = _primitiveType[TR::VectorInt8]            = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt8", TR::VectorInt8, client);
+   VectorInt16  = _primitiveType[TR::VectorInt16]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt16", TR::VectorInt16, client);
+   VectorInt32  = _primitiveType[TR::VectorInt32]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt32", TR::VectorInt32, client);
+   VectorInt64  = _primitiveType[TR::VectorInt64]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorInt64", TR::VectorInt64, client);
+   VectorFloat  = _primitiveType[TR::VectorFloat]           = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorFloat", TR::VectorFloat, client);
+   VectorDouble = _primitiveType[TR::VectorDouble]          = new (PERSISTENT_NEW) OMR::PrimitiveType("VectorDouble", TR::VectorDouble, client);
+
+   // pointer to primitive types
+   pNoType       = _pointerToPrimitiveType[TR::NoType]       = new (PERSISTENT_NEW) OMR::PointerType(NoType);
+   pInt8         = _pointerToPrimitiveType[TR::Int8]         = new (PERSISTENT_NEW) OMR::PointerType(Int8);
+   pInt16        = _pointerToPrimitiveType[TR::Int16]        = new (PERSISTENT_NEW) OMR::PointerType(Int16);
+   pInt32        = _pointerToPrimitiveType[TR::Int32]        = new (PERSISTENT_NEW) OMR::PointerType(Int32);
+   pInt64        = _pointerToPrimitiveType[TR::Int64]        = new (PERSISTENT_NEW) OMR::PointerType(Int64);
+   pFloat        = _pointerToPrimitiveType[TR::Float]        = new (PERSISTENT_NEW) OMR::PointerType(Float);
+   pDouble       = _pointerToPrimitiveType[TR::Double]       = new (PERSISTENT_NEW) OMR::PointerType(Double);
+   pAddress      = _pointerToPrimitiveType[TR::Address]      = new (PERSISTENT_NEW) OMR::PointerType(Address);
+   pVectorInt8   = _pointerToPrimitiveType[TR::VectorInt8]   = new (PERSISTENT_NEW) OMR::PointerType(VectorInt8);
+   pVectorInt16  = _pointerToPrimitiveType[TR::VectorInt16]  = new (PERSISTENT_NEW) OMR::PointerType(VectorInt16);
+   pVectorInt32  = _pointerToPrimitiveType[TR::VectorInt32]  = new (PERSISTENT_NEW) OMR::PointerType(VectorInt32);
+   pVectorInt64  = _pointerToPrimitiveType[TR::VectorInt64]  = new (PERSISTENT_NEW) OMR::PointerType(VectorInt64);
+   pVectorFloat  = _pointerToPrimitiveType[TR::VectorFloat]  = new (PERSISTENT_NEW) OMR::PointerType(VectorFloat);
+   pVectorDouble = _pointerToPrimitiveType[TR::VectorDouble] = new (PERSISTENT_NEW) OMR::PointerType(VectorDouble);
+
+   if (TR::Compiler->target.is64Bit())
+      {
+      Word =  _primitiveType[TR::Int64]; 
+      pWord =  _pointerToPrimitiveType[TR::Int64];
+      }
+   else
+      {
+      Word =  _primitiveType[TR::Int32];
+      pWord =  _pointerToPrimitiveType[TR::Int32];
+      }
+   }
+
+OMR::TypeDictionaryImpl::~TypeDictionaryImpl() throw()
+   {
+   // Cleanup allocations in _memoryRegion *before* its destroyed below (see note in constructor)
+   _structsByName.clear();
+   _unionsByName.clear();
+
+   _trMemory->~TR_Memory();
+   ::operator delete(_trMemory, TR::Compiler->persistentAllocator());
+   _memoryRegion->~Region();
+   ::operator delete(_memoryRegion, TR::Compiler->persistentAllocator());
+   static_cast<TR::SystemSegmentProvider *>(_segmentProvider)->~SystemSegmentProvider();
+   ::operator delete(_segmentProvider, TR::Compiler->persistentAllocator());
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::LookupStruct(const char *structName)
+   {
+   return getStruct(structName);
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::LookupUnion(const char *unionName)
+   {
+   return getUnion(unionName);
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::DefineStruct(const char *structName)
+   {
+   TR_ASSERT_FATAL(_structsByName.find(structName) == _structsByName.end(), "Struct '%s' already exists", structName);
+
+   StructType *newType = new (PERSISTENT_NEW) StructType(structName, _client);
+   _structsByName.insert(std::make_pair(structName, newType));
+
+   return newType;
+   }
+
+void
+OMR::TypeDictionaryImpl::DefineField(const char *structName, const char *fieldName, TR::IlTypeImpl *type, size_t offset)
+   {
+   getStruct(structName)->AddField(fieldName, type, offset);
+   }
+
+void
+OMR::TypeDictionaryImpl::DefineField(const char *structName, const char *fieldName, TR::IlTypeImpl *type)
+   {
+   getStruct(structName)->AddField(fieldName, type);
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::GetFieldType(const char *structName, const char *fieldName)
+   {
+   return getStruct(structName)->getFieldType(fieldName);
+   }
+
+size_t
+OMR::TypeDictionaryImpl::OffsetOf(const char *structName, const char *fieldName)
+   {
+   return getStruct(structName)->getFieldOffset(fieldName);
+   }
+
+void
+OMR::TypeDictionaryImpl::CloseStruct(const char *structName, size_t finalSize)
+   {
+   getStruct(structName)->Close(finalSize);
+   }
+
+void
+OMR::TypeDictionaryImpl::CloseStruct(const char *structName)
+   {
+   getStruct(structName)->Close();
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::DefineUnion(const char *unionName)
+   {
+   TR_ASSERT_FATAL(_unionsByName.find(unionName) == _unionsByName.end(), "Union '%s' already exists", unionName);
+   
+   UnionType *newType = new (PERSISTENT_NEW) UnionType(unionName, _client, _trMemory);
+   _unionsByName.insert(std::make_pair(unionName, newType));
+
+   return newType;
+   }
+
+void
+OMR::TypeDictionaryImpl::UnionField(const char *unionName, const char *fieldName, TR::IlTypeImpl *type)
+   {
+   getUnion(unionName)->AddField(fieldName, type);
+   }
+
+void
+OMR::TypeDictionaryImpl::CloseUnion(const char *unionName)
+   {
+   getUnion(unionName)->Close();
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::UnionFieldType(const char *unionName, const char *fieldName)
+   {
+   return getUnion(unionName)->getFieldType(fieldName);
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::PointerTo(const char *structName)
+   {
+   return PointerTo(LookupStruct(structName));
+   }
+
+TR::IlTypeImpl *
+OMR::TypeDictionaryImpl::PointerTo(TR::IlTypeImpl *baseType)
+   {
+   return new (PERSISTENT_NEW) PointerType(baseType);
+   }
+
+TR::IlReference *
+OMR::TypeDictionaryImpl::FieldReference(const char *typeName, const char *fieldName)
+   {
+   StructMap::iterator structIterator = _structsByName.find(typeName);
+   if (structIterator != _structsByName.end())
+      {
+      StructType *theStruct = structIterator->second;
+      return theStruct->getFieldSymRef(fieldName);
+      }
+
+   UnionMap::iterator unionIterator = _unionsByName.find(typeName);
+   if (unionIterator != _unionsByName.end())
+      {
+      UnionType *theUnion = unionIterator->second;
+      return theUnion->getFieldSymRef(fieldName);
+      }
+
+   TR_ASSERT_FATAL(false, "No type with name '%s'", typeName);
+   return NULL;
+   }
+
+void
+OMR::TypeDictionaryImpl::notifyCompilationDone()
+   {
+   // clear all symbol references for fields
+   for (StructMap::iterator it = _structsByName.begin(); it != _structsByName.end(); it++)
+      {
+      StructType *aStruct = it->second;
+      aStruct->clearSymRefs();
+      }
+
+   // clear all symbol references for union fields
+   for (UnionMap::iterator it = _unionsByName.begin(); it != _unionsByName.end(); it++)
+      {
+      UnionType *aUnion = it->second;
+      aUnion->clearSymRefs();
+      }
+   }
+
+OMR::StructType *
+OMR::TypeDictionaryImpl::getStruct(const char *structName)
+   {
+   StructMap::iterator it = _structsByName.find(structName);
+   TR_ASSERT_FATAL(it != _structsByName.end(), "No struct named '%s'", structName);
+
+   StructType *theStruct = it->second;
+   return theStruct;
+   }
+
+OMR::UnionType *
+OMR::TypeDictionaryImpl::getUnion(const char *unionName)
+   {
+   UnionMap::iterator it = _unionsByName.find(unionName);
+   TR_ASSERT_FATAL(it != _unionsByName.end(), "No union named '%s'", unionName);
+
+   UnionType *theUnion = it->second;
+   return theUnion;
+   }

--- a/compiler/ilgen/TypeDictionaryImpl.hpp
+++ b/compiler/ilgen/TypeDictionaryImpl.hpp
@@ -1,0 +1,362 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+#ifndef OMR_TYPEDICTIONARY_IMPL_INCL
+#define OMR_TYPEDICTIONARY_IMPL_INCL
+
+
+#ifndef TR_TYPEDICTIONARY_IMPL_DEFINED
+#define TR_TYPEDICTIONARY_IMPL_DEFINED
+#define PUT_OMR_TYPEDICTIONARY_IMPL_INTO_TR
+#endif
+
+
+#include "map"
+#include "env/TypedAllocator.hpp"
+#include "infra/BitVector.hpp"
+
+class TR_Memory;
+class TR_BitVector;
+
+namespace OMR { class StructType; }
+namespace OMR { class UnionType; }
+
+namespace TR  { class SegmentProvider; }
+namespace TR  { class Region; }
+namespace TR  { class SymbolReference; }
+namespace TR  { typedef SymbolReference IlReference; }
+
+#include "ilgen/IlTypeImpl.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+namespace OMR
+{
+
+class PrimitiveType : public TR::IlTypeImpl
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   PrimitiveType(const char * name, TR::DataType type, TR::TypeDictionary *dict) :
+      TR::IlTypeImpl(name, dict),
+      _type(type)
+      { }
+   virtual ~PrimitiveType()
+      { }
+
+   virtual TR::IlType *getPrimitiveType()
+      {
+      return _dict->PrimitiveType(_type);
+      }
+
+   virtual size_t getSize() { return TR::DataType::getSize(_type); }
+
+   virtual TR::DataType getRealPrimitiveType()
+      {
+      return _type;
+      }
+
+protected:
+   TR::DataType _type;
+   };
+
+
+class FieldInfo
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   FieldInfo(const char *name, size_t offset, TR::IlTypeImpl *type) :
+      _next(0),
+      _name(name),
+      _offset(offset),
+      _type(type),
+      _symRef(0)
+      {
+      }
+
+   void cacheSymRef(TR::SymbolReference *symRef) { _symRef = symRef; }
+   TR::SymbolReference *getSymRef()              { return _symRef; }
+   void clearSymRef()                            { _symRef = NULL; }
+
+   TR::IlTypeImpl *getType()                     { return _type; }
+
+   TR::DataType getPrimitiveType()               { return _type->getRealPrimitiveType(); }
+
+   size_t getOffset()                            { return _offset; }
+
+   FieldInfo *getNext()                          { return _next; }
+   void setNext(FieldInfo *next)                 { _next = next; }
+
+   FieldInfo           * _next;
+   const char          * _name;
+   size_t                _offset;
+   TR::IlTypeImpl      * _type;
+   TR::SymbolReference * _symRef;
+   };
+
+
+class StructType : public TR::IlTypeImpl
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   StructType(const char *name, TR::TypeDictionary *dict) :
+      TR::IlTypeImpl(name, dict),
+      _firstField(0),
+      _lastField(0),
+      _size(0),
+      _closed(false)
+      { }
+   virtual ~StructType()
+      { }
+
+   virtual TR::IlType *getPrimitiveType()            { return _dict->PrimitiveType(TR::Address); }
+   virtual TR::DataType getRealPrimitiveType()       { return TR::Address; }
+
+   void Close(size_t finalSize)                      { TR_ASSERT(_size <= finalSize, "Final size %d of struct %s is less than its current size %d\n", finalSize, _name, _size); _size = finalSize; _closed = true; };
+   void Close()                                      { _closed = true; };
+
+   void AddField(const char *name, TR::IlTypeImpl *fieldType, size_t offset);
+   void AddField(const char *name, TR::IlTypeImpl *fieldType);
+   TR::IlTypeImpl * getFieldType(const char *fieldName);
+   size_t getFieldOffset(const char *fieldName);
+
+   TR::SymbolReference *getFieldSymRef(const char *name);
+   bool isStruct() { return true; }
+   virtual size_t getSize() { return _size; }
+
+   void clearSymRefs();
+
+protected:
+   FieldInfo * findField(const char *fieldName);
+
+   FieldInfo * _firstField;
+   FieldInfo * _lastField;
+   size_t      _size;
+   bool        _closed;
+   };
+
+
+class UnionType : public TR::IlTypeImpl
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   UnionType(const char *name, TR::TypeDictionary *dict, TR_Memory* trMemory) :
+      TR::IlTypeImpl(name, dict),
+      _firstField(0),
+      _lastField(0),
+      _size(0),
+      _closed(false),
+      _symRefBV(4, trMemory),
+      _trMemory(trMemory)
+      { }
+   virtual ~UnionType()
+      { }
+
+   virtual TR::IlType *getPrimitiveType()            { return _dict->PrimitiveType(TR::Address); }
+   virtual TR::DataType getRealPrimitiveType()       { return TR::Address; }
+   void Close();
+
+   void AddField(const char *name, TR::IlTypeImpl *fieldType);
+   TR::IlTypeImpl * getFieldType(const char *fieldName);
+
+   TR::SymbolReference *getFieldSymRef(const char *name);
+   virtual bool isUnion() { return true; }
+   virtual size_t getSize() { return _size; }
+
+   void clearSymRefs();
+
+protected:
+   FieldInfo * findField(const char *fieldName);
+
+   FieldInfo  * _firstField;
+   FieldInfo  * _lastField;
+   size_t       _size;
+   bool         _closed;
+   TR_BitVector _symRefBV;
+   TR_Memory*   _trMemory;
+   };
+
+
+class PointerType : public TR::IlTypeImpl
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   PointerType(TR::IlTypeImpl *baseType) :
+      TR::IlTypeImpl(_nameArray, baseType->dict()),
+      _baseType(baseType)
+      {
+      char *baseName = (char *)_baseType->getName();
+      TR_ASSERT(strlen(baseName) < 45, "cannot store name of pointer type");
+      sprintf(_nameArray, "L%s;", baseName);
+      }
+   virtual bool isPointer() { return true; }
+
+   virtual TR::IlTypeImpl *baseType() { return _baseType; }
+
+   virtual const char *getName() { return _name; }
+
+   virtual TR::IlType *getPrimitiveType()      { return _dict->PrimitiveType(TR::Address); }
+   virtual TR::DataType getRealPrimitiveType() { return TR::Address; }
+
+   virtual size_t getSize() { return TR::DataType::getSize(TR::Address); }
+
+protected:
+   TR::IlTypeImpl      * _baseType;
+   char                  _nameArray[48];
+   };
+
+
+class TypeDictionaryImpl
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   static TR::TypeDictionaryImpl *allocate(TR::TypeDictionary *client);
+
+   TypeDictionaryImpl(TR::TypeDictionary *client);
+   TypeDictionaryImpl(const TypeDictionaryImpl &src) = delete;
+   ~TypeDictionaryImpl() throw();
+
+   /**
+    * TypeDictionary public API implementations, in alphabetical order
+    */
+
+   void CloseStruct(const char *structName);
+   void CloseStruct(const char *structName, size_t finalSize);
+   void DefineField(const char *structName, const char *fieldName, TR::IlTypeImpl *type);
+   void DefineField(const char *structName, const char *fieldName, TR::IlTypeImpl *type, size_t offset);
+   TR::IlTypeImpl * DefineStruct(const char *structName);
+   TR::IlTypeImpl * DefineUnion(const char *unionName);
+   TR::IlTypeImpl * GetFieldType(const char *structName, const char *fieldName);
+   TR::IlTypeImpl * LookupStruct(const char *structName);
+   TR::IlTypeImpl * LookupUnion(const char *unionName);
+   size_t OffsetOf(const char *structName, const char *fieldName);
+   TR::IlTypeImpl *PointerTo(TR::DataType baseType)
+      { return PointerTo(_primitiveType[baseType]->impl()); }
+   TR::IlTypeImpl *PointerTo(TR::IlTypeImpl *baseType);
+   TR::IlTypeImpl *PointerTo(const char *structName);
+   TR::IlTypeImpl *PrimitiveType(TR::DataType primitiveType)
+      { return _primitiveType[primitiveType]->impl(); }
+   void UnionField(const char *unionName, const char *fieldName, TR::IlTypeImpl *type);
+   void CloseUnion(const char *unionName);
+   TR::IlTypeImpl * UnionFieldType(const char *unionName, const char *fieldName);
+
+   /**
+    * public API for other JitBuilder classes
+    */
+
+   TR_Memory *trMemory()
+      { return _trMemory; }
+   TR::IlReference *FieldReference(const char *typeName, const char *fieldName);
+
+   /*
+    * @brief advise that compilation is complete so compilation-specific objects like symbol references can be cleared from caches
+    */
+   void notifyCompilationDone();
+
+   // convenient access for primitive types
+   TR::IlTypeImpl * NoType;
+   TR::IlTypeImpl * Int8;
+   TR::IlTypeImpl * Int16;
+   TR::IlTypeImpl * Int32;
+   TR::IlTypeImpl * Int64;
+   TR::IlTypeImpl * Float;
+   TR::IlTypeImpl * Double;
+   TR::IlTypeImpl * Address;
+   TR::IlTypeImpl * VectorInt8;
+   TR::IlTypeImpl * VectorInt16;
+   TR::IlTypeImpl * VectorInt32;
+   TR::IlTypeImpl * VectorInt64;
+   TR::IlTypeImpl * VectorFloat;
+   TR::IlTypeImpl * VectorDouble;
+
+   // convenient access for pointer types
+   TR::IlTypeImpl * pNoType;
+   TR::IlTypeImpl * pInt8;
+   TR::IlTypeImpl * pInt16;
+   TR::IlTypeImpl * pInt32;
+   TR::IlTypeImpl * pInt64;
+   TR::IlTypeImpl * pFloat;
+   TR::IlTypeImpl * pDouble;
+   TR::IlTypeImpl * pAddress;
+   TR::IlTypeImpl * pVectorInt8;
+   TR::IlTypeImpl * pVectorInt16;
+   TR::IlTypeImpl * pVectorInt32;
+   TR::IlTypeImpl * pVectorInt64;
+   TR::IlTypeImpl * pVectorFloat;
+   TR::IlTypeImpl * pVectorDouble;
+
+   // convenient access for machine word sized integer types
+   TR::IlType     * Word;
+   TR::IlType     * pWord;
+
+protected:
+   TR::SegmentProvider * _segmentProvider;
+   TR::Region          * _memoryRegion;
+   TR_Memory           * _trMemory;
+   TR::TypeDictionary  * _client;
+
+   typedef bool (*StrComparator)(const char *, const char *);
+
+   typedef TR::typed_allocator<std::pair<const char * const, OMR::StructType *>, TR::Region &> StructMapAllocator;
+   typedef std::map<const char *, OMR::StructType *, StrComparator, StructMapAllocator> StructMap;
+   StructMap             _structsByName;
+
+   typedef TR::typed_allocator<std::pair<const char * const, OMR::UnionType *>, TR::Region &> UnionMapAllocator;
+   typedef std::map<const char *, OMR::UnionType *, StrComparator, UnionMapAllocator> UnionMap;
+   UnionMap              _unionsByName;
+
+   TR::IlTypeImpl      * _primitiveType[TR::NumOMRTypes];
+
+   TR::IlTypeImpl      * _pointerToPrimitiveType[TR::NumOMRTypes];
+
+   OMR::StructType * getStruct(const char *structName);
+   OMR::UnionType  * getUnion(const char *unionName);
+
+private:
+   static const uint8_t primitiveTypeAlignment[TR::NumOMRTypes];
+   };
+
+} // namespace OMR
+
+
+#if defined(PUT_OMR_TYPEDICTIONARY_IMPL_INTO_TR)
+
+namespace TR
+{
+
+class TypeDictionaryImpl : public OMR::TypeDictionaryImpl
+   {
+   public:
+      TypeDictionaryImpl(TR::TypeDictionary *client)
+         : OMR::TypeDictionaryImpl(client)
+         { }
+   };
+
+} // namespace TR
+
+#endif // defined(PUT_OMR_TYPEDICTIONARY_IMPL_INTO_TR)
+
+#endif // !defined(OMR_TYPEDICTIONARY_IMPL_INCL)

--- a/compiler/ilgen/VirtualMachineOperandArray.hpp
+++ b/compiler/ilgen/VirtualMachineOperandArray.hpp
@@ -76,6 +76,11 @@ class VirtualMachineOperandArray : public VirtualMachineState
    VirtualMachineOperandArray(VirtualMachineOperandArray *other);
 
    /**
+    * @brief destructor
+    */
+   ~VirtualMachineOperandArray();
+
+   /**
     * @brief write the simulated operand array to the virtual machine
     * @param b the builder where the operations will be placed to recreate the virtual machine operand array
     */

--- a/compiler/ilgen/VirtualMachineRegister.cpp
+++ b/compiler/ilgen/VirtualMachineRegister.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,12 +19,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#include <stdint.h>
-#include "ilgen/IlInjector.hpp"
-#include "ilgen/IlValueImpl.hpp"
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/IlType.hpp"
+#include "ilgen/IlTypeImpl.hpp"  // must move out
 
-TR::IlValueImpl *
-OMR::IlValue::impl()
+OMR::VirtualMachineRegister::VirtualMachineRegister(TR::IlBuilder *b,
+                                                    const char * const localName,
+                                                    TR::IlType * pointerToRegisterType,
+                                                    uint32_t adjustByStep,
+                                                    TR::IlValue * addressOfRegister)
+   : OMR::VirtualMachineState(),
+   _localName(localName),
+   _addressOfRegister(addressOfRegister),
+   _pointerToRegisterType(pointerToRegisterType),
+   _elementType(pointerToRegisterType->impl()->baseType()->baseType()),
+   _adjustByStep(adjustByStep)
    {
-   return static_cast<TR::IlValueImpl *>(this);
+   Reload(b);
    }

--- a/compiler/ilgen/VirtualMachineRegister.hpp
+++ b/compiler/ilgen/VirtualMachineRegister.hpp
@@ -25,6 +25,7 @@
 
 #include "ilgen/VirtualMachineState.hpp"
 #include "ilgen/IlBuilder.hpp"
+#include "ilgen/IlType.hpp"
 #include "ilgen/TypeDictionary.hpp"
 
 namespace TR { class IlBuilder; }
@@ -84,17 +85,7 @@ class VirtualMachineRegister : public OMR::VirtualMachineState
                           const char * const localName,
                           TR::IlType * pointerToRegisterType,
                           uint32_t adjustByStep,
-                          TR::IlValue * addressOfRegister)
-      : OMR::VirtualMachineState(),
-      _localName(localName),
-      _addressOfRegister(addressOfRegister),
-      _pointerToRegisterType(pointerToRegisterType),
-      _elementType(pointerToRegisterType->baseType()->baseType()),
-      _adjustByStep(adjustByStep)
-      {
-      Reload(b);
-      }
-
+                          TR::IlValue * addressOfRegister);
   
    /**
     * @brief write the simulated register value to the virtual machine
@@ -114,7 +105,7 @@ class VirtualMachineRegister : public OMR::VirtualMachineState
    virtual void Reload(TR::IlBuilder *b)
       {
       b->Store(_localName,
-      b->   LoadAt((TR::IlType *)_pointerToRegisterType,
+      b->   LoadAt(_pointerToRegisterType,
                _addressOfRegister));
       }
 

--- a/compiler/ilgen/VirtualMachineRegisterInStruct.hpp
+++ b/compiler/ilgen/VirtualMachineRegisterInStruct.hpp
@@ -68,7 +68,7 @@ class VirtualMachineRegisterInStruct : public ::OMR::VirtualMachineRegister
       _fieldName(fieldName),
       _localNameHoldingStructAddress(localNameHoldingStructAddress)
       {
-      _elementType = b->typeDictionary()->GetFieldType(structName, fieldName)->baseType()->baseType();
+      _elementType = b->methodBuilder()->typeDictionary()->GetFieldType(structName, fieldName)->baseType()->baseType();
       _adjustByStep = _elementType->getSize();
       Reload(b);
       }

--- a/compiler/ilgen/VirtualMachineState.hpp
+++ b/compiler/ilgen/VirtualMachineState.hpp
@@ -24,10 +24,6 @@
 
 
 namespace TR { class IlBuilder; }
-class TR_Memory;
-
-template <class T> class List;
-template <class T> class ListAppender;
 
 namespace OMR
 {

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5368,6 +5368,22 @@ class IfxcmpgeToIfxcmpeqReducer
          case TR::iflucmpge:
             result =  isReducibleSpecific<uint64_t>();
             break;
+
+         case TR::ifbcmple:
+         case TR::ifbucmple:
+         case TR::ifscmple:
+         case TR::ifsucmple:
+         case TR::ificmple:
+         case TR::ifiucmple:
+         case TR::iflcmple:
+         case TR::iflucmple:
+            // earlier xforms to reverse children may bring these opcodes here
+            // just return false
+            break;
+
+         default:
+            TR_ASSERT(0, "unexpected opcode provided to isReducible()");
+            break;
          }
 
          return result;

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -221,15 +221,24 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/env/OMRIO.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRKnownObjectTable.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/Globals.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlType.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlTypeImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlValueImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilderImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/MethodBuilderImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/ThunkBuilderImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilderImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionaryImpl.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/Alignment.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/CodeCacheTypes.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCache.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -93,6 +93,9 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRILOpCodesEnum.hpp: $(FIXED_SRCBASE
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/ILHelpers.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/il/ILHelpers.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il
 	cp $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlType.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlType.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
@@ -148,6 +151,7 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRDataTypes.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRDataTypes_inlines.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/il/OMRILOpCodesEnum.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlType.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlValue.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlInjector.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlBuilder.hpp \

--- a/jitbuilder/compile/Method.hpp
+++ b/jitbuilder/compile/Method.hpp
@@ -34,7 +34,7 @@
 #include "compile/ResolvedMethod.hpp"
 
 namespace TR { class IlGeneratorMethodDetails; }
-namespace TR { class IlType; }
+namespace TR { class IlTypeImpl; }
 namespace TR { class TypeDictionary; }
 namespace TR { class IlInjector; }
 namespace TR { class MethodBuilder; }
@@ -112,8 +112,8 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
                   const char      * lineNumber,
                   char            * name,
                   int32_t           numParms,
-                  TR::IlType     ** parmTypes,
-                  TR::IlType      * returnType,
+                  TR::IlTypeImpl ** parmTypes,
+                  TR::IlTypeImpl  * returnType,
                   void            * entryPoint,
                   TR::IlInjector  * ilInjector)
       : _fileName(fileName),
@@ -143,7 +143,7 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
    virtual void                * resolvedMethodAddress()                    { return (void *)_ilInjector; }
 
    virtual uint16_t              numberOfParameterSlots()                   { return _numParms; }
-   virtual TR::DataType         parmType(uint32_t slot);
+   virtual TR::DataType          parmType(uint32_t slot);
    virtual uint16_t              numberOfTemps()                            { return 0; }
 
    virtual void                * startAddressForJittedMethod()              { return (getEntryPoint()); }
@@ -156,8 +156,8 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
 
    const char                  * getLineNumber()                            { return _lineNumber;}
    char                        * getSignature()                             { return _signature;}
-   TR::DataType                 returnType();
-   TR::IlType                  * returnIlType()                             { return _returnType; }
+   TR::DataType                  returnType();
+   TR::IlTypeImpl              * returnIlType()                             { return _returnType; }
    int32_t                       getNumArgs()                               { return _numParms;}
    void                          setEntryPoint(void *ep)                    { _entryPoint = ep; }
    void                        * getEntryPoint()                            { return _entryPoint; }
@@ -171,20 +171,22 @@ class ResolvedMethod : public ResolvedMethodBase, public Method
                                TR::FrontEnd *fe,
                                TR::SymbolReferenceTable *symRefTab);
 
+   void compilationDone();
+
    protected:
-   const char *_fileName;
-   const char *_lineNumber;
+   const char      * _fileName;
+   const char      * _lineNumber;
 
-   char *_name;
-   char *_signature;
-   char  _signatureChars[64];
-   char *_externalName;
+   char            * _name;
+   char            * _signature;
+   char              _signatureChars[64];
+   char            * _externalName;
 
-   int32_t          _numParms;
-   TR::IlType    ** _parmTypes;
-   TR::IlType     * _returnType;
-   void           * _entryPoint;
-   TR::IlInjector * _ilInjector;
+   int32_t           _numParms;
+   TR::IlTypeImpl ** _parmTypes;
+   TR::IlTypeImpl  * _returnType;
+   void            * _entryPoint;
+   TR::IlInjector  * _ilInjector;
    };
 
 
@@ -205,8 +207,8 @@ namespace TR
                         char            * lineNumber,
                         char            * name,
                         int32_t           numArgs,
-                        TR::IlType     ** parmTypes,
-                        TR::IlType      * returnType,
+                        TR::IlTypeImpl ** parmTypes,
+                        TR::IlTypeImpl  * returnType,
                         void            * entryPoint,
                         TR::IlInjector  * ilInjector)
             : JitBuilder::ResolvedMethod(fileName, lineNumber, name, numArgs,

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -196,7 +196,7 @@ compileMethodBuilder(TR::MethodBuilder *m, uint8_t **entry)
 
    int32_t rc=0;
    *entry = compileMethodFromDetails(NULL, details, warm, rc);
-   m->typeDictionary()->NotifyCompilationDone();
+   resolvedMethod.compilationDone();
    return rc;
    }
 

--- a/jitbuilder/release/src/Conditionals.cpp
+++ b/jitbuilder/release/src/Conditionals.cpp
@@ -202,29 +202,29 @@ main(int argc, char *argv[])
 
    total=0; pass=0;
 
-   L=0, U=10000; x=50;        total++; if (compare(x, L, U) != 0) pass++;
-   L=0, U=10000; x=L;         total++; if (compare(x, L, U) != 0) pass++;
-   L=0, U=10000; x=L-1;       total++; if (compare(x, L, U) != 0) pass++;
-   L=0, U=10000; x=-50000;    total++; if (compare(x, L, U) != 0) pass++;
-   L=0, U=10000; x=U-1;       total++; if (compare(x, L, U) != 0) pass++;
-   L=0, U=10000; x=U;         total++; if (compare(x, L, U) != 0) pass++;
-   L=0, U=10000; x=50000;     total++; if (compare(x, L, U) != 0) pass++;
+   L=0, U=10000; x=50;        total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=0, U=10000; x=L;         total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=0, U=10000; x=L-1;       total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=0, U=10000; x=-50000;    total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=0, U=10000; x=U-1;       total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=0, U=10000; x=U;         total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=0, U=10000; x=50000;     total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
 
-   L=-25, U=25; x=0;          total++; if (compare(x, L, U) != 0) pass++;
-   L=-25, U=25; x=L;          total++; if (compare(x, L, U) != 0) pass++;
-   L=-25, U=25; x=L-1;        total++; if (compare(x, L, U) != 0) pass++;
-   L=-25, U=25; x=-100;       total++; if (compare(x, L, U) != 0) pass++;
-   L=-25, U=25; x=U-1;        total++; if (compare(x, L, U) != 0) pass++;
-   L=-25, U=25; x=U;          total++; if (compare(x, L, U) != 0) pass++;
-   L=-25, U=25; x=100;        total++; if (compare(x, L, U) != 0) pass++;
+   L=-25, U=25; x=0;          total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-25, U=25; x=L;          total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-25, U=25; x=L-1;        total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-25, U=25; x=-100;       total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-25, U=25; x=U-1;        total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-25, U=25; x=U;          total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-25, U=25; x=100;        total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
 
-   L=-1000, U=-900; x=-950;   total++; if (compare(x, L, U) != 0) pass++;
-   L=-1000, U=-900; x=L;      total++; if (compare(x, L, U) != 0) pass++;
-   L=-1000, U=-900; x=L-1;    total++; if (compare(x, L, U) != 0) pass++;
-   L=-1000, U=-900; x=-10000; total++; if (compare(x, L, U) != 0) pass++;
-   L=-1000, U=-900; x=U-1;    total++; if (compare(x, L, U) != 0) pass++;
-   L=-1000, U=-900; x=U;      total++; if (compare(x, L, U) != 0) pass++;
-   L=-1000, U=-900; x=-500;   total++; if (compare(x, L, U) != 0) pass++;
+   L=-1000, U=-900; x=-950;   total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-1000, U=-900; x=L;      total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-1000, U=-900; x=L-1;    total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-1000, U=-900; x=-10000; total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-1000, U=-900; x=U-1;    total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-1000, U=-900; x=U;      total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
+   L=-1000, U=-900; x=-500;   total++; if (compare(x, L, U) != 0) pass++; else printf("Fail L=%d, U=%d, x=%d\n", L, U, x);
 
    cout << "Step 5: shutdown JIT\n";
    shutdownJit();

--- a/jitbuilder/release/src/LinkedList.hpp
+++ b/jitbuilder/release/src/LinkedList.hpp
@@ -39,11 +39,6 @@ typedef int32_t (LinkedListFunctionType)(Element *, int16_t);
 
 class LinkedListMethod : public TR::MethodBuilder
    {
-   private:
-   TR::IlReference *_keyRef;
-   TR::IlReference *_valRef;
-   TR::IlReference *_nextRef;
-
    public:
    LinkedListMethod(TR::TypeDictionary *);
    virtual bool buildIL();

--- a/jitbuilder/release/src/OperandArrayTests.cpp
+++ b/jitbuilder/release/src/OperandArrayTests.cpp
@@ -506,7 +506,7 @@ OperandArrayTestMethod::testArray(TR::BytecodeBuilder *builder, bool useEqual)
 bool
 OperandArrayTestMethod::buildIL()
    {
-   TR::IlType *pElementType = _types->PointerTo(_types->PointerTo(Word));
+   TR::IlType *pElementType = typeDictionary()->PointerTo(typeDictionary()->PointerTo(Word));
 
    Call("createArray", 0);
 
@@ -534,7 +534,7 @@ OperandArrayTestUsingFalseMethod::OperandArrayTestUsingFalseMethod(TR::TypeDicti
 bool
 OperandArrayTestUsingFalseMethod::buildIL()
    {
-   TR::IlType *pElementType = _types->PointerTo(_types->PointerTo(Word));
+   TR::IlType *pElementType = typeDictionary()->PointerTo(typeDictionary()->PointerTo(Word));
 
    Call("createArray", 0);
 

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -562,7 +562,7 @@ OperandStackTestMethod::testStack(TR::BytecodeBuilder *b, bool useEqual)
 bool
 OperandStackTestMethod::buildIL()
    {
-   TR::IlType *pElementType = _types->PointerTo(_types->PointerTo(STACKVALUEILTYPE));
+   TR::IlType *pElementType = typeDictionary()->PointerTo(typeDictionary()->PointerTo(STACKVALUEILTYPE));
 
    Call("createStack", 0);
 

--- a/jitbuilder/release/src/Simple.cpp
+++ b/jitbuilder/release/src/Simple.cpp
@@ -79,7 +79,7 @@ main(int argc, char *argv[])
 SimpleMethod::SimpleMethod(TR::TypeDictionary *d)
    : MethodBuilder(d)
    {
-   DefineLine(LINETOSTR(__LINE__));
+   DefineLine(__LINE__);
    DefineFile(__FILE__);
 
    DefineName("increment");

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -28,8 +28,9 @@
 #include <errno.h>
 
 #include "Jit.hpp"
-#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/IlType.hpp"
 #include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
 #include "StructArray.hpp"
 
 

--- a/jitbuilder/release/src/ToIlType.cpp
+++ b/jitbuilder/release/src/ToIlType.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 
 #include "Jit.hpp"
+#include "ilgen/IlType.hpp"
 #include "ilgen/TypeDictionary.hpp"
 
 // types for use in test cases
@@ -43,16 +44,16 @@ int main()
    TR::TypeDictionary d;
 
    std::cout << "Step 3: test signed integral types\n";
-   assert(TR::Int8 == d.toIlType<int8_t>()->getPrimitiveType());
-   assert(TR::Int16 == d.toIlType<int16_t>()->getPrimitiveType());
-   assert(TR::Int32 == d.toIlType<int32_t>()->getPrimitiveType());
-   assert(TR::Int64 == d.toIlType<int64_t>()->getPrimitiveType());
+   assert(d.Int8 == d.toIlType<int8_t>()->getPrimitiveType());
+   assert(d.Int16 == d.toIlType<int16_t>()->getPrimitiveType());
+   assert(d.Int32 == d.toIlType<int32_t>()->getPrimitiveType());
+   assert(d.Int64 == d.toIlType<int64_t>()->getPrimitiveType());
 
    std::cout << "Step 4: test unsigned integral types\n";
-   assert(TR::Int8 == d.toIlType<uint8_t>()->getPrimitiveType());
-   assert(TR::Int16 == d.toIlType<uint16_t>()->getPrimitiveType());
-   assert(TR::Int32 == d.toIlType<uint32_t>()->getPrimitiveType());
-   assert(TR::Int64 == d.toIlType<uint64_t>()->getPrimitiveType());
+   assert(d.Int8 == d.toIlType<uint8_t>()->getPrimitiveType());
+   assert(d.Int16 == d.toIlType<uint16_t>()->getPrimitiveType());
+   assert(d.Int32 == d.toIlType<uint32_t>()->getPrimitiveType());
+   assert(d.Int64 == d.toIlType<uint64_t>()->getPrimitiveType());
 
    std::cout << "Step 5: test language primitive signed integral types\n";
    assert(sizeof(char) == d.toIlType<char>()->getSize());
@@ -69,52 +70,52 @@ int main()
    assert(sizeof(unsigned long long) == d.toIlType<unsigned long long>()->getSize());
 
    std::cout << "Step 7: test floating point types\n";
-   assert(TR::Float == d.toIlType<float>()->getPrimitiveType());
-   assert(TR::Double == d.toIlType<double>()->getPrimitiveType());
+   assert(d.Float == d.toIlType<float>()->getPrimitiveType());
+   assert(d.Double == d.toIlType<double>()->getPrimitiveType());
 
    std::cout << "Step 8: test cv qualified types\n";
-   assert(TR::Int8 == d.toIlType<const int8_t>()->getPrimitiveType());
-   assert(TR::Int16 == d.toIlType<volatile uint16_t>()->getPrimitiveType());
-   assert(TR::Int32 == d.toIlType<const volatile int32_t>()->getPrimitiveType());
+   assert(d.Int8 == d.toIlType<const int8_t>()->getPrimitiveType());
+   assert(d.Int16 == d.toIlType<volatile uint16_t>()->getPrimitiveType());
+   assert(d.Int32 == d.toIlType<const volatile int32_t>()->getPrimitiveType());
 
    std::cout << "Step 9: test void type\n";
-   assert(TR::NoType == d.toIlType<void>()->getPrimitiveType());
+   assert(d.NoType == d.toIlType<void>()->getPrimitiveType());
 
    std::cout << "Step 10: test pointer to primitive types\n";
    auto pInt32_type = d.toIlType<int32_t*>();
    assert(true == pInt32_type->isPointer());
-   assert(TR::Int32 == pInt32_type->baseType()->getPrimitiveType());
+   assert(d.Int32 == pInt32_type->baseType()->getPrimitiveType());
 
    auto pDouble_type = d.toIlType<double*>();
    assert(true == pDouble_type->isPointer());
-   assert(TR::Double == pDouble_type->baseType()->getPrimitiveType());
+   assert(d.Double == pDouble_type->baseType()->getPrimitiveType());
 
    auto pVoid_type = d.toIlType<void*>();
    assert(true == pVoid_type->isPointer());
-   assert(TR::NoType == pVoid_type->baseType()->getPrimitiveType());
+   assert(d.NoType == pVoid_type->baseType()->getPrimitiveType());
 
    std::cout << "Step 11: test pointer to pointer to primitive types\n";
    auto ppInt32_type = d.toIlType<int32_t**>();
    assert(true == ppInt32_type->isPointer());
    assert(true == ppInt32_type->baseType()->isPointer());
-   assert(TR::Int32 == ppInt32_type->baseType()->baseType()->getPrimitiveType());
+   assert(d.Int32 == ppInt32_type->baseType()->baseType()->getPrimitiveType());
 
    auto ppDouble_type = d.toIlType<double**>();
    assert(true == ppDouble_type->isPointer());
    assert(true == ppDouble_type->baseType()->isPointer());
-   assert(TR::Double == ppDouble_type->baseType()->baseType()->getPrimitiveType());
+   assert(d.Double == ppDouble_type->baseType()->baseType()->getPrimitiveType());
 
    auto ppVoid_type = d.toIlType<void**>();
    assert(true == ppVoid_type->isPointer());
    assert(true == ppVoid_type->baseType()->isPointer());
-   assert(TR::NoType == ppVoid_type->baseType()->baseType()->getPrimitiveType());
+   assert(d.NoType == ppVoid_type->baseType()->baseType()->getPrimitiveType());
 
 #ifdef EXPECTED_FAIL
    /* Note: If enabled, the following tests should result in compilation errors. */
 
    // test enum types
-   assert(TR::Int8 == d.toIlType<Int8Enum>()->getPrimitiveType());
-   assert(TR::Int64 == d.toIlType<Int64Enum>()->getPrimitiveType());
+   assert(d.Int8 == d.toIlType<Int8Enum>()->getPrimitiveType());
+   assert(d.Int64 == d.toIlType<Int64Enum>()->getPrimitiveType());
 
    // test array type
    d.toIlType<int[10]>();

--- a/jitbuilder/release/src/Union.cpp
+++ b/jitbuilder/release/src/Union.cpp
@@ -24,8 +24,9 @@
 #include <assert.h>
 
 #include "Jit.hpp"
-#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/IlType.hpp"
 #include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
 #include "Union.hpp"
 
 SetUnionByteBuilder::SetUnionByteBuilder(TR::TypeDictionary *d)


### PR DESCRIPTION
Separate out the client API into its own set of classes distinct from implementation, with the goals to semantically version the client API (#1819), to eventually be able to cleanly separate different possible implementations of the client API (#1818), and to make it somewhat easier to create different language bindings into the JitBuilder library (e.g. #2049, https://github.com/eclipse/openj9/issues/806).

This is work in progress because all the changes are all scrunched together in mostly one massive commit and all the commit messages are minimal, but I now have everything rebased to master and working on my laptop so I wanted to check whether there are any platform issues remaining. Before removing the WIP, I'll tease the one massive commit into several more meaningful commits, though I am unlikely to make the interim commits fully build-able due to the pervasiveness of this change.

I will be changing history on this branch, so I don't recommend anyone to build upon it in its current form.

I'll also make this PR message more meaningful :) .