### PR TITLE
Remove setEvaluateNodeInRegPair in Z CodeGenerator

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -600,32 +600,6 @@ public:
    virtual void startInternalControlFlow(TR::Instruction *instr);
    virtual void endInternalControlFlow(TR::Instruction *instr) { _internalControlFlowRegisters.clear(); }
 
-   void setEvaluateNodeInRegPair(TR::Node * node, bool b = true)
-   {
-   if( !(node->getOpCodeValue()== TR::lload || node->getOpCodeValue() == TR::lloadi || node->getOpCodeValue() == TR::lconst))
-      return;
-
-   CS2::HashIndex hashIndex = 0;
-   if (_nodesToBeEvaluatedInRegPairs.Locate(node->getGlobalIndex(), hashIndex))
-      {
-      _nodesToBeEvaluatedInRegPairs.SetDataAt(hashIndex,b);
-      }
-   else
-      {
-
-      _nodesToBeEvaluatedInRegPairs.Add(node->getGlobalIndex(), b);
-      }
-   }
-
-   bool evaluateNodeInRegPair(TR::Node * node)
-   {
-   CS2::HashIndex hashIndex = 0;
-   if (!_nodesToBeEvaluatedInRegPairs.Locate(node->getGlobalIndex(), hashIndex))
-      return false;
-   else
-      return _nodesToBeEvaluatedInRegPairs.DataAt(hashIndex);
-   }
-
    bool doRematerialization() {return true;}
 
    void dumpDataSnippets(TR::FILE *outFile);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -220,7 +220,7 @@ generateLoad32BitConstant(TR::CodeGenerator* cg, TR::Node* node, int32_t value, 
    TR::Symbol *sym = NULL;
    if (node->getOpCode().hasSymbolReference())
       sym = node->getSymbol();
-   bool needRegPair = cg->evaluateNodeInRegPair(node) || !(TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit());
+   bool needRegPair = !(TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit());
    bool load64bit = !needRegPair &&
                     (node->getType().isInt64() || node->isExtendedTo64BitAtSource());
 
@@ -4971,7 +4971,7 @@ genericLoadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference *
    TR::RegisterDependencyConditions * flogrDeps;
    TR::Instruction * cursor;
    TR::Register * targetRegister = srcRegister;
-   const bool useRegPairs = (numberOfExtendBits==64 && TR::Compiler->target.is32Bit() && !cg->use64BitRegsOn32Bit()) || cg->evaluateNodeInRegPair(node);
+   const bool useRegPairs = numberOfExtendBits==64 && TR::Compiler->target.is32Bit() && !cg->use64BitRegsOn32Bit();
    const bool canClobberSrcReg = form==RegReg && couldIgnoreExtend_OR_canClobberSrcReg;
 
    // Compile-time constant-folding variable
@@ -5609,9 +5609,9 @@ bool relativeLongLoadHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Registe
 
       TR_ASSERT(op != TR::InstOpCode::BAD, "Bad opcode selection in relative load helper!\n");
 
-      if ( (!disableFORCELRL || cg->canUseRelativeLongInstructions(staticAddress)) &&
-           ( (TR::Compiler->target.is32Bit() && (staticAddress&0x3) == 0)  ||
-             ( TR::Compiler->target.is64Bit() && (staticAddress&0x7) == 0)
+      if ((!disableFORCELRL || cg->canUseRelativeLongInstructions(staticAddress)) &&
+           ((TR::Compiler->target.is32Bit() && (staticAddress&0x3) == 0)  ||
+             (TR::Compiler->target.is64Bit() && (staticAddress&0x7) == 0)
            )
          )
          {
@@ -5732,7 +5732,7 @@ lloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * highM
    {
    TR::Compilation *comp = cg->comp();
    //TR_ASSERTC( !isReversed,comp, "need to write logic for reverse load still");
-   TR_ASSERT(TR::Compiler->target.is32Bit() || cg->evaluateNodeInRegPair(node), "should call 64-bit version: lloadHelper64()!\n");
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "should call 64-bit version: lloadHelper64()!\n");
    TR::RegisterPair       * longRegister = cg->allocateConsecutiveRegisterPair();
    // Force Memref to get a new reg.  Re-using the pair screws it up.
    node->setRegister(NULL);
@@ -5795,9 +5795,7 @@ lloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * highM
       else
          longRegister = (TR::RegisterPair *)genericLoad<64>(node, cg, highMR, longRegister);
       }
-   //IvanB
-   //if (!cg->evaluateNodeInRegPair(node))
-      node->setRegister(longRegister);
+   node->setRegister(longRegister);
    highMR->stopUsingMemRefRegister(cg);
    return longRegister;
    }
@@ -5806,7 +5804,7 @@ TR::Register *
 lloadHelper64(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * highMR, bool isReversed)
    {
    //TR_ASSERTC(!isReversed, cg->comp(), "need to write logic for reverse load still");
-   TR_ASSERT( TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit(), "should call 32-bit version: lloadHelper()");
+   TR_ASSERT(TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit(), "should call 32-bit version: lloadHelper()");
 
 
    TR::Register * longRegister = cg->allocate64bitRegister();
@@ -6185,8 +6183,8 @@ bool relativeLongStoreHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Node *
 
       TR::Register * sourceRegister = cg->evaluate(valueChild);
 
-      if ( (TR::Compiler->target.is32Bit() && (staticAddress&0x3) == 0)  ||
-           ( TR::Compiler->target.is64Bit() && (staticAddress&0x7) == 0)
+      if ((TR::Compiler->target.is32Bit() && (staticAddress&0x3) == 0)  ||
+           (TR::Compiler->target.is64Bit() && (staticAddress&0x7) == 0)
          )
          {
          generateRILInstruction(cg, op, node, sourceRegister, symRef, reinterpret_cast<void*>(staticAddress));
@@ -6733,7 +6731,7 @@ istoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
 TR::MemoryReference *
 lstoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
    {
-   TR_ASSERT( TR::Compiler->target.is32Bit(), "must call 64bit version: lstoreHelper64(...)");
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "must call 64bit version: lstoreHelper64(...)");
 
    if (directMemoryStoreHelper(cg, node))
       {
@@ -6812,7 +6810,7 @@ lstoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
 TR::MemoryReference *
 lstoreHelper64(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
    {
-   TR_ASSERT( TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit(), "must call 32bit version -- lstoreHelper(...)");
+   TR_ASSERT(TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit(), "must call 32bit version -- lstoreHelper(...)");
    TR::Node * valueChild;
    TR::Node * addrChild = NULL;
 
@@ -7363,8 +7361,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("lload", node, cg);
-   if (!cg->evaluateNodeInRegPair(node) &&
-      (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit()))
+   if (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit())
       {
       return lloadHelper64(node, cg, NULL);
       }

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -77,7 +77,7 @@ extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
 TR::Register *
 lconstHelper(TR::Node * node, TR::CodeGenerator * cg)
    {
-   TR_ASSERT( TR::Compiler->target.is32Bit() || cg->evaluateNodeInRegPair(node), "lconstHelper() is for 32bit only!");
+   TR_ASSERT(TR::Compiler->target.is32Bit(), "lconstHelper() is for 32bit only!");
    TR::Register * lowRegister = cg->allocateRegister();
    TR::Register * highRegister = cg->allocateRegister();
 
@@ -154,7 +154,7 @@ OMR::Z::TreeEvaluator::lconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("lconst", node, cg);
    TR::Register * longRegister;
-   if ((TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit()) && !cg->evaluateNodeInRegPair(node))
+   if (TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit())
       {
       return lconstHelper64(node, cg);
       }


### PR DESCRIPTION
Remove evaluateNodeInRegPair and fold as it returns false.

Closes: #2060 

Signed-off-by: Shivam Mittal <shivammittal99@gmail.com>