### PR TITLE
Flush RS prior STW Scavenge just for Mutators

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -571,9 +571,8 @@ public:
 
 	MMINLINE MM_WorkStack *getWorkStack() { return &_workStack; }
 
-	MMINLINE void flushNonAllocationCaches() { _delegate.flushNonAllocationCaches(); }
-	virtual void flushGCCaches(MM_EnvironmentBase *env) {}
-	
+	virtual void flushNonAllocationCaches() { _delegate.flushNonAllocationCaches(); }
+	virtual void flushGCCaches() {}
 
 	/**
 	 * Get a pointer to common GC metadata attached to this environment. The GC environment structure

--- a/gc/base/OMRVMThreadInterface.cpp
+++ b/gc/base/OMRVMThreadInterface.cpp
@@ -35,19 +35,13 @@ GC_OMRVMThreadInterface::flushCachesForWalk(MM_EnvironmentBase *env)
 	env->_objectAllocationInterface->flushCache(env);
 	/* If we are in a middle of a concurrent GC, we want to flush GC caches, typically for mutator threads doing GC work.
 	 * (GC threads are  smart enough to do it themselves, before they let the walk occur) */
-	env->flushGCCaches(env);
+	env->flushGCCaches();
 }
 
 void
 GC_OMRVMThreadInterface::flushNonAllocationCaches(MM_EnvironmentBase *env)
 {
 	env->flushNonAllocationCaches();
-
-#if defined(OMR_GC_MODRON_SCAVENGER)
-	if (env->getExtensions()->isStandardGC()) {
-		((MM_EnvironmentStandard *)env)->flushRememberedSet();
-	}
-#endif
 }
 
 void

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -70,7 +70,8 @@ private:
 public:
 	static MM_EnvironmentStandard *newInstance(MM_GCExtensionsBase *extensions, OMR_VMThread *vmThread);
 	
-	virtual void flushGCCaches(MM_EnvironmentBase *env);
+	virtual void flushNonAllocationCaches();
+	virtual void flushGCCaches();
 
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(OMR_VMThread *omrVMThread) { return static_cast<MM_EnvironmentStandard*>(omrVMThread->_gcOmrVMThreadExtensions); }
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(MM_EnvironmentBase *env) { return static_cast<MM_EnvironmentStandard*>(env); }


### PR DESCRIPTION
Flushing Scavenger Remembered Set fragment within thread GC Environments
for all threads (including GC once), prior the second/last STW phase
within Concurrent Scavenger cycle, while concurrent phase is still in
progress is not correct - it interferes with GC background threads that
are still using this RS fragments.

Only RS fragments for mutators (that generate remembered objects through
Write Barrier) should be flushed.

Also doing minor re-org (moving RS aware code into Environment, rather
in VMInternface), and simplifying (removing redundant Enviroment
parameters).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>