### PR TITLE
Added 16 bit padding in HashtableInputData 

### DIFF
--- a/fvtest/algotest/algorithm_test_internal.h
+++ b/fvtest/algotest/algorithm_test_internal.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,6 +50,7 @@ typedef struct HashtableInputData {
 	uint32_t listToTreeThreshold;
 	BOOLEAN forceCollisions;
 	BOOLEAN collisionResistant;
+	uint16_t padding;
 } HashtableInputData;
 
 /* ---------------- avltest.c ---------------- */


### PR DESCRIPTION
Added a 16 bit padding variable in `struct HashtableInputData` in `algorithm_test_internal.h` to fill 32 byte alignment.
This fixes four (all) errors generated by `omralgotest` on valgrind when gtest tries to print `HashtableInputData` and supposedly using `sizeof()` for it. `sizeof()` returned 32 for struct, resulting in print operations using remaining  un-initialized 16 bits causing these errors. 

[Valgrind errors fixed](https://github.com/eclipse/omr/files/1668617/Algotest_logs.txt)

Signed-off-by: Varun Garg <varun.10@live.com>