### PR TITLE
Fix std::map::value_type to match the type of the allocator

### DIFF
--- a/compiler/optimizer/LoadExtensions.hpp
+++ b/compiler/optimizer/LoadExtensions.hpp
@@ -225,9 +225,9 @@ class TR_LoadExtensions : public TR::Optimization
 
    private:
 
-   typedef TR::typed_allocator<std::pair<const TR::Node*, int32_t>, TR::Region&> NodeToIntTableAllocator;
-   typedef std::less<TR::Node*> NodeToIntTableComparator;
-   typedef std::map<TR::Node*, int32_t, NodeToIntTableComparator, NodeToIntTableAllocator> NodeToIntTable;
+   typedef TR::typed_allocator<std::pair<const TR::Node* const, int32_t>, TR::Region&> NodeToIntTableAllocator;
+   typedef std::less<const TR::Node*> NodeToIntTableComparator;
+   typedef std::map<const TR::Node*, int32_t, NodeToIntTableComparator, NodeToIntTableAllocator> NodeToIntTable;
 
    /** \brief
     *     Keeps track of all nodes which should be excluded from consideration in this optimization.


### PR DESCRIPTION
Some compilers require (via static_assert) that the type of the value
match the type of the allocator value. In this case it does not matter
whether either are const so we make the map value_type as such.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>