### PR TITLE
Enable generation of ReferenceArrayCopy for ARM

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,6 +141,7 @@ OMR::ARM::CodeGenerator::CodeGenerator()
    self()->setSupportsScaledIndexAddressing();
    self()->setSupportsAlignedAccessOnly();
    self()->setSupportsPrimitiveArrayCopy();
+   self()->setSupportsReferenceArrayCopy();
    self()->setSupportsLoweringConstIDiv();
    self()->setSupportsNewInstanceImplOpt();
 


### PR DESCRIPTION
Call setSupportsReferenceArrayCopy() in the ARM JIT.
Write barrier for arraycopy was enabled for ARM by #2186.

Signed-off-by: knn-k <konno@jp.ibm.com>