### PR TITLE
Remove deprecated flag of to ArraySetToZero

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1441,9 +1441,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsArraySet() {return _flags1.testAny(SupportsArraySet);}
    void setSupportsArraySet() {_flags1.set(SupportsArraySet);}
 
-   bool getSupportsArraySetToZero() {return _flags3.testAny(SupportsArraySetToZero);}
-   void setSupportsArraySetToZero() {_flags3.set(SupportsArraySetToZero);}
-
    bool getSupportsArrayCmp() {return _flags1.testAny(SupportsArrayCmp);}
    void setSupportsArrayCmp() {_flags1.set(SupportsArrayCmp);}
 
@@ -1752,7 +1749,7 @@ class OMR_EXTENSIBLE CodeGenerator
       SupportsShrinkWrapping                              = 0x00100000,
       ShrinkWrappingDone                                  = 0x00200000,
       SupportsStackAllocationOfArraylets                  = 0x00400000,
-      SupportsArraySetToZero                              = 0x00800000,
+      //                                                  = 0x00800000,  AVAILABLE FOR USE!
       SupportsDoubleWordCAS                               = 0x01000000,
       SupportsDoubleWordSet                               = 0x02000000,
       UsesLoadStoreMultiple                               = 0x04000000,

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -218,7 +218,6 @@ OMR::Power::CodeGenerator::CodeGenerator() :
     if (self()->comp()->getOption(TR_AggressiveOpts) &&
         !self()->comp()->getOption(TR_DisableArraySetOpts))
        {
-       self()->setSupportsArraySetToZero();
        self()->setSupportsArraySet();
        }
     self()->setSupportsArrayCmp();

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -371,7 +371,6 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
 
    if (!comp->getOption(TR_DisableArraySetOpts))
       {
-      self()->setSupportsArraySetToZero();
       self()->setSupportsArraySet();
       }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -668,7 +668,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
    if (!comp->getOption(TR_DisableArraySetOpts))
       {
       self()->setSupportsArraySet();
-      self()->setSupportsArraySetToZero();
       }
    self()->setSupportsArrayCmp();
    self()->setSupportsArrayCmpSign();


### PR DESCRIPTION
ArraySetToZero has been deprecated for a while, removing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>