### PR TITLE
Give DefiningMapAllocator a const key type

### DIFF
--- a/compiler/compile/OSRData.hpp
+++ b/compiler/compile/OSRData.hpp
@@ -91,7 +91,7 @@ namespace TR
       };
    }
 
-typedef TR::typed_allocator<std::pair<int32_t , TR_BitVector*>, TR::Region&> DefiningMapAllocator;
+typedef TR::typed_allocator<std::pair<const int32_t, TR_BitVector*>, TR::Region&> DefiningMapAllocator;
 typedef std::less<int32_t> DefiningMapComparator;
 typedef std::map<int32_t, TR_BitVector*, DefiningMapComparator, DefiningMapAllocator> DefiningMap;
 


### PR DESCRIPTION
TR::typed_allocator requires a const key type or else recent version of XCode
(more recent than used on our build machines apparently) will not match the
template classes properly. This commit simply makes the key type const.

I tested on all platforms to verify builds, since an earlier version of
this fix broke builds on some platforms.

Fixes: #2192

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>