### PR TITLE
Enable OMRChecker testing script to read CLANG environment variable

### DIFF
--- a/tools/compiler/OMRChecker/test.py
+++ b/tools/compiler/OMRChecker/test.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
 
 ###############################################################################
-# Copyright (c) 2016, 2016 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,8 @@ class OMRChecker(tool.Tool):
    '''A wrapper providing an interface for interacting with OMRChecker.'''
 
    def __init__(self, checker):
-      base = ['clang++', '-fsyntax-only', '-Xclang', '-load', '-Xclang', checker, '-Xclang', '-add-plugin', '-Xclang', 'omr-checker'] 
+      clang = os.getenv('CLANG', 'clang++')
+      base = [clang, '-fsyntax-only', '-Xclang', '-load', '-Xclang', checker, '-Xclang', '-add-plugin', '-Xclang', 'omr-checker'] 
       super(OMRChecker, self).__init__(lambda args: base + args)
 
 
@@ -73,7 +74,7 @@ class TestReturnNotZero(CheckerTestCase):
 if __name__ == '__main__':
    args = arg_parser.parse_args(sys.argv[1:])
    args = vars(args)
-   
+
    if not os.path.exists(args['CHECKER']):
       print("Could not find: " + args['CHECKER'])
       exit(1)


### PR DESCRIPTION
Currently, the test script always uses "clang++" to call Clang for
testing OMRChecker. This causes problems, when "clang++" calls an
unsupported clang version by default. There are a number of problems
that can arise from this, such as when using different Linux distros.
The increased flexibility was achieved by 1 change:
  - The constructor of class OMRChecker has been modified to pull and use
    Clang calling info from the environment, by looking for the env
    variable 'CLANG'. If no such env variable exists, then the default
    'clang++' is used.

This change is a requirement for addressing [issue 729](https://github.com/eclipse/openj9/issues/729) in eclipse/openj9.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>