### PR TITLE
Avoid IsZero overhead after calling getUseDef

### DIFF
--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -769,8 +769,7 @@ int32_t TR_CopyPropagation::perform()
             if (useDefInfo->getSingleDefiningLoad(useNode) == fixUseNode)
                {
                TR_UseDefInfo::BitVector defsOfUseToBeFixed(comp()->allocator());
-               useDefInfo->getUseDef(defsOfUseToBeFixed, fixUseIndex);
-               if (!defsOfUseToBeFixed.IsZero())
+               if (useDefInfo->getUseDef(defsOfUseToBeFixed, fixUseIndex))
                   {
                   TR_UseDefInfo::BitVector::Cursor cursor(defsOfUseToBeFixed);
                   for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -796,9 +795,8 @@ int32_t TR_CopyPropagation::perform()
    for (int32_t i = useDefInfo->getFirstUseIndex(); i <= lastUseIndex; i++)
       {
       TR_UseDefInfo::BitVector defs(comp()->allocator());
-      useDefInfo->getUseDef(defs, i);
 
-      if (!defs.IsZero())
+      if (useDefInfo->getUseDef(defs, i))
          {
          TR::Node *useNode = useDefInfo->getNode(i);
          _useTree = NULL;
@@ -982,8 +980,7 @@ int32_t TR_CopyPropagation::perform()
             if (useDefInfo->getSingleDefiningLoad(useNode) == fixUseNode)
                {
                TR_UseDefInfo::BitVector defsOfUseToBeFixed(comp()->allocator());
-               useDefInfo->getUseDef(defsOfUseToBeFixed, fixUseIndex);
-               if (!defsOfUseToBeFixed.IsZero())
+               if (useDefInfo->getUseDef(defsOfUseToBeFixed, fixUseIndex))
                   {
                   TR_UseDefInfo::BitVector::Cursor cursor(defsOfUseToBeFixed);
                   for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -1006,8 +1003,7 @@ int32_t TR_CopyPropagation::perform()
       else if (itr->second != 0)
          {
          TR_UseDefInfo::BitVector defsOfRhs(comp()->allocator());
-         useDefInfo->getUseDef(defsOfRhs, itr->second);
-         if (!defsOfRhs.IsZero())
+         if (useDefInfo->getUseDef(defsOfRhs, itr->second))
             {
             TR_UseDefInfo::BitVector::Cursor cursor(defsOfRhs);
             for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3848,8 +3848,7 @@ bool TR_GlobalRegisterAllocator::isDependentStore(TR::Node *node, const TR_UseDe
          *seenLoad = true;
          int32_t useIndex = node->getUseDefIndex();
          TR_UseDefInfo::BitVector childDefs(comp()->allocator());
-         optimizer()->getUseDefInfo()->getUseDef(childDefs, useIndex);
-         if (!childDefs.IsZero())
+         if (optimizer()->getUseDefInfo()->getUseDef(childDefs, useIndex))
             {
             TR_UseDefInfo::BitVector temp(comp()->allocator());
             temp = childDefs;
@@ -4155,8 +4154,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
 
             int32_t useIndex = node->getUseDefIndex();
             TR_UseDefInfo::BitVector defs(comp()->allocator());
-            info->getUseDef(defs, useIndex);
-            if (!defs.IsZero())
+            if (info->getUseDef(defs, useIndex))
                {
                TR_UseDefInfo::BitVector::Cursor cursor(defs);
                for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -4232,8 +4230,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
          //printf("Skip sign extension at node %p in %s\n", node, comp->getCurrentMethod()->signature());
          int32_t useIndex = node->getUseDefIndex();
          TR_UseDefInfo::BitVector defs(comp()->allocator());
-         info->getUseDef(defs, useIndex);
-         if (!defs.IsZero())
+         if (info->getUseDef(defs, useIndex))
             {
             TR_UseDefInfo::BitVector::Cursor cursor(defs);
             for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -4444,8 +4441,7 @@ void TR_GlobalRegisterAllocator::signExtendAllDefNodes(TR::Node *defNode, List<T
 
       TR_UseDefInfo *info = optimizer()->getUseDefInfo();
       TR_UseDefInfo::BitVector defs(comp()->allocator());
-      info->getUseDef(defs, useIndex);
-      if (!defs.IsZero())
+      if (info->getUseDef(defs, useIndex))
          {
          TR_UseDefInfo::BitVector::Cursor cursor(defs);
          for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -3761,8 +3761,7 @@ TR::Node *TR_LoopStrider::updateLoadUsedInLoopIncrement(TR::Node *node, int32_t 
          return NULL;
 
       TR_UseDefInfo::BitVector defs(comp()->allocator());
-      useDefInfo->getUseDef(defs, useIndex);
-      if (!defs.IsZero() && (defs.PopulationCount() == 1))
+      if (useDefInfo->getUseDef(defs, useIndex) && (defs.PopulationCount() == 1))
          {
          TR_UseDefInfo::BitVector::Cursor cursor(defs);
          for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())

--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -396,10 +396,8 @@ int32_t TR_IsolatedStoreElimination::perform()
                traceMsg(comp(), "correcting UseDefInfo:\n");
                }
             TR_UseDefInfo::BitVector defsOfRhs(comp()->allocator());
-            useDefInfo->getUseDef(defsOfRhs, node->getFirstChild()->getUseDefIndex());
             TR_UseDefInfo::BitVector nodeUses(comp()->allocator());
-            useDefInfo->getUsesFromDef(nodeUses, useDefIndex);
-            if (!defsOfRhs.IsZero() && !nodeUses.IsZero())
+            if (useDefInfo->getUseDef(defsOfRhs, node->getFirstChild()->getUseDefIndex()) && useDefInfo->getUsesFromDef(nodeUses, useDefIndex))
                {
                TR_UseDefInfo::BitVector::Cursor cursor1(defsOfRhs);
                for (cursor1.SetToFirstOne(); cursor1.Valid(); cursor1.SetToNextOne())
@@ -546,8 +544,7 @@ void TR_IsolatedStoreElimination::removeRedundantSpills()
             continue;
 
          TR_UseDefInfo::BitVector defs(comp()->allocator());
-         useDefInfo->getUseDef(defs, useIndex);
-         if (!defs.IsZero())
+         if (useDefInfo->getUseDef(defs, useIndex))
             {
             bool redundantStore= true;
             TR_UseDefInfo::BitVector::Cursor cursor(defs);
@@ -796,8 +793,7 @@ bool TR_IsolatedStoreElimination::groupIsolatedStores(int32_t defIndex,TR_BitVec
    //If even one of the uses is not under store node, then it imposible to remove this def, and thus return.
 
    TR_UseDefInfo::BitVector usesOfThisDef(comp()->allocator());
-   info->getUsesFromDef(usesOfThisDef, defIndex+info->getFirstDefIndex());
-   if (usesOfThisDef.IsZero())
+   if (!info->getUsesFromDef(usesOfThisDef, defIndex+info->getFirstDefIndex()))
       {
       if (trace())
          traceMsg(comp(), "groupIsolated - DEF %d has no uses - can be removed \n", defIndex);

--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -240,7 +240,6 @@ void TR_LoadExtensions::findPreferredLoadExtensions(TR::Node* parent)
             if (useDefInfo != NULL && useDefInfo->infoIsValid() && useRegLoad->getUseDefIndex() != 0 && useDefInfo->isUseIndex(useRegLoad->getUseDefIndex() != 0))
                {
                TR_UseDefInfo::BitVector info(comp()->allocator());
-
                if (useDefInfo->getUseDef(info, useRegLoad->getUseDefIndex()))
                   {
                   if (trace())

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -3839,8 +3839,7 @@ TR::Node *TR_LoopTransformer::updateLoadUsedInLoopIncrement(TR::Node *node, int3
          return NULL;
 
       TR_UseDefInfo::BitVector defs(comp()->allocator());
-      useDefInfo->getUseDef(defs, useIndex);
-      if (!defs.IsZero() && (defs.PopulationCount() == 1))
+      if (useDefInfo->getUseDef(defs, useIndex) && (defs.PopulationCount() == 1))
          {
          TR_UseDefInfo::BitVector::Cursor cursor(defs);
          for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -2054,7 +2054,7 @@ TR::Node *TR_LoopVersioner::isDependentOnInvariant(TR::Node *useNode)
       return NULL;
 
    TR_UseDefInfo::BitVector defs(comp()->allocator());
-   useDefInfo->getUseDef(defs, useIndex);
+   bool isNonZero = useDefInfo->getUseDef(defs, useIndex);
    TR_UseDefInfo::BitVector::Cursor cursor(defs);
    cursor.SetToFirstOne();
 
@@ -2067,7 +2067,7 @@ TR::Node *TR_LoopVersioner::isDependentOnInvariant(TR::Node *useNode)
    if (trace())
       traceMsg(comp(),"Definition Counts for node [%p] is %d inside isDependentOnInvariant \n", useNode,defs.PopulationCount());
    TR::Node *childNode = NULL;
-   if (!defs.IsZero()) //&&
+   if (isNonZero) //&&
        //(defs.PopulationCount() == 1) &&
        //_writtenExactlyOnce.ValueAt(useNode->getSymbolReference()->getReferenceNumber()))
       {
@@ -2119,8 +2119,7 @@ TR::Node *TR_LoopVersioner::isDependentOnInductionVariable(
       return NULL;
 
    TR_UseDefInfo::BitVector defs(comp()->allocator());
-   useDefInfo->getUseDef(defs, useIndex);
-   if (!defs.IsZero() &&
+   if (useDefInfo->getUseDef(defs, useIndex) &&
        (defs.PopulationCount() == 1) &&
        _writtenExactlyOnce.ValueAt(useNode->getSymbolReference()->getReferenceNumber()))
       {
@@ -2667,8 +2666,7 @@ bool TR_LoopVersioner::isDependentOnAllocation(TR::Node *useNode, int32_t recurs
 
 
    TR_UseDefInfo::BitVector defs(comp()->allocator());
-   useDefInfo->getUseDef(defs, useIndex);
-   if (!defs.IsZero())
+   if (useDefInfo->getUseDef(defs, useIndex))
       {
       bool pointsToNew = false;
       bool pointsToNonNew = false;

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -1906,8 +1906,7 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
       }
 
    TR_UseDefInfo::BitVector defs(comp()->allocator());
-   _useDefInfo->getUseDef(defs, useDefIndex);
-   if (defs.IsZero())
+   if (!_useDefInfo->getUseDef(defs, useDefIndex))
       return NULL;
 
    int32_t baseValueNumber = -1;
@@ -2132,8 +2131,7 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
                                  avoidMerge = true;
 
                               TR_UseDefInfo::BitVector thisDefs(comp()->allocator());
-                              _useDefInfo->getUseDef(thisDefs, thisUseDefIndex);
-                              if (thisDefs.IsZero() || (!(thisDefs == defs)))
+                              if (!_useDefInfo->getUseDef(thisDefs, thisUseDefIndex) || (!(thisDefs == defs)))
                                  avoidMerge = true;
                               }
 
@@ -2417,8 +2415,7 @@ TR::VPConstraint *OMR::ValuePropagation::mergeDefConstraints(TR::Node *node, int
                                     avoidMerge = true;
 
                                  TR_UseDefInfo::BitVector thisDefs(comp()->allocator());
-                                 _useDefInfo->getUseDef(thisDefs, thisUseDefIndex);
-                                 if (thisDefs.IsZero() || (!(thisDefs == defs)))
+                                 if (!_useDefInfo->getUseDef(thisDefs, thisUseDefIndex) || (!(thisDefs == defs)))
                                     avoidMerge = true;
                                  }
 
@@ -2976,8 +2973,7 @@ void OMR::ValuePropagation::checkForInductionVariableIncrement(TR::Node *node)
    if (isInductionVariable)
       {
       TR_UseDefInfo::BitVector defs(comp()->allocator());
-      _useDefInfo->getUseDef(defs, useIndex);
-      if (defs.IsZero())
+      if (!_useDefInfo->getUseDef(defs, useIndex))
          isInductionVariable = false;
       else
          {

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2973,8 +2973,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
             if (useDefInfo->isUseIndex(useIndex))
                {
                TR_UseDefInfo::BitVector defs(vp->comp()->allocator());
-               useDefInfo->getUseDef(defs, useIndex);
-               if (!defs.IsZero())
+               if (useDefInfo->getUseDef(defs, useIndex))
                   {
                   TR_UseDefInfo::BitVector::Cursor cursor(defs);
                   for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -3063,8 +3062,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
             if (useDefInfo->isUseIndex(useIndex))
                {
                TR_UseDefInfo::BitVector defs(vp->comp()->allocator());
-               useDefInfo->getUseDef(defs, useIndex);
-               if (!defs.IsZero())
+               if (useDefInfo->getUseDef(defs, useIndex))
                   {
                   TR_UseDefInfo::BitVector::Cursor cursor(defs);
                   for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -3096,8 +3094,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
                            if (useDefInfo->isUseIndex(useIndexA))
                               {
                               TR_UseDefInfo::BitVector defsA(vp->comp()->allocator());
-                              useDefInfo->getUseDef(defsA, useIndexA);
-                              if (!defsA.IsZero())
+                              if (useDefInfo->getUseDef(defsA, useIndexA))
                                  {
                                  TR_UseDefInfo::BitVector::Cursor cursorA(defsA);
                                  for (cursorA.SetToFirstOne(); cursorA.Valid(); cursorA.SetToNextOne())
@@ -3961,8 +3958,7 @@ TR::Node *constrainCheckcast(OMR::ValuePropagation *vp, TR::Node *node)
             if (useDefInfo->isUseIndex(useIndex))
                {
                TR_UseDefInfo::BitVector defs(vp->comp()->allocator());
-               useDefInfo->getUseDef(defs, useIndex);
-               if (!defs.IsZero())
+               if (useDefInfo->getUseDef(defs, useIndex))
                   {
                   TR_UseDefInfo::BitVector::Cursor cursor(defs);
                   for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -5384,8 +5380,7 @@ TR::Node *constrainCall(OMR::ValuePropagation *vp, TR::Node *node)
                if (useDefInfo->isUseIndex(useIndex))
                   {
                   TR_UseDefInfo::BitVector defs(vp->comp()->allocator());
-                  useDefInfo->getUseDef(defs, useIndex);
-                  if (!defs.IsZero())
+                  if (useDefInfo->getUseDef(defs, useIndex))
                      {
                      TR_UseDefInfo::BitVector::Cursor cursor(defs);
                      for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
@@ -5413,8 +5408,7 @@ TR::Node *constrainCall(OMR::ValuePropagation *vp, TR::Node *node)
                               if (useDefInfo->isUseIndex(useIndexC))
                                  {
                                  TR_UseDefInfo::BitVector defsC(vp->comp()->allocator());
-                                 useDefInfo->getUseDef(defsC, useIndexC);
-                                 if (!defsC.IsZero())
+                                 if (useDefInfo->getUseDef(defsC, useIndexC))
                                     {
                                     TR_UseDefInfo::BitVector::Cursor cursorC(defsC);
                                     for (cursorC.SetToFirstOne(); cursorC.Valid(); cursorC.SetToNextOne())
@@ -8416,8 +8410,7 @@ void replaceWithSmallerType(OMR::ValuePropagation *vp, TR::Node *node)
       return;
 
    TR_UseDefInfo::BitVector defs(vp->comp()->allocator());
-   useDefInfo->getUseDef(defs, useIndex);
-   if (defs.IsZero() || (defs.PopulationCount() > 1))
+   if (!useDefInfo->getUseDef(defs, useIndex) || (defs.PopulationCount() > 1))
       return;
    TR_UseDefInfo::BitVector::Cursor cursor(defs);
    cursor.SetToFirstOne();


### PR DESCRIPTION
As mentioned in issue #2175 the result of getUseDef
has already been checked for zero (the return value
of getUseDef is false if zero). So there is no need
to check IsZero again and this is the change in this commit.

Issue: #2175

Signed-off-by: Vijay Sundaresan <vijaysun@ca.ibm.com>