### PR TITLE
Replace trfprintf calls with traceMsg

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -720,8 +720,7 @@ OMR::CodeGenerator::doInstructionSelection()
          // the others
          self()->getDebug()->saveNodeChecklist(nodeChecklistBeforeDump);
          self()->getDebug()->dumpSingleTreeWithInstrs(tt, NULL, true, false, true, true);
-         trfprintf(comp->getOutFile(),"\n------------------------------\n");
-         trfflush(comp->getOutFile());
+         traceMsg(comp, "\n------------------------------\n");
          }
 
       self()->setCurrentEvaluationTreeTop(tt);
@@ -806,16 +805,16 @@ OMR::CodeGenerator::doInstructionSelection()
          self()->getDebug()->restoreNodeChecklist(nodeChecklistBeforeDump);
          if (tt == self()->getCurrentEvaluationTreeTop())
             {
-            trfprintf(comp->getOutFile(),"------------------------------\n");
+            traceMsg(comp, "------------------------------\n");
             self()->getDebug()->dumpSingleTreeWithInstrs(tt, prevInstr->getNext(), true, true, true, false);
             }
          else
             {
             // dump all the trees that the evaluator handled
-            trfprintf(comp->getOutFile(),"------------------------------");
+            traceMsg(comp, "------------------------------");
             for (TR::TreeTop *dumptt = tt; dumptt != self()->getCurrentEvaluationTreeTop()->getNextTreeTop(); dumptt = dumptt->getNextTreeTop())
                {
-               trfprintf(comp->getOutFile(),"\n");
+               traceMsg(comp, "\n");
                self()->getDebug()->dumpSingleTreeWithInstrs(dumptt, NULL, true, false, true, false);
                }
 


### PR DESCRIPTION
trfprintf calls inside of doInstructionSelection do not do a null check on the file handle before writing. This can cause crashes when the file handle is null (which is a possibility when we run out of file handles (ulimit -n)). These calls should be replaced with traceMsg, which does a null check before trying to print.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>