### PR TITLE
Disable vmThread reclamation on 32-bit Windows

### DIFF
--- a/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,7 +68,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::X86::CodeGenerator
    bool opCodeIsNoOpOnThisPlatform(TR::ILOpCode &opCode);
 
    bool internalPointerSupportImplemented() { return true; }
-   virtual bool allowVMThreadRematerialization() { return false; }
 
    protected:
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -976,19 +976,12 @@ bool OMR::X86::CodeGenerator::supportsAddressRematerialization()         { stati
 
 bool OMR::X86::CodeGenerator::allowVMThreadRematerialization()
    {
-   if (self()->comp()->getOptions()->getOption(TR_DisableTraps)) return false;
-
-   static bool flag = (feGetEnv("TR_disableRematerializeVMThread") == NULL);
-   return flag;
+   return false;
    }
 
 bool OMR::X86::CodeGenerator::supportsFS0VMThreadRematerialization()
    {
-#ifdef WINDOWS
-   return allowVMThreadRematerialization();
-#else
    return false;
-#endif
    }
 
 #undef ALLOWED_TO_REMATERIALIZE

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,8 +104,6 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
          TR::RealRegister *ebp = self()->machine()->getX86RealRegister(TR::RealRegister::ebp);
          ebp->resetState(TR::RealRegister::Free);
          ebp->setAssignedRegister(NULL);
-         if (!self()->comp()->getOptions()->getOption(TR_DisableVMThreadGRA))
-            self()->setSupportsVMThreadGRA();
          }
 
       // The default CTM behaviour is to do the conversion via X87 instructions.


### PR DESCRIPTION
In preparation for removing the vmThread reclamation logic, it must first
be disabled on the 32-bit platforms where it is enabled to aid with its
surgical removal:

* force `allowVMThreadRematerialization` to always return `false`.  While
this affects both Windows and Linux 32-bit, in practice this will have no
effect on Linux 32-bit because querying this setting is always coupled with
one of the other reclamation options below that mask its effect.  This
function always returns `false` on 64-bit platforms.
* force `supportsFS0VMThreadRematerialization` to always return `false`.
This affects Win32 only.
* remove calls to `setSupportsVMThreadGRA`, thereby causing queries to
`getSupportsVMThreadGRA` to always return `false`.  This affects Win32
only.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>