### PR TITLE
Fixed Valgrind errors in signal tests

### DIFF
--- a/fvtest/sigtest/main.cpp
+++ b/fvtest/sigtest/main.cpp
@@ -40,5 +40,6 @@ testMain(int argc, char **argv, char **envp)
 	omrTestEnv = (PortEnvironment *)testing::AddGlobalTestEnvironment(new PortEnvironment(argc, argv));
 	int result = RUN_ALL_TESTS();
 	DETACH_OMRTHREAD();
+	omrthread_shutdown_library();
 	return result;
 }

--- a/fvtest/sigtest/sigTest.cpp
+++ b/fvtest/sigtest/sigTest.cpp
@@ -506,6 +506,7 @@ setupExistingHandlerConditions(bool existingPrimary, bool existingSecondary, boo
 			stack.ss_flags = SS_DISABLE;
 			/* To compensate for OSX bug, this is needed to prevent ENOMEM error. */
 			stack.ss_size = SIGSTKSZ;
+			stack.ss_sp = NULL;
 		}
 		if (0 != sigaltstack(&stack, NULL)) {
 			rc = OMR_ERROR_INTERNAL;


### PR DESCRIPTION
Fixed valgrind errors in `omrsigtest` caused by

1. Skipping initializion of `stack.ss_sp` and passing `stack` to `sigaltstack(&stack, NULL)`.
2. Not freeing omrthread variables, that can be freed by calling `omrthread_shutdown_library();` at end of `testMain()`

May affect issue: #1792

[Valgrind errors fixed](https://github.com/eclipse/omr/files/1671039/sigTestOut.txt)

Signed-off-by: Varun Garg <varun.10@live.com>