### PR TITLE
CMake: Remove superfluous call to make_compiler_target

### DIFF
--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -99,9 +99,6 @@ add_executable(compilertest
 )
 
 
-# Inherit the include path from the compiler component
-make_compiler_target(compilertest PRIVATE COMPILER testcompiler)
-
 # target_include_directories(compilertest PRIVATE
 # 	${PROJECT_SOURCE_DIR}/third_party/gtest-1.7.0/
 # 	${PROJECT_SOURCE_DIR}/third_party/gtest-1.7.0/include


### PR DESCRIPTION
testcompiler already exports the required include paths etc.
Since compilertest links against testcompiler it gets these for free

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>