### PR TITLE
Initial changes to be able to compile OMR with Clang 5.0 under Windows

### DIFF
--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -115,9 +115,15 @@ macro(omr_detect_system_information)
 		elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
 			set(_OMR_TOOLCONFIG "msvc")
 		elseif(CMAKE_C_COMPILER_ID MATCHES "^(Apple)?Clang$")
-			#TODO we dont actually have a clang config.
-			# Just use GNU config
-			set(_OMR_TOOLCONFIG "gnu")
+			if("x${CMAKE_C_SIMULATE_ID}" STREQUAL "xMSVC"
+				    OR "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
+				# clang on Windows mimics MSVC
+				set(_OMR_TOOLCONFIG "msvc")
+			else()
+				#TODO we dont actually have a clang config.
+				# Just use GNU config
+				set(_OMR_TOOLCONFIG "gnu")
+			endif()
 		elseif(CMAKE_C_COMPILER_ID STREQUAL "XL")
 			set(_OMR_TOOLCONFIG "xlc")
 		else()

--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -83,6 +83,12 @@ macro(omr_toolconfig_global_setup)
 	# Strip out exception handling flags (added by default by cmake)
 	omr_remove_flags(CMAKE_CXX_FLAGS /EHsc /GR)
 
+	# FIXME: disable several warnings while compiling with CLang.
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+		omr_append_flags(CMAKE_C_FLAGS -Wno-error=unused-command-line-argument -Wno-error=comment -Wno-error=deprecated)
+		omr_append_flags(CMAKE_CXX_FLAGS -Wno-error=unused-command-line-argument -Wno-error=comment -Wno-error=deprecated)
+	endif()
+
 	# Hack up output dir to fix dll dependency issues on windows
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 endmacro(omr_toolconfig_global_setup)

--- a/omrsigcompat/omrsig.cpp
+++ b/omrsigcompat/omrsig.cpp
@@ -197,8 +197,12 @@ omrsig_handler(int sig, void *siginfo, void *uc)
 sighandler_t
 omrsig_primary_signal(int signum, sighandler_t handler)
 {
-	struct sigaction act = {{0}};
-	struct sigaction oldact = {{0}};
+	struct sigaction act;
+	struct sigaction oldact;
+
+	memset(&act, 0, sizeof(struct sigaction));
+	memset(&oldact, 0, sizeof(struct sigaction));
+
 	act.sa_handler = handler;
 #if defined(POSIX_SIGNAL)
 	/* Add necessary flags to emulate signal() behavior using sigaction(). */
@@ -223,8 +227,13 @@ omrsig_primary_sigaction(int signum, const struct sigaction *act, struct sigacti
 #endif /* defined(POSIX_SIGNAL) */
 
 #if defined(WIN32)
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-dllimport"
+#else
 #pragma warning(push)
 #pragma warning(disable : 4273)
+#endif /* defined (__clang__) */
 void (__cdecl * __cdecl
 signal(_In_ int signum, _In_opt_ void (__cdecl * handler)(int)))(int)
 #else /* defined(WIN32) */
@@ -235,14 +244,22 @@ signal(int signum, sighandler_t handler) __THROW
 	return omrsig_signal_internal(signum, handler);
 }
 #if defined(WIN32)
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#else
 #pragma warning(pop)
+#endif /* defined (__clang__) */
 #endif /* defined(WIN32) */
 
 static sighandler_t
 omrsig_signal_internal(int signum, sighandler_t handler)
 {
-	struct sigaction act = {{0}};
-	struct sigaction oldact = {{0}};
+	struct sigaction act;
+	struct sigaction oldact;
+
+	memset(&act, 0, sizeof(struct sigaction));
+	memset(&oldact, 0, sizeof(struct sigaction));
+
 	oldact.sa_handler = SIG_DFL;
 	act.sa_handler = handler;
 #if defined(POSIX_SIGNAL)

--- a/omrtrace/omrtrace_internal.h
+++ b/omrtrace/omrtrace_internal.h
@@ -97,7 +97,7 @@ extern "C" {
 /* assert() and abort() are a bit useless on Windows - they
  * just print a message. Force a GPF instead.
  */
-#if defined(WIN32)
+#if defined(WIN32) && !defined(__clang__)
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/port/common/omrfile_blockingasync.c
+++ b/port/common/omrfile_blockingasync.c
@@ -132,7 +132,7 @@ omrfile_blockingasync_read(struct OMRPortLibrary *portLibrary, intptr_t fd, void
  * @return Number of bytes written on success, portable error return code (which is negative) on failure.
  */
 intptr_t
-omrfile_blockingasync_write(struct OMRPortLibrary *portLibrary, intptr_t fd, void *buf, intptr_t nbytes)
+omrfile_blockingasync_write(struct OMRPortLibrary *portLibrary, intptr_t fd, const void *buf, intptr_t nbytes)
 {
 	return -1;
 }

--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -2474,7 +2474,7 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 	uintptr_t requiredBufferSize = 0;
 	encodingState = NULL;
 	/* MultiByteToWideChar is not resumable, so we need a buffer large enough to hold the entire intermediate result */
-	requiredBufferSize = WIDE_CHAR_SIZE * MultiByteToWideChar(codePage, OS_ENCODING_MB_FLAGS, inBuffer, (int) inBufferSize,
+	requiredBufferSize = WIDE_CHAR_SIZE * MultiByteToWideChar(codePage, OS_ENCODING_MB_FLAGS, (LPCSTR)inBuffer, (int) inBufferSize,
 						 NULL, 0); /* get required buffer size */
 	if (requiredBufferSize > CONVERSION_BUFFER_SIZE) {
 		wideBuffer = portLibrary->mem_allocate_memory(portLibrary, requiredBufferSize, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
@@ -3008,7 +3008,7 @@ convertPlatformToWide(struct OMRPortLibrary *portLibrary, charconvState_t encodi
 {
 	int32_t resultSize = -1;
 #if defined(WIN32)
-	int32_t mbChars = (int32_t)MultiByteToWideChar(codePage, OS_ENCODING_MB_FLAGS, *inBuffer, (int)*inBufferSize, (LPWSTR)outBuffer, (int)outBufferSize);
+	int32_t mbChars = (int32_t)MultiByteToWideChar(codePage, OS_ENCODING_MB_FLAGS, (LPCSTR)*inBuffer, (int)*inBufferSize, (LPWSTR)outBuffer, (int)outBufferSize);
 	if ((outBufferSize > 0) && (0 == mbChars)) {
 		resultSize = OMRPORT_ERROR_STRING_BUFFER_TOO_SMALL; /* should not happen: caller should have allocated a sufficiently large buffer */
 	} else {
@@ -3060,9 +3060,9 @@ static int32_t
 convertWideToPlatform(struct OMRPortLibrary *portLibrary, charconvState_t encodingState, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize)
 {
 	int32_t resultSize = -1;
+#if defined(J9STR_USE_ICONV)
 	uint8_t *platformCursor = (0 == outBufferSize)? NULL : outBuffer;
 	uintptr_t platformLimit = outBufferSize;
-#if defined(J9STR_USE_ICONV)
 	uintptr_t wideRemaining = *inBufferSize;
 
 	if (0 == outBufferSize) { /* get the required buffer size */

--- a/port/win32/j9nlshelpers.c
+++ b/port/win32/j9nlshelpers.c
@@ -57,8 +57,6 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	char country[8];
 	J9NLSDataCache *nls = &portLibrary->portGlobals->nls_data;
 
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
-
 	/* Get the language */
 	infoType = LOCALE_SISO639LANGNAME;
 

--- a/port/win32/omrfile_blockingasync.c
+++ b/port/win32/omrfile_blockingasync.c
@@ -93,7 +93,7 @@ omrfile_blockingasync_read(struct OMRPortLibrary *portLibrary, intptr_t fd, void
 
 	memset(&overlapped, '\0', sizeof(OVERLAPPED));
 	overlapped.hEvent = overlappedHandle;
-	overlapped.Offset = SetFilePointer(fileHandle, 0, &highOffset, FILE_CURRENT);
+	overlapped.Offset = SetFilePointer(fileHandle, 0, (PLONG)&highOffset, FILE_CURRENT);
 	overlapped.OffsetHigh = highOffset;
 
 	/* ReadFile limits the buffer to DWORD size and returns the number of bytes read,
@@ -139,7 +139,7 @@ error:
 
 
 intptr_t
-omrfile_blockingasync_write(struct OMRPortLibrary *portLibrary, intptr_t fd, void *buf, intptr_t nbytes)
+omrfile_blockingasync_write(struct OMRPortLibrary *portLibrary, intptr_t fd, const void *buf, intptr_t nbytes)
 {
 	DWORD bytesWritten;
 	intptr_t toWrite = 0;
@@ -163,7 +163,7 @@ omrfile_blockingasync_write(struct OMRPortLibrary *portLibrary, intptr_t fd, voi
 
 	memset(&overlapped, '\0', sizeof(OVERLAPPED));
 	overlapped.hEvent = overlappedHandle;
-	overlapped.Offset = SetFilePointer(fileHandle, 0, &highOffset, FILE_CURRENT);
+	overlapped.Offset = SetFilePointer(fileHandle, 0, (PLONG)&highOffset, FILE_CURRENT);
 	overlapped.OffsetHigh = highOffset;
 	filePtr = (DWORDLONG)overlapped.Offset | ((DWORDLONG)overlapped.OffsetHigh << 32);
 

--- a/port/win32/omrfilestream.c
+++ b/port/win32/omrfilestream.c
@@ -332,7 +332,6 @@ omrfilestream_fdopen(OMRPortLibrary *portLibrary, intptr_t fd, int32_t flags)
 	OMRFileStream *fileStream = NULL;
 	HANDLE handle = 0;
 	int fileDescriptor = 0;
-	intptr_t rc = 0;
 
 	Trc_PRT_filestream_fdopen_Entry(fd, flags);
 

--- a/port/win32/omrosbacktrace_impl.c
+++ b/port/win32/omrosbacktrace_impl.c
@@ -254,7 +254,7 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
 	HANDLE process = NULL;
 	HANDLE thread = NULL;
 	CONTEXT threadContext = {0};
-	STACKFRAME64 stackFrame = {0};
+	STACKFRAME64 stackFrame;
 	J9PlatformStackFrame **nextFrame;
 	struct J9Win32SignalInfo *sigInfo = (struct J9Win32SignalInfo *)signalInfo;
 
@@ -299,6 +299,7 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
 		memcpy(&threadContext, threadInfo->context, sizeof(CONTEXT));
 	}
 
+	ZeroMemory(&stackFrame, sizeof(STACKFRAME64));
 	/* check that we have loaded the dbg help library functions and symbols */
 	if (0 == load_dbg_functions(portLibrary) && 0 == load_dbg_symbols(portLibrary)) {
 		/* initialize the stackframe */

--- a/port/win32/omrtty.c
+++ b/port/win32/omrtty.c
@@ -247,7 +247,6 @@ omrtty_available(struct OMRPortLibrary *portLibrary)
 
 			if (PeekConsoleInput(PPG_tty_consoleInputHd, (INPUT_RECORD *)PPG_tty_consoleEventBuffer, EVENTS_TO_CAPTURE, &available)) {
 				int x = 0;
-				int count = 0;
 				INPUT_RECORD *inputRecordPointer = (INPUT_RECORD *)PPG_tty_consoleEventBuffer;	/* provided to avoid some casting */
 				BOOL bytesCanBeRead = FALSE;
 

--- a/port/win32/omrvmem.c
+++ b/port/win32/omrvmem.c
@@ -1190,7 +1190,6 @@ touchOnNumaNode(struct OMRPortLibrary *portLibrary, uintptr_t pageSizeInBytes, v
 				PROCESSOR_NUMBER newProc;
 				KAFFINITY groupAffinity = processorMask.Mask;
 				BOOLEAN didBind = FALSE;
-				BYTE proc = 0;
 				BYTE index = 0;
 
 				memcpy(&newProc, &originalProc, sizeof(newProc));

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1210,7 +1210,6 @@ consoleCtrlHandler(DWORD dwCtrlType)
 
 	if (0 == omrthread_attach_ex(NULL, J9THREAD_ATTR_DEFAULT)) {
 		J9WinAMD64AsyncHandlerRecord *cursor;
-		uint32_t handlerCount = 0;
 
 		/* incrementing the asyncThreadCount will prevent the list from being modified while we use it */
 		omrthread_monitor_enter(asyncMonitor);

--- a/tools/tracegen/TraceHeaderWriter.cpp
+++ b/tools/tracegen/TraceHeaderWriter.cpp
@@ -74,7 +74,7 @@ const char *UT_H_FILE_HEADER_TEMPLATE =
 "extern \"C\" {\n"
 "#endif\n"
 "\n"
-"#ifdef __clang__\n"
+"#if (defined (__clang__) && !defined(_MSC_VER))\n"
 "#include <unistd.h>\n"
 "#define Trace_Unreachable() _exit(-1)\n"
 "#else\n"

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -37,11 +37,14 @@ target_include_directories(j9hook_obj
 add_library(j9hookstatic STATIC
 	$<TARGET_OBJECTS:j9hook_obj>
 )
+
 if(OMR_WARNINGS_AS_ERRORS)
+	target_compile_options(j9hook_obj PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 	target_compile_options(j9hookstatic PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()
 
 if(OMR_ENHANCED_WARNINGS)
+	target_compile_options(j9hook_obj PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 	target_compile_options(j9hookstatic PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 


### PR DESCRIPTION
Closing #2191 as it has several unnecessary merge commits.
This is cmake-based config only.
Changes I made:
Modified cmake scripts
Removed unused variables
Fixed some type casts
Removed some {{0}} initializers, clang doesn't like it sometimes. Replaced with memset().
Made several function definitions consistent with it's declarations.
