### PR TITLE
Check OSXSAVE when detecting AVX support

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,6 +128,7 @@ struct TR_X86ProcessorInfo
       TR_UnknownVendor                 = 0x04
       };
 
+   bool enabledXSAVE()                     {return _featureFlags2.testAny(TR_OSXSAVE);}
    bool hasBuiltInFPU()                    {return _featureFlags.testAny(TR_BuiltInFPU);}
    bool supportsVirtualModeExtension()     {return _featureFlags.testAny(TR_VirtualModeExtension);}
    bool supportsDebuggingExtension()       {return _featureFlags.testAny(TR_DebuggingExtension);}
@@ -158,11 +159,11 @@ struct TR_X86ProcessorInfo
    bool supportsSSSE3()                    {return _featureFlags2.testAny(TR_SSSE3);}
    bool supportsSSE4_1()                   {return _featureFlags2.testAny(TR_SSE4_1);}
    bool supportsSSE4_2()                   {return _featureFlags2.testAny(TR_SSE4_2);}
-   bool supportsAVX()                      {return _featureFlags2.testAny(TR_AVX);}
-   bool supportsAVX2()                     {return _featureFlags8.testAny(TR_AVX2);}
-   bool supportsBMI1()                     {return _featureFlags8.testAny(TR_BMI1);}
-   bool supportsBMI2()                     {return _featureFlags8.testAny(TR_BMI2);}
-   bool supportsFMA()                      {return _featureFlags2.testAny(TR_FMA);}
+   bool supportsAVX()                      {return _featureFlags2.testAny(TR_AVX) && enabledXSAVE();}
+   bool supportsAVX2()                     {return _featureFlags8.testAny(TR_AVX2) && enabledXSAVE();}
+   bool supportsBMI1()                     {return _featureFlags8.testAny(TR_BMI1) && enabledXSAVE();}
+   bool supportsBMI2()                     {return _featureFlags8.testAny(TR_BMI2) && enabledXSAVE();}
+   bool supportsFMA()                      {return _featureFlags2.testAny(TR_FMA) && enabledXSAVE();}
    bool supportsCLMUL()                    {return _featureFlags2.testAny(TR_CLMUL);}
    bool supportsAESNI()                    {return _featureFlags2.testAny(TR_AESNI);}
    bool supportsPOPCNT()                   {return _featureFlags2.testAny(TR_POPCNT);}

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1433,7 +1433,7 @@ TR::X86RegInstruction::enlarge(int32_t requestedEnlargementSize, int32_t maxEnla
    if (disableRexExpansion || TR::comp()->getOption(TR_DisableZealousCodegenOpts))
       return OMR::X86::EnlargementResult(0, 0);
 
-   if (getOpCode().info().supportsAVX() && getOpCode().info().allowsAVX())
+   if (getOpCode().info().supportsAVX() && cg()->getX86ProcessorInfo().supportsAVX())
       return OMR::X86::EnlargementResult(0, 0); // REX expansion isn't allowed for AVX instructions
 
    if ((maxEnlargementSize < requestedEnlargementSize && !allowPartialEnlargement) || requestedEnlargementSize < 1)

--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -385,7 +385,6 @@ class TR_X86OpCode
       template <class TBuffer> inline typename TBuffer::cursor_t encode(typename TBuffer::cursor_t cursor, uint8_t rexbits) const;
       // finalize instruction prefix information, currently only in-use for AVX instructions for VEX.vvvv field
       inline void finalize(uint8_t* cursor) const;
-      inline bool allowsAVX() const;
       };
    template <typename TCursor>
    class BufferBase

--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,12 +22,6 @@
 #ifndef X86OPS_INLINES_INCL
 #define X86OPS_INLINES_INCL
 
-inline bool TR_X86OpCode::OpCode_t::allowsAVX() const
-   {
-   static bool enable = TR::CodeGenerator::getX86ProcessorInfo().supportsAVX() && !feGetEnv("TR_DisableAVX");
-   return enable;
-   }
-
 template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCode_t::encode(typename TBuffer::cursor_t cursor, uint8_t rexbits) const
    {
    TBuffer buffer(cursor);
@@ -44,7 +38,7 @@ template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCo
    rex.W = rex_w;
    TR_ASSERT(TR::Compiler->target.is64Bit() || !rex.value(), "ERROR: REX.W used on X86-32. OpCode = %d; rex = %02x", opcode, (uint32_t)(uint8_t)rex.value());
    // Use AVX if possible
-   if (supportsAVX() && allowsAVX())
+   if (supportsAVX() && TR::CodeGenerator::getX86ProcessorInfo().supportsAVX())
       {
       TR::Instruction::VEX<3> vex(rex, modrm_opcode);
       vex.m = escape;


### PR DESCRIPTION
OSXSAVE flag tells if OS enables XSAVE instruction,
which is a strong indication that AVX is enabled by
the OS.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>