### PR TITLE
Small fixes

### DIFF
--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -154,7 +154,6 @@ public:
    TR::IlValue *ConstDouble(double value);
    TR::IlValue *ConstAddress(const void * const value);
    TR::IlValue *ConstString(const char * const value);
-   TR::IlValue *ConstzeroValueForValue(TR::IlValue *v);
 
    TR::IlValue *Const(int8_t value)             { return ConstInt8(value); }
    TR::IlValue *Const(int16_t value)            { return ConstInt16(value); }

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -5368,6 +5368,23 @@ class IfxcmpgeToIfxcmpeqReducer
          case TR::iflucmpge:
             result =  isReducibleSpecific<uint64_t>();
             break;
+
+         case TR::ifbcmple:
+         case TR::ifbucmple:
+         case TR::ifscmple:
+         case TR::ifsucmple:
+         case TR::ificmple:
+         case TR::ifiucmple:
+         case TR::iflcmple:
+         case TR::iflucmple:
+            // earlier xforms to reverse children may bring these opcodes here
+            // do not reduce in this case
+            result = false;
+            break;
+
+         default:
+            TR_ASSERT(0, "unexpected opcode provided to isReducible()");
+            break;
          }
 
          return result;


### PR DESCRIPTION
Two small unrelated and noncritical fixes:
1) to eliminate a warning in OMRSimplifierHandlers.cpp, I added some cases to a switch as well as a default handler
2) I removed an unimplemented service from JitBuilder called "ConstzeroForValue"