### PR TITLE
Remove more VMThread reclamation logic from the x86 CodeGenerator

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1281,21 +1281,18 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
          }
 
       TR_BitVector remainingRegisters = availableRegisters;
-      if (!self()->comp()->cg()->getSupportsVMThreadGRA() || self()->comp()->getOption(TR_DisableLateEdgeSplitting))
+      TR_BitVector *spilledRegisters = self()->getGlobalRegisters(TR_vmThreadSpill, self()->comp()->getMethodSymbol()->getLinkageConvention());
+      if (spilledRegisters)
          {
-         TR_BitVector *spilledRegisters = self()->getGlobalRegisters(TR_vmThreadSpill, self()->comp()->getMethodSymbol()->getLinkageConvention());
-         if (spilledRegisters)
+         if (self()->traceSimulateTreeEvaluation())
             {
-            if (self()->traceSimulateTreeEvaluation())
-               {
-               TR_BitVector regsToPrint = remainingRegisters;
-               regsToPrint &= *spilledRegisters;
-               traceMsg(self()->comp(), "            vmThread register not enabled; rejected: ");
-               self()->getDebug()->print(self()->comp()->getOptions()->getLogFile(), &regsToPrint);
-               traceMsg(self()->comp(), "\n");
-               }
-            remainingRegisters -= *spilledRegisters;
+            TR_BitVector regsToPrint = remainingRegisters;
+            regsToPrint &= *spilledRegisters;
+            traceMsg(self()->comp(), "            vmThread register not enabled; rejected: ");
+            self()->getDebug()->print(self()->comp()->getOptions()->getLogFile(), &regsToPrint);
+            traceMsg(self()->comp(), "\n");
             }
+         remainingRegisters -= *spilledRegisters;
          }
 
       // 1. Simulate register pressure in each extended basic block.

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -977,7 +977,7 @@ OMR::CodeGenerator::canClobberNodesRegister(
 void
 OMR::CodeGenerator::setVMThreadRequired(bool v)
    {
-   if (self()->comp()->getOption(TR_DisableLateEdgeSplitting) && _liveRegisters[TR_GPR])
+   if (_liveRegisters[TR_GPR])
       {
       if (v)
          {
@@ -1159,7 +1159,7 @@ bool OMR::CodeGenerator::supportsNativeLongOperations() { return (TR::Compiler->
 void
 OMR::CodeGenerator::setVMThreadSpillInstruction(TR::Instruction *i)
    {
-   if (_vmThreadSpillInstr == NULL && self()->comp()->getOption(TR_DisableLateEdgeSplitting))
+   if (_vmThreadSpillInstr == NULL)
       {
       _vmThreadSpillInstr = i;
       }

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -923,8 +923,6 @@ int32_t OMR::Compilation::compile()
          {
          if (!TR::Compiler->target.cpu.isPower())
             TR::Options::getCmdLineOptions()->setOption(TR_DisableInternalPointers);
-         if (TR::Compiler->target.cpu.isX86())
-            TR::Options::getCmdLineOptions()->setOption(TR_DisableLateEdgeSplitting);  // TR_DisableLateEdgeSplitting only used on X86
          }
       self()->getOptions()->setOption(TR_DisablePartialInlining);
       }

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -392,7 +392,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableJProfilingThread",            "O\tdisable separate thread for JProfiling", SET_OPTION_BIT(TR_DisableJProfilerThread), "F", NOT_IN_SUBSET},
    {"disableKnownObjectTable",            "O\tdisable support for including heap object info in symbol references", SET_OPTION_BIT(TR_DisableKnownObjectTable), "F"},
    {"disableLastITableCache",             "C\tdisable using class lastITable cache for interface dispatches",  SET_OPTION_BIT(TR_DisableLastITableCache), "F"},
-   {"disableLateEdgeSplitting",           "C\tconservatively add regdeps for the vmthread on any edge that might need it",  SET_OPTION_BIT(TR_DisableLateEdgeSplitting), "F"},
    {"disableLeafRoutineDetection",        "O\tdisable lleaf routine detection on zlinux", SET_OPTION_BIT(TR_DisableLeafRoutineDetection), "F"},
    {"disableLinkageRegisterAllocation",   "O\tdon't turn parm loads into RegLoads in first basic block",  SET_OPTION_BIT(TR_DisableLinkageRegisterAllocation), "F"},
    {"disableLiveMonitorMetadata",         "O\tdisable the creation of live monitor metadata", SET_OPTION_BIT(TR_DisableLiveMonitorMetadata), "F"},
@@ -700,7 +699,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableLargeCodePages",              "C\tenable large code pages",  SET_OPTION_BIT(TR_EnableLargeCodePages), "F"},
    {"enableLastRetrialLogging",          "O\tenable fullTrace logging for last compilation attempt. Needs to have a log defined on the command line", SET_OPTION_BIT(TR_EnableLastCompilationRetrialLogging), "F"},
    {"enableLateCleanFolding",            "O\tfold pdclean flags into pdstore nodes right before codegen",  SET_OPTION_BIT(TR_EnableLateCleanFolding), "F"},
-   {"enableLateEdgeSplitting",           "C\trematerialize the vmthread at codegen time only on paths that need it",  RESET_OPTION_BIT(TR_DisableLateEdgeSplitting), "F"},
    {"enableLinkagePreserveStrategy2",              "O\tenable linkage strategy 2", SET_OPTION_BIT(TR_LinkagePreserveStrategy2), "F"},
    {"enableLocalVPSkipLowFreqBlock",     "O\tSkip processing of low frequency blocks in localVP", SET_OPTION_BIT(TR_EnableLocalVPSkipLowFreqBlock), "F" },
    {"enableLongRegAllocation",            "O\tenable allocation of 64-bit regs on 32-bit",      SET_OPTION_BIT(TR_Enable64BitRegsOn32Bit), "F"},
@@ -4615,7 +4613,6 @@ OMR::Options::TR_OptionStringToBit OMR::Options::_optionStringToBitMapping[] = {
 // Local RA named trace options
 { "deps", TR_TraceRADependencies },
 { "details", TR_TraceRADetails },
-{ "lateEdgeSplitting", TR_TraceRALateEdgeSplitting },
 { "preRA", TR_TraceRAPreAssignmentInstruction },
 { "spillTemps", TR_TraceRASpillTemps },
 { "states", TR_TraceRARegisterStates },

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -318,7 +318,7 @@ enum TR_CompilationOptions
    TR_DisableSSOpts                       = 0x00000080 + 7,
    TR_TraceObjectFileGeneration           = 0x00000100 + 7,
    TR_DisableDelayRelocationForAOTCompilations   = 0x00000200 + 7,
-   TR_DisableLateEdgeSplitting            = 0x00000400 + 7,
+   // Available                           = 0x00000400 + 7,
    TR_DisableLoopReplicatorColdSideEntryCheck = 0x00000800 + 7,
    TR_TraceVFPSubstitution                = 0x00001000 + 7,
    TR_DontDowgradeToColdDuringGracePeriod = 0x00002000 + 7,
@@ -1044,7 +1044,7 @@ enum TR_CompilationOptions
    TR_TraceRAPreAssignmentInstruction   = 0x00000008,
    TR_TraceRARegisterStates             = 0x00000010,
    TR_TraceRASpillTemps                 = 0x00000020,
-   TR_TraceRALateEdgeSplitting          = 0x00000040,
+   // Available                         = 0x00000040,
    TR_TraceRAListing                    = 0x00000200,
 
    // Instruction Level GRA tracing option word

--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -432,10 +432,6 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
    uint32_t                           numAdditionalRegDeps = 5;
    List<TR::Register>                 popRegisters(cg()->trMemory());
 
-   bool needVMThreadDep =
-      comp->getOption(TR_DisableLateEdgeSplitting) ||
-      !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", root->getOpCode().getName(), cg()->getDebug()->getName(root));
-
    if (getCmpReg1Mem2())
       {
       lowMR  = generateX86MemoryReference(secondChild, cg());
@@ -464,12 +460,6 @@ void TR_X86CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node       *
    else
       {
       deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)numAdditionalRegDeps, cg());
-      }
-
-   if (deps && needVMThreadDep && cg()->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-      {
-      deps->addPostCondition(cg()->getVMThreadRegister(),
-                             (TR::RealRegister::RegNum)cg()->getVMThreadRegister()->getAssociation(), cg());
       }
 
    startLabel->setStartInternalControlFlow();
@@ -796,10 +786,6 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
    uint32_t                           numAdditionalRegDeps = 5;
    List<TR::Register>                 popRegisters(cg()->trMemory());
 
-   bool needVMThreadDep =
-      comp->getOption(TR_DisableLateEdgeSplitting) ||
-      !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", root->getOpCode().getName(), cg()->getDebug()->getName(root));
-
    if (getCmpReg1Mem2())
       {
       lowMR  = generateX86MemoryReference(secondChild, cg());
@@ -839,12 +825,6 @@ void TR_X86CompareAnalyser::longEqualityCompareAndBranchAnalyser(TR::Node       
          }
 
       deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)numAdditionalRegDeps, cg());
-      }
-
-   if (deps && needVMThreadDep && cg()->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-      {
-      deps->addPostCondition(cg()->getVMThreadRegister(),
-                             (TR::RealRegister::RegNum)cg()->getVMThreadRegister()->getAssociation(), cg());
       }
 
    generateLabelInstruction(LABEL, root, startLabel, cg());
@@ -1093,16 +1073,6 @@ TR::Register *TR_X86CompareAnalyser::longOrderedBooleanAnalyser(TR::Node       *
    TR::MemoryReference  *lowMR = NULL;
    TR::MemoryReference  *highMR;
 
-   bool needVMThreadDep =
-      comp->getOption(TR_DisableLateEdgeSplitting) ||
-      !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", root->getOpCode().getName(), cg()->getDebug()->getName(root));
-
-   if (deps && needVMThreadDep && cg()->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-      {
-      deps->addPostCondition(cg()->getVMThreadRegister(),
-                             (TR::RealRegister::RegNum)cg()->getVMThreadRegister()->getAssociation(), cg());
-      }
-
    startLabel->setStartInternalControlFlow();
    doneLabel->setEndInternalControlFlow();
    generateLabelInstruction(LABEL, root, startLabel, cg());
@@ -1214,16 +1184,6 @@ TR::Register *TR_X86CompareAnalyser::longCMPAnalyser(TR::Node *root)
    TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, 6, cg());
    TR::MemoryReference  *lowMR = NULL;
    TR::MemoryReference  *highMR;
-
-   bool needVMThreadDep =
-      comp->getOption(TR_DisableLateEdgeSplitting) ||
-      !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", root->getOpCode().getName(), cg()->getDebug()->getName(root));
-
-   if (deps && needVMThreadDep && cg()->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-      {
-      deps->addPostCondition(cg()->getVMThreadRegister(),
-                             (TR::RealRegister::RegNum)cg()->getVMThreadRegister()->getAssociation(), cg());
-      }
 
    startLabel->setStartInternalControlFlow();
    doneLabel->setEndInternalControlFlow();

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3546,8 +3546,6 @@ void OMR::X86::CodeGenerator::clearDeferredSplits()
    {
    if (_internalControlFlowNestingDepth == 0)
       {
-      if (self()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-         traceMsg(self()->comp(), "LATE EDGE SPLITTING: clearDeferredSplits\n");
       _deferredSplits.clear();
       }
    else
@@ -3559,17 +3557,9 @@ void OMR::X86::CodeGenerator::clearDeferredSplits()
 
 void OMR::X86::CodeGenerator::performDeferredSplits()
    {
-   if (self()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-      traceMsg(self()->comp(), "LATE EDGE SPLITTING: performDeferredSplits\n");
-
    for (auto li = _deferredSplits.begin(); li != _deferredSplits.end(); ++li)
       {
       TR::LabelSymbol *newLabelSymbol = self()->splitLabel((*li)->getLabelSymbol());
-      if (self()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-         traceMsg(self()->comp(), "LATE EDGE SPLITTING: Pointed branch %s at vmThread-restoring label %s\n",
-                  self()->getDebug()->getName(*li),
-                  self()->getDebug()->getName(newLabelSymbol));
-
       (*li)->setLabelSymbol(newLabelSymbol);
       }
 
@@ -3619,10 +3609,6 @@ TR::LabelSymbol *OMR::X86::CodeGenerator::splitLabel(TR::LabelSymbol *targetLabe
       targetLabel->setVMThreadRestoringLabel(newLabel);
       newLabel->setInstruction(generateLabelInstruction(targetLabel->getInstruction()->getPrev(), LABEL, newLabel, self()));
       self()->generateDebugCounter(targetLabel->getInstruction(), "cg.lateSplitEdges", 1, TR::DebugCounter::Exorbitant);
-      if (self()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-         traceMsg(self()->comp(), "LATE EDGE SPLITTING: Inserted vmThread-restoring label %s before %s\n",
-            self()->getDebug()->getName(newLabel),
-            self()->getDebug()->getName(targetLabel));
       }
 
    // Conservatively store ebp in the prologue just in case any of these split labels decide they need to load it
@@ -3640,8 +3626,6 @@ TR::LabelSymbol *OMR::X86::CodeGenerator::splitLabel(TR::LabelSymbol *targetLabe
    // Set spill instruction to the "spill in prolog" value.
    //
    self()->setVMThreadSpillInstruction((TR::Instruction *)0xffffffff);
-   if (self()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-      traceMsg(self()->comp(), "LATE EDGE SPLITTING: Store ebp in prologue\n");
 
    return targetLabel->getVMThreadRestoringLabel();
    }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1501,22 +1501,6 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       {
       TR::Instruction  *inst = instructionCursor;
 
-      // Detect BBEnd end of a non-extended block or the last BBEnd end of an extended block
-      if (comp->cg()->getSupportsVMThreadGRA() && inst->getKind() == TR::Instruction::IsLabel && vmThreadIndex != TR::RealRegister::NoReg)
-         {
-         TR::Node *node = inst->getNode();
-         if (node && node->getOpCodeValue() == TR::BBEnd)
-            {
-            TR::Block *block = node->getBlock();
-            if (block && (!block->getNextBlock() || !block->getNextBlock()->isExtensionOfPreviousBlock()))
-               { // Reset vmThread register state.
-               TR::RealRegister *vmThreadRealReg = self()->machine()->getX86RealRegister(TR::RealRegister::ebp);
-               self()->getVMThreadRegister()->setAssignedRegister(NULL);
-               vmThreadRealReg->setAssignedRegister(NULL);
-               vmThreadRealReg->setState(TR::RealRegister::Free);
-               }
-            }
-         }
 #ifdef DEBUG
       if (dumpPreGP)
          {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -580,18 +580,10 @@ OMR::X86::CodeGenerator::beginInstructionSelection()
          _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, DDImm4, 0, self());
       }
 
-   TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)1, self());
-   if (_linkageProperties->getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-      {
-      deps->addPostCondition(self()->getVMThreadRegister(),
-                             (TR::RealRegister::RegNum)self()->getVMThreadRegister()->getAssociation(), self());
-      }
-   deps->stopAddingPostConditions();
-
    if (self()->getAppendInstruction())
-      generateInstruction(PROCENTRY, startNode, deps, self());
+      generateInstruction(PROCENTRY, startNode, self());
    else
-      new (self()->trHeapMemory()) TR::Instruction(deps, PROCENTRY, (TR::Instruction *)NULL, self());
+      new (self()->trHeapMemory()) TR::Instruction(PROCENTRY, (TR::Instruction *)NULL, self());
 
    // Set the default FPCW to single precision mode if we are allowed to.
    //
@@ -1491,8 +1483,6 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
          self()->setSpilledRegisterList(new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator())));
          }
       }
-
-   TR::RealRegister::RegNum vmThreadIndex = _linkageProperties->getMethodMetaDataRegister();
 
    if (self()->getDebug())
       self()->getDebug()->startTracingRegisterAssignment("backward", kindsToAssign);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4042,26 +4042,10 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
          generateAlignmentInstruction(node, 16, cg); // TODO: Derive alignment from CPU cache information
          }
 
-      if (comp->getOption(TR_DisableLateEdgeSplitting))
-         {
-         // Check the cfg edge for the mustRestoreVMThreadRegister attribute. If markked then
-         // there can be only one incoming edge.
-         TR::CFGEdge *edge = (!block->getPredecessors().empty()) ? block->getPredecessors().front() : NULL;
-         if (node->getNumChildren() > 0)
-            inst = generateLabelInstruction(LABEL, node, label, node->getFirstChild(), &popRegisters, true, cg);
-         else
-            inst = generateLabelInstruction(LABEL, node, node->getLabel(), true, cg);
-         }
+      if (node->getNumChildren() > 0)
+         inst = generateLabelInstruction(LABEL, node, label, node->getFirstChild(), &popRegisters, true, cg);
       else
-         {
-         bool needVMThreadDep =
-            !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n",
-                                     node->getOpCode().getName(), cg->getDebug()->getName(node));
-         if (node->getNumChildren() > 0)
-            inst = generateLabelInstruction(LABEL, node, label, node->getFirstChild(), &popRegisters, needVMThreadDep, cg);
-         else
-            inst = generateLabelInstruction(LABEL, node, node->getLabel(), needVMThreadDep, cg);
-         }
+         inst = generateLabelInstruction(LABEL, node, node->getLabel(), true, cg);
 
       if (inst->getDependencyConditions())
          inst->getDependencyConditions()->setMayNeedToPopFPRegisters(true);
@@ -4144,9 +4128,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGe
          machine->createRegisterAssociationDirective(cg->getAppendInstruction());
          }
 
-      bool needVMThreadDep =
-         comp->getOption(TR_DisableLateEdgeSplitting) ||
-         !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", node->getOpCode().getName(), cg->getDebug()->getName(node));
+      bool needVMThreadDep = true;
 
       // This label is also used by RegisterDependency to detect the end of a block.
       TR::Instruction *labelInst = NULL;

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4047,32 +4047,10 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
          // Check the cfg edge for the mustRestoreVMThreadRegister attribute. If markked then
          // there can be only one incoming edge.
          TR::CFGEdge *edge = (!block->getPredecessors().empty()) ? block->getPredecessors().front() : NULL;
-         if (cg->getSupportsVMThreadGRA() &&
-             edge && edge->mustRestoreVMThreadRegister())
-            {
-            // Add a dummy register dependency on ebp to force a vmThread reload.
-            TR::RegisterDependencyConditions  *glRegDeps;
-            if (node->getNumChildren() > 0)
-               {
-               cg->evaluate(node->getFirstChild());
-               glRegDeps = generateRegisterDependencyConditions(node->getFirstChild(), cg, 1, &popRegisters);
-               }
-            else
-               glRegDeps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)1, cg);
-
-            TR::Register *dummyReg = cg->allocateRegister();
-            glRegDeps->addPostCondition(dummyReg, TR::RealRegister::ebp, cg);
-            glRegDeps->stopAddingConditions();
-            inst = new (cg->trHeapMemory()) TR::X86LabelInstruction(LABEL, node, label, glRegDeps, cg);
-            cg->stopUsingRegister(dummyReg);
-            }
+         if (node->getNumChildren() > 0)
+            inst = generateLabelInstruction(LABEL, node, label, node->getFirstChild(), &popRegisters, true, cg);
          else
-            {
-            if (node->getNumChildren() > 0)
-               inst = generateLabelInstruction(LABEL, node, label, node->getFirstChild(), &popRegisters, true, cg);
-            else
-               inst = generateLabelInstruction(LABEL, node, node->getLabel(), true, cg);
-            }
+            inst = generateLabelInstruction(LABEL, node, node->getLabel(), true, cg);
          }
       else
          {
@@ -4875,11 +4853,11 @@ OMR::X86::TreeEvaluator::bitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *
    // Zero result reg
    TR::Register *resultReg = cg->allocateRegister(TR_GPR);
    generateRegRegInstruction(XORRegReg(nodeIs64Bit), node, resultReg, resultReg, cg);
-   
+
    if (length->getOpCode().isLoadConst())
       {
       // Manage the constant length case
-      uintptrj_t arrayLen = TR::TreeEvaluator::integerConstNodeValue(length, cg); 
+      uintptrj_t arrayLen = TR::TreeEvaluator::integerConstNodeValue(length, cg);
       for (uintptrj_t x = 0; x < arrayLen; ++x)
          {
          // Zero tmpReg if SET won't do it

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -403,88 +403,6 @@ void TR::X86LabelInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned
          if (cg()->enableBetterSpillPlacements())
             cg()->saveBetterSpillPlacements(this);
          }
-
-      if (!comp->getOption(TR_DisableLateEdgeSplitting) && cg()->getProperties().getMethodMetaDataRegister())
-         {
-         // If we find a branch instruction that doesn't have vmthread in ebp,
-         // jumping to a label that needs vmthread in ebp, then we need to insert
-         // an ebp load.  We want to insert it just before the target label, and
-         // change the offending branch so it jumps to the load instead.  We're
-         // effectively splitting the edge, with branches needing an ebp load
-         // jumping to the load instructions, and other branches jumping to the
-         // original label.
-         //
-         // This logic has three parts:
-         // 1. Identify block exits where the vmthread is not in ebp.  At that point,
-         // we'll split the edge and add a second label.
-         // 2. Identify labels where the vmthread must be in ebp.  Mark such labels
-         // with IsVMThreadLive.
-         // 3. (After register assignment, during size estimation.)  Find labels that
-         // have been split AND have IsVMThreadLive.  Insert an ebp load between the labels.
-
-         TR::RealRegister    *ebp = cg()->machine()->getX86RealRegister(cg()->getProperties().getMethodMetaDataRegister());
-         bool ebpIsVMThreadRegister = ebp->getAssignedRegister() == cg()->getVMThreadRegister();
-         bool ebpIsUnknown          = ebp->getAssignedRegister() == NULL;
-
-         if (getOpCodeValue() == LABEL && ebpIsVMThreadRegister)
-            {
-            // (This is step 2.)
-            //
-            _symbol->setVMThreadLive();
-            }
-         else if (getNode()->getOpCodeValue() == TR::BBStart && !getNode()->getBlock()->isExtensionOfPreviousBlock() && cg()->hasDeferredSplits())
-            {
-            // If we got to the top of the block without assigning ebp to
-            // anything, we have a choice.  We can either mark this label with
-            // setVMThreadLive(), making all the deferred splits unnecessary;
-            // or we can perform the splits.  The former has a decent chance of
-            // keeping ebp loads out of loops, so we do that.
-            //
-            if (cg()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-               traceMsg(comp, "O^O LATE EDGE SPLITTING: BBStart label %s needs vmthread in ebp because of deferred splits\n",
-                  cg()->getDebug()->getName(this));
-
-            _symbol->setVMThreadLive();
-            cg()->clearDeferredSplits();
-            }
-         else if (!ebpIsVMThreadRegister)
-            {
-            // (This is step 1.)
-            //
-            if (getNode()->getOpCodeValue() == TR::BBEnd)
-               {
-               // Check for a BBEnd that falls through to a different extended block
-               //
-               // Note that this logic doesn't *prove* that the BBEnd falls
-               // through -- there could be an unconditional branch (goto, table,
-               // or lookup) with the next block as a successor -- but then
-               // unnecessarily splitting this edge will, at worst, cause us to
-               // insert a useless vmthread rematerialization that is never
-               // executed.
-               //
-               TR::Block *nextBlock = getNode()->getBlock()->getNextBlock();
-               if (nextBlock && getNode()->getBlock()->hasSuccessor(nextBlock) && !nextBlock->isExtensionOfPreviousBlock())
-                  {
-                  cg()->splitLabel(nextBlock->getEntry()->getNode()->getLabel());
-                  }
-               }
-            else if (getOpCode().isBranchOp())
-               {
-               // Not split when _symbol is Outline instruction's entry label
-               if (_symbol->getInstruction() && !cg()->findOutlinedInstructionsFromLabel(_symbol))
-                  {
-                  TR::LabelSymbol *newLabelSymbol = cg()->splitLabel(_symbol, this);
-
-                  if (cg()->getTraceRAOption(TR_TraceRALateEdgeSplitting) && newLabelSymbol != _symbol)
-                     traceMsg(comp, "O^O LATE EDGE SPLITTING: Pointed branch %s at vmThread-restoring label %s\n",
-                        cg()->getDebug()->getName(this),
-                        cg()->getDebug()->getName(newLabelSymbol));
-
-                  _symbol = newLabelSymbol;
-                  }
-               }
-            }
-         }
       }
    else
       {
@@ -1920,11 +1838,6 @@ void TR::X86MemTableInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssig
             if (targetLabel->getInstruction())
                {
                relocation->setLabel(cg()->splitLabel(targetLabel));
-               if (cg()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-                  traceMsg(cg()->comp(), "O^O LATE EDGE SPLITTING: Pointed jump table entry %d of %s at vmThread-restoring label %s\n",
-                     i,
-                     cg()->getDebug()->getName(this),
-                     cg()->getDebug()->getName(relocation->getLabel()));
                }
             }
          }

--- a/compiler/x/codegen/OutlinedInstructions.cpp
+++ b/compiler/x/codegen/OutlinedInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -174,23 +174,11 @@ void TR_OutlinedInstructions::generateOutlinedInstructionsDispatch()
 
    new (_cg->trHeapMemory()) TR::X86LabelInstruction(NULL, LABEL, _entryLabel, _cg);
 
-   if (_rematerializeVMThread)
-      {
-      generateRegInstruction(PUSHReg, _callNode, vmThreadReg, _cg);
-      generateRestoreVMThreadInstruction ( _callNode, _cg);
-      TR::MemoryReference  *vmThreadMR = generateX86MemoryReference(vmThreadReg, (TR::Compiler->target.is64Bit()) ? 16 : 8, _cg);
-      generateRegMemInstruction (LRegMem(), _callNode, vmThreadReg, vmThreadMR, _cg);
-      }
    TR::Register *resultReg=NULL;
    if (_callNode->getOpCode().isCallIndirect())
       resultReg = TR::TreeEvaluator::performCall(_callNode, true, false, _cg);
    else
       resultReg = TR::TreeEvaluator::performCall(_callNode, false, false, _cg);
-
-   if (_rematerializeVMThread)
-      {
-      generateRegInstruction(POPReg, _callNode, vmThreadReg, _cg);
-      }
 
    if (_targetReg)
       {

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -631,40 +631,6 @@ int32_t TR::X86LabelInstruction::estimateBinaryLength(int32_t currentEstimate)
       }
    else if (getOpCodeValue() == LABEL)
       {
-      if (!comp->getOption(TR_DisableLateEdgeSplitting) && _symbol->getVMThreadRestoringLabel() && _symbol->isVMThreadLive())
-         {
-         // If this label is the second of a split pair, and vmThread is live at this label,
-         // then we need a load of the vmThread immediately before this label.
-         // Generate it, and include its size estimate.
-         //
-         TR::Register         *vmThreadVirtualReg = cg()->getVMThreadRegister();
-         TR::RealRegister     *vmThreadRealReg    = cg()->machine()->getX86RealRegister(cg()->getProperties().getMethodMetaDataRegister());
-         if (vmThreadRealReg->getHasBeenAssignedInMethod() || !performTransformation(comp, "O^O LATE EDGE SPLITTING: Skip vmThread reload at %p because ebp was never assigned\n", this)) // TODO: could we use getModified instead?
-            {
-            if (vmThreadVirtualReg->getBackingStorage() == NULL)
-               {
-               // copied from RegisterDependency.cpp
-               vmThreadVirtualReg->setBackingStorage(cg()->allocateVMThreadSpill());
-               cg()->getSpilledIntRegisters().push_front(vmThreadVirtualReg);
-               }
-            // Set spill instruction to the "spill in prolog" value.
-            cg()->setVMThreadSpillInstruction((TR::Instruction *)0xffffffff);
-            if (cg()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-               traceMsg(comp, "LATE EDGE SPLITTING: Store ebp in prologue\n");
-
-            TR::Instruction *ebpLoad = generateRegMemInstruction(getPrev(), LRegMem(), vmThreadRealReg,
-                                                                  generateX86MemoryReference(vmThreadVirtualReg->getBackingStorage()->getSymbolReference(), cg()), cg());
-            currentEstimate = ebpLoad->estimateBinaryLength(currentEstimate);
-            if (cg()->getTraceRAOption(TR_TraceRALateEdgeSplitting))
-               traceMsg(comp, "LATE EDGE SPLITTING: Added vmThread rematerialization %s before label %s\n",
-                  cg()->getDebug()->getName(ebpLoad),
-                  cg()->getDebug()->getName(_symbol));
-
-            TR::Instruction *bump = cg()->generateDebugCounter(ebpLoad, "cg.lateSplitEdges:reloaded", 1, TR::DebugCounter::Expensive);
-            if (bump != ebpLoad)
-               currentEstimate = bump->estimateBinaryLength(currentEstimate);
-            }
-         }
       getLabelSymbol()->setEstimatedCodeLocation(currentEstimate);
       }
    else // assume absolute code reference
@@ -953,7 +919,7 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                   __FILE__, __LINE__, getNode());
                break;
             case TR_MethodPointer:
-               if (getNode() && getNode()->getInlinedSiteIndex() == -1 && 
+               if (getNode() && getNode()->getInlinedSiteIndex() == -1 &&
                   (void *)(uintptr_t) getSourceImmediate() == cg()->comp()->getCurrentMethod()->resolvedMethodAddress())
                   setReloKind(TR_RamMethod);
                // intentional fall-through
@@ -964,8 +930,8 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                                                                            (uint8_t*)getNode(),
                                                                            (TR_ExternalRelocationTargetKind) _reloKind,
                                                                            cg()),
-                  __FILE__, 
-                  __LINE__, 
+                  __FILE__,
+                  __LINE__,
                   getNode());
                   break;
             default:

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -91,21 +91,6 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
       self()->setSupportsDivCheck();
       self()->setJNILinkageCalleeCleanup();
 
-      // The non-linear register assigner doesn't know about EBP spills yet.
-      //
-      static char *disableEBPasGPR = feGetEnv("TR_DisableEBPasGPR");
-      if (!disableEBPasGPR && self()->allowVMThreadRematerialization() && !self()->comp()->requiresSpineChecks()
-          //when OSR is enabled, we don't want to generate any code in the osr code block or the osr catch block
-          //that causes ebp to be restored (because it was saved at some other jitted code).
-          //if we don't, when we jump to the osr catch block, we trash ebp by that restore
-          && !self()->comp()->getOption(TR_EnableOSR)
-         )
-         {
-         TR::RealRegister *ebp = self()->machine()->getX86RealRegister(TR::RealRegister::ebp);
-         ebp->resetState(TR::RealRegister::Free);
-         ebp->setAssignedRegister(NULL);
-         }
-
       // The default CTM behaviour is to do the conversion via X87 instructions.
       //
       static char *dontUseGPRsForWin32CTMConversion = feGetEnv("TR_DontUseGPRsForWin32CTMConversion");

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -214,10 +214,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
       TR::LabelSymbol *destinationLabel = node->getBranchDestination()->getNode()->getLabel();
       List<TR::Register> popRegisters(cg->trMemory());
 
-      bool needVMThreadDep =
-         comp->getOption(TR_DisableLateEdgeSplitting) ||
-         !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", node->getOpCode().getName(), cg->getDebug()->getName(node));
-
       startLabel->setStartInternalControlFlow();
       doneLabel->setEndInternalControlFlow();
       generateLabelInstruction(LABEL, node, startLabel, cg);
@@ -229,14 +225,9 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
          {
          TR::Node *third = node->getChild(2);
          cg->evaluate(third);
-         deps = generateRegisterDependencyConditions(third, cg, 3, &popRegisters);
+         deps = generateRegisterDependencyConditions(third, cg, 2, &popRegisters);
          deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
          deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
-         if (needVMThreadDep && cg->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-            {
-            deps->addPostCondition(cg->getVMThreadRegister(),
-                                   (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
-            }
          deps->stopAddingConditions();
 
          cg->setVMThreadRequired(true);
@@ -252,14 +243,9 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
          generateLabelInstruction(JNE4, node, doneLabel, cg);
          compareGPRegisterToImmediate(node, cmpRegister->getLowOrder(), lowValue, cg);
          generateLabelInstruction(lowOrderBranchOp, node, destinationLabel, cg);
-         deps = generateRegisterDependencyConditions((uint8_t)0, 3, cg);
+         deps = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
          deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
          deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
-         if (needVMThreadDep && cg->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-            {
-            deps->addPostCondition(cg->getVMThreadRegister(),
-                                   (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
-            }
          deps->stopAddingConditions();
          }
 
@@ -616,23 +602,14 @@ TR::Register *OMR::X86::I386::TreeEvaluator::integerPairReturnEvaluator(TR::Node
    TR::RealRegister::RegNum machineHighReturnRegister =
       linkageProperties.getLongHighReturnRegister();
 
-   TR::RegisterDependencyConditions  *dependencies;
+   TR::RegisterDependencyConditions *dependencies = NULL;
    if (machineLowReturnRegister != TR::RealRegister::NoReg)
       {
       dependencies = generateRegisterDependencyConditions((uint8_t)3, 0, cg);
       dependencies->addPreCondition(lowRegister, machineLowReturnRegister, cg);
       dependencies->addPreCondition(highRegister, machineHighReturnRegister, cg);
+      dependencies->stopAddingConditions();
       }
-   else
-      {
-      dependencies = generateRegisterDependencyConditions((uint8_t)1, 0, cg);
-      }
-
-   if (cg->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
-      {
-      dependencies->addPreCondition(cg->getVMThreadRegister(), (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
-      }
-   dependencies->stopAddingConditions();
 
    if (linkageProperties.getCallerCleanup())
       {
@@ -3429,10 +3406,8 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             {
             TR::Node *third = node->getChild(2);
             cg->evaluate(third);
-            deps = generateRegisterDependencyConditions(third, cg, 3, &popRegisters);
+            deps = generateRegisterDependencyConditions(third, cg, 2, &popRegisters);
             deps->setMayNeedToPopFPRegisters(true);
-            if (needVMThreadDep)
-               deps->addPostCondition(cg->getVMThreadRegister(), (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
             deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
             deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
             deps->stopAddingConditions();
@@ -3446,11 +3421,9 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             generateLabelInstruction(JNE4, node, doneLabel, needVMThreadDep, cg);
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);
             generateLabelInstruction(JE4, node, destinationLabel, needVMThreadDep, cg);
-            deps = generateRegisterDependencyConditions((uint8_t)0, needVMThreadDep?3:2, cg);
+            deps = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
             deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
             deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
-            if (needVMThreadDep)
-               deps->addPostCondition(cg->getVMThreadRegister(), (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
             }
 
          generateLabelInstruction(LABEL, node, doneLabel, deps, cg);
@@ -3572,8 +3545,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             cg->evaluate(third);
             deps = generateRegisterDependencyConditions(third, cg, 1, &popRegisters);
             deps->setMayNeedToPopFPRegisters(true);
-            if (needVMThreadDep)
-               deps->addPostCondition(cg->getVMThreadRegister(), (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
             deps->stopAddingConditions();
             generateLabelInstruction(JNE4, node, destinationLabel, deps, cg);
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -3322,9 +3322,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
       TR::Register                         *cmpRegister = NULL;
       TR::RegisterDependencyConditions  *deps        = NULL;
 
-      bool needVMThreadDep =
-         comp->getOption(TR_DisableLateEdgeSplitting) ||
-         !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", node->getOpCode().getName(), cg->getDebug()->getName(node));
+      bool needVMThreadDep = true;
 
       if ((lowValue | highValue) == 0)
          {
@@ -3467,9 +3465,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
       TR::Register                         *cmpRegister = NULL;
       TR::RegisterDependencyConditions  *deps        = NULL;
 
-      bool needVMThreadDep =
-         comp->getOption(TR_DisableLateEdgeSplitting) ||
-         !performTransformation(comp, "O^O LATE EDGE SPLITTING: Omit ebp dependency for %s node %s\n", node->getOpCode().getName(), cg->getDebug()->getName(node));
+      bool needVMThreadDep = true;
 
       if ((lowValue | highValue) == 0)
          {


### PR DESCRIPTION
* Disable late edge splitting
* Do not add VMThread pre/post conditions on x86
* Do not override initial register state of EBP on Win32
* Remove vmThread rematerialization logic from OutlinedInstructions
* Remove uses of getSupportsVMThreadGRA()

Issue: #2256