### PR TITLE
Remove unused debug functions for ARM

### DIFF
--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -24,7 +24,6 @@ int jitDebugARM;
 #else
 
 #include "arm/codegen/ARMInstruction.hpp"
-#include "arm/codegen/ARMDisassem.hpp"
 #ifdef J9_PROJECT_SPECIFIC
 #include "arm/codegen/ARMRecompilationSnippet.hpp"
 #endif
@@ -1535,21 +1534,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMRecompilationSnippet * snippet)
    // startPC
    printPrefix(pOutFile, NULL, cursor, 4);
    trfprintf(pOutFile, "dd \t0x%08x\t\t; startPC ", _cg->getCodeStart());
-#endif
-   }
-
-void
-TR_Debug::printARM(TR::FILE *pOutFile, uint8_t* instrStart, uint8_t* instrEnd)
-   {
-#ifdef J9_PROJECT_SPECIFIC
-   char opcodeBuf[MIN_mbuffer];
-   char opBuf[MIN_ibuffer];
-
-   for ( ; instrStart < instrEnd; instrStart += 4)
-      {
-      disassemble((int32_t*)instrStart, opcodeBuf, opBuf);
-      trfprintf(pOutFile, "0x%08x %08x        %-11s%s\n",instrStart,*(uint32_t*)instrStart,opcodeBuf,opBuf);
-      }
 #endif
    }
 

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -703,29 +703,6 @@ TR_Debug::printInstrDumpHeader(const char * title)
       }
    }
 
-#if defined(TR_TARGET_ARM)
-void
-TR_Debug::printAsmDumpHeader()
-   {
-   if (_file == NULL)
-      return;
-
-   int addressFieldWidth   = TR::Compiler->debug.hexAddressFieldWidthInChars();
-   int codeByteColumnWidth = TR::Compiler->debug.codeByteColumnWidth();
-
-   char* buff = (char *)_comp->trMemory()->allocateHeapMemory(addressFieldWidth);
-   memset(buff, '-', addressFieldWidth-2);
-   buff[addressFieldWidth-2] = '\0' ;
-
-   trfprintf(_file, "\n  +%s-------------------------------------- instruction address", buff);
-   trfprintf(_file, "\n  |%*s +----------------------------------------- binary representation", addressFieldWidth - 3, " ", addressFieldWidth - 1, " ");
-   trfprintf(_file, "\n  |%*s | %*s+----------------------------- opcode and operands", addressFieldWidth - 3, " ", codeByteColumnWidth + 4, " ");
-   trfprintf(_file, "\n  |%*s | %*s|\t\t\t\t    +------- additional information", addressFieldWidth - 3, " ", codeByteColumnWidth + 4, " ");
-   trfprintf(_file, "\n  |%*s | %*s|\t\t\t\t    |", addressFieldWidth - 3, " ", codeByteColumnWidth + 4, " ");
-   trfprintf(_file, "\n  V%*s V %*sV\t\t\t\t    V\n", addressFieldWidth - 3, " ", codeByteColumnWidth + 4, " ");
-   }
-#endif
-
 
 #define MAX_PREFIX_WIDTH 80
 
@@ -3418,16 +3395,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::RegisterMappedSymbol *localCursor, bool 
 void
 TR_Debug::print(TR::FILE *pOutFile, uint8_t* instrStart, uint8_t* instrEnd)
    {
-#if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM() && pOutFile != NULL)
-      {
-      trfprintf(pOutFile, "\nAssembly:\n");
-
-      printAsmDumpHeader();
-
-      printARM(pOutFile, instrStart, instrEnd);
-      }
-#endif
    }
 
 void

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -426,9 +426,6 @@ public:
    virtual void         printHeader();
    virtual void         printMethodHotness();
    virtual void         printInstrDumpHeader(const char * title);
-#if defined(TR_TARGET_ARM)
-   virtual void         printAsmDumpHeader();
-#endif
 
    virtual void         printByteCodeAnnotations();
    virtual void         printAnnotationInfoEntry(J9AnnotationInfo *,J9AnnotationInfoEntry *,int32_t);
@@ -977,7 +974,6 @@ public:
    void print(TR::FILE *, TR::ARMStackCheckFailureSnippet *);
    void print(TR::FILE *, TR::UnresolvedDataSnippet *);
    void print(TR::FILE *, TR::ARMRecompilationSnippet *);
-   void printARM(TR::FILE *, uint8_t *, uint8_t *);
 #endif
 #ifdef TR_TARGET_S390
    void printPrefix(TR::FILE *, TR::Instruction *);


### PR DESCRIPTION
This commit removes some debug functions for ARM that are no longer
used: printAsmDumpHeader() and printARM().

Signed-off-by: knn-k <konno@jp.ibm.com>