### PR TITLE
Generate sxtb/sxth and uxtb/uxth instructions for ARM

### DIFF
--- a/compiler/arm/codegen/ARMOps.hpp
+++ b/compiler/arm/codegen/ARMOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,6 +83,10 @@ typedef enum  {
    ARMOp_stm,              // Store multiple words
    ARMOp_stmdb,            // Store multiple words, decrement before
    ARMOp_swp,              // Swap dword
+   ARMOp_sxtb,             // Sign extend byte
+   ARMOp_sxth,             // Sign extend halfword
+   ARMOp_uxtb,             // Zero extend byte
+   ARMOp_uxth,             // Zero extend halfword
    ARMOp_fence,            // Fence
    ARMOp_ret,              // Return
    ARMOp_wrtbar,           // Write barrier directive

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -455,8 +455,7 @@ public:
 }
 
 static void constLengthArrayCopyEvaluator(TR::Node *node, int32_t byteLen, TR::Register *src, TR::Register *dst, TR::CodeGenerator *cg);
-static void signExtend(TR::Node *node, TR::Register *dst, TR::Register *src, int32_t bitsInDst, TR::CodeGenerator *cg);
-static void zeroExtend(TR::Node *node, TR::Register *dst, TR::Register *src, int32_t bitsInDst, TR::CodeGenerator *cg);
+static void generateSignOrZeroExtend(TR::Node *node, TR::Register *dst, TR::Register *src, bool needSignExtend, int32_t bitsInDst, TR::CodeGenerator *cg);
 void simplifyANDRegImm(TR::Register *trgReg, TR::Register *srcReg, int32_t value);
 static TR::Register *ishiftAnalyser(TR::Node *node, TR::CodeGenerator *cg,TR_ARMOpCodes regOp);
 

--- a/compiler/arm/codegen/OpBinary.cpp
+++ b/compiler/arm/codegen/OpBinary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -83,6 +83,10 @@ const TR_ARMOpCode::TR_OpCodeBinaryEntry TR_ARMOpCode::binaryEncodings[ARMNumOpC
    0x08800000,  // stm
    0x09200000,  // stmdb
    0x01000090,  // swp
+   0x06AF0070,  // sxtb
+   0x06BF0070,  // sxth
+   0x06EF0070,  // uxtb
+   0x06FF0070,  // uxth
    0x00000000,  // fence
    0x00000000,  // ret
    0x00000000,  // wrtbar

--- a/compiler/arm/codegen/OpProperties.cpp
+++ b/compiler/arm/codegen/OpProperties.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -201,6 +201,18 @@ ARMOpProp_Arch4,
 0,
 
 // swp
+0,
+
+// sxtb
+0,
+
+// sxth
+0,
+
+// uxtb
+0,
+
+// uxth
 0,
 
 // fence


### PR DESCRIPTION
This commit adds code generation of ARM's sxtb/sxth instructions
and uxtb/uxth instructions for improving the instruction sequences
of sign extension and of zero extension, respectively.

Signed-off-by: knn-k <konno@jp.ibm.com>