### PR TITLE
Add support for sxtb/sxth/uxtb/uxth instructions to ARMDebug.cpp

### DIFF
--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1677,6 +1677,10 @@ static const char * opCodeToNameMap[] =
    "stm",
    "stmdb",
    "swp",
+   "sxtb",
+   "sxth",
+   "uxtb",
+   "uxth",
    "fence",
    "ret",
    "wrtbar",


### PR DESCRIPTION
This commit adds 4 instruction names in opCodeToNameMap[] in
ARMDebug.cpp.  The new instructions were added by PR #2239.

Signed-off-by: knn-k <konno@jp.ibm.com>