### PR TITLE
Removed unused aggregateShadowSymbol data structures

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -118,8 +118,6 @@ OMR::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation
      _methodsBySignature(8, comp->allocator("SymRefTab")), // TODO: Determine a suitable default size
      _hasImmutable(false),
      _hasUserField(false),
-     _aggregateShadowSymbolMap(8, comp->allocator("SymRefTab")),
-     _aggregateShadowSymbolReferenceMap(8, comp->allocator("SymRefTab")),
      _sharedAliasMap(NULL)
    {
    _numHelperSymbols = TR_numRuntimeHelpers + 1;;

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -476,9 +476,6 @@ class SymbolReferenceTable
    List<TR::SymbolReference>            _currentThreadDebugEventDataSymbolRefs;
 
    uint32_t                            _nextRegShadowIndex;
-
-   CS2::HashTable<uint32_t, TR::Symbol *, TR::Allocator> _aggregateShadowSymbolMap;
-   CS2::HashTable<TR::SparseBitVector *, TR::SymbolReference *, TR::Allocator> _aggregateShadowSymbolReferenceMap;
    int32_t                             _numUnresolvedSymbols;
    uint32_t                            _numHelperSymbols;
    uint32_t                            _numPredefinedSymbols;


### PR DESCRIPTION
The following data structures:
- _aggregateShadowSymbolMap
- _aggregateShadowSymbolReferenceMap
were present in OMR::SymbolReferenceTable, but were no longer used.
They have been removed.

Closes: #2124
Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>