### PR TITLE
Remove RestrictedRegister fields and functions from OMR::Z::CodeGenerator

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -2441,11 +2441,6 @@ OMR::CodeGenerator::simulateBlockEvaluation(
    TR_ASSERT(!block->isExtensionOfPreviousBlock(), "simulateBlockEvaluation operates on extended basic blocks");
    state->_currentBlock = block;
 
-#if defined(TR_TARGET_S390)
-   if (self()->getCurrentlyRestrictedRegisters())
-      self()->getCurrentlyRestrictedRegisters()->empty();
-#endif
-
    if (self()->traceSimulateTreeEvaluation())
       {
       traceMsg(self()->comp(), "            { simulating block_%d", block->getNumber());

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -712,9 +712,6 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    TR::Instruction *cursor=NULL;
    TR::Compilation *comp = cg->comp();
 
-   // div uses reg pairs that can interfeer with currently clobbered reg
-   cg->clearCurrentlyClobberedRestrictedRegister();
-
    TR::RegisterPair * dividendPair = (TR::RegisterPair *) cg->gprClobberEvaluate(firstChild);
 
    int32_t shiftAmnt;
@@ -1108,8 +1105,6 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
    TR::Instruction * cursor = NULL;
-   // div uses reg pairs that can interfeer with currently clobbered reg
-   cg->clearCurrentlyClobberedRestrictedRegister();
 
    int32_t shiftAmnt;
    // A/A, return 1 (div) or 0 (rem).
@@ -1900,27 +1895,9 @@ TR::Register *
 OMR::Z::TreeEvaluator::addrAddHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (node->getOpCodeValue() == TR::aiadd)
-      {
-      if (cg->getCurrentRegisterPressure() < CODEGEN_REGPRESSURE_THRESHOLD)
-         return generic32BitAddEvaluator(node, cg);
-      else
-         {
-         TR_S390BinaryCommutativeAnalyser temp(cg);
-         temp.integerAddAnalyser(node, TR::InstOpCode::ALR, TR::InstOpCode::AL, TR::InstOpCode::LR);
-         return node->getRegister();
-         }
-      }
+      return generic32BitAddEvaluator(node, cg);
    else if (node->getOpCodeValue() == TR::aladd)
-      {
-      if (cg->getCurrentRegisterPressure() < CODEGEN_REGPRESSURE_THRESHOLD)
-         return TR::TreeEvaluator::laddEvaluator(node, cg);
-      else
-         {
-         TR_S390BinaryCommutativeAnalyser temp(cg);
-         temp.integerAddAnalyser(node, TR::InstOpCode::ALGR, TR::InstOpCode::ALG, TR::InstOpCode::LGR);
-         return node->getRegister();
-         }
-      }
+      return TR::TreeEvaluator::laddEvaluator(node, cg);
    else
       TR_ASSERT(0,"Wrong il-opCode for calling addAddHelper!\n");
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -163,10 +163,6 @@ extern int64_t getIntegralValue(TR::Node* node);
 #define TR_MAX_SEARCH_STRING_SIZE (TR_MAX_SS1_SIZE)
 #define TR_MAX_REPLACE_CHAR_STRING_SIZE 1
 #define TR_MAX_BEFORE_AFTER_SIZE 1
-
-
-// heuristic codegen register pressure threshold (restricted registers)
-#define CODEGEN_REGPRESSURE_THRESHOLD 14
 
 // performance thresholds -- until SRST and similar instructions are used inline
 #define TR_MAX_REPLACE_ALL_LOOP_PERF 150              // search > 1 byte (otherwise it is table lookup)
@@ -721,41 +717,6 @@ public:
     */
    TR::Instruction* insertPad(TR::Node* node, TR::Instruction* cursor, uint32_t size, bool prependCursor);
 
-   void setCurrentlyClobberedRestrictedRegister(int32_t regNum)
-      {
-      _currentlyClobberedRestrictedRegister = regNum;
-      }
-   void clearCurrentlyClobberedRestrictedRegister()
-      {
-      _currentlyClobberedRestrictedRegister = TR_INVALID_REGISTER;
-      }
-   int32_t getCurrentlyClobberedRestrictedRegister(int32_t regNum)
-      {
-      return _currentlyClobberedRestrictedRegister;
-      }
-
-   TR_BitVector * setKilledRestrictedRegisters(TR_BitVector *killRestrictedRegsBV)
-      {
-      return _killedRestrictedRegisters = killRestrictedRegsBV;
-      }
-   TR_BitVector * getKilledRestrictedRegisters()
-      {
-      return _killedRestrictedRegisters;
-      }
-
-   TR_BitVector * setCurrentlyRestrictedRegisters(TR_BitVector *currentRestrictedRegsBV)
-      {
-      return _currentlyRestrictedRegisters = currentRestrictedRegsBV;
-      }
-
-   TR_BitVector * getCurrentlyRestrictedRegisters()
-      {
-      return _currentlyRestrictedRegisters;
-      }
-
-   /** Heuristicly get the register pressure for doing codegen */
-   int8_t getCurrentRegisterPressure(TR_RegisterKinds rk = TR_GPR);
-
     struct TR_S390ConstantDataSnippetKey
         {
            void * c;
@@ -1077,9 +1038,6 @@ private:
 
    TR::SymbolReference* _reusableTempSlot;
 
-   TR_BitVector  *_currentlyRestrictedRegisters;
-   TR_BitVector  *_killedRestrictedRegisters;
-
    TR::list<TR::Register *> _internalControlFlowRegisters;
 
    CS2::HashTable<ncount_t, bool, TR::Allocator> _nodesToBeEvaluatedInRegPairs;
@@ -1118,7 +1076,6 @@ private:
    TR::Node *_nodeAddressOfCachedStatic;
    protected:
 
-   int32_t _currentlyClobberedRestrictedRegister;
    TR::SparseBitVector _bucketPlusIndexRegisters;
    TR::Instruction *_currentDEPEND;
    };

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -849,8 +849,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
                if (sourceRegister == targetRegister)
                   {
                   // testing register pressure
-                  if (cg->getCurrentRegisterPressure() < CODEGEN_REGPRESSURE_THRESHOLD &&
-                      !comp->getJittedMethodSymbol()->isNoTemps())
+                  if (!comp->getJittedMethodSymbol()->isNoTemps())
                      {
                      TR::Register * tempReg = cg->allocateRegister();
                      cursor = generateRIInstruction(cg, TR::InstOpCode::LHI, node, tempReg, value, preced);
@@ -910,8 +909,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
                if (sourceRegister == targetRegister)
                   {
                   // testing register pressure
-                  if (cg->getCurrentRegisterPressure() < CODEGEN_REGPRESSURE_THRESHOLD &&
-                        !comp->getJittedMethodSymbol()->isNoTemps())
+                  if (!comp->getJittedMethodSymbol()->isNoTemps())
                      {
                      TR::Register * tempReg = cg->allocate64bitRegister();
                      cursor = generateRIInstruction(cg, TR::InstOpCode::LGHI, node, tempReg, value, preced);
@@ -1047,8 +1045,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
                else
                   {
                   // testing register pressure
-                  if (cg->getCurrentRegisterPressure() >= CODEGEN_REGPRESSURE_THRESHOLD &&
-                        !comp->getJittedMethodSymbol()->isNoTemps())
+                  if (!comp->getJittedMethodSymbol()->isNoTemps())
                      {
                      if (!targetRegister)
                         targetRegister = sourceRegister;
@@ -2715,7 +2712,7 @@ tryGenerateCLCForComparison(TR::Node *node, TR::CodeGenerator *cg)
 
    uint16_t numOfBytesToCompare = operand1->getSize();
    // CLC is slower than CL when the length is 4 bytes
-   if (numOfBytesToCompare == 4  && cg->getCurrentRegisterPressure() < CODEGEN_REGPRESSURE_THRESHOLD)
+   if (numOfBytesToCompare == 4)
       {
       return 0;
       }


### PR DESCRIPTION
This pull request is for the removal of the following fields and functions:
```plaintext
setCurrentlyClobberedRestrictedRegister
clearCurrentlyClobberedRestrictedRegister
getCurrentlyClobberedRestrictedRegister
setKilledRestrictedRegisters
getKilledRestrictedRegisters
setCurrentlyRestrictedRegisters
getCurrentlyRestrictedRegisters
```

These fields and functions are not used in OMR or any other downstream projects.

Issue: #2063
Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>