### PR TITLE
64 bit builds should assume a 64 bit processor on Power

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3926,7 +3926,18 @@ bool OMR::Power::CodeGenerator::supportsTransientPrefetch()
 
 bool OMR::Power::CodeGenerator::is64BitProcessor()
    {
-   return TR::Compiler->target.cpu.getPPCis64bit();
+   /*
+    * If the target is 64 bit, the CPU must also be 64 bit (even if we don't specifically know which Power CPU it is) so this can just return true.
+    * If the target is not 64 bit, we need to check the CPU properties to try and find out if the CPU is 64 bit or not.
+    */
+   if (TR::Compiler->target.is64Bit())
+      {
+      return true;
+      }
+   else
+      {
+      return TR::Compiler->target.cpu.getPPCis64bit();
+      }
    }
 
 bool OMR::Power::CodeGenerator::getSupportsIbyteswap()


### PR DESCRIPTION
This is a change targeting Power. The runtime check is64BitProcessor now
checks to see if it is a 64 bit build. If so, it just returns true since
a 64 bit build must be running on a 64 bit processor. If not, the function
will check the CPU properties as before.

Issue: #2232
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>