### PR TITLE
Improve and document Load Extensions optimization

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -258,7 +258,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _lowestSavedReg(0),
      _preJitMethodEntrySize(0),
      _jitMethodEntryPaddingSize(0),
-     _signExtensionFlags(NULL),
      _lastInstructionBeforeCurrentEvaluationTreeTop(NULL),
      _unlatchedRegisterList(NULL),
      _indentation(2),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -776,8 +776,6 @@ class OMR_EXTENSIBLE CodeGenerator
    // Load extensions (Z)
 
    TR::SparseBitVector & getExtendedToInt64GlobalRegisters()  { return _extendedToInt64GlobalRegisters; }
-   TR_BitVector *signExtensionFlags() {return _signExtensionFlags;}
-   TR_BitVector *setSignExtensionFlags(TR_BitVector* flag) { return _signExtensionFlags = flag; }
 
    // --------------------------------------------------------------------------
    // Live registers
@@ -1836,7 +1834,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR_BitVector *_liveButMaybeUnreferencedLocals;
    bool _lmmdFailed;
-   TR_BitVector *_signExtensionFlags;
    TR_BitVector *_assignedGlobalRegisters;
 
    TR_LiveRegisters *_liveRegisters[NumRegisterKinds];

--- a/compiler/optimizer/LoadExtensions.hpp
+++ b/compiler/optimizer/LoadExtensions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-#ifndef LOADEXTENSIONS_HPP_
-#define LOADEXTENSIONS_HPP_
+#ifndef LOADEXTENSIONS_INCL
+#define LOADEXTENSIONS_INCL
 
 #include <stdint.h>                           // for int32_t
 #include "codegen/CodeGenerator.hpp"          // for CodeGenerator
@@ -34,81 +34,211 @@
 #include "optimizer/Optimization_inlines.hpp" // for Optimization inlines
 #include "optimizer/OptimizationManager.hpp"  // for OptimizationManager
 
-class TR_BitVector;
-class TR_UseDefInfo;
-
+/** \brief
+ *     Examines how often a load is being used to feed into a signed vs. unsigned conversion (ex. i2l vs iu2l) and
+ *     attempts to skip the conversion by sign/zero extending the load at the point it is evaluated (where the source 
+ *     value is actually loaded). This codegen optimization relies on the assumption that the target codegen supports 
+ *     load and sign/zero extend instructions and that emitting such an instruction is no more expensive than an 
+ *     ordinary load.
+ *
+ *  \details
+ *     This codegen phase pass consists of two steps; the find and the flag preferred load extensions steps.
+ *
+ *     1. Find preferred load extensions
+ *
+ *        We iterate through every node in the current compilation unit looking for conversion operations with loads
+ *        as the operand. For example a conversion from int to long of a field load o.f:
+ *
+ *        \code
+ *        i2l
+ *          iloadi <f>
+ *            aload <o>
+ *        \endcode
+ *
+ *        For each such conversion, depending on the type, i.e. sign/zero extension, we record how often each unique
+ *        load feeds into such a conversion. In the above snippet the conversion is a sign extension so we would bias
+ *        the load towards sign extensions. If the same load were to appear underneath an iu2l conversion we would bias
+ *        the load towards zero extensions.
+ *
+ *        When all trees in the compilation unit have been processed for each load we know exactly how many times it
+ *        appears underneath a signed vs. unsigned conversion.
+ *
+ *     2. Flag preferred load extensions
+ *
+ *        Since we know the preference of sign vs. zero extension for each load we can now traverse the compilation
+ *        unit again and based on the preference of a load we can mark it with the signExtendTo[32|64]BitAtSource or 
+ *        zeroExtendTo[32|64]BitAtSource flags to force the extension to happen right at the source. Since we have an
+ *        implicit assumption that such extensions are effectively free we can now skip the evaluation of all 
+ *        conversions of the respective extensions.
+ *
+ *        For example in the above code snippet if the load was found to prefer sign extensions we can mark the load
+ *        with the signExtendTo64BitAtSource flag and subsequently the i2l conversion can be skipped by marking it with
+ *        the unneededConv flag. The final trees will look like this:
+ *
+ *        \code
+ *        i2l (unneededConv)
+ *          iloadi <f> (signExtendTo64BitAtSource)
+ *            aload <o>
+ *        \endcode
+ *
+ *        Note that if the same load were to appear underneath an iu2l conversion, this conversion cannot be skipped
+ *        because of the extension preference of the load.
+ *
+ *     All load evaluators must respect the signExtendTo[32|64]BitAtSource and zeroExtendTo[32|64]BitAtSource flags.
+ *
+ *  \section Debug Counters
+ *     You can track the locations of where this optimization succeeded via the following debug counter:
+ *
+ *     \code
+ *     -Xjit:staticDebugCounters={codegen/LoadExtensions/success/unneededConversion*}
+ *     \endcode
+ *
+ *  \section Node Flags
+ *     This optimization sets the following node flags:
+ *        - unneededConv
+ *        - signExtendTo32BitAtSource
+ *        - signExtendTo64BitAtSource
+ *        - zeroExtendTo32BitAtSource
+ *        - zeroExtendTo64BitAtSource
+ */
 class TR_LoadExtensions : public TR::Optimization
    {
-private:
-   int32_t * _counts;
-   int _seenLoads;
-   TR_BitVector *_signExtensionFlags;
-   TR_UseDefInfo *_useDefInfo;
+   public:
 
-   /* \brief
-    *    Keeps track of all nodes which should be excluded from consideration in this optimization.
+   /** \brief
+    *     Helper function to create an instance of the LoadExtensions optimization using the
+    *     OptimizationManager's default allocator.
+    *
+    *  \param manager
+    *     The optimization manager.
     */
-   TR::SparseBitVector _excludedNodes;
-
-   enum overrideFlags
-      {
-      narrowOverride  = 0x01,
-      regLoadOverride = 0x02,
-      totalFlags      = 0x04
-      };
-
-public:
-   // TR_ALLOC(TR_Memory::Optimization) will stack-allocate for now
-
-   TR_LoadExtensions(TR::OptimizationManager *manager);
-   static TR::Optimization *create(TR::OptimizationManager *manager)
+   static TR::Optimization* create(TR::OptimizationManager* manager)
       {
       return new (manager->allocator()) TR_LoadExtensions(manager);
       }
 
+   /** \brief
+    *     Initializes the LoadExtensions codegen phase.
+    *
+    *  \param manager
+    *     The optimization manager for this local optimization.
+    */
+   TR_LoadExtensions(TR::OptimizationManager* manager);
+
+   /** \brief
+    *     Performs the optimization on this compilation unit.
+    *
+    *  \return
+    *     1 if any transformation was performed; 0 otherwise.
+    */
    int32_t perform();
-   virtual const char * optDetailString() const throw();
 
-   inline TR_BitVector * getFlags() { return _signExtensionFlags; }
-   static bool supportedConstLoad(TR::Node *load, TR::Compilation * c);
-   static bool supportedType(TR::Node* node)
+   virtual const char* optDetailString() const throw()
       {
-      //The z codegen doesn't generate the correct instructions (yet) to allow this
-      //TR::comp()->getOption(TR_DisableDirectStaticAccessOnZ) &&
-
-      if ( !TR::comp()->cg()->getAccessStaticsIndirectly() && node->getOpCode().hasSymbolReference() && node->getSymbol()->isStatic() &&
-           node->getOpCode().isLoadDirect() && ! (node->getOpCode().isInt() || node->getOpCode().isLong()))
-         return false;
-
-      return node->getType().isIntegral() || node->getType().isAddress();
-      }
-private:
-   inline bool countIsSigned(TR::Node* load)
-      {
-      if (load->getType().isAddress() || load->getType().isAggregate())
-         return false;
-      else
-         return _counts[load->getGlobalIndex()]/totalFlags >= 0; //bias towards signed load
+      return "O^O LOAD EXTENSIONS: ";
       }
 
-   inline void setOverrideOpt(TR::Node* node, overrideFlags overrideType)
-      {
-      if (trace()) traceMsg(comp(), "Setting override on node %p at %d\n", node, node->getGlobalIndex());
-      _counts[node->getGlobalIndex()] |= overrideType;
-      }
+   private:
 
-   inline bool isOverriden(TR::Node* node, overrideFlags overrideType)
-      {
-      if (trace()) traceMsg(comp(), "Checking override on node %p at %d\n", node, node->getGlobalIndex());
-      return _counts[node->getGlobalIndex()] & overrideType;
-      }
+   /** \brief
+    *     Determines whether the conversion of a load can be skipped based on the loads extension preference and if the
+    *     conversion can be skipped determine whether the respective load needs to be sign/zero extended.
+    *
+    *  \param conversion
+    *     The conversion to examine.
+    *
+    *  \param child
+    *     The child on which the conversion acts. Note this may not necessarily be the conversions first child as the
+    *     conversion may act indirectly on a globally allocated register.
+    *
+    *  \param forceExtension
+    *     Determines whether the respective child load needs to be sign/zero extended.
+    *
+    *  \return
+    *     <c>true</c> if this \p conversion can be skipped; <c>false</c> otherwise.
+    */
+   const bool canSkipConversion(TR::Node* conversion, TR::Node* child, bool& forceExtension);
 
-   void countLoad(TR::Node* load, TR::Node* conversion);
-   void countLoadExtensions(TR::Node *parent, vcount_t visitCount);
-   bool detectUnneededConversionPattern(TR::Node* conversion, TR::Node* child, bool& mustForce64);
-   bool detectReverseNeededConversionPattern(TR::Node* parent, TR::Node* conversion);
-   void setPreferredExtension(TR::Node *node, vcount_t visitCount);
-   ncount_t indexNodesForCodegen(TR::Node *parent, ncount_t nodeCount, vcount_t visitCount);
+   /** \brief
+    *     Finds the (zero/sign) extension preference of a node.
+    *
+    *  \param node
+    *     The node to examine.
+    */
+   void findPreferredLoadExtensions(TR::Node* node);
+
+   /** \brief
+    *     Flags conversions with the unneededConv flag and sets preference of loads to zero/sign extend at source by
+    *     flagging them with signExtendTo[32|64]BitAtSource and zeroExtendTo[32|64]BitAtSource flags.
+    *
+    *  \param node
+    *     The node to flag.
+    */
+   void flagPreferredLoadExtensions(TR::Node* node);
+
+   /** \brief
+    *     Determines whether a node is of the supported type for skipping conversion operations or forcing sign or zero
+    *     extensions on loads.
+    *
+    *  \param node
+    *     The node to examine.
+    *
+    *  \return
+    *     <c>true</c> if this \p node is a load which is a candidate type for this optimization; <c>false</c> otherwise.
+    */
+   const bool isSupportedType(TR::Node* node) const;
+
+   /** \brief
+    *     Determines whether a node is a load candidate for skipping conversion operations.
+    *
+    *  \param node
+    *     The node to examine.
+    *
+    *  \return
+    *     <c>true</c> if this \p node is a load which is a candidate type for this optimization; <c>false</c> otherwise.
+    */
+   const bool isSupportedLoad(TR::Node* node) const;
+
+   /** \brief
+    *     Gets the zero/sign extension preference of a load.
+    *
+    *  \param load
+    *     The load to examine.
+    *
+    *  \return
+    *     Negative value if this \p load prefers to be zero extended and a positive value if this \p load prefers to be
+    *     sign extended.
+    */
+   const int32_t getExtensionPreference(TR::Node* load) const;
+
+   /** \brief
+    *     Sets the zero/sign extension preference of a load based on the conversion it feeds into.
+    *
+    *  \param load
+    *     The load to examine.
+    *
+    *  \return
+    *     Negative value if this \p load prefers to be zero extended and a positive value if this \p load prefers to be
+    *     sign extended.
+    */
+   const int32_t setExtensionPreference(TR::Node* load, TR::Node* conversion);
+
+   private:
+
+   typedef TR::typed_allocator<std::pair<const TR::Node*, int32_t>, TR::Region&> NodeToIntTableAllocator;
+   typedef std::less<TR::Node*> NodeToIntTableComparator;
+   typedef std::map<TR::Node*, int32_t, NodeToIntTableComparator, NodeToIntTableAllocator> NodeToIntTable;
+
+   /** \brief
+    *     Keeps track of all nodes which should be excluded from consideration in this optimization.
+    */
+   NodeToIntTable* excludedNodes;
+
+   /** \brief
+    *     Keeps track of the load extension preference where a negative value indicates a preference towards a zero
+    *     extension and a positive value indicates a preference towards a sign extension.
+    */
+   NodeToIntTable* loadExtensionPreference;
    };
 
-#endif /* LOADEXTENSIONS_HPP_ */
+#endif /* LOADEXTENSIONS_INCL_ */

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6401,7 +6401,7 @@ TR::Node *iaddSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       // n1.3083n   (  0)      iadd (in *GPR_6512) (profilingCode )                                             [0x2BB38260] loc=[-1,2848,1153] rc=0 vc=631 vn=- sti=- udi=14723 nc=2 flg=0x80
       // n1.3081n   (  0)        a2i (in *GPR_6512) (profilingCode unneededConv )                               [0x2BB381C0] loc=[-1,2847,1153] rc=0 vc=631 vn=- sti=- udi=14723 nc=1 addr=4 flg=0x8080
       // n1.26322n  (  0)          aiadd (in *GPR_6512) (profilingCode X>=0 internalPtr )                       [0x374931DC] loc=[-1,2844,1153] rc=0 vc=1859 vn=- sti=- udi=14723 nc=2 addr=4 flg=0x8180
-      // n1.3077n   (  2)            ==>aload (in GPR_6513) (profilingCode isUnsignedLoad )
+      // n1.3077n   (  2)            ==>aload (in GPR_6513) (profilingCode )
       // n1.3086n   (  0)            ==>iconst 692 (profilingCode X!=0 X>=0 )
       // n1.3082n   (  0)        iconst -24 (profilingCode X!=0 X<=0 )                                          [0x2BB38210] loc=[-1,2848,1153] rc=0 vc=631 vn=- sti=- udi=- nc=0 flg=0x284
       //

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1074,9 +1074,10 @@ TR_Debug::nodePrintAllFlags(TR::Node *node, TR_PrettyPrinterString &output)
    output.append(format, node->printIsArrayChkPrimitiveArray2());
    output.append(format, node->printIsArrayChkReferenceArray2());
    output.append(format, node->printNeedsPrecisionAdjustment());
-   output.append(format, node->printCouldIgnoreExtend());
-   output.append(format, node->printForce64BitLoad());
-   output.append(format, node->printIsUnsignedLoad());
+   output.append(format, node->printIsSignExtendedTo32BitAtSource());
+   output.append(format, node->printIsSignExtendedTo64BitAtSource());
+   output.append(format, node->printIsZeroExtendedTo32BitAtSource());
+   output.append(format, node->printIsZeroExtendedTo64BitAtSource());
    output.append(format, node->printNeedsSignExtension());
    output.append(format, node->printSkipSignExtension());
    output.append(format, node->printSetUseSignExtensionMode());

--- a/compiler/z/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/z/codegen/OMRCodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,6 @@ OMR::Z::CodeGenPhase::performMarkLoadAsZeroOrSignExtensionPhase(TR::CodeGenerato
       TR::OptimizationManager *manager = comp->getOptimizer()->getOptimization(OMR::loadExtensions);
       TR_ASSERT(manager, "Load extensions optimization should be initialized.");
       TR_LoadExtensions *loadExtensions = (TR_LoadExtensions *) manager->factory()(manager);
-      cg->setSignExtensionFlags( loadExtensions->getFlags() );
       loadExtensions->perform();
       delete loadExtensions;
       }

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -729,7 +729,7 @@ generateRXInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::N
    TR::Compilation *comp = cg->comp();
 
    TR_ASSERT(treg->getRealRegister()!=NULL || // Not in RA
-           op != TR::InstOpCode::L || n->couldIgnoreExtend() || !n->force64BitLoad(), "Generating an TR::InstOpCode::L, when LLGF|LGF should be used");
+           op != TR::InstOpCode::L || !n->isExtendedTo64BitAtSource(), "Generating an TR::InstOpCode::L, when LLGF|LGF should be used");
    if (cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) && treg->assignToHPR())
       {
       switch(op)

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -172,7 +172,7 @@ OMR::Z::TreeEvaluator::bconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   if (node->getOpCodeValue() == TR::buconst || node->isUnsignedLoad())
+   if (node->getOpCodeValue() == TR::buconst)
       generateLoad32BitConstant(cg, node, node->getByte() & 0xFF, tempReg, true);
    else
       {
@@ -190,7 +190,7 @@ OMR::Z::TreeEvaluator::sconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   int32_t value = (node->isUnsigned() || node->isUnsignedLoad()) ? node->getConst<uint16_t>() : node->getShortInt();
+   int32_t value = node->isUnsigned() ? node->getConst<uint16_t>() : node->getShortInt();
    generateLoad32BitConstant(cg, node, value, tempReg, true);
    return tempReg;
    }


### PR DESCRIPTION
- Remove PLX stale case which makes assumptions on unqueried
  isUsing32BitEvaluator
- Remove case for conversion of AND operations as this is caught by the
  simplifier
- Remove boolean compare case and right shift cases as these are caught
  by the simplifier
- Remove the conversion and reverse conversion case as this is caught
  by the simplifier
- Intorduce new node flags to represent sign/zero extensions
- Remove super hacky SignExtensionFlagsIndex and SupportedType
- Fix bugs related to load counting not to bias signed extensions
- Fully document the optimization and all flags used
- Add static debug counters to track use cases
- Add more tracing to the optimization for debugging

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>