### PR TITLE
Remove currentThreadDebugEventData structures

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -112,8 +112,6 @@ OMR::SymbolReferenceTable::SymbolReferenceTable(size_t sizeHint, TR::Compilation
      _classStaticsSymbolRefs(comp->trMemory()),
      _classDLPStaticsSymbolRefs(comp->trMemory()),
      _debugCounterSymbolRefs(comp->trMemory()),
-     _currentThreadDebugEventDataSymbol(0),
-     _currentThreadDebugEventDataSymbolRefs(comp->trMemory()),
      _methodsBySignature(8, comp->allocator("SymRefTab")), // TODO: Determine a suitable default size
      _hasImmutable(false),
      _hasUserField(false),

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -471,8 +471,6 @@ class SymbolReferenceTable
    List<TR::SymbolReference>            _classStaticsSymbolRefs;
    List<TR::SymbolReference>            _classDLPStaticsSymbolRefs;
    List<TR::SymbolReference>            _debugCounterSymbolRefs;
-   TR::Symbol                           *_currentThreadDebugEventDataSymbol;
-   List<TR::SymbolReference>            _currentThreadDebugEventDataSymbolRefs;
 
    uint32_t                            _nextRegShadowIndex;
    int32_t                             _numUnresolvedSymbols;


### PR DESCRIPTION
To be relocated to OpenJ9

Closes: #2125 
OpenJ9 PR: eclipse/openj9#1039

Signed-off-by: Shivam Mittal <shivammittal99@gmail.com>