### PR TITLE
Re-introduce the lurem opcode

### DIFF
--- a/compiler/arm/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/TreeEvaluatorTable.hpp
@@ -119,6 +119,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::srem
    TR::TreeEvaluator::iremEvaluator,        // TR::iurem
+   TR::TreeEvaluator::lremEvaluator,        // TR::lurem
    TR::TreeEvaluator::inegEvaluator,        // TR::ineg
    TR::TreeEvaluator::lnegEvaluator,        // TR::lneg
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -1461,6 +1461,27 @@
    /* .ifCompareOpCode      = */ TR::BadILOp,
    },
 
+   /*!
+    * \brief unsigned remainder (long)
+    *
+    * See iurem
+    */
+   {
+   /* .opcode               = */ TR::lurem,
+   /* .name                 = */ "lurem",
+   /* .properties1          = */ ILProp1::Rem,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
+   /* .properties3          = */ ILProp3::LikeUse,
+   /* .properties4          = */ 0,
+   /* .dataType             = */ TR::Int64,
+   /* .typeProperties       = */ ILTypeProp::Size_8 | ILTypeProp::Unsigned,
+   /* .childProperties      = */ TWO_SAME_CHILD(TR::Int64),
+   /* .swapChildrenOpCode   = */ TR::BadILOp,
+   /* .reverseBranchOpCode  = */ TR::BadILOp,
+   /* .booleanCompareOpCode = */ TR::BadILOp,
+   /* .ifCompareOpCode      = */ TR::BadILOp,
+   },
+
    {
    /* .opcode               = */ TR::ineg,
    /* .name                 = */ "ineg",

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -135,6 +135,7 @@
    brem,     // remainder of 2 bytes                   (child1 % child2)
    srem,     // remainder of 2 short integers          (child1 % child2)
    iurem,    // remainder of 2 unsigned integers       (child1 % child2)
+   lurem,    // remainder of 2 unsigned long integers  (child1 % child2)
    ineg,     // negate an integer
    lneg,     // negate a long integer
    fneg,     // negate a float

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -924,6 +924,7 @@ public:
          case TR::lmul:   return TR::imul;
          case TR::ldiv:   return TR::idiv;
          case TR::lrem:   return TR::irem;
+         case TR::lurem:  return TR::iurem;
          case TR::labs:   return TR::iabs;
          case TR::lneg:   return TR::ineg;
          case TR::luneg:  return TR::iuneg;

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -9424,6 +9424,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    // Only try to fold if the divisor is non-zero.
    // Handle the special case of dividing the maximum negative value by -1
    //
+   bool isUnsigned = node->getOpCodeValue() == TR::lurem;
    if (secondChild->getOpCode().isLoadConst())
       {
       int64_t divisor = secondChild->getLongInt();
@@ -9432,7 +9433,7 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       bool upwr2 = (udivisor & (udivisor - 1)) == 0;
       if (divisor != 0)
          {
-         if (divisor == 1 || (divisor == -1))
+         if (divisor == 1 || (!isUnsigned && (divisor == -1)))
             {
             foldLongIntConstant(node, 0, s, true /* anchorChildren */);
             return node;
@@ -9440,14 +9441,16 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          else if (firstChild->getOpCode().isLoadConst())
             {
             int64_t dividend = firstChild->getLongInt();
-            if (divisor == -1 && dividend == TR::getMinSigned<TR::Int64>())
+            if (isUnsigned)
+               foldLongIntConstant(node, (uint64_t) dividend % (uint64_t)divisor, s, false /* !anchorChildren */);
+            else if (divisor == -1 && dividend == TR::getMinSigned<TR::Int64>())
                foldLongIntConstant(node, 0, s, false /* !anchorChildren */);
             else
                foldLongIntConstant(node, dividend % divisor, s, false /* !anchorChildren */);
             return node;
             }
          // Design 1792
-         else if ((!disableILRemPwr2Opt) && ((shftAmnt = TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(divisor)) > 0) &&
+         else if ( (!isUnsigned) && (!disableILRemPwr2Opt) && ((shftAmnt = TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(divisor)) > 0) &&
             (secondChild->getReferenceCount()==1) && performTransformation(s->comp(), "%sPwr of 2 lrem opt node %p\n", s->optDetailString(), node) )
             {
             secondChild->decReferenceCount();
@@ -9487,7 +9490,16 @@ TR::Node *lremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
             node->getSecondChild()->incReferenceCount();
             return node;
             }
-         // Disabled pending approval of design 1055.
+         else if (isUnsigned && (!disableILRemPwr2Opt) && upwr2 &&
+                  performTransformation(s->comp(), "%sPwr of 2 lurem opt node %p\n", s->optDetailString(), node))
+            {
+            TR::Node::recreate(node, TR::land);
+            TR::Node* lconstNode = TR::Node::create(node, TR::lconst, 0, 0);
+            lconstNode->setLongInt(udivisor - 1);
+            node->getSecondChild()->decReferenceCount();
+            node->setAndIncChild(1, lconstNode);
+            }
+// Disabled pending approval of design 1055.
 #ifdef TR_DESIGN_1055
          else if (s->cg()->getSupportsLoweringConstLDiv() && !isPowerOf2(divisor) && !skipRemLowering(divisor, s))
             {
@@ -16579,7 +16591,7 @@ TR::Node *arraycopybndchkSimplifier(TR::Node * node, TR::Block * block, TR::Simp
       TR::Node * boundChild  = lhsChild;
       TR::Node * lengthChild = rhsChild->getSecondChild();
       TR::Node * indexChild  = rhsChild->getFirstChild();
-      if (lengthChild == boundChild || 
+      if (lengthChild == boundChild ||
           s->isBoundDefinitelyGELength(boundChild, lengthChild))
          {
          if (indexChild->isZero())

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -110,6 +110,7 @@
    bremSimplifier,          // TR::brem
    sremSimplifier,          // TR::srem
    iremSimplifier,          // TR::iurem
+   lremSimplifier,          // TR::lurem
    inegSimplifier,          // TR::ineg
    lnegSimplifier,          // TR::lneg
    fnegSimplifier,          // TR::fneg

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -6866,7 +6866,7 @@ TR::Node *removeRedundantREM(OMR::ValuePropagation *vp, TR::Node *node, TR::VPCo
          //    child prec=3 (i.e. max value is 999)
          //    iconst 1000
          //
-         // this doesn't work for unsigned (iurem) as these ops treat the operands as unsigned so, for example, a prec=1 dividend that is negative
+         // this doesn't work for unsigned (iurem/lurem) as these ops treat the operands as unsigned so, for example, a prec=1 dividend that is negative
          // when interpreted as unsigned will actually have 10 digits of precision (-1 would be 0xFFffFFff = 4,294,967,295)
          //
          return vp->replaceNode(node, node->getFirstChild(), vp->_curTree);
@@ -6978,6 +6978,62 @@ TR::Node *constrainLrem(OMR::ValuePropagation *vp, TR::Node *node)
          constraint = TR::VPLongRange::create(vp, -rhsConst, 0);
       else
          constraint = TR::VPLongRange::create(vp, -rhsConst, rhsConst);
+
+      if (constraint)
+         {
+         bool didReduction = reduceLongOpToIntegerOp(vp, node, constraint);
+         vp->addBlockOrGlobalConstraint(node, constraint ,lhsGlobal);
+
+         if (didReduction)
+            return node;
+         }
+      }
+
+   if (vp->isHighWordZero(node))
+      node->setIsHighWordZero(true);
+
+   if (constraint && lhs && lhs->asLongConstraint() && rhs && rhs->asLongConstraint())
+      {
+      TR::Node *newNode = removeRedundantREM(vp, node, constraint, lhs, rhs);
+      if (NULL != newNode)
+         node = newNode;
+      }
+
+   checkForNonNegativeAndOverflowProperties(vp, node);
+
+   return node;
+   }
+
+TR::Node *constrainLurem(OMR::ValuePropagation *vp, TR::Node *node)
+   {
+   if (findConstant(vp, node))
+      {
+      return node;
+      }
+   constrainChildren(vp, node);
+
+   bool lhsGlobal, rhsGlobal;
+   TR::VPConstraint *lhs = vp->getConstraint(node->getFirstChild(), lhsGlobal);
+   TR::VPConstraint *rhs = vp->getConstraint(node->getSecondChild(), rhsGlobal);
+   TR::VPConstraint *constraint = NULL;
+   lhsGlobal &= rhsGlobal;
+   if (lhs && lhs->asLongConst() &&
+       rhs && rhs->asLongConst())
+      {
+      //
+      // REMOVED AS IT WOULD LEAD TO AN ASSERT POST FORK
+      //
+      TR_ASSERT(0, "constrainLurem not supported");
+      }
+   else if (rhs && rhs->asLongConst() && lhs && lhs->asLongConstraint())
+      {
+      uint64_t lhsLow = lhs->asLongConstraint()->getUnsignedLowLong();
+      uint64_t lhsHigh = lhs->asLongConstraint()->getUnsignedHighLong();
+      uint64_t rhsConst = rhs->asLongConst()->getUnsignedLong();
+      if(lhsHigh > rhsConst)
+         constraint = TR::VPLongRange::create(vp,0,rhsConst);
+      else
+         constraint = TR::VPLongRange::create(vp,0,lhsHigh);
 
       if (constraint)
          {

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -105,6 +105,7 @@ TR::Node *constrainLongConst(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLongStore(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLor(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLrem(OMR::ValuePropagation *vp, TR::Node *node);
+TR::Node *constrainLurem(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLshl(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLshr(OMR::ValuePropagation *vp, TR::Node *node);
 TR::Node *constrainLushr(OMR::ValuePropagation *vp, TR::Node *node);
@@ -250,6 +251,7 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,        // TR::brem
    constrainChildren,        // TR::srem
    constrainIrem,            // TR::iurem
+   constrainLurem,            // TR::lurem
    constrainIneg,            // TR::ineg
    constrainLneg,            // TR::lneg
    constrainChildren,        // TR::fneg

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -2372,6 +2372,8 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    int64_t divisor = 0;
    TR::Compilation * comp = cg->comp();
 
+   TR_ASSERT(node->getOpCodeValue() != TR::lurem, "TR::ludiv is not impelemented yet for 64-bit target\n");
+
    if (secondChild->getOpCode().isLoadConst())
       divisor =  secondChild->getLongInt();
    else if ( firstChild->getOpCode().isLoadConst())
@@ -2457,6 +2459,7 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    return trgReg;
    }
 
+// also handles lurem
 TR::Register *OMR::Power::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -111,6 +111,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                 // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,                 // TR::srem
    TR::TreeEvaluator::iremEvaluator,                    // TR::iurem
+   TR::TreeEvaluator::lremEvaluator,                    // TR::lurem
    TR::TreeEvaluator::inegEvaluator,                    // TR::ineg
    TR::TreeEvaluator::lnegEvaluator,                    // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2389,6 +2389,7 @@ int32_t childTypes[] =
    TR::Int8,                      // TR::brem
    TR::Int16,                     // TR::srem
    TR::Int32,                     // TR::iurem
+   TR::Int64,                     // TR::lurem
    TR::Int32,                     // TR::ineg
    TR::Int64,                     // TR::lneg
    TR::Float,                      // TR::fneg

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -112,6 +112,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::srem
    TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::iurem
+   TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::lurem
    TR::TreeEvaluator::integerNegEvaluator,              // TR::ineg
    TR::TreeEvaluator::integerNegEvaluator,              // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -112,6 +112,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::srem
    TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::iurem
+   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::lurem
    TR::TreeEvaluator::integerNegEvaluator,              // TR::ineg
    TR::TreeEvaluator::integerPairNegEvaluator,         // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -112,6 +112,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,        // TR::brem
    TR::TreeEvaluator::unImpOpEvaluator,        // TR::srem
    TR::TreeEvaluator::iremEvaluator,        // TR::iurem
+   TR::TreeEvaluator::lremEvaluator,        // TR::lurem
    TR::TreeEvaluator::inegEvaluator,        // TR::ineg
    TR::TreeEvaluator::lnegEvaluator,        // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,        // TR::fneg

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -22,6 +22,8 @@
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
 
+// signed 32-bit integer arithmetic ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 int32_t iadd(int32_t l, int32_t r) {
     return l+r;
 }
@@ -116,3 +118,170 @@ INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int32Arithmetic, ::testing::Combine(
     ::testing::Values(
         std::make_tuple("idiv", idiv),
         std::make_tuple("irem", irem) )));
+
+// unsigned 32-bit integer arithmetic ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+uint32_t iudiv(uint32_t l, uint32_t r) {
+    return l/r;
+}
+
+uint32_t iurem(uint32_t l, uint32_t r) {
+    return l%r;
+}
+
+class UInt32Arithmetic : public TRTest::BinaryOpTest<uint32_t> {};
+
+TEST_P(UInt32Arithmetic, UsingConst) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int32 (block (iureturn (%s (iuconst %u) (iuconst %u)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<uint32_t (*)(void)>();
+    volatile auto exp = param.oracle(param.lhs, param.rhs);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
+}
+
+TEST_P(UInt32Arithmetic, UsingLoadParam) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int32 args=[Int32, Int32] (block (iureturn (%s (iuload parm=0) (iuload parm=1)) )))", param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<uint32_t (*)(uint32_t, uint32_t)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+INSTANTIATE_TEST_CASE_P(DivArithmeticTest, UInt32Arithmetic, ::testing::Combine(
+    ::testing::ValuesIn(
+        TRTest::filter(TRTest::const_value_pairs<uint32_t, uint32_t>(), div_filter<uint32_t> )),
+    ::testing::Values(
+        std::make_tuple("iudiv", iudiv),
+        std::make_tuple("iurem", iurem) )));
+
+// signed 64-bit integer arithmetic ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/*
+ * This function is called `tr_ldiv` to avoid conflicting with `ldiv` in `stdlib.h`.
+ */
+int64_t tr_ldiv(int64_t l, int64_t r) {
+    return l/r;
+}
+
+int64_t lrem(int64_t l, int64_t r) {
+    return l%r;
+}
+
+class Int64Arithmetic : public TRTest::BinaryOpTest<int64_t> {};
+
+TEST_P(Int64Arithmetic, UsingConst) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int64 (block (lreturn (%s (lconst %ld) (lconst %ld)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(void)>();
+    volatile auto exp = param.oracle(param.lhs, param.rhs);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
+}
+
+TEST_P(Int64Arithmetic, UsingLoadParam) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int64 args=[Int64, Int64] (block (lreturn (%s (lload parm=0) (lload parm=1)) )))", param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int64_t, int64_t)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+INSTANTIATE_TEST_CASE_P(DivArithmeticTest, Int64Arithmetic, ::testing::Combine(
+    ::testing::ValuesIn(
+        TRTest::filter(TRTest::const_value_pairs<int64_t, int64_t>(), div_filter<int64_t> )),
+    ::testing::Values(
+        std::make_tuple("ldiv", tr_ldiv),
+        std::make_tuple("lrem", lrem) )));
+
+// unsigned 64-bit integer arithmetic ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+uint64_t ludiv(uint64_t l, uint64_t r) {
+    return l/r;
+}
+
+uint64_t lurem(uint64_t l, uint64_t r) {
+    return l%r;
+}
+
+class UInt64Arithmetic : public TRTest::BinaryOpTest<uint64_t> {};
+
+TEST_P(UInt64Arithmetic, UsingConst) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int64 (block (lureturn (%s (luconst %lu) (luconst %lu)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<uint64_t (*)(void)>();
+    volatile auto exp = param.oracle(param.lhs, param.rhs);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
+}
+
+TEST_P(UInt64Arithmetic, UsingLoadParam) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int64 args=[Int64, Int64] (block (lureturn (%s (luload parm=0) (luload parm=1)) )))", param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<uint64_t (*)(uint64_t, uint64_t)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+INSTANTIATE_TEST_CASE_P(DivArithmeticTest, UInt64Arithmetic, ::testing::Combine(
+    ::testing::ValuesIn(
+        TRTest::filter(TRTest::const_value_pairs<uint64_t, uint64_t>(), div_filter<uint64_t> )),
+    ::testing::Values(
+        std::make_tuple("lurem", lurem) )));

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -127,7 +127,7 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
         auto value = tree->getPositionalArg(0)->getValue();
 
         // assume the constant to be loaded is the first argument of the AST node
-        if (opcode.isIntegerOrAddress()) {
+        if (opcode.isIntegerOrAddress() || opcode.isUnsigned()) {
            auto v = value->get<int64_t>();
            node->set64bitIntegralValue(v);
            TraceIL("integral value %d\n", v);


### PR DESCRIPTION
This changeset re-introduces the `lurem` opcode by reverting #269 and applying necessary patches to make the code up-to-date with more recent changes. Some tests for this and related opcodes are also added.

Fixes #2212 