### PR TITLE
Co-operative copy of large objects in CS

### DIFF
--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,6 +62,10 @@ struct OMR_VMThread;
 #define OMR_OBJECT_METADATA_FLAGS_MASK		0xFF
 #define OMR_OBJECT_METADATA_AGE_MASK		0xF0
 #define OMR_OBJECT_METADATA_AGE_SHIFT		4
+
+#if (0 != (OMR_OBJECT_METADATA_FLAGS_MASK & COPY_PROGRESS_INFO_MASK))
+#error "mask overlap: OMR_OBJECT_METADATA_FLAGS_MASK, COPY_PROGRESS_INFO_MASK"
+#endif
 
 /**
  * Remembered bit states overlay tenured header age flags. These are normalized to low-order byte, as above.
@@ -765,9 +769,6 @@ public:
 	MMINLINE void
 	fixupForwardedObject(MM_ForwardedHeader *forwardedHeader, omrobjectptr_t destinationObjectPtr, uintptr_t objectAge)
 	{
-		/* Copy the preserved fields from the forwarded header into the destination object */
-		forwardedHeader->fixupForwardedObject(destinationObjectPtr);
-
 		uintptr_t age = objectAge << OMR_OBJECT_METADATA_AGE_SHIFT;
 		setObjectFlags(destinationObjectPtr, OMR_OBJECT_METADATA_AGE_MASK, age);
 	}

--- a/gc/base/SlotObject.hpp
+++ b/gc/base/SlotObject.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,18 +104,15 @@ public:
 	 */ 	
 	MMINLINE bool atomicWriteReferenceToSlot(omrobjectptr_t oldReference, omrobjectptr_t newReference)
 	{
-		bool swapResult = false;
+		/* Caller should ensure oldReference != newReference */
+		fomrobject_t compressedOld = convertTokenFromPointer(oldReference);
+		fomrobject_t compressedNew = convertTokenFromPointer(newReference);
 		
-		if (oldReference != newReference) {
-			fomrobject_t compressedOld = convertTokenFromPointer(oldReference);
-			fomrobject_t compressedNew = convertTokenFromPointer(newReference);
-		
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
-			swapResult = ((uint32_t)(uintptr_t)compressedOld == MM_AtomicOperations::lockCompareExchangeU32((uint32_t *)_slot, (uint32_t)(uintptr_t)compressedOld, (uint32_t)(uintptr_t)compressedNew));
+#if defined (OMR_GC_COMPRESSED_POINTERS)
+		bool swapResult = ((uint32_t)(uintptr_t)compressedOld == MM_AtomicOperations::lockCompareExchangeU32((uint32_t *)_slot, (uint32_t)(uintptr_t)compressedOld, (uint32_t)(uintptr_t)compressedNew));
 #else
-			swapResult = ((uintptr_t)compressedOld == MM_AtomicOperations::lockCompareExchange((uintptr_t *)_slot, (uintptr_t)compressedOld, (uintptr_t)compressedNew));
-#endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
-		}
+		bool swapResult = ((uintptr_t)compressedOld == MM_AtomicOperations::lockCompareExchange((uintptr_t *)_slot, (uintptr_t)compressedOld, (uintptr_t)compressedNew));
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 		
 		return swapResult;
 	}

--- a/gc/structs/ForwardedHeader.hpp
+++ b/gc/structs/ForwardedHeader.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,38 @@
 #error "MutableHeaderFields requires sizeof(fomrobject_t) == sizeof(j9objectclass_t)"
 #endif /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) != defined(OMR_GC_COMPRESSED_POINTERS) */
 
+/* Source object header bits */
 #define OMR_FORWARDED_TAG 4
+/* If 'being copied hint' is set, it hints that destination might still be being copied (although it might have just completed).
+   It tells the caller it should go and fetch master info from the destination header to tell if coping is really complete.
+   If hint is reset, the copying is definitely complete, no need to fetch the master info.
+   This hint is not necessary for correctness of copying protocol, it's just an optimization to avoid visiting destination object header
+   in cases when it's likely not in data cash (GC thread encountering already forwarded object) */
+#define OMR_BEING_COPIED_HINT 2
+#define OMR_SELF_FORWARDED_TAG J9_GC_MULTI_SLOT_HOLE
+
+
+/* Destination object header bits, masks, consts... */
+/* Master being-copied bit is the destination header. If set, object is still being copied,
+   and the rest of the header indicate progress info (bytes yet to copy and number of threads participating).
+   If the bit is reset, the object is fully copied, and the rest of header is fully restored (class info etc).
+ */
+#define OMR_BEING_COPIED_TAG OMR_FORWARDED_TAG
+/* 
+   Shift is exactly bit size of OMR_OBJECT_METADATA_FLAGS_MASK, which is not visible here. 
+   Constants here, are however visible in OMR object model and  
+   we do assert there that our masks do not overlap with flags mask */
+#define OUTSTANDING_COPIES_SHIFT 8
+/* 4 bits reserved for outstandingCopy count */
+#define OUTSTANDING_COPIES_MASK_BASE 0xf
+/* actually limit on outstandingCopy count is conservatively set to a lower number than what is the bit allotment (OUTSTANDING_COPIES_MASK_BASE),
+ * since having too many copies in parallel may be counterproductive */
+#define MAX_OUTSTANDING_COPIES 4
+#define SIZE_ALIGNMENT 0xfffUL
+#define REMAINING_SIZE_MASK ~SIZE_ALIGNMENT
+#define OUTSTANDING_COPIES_MASK (OUTSTANDING_COPIES_MASK_BASE << OUTSTANDING_COPIES_SHIFT)
+#define COPY_PROGRESS_INFO_MASK (REMAINING_SIZE_MASK | OUTSTANDING_COPIES_MASK)
+#define SIZE_OF_SECTION_TO_COPY(size) ((size) >> 7)
 
 /**
  * Scavenger forwarding header is used to distinguish objects in evacuate space that are being/have been
@@ -81,11 +112,62 @@ private:
 	const uintptr_t _forwardingSlotOffset;		/**< fomrobject_t offset from _objectPtr to fomrobject_t slot that will hold the forwarding pointer */
 	static const uintptr_t _forwardedTag = OMR_FORWARDED_TAG;	/**< bit mask used to mark forwarding slot value as forwarding pointer */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	static const uintptr_t _selfForwardedTag = _forwardedTag | J9_GC_MULTI_SLOT_HOLE;	
+	static const fomrobject_t _selfForwardedTag = (fomrobject_t)(_forwardedTag | OMR_SELF_FORWARDED_TAG);	
+	static const fomrobject_t _beingCopiedHint = (fomrobject_t)OMR_BEING_COPIED_HINT; /**< used in source object f/w pointer to hint that object might still be being copied */
+	static const fomrobject_t _beingCopiedTag = (fomrobject_t)OMR_BEING_COPIED_TAG; /**< used in destination object, but using the same bit as _forwardedTag in source object */
+	static const fomrobject_t _remainingSizeMask = (fomrobject_t)REMAINING_SIZE_MASK; 
+	static const fomrobject_t _copyProgressInfoMask = (fomrobject_t)(_remainingSizeMask | OUTSTANDING_COPIES_MASK);
+	static const uintptr_t _copySizeAlignement = (uintptr_t)SIZE_ALIGNMENT;
+	static const uintptr_t _minIncrement = (131072 & _remainingSizeMask); /**< min size of copy section; does not have to be a power of 2, but it has to be aligned with _copySizeAlignement */ 
+	
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 /*
  * Function members
  */
+private:
+	MMINLINE_DEBUG static fomrobject_t
+	lockCompareExchangeObjectHeader(volatile fomrobject_t *address, fomrobject_t oldValue, fomrobject_t newValue)
+	{
+#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+		return MM_AtomicOperations::lockCompareExchangeU32((volatile uint32_t*)address, oldValue, newValue);
+#else /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
+		return MM_AtomicOperations::lockCompareExchange((volatile uintptr_t*)address, oldValue, newValue);
+#endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
+	}
+	
+	/**
+	 * Atomically try to win forwarding. It's internal implementation of public setForwardedObject()
+	 */
+	omrobjectptr_t setForwardedObjectInternal(omrobjectptr_t destinationObjectPtr, uintptr_t forwardedTag);
+	
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	/**
+	 * Try to win a section of large object that is still being copied
+	 */
+	static uintptr_t winObjectSectionToCopy(volatile fomrobject_t *copyProgressSlot, fomrobject_t oldValue, uintptr_t *remainingSizeToCopy, uintptr_t outstandingCopies);
+	
+	/**
+	 * Just spin (or pause) for certain amount of cycles
+	 */
+	static void wait(uintptr_t *spinCount);
+
+	/**
+	 * Return true, if based on the hint in forwarding header, the object might still be copied
+	 */
+	MMINLINE bool
+	isBeingCopied()
+	{
+		/* strictly forwarded object with _beingCopiedHint set */
+		return (_beingCopiedHint | _forwardedTag) == (_preserved.slot & (_beingCopiedHint | _selfForwardedTag));
+	}
+	
+	/**
+	 * Based on progress info in destination object header, try to participate in copying,
+	 * wait if all work is done (but still copy is in progress), or simply return if copy is complete)
+	 */
+	void copyOrWaitOutline(omrobjectptr_t destinationObjectPtr);
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+	
 public:
 #if defined(FORWARDEDHEADER_DEBUG)
 #define ForwardedHeaderAssertCondition(condition) #condition
@@ -106,8 +188,10 @@ public:
 	 *
 	 * @return the winning forwarded object (either destinationObjectPtr or one written by another thread)
 	 */
-	omrobjectptr_t setForwardedObject(omrobjectptr_t destinationObjectPtr);
-
+	MMINLINE omrobjectptr_t setForwardedObject(omrobjectptr_t destinationObjectPtr) {
+		return setForwardedObjectInternal(destinationObjectPtr, _forwardedTag);
+	}
+	
 	/**
 	 * Return the (strictly) forwarded version of the object, or NULL if the object has not been (strictly) forwarded.
 	 */
@@ -148,20 +232,96 @@ public:
 	MMINLINE bool
 	isSelfForwardedPointer()
 	{
-		return _selfForwardedTag == ((uintptr_t)_preserved.slot & _selfForwardedTag);
+		return _selfForwardedTag == (_preserved.slot & _selfForwardedTag);
 	}
 	
 	MMINLINE bool
 	isStrictlyForwardedPointer()
 	{
-		return _forwardedTag == ((uintptr_t)_preserved.slot & _selfForwardedTag);
+		/* only _forwardedTag set ('self forwarded bit' reset) */
+		return _forwardedTag == (_preserved.slot & _selfForwardedTag);
 	}
-
 	
 	omrobjectptr_t setSelfForwardedObject();
 	
 	void restoreSelfForwardedPointer();
+	
+	/**
+	 * Initial step for destination object fixup - restore object flags and overlap, while still maintaining progess info and being copied bit.
+	 */
+	MMINLINE void
+	commenceFixup(omrobjectptr_t destinationObjectPtr)
+	{
+		MutableHeaderFields* newHeader = (MutableHeaderFields *)((fomrobject_t *)destinationObjectPtr + _forwardingSlotOffset);
+		
+		/* copy preserved flags, and keep the rest (which should be all 0s) */
+		newHeader->slot = (_preserved.slot & ~_copyProgressInfoMask) | _beingCopiedTag;
+
+#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+		newHeader->overlap = _preserved.overlap;
+#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+	}	
+	
+	/**
+	 * Final fixup step. Reset copy-in-progress flag and set info (typically class) that overlap with progress info.
+	 * This operation must be atomic (single memory update)
+	 */ 
+	MMINLINE void
+	commitFixup(omrobjectptr_t destinationObjectPtr)
+	{
+		MutableHeaderFields* newHeader = (MutableHeaderFields *)((fomrobject_t *)destinationObjectPtr + _forwardingSlotOffset);
+
+		/* before we announce this copy of the object is available, do a write sync */
+		MM_AtomicOperations::storeSync();
+		
+		/* get flags */
+		newHeader->slot = (_preserved.slot & _copyProgressInfoMask) | (newHeader->slot & ~_copyProgressInfoMask & ~(fomrobject_t)_beingCopiedTag);
+		
+		/* remove the hint in the source object */
+		volatile MutableHeaderFields* objectHeader = (volatile MutableHeaderFields *)((fomrobject_t*)_objectPtr + _forwardingSlotOffset);
+		objectHeader->slot &= ~_beingCopiedHint;
+	}
+	
+	/**
+	 * A variant of setForwardedObject(), that will also set being-copied hint in the forwarding header
+	 */
+	MMINLINE omrobjectptr_t
+	setForwardedObjectWithBeingCopiedHint(omrobjectptr_t destinationObjectPtr)
+	{
+		return setForwardedObjectInternal(destinationObjectPtr, _forwardedTag | _beingCopiedHint);
+	}	
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
+	/**
+	 * Copy intermediate section of the object. Could be done by any thread that is interested in this object
+	 */
+	void copySection(omrobjectptr_t destinationObjectPtr, uintptr_t remainingSizeToCopy, uintptr_t sizeToCopy);
+	
+	/** 
+	 * Try helping with object copying or if no outstanding work left just wait till copy is complete.
+	 * Used by threads that tried to win forwarding, but lost.
+	 */
+	MMINLINE void 
+	copyOrWait(omrobjectptr_t destinationObjectPtr)
+	{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		/* Check the hint bit in the forwarding pointer itself, before fetching the master info in the destination object header */ 
+		if (isBeingCopied()) {
+			copyOrWaitOutline(destinationObjectPtr);
+		}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */		
+	}	
+	
+	/**
+	 * Try helping with object copying or if no outstandig work left just wait till copy is complete.
+	 * Used only by the thread that won forwarding.
+	 */
+	void copyOrWaitWinner(omrobjectptr_t destinationObjectPtr);
+	
+	/**
+	 * Setup initial copy-progress information
+     */
+	uintptr_t copySetup(omrobjectptr_t destinationObjectPtr, uintptr_t *remainingSizeToCopy);
 
 	/**
 	 * This method will assert if the object has been forwarded. Use isForwardedPointer() to test before calling.
@@ -232,7 +392,7 @@ public:
 		newHeader->overlap = _preserved.overlap;
 #endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
 	}
-
+	
 	/**
 	 * Determine if the current object is a reverse forwarded object.
 	 *


### PR DESCRIPTION
For large objects, before trying to win forwarding, setup destination
header object to indicate that object is in progress. Then threads that
see the object is forwarded, but still being copied, will wait instead
of trying to create its own copy.

Further, while waiting, those threads will try to participate in
copying. Destination object header, beside the being-copied bit will
contantin progress info: amount of bytes yet to copy and count of
threads already participating. Threads atomically try to win a section
of object to copy. Once, everything is taken to copy (0 bytes yet to
copy), and all threads are done with the last section and decrement the
participation count, the winning threads will do the final steps of
fixup and replace the progress info with the valid object header.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>