### PR TITLE
Eliminate last bits of early jitbuilder replay support

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -154,21 +154,6 @@ IlBuilder::setupForBuildIL()
    _exitBlock = emptyBlock();
    }
 
-
-#if 0
-char *
-IlBuilder::getName()
-   {
-   if (!_haveReplayName)
-      {
-      sprintf(_replayName, "B_%p", this);
-      _haveReplayName = true;
-      }
-   return _replayName;
-   }
-#endif
-
-
 void
 IlBuilder::print(const char *title, bool recurse)
    {

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -318,4 +318,4 @@ test_calls.o : call
 
 
 clean:
-	@rm -f $(ALL_TESTS) useIncrement useCall replay *.o
+	@rm -f $(ALL_TESTS) useIncrement useCall *.o


### PR DESCRIPTION
There is one last piece of code in IlBuilder.cpp and in
the JitBuilder makefile to finish removing the early replay
support.

Fixes: #1818

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>