### PR TITLE
Preparations for use of ddrgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2017 IBM Corp. and others
+# Copyright (c) 2014, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
 ###############################################################################
 
 build/
+objs/
 CMakeFiles/
 CMakeCache.txt
 omrcfg.h

--- a/compiler/env/defines.h
+++ b/compiler/env/defines.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,6 @@
    Note that this file is included is asm code as well. Apart from C
    pre-processor macros, it shouldn't contain anything else.
 */
-
 
 /* Operating Systems */
 #ifndef OMR_LINUX
@@ -82,6 +81,8 @@
 #ifndef COMPILER_CLANG
 #  define COMPILER_CLANG 304
 #endif
+
+/* @ddr_namespace: map_to_type=TRBuildFlags */
 
 /*
   Standardize the OS macros Use HOST_OS instead of various different
@@ -168,6 +169,8 @@
 #if (HOST_ARCH == ARCH_ARM)
 #  define TR_HOST_ARM    1
 #endif
+
+/* @ddr_namespace: default */
 
 /* FIXME: we need to document what these ifdefs do
    If these are permanently enabled, the ifdefs should be removed

--- a/ddr_artifacts.mk
+++ b/ddr_artifacts.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,10 +30,10 @@ top_srcdir = .
 include $(top_srcdir)/omrmakefiles/configure.mk
 
 # Ensure the source tree path is canonically-formed and ends with /
-abs_srcroot = $(abspath $(TOP_SRCDIR))/
+abs_srcroot := $(subst //,/,$(abspath $(TOP_SRCDIR))/)
 
 all: check-vars
-	./tools/ddrgen/src/macros/getMacros.sh $(abs_srcroot)
+	bash $(top_srcdir)/ddr/tools/getmacros $(abs_srcroot)
 	$(exe_output_dir)/ddrgen --filelist $(DBG_FILE_LIST) --macrolist $(abs_srcroot)macroList 
 
 check-vars:

--- a/fvtest/omrtest.mk
+++ b/fvtest/omrtest.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,8 +45,8 @@ omr_algotest:
 	./omralgotest -avltest:fvtest/algotest/avltest.lst
 
 omr_ddrtest:
-	tools/ddrgen/src/macros/getMacros.sh "tools/ddrgen/test"
-	./ddrgen ./ddrgentest --macrolist test/macroList
+	bash $(top_srcdir)/ddr/tools/getmacros tools/ddrgen/test
+	./ddrgen ddrgentest --macrolist test/macroList
 
 omr_gctest:
 	./omrgctest --gtest_filter="gcFunctionalTest*"

--- a/gc/base/segregated/RegionPoolSegregated.hpp
+++ b/gc/base/segregated/RegionPoolSegregated.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,8 @@ class MM_LockingHeapRegionQueue;
 
 #define PRIMARY_BUCKET 0
 #define SKIP_AVAILABLE_REGION_FOR_ALLOCATION 1
+
+/* @ddr_namespace: map_to_type=MM_RegionPoolSegregated */
 
 /*
  * Thresholds for dividing available list into buckets so that we tend to

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,6 +29,8 @@
 #if !defined(OMRCFG_H_)
 #define OMRCFG_H_
 
+/* @ddr_namespace: map_to_type=OmrBuildFlags */
+
 #undef OMR_GC
 #undef OMR_JIT
 #undef OMR_JITBUILDER
@@ -57,7 +59,6 @@
 #undef OMR_GC_NON_ZERO_TLH
 #undef OMR_GC_SEGREGATED_HEAP
 #undef OMR_GC_THREAD_LOCAL_HEAP
-
 
 /**
  * Tells if a platform has support for Semaphores.

--- a/include_core/omrhashtable.h
+++ b/include_core/omrhashtable.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,15 +31,17 @@
 extern "C" {
 #endif
 
-
 /* DO NOT DIRECTLY INCLUDE THIS FILE! */
 /* Include hashtable_api.h instead */
-
 
 #include "omravl.h"
 #include "omrcomp.h"
 #include "omrport.h"
 #include "pool_api.h"
+
+/*
+ * @ddr_namespace: map_to_type=J9HashtableConstants
+ */
 
 /**
  * Hash table flags
@@ -50,7 +52,11 @@ extern "C" {
 #define J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION	0x00000008	/*!< Allow space optimized hashTable, some functions not supported */
 #define J9HASH_TABLE_DO_NOT_REHASH	0x00000010	/*!< Do not rehash the table while set */
 
-#define J9HASH_TABLE_AVL_TREE_TAG_BIT ((uintptr_t)0x00000001) /*!< Bit to indicate that hastable slot contains a pointer to an AVL tree */
+/*
+ * This used to include a cast to uintptr_t, but ddrgen doesn't
+ * handle casts; that cast has been moved to hashtable.c.
+ */
+#define J9HASH_TABLE_AVL_TREE_TAG_BIT 0x00000001 /*!< Bit to indicate that hastable slot contains a pointer to an AVL tree */
 
 /**
  * Hash Table state constants for iteration
@@ -58,6 +64,10 @@ extern "C" {
 #define J9HASH_TABLE_ITERATE_STATE_LIST_NODES 0
 #define J9HASH_TABLE_ITERATE_STATE_TREE_NODES 1
 #define J9HASH_TABLE_ITERATE_STATE_FINISHED  2
+
+/*
+ * @ddr_namespace: default
+ */
 
 /**
  * Macros for getting at data directly from AVLTreeNodes

--- a/omrcfg.CMakeTemplate.h
+++ b/omrcfg.CMakeTemplate.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,8 @@
 
 #if !defined(OMRCFG_H_)
 #define OMRCFG_H_
+
+/* @ddr_namespace: map_to_type=OmrBuildFlags */
 
 #cmakedefine OMR_GC
 #cmakedefine OMR_JIT

--- a/util/hashtable/hashtable.c
+++ b/util/hashtable/hashtable.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@
  */
 #define NEXT(p) *((void **)((uint8_t *)p + table->listNodeSize - sizeof(uintptr_t)))
 
-#define AVL_TREE_TAG_BIT ((uintptr_t)0x00000001)
+#define AVL_TREE_TAG_BIT ((uintptr_t)J9HASH_TABLE_AVL_TREE_TAG_BIT)
 #define AVL_TREE_TAGGED(p) (((uintptr_t)(p)) & AVL_TREE_TAG_BIT)
 #define AVL_TREE_TAG(p) ((J9AVLTree *)(((uintptr_t)(p)) | AVL_TREE_TAG_BIT))
 #define AVL_TREE_UNTAG(p) ((J9AVLTree *)(((uintptr_t)(p)) & (~AVL_TREE_TAG_BIT)))


### PR DESCRIPTION
Preparations for use of ddrgen in support of openj9#378

* correct references to getmacros script
* add missing ddr_namespace annotations
* use J9HASH_TABLE_AVL_TREE_TAG_BIT instead of hard-coded constant
* ignore objs directory