### PR TITLE
New option for downgrading optimization level to cold

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -605,6 +605,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"dontActivateCompThreadWhenHighPriReqIsBlocked", "M\tdo not activate another compilation thread when high priority request is blocked",  RESET_OPTION_BIT(TR_ActivateCompThreadWhenHighPriReqIsBlocked), "F", NOT_IN_SUBSET},
    {"dontAddHWPDataToIProfiler",          "O\tDont add HW Data to IProfiler", SET_OPTION_BIT(TR_DontAddHWPDataToIProfiler), "F", NOT_IN_SUBSET},
    {"dontDowngradeToCold",                "M\tdon't downgrade first time compilations from warm to cold", SET_OPTION_BIT(TR_DontDowngradeToCold), "F", NOT_IN_SUBSET},
+   {"dontDowngradeToColdDuringGracePeriod","M\tdon't downgrade first time compilations from warm to cold during grace period (first second of run)", SET_OPTION_BIT(TR_DontDowgradeToColdDuringGracePeriod), "F", NOT_IN_SUBSET },
    {"dontDowngradeWhenRIIsTemporarilyOff","M\t", SET_OPTION_BIT(TR_DontDowngradeWhenRIIsTemporarilyOff), "F", NOT_IN_SUBSET },
    {"dontIncreaseCountsForNonBootstrapMethods", "M\t", RESET_OPTION_BIT(TR_IncreaseCountsForNonBootstrapMethods), "F", NOT_IN_SUBSET }, // Xjit: option
    {"dontInline=",                        "O{regex}\tlist of callee methods to not inline",

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -321,7 +321,7 @@ enum TR_CompilationOptions
    TR_DisableLateEdgeSplitting            = 0x00000400 + 7,
    TR_DisableLoopReplicatorColdSideEntryCheck = 0x00000800 + 7,
    TR_TraceVFPSubstitution                = 0x00001000 + 7,
-   // Available                           = 0x00002000 + 7,
+   TR_DontDowgradeToColdDuringGracePeriod = 0x00002000 + 7,
    TR_EnableRecompilationPushing          = 0x00004000 + 7,
    TR_EnableJCLInline                     = 0x00008000 + 7, // enable JCL Integer and Long methods inline
    TR_DisableTreePatternMatching          = 0x00010000 + 7,


### PR DESCRIPTION
This commit introduces a new option -Xjit:dontDowngradeToColdDuringGracePeriod
which will be used to turn off a new compilation heuristic in openj9
which allows compilations to be downgraded from 'warm' to 'cold' during
the "grace period" (first second of run)

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>