### PR TITLE
Adds x86 instruction PMOVZXBD

### DIFF
--- a/compiler/x/codegen/X86Ops.ins
+++ b/compiler/x/codegen/X86Ops.ins
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2442,6 +2442,10 @@ INSTRUCTION(PMOVMSKB4RegReg, pmovmskb,
             BINARY(VEX_L128, VEX_vNONE, PREFIX_66, REX__, ESCAPE_0F__, 0xd7, 0, ModRM_RM__, Immediate_0),
             PROPERTY0(IA32OpProp_SourceRegisterInModRM),
             PROPERTY1(IA32OpProp1_XMMSource)),
+INSTRUCTION(PMOVZXBD, pmovzxbd,
+            BINARY(VEX_L128, VEX_vNONE, PREFIX_66, REX__, ESCAPE_0F38, 0x31, 0, ModRM_RM__, Immediate_0),
+            PROPERTY0(IA32OpProp_SourceRegisterInModRM),
+            PROPERTY1(IA32OpProp1_XMMSource | IA32OpProp1_XMMTarget)),
 INSTRUCTION(PMOVZXWD, pmovzxwd,
             BINARY(VEX_L128, VEX_vNONE, PREFIX_66, REX__, ESCAPE_0F38, 0x33, 0, ModRM_RM__, Immediate_0),
             PROPERTY0(IA32OpProp_SourceRegisterInModRM),


### PR DESCRIPTION
This instruction zero extends each of the lower dword's 4 packed integers (1 byte) to signed dword integers (4 bytes).

Signed-off-by: Mansoor Saqib <Mansoor.Saqib@ibm.com>