### PR TITLE
Fix multiple issues with ddrgen

### DIFF
--- a/ddr/include/ddr/blobgen/genBlob.hpp
+++ b/ddr/include/ddr/blobgen/genBlob.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,22 +22,18 @@
 #ifndef GENBLOB_HPP
 #define GENBLOB_HPP
 
-#include "ddr/config.hpp"
-
 #include "ddr/std/string.hpp"
-#include <vector>
-
-#include "omrport.h"
 #include "ddr/error.hpp"
+#include "omrport.h"
 
 using std::string;
 
-class Symbol_IR;
-class Type;
+class ClassUDT;
 class EnumUDT;
 class NamespaceUDT;
+class Symbol_IR;
+class Type;
 class TypedefUDT;
-class ClassUDT;
 class UnionUDT;
 
 DDR_RC genBlob(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *supersetFile, const char *blobFile, bool printEmptyTypes);

--- a/ddr/include/ddr/blobgen/java/genBinaryBlob.hpp
+++ b/ddr/include/ddr/blobgen/java/genBinaryBlob.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,23 +22,18 @@
 #ifndef GENBINARYBLOB_HPP
 #define GENBINARYBLOB_HPP
 
+#include "ddr/blobgen/genBlob.hpp"
+
 #include "hashtable_api.h"
 #include "omrutil.h"
 #include "omrport.h"
 
-#include "ddr/ir/ClassUDT.hpp"
-#include "ddr/config.hpp"
-#include "ddr/ir/EnumMember.hpp"
-#include "ddr/ir/EnumUDT.hpp"
-#include "ddr/ir/Field.hpp"
-#include "ddr/ir/Macro.hpp"
-#include "ddr/ir/Symbol_IR.hpp"
-#include "ddr/ir/TypedefUDT.hpp"
-#include "ddr/ir/UnionUDT.hpp"
+class BlobBuildVisitor;
+class BlobEnumerateVisitor;
+class Field;
+class Symbol_IR;
 
-using std::pair;
-
-class JavaBlobGenerator: public BlobGenerator
+class JavaBlobGenerator : public BlobGenerator
 {
 private:
 	typedef struct BitField {
@@ -127,29 +122,24 @@ private:
 		DDR_RC initializeBitfieldFormat(uint8_t *bitfieldFormat);
 	};
 
-	static pair<string, unsigned long long> cLimits[];
-
 	BuildBlobInfo _buildInfo;
 	bool _printEmptyTypes;
 
 	void copyStringTable();
 	DDR_RC stringTableOffset(BlobHeader *blobHeader, J9HashTable *stringTable, const char *cString, uint32_t *offset);
-	DDR_RC enumerateCLimits();
-	DDR_RC addCLimits();
-	DDR_RC countStructsAndStrings(Symbol_IR *const ir);
+	DDR_RC countStructsAndStrings(Symbol_IR *ir);
 	DDR_RC addFieldAndConstCount(bool addStructureCount, size_t fieldCount, size_t constCount);
-	DDR_RC buildBlobData(OMRPortLibrary *portLibrary, Symbol_IR *const ir);
-	DDR_RC addBlobField(Field *f, uint32_t *fieldCount, uint32_t *constCount);
-	DDR_RC addBlobField(Field *f, uint32_t *fieldCount, uint32_t *constCount, string prefix);
-	DDR_RC addBlobConst(string name, long long value, uint32_t *constCount);
-	DDR_RC addBlobStruct(string name, string superName, uint32_t constCount, uint32_t fieldCount, uint32_t size);
-	DDR_RC formatFieldType(Field *f, string *fieldType);
+	DDR_RC buildBlobData(OMRPortLibrary *portLibrary, Symbol_IR *ir);
+	DDR_RC addBlobField(Field *field, uint32_t *fieldCount, const string &prefix);
+	DDR_RC addBlobConst(const string &name, long long value, uint32_t *constCount);
+	DDR_RC addBlobStruct(const string &name, const string &superName, uint32_t constCount, uint32_t fieldCount, uint32_t size);
+	DDR_RC formatFieldType(Field *field, string *fieldType);
 
 	friend class BlobBuildVisitor;
 	friend class BlobEnumerateVisitor;
 
 public:
-	JavaBlobGenerator(bool printEmptyTypes) : _printEmptyTypes(printEmptyTypes) {}
+	explicit JavaBlobGenerator(bool printEmptyTypes) : _printEmptyTypes(printEmptyTypes) {}
 	DDR_RC genBinaryBlob(struct OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *blobFile);
 };
 

--- a/ddr/include/ddr/blobgen/java/genSuperset.hpp
+++ b/ddr/include/ddr/blobgen/java/genSuperset.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,30 +22,27 @@
 #ifndef GENSUPERSET_HPP
 #define GENSUPERSET_HPP
 
-#include "ddr/config.hpp"
-
-#include "ddr/std/sstream.hpp"
-#include <stdio.h>
-#include <string.h>
-
-#include "ddr/ir/ClassType.hpp"
-#include "ddr/ir/EnumMember.hpp"
-#include "ddr/ir/Field.hpp"
+#include "ddr/blobgen/genBlob.hpp"
 #include "ddr/ir/Symbol_IR.hpp"
+#include "ddr/std/sstream.hpp"
 #include "ddr/std/unordered_map.hpp"
 
+#include <string.h>
+
 using std::string;
-using std::stringstream;
 
+class Field;
+class SupersetFieldVisitor;
 class SupersetVisitor;
+class Symbol_IR;
 
-class JavaSupersetGenerator: public SupersetGenerator
+class JavaSupersetGenerator : public SupersetGenerator
 {
 private:
 	set<string> _baseTypedefSet; /* Set of types renamed to "[U/I][SIZE]" */
 	unordered_map<string, string> _baseTypedefMap; /* Types remapped for assembled type names. */
 	unordered_map<string, string> _baseTypedefReplace; /* Type names which are replaced everywhere. */
-	set<string> _baseTypedefIgnore; /* Set of types to not rename when found as a typedef */
+	set<string> _opaqueTypeNames; /* Set of types to not rename when found as a typedef */
 	intptr_t _file;
 	OMRPortLibrary *_portLibrary;
 	bool _printEmptyTypes;
@@ -53,17 +50,15 @@ private:
 	void initBaseTypedefSet();
 	void convertJ9BaseTypedef(Type *type, string *name);
 	void replaceBaseTypedef(Type *type, string *name);
-	DDR_RC getFieldType(Field *f, string *assembledTypeName, string *simpleTypeName);
-	DDR_RC printFieldMember(Field *field, string prefix);
-	void printConstantMember(string name);
+	DDR_RC getFieldType(Field *field, string *assembledTypeName, string *simpleTypeName);
+	DDR_RC printFieldMember(Field *field, const string &prefix);
+	void printConstantMember(const string &name);
 
-	string replace(string str, string subStr, string newStr);
-
-	friend class SupersetVisitor;
 	friend class SupersetFieldVisitor;
+	friend class SupersetVisitor;
 
 public:
-	JavaSupersetGenerator(bool printEmptyTypes);
+	explicit JavaSupersetGenerator(bool printEmptyTypes);
 
 	DDR_RC printSuperset(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *supersetFile);
 };

--- a/ddr/include/ddr/config.hpp
+++ b/ddr/include/ddr/config.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,6 +23,7 @@
 #define CONFIG_HPP
 
 #include "omrcfg.h"
+#include "omrcomp.h"
 
 /* Enable standard limit macros on z/OS. */
 

--- a/ddr/include/ddr/error.hpp
+++ b/ddr/include/ddr/error.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,11 +25,11 @@
 #include <ddr/config.hpp>
 #include <stdio.h>
 
-#define ERRMSG(...) { \
-	fprintf(stderr, "Error: %s:%d %s - ", __FILE__, __LINE__, __FUNCTION__);\
-	fprintf(stderr, __VA_ARGS__);\
-	fprintf(stderr, "\n");\
-}
+#define ERRMSG(...) do { \
+	fprintf(stderr, "Error: %s:%d %s - ", __FILE__, __LINE__, __FUNCTION__); \
+	fprintf(stderr, __VA_ARGS__); \
+	fprintf(stderr, "\n"); \
+} while (0)
 
 #if 0
 /* Enable debug printf output */
@@ -37,14 +37,14 @@
 #endif
 
 #if defined(DEBUGPRINTF_ON)
-#define DEBUGPRINTF(...) { \
-	printf("DEBUG: %s[%d]: %s: ", __FILE__, __LINE__, __FUNCTION__);\
-	printf(__VA_ARGS__);\
-	printf("\n");\
-	fflush(stdout);\
-}
+#define DEBUGPRINTF(...) do { \
+	printf("DEBUG: %s:%d %s - ", __FILE__, __LINE__, __FUNCTION__); \
+	printf(__VA_ARGS__); \
+	printf("\n"); \
+	fflush(stdout); \
+} while (0)
 #else
-#define DEBUGPRINTF(...)
+#define DEBUGPRINTF(...) do {} while(0)
 #endif /* defined(DEBUG) */
 
 enum DDR_RC {

--- a/ddr/include/ddr/ir/ClassType.hpp
+++ b/ddr/include/ddr/ir/ClassType.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,30 +22,28 @@
 #ifndef CLASSTYPE_HPP
 #define CLASSTYPE_HPP
 
-#include "ddr/config.hpp"
-
-#include "ddr/ir/EnumMember.hpp"
-#include "ddr/ir/Field.hpp"
 #include "ddr/ir/NamespaceUDT.hpp"
-#include "ddr/ir/UDT.hpp"
+
+class EnumMember;
+class Field;
 
 using std::vector;
 
 class ClassType : public NamespaceUDT
 {
 public:
+	bool _isComplete; /* as opposed to just a forward declaration */
 	vector<Field *> _fieldMembers;
 	vector<EnumMember *> _enumMembers; /* used for anonymous enums*/
 
-	ClassType(size_t size, unsigned int lineNumber = 0);
+	explicit ClassType(size_t size, unsigned int lineNumber = 0);
 	virtual ~ClassType();
 
-	virtual bool isAnonymousType();
 	virtual void computeFieldOffsets();
-	virtual void renameFieldsAndMacros(FieldOverride fieldOverride, Type *replacementType);
+	virtual void renameFieldsAndMacros(const FieldOverride &fieldOverride, Type *replacementType);
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToClasstype(ClassType const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToClasstype(const ClassType &) const;
 };
 
 #endif /* CLASSTYPE_HPP */

--- a/ddr/include/ddr/ir/ClassUDT.hpp
+++ b/ddr/include/ddr/ir/ClassUDT.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,27 +22,25 @@
 #ifndef CLASSUDT_HPP
 #define CLASSUDT_HPP
 
-#include "ddr/config.hpp"
-
 #include "ddr/ir/ClassType.hpp"
 #include "ddr/error.hpp"
 
 /* This type represents both class and struct types */
-class ClassUDT: public ClassType
+class ClassUDT : public ClassType
 {
 public:
 	ClassUDT *_superClass;
 	bool _isClass;
 
-	ClassUDT(size_t size, bool isClass = true, unsigned int lineNumber = 0);
+	explicit ClassUDT(size_t size, bool isClass = true, unsigned int lineNumber = 0);
 	virtual ~ClassUDT();
 
 	virtual string getSymbolKindName();
 
-	virtual DDR_RC acceptVisitor(TypeVisitor const &visitor);
+	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToClass(ClassUDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToClass(const ClassUDT &) const;
 };
 
 #endif /* CLASSUDT_HPP */

--- a/ddr/include/ddr/ir/EnumMember.hpp
+++ b/ddr/include/ddr/ir/EnumMember.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,15 +24,13 @@
 
 #include "ddr/ir/Members.hpp"
 
-class EnumMember: public Members
+class EnumMember : public Members
 {
 public:
 	int _value;
 
 	EnumMember();
-
 	virtual ~EnumMember();
-
 };
 
 #endif /* ENUMMEMBER_HPP */

--- a/ddr/include/ddr/ir/EnumUDT.hpp
+++ b/ddr/include/ddr/ir/EnumUDT.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,29 +22,25 @@
 #ifndef ENUMUDT_HPP
 #define ENUMUDT_HPP
 
-#include "ddr/config.hpp"
-
 #include "ddr/error.hpp"
-#include "ddr/ir/EnumMember.hpp"
 #include "ddr/ir/UDT.hpp"
 
-using std::vector;
+class EnumMember;
 
-class EnumUDT: public UDT
+class EnumUDT : public UDT
 {
 public:
-	vector<EnumMember *> _enumMembers;
+	std::vector<EnumMember *> _enumMembers;
 
-	EnumUDT(unsigned int lineNumber = 0);
+	explicit EnumUDT(unsigned int lineNumber = 0);
 	virtual ~EnumUDT();
 
-	bool isAnonymousType();
 	virtual string getSymbolKindName();
 
-	virtual DDR_RC acceptVisitor(TypeVisitor const &visitor);
+	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToEnum(EnumUDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToEnum(const EnumUDT &) const;
 };
 
 #endif /* ENUMUDT_HPP */

--- a/ddr/include/ddr/ir/Field.hpp
+++ b/ddr/include/ddr/ir/Field.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,15 +22,10 @@
 #ifndef FIELD_HPP
 #define FIELD_HPP
 
-#include "ddr/config.hpp"
-
-#include "ddr/std/string.hpp"
-
 #include "ddr/ir/Members.hpp"
 #include "ddr/ir/Modifiers.hpp"
-#include "ddr/ir/Type.hpp"
 
-using std::string;
+class Type;
 
 class Field : public Members
 {
@@ -44,7 +39,7 @@ public:
 
 	Field();
 
-	string getTypeName();
+	const std::string &getTypeName() const;
 };
 
 #endif /* FIELD_HPP */

--- a/ddr/include/ddr/ir/Macro.hpp
+++ b/ddr/include/ddr/ir/Macro.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,10 +22,7 @@
 #ifndef MACRO_HPP
 #define MACRO_HPP
 
-#include "ddr/config.hpp"
-
 #include "ddr/error.hpp"
-
 #include "ddr/std/string.hpp"
 
 class Macro
@@ -36,17 +33,24 @@ private:
 public:
 	std::string _name;
 
-	Macro(std::string name, std::string value) : _value(value), _name(name)
+	Macro(const std::string &name, const std::string &value)
+		: _value(value), _name(name)
 	{
 	}
 
-	std::string
+	const std::string &
 	getValue() const
 	{
 		return _value;
 	}
 
-	DDR_RC getNumeric(long long *ret);
+	void
+	setValue(const std::string &value)
+	{
+		_value = value;
+	}
+
+	DDR_RC getNumeric(long long *ret) const;
 };
 
 #endif /* MACRO_HPP */

--- a/ddr/include/ddr/ir/Members.hpp
+++ b/ddr/include/ddr/ir/Members.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 #define MEMBERS_HPP
 
 #include "ddr/config.hpp"
-
 #include "ddr/std/string.hpp"
 
 class Members

--- a/ddr/include/ddr/ir/Modifiers.hpp
+++ b/ddr/include/ddr/ir/Modifiers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,31 +32,29 @@ class Modifiers
 {
 public:
 	vector<size_t> _arrayLengths;
-	int _modifierFlags;
-	size_t _offset;
+	uint8_t _modifierFlags;
 	size_t _pointerCount;
 	size_t _referenceCount;
 
-	static const int MODIFIER_FLAGS = 31;
-	static const int NO_MOD = 0;
-	static const int CONST_TYPE = 1;
-	static const int VOLATILE_TYPE = 2;
-	static const int UNALIGNED_TYPE = 4;
-	static const int RESTRICT_TYPE = 8;
-	static const int SHARED_TYPE = 16;
-	static const string MODIFIER_NAMES[];
+	static const uint8_t MODIFIER_FLAGS = 31;
+	static const uint8_t NO_MOD = 0;
+	static const uint8_t CONST_TYPE = 1;
+	static const uint8_t VOLATILE_TYPE = 2;
+	static const uint8_t UNALIGNED_TYPE = 4;
+	static const uint8_t RESTRICT_TYPE = 8;
+	static const uint8_t SHARED_TYPE = 16;
 
 	Modifiers();
 	~Modifiers();
 
-	string getPointerType();
-	string getModifierNames();
+	string getPointerType() const;
+	string getModifierNames() const;
 	void addArrayDimension(size_t length);
-	bool isArray();
-	size_t getArrayLength(size_t i);
-	size_t getArrayDimensions();
-	size_t getSize(size_t typeSize);
-	bool operator==(Modifiers const& type) const;
+	bool isArray() const;
+	size_t getArrayLength(size_t index) const;
+	size_t getArrayDimensions() const;
+	size_t getSize(size_t typeSize) const;
+	bool operator==(const Modifiers &type) const;
 };
 
 #endif /* MODIFIERS_HPP */

--- a/ddr/include/ddr/ir/NamespaceUDT.hpp
+++ b/ddr/include/ddr/ir/NamespaceUDT.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,10 +22,6 @@
 #ifndef NAMESPACEUDT_HPP
 #define NAMESPACEUDT_HPP
 
-#include "ddr/config.hpp"
-
-#include "ddr/std/string.hpp"
-
 #include "ddr/ir/Macro.hpp"
 #include "ddr/ir/UDT.hpp"
 
@@ -35,19 +31,19 @@ public:
 	std::vector<UDT *> _subUDTs;
 	std::vector<Macro> _macros;
 
-	NamespaceUDT(unsigned int lineNumber = 0);
+	explicit NamespaceUDT(unsigned int lineNumber = 0);
 	~NamespaceUDT();
 
-	virtual DDR_RC acceptVisitor(TypeVisitor const &visitor);
-	virtual void checkDuplicate(Symbol_IR *ir);
+	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
+	virtual bool insertUnique(Symbol_IR *ir);
 	virtual string getSymbolKindName();
 	virtual void computeFieldOffsets();
 	virtual void addMacro(Macro *macro);
 	virtual std::vector<UDT *> * getSubUDTS();
-	virtual void renameFieldsAndMacros(FieldOverride fieldOverride, Type *replacementType);
+	virtual void renameFieldsAndMacros(const FieldOverride &fieldOverride, Type *replacementType);
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToNamespace(NamespaceUDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToNamespace(const NamespaceUDT &) const;
 };
 
 #endif /* NAMESPACEUDT_HPP */

--- a/ddr/include/ddr/ir/Symbol_IR.hpp
+++ b/ddr/include/ddr/ir/Symbol_IR.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,20 +22,18 @@
 #ifndef SYMBOL_IR_HPP
 #define SYMBOL_IR_HPP
 
-#include "ddr/config.hpp"
-
-#include <vector>
-#include <set>
+#include "ddr/ir/EnumMember.hpp"
+#include "ddr/ir/Field.hpp"
+#include "ddr/ir/Type.hpp"
 #include "ddr/std/unordered_map.hpp"
 
 #include "omrport.h"
 
-#include "ddr/ir/EnumMember.hpp"
-#include "ddr/ir/Field.hpp"
-#include "ddr/ir/Type.hpp"
+#include <set>
+#include <vector>
 
-using std::vector;
 using std::set;
+using std::vector;
 
 struct FieldOverride {
 	string structName;
@@ -44,8 +42,9 @@ struct FieldOverride {
 	bool isTypeOverride;
 };
 
-class Field;
+class MergeVisitor;
 class NamespaceUDT;
+class TypeReplaceVisitor;
 
 class Symbol_IR {
 public:
@@ -59,17 +58,19 @@ public:
 	set<string> _fullTypeNames;
 	set<Type *> _typeSet;
 	unordered_map<string, set<Type *> > _typeMap;
+	/* Types with names in this set are treated as opaque and not expanded. */
+	set<string> _opaqueTypeNames;
 
-	Symbol_IR() {}
+	Symbol_IR() : _types(), _fullTypeNames(), _typeSet(), _typeMap(), _opaqueTypeNames() {}
 	~Symbol_IR();
 
-	DDR_RC applyOverrideList(OMRPortLibrary *portLibrary, const char *overrideFiles);
+	DDR_RC applyOverridesFile(OMRPortLibrary *portLibrary, const char *overridesFile);
+	DDR_RC applyOverridesList(OMRPortLibrary *portLibrary, const char *overridesListFile);
 	void computeOffsets();
 	void removeDuplicates();
 	DDR_RC mergeIR(Symbol_IR *other);
 
 private:
-	DDR_RC applyOverrides(OMRPortLibrary *portLibrary, const char *overrideFile);
 	template<typename T> void mergeTypes(vector<T *> *source, vector<T *> *other,
 		NamespaceUDT *outerNamespace, vector<Type *> *merged);
 	void mergeFields(vector<Field *> *source, vector<Field *> *other, Type *type, vector<Type *> *merged);

--- a/ddr/include/ddr/ir/Type.hpp
+++ b/ddr/include/ddr/ir/Type.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,15 +22,13 @@
 #ifndef TYPE_HPP
 #define TYPE_HPP
 
-#include "ddr/config.hpp"
-
-#include <set>
-#include "ddr/std/string.hpp"
-
 #include "ddr/blobgen/genBlob.hpp"
 #include "ddr/ir/Symbol_IR.hpp"
 #include "ddr/ir/TypeVisitor.hpp"
 #include "ddr/scanner/Scanner.hpp"
+#include "ddr/std/string.hpp"
+
+#include <set>
 
 using std::set;
 using std::string;
@@ -49,40 +47,45 @@ struct FieldOverride;
 class Type
 {
 public:
+	bool _blacklisted;
 	string _name;
 	size_t _sizeOf; /* Size of type in bytes */
-	bool _isDuplicate;
 
-	Type(size_t size);
+	explicit Type(size_t size);
 	virtual ~Type();
 
-	virtual bool isAnonymousType();
+	bool isAnonymousType() const;
 
 	virtual string getFullName();
 	virtual string getSymbolKindName();
 
 	/* Visitor pattern function to allow the scanner/generator/IR to dispatch functionality based on type. */
-	virtual DDR_RC acceptVisitor(TypeVisitor const &visitor);
+	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 
-	virtual void checkDuplicate(Symbol_IR *ir);
+	/*
+	 * Insert this type into the map in 'ir' and return true if its
+	 * name doesn't clash; otherwise do nothing and return false.
+	 */
+	virtual bool insertUnique(Symbol_IR *ir);
+
 	virtual NamespaceUDT *getNamespace();
 	virtual size_t getPointerCount();
 	virtual size_t getArrayDimensions();
 	virtual void computeFieldOffsets();
 	virtual void addMacro(Macro *macro);
 	virtual vector<UDT *> *getSubUDTS();
-	virtual void renameFieldsAndMacros(FieldOverride fieldOverride, Type *replacementType);
+	virtual void renameFieldsAndMacros(const FieldOverride &fieldOverride, Type *replacementType);
 	virtual Type *getBaseType();
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToClass(ClassUDT const &) const;
-	virtual bool compareToClasstype(ClassType const &) const;
-	virtual bool compareToEnum(EnumUDT const &) const;
-	virtual bool compareToNamespace(NamespaceUDT const &) const;
-	virtual bool compareToType(Type const &) const;
-	virtual bool compareToTypedef(TypedefUDT const &) const;
-	virtual bool compareToUDT(UDT const &) const;
-	virtual bool compareToUnion(UnionUDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToClass(const ClassUDT &) const;
+	virtual bool compareToClasstype(const ClassType &) const;
+	virtual bool compareToEnum(const EnumUDT &) const;
+	virtual bool compareToNamespace(const NamespaceUDT &) const;
+	virtual bool compareToType(const Type &) const;
+	virtual bool compareToTypedef(const TypedefUDT &) const;
+	virtual bool compareToUDT(const UDT &) const;
+	virtual bool compareToUnion(const UnionUDT &) const;
 };
 
 #endif /* TYPE_HPP */

--- a/ddr/include/ddr/ir/TypeVisitor.hpp
+++ b/ddr/include/ddr/ir/TypeVisitor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,29 +22,24 @@
 #ifndef TYPEVISITOR_HPP
 #define TYPEVISITOR_HPP
 
-#include "ddr/config.hpp"
-
 #include "ddr/error.hpp"
 
-using std::string;
-
-class Symbol_IR;
-class Type;
+class ClassUDT;
 class EnumUDT;
 class NamespaceUDT;
+class Type;
 class TypedefUDT;
-class ClassUDT;
 class UnionUDT;
 
 class TypeVisitor
 {
 public:
 	virtual DDR_RC visitType(Type *type) const = 0;
-	virtual DDR_RC visitType(NamespaceUDT *type) const = 0;
-	virtual DDR_RC visitType(EnumUDT *type) const = 0;
-	virtual DDR_RC visitType(TypedefUDT *type) const = 0;
-	virtual DDR_RC visitType(ClassUDT *type) const = 0;
-	virtual DDR_RC visitType(UnionUDT *type) const = 0;
+	virtual DDR_RC visitClass(ClassUDT *type) const = 0;
+	virtual DDR_RC visitEnum(EnumUDT *type) const = 0;
+	virtual DDR_RC visitNamespace(NamespaceUDT *type) const = 0;
+	virtual DDR_RC visitTypedef(TypedefUDT *type) const = 0;
+	virtual DDR_RC visitUnion(UnionUDT *type) const = 0;
 };
 
 #endif /* TYPEVISITOR_HPP */

--- a/ddr/include/ddr/ir/TypedefUDT.hpp
+++ b/ddr/include/ddr/ir/TypedefUDT.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,11 +22,7 @@
 #ifndef TYPEDEFUDT_HPP
 #define TYPEDEFUDT_HPP
 
-#include "ddr/config.hpp"
-
-#include "ddr/std/string.hpp"
-
-#include "Modifiers.hpp"
+#include "ddr/ir/Modifiers.hpp"
 #include "ddr/ir/UDT.hpp"
 
 class TypedefUDT : public UDT
@@ -35,18 +31,18 @@ public:
 	Type *_aliasedType;
 	Modifiers _modifiers;
 
-	TypedefUDT(unsigned int lineNumber = 0);
+	explicit TypedefUDT(unsigned int lineNumber = 0);
 	~TypedefUDT();
 
-	virtual DDR_RC acceptVisitor(TypeVisitor const &visitor);
-	virtual void checkDuplicate(Symbol_IR *ir);
+	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
+	virtual bool insertUnique(Symbol_IR *ir);
 	virtual string getSymbolKindName();
 	virtual size_t getPointerCount();
 	virtual size_t getArrayDimensions();
 	virtual Type *getBaseType();
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToTypedef(TypedefUDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToTypedef(const TypedefUDT &) const;
 };
 
 #endif /* TYPEDEFUDT_HPP */

--- a/ddr/include/ddr/ir/UDT.hpp
+++ b/ddr/include/ddr/ir/UDT.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,29 +22,23 @@
 #ifndef UDT_HPP
 #define UDT_HPP
 
-#include "ddr/config.hpp"
-
-#include <vector>
-
-#include "ddr/ir/Members.hpp"
-#include "ddr/ir/Macro.hpp"
 #include "ddr/ir/Type.hpp"
 
 class UDT : public Type
 {
 public:
 	NamespaceUDT *_outerNamespace;
-	unsigned int _lineNumber;
+	unsigned int const _lineNumber;
 
-	UDT(size_t size, unsigned int lineNumber = 0);
+	explicit UDT(size_t size, unsigned int lineNumber = 0);
 	virtual ~UDT();
 
 	virtual string getFullName();
-	virtual void checkDuplicate(Symbol_IR *ir);
+	virtual bool insertUnique(Symbol_IR *ir);
 	virtual NamespaceUDT * getNamespace();
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToUDT(UDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToUDT(const UDT &) const;
 };
 
 #endif /* UDT_HPP */

--- a/ddr/include/ddr/ir/UnionUDT.hpp
+++ b/ddr/include/ddr/ir/UnionUDT.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,18 +24,17 @@
 
 #include "ddr/ir/ClassType.hpp"
 
-class UnionUDT: public ClassType
+class UnionUDT : public ClassType
 {
 public:
-	UnionUDT(size_t size, unsigned int lineNumber = 0);
-
+	explicit UnionUDT(size_t size, unsigned int lineNumber = 0);
 	virtual ~UnionUDT();
 
-	virtual DDR_RC acceptVisitor(TypeVisitor const &visitor);
+	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 	virtual string getSymbolKindName();
 
-	bool operator==(Type const & rhs) const;
-	virtual bool compareToUnion(UnionUDT const &) const;
+	bool operator==(const Type & rhs) const;
+	virtual bool compareToUnion(const UnionUDT &) const;
 };
 
 #endif /* UNIONUDT_HPP */

--- a/ddr/include/ddr/macros/MacroInfo.hpp
+++ b/ddr/include/ddr/macros/MacroInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,33 +23,31 @@
 #define MACROINFO_HPP
 
 #include "ddr/std/string.hpp"
-#include <set>
-#include <vector>
 
+#include <set>
+
+using std::pair;
 using std::set;
 using std::string;
-using std::pair;
-using std::vector;
-using std::ifstream;
 
 class MacroInfo {
 private:
-	/* This could be a real type name, or a fake type name representing a custom rule
-	 * associated with a macro, or a name based off of a file
+	/* This could be a real type name, or a fake type name representing a
+	 * custom rule associated with a macro, or a name based off of a file.
 	 */
-	string _typeName;
+	const string _typeName;
 
 	/* A list of all macros associated with typeName */
 	set<pair<string, string> > _macros;
 
 public:
-	MacroInfo(string typeName);
+	explicit MacroInfo(const string &typeName);
 
-	string getTypeName();
-	void addMacro(pair<string, string> p);
-	size_t getNumMacros();
-	set<pair<string, string> >::iterator getMacroStart();
-	set<pair<string, string> >::iterator getMacroEnd();
+	const string &getTypeName() const;
+	void addMacro(const string &name, const string &value);
+	size_t getNumMacros() const;
+	set<pair<string, string> >::const_iterator getMacroStart() const;
+	set<pair<string, string> >::const_iterator getMacroEnd() const;
 };
 
 #endif /* MACROINFO_HPP */

--- a/ddr/include/ddr/macros/MacroTool.hpp
+++ b/ddr/include/ddr/macros/MacroTool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,27 +22,21 @@
 #ifndef MACROTOOL_HPP
 #define MACROTOOL_HPP
 
-#include "ddr/std/string.hpp"
-
-#include "ddr/config.hpp"
+#include "ddr/error.hpp"
 #include "ddr/macros/MacroInfo.hpp"
-#include "ddr/ir/Symbol_IR.hpp"
 
-using std::string;
-using std::vector;
+#include <vector>
+
+class Symbol_IR;
 
 class MacroTool
 {
 private:
-	vector<MacroInfo> macroList;
-
-	string getTypeName(string s);
-	pair<string, string> getMacroInfo(string s);
-	string getFileName(string s);
+	std::vector<MacroInfo> macroList;
 
 public:
-	DDR_RC getMacros(string fname);
-	DDR_RC addMacrosToIR(Symbol_IR *ir);
+	DDR_RC getMacros(const std::string &fname);
+	DDR_RC addMacrosToIR(Symbol_IR *ir) const;
 };
 
 #endif /* MACROTOOL_HPP */

--- a/ddr/include/ddr/scanner/Scanner.hpp
+++ b/ddr/include/ddr/scanner/Scanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,22 +22,20 @@
 #ifndef SCANNER_HPP
 #define SCANNER_HPP
 
-#include "ddr/config.hpp"
-
-#include <set>
+#include "ddr/error.hpp"
 #include "ddr/std/string.hpp"
-#include <vector>
 
 #include "omrport.h"
 
-#include "ddr/error.hpp"
+#include <set>
+#include <vector>
 
-class Symbol_IR;
-class Type;
+class ClassUDT;
 class EnumUDT;
 class NamespaceUDT;
+class Symbol_IR;
+class Type;
 class TypedefUDT;
-class ClassUDT;
 class UnionUDT;
 
 using std::set;
@@ -47,15 +45,16 @@ using std::vector;
 class Scanner
 {
 public:
-	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *const ir, vector<string> *debugFiles, string blacklistPath) = 0;
+	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir,
+			vector<string> *debugFiles, const char *blacklistPath) = 0;
 	
 protected:
 	set<string> _blacklistedFiles;
 	set<string> _blacklistedTypes;
 
-	bool checkBlacklistedType(string name);
-	bool checkBlacklistedFile(string name);
-	DDR_RC loadBlacklist(string file);
+	bool checkBlacklistedType(const string &name) const;
+	bool checkBlacklistedFile(const string &name) const;
+	DDR_RC loadBlacklist(const char *file);
 };
 
 #endif /* SCANNER_HPP */

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@
 
 #if defined(OSX)
 #include <sys/fcntl.h>
-#endif /*defined(OSX)*/
+#endif /* OSX */
 
 #if defined(AIXPPC)
 #include <unistd.h>
@@ -77,16 +77,16 @@ typedef void (*Dwarf_Handler)(Dwarf_Error error, Dwarf_Ptr errarg);
 
 typedef vector<string> str_vect;
 
-#define DW_DLE_NE				0x00 /* No error */
-#define DW_DLE_ATTR_FORM_BAD	0x01 /* Wrong form for attribute */
-#define DW_DLE_BADOFF			0x02 /* Invalid offset */
-#define DW_DLE_DIE_NULL			0x03 /* Die NULL */
-#define DW_DLE_FNO				0x04 /* File not open */
-#define DW_DLE_IA				0x05 /* Invalid argument */
-#define DW_DLE_IOF				0x06 /* I/O failure */
-#define DW_DLE_MAF				0x07 /* Memory allocation failure */
-#define DW_DLE_NOB				0x08 /* Not an object file */
-#define DW_DLE_VMM				0x09 /* Dwarf format/library version mismatch */
+#define DW_DLE_NE             0x00 /* No error */
+#define DW_DLE_ATTR_FORM_BAD  0x01 /* Wrong form for attribute */
+#define DW_DLE_BADOFF         0x02 /* Invalid offset */
+#define DW_DLE_DIE_NULL       0x03 /* Die NULL */
+#define DW_DLE_FNO            0x04 /* File not open */
+#define DW_DLE_IA             0x05 /* Invalid argument */
+#define DW_DLE_IOF            0x06 /* I/O failure */
+#define DW_DLE_MAF            0x07 /* Memory allocation failure */
+#define DW_DLE_NOB            0x08 /* Not an object file */
+#define DW_DLE_VMM            0x09 /* Dwarf format/library version mismatch */
 
 #define DW_DLC_READ 0x01
 
@@ -121,6 +121,7 @@ typedef vector<string> str_vect;
 #define DW_FORM_udata 0x05
 #define DW_FORM_sdata 0x06
 #define DW_FORM_string 0x07
+#define DW_FORM_flag 0x0c
 
 #define DW_TAG_unknown 0x00
 #define DW_TAG_array_type 0x01
@@ -160,7 +161,7 @@ struct Dwarf_CU_Context
 	Dwarf_Half _addressSize;
 	Dwarf_Unsigned _nextCUheaderOffset;
 	Dwarf_CU_Context *_nextCU;
-	
+
 	static vector<string> _fileList;
 	static Dwarf_CU_Context *_firstCU;
 	static Dwarf_CU_Context *_currentCU;
@@ -177,19 +178,34 @@ struct Dwarf_Die_s
 	Dwarf_Die_s *_child;
 	Dwarf_CU_Context *_context;
 	Dwarf_Attribute_s *_attribute;
-	
+
 	static unordered_map<Dwarf_Off, Dwarf_Die> refMap;
 };
+
 struct Dwarf_Attribute_s
 {
 	Dwarf_Half _type;
 	Dwarf_Attribute_s *_nextAttr;
 	Dwarf_Half _form;
+	Dwarf_Bool _flag;
 	Dwarf_Signed _sdata;
 	Dwarf_Unsigned _udata;
 	char *_stringdata;
 	Dwarf_Off _refdata;
 	Dwarf_Die_s *_ref;
+
+	Dwarf_Attribute_s()
+		: _type(DW_AT_unknown)
+		, _nextAttr(NULL)
+		, _form(DW_FORM_unknown)
+		, _flag(false)
+		, _sdata(0)
+		, _udata(0)
+		, _stringdata(NULL)
+		, _refdata(0)
+		, _ref(NULL)
+	{
+	}
 };
 
 int dwarf_srcfiles(Dwarf_Die die, char ***srcfiles, Dwarf_Signed *filecount, Dwarf_Error *error);
@@ -208,17 +224,19 @@ void dwarf_dealloc(Dwarf_Debug dbg, void *space, Dwarf_Unsigned type);
 
 int dwarf_hasattr(Dwarf_Die die, Dwarf_Half attr, Dwarf_Bool *returned_bool, Dwarf_Error *error);
 
-int dwarf_formudata(Dwarf_Attribute attr, Dwarf_Unsigned  *returned_val, Dwarf_Error *error);
+int dwarf_formflag(Dwarf_Attribute attr, Dwarf_Bool *returned_flag, Dwarf_Error *error);
+
+int dwarf_formudata(Dwarf_Attribute attr, Dwarf_Unsigned *returned_val, Dwarf_Error *error);
 
 int dwarf_diename(Dwarf_Die die, char **diename, Dwarf_Error *error);
 
 int dwarf_global_formref(Dwarf_Attribute attr, Dwarf_Off *return_offset, Dwarf_Error *error);
 
 int dwarf_offdie_b(Dwarf_Debug dbg,
-    Dwarf_Off offset,
-    Dwarf_Bool is_info,
-    Dwarf_Die *return_die,
-    Dwarf_Error *error);
+	Dwarf_Off offset,
+	Dwarf_Bool is_info,
+	Dwarf_Die *return_die,
+	Dwarf_Error *error);
 
 int dwarf_child(Dwarf_Die die, Dwarf_Die *return_childdie, Dwarf_Error *error);
 
@@ -226,26 +244,26 @@ int dwarf_whatform(Dwarf_Attribute attr, Dwarf_Half *returned_final_form, Dwarf_
 
 int dwarf_tag(Dwarf_Die die, Dwarf_Half *return_tag, Dwarf_Error *error);
 
-int dwarf_formsdata(Dwarf_Attribute attr, Dwarf_Signed  *returned_val, Dwarf_Error *error);
+int dwarf_formsdata(Dwarf_Attribute attr, Dwarf_Signed *returned_val, Dwarf_Error *error);
 
 int dwarf_next_cu_header(Dwarf_Debug dbg,
-    Dwarf_Unsigned *cu_header_length,
-    Dwarf_Half *version_stamp,
-    Dwarf_Off *abbrev_offset,
-    Dwarf_Half *address_size,
-    Dwarf_Unsigned *next_cu_header_offset,
-    Dwarf_Error *error);
+	Dwarf_Unsigned *cu_header_length,
+	Dwarf_Half *version_stamp,
+	Dwarf_Off *abbrev_offset,
+	Dwarf_Half *address_size,
+	Dwarf_Unsigned *next_cu_header_offset,
+	Dwarf_Error *error);
 
 int dwarf_siblingof(Dwarf_Debug dbg, Dwarf_Die die, Dwarf_Die *dieOut, Dwarf_Error *error);
 
 int dwarf_finish(Dwarf_Debug dbg, Dwarf_Error *error);
 
 int dwarf_init(int fd,
-    Dwarf_Unsigned access,
-    Dwarf_Handler errhand,
-    Dwarf_Ptr errarg,
-    Dwarf_Debug *dbg,
-    Dwarf_Error *error);
+	Dwarf_Unsigned access,
+	Dwarf_Handler errhand,
+	Dwarf_Ptr errarg,
+	Dwarf_Debug *dbg,
+	Dwarf_Error *error);
 
 int dwarf_dieoffset(Dwarf_Die die, Dwarf_Off *dieOffset, Dwarf_Error *error);
 

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -106,6 +106,7 @@ typedef vector<string> str_vect;
 #define DW_AT_specification 0x09
 #define DW_AT_type 0x0a
 #define DW_AT_upper_bound 0x0b
+#define DW_AT_external 0x0c
 
 #define DW_DLA_ATTR 0x01
 #define DW_DLA_DIE 0x02

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@
 #elif defined(HAVE_LIBDWARF_DWARF_H)
 #include <libdwarf/dwarf.h>
 #else
-#error
+#error "Need dwarf.h or libdwarf/dwarf.h"
 #endif /* defined(HAVE_DWARF_H) */
 
 #if defined(HAVE_LIBDWARF_H)
@@ -44,13 +44,12 @@
 #elif defined(HAVE_LIBDWARF_LIBDWARF_H)
 #include <libdwarf/libdwarf.h>
 #else
-#error
-#endif
+#error "Need libdwarf.h or libdwarf/libdwarf.h"
+#endif /* defined(HAVE_LIBDWARF_H) */
 
 #endif /* defined(OSX) || defined(AIXPPX) */
 
 #include "ddr/ir/ClassUDT.hpp"
-#include "ddr/config.hpp"
 #include "ddr/ir/EnumUDT.hpp"
 #include "ddr/scanner/Scanner.hpp"
 #include "ddr/ir/Symbol_IR.hpp"
@@ -66,13 +65,14 @@ using std::tr1::hash;
 using std::hash;
 #endif
 
-class DwarfScanner: public Scanner
+class DwarfScanner : public Scanner
 {
 public:
 	DwarfScanner();
 	~DwarfScanner();
 
-	DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *const ir, vector<string> *debugFiles, string blacklistPath);
+	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir,
+			vector<string> *debugFiles, const char *blacklistPath);
 
 private:
 	Dwarf_Signed _fileNameCount;
@@ -83,14 +83,14 @@ private:
 	Dwarf_Debug _debug;
 
 	DDR_RC scanFile(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *filepath);
-	DDR_RC traverse_cu_in_debug_section(Symbol_IR *const ir);
-	DDR_RC addDieToIR(Dwarf_Die die, Dwarf_Half tag, bool ignoreFilter, NamespaceUDT *outerUDT, Type **type);
-	DDR_RC getOrCreateNewType(Dwarf_Die die, Dwarf_Half tag, Type **const newUDT, NamespaceUDT *outerUDT, bool *isNewType);
-	DDR_RC createNewType(Dwarf_Die die, Dwarf_Half tag, string dieName, Type **const newUDT);
-	DDR_RC scanClassChildren(NamespaceUDT *newClass, Dwarf_Die die, bool alreadyHadFields);
-	DDR_RC addEnumMember(Dwarf_Die die, EnumUDT *const udt);
-	DDR_RC addClassField(Dwarf_Die die, ClassType *const newClass, string fieldName);
-	DDR_RC getSuperUDT(Dwarf_Die die, ClassUDT *const udt);
+	DDR_RC traverse_cu_in_debug_section(Symbol_IR *ir);
+	DDR_RC addDieToIR(Dwarf_Die die, Dwarf_Half tag, NamespaceUDT *outerUDT, Type **type);
+	DDR_RC getOrCreateNewType(Dwarf_Die die, Dwarf_Half tag, Type **newUDT, NamespaceUDT *outerUDT, bool *isNewType);
+	DDR_RC createNewType(Dwarf_Die die, Dwarf_Half tag, const char *dieName, Type **newUDT);
+	DDR_RC scanClassChildren(NamespaceUDT *newClass, Dwarf_Die die);
+	DDR_RC addEnumMember(Dwarf_Die die, EnumUDT *udt);
+	DDR_RC addClassField(Dwarf_Die die, ClassType *newClass, const string &fieldName);
+	DDR_RC getSuperUDT(Dwarf_Die die, ClassUDT *udt);
 	DDR_RC getTypeInfo(Dwarf_Die die, Dwarf_Die *dieout, string *typeName, Modifiers *modifiers, size_t *typeSize, size_t *bitField);
 	DDR_RC getTypeSize(Dwarf_Die die, size_t *typeSize);
 	DDR_RC getTypeTag(Dwarf_Die die, Dwarf_Die *typedie, Dwarf_Half *tag);

--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,7 +57,8 @@ typedef struct PostponedType
 class PdbScanner: public Scanner
 {
 public:
-	DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *const ir, vector<string> *debugFiles, string blacklistPath);
+	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir,
+			vector<string> *debugFiles, const char *blacklistPath);
 
 private:
 	Symbol_IR *_ir;
@@ -65,7 +66,7 @@ private:
 	vector<PostponedType> _postponedFields;
 
 	void addType(Type *type, bool addToIR);
-	DDR_RC addFieldMember(IDiaSymbol *symbol, ClassUDT *const udt);
+	DDR_RC addFieldMember(IDiaSymbol *symbol, ClassUDT *udt);
 	DDR_RC setBaseType(IDiaSymbol *typeSymbol, Type **type);
 	DDR_RC setBaseTypeFloat(ULONGLONG ulLen, Type **type);
 	DDR_RC setBaseTypeInt(ULONGLONG ulLen, Type **type);
@@ -79,7 +80,7 @@ private:
 	DDR_RC setMemberOffset(IDiaSymbol *symbol, Field *newField);
 
 	DDR_RC addChildrenSymbols(IDiaSymbol *symbol, enum SymTagEnum symTag, NamespaceUDT *outerUDT);
-	DDR_RC addEnumMembers(IDiaSymbol *diaSymbol, EnumUDT *const e);
+	DDR_RC addEnumMembers(IDiaSymbol *diaSymbol, EnumUDT *e);
 	DDR_RC createClassUDT(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
 	DDR_RC createEnumUDT(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
 	DDR_RC createTypedef(IDiaSymbol *symbol, NamespaceUDT *outerUDT);

--- a/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,27 +23,39 @@
 #define __IBMCPP_TR1__ 1
 #endif /* defined(AIXPPC) || defined(J9ZOS390) */
 
-#include <stdio.h>
-
 #include "ddr/blobgen/genBlob.hpp"
 #include "ddr/blobgen/java/genBinaryBlob.hpp"
 #include "ddr/blobgen/java/genSuperset.hpp"
 
+#include <stdio.h>
+
 DDR_RC
-genBlob(struct OMRPortLibrary *portLibrary, Symbol_IR *const ir, const char *supersetFile, const char *blobFile, bool printEmptyTypes)
+genBlob(struct OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *supersetFile, const char *blobFile, bool printEmptyTypes)
 {
-	JavaSupersetGenerator supersetGenerator(printEmptyTypes);
-	DDR_RC rc = supersetGenerator.printSuperset(portLibrary, ir, supersetFile);
+	DDR_RC rc = DDR_RC_OK;
 
-	if (DDR_RC_OK == rc) {
-		printf("Superset written to file: %s\n", supersetFile);
-
+	if (NULL != blobFile) {
 		JavaBlobGenerator blobGenerator(printEmptyTypes);
+
 		rc = blobGenerator.genBinaryBlob(portLibrary, ir, blobFile);
+
+		if (DDR_RC_OK == rc) {
+			printf("Blob written to file: %s\n", blobFile);
+		} else {
+			printf("Blob NOT written to file: %s\n", blobFile);
+		}
 	}
 
-	if (DDR_RC_OK == rc) {
-		printf("Blob written to file: %s\n", blobFile);
+	if ((DDR_RC_OK == rc) && (NULL != supersetFile)) {
+		JavaSupersetGenerator supersetGenerator(printEmptyTypes);
+
+		rc = supersetGenerator.printSuperset(portLibrary, ir, supersetFile);
+
+		if (DDR_RC_OK == rc) {
+			printf("Superset written to file: %s\n", supersetFile);
+		} else {
+			printf("Superset NOT written to file: %s\n", supersetFile);
+		}
 	}
 
 	return rc;

--- a/ddr/lib/ddr-blobgen/java/genSuperset.cpp
+++ b/ddr/lib/ddr-blobgen/java/genSuperset.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,18 +21,42 @@
 
 #include "ddr/blobgen/java/genSuperset.hpp"
 
-#include <assert.h>
-#include <stdio.h>
-
-#include "ddr/config.hpp"
 #include "ddr/ir/ClassUDT.hpp"
 #include "ddr/ir/EnumMember.hpp"
 #include "ddr/ir/EnumUDT.hpp"
 #include "ddr/ir/TypedefUDT.hpp"
-#include "ddr/ir/TypeVisitor.hpp"
 #include "ddr/ir/UnionUDT.hpp"
+#include "ddr/std/sstream.hpp"
 
-JavaSupersetGenerator::JavaSupersetGenerator(bool printEmptyTypes) : _file(0), _portLibrary(NULL), _printEmptyTypes(printEmptyTypes)
+#include <assert.h>
+#include <stdio.h>
+
+using std::stringstream;
+
+static string
+replaceAll(string str, const string &subStr, const string &newStr)
+{
+	for (size_t i = 0;;) {
+		i = str.find(subStr, i);
+		if (string::npos == i) {
+			break;
+		}
+
+		str.replace(i, subStr.length(), newStr);
+		i += subStr.length() - newStr.length();
+	}
+
+	return str;
+}
+
+JavaSupersetGenerator::JavaSupersetGenerator(bool printEmptyTypes)
+	: _baseTypedefSet()
+	, _baseTypedefMap()
+	, _baseTypedefReplace()
+	, _opaqueTypeNames()
+	, _file(0)
+	, _portLibrary(NULL)
+	, _printEmptyTypes(printEmptyTypes)
 {
 	initBaseTypedefSet();
 }
@@ -94,15 +118,17 @@ JavaSupersetGenerator::initBaseTypedefSet()
 	_baseTypedefReplace["I_64"] = "I64";
 	_baseTypedefReplace["I_128"] = "I128";
 
-	_baseTypedefIgnore.insert("IDATA");
-	_baseTypedefIgnore.insert("UDATA");
-	for (unordered_map<string, string>::iterator it = _baseTypedefReplace.begin(); it != _baseTypedefReplace.end(); ++ it) {
-		_baseTypedefIgnore.insert(it->first);
-		_baseTypedefIgnore.insert(it->second);
+	_opaqueTypeNames.insert("IDATA");
+	_opaqueTypeNames.insert("UDATA");
+
+	for (unordered_map<string, string>::const_iterator it = _baseTypedefReplace.begin(); it != _baseTypedefReplace.end(); ++ it) {
+		_opaqueTypeNames.insert(it->first);
+		_opaqueTypeNames.insert(it->second);
 	}
-	for (unordered_map<string, string>::iterator it = _baseTypedefMap.begin(); it != _baseTypedefMap.end(); ++ it) {
-		_baseTypedefIgnore.insert(it->first);
-		_baseTypedefIgnore.insert(it->second);
+
+	for (unordered_map<string, string>::const_iterator it = _baseTypedefMap.begin(); it != _baseTypedefMap.end(); ++ it) {
+		_opaqueTypeNames.insert(it->first);
+		_opaqueTypeNames.insert(it->second);
 	}
 }
 
@@ -116,7 +142,7 @@ JavaSupersetGenerator::convertJ9BaseTypedef(Type *type, string *typeName)
 		name = _baseTypedefMap[name];
 	} else if (_baseTypedefSet.find(name) != _baseTypedefSet.end()) {
 		stringstream ss;
-		ss << (0 == strchr(name.c_str(), 'u') ? "I" : "U")
+		ss << ((string::npos == name.find_first_of('u')) ? "I" : "U")
 		   << (type->_sizeOf * 8);
 		name = ss.str();
 	} else {
@@ -132,10 +158,11 @@ JavaSupersetGenerator::replaceBaseTypedef(Type *type, string *name)
 	 * types such as "U_32" are replaced with "U32" and function pointers
 	 * are replaced with "void*".
 	 */
-	if (_baseTypedefReplace.find(*name) != _baseTypedefReplace.end()) {
-		*name = _baseTypedefReplace[*name];
+	unordered_map<string, string>::const_iterator it = _baseTypedefReplace.find(*name);
+	if (it != _baseTypedefReplace.end()) {
+		*name = it->second;
 	} else {
-		for (unordered_map<string, string>::iterator it = _baseTypedefReplace.begin(); it != _baseTypedefReplace.end(); it ++) {
+		for (it = _baseTypedefReplace.begin(); it != _baseTypedefReplace.end(); ++it) {
 			size_t index = name->find(it->first);
 			if (string::npos != index) {
 				name->replace(index, it->first.length(), it->second);
@@ -147,23 +174,25 @@ JavaSupersetGenerator::replaceBaseTypedef(Type *type, string *name)
 class SupersetFieldVisitor : public TypeVisitor
 {
 private:
-	JavaSupersetGenerator *_gen;
-	string *_typeName;
-	string *_simpleName;
-	string *_prefixBase;
-	string *_prefix;
-	string *_pointerTypeBase;
+	JavaSupersetGenerator * const _gen;
+	string * const _typeName;
+	string * const _simpleName;
+	string * const _prefixBase;
+	string * const _prefix;
+	string * const _pointerTypeBase;
 
 public:
 	SupersetFieldVisitor(JavaSupersetGenerator *gen, string *typeName, string *simpleName, string *prefixBase, string *prefix, string *pointerTypeBase)
-		: _gen(gen), _typeName(typeName), _simpleName(simpleName), _prefixBase(prefixBase), _prefix(prefix), _pointerTypeBase(pointerTypeBase) {}
+		: _gen(gen), _typeName(typeName), _simpleName(simpleName), _prefixBase(prefixBase), _prefix(prefix), _pointerTypeBase(pointerTypeBase)
+	{
+	}
 
-	DDR_RC visitType(Type *type) const;
-	DDR_RC visitType(NamespaceUDT *type) const;
-	DDR_RC visitType(EnumUDT *type) const;
-	DDR_RC visitType(TypedefUDT *type) const;
-	DDR_RC visitType(ClassUDT *type) const;
-	DDR_RC visitType(UnionUDT *type) const;
+	virtual DDR_RC visitType(Type *type) const;
+	virtual DDR_RC visitClass(ClassUDT *type) const;
+	virtual DDR_RC visitEnum(EnumUDT *type) const;
+	virtual DDR_RC visitNamespace(NamespaceUDT *type) const;
+	virtual DDR_RC visitTypedef(TypedefUDT *type) const;
+	virtual DDR_RC visitUnion(UnionUDT *type) const;
 };
 
 DDR_RC
@@ -176,42 +205,65 @@ SupersetFieldVisitor::visitType(Type *type) const
 }
 
 DDR_RC
-SupersetFieldVisitor::visitType(NamespaceUDT *type) const
+SupersetFieldVisitor::visitNamespace(NamespaceUDT *type) const
 {
-	*_simpleName = _gen->replace(type->getFullName(), "::", "$");
+	*_simpleName = replaceAll(type->getFullName(), "::", "$");
 	*_typeName = *_simpleName;
 	return DDR_RC_OK;
 }
 
 DDR_RC
-SupersetFieldVisitor::visitType(EnumUDT *type) const
+SupersetFieldVisitor::visitEnum(EnumUDT *type) const
 {
-	*_simpleName = _gen->replace(type->getFullName(), "::", "$");
+	*_simpleName = replaceAll(type->getFullName(), "::", "$");
 	*_typeName = *_simpleName;
 	return DDR_RC_OK;
 }
 
-DDR_RC
-SupersetFieldVisitor::visitType(TypedefUDT *type) const
+static Type *
+getBaseType(TypedefUDT *type, const set<string> &opaqueNames)
 {
 	Type *baseType = type;
-	string name = baseType->_name;
-	while ((_gen->_baseTypedefIgnore.find(name) == _gen->_baseTypedefIgnore.end()) && (NULL != baseType->getBaseType())) {
-		baseType = baseType->getBaseType();
-		name = baseType->_name;
+	const string *name = &baseType->_name;
+	set<Type *> baseTypes;
+
+	/* stop if we find a name that should treated as opaque */
+	while (opaqueNames.find(*name) == opaqueNames.end()) {
+		baseTypes.insert(baseType);
+
+		Type * nextBase = baseType->getBaseType();
+
+		if (NULL == nextBase) {
+			/* this is the end of the chain */
+			break;
+		} else if (baseTypes.find(nextBase) != baseTypes.end()) {
+			/* this signals a cycle in the chain of base types */
+			break;
+		}
+
+		baseType = nextBase;
+		name = &baseType->_name;
 	}
+
+	return baseType;
+}
+
+DDR_RC
+SupersetFieldVisitor::visitTypedef(TypedefUDT *type) const
+{
+	Type *baseType = getBaseType(type, _gen->_opaqueTypeNames);
 	if (baseType == type) {
-		*_typeName = _gen->replace(type->getFullName(), "::", "$");
+		*_typeName = replaceAll(type->getFullName(), "::", "$");
 		_gen->convertJ9BaseTypedef(type, _typeName);
 	} else {
 		baseType->acceptVisitor(SupersetFieldVisitor(_gen, _typeName, _simpleName, _prefixBase, _prefix, _pointerTypeBase));
 	}
-			
+
 	if (type->getSymbolKindName().empty()) {
 		*_simpleName = type->_name;
 		_gen->replaceBaseTypedef(type, _simpleName);
 	} else {
-		*_simpleName = _gen->replace(type->getFullName(), "::", "$");
+		*_simpleName = replaceAll(type->getFullName(), "::", "$");
 	}
 
 	/* Get the field type. */
@@ -225,10 +277,10 @@ SupersetFieldVisitor::visitType(TypedefUDT *type) const
 	}
 
 	/* Get field pointer/array notation. */
-	for (size_t i = 0; i < type->getPointerCount(); i += 1) {
+	for (size_t i = type->getPointerCount(); i != 0; i -= 1) {
 		*_pointerTypeBase = "*" + *_pointerTypeBase;
 	}
-	for (size_t i = 0; i < type->getArrayDimensions(); i += 1) {
+	for (size_t i = type->getArrayDimensions(); i != 0; i -= 1) {
 		*_pointerTypeBase = *_pointerTypeBase + "[]";
 	}
 
@@ -236,20 +288,20 @@ SupersetFieldVisitor::visitType(TypedefUDT *type) const
 }
 
 DDR_RC
-SupersetFieldVisitor::visitType(ClassUDT *type) const
+SupersetFieldVisitor::visitClass(ClassUDT *type) const
 {
-	return visitType((NamespaceUDT *)type);
+	return visitNamespace(type);
 }
 
 DDR_RC
-SupersetFieldVisitor::visitType(UnionUDT *type) const
+SupersetFieldVisitor::visitUnion(UnionUDT *type) const
 {
-	return visitType((NamespaceUDT *)type);
+	return visitNamespace(type);
 }
 
 /* The printed format for fields is:
  *     F|PREFIX OUTER_TYPE$assembledBaseTypeName:BIT_FIELD|MODIFIERS PREFIX OUTER_TYPE.typeName:BIT_FIELD
- * - For fields with a type which are not typedefs, the assembled base type name
+ * - For fields with a type which is not a typedef, the assembled base type name
  *   and type name are identical. For fields with a typedef type, the type name
  *   is of the type directly and the assembled base type name is constructed by
  *   recursively following the chain of typedefs until a non-typedef type is found.
@@ -263,23 +315,24 @@ SupersetFieldVisitor::visitType(UnionUDT *type) const
  * - BIT_FIELD: the member's bit field, added to both assembled and type names.
  */
 DDR_RC
-JavaSupersetGenerator::getFieldType(Field *f, string *assembledTypeName, string *simpleTypeName)
+JavaSupersetGenerator::getFieldType(Field *field, string *assembledTypeName, string *simpleTypeName)
 {
 	DDR_RC rc = DDR_RC_OK;
 
 	/* Get modifier name list for the field. */
 	string modifiers;
-	if (0 != (f->_modifiers._modifierFlags & ~Modifiers::MODIFIER_FLAGS)) {
-		ERRMSG("Unhandled field modifer flags: %d", f->_modifiers._modifierFlags);
+	if (0 != (field->_modifiers._modifierFlags & ~Modifiers::MODIFIER_FLAGS)) {
+		ERRMSG("Unhandled field modifer flags: %d", field->_modifiers._modifierFlags);
 		rc = DDR_RC_ERROR;
 	} else {
-		modifiers =  f->_modifiers.getModifierNames();
+		modifiers = field->_modifiers.getModifierNames();
 	}
 
 	/* Get field pointer/array notation. */
 	string pointerType = "";
+
 	if (DDR_RC_OK == rc) {
-		pointerType = f->_modifiers.getPointerType();
+		pointerType = field->_modifiers.getPointerType();
 	}
 
 	string typeName = "";
@@ -287,20 +340,25 @@ JavaSupersetGenerator::getFieldType(Field *f, string *assembledTypeName, string 
 	string prefix = "";
 	string prefixBase = "";
 	string pointerTypeBase = pointerType;
+
 	if (DDR_RC_OK == rc) {
-		if (NULL == f->_fieldType) {
+		Type *fieldType = field->_fieldType;
+
+		if ((NULL == fieldType) || fieldType->_blacklisted || (field->_modifiers._pointerCount > 1)) {
 			typeName = "void";
 			simpleName = "void";
 		} else {
-			rc = f->_fieldType->acceptVisitor(SupersetFieldVisitor(this, &typeName, &simpleName, &prefixBase, &prefix, &pointerTypeBase));
+			rc = fieldType->acceptVisitor(SupersetFieldVisitor(this, &typeName, &simpleName, &prefixBase, &prefix, &pointerTypeBase));
 		}
 	}
-	
+
 	/* Get the bit field, if it has one. */
 	string bitField;
-	if ((DDR_RC_OK == rc) && (0 != f->_bitField)) {
+
+	if ((DDR_RC_OK == rc) && (0 != field->_bitField)) {
 		stringstream ss;
-		ss << ":" << f->_bitField;
+
+		ss << ":" << field->_bitField;
 		bitField = ss.str();
 	}
 
@@ -308,6 +366,7 @@ JavaSupersetGenerator::getFieldType(Field *f, string *assembledTypeName, string 
 	if (NULL != assembledTypeName) {
 		*assembledTypeName = prefixBase + typeName + pointerTypeBase + bitField;
 	}
+
 	if (NULL != simpleTypeName) {
 		*simpleTypeName = modifiers + prefix + simpleName + pointerType + bitField;
 	}
@@ -318,19 +377,26 @@ JavaSupersetGenerator::getFieldType(Field *f, string *assembledTypeName, string 
 class SupersetVisitor : public TypeVisitor
 {
 private:
-	JavaSupersetGenerator *_supersetGen;
-	bool _addFieldsOnly;
-	string _prefix;
+	JavaSupersetGenerator * const _supersetGen;
+	const bool _addFieldsOnly;
+	const string _prefix;
+
+	DDR_RC writeType(Type *type, Type *superClass) const;
 
 public:
-	SupersetVisitor(JavaSupersetGenerator *supersetGen, bool addFieldsOnly, string prefix) : _supersetGen(supersetGen), _addFieldsOnly(addFieldsOnly), _prefix(prefix) {}
+	SupersetVisitor(JavaSupersetGenerator *supersetGen, bool addFieldsOnly, const string &prefix)
+		: _supersetGen(supersetGen)
+		, _addFieldsOnly(addFieldsOnly)
+		, _prefix(prefix)
+	{
+	}
 
-	DDR_RC visitType(Type *type) const;
-	DDR_RC visitType(NamespaceUDT *type) const;
-	DDR_RC visitType(EnumUDT *type) const;
-	DDR_RC visitType(TypedefUDT *type) const;
-	DDR_RC visitType(ClassUDT *type) const;
-	DDR_RC visitType(UnionUDT *type) const;
+	virtual DDR_RC visitType(Type *type) const;
+	virtual DDR_RC visitClass(ClassUDT *type) const;
+	virtual DDR_RC visitEnum(EnumUDT *type) const;
+	virtual DDR_RC visitNamespace(NamespaceUDT *type) const;
+	virtual DDR_RC visitTypedef(TypedefUDT *type) const;
+	virtual DDR_RC visitUnion(UnionUDT *type) const;
 };
 
 /* Print a field member with the format:
@@ -338,31 +404,33 @@ public:
  * See getFieldType() for more details on how these type names are constructed.
  */
 DDR_RC
-JavaSupersetGenerator::printFieldMember(Field *field, string prefix = "")
+JavaSupersetGenerator::printFieldMember(Field *field, const string &prefix)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
 	DDR_RC rc = DDR_RC_OK;
+
 	/* If the type of a field is an anonymous inner type, print its fields prefixed by its field
 	 * name in place of the field.
 	 */
 	if (!field->_isStatic) {
-		if ((NULL != field->_fieldType) && field->_fieldType->isAnonymousType()) {
-			field->_fieldType->acceptVisitor(SupersetVisitor(this, true, prefix + field->_name + "."));
-		} else {
-			string nameFormatted = prefix + (field->_name == "class" ? "klass" : field->_name);
-			string lineToPrint = "F|" + replace(nameFormatted, ".", "$") + "|" + nameFormatted + "|";
+		Type *fieldType = field->_fieldType;
 
+		if ((NULL != fieldType) && fieldType->isAnonymousType()) {
+			fieldType->acceptVisitor(SupersetVisitor(this, true, prefix + field->_name + "."));
+		} else {
 			string assembledTypeName;
 			string simpleTypeName;
 
 			rc = getFieldType(field, &assembledTypeName, &simpleTypeName);
 			if (DDR_RC_OK != rc) {
 				ERRMSG("Could not assemble field type name");
-			}
+			} else {
+				string nameFormatted = prefix + (field->_name == "class" ? "klass" : field->_name);
+				string lineToPrint = "F|" + replaceAll(nameFormatted, ".", "$")
+								    + "|" + nameFormatted
+								    + "|" + replaceAll(assembledTypeName, "::", "$")
+								    + "|" + simpleTypeName + "\n";
 
-			if (DDR_RC_OK == rc) {
-				string fieldFormatted = replace(assembledTypeName, "::", "$");
-				lineToPrint += fieldFormatted + "|" + simpleTypeName + "\n";
 				omrfile_write(_file, lineToPrint.c_str(), lineToPrint.length());
 			}
 		}
@@ -372,28 +440,35 @@ JavaSupersetGenerator::printFieldMember(Field *field, string prefix = "")
 }
 
 void
-JavaSupersetGenerator::printConstantMember(string name)
+JavaSupersetGenerator::printConstantMember(const string &name)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
 	string lineToPrint = "C|" + name + "\n";
+
 	omrfile_write(_file, lineToPrint.c_str(), lineToPrint.length());
 }
 
-string
-JavaSupersetGenerator::replace(string str, string subStr, string newStr)
+DDR_RC
+SupersetVisitor::writeType(Type *type, Type *superClass) const
 {
-	size_t i = 0;
-	while (true) {
-		i = str.find(subStr, i);
-		if (string::npos == i) {
-			break;
-		}
+	OMRPORT_ACCESS_FROM_OMRPORT(_supersetGen->_portLibrary);
+	const string nameFormatted = replaceAll(type->getFullName(), "::", "$");
+	string superFormatted;
 
-		str.replace(i, subStr.length(), newStr);
-		i += subStr.length() - 1;
+	if (NULL != superClass) {
+		superFormatted = replaceAll(superClass->getFullName(), "::", "$");
 	}
 
-	return str;
+	const string lineToPrint = "S|" + nameFormatted + "|" + nameFormatted + "Pointer|" + superFormatted + "\n";
+	const size_t lengthToPrint = lineToPrint.length();
+	DDR_RC rc = DDR_RC_OK;
+
+	if (lengthToPrint != (size_t)omrfile_write(_supersetGen->_file, lineToPrint.c_str(), lengthToPrint)) {
+		ERRMSG("Write failed");
+		rc = DDR_RC_ERROR;
+	}
+
+	return rc;
 }
 
 DDR_RC
@@ -404,221 +479,210 @@ SupersetVisitor::visitType(Type *type) const
 }
 
 DDR_RC
-SupersetVisitor::visitType(TypedefUDT *type) const
+SupersetVisitor::visitTypedef(TypedefUDT *type) const
 {
-	/* No-op: do not print base types at this time. */
-	return DDR_RC_OK;
-}
-
-DDR_RC
-SupersetVisitor::visitType(ClassUDT *type) const
-{
-	OMRPORT_ACCESS_FROM_OMRPORT(_supersetGen->_portLibrary);
 	DDR_RC rc = DDR_RC_OK;
-	if (!type->_isDuplicate) {
-		if ((!type->isAnonymousType() || _addFieldsOnly)
-			&& ((type->_fieldMembers.size() > 0) || _supersetGen->_printEmptyTypes)) {
-			if (!_addFieldsOnly) {
-				string nameFormatted = _supersetGen->replace(type->getFullName(), "::", "$");
-				string lineToPrint = "S|" + nameFormatted + "|" + nameFormatted + "Pointer|";
-				if (NULL != type->_superClass) {
-					string superClassFormatted = _supersetGen->replace(type->_superClass->getFullName(), "::", "$");
-					lineToPrint += superClassFormatted + "\n";
-				} else {
-					lineToPrint += "\n";
-				}
-				omrfile_write(_supersetGen->_file, lineToPrint.c_str(), lineToPrint.length());
-			}
 
-			for (vector<EnumMember *>::iterator m = type->_enumMembers.begin(); m != type->_enumMembers.end(); ++m) {
-				_supersetGen->printConstantMember((*m)->_name);
-			}
+	if (!_addFieldsOnly) {
+		Type *baseType = getBaseType(type, _supersetGen->_opaqueTypeNames);
 
-			for (vector<Field *>::iterator m = type->_fieldMembers.begin(); m != type->_fieldMembers.end(); ++m) {
-				rc = _supersetGen->printFieldMember(*m, _prefix);
-				if (DDR_RC_OK != rc) {
-					break;
-				}
-			}
-
+		/* print this typedef if its name is different than its baseType */
+		if (baseType->_name != type->_name) {
+			rc = writeType(type, NULL);
 			if (DDR_RC_OK == rc) {
-				for (vector<Macro>::iterator m = type->_macros.begin(); m != type->_macros.end(); ++m) {
-					if (DDR_RC_OK == m->getNumeric(NULL)) {
-						_supersetGen->printConstantMember(m->_name);
-					}
-				}
+				rc = baseType->acceptVisitor(SupersetVisitor(_supersetGen, true, _prefix));
 			}
 		}
 	}
 
-	/* Anonymous sub udt's not used as fields are to have their fields added to this struct.*/
-	if ((DDR_RC_OK == rc) && (!_addFieldsOnly)) {
-		for (vector<UDT *>::iterator it = type->_subUDTs.begin(); it != type->_subUDTs.end(); ++it) {
-			if ((*it)->isAnonymousType()) {
-				bool isUsedAsField = false;
-				for (vector<Field *>::iterator fit = type->_fieldMembers.begin(); fit != type->_fieldMembers.end(); fit += 1) {
-					if ((*fit)->_fieldType == (*it)) {
-						isUsedAsField = true;
-						break;
-					}
-				}
-				if (!isUsedAsField) {
-					rc = (*it)->acceptVisitor(SupersetVisitor(_supersetGen, true, _prefix));
-					if (DDR_RC_OK != rc) {
-						break;
-					}
-				}
-			}
-		}
-	}
-
-	if ((DDR_RC_OK == rc) && (!_addFieldsOnly)) {
-		for (vector<UDT *>::iterator it = type->_subUDTs.begin(); it != type->_subUDTs.end(); ++it) {
-			bool isUsedAsField = false;
-			if ((*it)->isAnonymousType()) {
-				for (vector<Field *>::iterator fit = type->_fieldMembers.begin(); fit != type->_fieldMembers.end(); fit += 1) {
-					if ((*fit)->_fieldType == (*it)) {
-						isUsedAsField = true;
-						break;
-					}
-				}
-			}
-			if (!(*it)->isAnonymousType() || isUsedAsField) {
-				rc = (*it)->acceptVisitor(SupersetVisitor(_supersetGen, false, _prefix));
-				if (DDR_RC_OK != rc) {
-					break;
-				}
-			}
-		}
-	}
 	return rc;
 }
 
 DDR_RC
-SupersetVisitor::visitType(UnionUDT *type) const
+SupersetVisitor::visitClass(ClassUDT *type) const
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(_supersetGen->_portLibrary);
 	DDR_RC rc = DDR_RC_OK;
-	if (!type->_isDuplicate) {
-		if ((!type->isAnonymousType() || _addFieldsOnly)
-			&& ((type->_fieldMembers.size() > 0) || _supersetGen->_printEmptyTypes)) {
-			if (!_addFieldsOnly) {
-				string nameFormatted = _supersetGen->replace(type->getFullName(), "::", "$");
-				string lineToPrint = "S|" + nameFormatted + "|" + nameFormatted + "Pointer|\n";
-				omrfile_write(_supersetGen->_file, lineToPrint.c_str(), lineToPrint.length());
-			}
 
-			for (vector<EnumMember *>::iterator m = type->_enumMembers.begin(); m != type->_enumMembers.end(); ++m) {
+	if ((_addFieldsOnly || !type->isAnonymousType())
+			&& (_supersetGen->_printEmptyTypes || !type->_fieldMembers.empty())) {
+		if (!_addFieldsOnly) {
+			rc = writeType(type, type->_superClass);
+		}
+
+		if (DDR_RC_OK == rc) {
+			for (vector<EnumMember *>::const_iterator m = type->_enumMembers.begin(); m != type->_enumMembers.end(); ++m) {
 				_supersetGen->printConstantMember((*m)->_name);
 			}
+		}
 
-			if (DDR_RC_OK == rc) {
-				for (vector<Field *>::iterator m = type->_fieldMembers.begin(); m != type->_fieldMembers.end(); ++m) {
-					rc = _supersetGen->printFieldMember(*m, _prefix);
-					if (DDR_RC_OK != rc) {
-						break;
-					}
-				}
-			}
-
-			if (DDR_RC_OK == rc) {
-				for (vector<Macro>::iterator m = type->_macros.begin(); m != type->_macros.end(); ++m) {
-					if (DDR_RC_OK == m->getNumeric(NULL)) {
-						_supersetGen->printConstantMember(m->_name);
-					}
+		if (DDR_RC_OK == rc) {
+			for (vector<Macro>::const_iterator m = type->_macros.begin(); m != type->_macros.end(); ++m) {
+				if (DDR_RC_OK == m->getNumeric(NULL)) {
+					_supersetGen->printConstantMember(m->_name);
 				}
 			}
 		}
-	}
-	if ((DDR_RC_OK == rc) && (!_addFieldsOnly)) {
-		for (vector<UDT *>::iterator v = type->_subUDTs.begin(); v != type->_subUDTs.end(); ++v) {
-			rc = (*v)->acceptVisitor(SupersetVisitor(_supersetGen, false, ""));
+
+		for (vector<Field *>::const_iterator m = type->_fieldMembers.begin(); m != type->_fieldMembers.end(); ++m) {
+			rc = _supersetGen->printFieldMember(*m, _prefix);
 			if (DDR_RC_OK != rc) {
 				break;
 			}
 		}
 	}
-	return rc;
-}
 
-DDR_RC
-SupersetVisitor::visitType(EnumUDT *type) const
-{
-	OMRPORT_ACCESS_FROM_OMRPORT(_supersetGen->_portLibrary);
-	DDR_RC rc = DDR_RC_OK;
-	if (!type->_isDuplicate) {
-		if ((!type->isAnonymousType() || _addFieldsOnly)
-			&& ((type->_enumMembers.size() > 0) || _supersetGen->_printEmptyTypes)) {
-			if (!_addFieldsOnly) {
-				string nameFormatted = _supersetGen->replace(type->getFullName(), "::", "$");
-				string lineToPrint = "S|" + nameFormatted + "|" + nameFormatted + "Pointer|\n";
-				omrfile_write(_supersetGen->_file, lineToPrint.c_str(), lineToPrint.length());
+	if ((DDR_RC_OK == rc) && !_addFieldsOnly) {
+		for (vector<UDT *>::const_iterator it = type->_subUDTs.begin(); it != type->_subUDTs.end(); ++it) {
+			UDT *nested = *it;
+			bool includeSubUDT = true;
+
+			if (nested->isAnonymousType()) {
+				includeSubUDT = false;
+				for (vector<Field *>::const_iterator fit = type->_fieldMembers.begin(); fit != type->_fieldMembers.end(); ++fit) {
+					if ((*fit)->_fieldType == nested) {
+						includeSubUDT = true;
+						break;
+					}
+				}
 			}
 
-			for (vector<EnumMember *>::iterator m = type->_enumMembers.begin(); m != type->_enumMembers.end(); ++m) {
-				_supersetGen->printConstantMember((*m)->_name);
+			if (includeSubUDT) {
+				rc = nested->acceptVisitor(SupersetVisitor(_supersetGen, false, _prefix));
+				if (DDR_RC_OK != rc) {
+					break;
+				}
 			}
 		}
 	}
+
 	return rc;
 }
 
 DDR_RC
-SupersetVisitor::visitType(NamespaceUDT *type) const
+SupersetVisitor::visitUnion(UnionUDT *type) const
 {
-	OMRPORT_ACCESS_FROM_OMRPORT(_supersetGen->_portLibrary);
 	DDR_RC rc = DDR_RC_OK;
-	if (!type->_isDuplicate) {
-		if (!type->isAnonymousType() || _addFieldsOnly) {
-			if (!_addFieldsOnly) {
-				string nameFormatted = _supersetGen->replace(type->getFullName(), "::", "$");
-				string lineToPrint = "S|" + nameFormatted + "|" + nameFormatted + "Pointer|\n";
-				omrfile_write(_supersetGen->_file, lineToPrint.c_str(), lineToPrint.length());
-			}
 
-			for (vector<Macro>::iterator m = type->_macros.begin(); m != type->_macros.end(); ++m) {
+	if ((_addFieldsOnly || !type->isAnonymousType())
+			&& (_supersetGen->_printEmptyTypes || !type->_fieldMembers.empty())) {
+		if (!_addFieldsOnly) {
+			rc = writeType(type, NULL);
+		}
+
+		if (DDR_RC_OK == rc) {
+			for (vector<EnumMember *>::const_iterator m = type->_enumMembers.begin(); m != type->_enumMembers.end(); ++m) {
+				_supersetGen->printConstantMember((*m)->_name);
+			}
+		}
+
+		if (DDR_RC_OK == rc) {
+			for (vector<Field *>::const_iterator m = type->_fieldMembers.begin(); m != type->_fieldMembers.end(); ++m) {
+				rc = _supersetGen->printFieldMember(*m, _prefix);
+				if (DDR_RC_OK != rc) {
+					break;
+				}
+			}
+		}
+
+		if (DDR_RC_OK == rc) {
+			for (vector<Macro>::const_iterator m = type->_macros.begin(); m != type->_macros.end(); ++m) {
 				if (DDR_RC_OK == m->getNumeric(NULL)) {
 					_supersetGen->printConstantMember(m->_name);
 				}
 			}
 		}
 	}
-	if (!_addFieldsOnly) {
-		/* Anonymous sub udt's are to have their fields added to this struct. */
-		for (vector<UDT *>::iterator v = type->_subUDTs.begin(); v != type->_subUDTs.end(); ++v) {
-			if ((*v)->isAnonymousType()) {
-				rc = (*v)->acceptVisitor(SupersetVisitor(_supersetGen, true, _prefix));
-				if (DDR_RC_OK != rc) {
-					break;
+
+	if ((DDR_RC_OK == rc) && !_addFieldsOnly) {
+		for (vector<UDT *>::const_iterator v = type->_subUDTs.begin(); v != type->_subUDTs.end(); ++v) {
+			rc = (*v)->acceptVisitor(SupersetVisitor(_supersetGen, false, ""));
+			if (DDR_RC_OK != rc) {
+				break;
+			}
+		}
+	}
+
+	return rc;
+}
+
+DDR_RC
+SupersetVisitor::visitEnum(EnumUDT *type) const
+{
+	DDR_RC rc = DDR_RC_OK;
+
+	if ((_addFieldsOnly || !type->isAnonymousType())
+			&& (_supersetGen->_printEmptyTypes || !type->_enumMembers.empty())) {
+		if (!_addFieldsOnly) {
+			rc = writeType(type, NULL);
+		}
+
+		if (DDR_RC_OK == rc) {
+			for (vector<EnumMember *>::const_iterator m = type->_enumMembers.begin(); m != type->_enumMembers.end(); ++m) {
+				_supersetGen->printConstantMember((*m)->_name);
+			}
+		}
+	}
+
+	return rc;
+}
+
+DDR_RC
+SupersetVisitor::visitNamespace(NamespaceUDT *type) const
+{
+	DDR_RC rc = DDR_RC_OK;
+
+	if (_addFieldsOnly || !type->isAnonymousType()) {
+		if (!_addFieldsOnly) {
+			rc = writeType(type, NULL);
+		}
+
+		if (DDR_RC_OK == rc) {
+			for (vector<Macro>::const_iterator m = type->_macros.begin(); m != type->_macros.end(); ++m) {
+				if (DDR_RC_OK == m->getNumeric(NULL)) {
+					_supersetGen->printConstantMember(m->_name);
 				}
 			}
 		}
+	}
 
-		for (vector<UDT *>::iterator v = type->_subUDTs.begin(); v != type->_subUDTs.end(); ++v) {
-			if (!(*v)->isAnonymousType()) {
-				rc = (*v)->acceptVisitor(SupersetVisitor(_supersetGen, false, _prefix));
+	if (!_addFieldsOnly) {
+		for (vector<UDT *>::const_iterator v = type->_subUDTs.begin(); v != type->_subUDTs.end(); ++v) {
+			UDT *nested = *v;
+
+			if (!nested->isAnonymousType()) {
+				rc = nested->acceptVisitor(*this);
 				if (DDR_RC_OK != rc) {
 					break;
 				}
 			}
 		}
 	}
+
 	return rc;
 }
 
 DDR_RC
 JavaSupersetGenerator::printSuperset(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *supersetFile)
 {
+	DDR_RC rc = DDR_RC_OK;
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+
 	_portLibrary = portLibrary;
 	_file = omrfile_open(supersetFile, EsOpenCreate | EsOpenWrite | EsOpenAppend | EsOpenTruncate, 0644);
 
-	DDR_RC rc = DDR_RC_OK;
-	for (vector<Type *>::iterator v = ir->_types.begin(); v != ir->_types.end(); ++v) {
-		rc = (*v)->acceptVisitor(SupersetVisitor(this, false, ""));
-		if (DDR_RC_OK != rc) {
-			break;
+	_opaqueTypeNames.insert(ir->_opaqueTypeNames.begin(), ir->_opaqueTypeNames.end());
+
+	const SupersetVisitor printer(this, false, "");
+
+	for (vector<Type *>::const_iterator v = ir->_types.begin(); v != ir->_types.end(); ++v) {
+		Type *type = *v;
+		if (!type->_blacklisted) {
+			rc = type->acceptVisitor(printer);
+			if (DDR_RC_OK != rc) {
+				break;
+			}
 		}
 	}
+
 	return rc;
 }

--- a/ddr/lib/ddr-ir/ClassUDT.cpp
+++ b/ddr/lib/ddr-ir/ClassUDT.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,9 @@ ClassUDT::ClassUDT(size_t size, bool isClass, unsigned int lineNumber)
 {
 }
 
-ClassUDT::~ClassUDT() {};
+ClassUDT::~ClassUDT()
+{
+}
 
 string
 ClassUDT::getSymbolKindName()
@@ -35,19 +37,19 @@ ClassUDT::getSymbolKindName()
 }
 
 DDR_RC
-ClassUDT::acceptVisitor(TypeVisitor const &visitor)
+ClassUDT::acceptVisitor(const TypeVisitor &visitor)
 {
-	return visitor.visitType(this);
+	return visitor.visitClass(this);
 }
 
 bool
-ClassUDT::operator==(Type const & rhs) const
+ClassUDT::operator==(const Type & rhs) const
 {
 	return rhs.compareToClass(*this);
 }
 
 bool
-ClassUDT::compareToClass(ClassUDT const &other) const
+ClassUDT::compareToClass(const ClassUDT &other) const
 {
 	return compareToClasstype(other)
 		&& (*_superClass == *other._superClass);

--- a/ddr/lib/ddr-ir/EnumMember.cpp
+++ b/ddr/lib/ddr-ir/EnumMember.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,8 +22,9 @@
 #include "ddr/ir/EnumMember.hpp"
 
 EnumMember::EnumMember()
+	: Members()
+	, _value(0)
 {
-	_value = 0;
 }
 
 EnumMember::~EnumMember()

--- a/ddr/lib/ddr-ir/EnumUDT.cpp
+++ b/ddr/lib/ddr-ir/EnumUDT.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,24 +26,14 @@
 EnumUDT::EnumUDT(unsigned int lineNumber)
 	: UDT(4, lineNumber)
 {
-};
+}
 
 EnumUDT::~EnumUDT()
 {
-	for (size_t i = 0; i < _enumMembers.size(); i++) {
-		if (_enumMembers[i] == NULL) {
-			ERRMSG("Null member, cannot free");
-		} else {
-			delete(_enumMembers[i]);
-		}
+	for (vector<EnumMember *>::iterator it = _enumMembers.begin(); it != _enumMembers.end(); ++it) {
+		delete *it;
 	}
 	_enumMembers.clear();
-}
-
-bool
-EnumUDT::isAnonymousType()
-{
-	return (NULL != _outerNamespace) && (_name.empty());
 }
 
 string
@@ -53,25 +43,25 @@ EnumUDT::getSymbolKindName()
 }
 
 DDR_RC
-EnumUDT::acceptVisitor(TypeVisitor const &visitor)
+EnumUDT::acceptVisitor(const TypeVisitor &visitor)
 {
-	return visitor.visitType(this);
+	return visitor.visitEnum(this);
 }
 
 bool
-EnumUDT::operator==(Type const & rhs) const
+EnumUDT::operator==(const Type & rhs) const
 {
 	return rhs.compareToEnum(*this);
 }
 
 bool
-EnumUDT::compareToEnum(EnumUDT const &other) const
+EnumUDT::compareToEnum(const EnumUDT &other) const
 {
 	bool enumMembersEqual = _enumMembers.size() == other._enumMembers.size();
 	vector<EnumMember *>::const_iterator it2 = other._enumMembers.begin();
 	for (vector<EnumMember *>::const_iterator it = _enumMembers.begin();
 		it != _enumMembers.end() && it2 != other._enumMembers.end() && enumMembersEqual;
-		++ it, ++ it2) {
+		++it, ++it2) {
 		enumMembersEqual = ((*it)->_name == (*it2)->_name) && ((*it)->_value == (*it2)->_value);
 	}
 	return compareToUDT(other)

--- a/ddr/lib/ddr-ir/Field.cpp
+++ b/ddr/lib/ddr-ir/Field.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,17 +20,20 @@
  *******************************************************************************/
 
 #include "ddr/ir/Field.hpp"
+#include "ddr/ir/Type.hpp"
 
 Field::Field()
-	: _fieldType(NULL),
-	  _sizeOf(0),
-	  _bitField(0),
-	  _isStatic(false)
+	: _fieldType(NULL)
+	, _sizeOf(0)
+	, _offset(0)
+	, _modifiers()
+	, _bitField(0)
+	, _isStatic(false)
 {
 }
 
-string
-Field::getTypeName()
+const string &
+Field::getTypeName() const
 {
 	return _fieldType->_name;
 }

--- a/ddr/lib/ddr-ir/Macro.cpp
+++ b/ddr/lib/ddr-ir/Macro.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,61 +19,48 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "ddr/config.hpp"
-
-#include "ddr/error.hpp"
 #include "ddr/ir/Macro.hpp"
 
-#include "ddr/std/sstream.hpp"
-#include <string.h>
+#include <stdlib.h>
 
 using std::string;
-using std::stringstream;
 
 DDR_RC
-Macro::getNumeric(long long *ret)
+Macro::getNumeric(long long *ret) const
 {
-	DDR_RC rc = DDR_RC_OK;
-	string value = getValue();
+	DDR_RC rc = DDR_RC_ERROR;
+	const string &value = getValue();
+	const char * const whitespace = "\t ";
 
-	if (value.length() > 0) {
-		/* If the pre-processed macro contains no brackets, read it as a number. */
-		if (string::npos == value.find('(')) {
-			stringstream ss;
-			ss << value;
-			long long valueNumeric = 0;
-			ss >> valueNumeric;
-			if (ss.fail()) {
-				rc = DDR_RC_ERROR;
-			} else if (NULL != ret) {
-				*ret = valueNumeric;
-			}
+	for (size_t start = 0, end = value.length() - 1; start <= end;) {
+		/* trim leading whitespace */
+		start = value.find_first_not_of(whitespace, start);
+		if (string::npos == start) {
+			break;
+		}
+
+		/* trim trailing whitespace */
+		end = value.find_last_not_of(whitespace, end);
+
+		if (('(' == value[start]) && (')' == value[end])) {
+			/* discard a pair of balanced parentheses and continue */
+			++start;
+			--end;
 		} else {
-			/* For macros containing brackets, extract the number. This works for casts
-			 * such as ((int)5).
-			 */
-			rc = DDR_RC_ERROR;
-			while (string::npos != value.find('(')) {
-				size_t lastOpenParen = value.find_last_of('(');
-				size_t nextCloseParen = value.find(')', lastOpenParen);
-				if (string::npos == nextCloseParen) {
-					break;
+			string trimmed = value.substr(start, end - start + 1);
+			const char * c_trimmed = trimmed.c_str();
+			char * end = NULL;
+			/* strtoll parses prefixes like '0x' when the final argument is 0 */
+			long long int valueNumeric = strtoll(c_trimmed, &end, 0);
+
+			if ((NULL != end) && ('\0' == *end)) {
+				/* strtoll consumed the whole string */
+				if (NULL != ret) {
+					*ret = valueNumeric;
 				}
-				string substr = value.substr(lastOpenParen + 1, nextCloseParen - lastOpenParen - 1);
-				stringstream ss;
-				ss << substr;
-				long long valueNumeric = 0;
-				ss >> valueNumeric;
-				if (!ss.fail()) {
-					rc = DDR_RC_OK;
-					if (NULL != ret) {
-						*ret = valueNumeric;
-					}
-					break;
-				} else {
-					value.replace(lastOpenParen, nextCloseParen, "");
-				}
+				rc = DDR_RC_OK;
 			}
+			break;
 		}
 	}
 

--- a/ddr/lib/ddr-ir/Macro.cpp
+++ b/ddr/lib/ddr-ir/Macro.cpp
@@ -23,6 +23,11 @@
 
 #include <stdlib.h>
 
+#if defined(_MSC_VER)
+/* Older Visual Studio compilers don't provide strtoll(). */
+#define strtoll(str, end, base) _strtoi64((str), (end), (base))
+#endif
+
 using std::string;
 
 DDR_RC

--- a/ddr/lib/ddr-ir/Type.cpp
+++ b/ddr/lib/ddr-ir/Type.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,17 +21,25 @@
 
 #include "ddr/ir/Type.hpp"
 
+// DEBUGGING
+#include "ddr/ir/Macro.hpp"
+#include <stdio.h>
+
 Type::Type(size_t size)
-	: _sizeOf(size), _isDuplicate(false)
+	: _blacklisted(false)
+	, _name()
+	, _sizeOf(size)
 {
 }
 
-Type::~Type() {}
+Type::~Type()
+{
+}
 
 bool
-Type::isAnonymousType()
+Type::isAnonymousType() const
 {
-	return false;
+	return _name.empty();
 }
 
 string
@@ -47,15 +55,16 @@ Type::getSymbolKindName()
 }
 
 DDR_RC
-Type::acceptVisitor(TypeVisitor const &visitor)
+Type::acceptVisitor(const TypeVisitor &visitor)
 {
 	return visitor.visitType(this);
 }
 
-void
-Type::checkDuplicate(Symbol_IR *ir)
+bool
+Type::insertUnique(Symbol_IR *ir)
 {
 	/* No-op: since Types aren't printed, there's no need to check if they're duplicates either */
+	return false;
 }
 
 NamespaceUDT *
@@ -86,16 +95,18 @@ void
 Type::addMacro(Macro *macro)
 {
 	/* No-op: macros cannot be associated with base types. */
+	printf("Type::addMacro: ignore(%s::%s = %s)\n",
+			_name.c_str(), macro->_name.c_str(), macro->getValue().c_str());
 }
 
-std::vector<UDT *> *
+vector<UDT *> *
 Type::getSubUDTS()
 {
 	return NULL;
 }
 
 void
-Type::renameFieldsAndMacros(FieldOverride fieldOverride, Type *replacementType)
+Type::renameFieldsAndMacros(const FieldOverride &fieldOverride, Type *replacementType)
 {
 	/* No-op: base types have no fields. */
 }
@@ -107,56 +118,56 @@ Type::getBaseType()
 }
 
 bool
-Type::operator==(Type const & rhs) const
+Type::operator==(const Type & rhs) const
 {
 	return rhs.compareToType(*this);
 }
 
 bool
-Type::compareToType(Type const &other) const
+Type::compareToType(const Type &other) const
 {
 	return (_name == other._name)
 		&& ((0 == _sizeOf) || (0 == other._sizeOf) || (_sizeOf == other._sizeOf));
 }
 
 bool
-Type::compareToUDT(UDT const &) const
+Type::compareToUDT(const UDT &) const
 {
 	return false;
 }
 
 bool
-Type::compareToNamespace(NamespaceUDT const &) const
+Type::compareToNamespace(const NamespaceUDT &) const
 {
 	return false;
 }
 
 bool
-Type::compareToEnum(EnumUDT const &) const
+Type::compareToEnum(const EnumUDT &) const
 {
 	return false;
 }
 
 bool
-Type::compareToTypedef(TypedefUDT const &) const
+Type::compareToTypedef(const TypedefUDT &) const
 {
 	return false;
 }
 
 bool
-Type::compareToClasstype(ClassType const &) const
+Type::compareToClasstype(const ClassType &) const
 {
 	return false;
 }
 
 bool
-Type::compareToUnion(UnionUDT const &) const
+Type::compareToUnion(const UnionUDT &) const
 {
 	return false;
 }
 
 bool
-Type::compareToClass(ClassUDT const &) const
+Type::compareToClass(const ClassUDT &) const
 {
 	return false;
 }

--- a/ddr/lib/ddr-ir/TypedefUDT.cpp
+++ b/ddr/lib/ddr-ir/TypedefUDT.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,22 +31,22 @@ TypedefUDT::~TypedefUDT()
 }
 
 DDR_RC
-TypedefUDT::acceptVisitor(TypeVisitor const &visitor)
+TypedefUDT::acceptVisitor(const TypeVisitor &visitor)
 {
-	return visitor.visitType(this);
+	return visitor.visitTypedef(this);
 }
 
-void
-TypedefUDT::checkDuplicate(Symbol_IR *ir)
+bool
+TypedefUDT::insertUnique(Symbol_IR *ir)
 {
-	/* No-op: since TypedefUDTs aren't printed, there's no need to check if they're duplicates either */
+	// FIXME remove this method?
+	return UDT::insertUnique(ir);
 }
 
 string
 TypedefUDT::getSymbolKindName()
 {
-	if (NULL == _aliasedType) return "";
-	return _aliasedType->getSymbolKindName();
+	return "";
 }
 
 size_t
@@ -76,13 +76,13 @@ TypedefUDT::getBaseType()
 }
 
 bool
-TypedefUDT::operator==(Type const & rhs) const
+TypedefUDT::operator==(const Type & rhs) const
 {
 	return rhs.compareToTypedef(*this);
 }
 
 bool
-TypedefUDT::compareToTypedef(TypedefUDT const &other) const
+TypedefUDT::compareToTypedef(const TypedefUDT &other) const
 {
 	return compareToType(other)
 		&& *_aliasedType == *other._aliasedType

--- a/ddr/lib/ddr-ir/UnionUDT.cpp
+++ b/ddr/lib/ddr-ir/UnionUDT.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,9 +29,9 @@ UnionUDT::UnionUDT(size_t size, unsigned int lineNumber)
 UnionUDT::~UnionUDT() {};
 
 DDR_RC
-UnionUDT::acceptVisitor(TypeVisitor const &visitor)
+UnionUDT::acceptVisitor(const TypeVisitor &visitor)
 {
-	return visitor.visitType(this);
+	return visitor.visitUnion(this);
 }
 
 string
@@ -41,13 +41,13 @@ UnionUDT::getSymbolKindName()
 }
 
 bool
-UnionUDT::operator==(Type const & rhs) const
+UnionUDT::operator==(const Type & rhs) const
 {
 	return rhs.compareToUnion(*this);
 }
 
 bool
-UnionUDT::compareToUnion(UnionUDT const &other) const
+UnionUDT::compareToUnion(const UnionUDT &other) const
 {
 	return compareToClasstype(other);
 }

--- a/ddr/lib/ddr-macros/MacroInfo.cpp
+++ b/ddr/lib/ddr-macros/MacroInfo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,37 +21,37 @@
 
 #include "ddr/macros/MacroInfo.hpp"
 
-MacroInfo::MacroInfo(string typeName)
+MacroInfo::MacroInfo(const string &typeName)
 	: _typeName(typeName)
 {
 }
 
-string
-MacroInfo::getTypeName()
+const string &
+MacroInfo::getTypeName() const
 {
 	return _typeName;
 }
 
 void
-MacroInfo::addMacro(pair<string, string> p)
+MacroInfo::addMacro(const string &name, const string &value)
 {
-	_macros.insert(p);
+	_macros.insert(make_pair(name, value));
 }
 
 size_t
-MacroInfo::getNumMacros()
+MacroInfo::getNumMacros() const
 {
 	return _macros.size();
 }
 
-set<pair<string, string> >::iterator
-MacroInfo::getMacroStart()
+set<pair<string, string> >::const_iterator
+MacroInfo::getMacroStart() const
 {
 	return _macros.begin();
 }
 
-set<pair<string, string> >::iterator
-MacroInfo::getMacroEnd()
+set<pair<string, string> >::const_iterator
+MacroInfo::getMacroEnd() const
 {
 	return _macros.end();
 }

--- a/ddr/lib/ddr-macros/MacroTool.cpp
+++ b/ddr/lib/ddr-macros/MacroTool.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,44 +19,25 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "ddr/config.hpp"
-
-#include "ddr/std/unordered_map.hpp"
-#include <fstream>
-#include <iostream>
-#include <set>
-
-#include "ddr/error.hpp"
 #include "ddr/macros/MacroTool.hpp"
+
 #include "ddr/ir/NamespaceUDT.hpp"
 #include "ddr/std/unordered_map.hpp"
 
+#include <fstream>
+#include <iostream>
 
-string
-MacroTool::getTypeName(string s)
-{
-	string typeEyeCatcher = "@TYPE_";
-	return s.substr(typeEyeCatcher.size());
-}
+#define FileBeginEyeCatcher "@DDRFILE_BEGIN "
+#define FileEndEyeCatcher "@DDRFILE_END "
+#define MacroEyeCatcher "@MACRO_"
+#define TypeEyeCatcher "@TYPE_"
 
-pair<string, string>
-MacroTool::getMacroInfo(string s)
-{
-	string macroEyeCatcher = "@MACRO_";
-	size_t pos = s.find(" ");
-	string name = s.substr(macroEyeCatcher.size(), pos - macroEyeCatcher.size());
-	/* pos is the location of a space. Add +1 to remove the space from the substring */
-	string value = s.substr(pos + 1);
-	pair<string, string> p(name, value);
-	return p;
-}
+#define LITERAL_STRLEN(s) (sizeof(s) - 1)
 
-string
-MacroTool::getFileName(string s)
+static bool
+startsWith(const string &str, const char *prefix, size_t prefix_len)
 {
-	string fileNameEyeCatcher = "@DDRFILE_BEGIN ";
-	string fileName = s.substr(fileNameEyeCatcher.size());
-	return fileName;
+	return 0 == str.compare(0, prefix_len, prefix, prefix_len);
 }
 
 /**
@@ -66,8 +47,8 @@ MacroTool::getFileName(string s)
  * type name. This vector is returned as an output parameter.
  * @return DDR_RC_OK on failure, DDR_RC_ERROR if an error is encountered.
  */
-	DDR_RC
-MacroTool::getMacros(string fname)
+DDR_RC
+MacroTool::getMacros(const string &fname)
 {
 	DDR_RC rc = DDR_RC_OK;
 
@@ -76,8 +57,7 @@ MacroTool::getMacros(string fname)
 		return DDR_RC_ERROR;
 	}
 
-	string line;
-	ifstream infile(fname.c_str());
+	std::ifstream infile(fname.c_str());
 
 	if (!infile) {
 		ERRMSG("invalid macrolist filename");
@@ -85,29 +65,45 @@ MacroTool::getMacros(string fname)
 	}
 
 	set<string> includeFileSet;
+	string line;
 	/* Parse the input file for macros with values. */
 	while (getline(infile, line)) {
-		if (0 == line.find("@DDRFILE_BEGIN")) {
-			string fileName = getFileName(line);
-			if (includeFileSet.end() != includeFileSet.find(fileName)) {
+		if (startsWith(line, FileBeginEyeCatcher, LITERAL_STRLEN(FileBeginEyeCatcher))) {
+			const string fileName = line.substr(LITERAL_STRLEN(FileBeginEyeCatcher));
+			if (includeFileSet.end() == includeFileSet.find(fileName)) {
+				includeFileSet.insert(fileName);
+			} else {
 				/* This include file was already processed.
 				 * Scan until the file end delimiter is found.
 				 */
 				while (getline(infile, line)) {
-					if (0 == line.find("@DDRFILE_END")) {
+					if (startsWith(line, FileEndEyeCatcher, LITERAL_STRLEN(FileEndEyeCatcher))) {
 						break;
 					}
 				}
-			} else {
-				includeFileSet.insert(fileName);
 			}
-		} else if (string::npos != line.find("@TYPE_")) {
-			MacroInfo m(getTypeName(line));
-			macroList.push_back(m);
-		} else if (string::npos != line.find("@MACRO_")) {
-			pair<string, string> macro = getMacroInfo(line);
-			if (!macro.second.empty()) {
-				macroList.back().addMacro(macro);
+		} else if (startsWith(line, TypeEyeCatcher, LITERAL_STRLEN(TypeEyeCatcher))) {
+			const string typeName = line.substr(LITERAL_STRLEN(TypeEyeCatcher));
+			MacroInfo info(typeName);
+			macroList.push_back(info);
+		} else if (startsWith(line, MacroEyeCatcher, LITERAL_STRLEN(MacroEyeCatcher))) {
+			const char * const whitespace = "\t ";
+			const size_t pos = line.find_first_of(whitespace);
+			if ((string::npos == pos) || (pos <= LITERAL_STRLEN(MacroEyeCatcher))) {
+				// input malformed: no space
+			} else {
+				/* omit leading whitespace */
+				size_t start = line.find_first_not_of(whitespace, pos);
+
+				if (string::npos != start) {
+					/* omit trailing whitespace */
+					size_t end = line.find_last_not_of(whitespace);
+
+					const string name = line.substr(LITERAL_STRLEN(MacroEyeCatcher), pos - LITERAL_STRLEN(MacroEyeCatcher) );
+					const string value = line.substr(start, end - start + 1);
+
+					macroList.back().addMacro(name, value);
+				}
 			}
 		}
 	}
@@ -116,7 +112,7 @@ MacroTool::getMacros(string fname)
 }
 
 DDR_RC
-MacroTool::addMacrosToIR(Symbol_IR *ir)
+MacroTool::addMacrosToIR(Symbol_IR *ir) const
 {
 	DDR_RC rc = DDR_RC_OK;
 
@@ -124,25 +120,42 @@ MacroTool::addMacrosToIR(Symbol_IR *ir)
 	 * can contain macros. This is used to add macros to existing types.
 	 */
 	unordered_map<string, Type *> irMap;
-	for (vector<Type *>::iterator it = ir->_types.begin(); it != ir->_types.end(); it += 1) {
-		irMap[(*it)->_name] = *it;
+	for (std::vector<Type *>::const_iterator it = ir->_types.begin(); it != ir->_types.end(); ++it) {
+		Type *type = *it;
+
+		if (type->isAnonymousType()) {
+			continue;
+		} else if (type->getSymbolKindName().empty()) {
+			continue;
+		} else {
+			const string &typeName = type->_name;
+
+			if (irMap.end() == irMap.find(typeName)) {
+				irMap[typeName] = type;
+			} else {
+				ERRMSG("Duplicate type name: %s", typeName.c_str());
+				return DDR_RC_ERROR;
+			}
+		}
 	}
 
-	for (vector<MacroInfo>::iterator it = macroList.begin(); it != macroList.end(); it += 1) {
+	for (std::vector<MacroInfo>::const_iterator it = macroList.begin(); it != macroList.end(); ++it) {
 		/* For each found MacroInfo which contains macros, add the macros to the IR. */
-		MacroInfo *macroInfo = &*it;
-		if (macroInfo->getNumMacros() > 0) {
+		const MacroInfo &macroInfo = *it;
+		if (macroInfo.getNumMacros() > 0) {
 			Type *outerType = NULL;
-			/* If there is a type of the correct name already, use it. Otherwise,
-			 * create a new namespace to contain the macros.
+			/* If there is a type of the correct name already, use it.
+			 * Otherwise, create a new namespace to contain the macros.
 			 */
-			if (irMap.find(macroInfo->getTypeName()) == irMap.end()) {
-				outerType = new NamespaceUDT();
-				outerType->_name = macroInfo->getTypeName();
-				ir->_types.push_back(outerType);
-				irMap[macroInfo->getTypeName()] = outerType;
+			const string &typeName = macroInfo.getTypeName();
+			unordered_map<string, Type *>::iterator mapIt = irMap.find(typeName);
+			if (irMap.end() != mapIt) {
+				outerType = mapIt->second;
 			} else {
-				outerType = irMap[macroInfo->getTypeName()];
+				outerType = new NamespaceUDT;
+				outerType->_name = typeName;
+				ir->_types.push_back(outerType);
+				irMap[typeName] = outerType;
 			}
 
 			if (NULL == outerType) {
@@ -150,9 +163,8 @@ MacroTool::addMacrosToIR(Symbol_IR *ir)
 				rc = DDR_RC_ERROR;
 				break;
 			} else {
-				for (set<pair<string, string> >::iterator it = macroInfo->getMacroStart(); it != macroInfo->getMacroEnd(); ++it) {
-					Macro macro(it->first, it->second);
-					outerType->addMacro(&macro);
+				for (set<pair<string, string> >::const_iterator it = macroInfo.getMacroStart(); it != macroInfo.getMacroEnd(); ++it) {
+					outerType->addMacro(new Macro(it->first, it->second));
 				}
 			}
 		}

--- a/ddr/lib/ddr-scanner/dwarf/AixSymbolTableParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/AixSymbolTableParser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,7 @@ dwarf_finish(Dwarf_Debug dbg, Dwarf_Error *error)
 		if (NULL != Dwarf_CU_Context::_currentCU->_die) {
 			deleteDie(Dwarf_CU_Context::_currentCU->_die);
 		}
-		delete(Dwarf_CU_Context::_currentCU);
+		delete Dwarf_CU_Context::_currentCU;
 		Dwarf_CU_Context::_currentCU = nextCU;
 	}
 
@@ -148,9 +148,9 @@ dwarf_init(int fd,
 
 	/* If the symbol table that we parsed contained no new files, create an empty placeholder generic CU and CU DIE. */
 	if (NULL == Dwarf_CU_Context::_firstCU) {
-		Dwarf_CU_Context *newCU = new Dwarf_CU_Context();
-		Dwarf_Die newDie = new Dwarf_Die_s();
-		Dwarf_Attribute name = new Dwarf_Attribute_s();
+		Dwarf_CU_Context *newCU = new Dwarf_CU_Context;
+		Dwarf_Die newDie = new Dwarf_Die_s;
+		Dwarf_Attribute name = new Dwarf_Attribute_s;
 
 		if ((NULL == newCU) || (NULL == newDie) || (NULL == name)) {
 			ret = DW_DLV_ERROR;
@@ -201,7 +201,7 @@ dwarf_init(int fd,
 static void
 checkBitFields(Dwarf_Error *error)
 {
-	for (size_t i = 0; i < bitFieldsToCheck.size(); i++) {
+	for (size_t i = 0; i < bitFieldsToCheck.size(); ++i) {
 		/* Since this is a field, the type attribute is always the attribute after the first of the die passed in. */
 		Dwarf_Attribute type = NULL;
 		Dwarf_Attribute bitSize = NULL;
@@ -257,7 +257,7 @@ checkBitFields(Dwarf_Error *error)
 				if (NULL != tmpAttribute->_nextAttr->_stringdata) {
 					free(tmpAttribute->_nextAttr->_stringdata);
 				}
-				delete(tmpAttribute->_nextAttr);
+				delete tmpAttribute->_nextAttr;
 				tmpAttribute->_nextAttr = NULL;
 			}
 		}
@@ -274,7 +274,7 @@ deleteDie(Dwarf_Die die)
 		if (NULL != attr->_stringdata) {
 			free(attr->_stringdata);
 		}
-		delete(attr);
+		delete attr;
 		attr = next;
 	}
 
@@ -285,7 +285,7 @@ deleteDie(Dwarf_Die die)
 	if (NULL != die->_child) {
 		deleteDie(die->_child);
 	}
-	delete(die);
+	delete die;
 }
 
 
@@ -342,12 +342,12 @@ parseArray(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 			 * arrayInfo[3] : array type
 			 */
 			/* Populate array */
-			Dwarf_Attribute type = new Dwarf_Attribute_s();
+			Dwarf_Attribute type = new Dwarf_Attribute_s;
 
 			/* Create a DIE to hold info about the subrange type. */
-			Dwarf_Die newDie = new Dwarf_Die_s();
-			Dwarf_Attribute subrangeType = new Dwarf_Attribute_s();
-			Dwarf_Attribute subrangeUpperBound = new Dwarf_Attribute_s();
+			Dwarf_Die newDie = new Dwarf_Die_s;
+			Dwarf_Attribute subrangeType = new Dwarf_Attribute_s;
+			Dwarf_Attribute subrangeUpperBound = new Dwarf_Attribute_s;
 			if ((NULL == type) || (NULL == newDie) || (NULL == subrangeType) || (NULL == subrangeUpperBound)) {
 				ret = DW_DLV_ERROR;
 				setError(error, DW_DLE_MAF);
@@ -414,8 +414,8 @@ parseBaseType(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 
 	/* Populate the DIE according to the base type specified. */
 	if (!BUILT_IN_TYPES[index].empty()) {
-		Dwarf_Attribute name = new Dwarf_Attribute_s();
-		Dwarf_Attribute size = new Dwarf_Attribute_s();
+		Dwarf_Attribute name = new Dwarf_Attribute_s;
+		Dwarf_Attribute size = new Dwarf_Attribute_s;
 		if ((NULL == name) || (NULL == size)) {
 			ret = DW_DLV_ERROR;
 			setError(error, DW_DLE_MAF);
@@ -492,7 +492,7 @@ parseNamelessReference(const string data, Dwarf_Die currentDie, Dwarf_Error *err
 {
 	int ret = DW_DLV_OK;
 	/* Give the DIE a type attribute. */
-	Dwarf_Attribute type = new Dwarf_Attribute_s();
+	Dwarf_Attribute type = new Dwarf_Attribute_s;
 	if (NULL == type) {
 		ret = DW_DLV_ERROR;
 		setError(error, DW_DLE_MAF);
@@ -670,7 +670,7 @@ parseStabstringDeclarationIntoDwarfDie(const string line, Dwarf_Error *error)
 
 		/* Create a new DIE only if it wasn't previously created. */
 		if (NULL == newDie) {
-			newDie = new Dwarf_Die_s();
+			newDie = new Dwarf_Die_s;
 			if (NULL == newDie) {
 				ret = DW_DLV_ERROR;
 				setError(error, DW_DLE_MAF);
@@ -821,13 +821,13 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 				filesAdded.insert(fileName);
 
 				/* Create one compilation unit context per file. */
-				Dwarf_CU_Context *newCU = new Dwarf_CU_Context();
+				Dwarf_CU_Context *newCU = new Dwarf_CU_Context;
 
 				/* Create a root DIE for the DIE tree in CU. */
-				Dwarf_Die newDie = new Dwarf_Die_s();
+				Dwarf_Die newDie = new Dwarf_Die_s;
 
 				/* Create name attribute for the DIE. */
-				Dwarf_Attribute name = new Dwarf_Attribute_s();
+				Dwarf_Attribute name = new Dwarf_Attribute_s;
 
 				if ((NULL == newCU) || (NULL == newDie) || (NULL == name)) {
 					ret = DW_DLV_ERROR;
@@ -983,7 +983,7 @@ parseEnum(const string data,
 			/* Create new DIEs for each of the enumerators. */
 			str_vect enumerators = split(members, ',');
 
-			Dwarf_Die newDie = new Dwarf_Die_s();
+			Dwarf_Die newDie = new Dwarf_Die_s;
 			if (NULL == newDie) {
 				ret = DW_DLV_ERROR;
 				setError(error, DW_DLE_MAF);
@@ -998,9 +998,9 @@ parseEnum(const string data,
 				newDie->_attribute = NULL;
 
 				currentDie->_child = newDie;
-				for (unsigned int i = 1; i < enumerators.size(); i++) {
+				for (unsigned int i = 1; i < enumerators.size(); ++i) {
 					if (DW_DLV_OK == ret) {
-						Dwarf_Die tempDie = new Dwarf_Die_s();
+						Dwarf_Die tempDie = new Dwarf_Die_s;
 						if (NULL == tempDie) {
 							ret = DW_DLV_ERROR;
 							setError(error, DW_DLE_MAF);
@@ -1024,8 +1024,8 @@ parseEnum(const string data,
 					for (str_vect::iterator it = enumerators.begin(); it != enumerators.end(); ++it) {
 						tmp = split(*it, ':');
 
-						Dwarf_Attribute enumeratorName = new Dwarf_Attribute_s();
-						Dwarf_Attribute enumeratorValue = new Dwarf_Attribute_s();
+						Dwarf_Attribute enumeratorName = new Dwarf_Attribute_s;
+						Dwarf_Attribute enumeratorValue = new Dwarf_Attribute_s;
 
 						if ((NULL == enumeratorName) || (NULL == enumeratorValue)) {
 							ret = DW_DLV_ERROR;
@@ -1077,9 +1077,9 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 	str_vect fieldAttributes = split(field[1], ',');
 
 	/* Create attributes. */
-	Dwarf_Attribute name = new Dwarf_Attribute_s();
-	Dwarf_Attribute type = new Dwarf_Attribute_s();
-	Dwarf_Attribute declFile = new Dwarf_Attribute_s();
+	Dwarf_Attribute name = new Dwarf_Attribute_s;
+	Dwarf_Attribute type = new Dwarf_Attribute_s;
+	Dwarf_Attribute declFile = new Dwarf_Attribute_s;
 
 	if ((NULL == name) || (NULL == type) || (NULL == declFile)) {
 		ret = DW_DLV_ERROR;
@@ -1125,7 +1125,7 @@ parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 				}
 			}
 			if (bitSizeNeeded) {
-				Dwarf_Attribute bitSize = new Dwarf_Attribute_s();
+				Dwarf_Attribute bitSize = new Dwarf_Attribute_s;
 				declFile->_nextAttr = bitSize;
 
 				/* Set the bit size. */
@@ -1180,9 +1180,9 @@ parseCstruct(const string data,
 				}
 			}
 
-			for (unsigned int i = 0; i < members.size(); i++) {
+			for (unsigned int i = 0; i < members.size(); ++i) {
 				if (DW_DLV_OK == ret) {
-					Dwarf_Die newDie = new Dwarf_Die_s();
+					Dwarf_Die newDie = new Dwarf_Die_s;
 					if (NULL == newDie) {
 						ret = DW_DLV_ERROR;
 						setError(error, DW_DLE_MAF);
@@ -1251,8 +1251,8 @@ parseCPPstruct(const string data,
 				int parentClassID = toInt(stripLeading(sizeTypeAndInheritance.substr(indexOfColon), ':'));
 
 				/* Create a DIE to record the inheritance. */
-				Dwarf_Die inheritanceDie = new Dwarf_Die_s();
-				Dwarf_Attribute type = new Dwarf_Attribute_s();
+				Dwarf_Die inheritanceDie = new Dwarf_Die_s;
+				Dwarf_Attribute type = new Dwarf_Attribute_s;
 
 				if ((NULL == type) || (NULL == inheritanceDie)) {
 					ret = DW_DLV_ERROR;
@@ -1304,9 +1304,9 @@ parseCPPstruct(const string data,
 						lastChild = lastChild->_sibling;
 					}
 				}
-				for (unsigned int i = 0; i < members.size(); i++) {
+				for (unsigned int i = 0; i < members.size(); ++i) {
 					if (DW_DLV_OK == ret) {
-						Dwarf_Die newDie = new Dwarf_Die_s();
+						Dwarf_Die newDie = new Dwarf_Die_s;
 						if (NULL == newDie) {
 							ret = DW_DLV_ERROR;
 							setError(error, DW_DLE_MAF);
@@ -1388,10 +1388,10 @@ parseTypeDef(const string data,
 	int ID = 0;
 
 	/* Set attributes for name, type, and declaring file. */
-	Dwarf_Attribute type = new Dwarf_Attribute_s();
-	Dwarf_Attribute name  = new Dwarf_Attribute_s();
-	Dwarf_Attribute declFile = new Dwarf_Attribute_s();
-	Dwarf_Attribute declLine = new Dwarf_Attribute_s();
+	Dwarf_Attribute type = new Dwarf_Attribute_s;
+	Dwarf_Attribute name  = new Dwarf_Attribute_s;
+	Dwarf_Attribute declFile = new Dwarf_Attribute_s;
+	Dwarf_Attribute declLine = new Dwarf_Attribute_s;
 
 	if ((NULL == type) || (NULL == name) || (NULL == declFile) || (NULL == declLine)) {
 		ret = DW_DLV_ERROR;
@@ -1451,8 +1451,8 @@ parseTypeDef(const string data,
 		} else {
 			/* If there is no declaring file then delete the attributes for the declFile and declLine. */
 			name->_nextAttr = NULL;
-			delete(declFile);
-			delete(declLine);
+			delete declFile;
+			delete declLine;
 		}
 
 		currentDie->_attribute = type;
@@ -1467,7 +1467,7 @@ static void
 populateAttributeReferences()
 {
 	/* Iterate through the vector containing all attributes to be populated. */
-	for (unsigned int i = 0; i < refsToPopulate.size(); i++) {
+	for (unsigned int i = 0; i < refsToPopulate.size(); ++i) {
 		Dwarf_Attribute tmp = refsToPopulate[i].second;
 
 		/* If the reference is to a built-in type then search the unordered_map containing built-in types. */
@@ -1541,9 +1541,9 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 	Dwarf_Die previousDie = NULL;
 
 	/* Populate the base types. */
-	for (unsigned int i = 1; i <= NUM_BUILT_IN_TYPES; i++) {
+	for (unsigned int i = 1; i <= NUM_BUILT_IN_TYPES; ++i) {
 		if ((DW_DLV_OK == ret) && (!BUILT_IN_TYPES[i].empty())) {
-			Dwarf_Die newDie = new Dwarf_Die_s();
+			Dwarf_Die newDie = new Dwarf_Die_s;
 			if (NULL == newDie) {
 				ret = DW_DLV_ERROR;
 				setError(error, DW_DLE_MAF);
@@ -1555,8 +1555,8 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 				newDie->_child = NULL;
 				newDie->_context = NULL;
 
-				Dwarf_Attribute name = new Dwarf_Attribute_s();
-				Dwarf_Attribute size = new Dwarf_Attribute_s();
+				Dwarf_Attribute name = new Dwarf_Attribute_s;
+				Dwarf_Attribute size = new Dwarf_Attribute_s;
 
 				if ((NULL == name)||(NULL == size)) {
 					ret = DW_DLV_ERROR;
@@ -1602,9 +1602,9 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 	}
 
 	/* For redundant types, create typedefs that refer to the base types created above. */
-	for (unsigned int i = 0; i <= NUM_BUILT_IN_TYPES; i++) {
+	for (unsigned int i = 0; i <= NUM_BUILT_IN_TYPES; ++i) {
 		if ((DW_DLV_OK == ret) && (!BUILT_IN_TYPES_THAT_ARE_TYPEDEFS[i].empty())) {
-			Dwarf_Die newDie = new Dwarf_Die_s();
+			Dwarf_Die newDie = new Dwarf_Die_s;
 			if (NULL == newDie) {
 				ret = DW_DLV_ERROR;
 				setError(error, DW_DLE_MAF);
@@ -1667,7 +1667,7 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 					/* Increment the refNumber to assign associate a unique number with each DIE. */
 					refNumber = refNumber + 1;
 				} else {
-					delete(newDie);
+					delete newDie;
 				}
 			}
 		}
@@ -1682,7 +1682,7 @@ static void
 populateNestedClasses()
 {
 	/* Iterate through all the nested classes found. */
-	for (unsigned int i = 0; i < nestedClassesToPopulate.size(); i++) {
+	for (unsigned int i = 0; i < nestedClassesToPopulate.size(); ++i) {
 		Dwarf_Die parent = nestedClassesToPopulate[i].second;
 		Dwarf_Die nestedClass = NULL;
 		if (NULL != parent) {
@@ -1761,12 +1761,12 @@ removeUselessStubs()
 						if (NULL != dieToCheck->_sibling) {
 							dieToCheck->_sibling->_previous = dieToCheck->_previous;
 						}
-						delete(dieToCheck);
+						delete dieToCheck;
 					}
 				}
 			}
 		}
-		it++;
+		++it;
 	}
 }
 
@@ -1800,10 +1800,10 @@ setDieAttributes(const string dieName,
 		}
 	} else {
 		/* Create attributes for name, size, and declaring file. */
-		Dwarf_Attribute name  = new Dwarf_Attribute_s();
-		Dwarf_Attribute size = new Dwarf_Attribute_s();
-		Dwarf_Attribute declFile = new Dwarf_Attribute_s();
-		Dwarf_Attribute declLine = new Dwarf_Attribute_s();
+		Dwarf_Attribute name  = new Dwarf_Attribute_s;
+		Dwarf_Attribute size = new Dwarf_Attribute_s;
+		Dwarf_Attribute declFile = new Dwarf_Attribute_s;
+		Dwarf_Attribute declLine = new Dwarf_Attribute_s;
 
 		if ((NULL == name) || (NULL == size) || (NULL == declFile) || (NULL == declLine)) {
 			ret = DW_DLV_ERROR;

--- a/ddr/test/expected_output/xa64/blob.dat.strings
+++ b/ddr/test/expected_output/xa64/blob.dat.strings
@@ -3,244 +3,394 @@ Blob Header:
  sizeofBool: 1
  sizeofUDATA: 8
  bitfieldFormat: 1
- structDataSize: 3308
- stringTableDataSize: 2818
- structureCount: 64
+ structDataSize: 5296
+ stringTableDataSize: 5376
+ structureCount: 101
 
 == STRINGS ==
-    1:        0 [2] Aa
-    2:        4 [2] Bb
-    3:        8 [2] Cc
-    4:        c [16] Sample1Constants
-    5:       1e [2] E1
-    6:       22 [2] E2
-    7:       26 [2] E3
-    8:       2a [1] E
-    9:       2e [1] x
-   10:       32 [9] uint16_t*
-   11:       3e [1] y
-   12:       42 [8] uint16_t
-   13:       4c [1] A
-   14:       50 [1] a
-   15:       54 [11] uint8_t[10]
-   16:       62 [1] b
-   17:       66 [16] uint16_t[10][10]
-   18:       78 [3] SOA
-   19:       7e [3] ihl
-   20:       84 [7] uint8_t
-   21:       8e [7] version
-   22:       98 [3] ecn
-   23:       9e [4] dscp
-   24:       a4 [7] tot_len
-   25:       ae [2] id
-   26:       b2 [7] fragOff
-   27:       bc [5] flags
-   28:       c4 [3] ttl
-   29:       ca [8] protocol
-   30:       d4 [5] check
-   31:       dc [5] saddr
-   32:       e4 [8] uint32_t
-   33:       ee [5] daddr
-   34:       f6 [4] IPv4
-   35:       fc [1] C
-   36:      100 [2] xy
-   37:      104 [8] struct C
-   38:      10e [1] z
-   39:      112 [1] D
-   40:      116 [8] ipHeader
-   41:      120 [11] struct IPv4
-   42:      12e [7] srcPort
-   43:      138 [8] destPort
-   44:      142 [6] length
-   45:      14a [8] checksum
-   46:      154 [9] UDPPacket
-   47:      160 [1] F
-   48:      164 [1] G
-   49:      168 [1] c
-   50:      16c [1] d
-   51:      170 [1] H
-   52:      174 [7] int64_t
-   53:      17e [5] width
-   54:      186 [6] height
-   55:      18e [3] Box
-   56:      194 [3] red
-   57:      19a [5] green
-   58:      1a2 [4] blue
-   59:      1a8 [9] RGBColour
-   60:      1b4 [2] i8
-   61:      1b8 [3] f16
-   62:      1be [5] arrI8
-   63:      1c6 [10] uint8_t[1]
-   64:      1d2 [10] Uniondata1
-   65:      1de [3] i16
-   66:      1e4 [3] f32
-   67:      1ea [10] uint8_t[3]
-   68:      1f6 [10] Uniondata2
-   69:      202 [10] uint8_t[4]
-   70:      20e [10] Uniondata3
-   71:      21a [10] uint8_t[5]
-   72:      226 [10] Uniondata4
-   73:      232 [4] name
-   74:      238 [8] char[32]
-   75:      242 [6] salary
-   76:      24a [5] float
-   77:      252 [9] worker_no
-   78:      25e [3] int
-   79:      264 [8] Unionjob
-   80:      26e [11] MyNamespace
-   81:      27c [6] THING1
-   82:      284 [6] THING2
-   83:      28c [6] THING3
-   84:      294 [19] MyNamespace__THINGS
-   85:      2aa [1] e
-   86:      2ae [14] MyNamespace__Q
-   87:      2be [24] MyNamespace__RGBColourV2
-   88:      2d8 [23] MyNamespace__Uniondata5
-   89:      2f2 [14] InnerNamespace
-   90:      302 [1] h
-   91:      306 [36] InnerNamespace__TypeInInnerNamespace
-   92:      32c [27] fieldOfForwardDeclaredClass
-   93:      34a [28] struct ForwardDeclaredClass*
-   94:      368 [24] HasAForwardDeclaredClass
-   95:      382 [23] instanceOfMyNestedClass
-   96:      39c [22] MyClass::MyNestedClass
-   97:      3b4 [4] data
-   98:      3ba [5] ENUM1
-   99:      3c2 [5] ENUM2
-  100:      3ca [5] ENUM3
-  101:      3d2 [1] Z
-  102:      3d6 [17] struct MyClass::Z
-  103:      3ea [11] instanceOfZ
-  104:      3f8 [7] MyClass
-  105:      402 [22] MyClass__MyNestedClass
-  106:      41a [1] g
-  107:      41e [8] uint64_t
-  108:      428 [15] uint16_t[20][5]
-  109:      43a [10] MyClass__Z
-  110:      446 [5] IDATA
-  111:      44e [2] S1
-  112:      452 [2] b2
-  113:      456 [9] struct S1
-  114:      462 [2] S2
-  115:      466 [9] struct S2
-  116:      472 [2] T2
-  117:      476 [9] struct T2
-  118:      482 [1] f
-  119:      486 [9] struct T3
-  120:      492 [2] T4
-  121:      496 [10] something1
-  122:      4a2 [10] something2
-  123:      4ae [10] something3
-  124:      4ba [10] something4
-  125:      4c6 [10] something5
-  126:      4d2 [10] somethingN
-  127:      4de [6] MyEnum
-  128:      4e6 [4] ipv6
-  129:      4ec [9] s.hi_ipv6
-  130:      4f8 [9] s.lo_ipv6
-  131:      504 [2] Ip
-  132:      508 [8] hashCode
-  133:      512 [16] volatile int64_t
-  134:      524 [5] BoxV2
-  135:      52c [10] staticTest
-  136:      538 [9] uintptr_t
-  137:      544 [5] data2
-  138:      54c [9] const int
-  139:      558 [3] Foo
-  140:      55e [8] voidStar
-  141:      568 [16] FunctionPointer*
-  142:      57a [16] HasVoidStarField
-  143:      58c [1] i
-  144:      590 [7] int32_t
-  145:      59a [1] s
-  146:      59e [7] int16_t
-  147:      5a8 [14] UnionFieldType
-  148:      5b8 [11] unionField1
-  149:      5c6 [20] union UnionFieldType
-  150:      5dc [11] unionField2
-  151:      5ea [13] HasUnionField
-  152:      5fa [1] q
-  153:      5fe [16] volatile uint8_t
-  154:      610 [1] r
-  155:      614 [13] const uint8_t
-  156:      624 [2] S3
-  157:      628 [5] speed
-  158:      630 [6] double
-  159:      638 [7] Vehicle
-  160:      642 [10] durability
-  161:      64e [3] Toy
-  162:      654 [9] hasWheels
-  163:      660 [11] MatchboxCar
-  164:      66e [15] functionPointer
-  165:      680 [15] FunctionPointer
-  166:      692 [9] INT_ARRAY
-  167:      69e [25] StructWithFunctionPointer
-  168:      6ba [1] l
-  169:      6be [8] long int
-  170:      6c8 [4] char
-  171:      6ce [4] bool
-  172:      6d4 [2] S4
-  173:      6d8 [15] innerField1.ui8
-  174:      6ea [15] innerField2.i16
-  175:      6fc [23] innerField3.innerStruct
-  176:      716 [20] struct ::InnerStruct
-  177:      72c [5] Outer
-  178:      734 [3] i32
-  179:      73a [13] __InnerStruct
-  180:      74a [32] instanceOfInnerClassWithSameName
-  181:      76c [52] OuterClassWithDifferentName1::InnerClassWithSameName
-  182:      7a2 [28] OuterClassWithDifferentName1
-  183:      7c0 [52] OuterClassWithDifferentName1__InnerClassWithSameName
-  184:      7f6 [52] OuterClassWithDifferentName2::InnerClassWithSameName
-  185:      82c [28] OuterClassWithDifferentName2
-  186:      84a [52] OuterClassWithDifferentName2__InnerClassWithSameName
-  187:      880 [4] real
-  188:      886 [9] imaginary
-  189:      892 [12] Complex<int>
-  190:      8a0 [15] Complex<double>
-  191:      8b2 [20] arrayWithTypedefType
-  192:      8c8 [10] UDATA2[12]
-  193:      8d4 [21] SArrayWithTypedefType
-  194:      8ec [11] numElements
-  195:      8fa [6] intArr
-  196:      902 [5] int[]
-  197:      90a [14] SNoLengthArray
-  198:      91a [8] SEAHORSE
-  199:      924 [9] TEST_FLAG
-  200:      930 [10] TEST_FLAG2
-  201:      93c [15] TEST_FLAG_UNDEF
-  202:      94e [25] TestFileInSubDirConstants
-  203:      96a [3] COW
-  204:      970 [19] TestHeaderConstants
-  205:      986 [18] myMapToTypeMacro1a
-  206:      99a [18] myMapToTypeMacro1b
-  207:      9ae [14] MapToTypeTest1
-  208:      9be [17] myMapToTypeMacro2
-  209:      9d2 [20] Map_to_typeConstants
-  210:      9e8 [17] myMapToTypeMacro3
-  211:      9fc [14] MapToTypeTest3
-  212:      a0c [17] myMapToTypeMacro4
-  213:      a20 [14] MapToTypeTest4
-  214:      a30 [7] dolphin
-  215:      a3a [4] fish
-  216:      a40 [7] octopus
-  217:      a4a [5] whale
-  218:      a52 [13] TestConstants
-  219:      a62 [8] CHAR_MAX
-  220:      a6c [8] CHAR_MIN
-  221:      a76 [7] INT_MAX
-  222:      a80 [7] INT_MIN
-  223:      a8a [8] LONG_MAX
-  224:      a94 [8] LONG_MIN
-  225:      a9e [9] SCHAR_MAX
-  226:      aaa [9] SCHAR_MIN
-  227:      ab6 [8] SHRT_MAX
-  228:      ac0 [8] SHRT_MIN
-  229:      aca [9] UCHAR_MAX
-  230:      ad6 [8] UINT_MAX
-  231:      ae0 [9] ULONG_MAX
-  232:      aec [9] USHRT_MAX
-  233:      af8 [7] CLimits
+    1:        0 [5] _next
+    2:        8 [18] struct _IO_marker*
+    3:       1c [5] _sbuf
+    4:       24 [16] struct _IO_FILE*
+    5:       36 [4] _pos
+    6:       3c [3] int
+    7:       42 [10] _IO_marker
+    8:       4e [6] _flags
+    9:       56 [12] _IO_read_ptr
+   10:       64 [5] char*
+   11:       6c [12] _IO_read_end
+   12:       7a [13] _IO_read_base
+   13:       8a [14] _IO_write_base
+   14:       9a [13] _IO_write_ptr
+   15:       aa [13] _IO_write_end
+   16:       ba [12] _IO_buf_base
+   17:       c8 [11] _IO_buf_end
+   18:       d6 [13] _IO_save_base
+   19:       e6 [15] _IO_backup_base
+   20:       f8 [12] _IO_save_end
+   21:      106 [8] _markers
+   22:      110 [6] _chain
+   23:      118 [7] _fileno
+   24:      122 [7] _flags2
+   25:      12c [11] _old_offset
+   26:      13a [7] __off_t
+   27:      144 [11] _cur_column
+   28:      152 [18] short unsigned int
+   29:      166 [14] _vtable_offset
+   30:      176 [11] signed char
+   31:      184 [9] _shortbuf
+   32:      190 [7] char[1]
+   33:      19a [5] _lock
+   34:      1a2 [11] _IO_lock_t*
+   35:      1b0 [7] _offset
+   36:      1ba [9] __off64_t
+   37:      1c6 [6] __pad1
+   38:      1ce [5] void*
+   39:      1d6 [6] __pad2
+   40:      1de [6] __pad3
+   41:      1e6 [6] __pad4
+   42:      1ee [6] __pad5
+   43:      1f6 [6] size_t
+   44:      1fe [5] _mode
+   45:      206 [8] _unused2
+   46:      210 [8] char[20]
+   47:      21a [8] _IO_FILE
+   48:      224 [9] gp_offset
+   49:      230 [12] unsigned int
+   50:      23e [9] fp_offset
+   51:      24a [17] overflow_arg_area
+   52:      25e [13] reg_save_area
+   53:      26e [35] typedef __va_list_tag __va_list_tag
+   54:      294 [7] __count
+   55:      29e [13] __value.__wch
+   56:      2ae [14] __value.__wchb
+   57:      2be [7] char[4]
+   58:      2c8 [11] __mbstate_t
+   59:      2d6 [3] std
+   60:      2dc [15] __exception_ptr
+   61:      2ee [19] _M_exception_object
+   62:      304 [30] __exception_ptr__exception_ptr
+   63:      324 [14] std__type_info
+   64:      334 [26] std__piecewise_construct_t
+   65:      350 [7] __debug
+   66:      35a [22] std__char_traits<char>
+   67:      372 [12] _S_boolalpha
+   68:      380 [6] _S_dec
+   69:      388 [8] _S_fixed
+   70:      392 [6] _S_hex
+   71:      39a [11] _S_internal
+   72:      3a8 [7] _S_left
+   73:      3b2 [6] _S_oct
+   74:      3ba [8] _S_right
+   75:      3c4 [13] _S_scientific
+   76:      3d4 [11] _S_showbase
+   77:      3e2 [12] _S_showpoint
+   78:      3f0 [10] _S_showpos
+   79:      3fc [9] _S_skipws
+   80:      408 [10] _S_unitbuf
+   81:      414 [12] _S_uppercase
+   82:      422 [14] _S_adjustfield
+   83:      432 [12] _S_basefield
+   84:      440 [13] _S_floatfield
+   85:      450 [19] _S_ios_fmtflags_end
+   86:      466 [19] _S_ios_fmtflags_max
+   87:      47c [19] _S_ios_fmtflags_min
+   88:      492 [18] std___Ios_Fmtflags
+   89:      4a6 [6] _S_app
+   90:      4ae [6] _S_ate
+   91:      4b6 [6] _S_bin
+   92:      4be [5] _S_in
+   93:      4c6 [6] _S_out
+   94:      4ce [8] _S_trunc
+   95:      4d8 [19] _S_ios_openmode_end
+   96:      4ee [19] _S_ios_openmode_max
+   97:      504 [19] _S_ios_openmode_min
+   98:      51a [18] std___Ios_Openmode
+   99:      52e [10] _S_goodbit
+  100:      53a [9] _S_badbit
+  101:      546 [9] _S_eofbit
+  102:      552 [10] _S_failbit
+  103:      55e [18] _S_ios_iostate_end
+  104:      572 [18] _S_ios_iostate_max
+  105:      586 [18] _S_ios_iostate_min
+  106:      59a [17] std___Ios_Iostate
+  107:      5ae [6] _S_beg
+  108:      5b6 [6] _S_cur
+  109:      5be [6] _S_end
+  110:      5c6 [18] _S_ios_seekdir_end
+  111:      5da [17] std___Ios_Seekdir
+  112:      5ee [13] std__ios_base
+  113:      5fe [14] ios_base__Init
+  114:      60e [49] std__basic_ostream<char, std::char_traits<char> >
+  115:      642 [16] std__ctype<char>
+  116:      654 [45] std__basic_ios<char, std::char_traits<char> >
+  117:      684 [6] tm_sec
+  118:      68c [6] tm_min
+  119:      694 [7] tm_hour
+  120:      69e [7] tm_mday
+  121:      6a8 [6] tm_mon
+  122:      6b0 [7] tm_year
+  123:      6ba [7] tm_wday
+  124:      6c4 [7] tm_yday
+  125:      6ce [8] tm_isdst
+  126:      6d8 [9] tm_gmtoff
+  127:      6e4 [8] long int
+  128:      6ee [7] tm_zone
+  129:      6f8 [11] const char*
+  130:      706 [2] tm
+  131:      70a [9] __gnu_cxx
+  132:      716 [40] __gnu_cxx____numeric_traits_integer<int>
+  133:      740 [43] __gnu_cxx____numeric_traits_floating<float>
+  134:      76e [44] __gnu_cxx____numeric_traits_floating<double>
+  135:      79c [49] __gnu_cxx____numeric_traits_floating<long double>
+  136:      7d0 [54] __gnu_cxx____numeric_traits_integer<long unsigned int>
+  137:      808 [41] __gnu_cxx____numeric_traits_integer<char>
+  138:      834 [46] __gnu_cxx____numeric_traits_integer<short int>
+  139:      864 [45] __gnu_cxx____numeric_traits_integer<long int>
+  140:      894 [11] __gnu_debug
+  141:      8a2 [13] decimal_point
+  142:      8b2 [13] thousands_sep
+  143:      8c2 [8] grouping
+  144:      8cc [15] int_curr_symbol
+  145:      8de [15] currency_symbol
+  146:      8f0 [17] mon_decimal_point
+  147:      904 [17] mon_thousands_sep
+  148:      918 [12] mon_grouping
+  149:      926 [13] positive_sign
+  150:      936 [13] negative_sign
+  151:      946 [15] int_frac_digits
+  152:      958 [4] char
+  153:      95e [11] frac_digits
+  154:      96c [13] p_cs_precedes
+  155:      97c [14] p_sep_by_space
+  156:      98c [13] n_cs_precedes
+  157:      99c [14] n_sep_by_space
+  158:      9ac [11] p_sign_posn
+  159:      9ba [11] n_sign_posn
+  160:      9c8 [17] int_p_cs_precedes
+  161:      9dc [18] int_p_sep_by_space
+  162:      9f0 [17] int_n_cs_precedes
+  163:      a04 [18] int_n_sep_by_space
+  164:      a18 [15] int_p_sign_posn
+  165:      a2a [15] int_n_sign_posn
+  166:      a3c [5] lconv
+  167:      a44 [4] quot
+  168:      a4a [3] rem
+  169:      a50 [5] div_t
+  170:      a58 [6] ldiv_t
+  171:      a60 [13] long long int
+  172:      a70 [7] lldiv_t
+  173:      a7a [5] __pos
+  174:      a82 [7] __state
+  175:      a8c [11] _G_fpos64_t
+  176:      a9a [2] E1
+  177:      a9e [2] E2
+  178:      aa2 [2] E3
+  179:      aa6 [1] E
+  180:      aaa [1] x
+  181:      aae [9] uint16_t*
+  182:      aba [1] y
+  183:      abe [8] uint16_t
+  184:      ac8 [1] A
+  185:      acc [1] a
+  186:      ad0 [17] unsigned char[10]
+  187:      ae4 [1] b
+  188:      ae8 [26] short unsigned int[10][10]
+  189:      b04 [3] SOA
+  190:      b0a [3] ihl
+  191:      b10 [7] uint8_t
+  192:      b1a [7] version
+  193:      b24 [3] ecn
+  194:      b2a [4] dscp
+  195:      b30 [7] tot_len
+  196:      b3a [2] id
+  197:      b3e [7] fragOff
+  198:      b48 [5] flags
+  199:      b50 [3] ttl
+  200:      b56 [8] protocol
+  201:      b60 [5] check
+  202:      b68 [5] saddr
+  203:      b70 [8] uint32_t
+  204:      b7a [5] daddr
+  205:      b82 [4] IPv4
+  206:      b88 [1] C
+  207:      b8c [2] xy
+  208:      b90 [8] struct C
+  209:      b9a [1] z
+  210:      b9e [1] D
+  211:      ba2 [8] ipHeader
+  212:      bac [11] struct IPv4
+  213:      bba [7] srcPort
+  214:      bc4 [8] destPort
+  215:      bce [6] length
+  216:      bd6 [8] checksum
+  217:      be0 [9] UDPPacket
+  218:      bec [1] F
+  219:      bf0 [1] G
+  220:      bf4 [1] c
+  221:      bf8 [1] d
+  222:      bfc [1] H
+  223:      c00 [5] Empty
+  224:      c08 [7] int64_t
+  225:      c12 [5] width
+  226:      c1a [6] height
+  227:      c22 [3] Box
+  228:      c28 [3] red
+  229:      c2e [5] green
+  230:      c36 [4] blue
+  231:      c3c [9] RGBColour
+  232:      c48 [2] i8
+  233:      c4c [3] f16
+  234:      c52 [5] arrI8
+  235:      c5a [16] unsigned char[1]
+  236:      c6c [10] Uniondata1
+  237:      c78 [3] i16
+  238:      c7e [3] f32
+  239:      c84 [16] unsigned char[3]
+  240:      c96 [10] Uniondata2
+  241:      ca2 [16] unsigned char[4]
+  242:      cb4 [10] Uniondata3
+  243:      cc0 [16] unsigned char[5]
+  244:      cd2 [10] Uniondata4
+  245:      cde [4] name
+  246:      ce4 [8] char[32]
+  247:      cee [6] salary
+  248:      cf6 [5] float
+  249:      cfe [9] worker_no
+  250:      d0a [8] Unionjob
+  251:      d14 [11] MyNamespace
+  252:      d22 [6] THING1
+  253:      d2a [6] THING2
+  254:      d32 [6] THING3
+  255:      d3a [19] MyNamespace__THINGS
+  256:      d50 [1] e
+  257:      d54 [14] MyNamespace__Q
+  258:      d64 [24] MyNamespace__RGBColourV2
+  259:      d7e [23] MyNamespace__Uniondata5
+  260:      d98 [14] InnerNamespace
+  261:      da8 [1] h
+  262:      dac [36] InnerNamespace__TypeInInnerNamespace
+  263:      dd2 [20] ForwardDeclaredClass
+  264:      de8 [27] fieldOfForwardDeclaredClass
+  265:      e06 [27] class ForwardDeclaredClass*
+  266:      e24 [24] HasAForwardDeclaredClass
+  267:      e3e [23] instanceOfMyNestedClass
+  268:      e58 [28] class MyClass::MyNestedClass
+  269:      e76 [4] data
+  270:      e7c [9] innerEnum
+  271:      e88 [23] enum MyClass::InnerEnum
+  272:      ea2 [1] Z
+  273:      ea6 [17] struct MyClass::Z
+  274:      eba [11] instanceOfZ
+  275:      ec8 [7] MyClass
+  276:      ed2 [22] MyClass__MyNestedClass
+  277:      eea [6] ENUM_A
+  278:      ef2 [6] ENUM_B
+  279:      efa [6] ENUM_C
+  280:      f02 [18] MyClass__InnerEnum
+  281:      f16 [1] g
+  282:      f1a [8] uint64_t
+  283:      f24 [25] short unsigned int[20][5]
+  284:      f40 [10] MyClass__Z
+  285:      f4c [5] IDATA
+  286:      f54 [2] S1
+  287:      f58 [2] b2
+  288:      f5c [9] struct S1
+  289:      f68 [2] S2
+  290:      f6c [2] T2
+  291:      f70 [1] f
+  292:      f74 [2] T3
+  293:      f78 [2] T4
+  294:      f7c [10] something1
+  295:      f88 [10] something2
+  296:      f94 [10] something3
+  297:      fa0 [10] something4
+  298:      fac [10] something5
+  299:      fb8 [10] somethingN
+  300:      fc4 [6] MyEnum
+  301:      fcc [4] ipv6
+  302:      fd2 [9] s.hi_ipv6
+  303:      fde [9] s.lo_ipv6
+  304:      fea [2] Ip
+  305:      fee [8] hashCode
+  306:      ff8 [16] volatile int64_t
+  307:     100a [5] BoxV2
+  308:     1012 [9] uintptr_t
+  309:     101e [5] data2
+  310:     1026 [9] const int
+  311:     1032 [3] Foo
+  312:     1038 [3] Bar
+  313:     103e [8] voidStar
+  314:     1048 [16] HasVoidStarField
+  315:     105a [1] i
+  316:     105e [7] int32_t
+  317:     1068 [1] s
+  318:     106c [7] int16_t
+  319:     1076 [14] UnionFieldType
+  320:     1086 [11] unionField1
+  321:     1094 [20] union UnionFieldType
+  322:     10aa [11] unionField2
+  323:     10b8 [13] HasUnionField
+  324:     10c8 [1] q
+  325:     10cc [16] volatile uint8_t
+  326:     10de [1] r
+  327:     10e2 [13] const uint8_t
+  328:     10f2 [2] S3
+  329:     10f6 [5] speed
+  330:     10fe [6] double
+  331:     1106 [7] Vehicle
+  332:     1110 [10] durability
+  333:     111c [3] Toy
+  334:     1122 [9] hasWheels
+  335:     112e [11] MatchboxCar
+  336:     113c [15] functionPointer
+  337:     114e [9] INT_ARRAY
+  338:     115a [25] StructWithFunctionPointer
+  339:     1176 [1] l
+  340:     117a [4] bool
+  341:     1180 [2] S4
+  342:     1184 [15] innerField1.ui8
+  343:     1196 [15] innerField2.i16
+  344:     11a8 [23] innerField3.innerStruct
+  345:     11c2 [27] struct Outer::::InnerStruct
+  346:     11e0 [5] Outer
+  347:     11e8 [32] instanceOfInnerClassWithSameName
+  348:     120a [58] class OuterClassWithDifferentName2::InnerClassWithSameName
+  349:     1246 [28] OuterClassWithDifferentName2
+  350:     1264 [52] OuterClassWithDifferentName2__InnerClassWithSameName
+  351:     129a [4] real
+  352:     12a0 [9] imaginary
+  353:     12ac [12] Complex<int>
+  354:     12ba [15] Complex<double>
+  355:     12cc [20] arrayWithTypedefType
+  356:     12e2 [16] unsigned int[12]
+  357:     12f4 [21] SArrayWithTypedefType
+  358:     130c [58] class OuterClassWithDifferentName1::InnerClassWithSameName
+  359:     1348 [28] OuterClassWithDifferentName1
+  360:     1366 [52] OuterClassWithDifferentName1__InnerClassWithSameName
+  361:     139c [11] numElements
+  362:     13aa [6] intArr
+  363:     13b2 [5] int[]
+  364:     13ba [14] SNoLengthArray
+  365:     13ca [3] COW
+  366:     13d0 [19] TestHeaderConstants
+  367:     13e6 [18] myMapToTypeMacro1a
+  368:     13fa [18] myMapToTypeMacro1b
+  369:     140e [14] MapToTypeTest1
+  370:     141e [17] myMapToTypeMacro2
+  371:     1432 [20] Map_to_typeConstants
+  372:     1448 [17] myMapToTypeMacro3
+  373:     145c [14] MapToTypeTest3
+  374:     146c [17] myMapToTypeMacro4
+  375:     1480 [14] MapToTypeTest4
+  376:     1490 [7] dolphin
+  377:     149a [7] octopus
+  378:     14a4 [5] whale
+  379:     14ac [13] TestConstants
+  380:     14bc [8] SEAHORSE
+  381:     14c6 [10] TEST_FLAG2
+  382:     14d2 [15] TEST_FLAG_UNDEF
+  383:     14e4 [25] TestFileInSubDirConstants
 
 == STRUCTS ==
 
@@ -255,6 +405,12 @@ Struct name: A
  Field declaredName: y
   declaredType: uint16_t
   offset: 8
+
+Struct name: Bar
+ superName: Foo
+ sizeOf: 16
+ fieldCount: 0
+ constCount: 0
 
 Struct name: Box
  no superName
@@ -301,40 +457,6 @@ Struct name: C
   declaredType: uint32_t
   offset: 4
 
-Struct name: CLimits
- no superName
- sizeOf: 0
- fieldCount: 0
- constCount: 14
- Constant name: CHAR_MAX
-  value: 127
- Constant name: CHAR_MIN
-  value: -128
- Constant name: INT_MAX
-  value: 2147483647
- Constant name: INT_MIN
-  value: -2147483648
- Constant name: LONG_MAX
-  value: 9223372036854775807
- Constant name: LONG_MIN
-  value: -9223372036854775808
- Constant name: SCHAR_MAX
-  value: 127
- Constant name: SCHAR_MIN
-  value: -128
- Constant name: SHRT_MAX
-  value: 32767
- Constant name: SHRT_MIN
-  value: -32768
- Constant name: UCHAR_MAX
-  value: 255
- Constant name: UINT_MAX
-  value: 4294967295
- Constant name: ULONG_MAX
-  value: -1
- Constant name: USHRT_MAX
-  value: 65535
-
 Struct name: Complex<double>
  no superName
  sizeOf: 16
@@ -373,7 +495,7 @@ Struct name: D
 
 Struct name: E
  no superName
- sizeOf: 0
+ sizeOf: 4
  fieldCount: 0
  constCount: 3
  Constant name: E1
@@ -382,6 +504,12 @@ Struct name: E
   value: 3
  Constant name: E3
   value: 4
+
+Struct name: Empty
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
 
 Struct name: F
  no superName
@@ -401,17 +529,20 @@ Struct name: F
 Struct name: Foo
  no superName
  sizeOf: 16
- fieldCount: 3
+ fieldCount: 2
  constCount: 0
- Field declaredName: staticTest
-  declaredType: int
-  offset: 0
  Field declaredName: data
   declaredType: uintptr_t
-  offset: 4
+  offset: 0
  Field declaredName: data2
   declaredType: const int
-  offset: 12
+  offset: 8
+
+Struct name: ForwardDeclaredClass
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
 
 Struct name: G
  no superName
@@ -452,7 +583,7 @@ Struct name: HasAForwardDeclaredClass
  fieldCount: 1
  constCount: 0
  Field declaredName: fieldOfForwardDeclaredClass
-  declaredType: struct ForwardDeclaredClass*
+  declaredType: class ForwardDeclaredClass*
   offset: 0
 
 Struct name: HasUnionField
@@ -464,7 +595,7 @@ Struct name: HasUnionField
   declaredType: union UnionFieldType
   offset: 0
  Field declaredName: unionField2
-  declaredType: union UnionFieldType
+  declaredType: UnionFieldType
   offset: 4
 
 Struct name: HasVoidStarField
@@ -473,7 +604,7 @@ Struct name: HasVoidStarField
  fieldCount: 1
  constCount: 0
  Field declaredName: voidStar
-  declaredType: FunctionPointer*
+  declaredType: void*
   offset: 0
 
 Struct name: IPv4
@@ -586,7 +717,7 @@ Struct name: Map_to_typeConstants
   value: 23
 
 Struct name: MatchboxCar
- superName: Toy
+ superName: Vehicle
  sizeOf: 16
  fieldCount: 1
  constCount: 0
@@ -597,25 +728,34 @@ Struct name: MatchboxCar
 Struct name: MyClass
  no superName
  sizeOf: 440
- fieldCount: 4
- constCount: 3
+ fieldCount: 5
+ constCount: 0
  Field declaredName: instanceOfMyNestedClass
-  declaredType: MyClass::MyNestedClass
+  declaredType: class MyClass::MyNestedClass
   offset: 0
  Field declaredName: data
   declaredType: int64_t
   offset: 4
+ Field declaredName: innerEnum
+  declaredType: enum MyClass::InnerEnum
+  offset: 16
  Field declaredName: Z
   declaredType: struct MyClass::Z
-  offset: 16
+  offset: 20
  Field declaredName: instanceOfZ
   declaredType: struct MyClass::Z
-  offset: 224
- Constant name: ENUM1
+  offset: 228
+
+Struct name: MyClass__InnerEnum
+ no superName
+ sizeOf: 4
+ fieldCount: 0
+ constCount: 3
+ Constant name: ENUM_A
   value: 0
- Constant name: ENUM2
+ Constant name: ENUM_B
   value: 1
- Constant name: ENUM3
+ Constant name: ENUM_C
   value: 2
 
 Struct name: MyClass__MyNestedClass
@@ -636,12 +776,12 @@ Struct name: MyClass__Z
   declaredType: uint64_t
   offset: 0
  Field declaredName: h
-  declaredType: uint16_t[20][5]
+  declaredType: short unsigned int[20][5]
   offset: 8
 
 Struct name: MyEnum
  no superName
- sizeOf: 0
+ sizeOf: 4
  fieldCount: 0
  constCount: 6
  Constant name: something1
@@ -672,7 +812,7 @@ Struct name: MyNamespace__Q
   declaredType: uint16_t
   offset: 0
  Field declaredName: e
-  declaredType: uint16_t[10][10]
+  declaredType: short unsigned int[10][10]
   offset: 2
 
 Struct name: MyNamespace__RGBColourV2
@@ -692,7 +832,7 @@ Struct name: MyNamespace__RGBColourV2
 
 Struct name: MyNamespace__THINGS
  no superName
- sizeOf: 0
+ sizeOf: 4
  fieldCount: 0
  constCount: 3
  Constant name: THING1
@@ -714,7 +854,7 @@ Struct name: MyNamespace__Uniondata5
   declaredType: uint32_t
   offset: 2
  Field declaredName: arrI8
-  declaredType: uint8_t[3]
+  declaredType: unsigned char[3]
   offset: 6
 
 Struct name: Outer
@@ -729,21 +869,21 @@ Struct name: Outer
   declaredType: int16_t
   offset: 0
  Field declaredName: innerField3.innerStruct
-  declaredType: struct ::InnerStruct
+  declaredType: struct Outer::::InnerStruct
   offset: 0
 
 Struct name: OuterClassWithDifferentName1
  no superName
- sizeOf: 8
+ sizeOf: 24
  fieldCount: 1
  constCount: 0
  Field declaredName: instanceOfInnerClassWithSameName
-  declaredType: OuterClassWithDifferentName1::InnerClassWithSameName
+  declaredType: class OuterClassWithDifferentName1::InnerClassWithSameName
   offset: 0
 
 Struct name: OuterClassWithDifferentName1__InnerClassWithSameName
  no superName
- sizeOf: 8
+ sizeOf: 16
  fieldCount: 1
  constCount: 0
  Field declaredName: g
@@ -756,7 +896,7 @@ Struct name: OuterClassWithDifferentName2
  fieldCount: 1
  constCount: 0
  Field declaredName: instanceOfInnerClassWithSameName
-  declaredType: OuterClassWithDifferentName2::InnerClassWithSameName
+  declaredType: class OuterClassWithDifferentName2::InnerClassWithSameName
   offset: 0
 
 Struct name: OuterClassWithDifferentName2__InnerClassWithSameName
@@ -843,7 +983,7 @@ Struct name: SArrayWithTypedefType
  fieldCount: 1
  constCount: 0
  Field declaredName: arrayWithTypedefType
-  declaredType: UDATA2[12]
+  declaredType: unsigned int[12]
   offset: 0
 
 Struct name: SNoLengthArray
@@ -864,23 +1004,11 @@ Struct name: SOA
  fieldCount: 2
  constCount: 0
  Field declaredName: a
-  declaredType: uint8_t[10]
+  declaredType: unsigned char[10]
   offset: 0
  Field declaredName: b
-  declaredType: uint16_t[10][10]
+  declaredType: short unsigned int[10][10]
   offset: 10
-
-Struct name: Sample1Constants
- no superName
- sizeOf: 0
- fieldCount: 0
- constCount: 3
- Constant name: Aa
-  value: 0
- Constant name: Bb
-  value: 1
- Constant name: Cc
-  value: 2
 
 Struct name: StructWithFunctionPointer
  no superName
@@ -888,7 +1016,7 @@ Struct name: StructWithFunctionPointer
  fieldCount: 2
  constCount: 0
  Field declaredName: functionPointer
-  declaredType: FunctionPointer
+  declaredType: void*
   offset: 0
  Field declaredName: i
   declaredType: INT_ARRAY
@@ -900,7 +1028,7 @@ Struct name: T2
  fieldCount: 1
  constCount: 0
  Field declaredName: c
-  declaredType: struct S2
+  declaredType: S2
   offset: 0
 
 Struct name: T4
@@ -909,24 +1037,22 @@ Struct name: T4
  fieldCount: 3
  constCount: 0
  Field declaredName: d
-  declaredType: struct T2
+  declaredType: T2
   offset: 0
  Field declaredName: e
-  declaredType: struct S2
+  declaredType: S2
   offset: 8
  Field declaredName: f
-  declaredType: struct T3
+  declaredType: T3
   offset: 16
 
 Struct name: TestConstants
  no superName
  sizeOf: 0
  fieldCount: 0
- constCount: 4
+ constCount: 3
  Constant name: dolphin
   value: 11
- Constant name: fish
-  value: 4
  Constant name: octopus
   value: 11
  Constant name: whale
@@ -936,11 +1062,9 @@ Struct name: TestFileInSubDirConstants
  no superName
  sizeOf: 0
  fieldCount: 0
- constCount: 4
+ constCount: 3
  Constant name: SEAHORSE
   value: 77
- Constant name: TEST_FLAG
-  value: 1
  Constant name: TEST_FLAG2
   value: 1
  Constant name: TEST_FLAG_UNDEF
@@ -1008,7 +1132,7 @@ Struct name: Uniondata1
   declaredType: uint32_t
   offset: 2
  Field declaredName: arrI8
-  declaredType: uint8_t[1]
+  declaredType: unsigned char[1]
   offset: 6
 
 Struct name: Uniondata2
@@ -1023,7 +1147,7 @@ Struct name: Uniondata2
   declaredType: uint32_t
   offset: 2
  Field declaredName: arrI8
-  declaredType: uint8_t[3]
+  declaredType: unsigned char[3]
   offset: 6
 
 Struct name: Uniondata3
@@ -1038,7 +1162,7 @@ Struct name: Uniondata3
   declaredType: uint32_t
   offset: 2
  Field declaredName: arrI8
-  declaredType: uint8_t[4]
+  declaredType: unsigned char[4]
   offset: 6
 
 Struct name: Uniondata4
@@ -1053,7 +1177,7 @@ Struct name: Uniondata4
   declaredType: uint32_t
   offset: 2
  Field declaredName: arrI8
-  declaredType: uint8_t[5]
+  declaredType: unsigned char[5]
   offset: 6
 
 Struct name: Unionjob
@@ -1080,11 +1204,549 @@ Struct name: Vehicle
   declaredType: double
   offset: 0
 
-Struct name: __InnerStruct
+Struct name: _G_fpos64_t
  no superName
- sizeOf: 4
+ sizeOf: 16
+ fieldCount: 2
+ constCount: 0
+ Field declaredName: __pos
+  declaredType: __off64_t
+  offset: 0
+ Field declaredName: __state
+  declaredType: __mbstate_t
+  offset: 8
+
+Struct name: _IO_FILE
+ no superName
+ sizeOf: 216
+ fieldCount: 29
+ constCount: 0
+ Field declaredName: _flags
+  declaredType: int
+  offset: 0
+ Field declaredName: _IO_read_ptr
+  declaredType: char*
+  offset: 4
+ Field declaredName: _IO_read_end
+  declaredType: char*
+  offset: 12
+ Field declaredName: _IO_read_base
+  declaredType: char*
+  offset: 20
+ Field declaredName: _IO_write_base
+  declaredType: char*
+  offset: 28
+ Field declaredName: _IO_write_ptr
+  declaredType: char*
+  offset: 36
+ Field declaredName: _IO_write_end
+  declaredType: char*
+  offset: 44
+ Field declaredName: _IO_buf_base
+  declaredType: char*
+  offset: 52
+ Field declaredName: _IO_buf_end
+  declaredType: char*
+  offset: 60
+ Field declaredName: _IO_save_base
+  declaredType: char*
+  offset: 68
+ Field declaredName: _IO_backup_base
+  declaredType: char*
+  offset: 76
+ Field declaredName: _IO_save_end
+  declaredType: char*
+  offset: 84
+ Field declaredName: _markers
+  declaredType: struct _IO_marker*
+  offset: 92
+ Field declaredName: _chain
+  declaredType: struct _IO_FILE*
+  offset: 100
+ Field declaredName: _fileno
+  declaredType: int
+  offset: 108
+ Field declaredName: _flags2
+  declaredType: int
+  offset: 112
+ Field declaredName: _old_offset
+  declaredType: __off_t
+  offset: 116
+ Field declaredName: _cur_column
+  declaredType: short unsigned int
+  offset: 124
+ Field declaredName: _vtable_offset
+  declaredType: signed char
+  offset: 126
+ Field declaredName: _shortbuf
+  declaredType: char[1]
+  offset: 127
+ Field declaredName: _lock
+  declaredType: _IO_lock_t*
+  offset: 128
+ Field declaredName: _offset
+  declaredType: __off64_t
+  offset: 136
+ Field declaredName: __pad1
+  declaredType: void*
+  offset: 144
+ Field declaredName: __pad2
+  declaredType: void*
+  offset: 152
+ Field declaredName: __pad3
+  declaredType: void*
+  offset: 160
+ Field declaredName: __pad4
+  declaredType: void*
+  offset: 168
+ Field declaredName: __pad5
+  declaredType: size_t
+  offset: 176
+ Field declaredName: _mode
+  declaredType: int
+  offset: 184
+ Field declaredName: _unused2
+  declaredType: char[20]
+  offset: 188
+
+Struct name: _IO_marker
+ no superName
+ sizeOf: 24
+ fieldCount: 3
+ constCount: 0
+ Field declaredName: _next
+  declaredType: struct _IO_marker*
+  offset: 0
+ Field declaredName: _sbuf
+  declaredType: struct _IO_FILE*
+  offset: 8
+ Field declaredName: _pos
+  declaredType: int
+  offset: 16
+
+Struct name: __debug
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __exception_ptr
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __exception_ptr__exception_ptr
+ no superName
+ sizeOf: 8
  fieldCount: 1
  constCount: 0
- Field declaredName: i32
-  declaredType: int32_t
+ Field declaredName: _M_exception_object
+  declaredType: void*
   offset: 0
+
+Struct name: __gnu_cxx
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_floating<double>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_floating<float>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_floating<long double>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_integer<char>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_integer<int>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_integer<long int>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_integer<long unsigned int>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_cxx____numeric_traits_integer<short int>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __gnu_debug
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: __mbstate_t
+ no superName
+ sizeOf: 8
+ fieldCount: 3
+ constCount: 0
+ Field declaredName: __count
+  declaredType: int
+  offset: 0
+ Field declaredName: __value.__wch
+  declaredType: unsigned int
+  offset: 0
+ Field declaredName: __value.__wchb
+  declaredType: char[4]
+  offset: 4
+
+Struct name: div_t
+ no superName
+ sizeOf: 8
+ fieldCount: 2
+ constCount: 0
+ Field declaredName: quot
+  declaredType: int
+  offset: 0
+ Field declaredName: rem
+  declaredType: int
+  offset: 4
+
+Struct name: ios_base__Init
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: lconv
+ no superName
+ sizeOf: 96
+ fieldCount: 24
+ constCount: 0
+ Field declaredName: decimal_point
+  declaredType: char*
+  offset: 0
+ Field declaredName: thousands_sep
+  declaredType: char*
+  offset: 8
+ Field declaredName: grouping
+  declaredType: char*
+  offset: 16
+ Field declaredName: int_curr_symbol
+  declaredType: char*
+  offset: 24
+ Field declaredName: currency_symbol
+  declaredType: char*
+  offset: 32
+ Field declaredName: mon_decimal_point
+  declaredType: char*
+  offset: 40
+ Field declaredName: mon_thousands_sep
+  declaredType: char*
+  offset: 48
+ Field declaredName: mon_grouping
+  declaredType: char*
+  offset: 56
+ Field declaredName: positive_sign
+  declaredType: char*
+  offset: 64
+ Field declaredName: negative_sign
+  declaredType: char*
+  offset: 72
+ Field declaredName: int_frac_digits
+  declaredType: char
+  offset: 80
+ Field declaredName: frac_digits
+  declaredType: char
+  offset: 81
+ Field declaredName: p_cs_precedes
+  declaredType: char
+  offset: 82
+ Field declaredName: p_sep_by_space
+  declaredType: char
+  offset: 83
+ Field declaredName: n_cs_precedes
+  declaredType: char
+  offset: 84
+ Field declaredName: n_sep_by_space
+  declaredType: char
+  offset: 85
+ Field declaredName: p_sign_posn
+  declaredType: char
+  offset: 86
+ Field declaredName: n_sign_posn
+  declaredType: char
+  offset: 87
+ Field declaredName: int_p_cs_precedes
+  declaredType: char
+  offset: 88
+ Field declaredName: int_p_sep_by_space
+  declaredType: char
+  offset: 89
+ Field declaredName: int_n_cs_precedes
+  declaredType: char
+  offset: 90
+ Field declaredName: int_n_sep_by_space
+  declaredType: char
+  offset: 91
+ Field declaredName: int_p_sign_posn
+  declaredType: char
+  offset: 92
+ Field declaredName: int_n_sign_posn
+  declaredType: char
+  offset: 93
+
+Struct name: ldiv_t
+ no superName
+ sizeOf: 16
+ fieldCount: 2
+ constCount: 0
+ Field declaredName: quot
+  declaredType: long int
+  offset: 0
+ Field declaredName: rem
+  declaredType: long int
+  offset: 8
+
+Struct name: lldiv_t
+ no superName
+ sizeOf: 16
+ fieldCount: 2
+ constCount: 0
+ Field declaredName: quot
+  declaredType: long long int
+  offset: 0
+ Field declaredName: rem
+  declaredType: long long int
+  offset: 8
+
+Struct name: std
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std___Ios_Fmtflags
+ no superName
+ sizeOf: 4
+ fieldCount: 0
+ constCount: 21
+ Constant name: _S_boolalpha
+  value: 1
+ Constant name: _S_dec
+  value: 2
+ Constant name: _S_fixed
+  value: 4
+ Constant name: _S_hex
+  value: 8
+ Constant name: _S_internal
+  value: 16
+ Constant name: _S_left
+  value: 32
+ Constant name: _S_oct
+  value: 64
+ Constant name: _S_right
+  value: 128
+ Constant name: _S_scientific
+  value: 256
+ Constant name: _S_showbase
+  value: 512
+ Constant name: _S_showpoint
+  value: 1024
+ Constant name: _S_showpos
+  value: 2048
+ Constant name: _S_skipws
+  value: 4096
+ Constant name: _S_unitbuf
+  value: 8192
+ Constant name: _S_uppercase
+  value: 16384
+ Constant name: _S_adjustfield
+  value: 176
+ Constant name: _S_basefield
+  value: 74
+ Constant name: _S_floatfield
+  value: 260
+ Constant name: _S_ios_fmtflags_end
+  value: 65536
+ Constant name: _S_ios_fmtflags_max
+  value: 2147483647
+ Constant name: _S_ios_fmtflags_min
+  value: -2147483648
+
+Struct name: std___Ios_Iostate
+ no superName
+ sizeOf: 4
+ fieldCount: 0
+ constCount: 7
+ Constant name: _S_goodbit
+  value: 0
+ Constant name: _S_badbit
+  value: 1
+ Constant name: _S_eofbit
+  value: 2
+ Constant name: _S_failbit
+  value: 4
+ Constant name: _S_ios_iostate_end
+  value: 65536
+ Constant name: _S_ios_iostate_max
+  value: 2147483647
+ Constant name: _S_ios_iostate_min
+  value: -2147483648
+
+Struct name: std___Ios_Openmode
+ no superName
+ sizeOf: 4
+ fieldCount: 0
+ constCount: 9
+ Constant name: _S_app
+  value: 1
+ Constant name: _S_ate
+  value: 2
+ Constant name: _S_bin
+  value: 4
+ Constant name: _S_in
+  value: 8
+ Constant name: _S_out
+  value: 16
+ Constant name: _S_trunc
+  value: 32
+ Constant name: _S_ios_openmode_end
+  value: 65536
+ Constant name: _S_ios_openmode_max
+  value: 2147483647
+ Constant name: _S_ios_openmode_min
+  value: -2147483648
+
+Struct name: std___Ios_Seekdir
+ no superName
+ sizeOf: 4
+ fieldCount: 0
+ constCount: 4
+ Constant name: _S_beg
+  value: 0
+ Constant name: _S_cur
+  value: 1
+ Constant name: _S_end
+  value: 2
+ Constant name: _S_ios_seekdir_end
+  value: 65536
+
+Struct name: std__basic_ios<char, std::char_traits<char> >
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std__basic_ostream<char, std::char_traits<char> >
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std__char_traits<char>
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std__ctype<char>
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std__ios_base
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std__piecewise_construct_t
+ no superName
+ sizeOf: 1
+ fieldCount: 0
+ constCount: 0
+
+Struct name: std__type_info
+ no superName
+ sizeOf: 0
+ fieldCount: 0
+ constCount: 0
+
+Struct name: tm
+ no superName
+ sizeOf: 56
+ fieldCount: 11
+ constCount: 0
+ Field declaredName: tm_sec
+  declaredType: int
+  offset: 0
+ Field declaredName: tm_min
+  declaredType: int
+  offset: 4
+ Field declaredName: tm_hour
+  declaredType: int
+  offset: 8
+ Field declaredName: tm_mday
+  declaredType: int
+  offset: 12
+ Field declaredName: tm_mon
+  declaredType: int
+  offset: 16
+ Field declaredName: tm_year
+  declaredType: int
+  offset: 20
+ Field declaredName: tm_wday
+  declaredType: int
+  offset: 24
+ Field declaredName: tm_yday
+  declaredType: int
+  offset: 28
+ Field declaredName: tm_isdst
+  declaredType: int
+  offset: 32
+ Field declaredName: tm_gmtoff
+  declaredType: long int
+  offset: 36
+ Field declaredName: tm_zone
+  declaredType: const char*
+  offset: 44
+
+Struct name: typedef __va_list_tag __va_list_tag
+ no superName
+ sizeOf: 24
+ fieldCount: 4
+ constCount: 0
+ Field declaredName: gp_offset
+  declaredType: unsigned int
+  offset: 0
+ Field declaredName: fp_offset
+  declaredType: unsigned int
+  offset: 4
+ Field declaredName: overflow_arg_area
+  declaredType: void*
+  offset: 8
+ Field declaredName: reg_save_area
+  declaredType: void*
+  offset: 16

--- a/ddr/test/expected_output/xa64/superset.out
+++ b/ddr/test/expected_output/xa64/superset.out
@@ -1,7 +1,304 @@
-S|Sample1Constants|Sample1ConstantsPointer|
-C|Aa
-C|Bb
-C|Cc
+S|int8_t|int8_tPointer|
+S|int16_t|int16_tPointer|
+S|int32_t|int32_tPointer|
+S|int64_t|int64_tPointer|
+S|uint8_t|uint8_tPointer|
+S|uint16_t|uint16_tPointer|
+S|uint32_t|uint32_tPointer|
+S|uint64_t|uint64_tPointer|
+S|int_least8_t|int_least8_tPointer|
+S|int_least16_t|int_least16_tPointer|
+S|int_least32_t|int_least32_tPointer|
+S|int_least64_t|int_least64_tPointer|
+S|uint_least8_t|uint_least8_tPointer|
+S|uint_least16_t|uint_least16_tPointer|
+S|uint_least32_t|uint_least32_tPointer|
+S|uint_least64_t|uint_least64_tPointer|
+S|int_fast8_t|int_fast8_tPointer|
+S|int_fast16_t|int_fast16_tPointer|
+S|int_fast32_t|int_fast32_tPointer|
+S|int_fast64_t|int_fast64_tPointer|
+S|uint_fast8_t|uint_fast8_tPointer|
+S|uint_fast16_t|uint_fast16_tPointer|
+S|uint_fast32_t|uint_fast32_tPointer|
+S|uint_fast64_t|uint_fast64_tPointer|
+S|intmax_t|intmax_tPointer|
+S|uintmax_t|uintmax_tPointer|
+S|_IO_marker|_IO_markerPointer|
+F|_next|_next|_IO_marker*|_IO_marker*
+F|_sbuf|_sbuf|_IO_FILE*|_IO_FILE*
+F|_pos|_pos|I32|int
+S|__off_t|__off_tPointer|
+S|__off64_t|__off64_tPointer|
+S|size_t|size_tPointer|
+S|_IO_FILE|_IO_FILEPointer|
+F|_flags|_flags|I32|int
+F|_IO_read_ptr|_IO_read_ptr|U8*|char*
+F|_IO_read_end|_IO_read_end|U8*|char*
+F|_IO_read_base|_IO_read_base|U8*|char*
+F|_IO_write_base|_IO_write_base|U8*|char*
+F|_IO_write_ptr|_IO_write_ptr|U8*|char*
+F|_IO_write_end|_IO_write_end|U8*|char*
+F|_IO_buf_base|_IO_buf_base|U8*|char*
+F|_IO_buf_end|_IO_buf_end|U8*|char*
+F|_IO_save_base|_IO_save_base|U8*|char*
+F|_IO_backup_base|_IO_backup_base|U8*|char*
+F|_IO_save_end|_IO_save_end|U8*|char*
+F|_markers|_markers|_IO_marker*|_IO_marker*
+F|_chain|_chain|_IO_FILE*|_IO_FILE*
+F|_fileno|_fileno|I32|int
+F|_flags2|_flags2|I32|int
+F|_old_offset|_old_offset|I64|__off_t
+F|_cur_column|_cur_column|U16|short unsigned int
+F|_vtable_offset|_vtable_offset|I8|signed char
+F|_shortbuf|_shortbuf|U8[]|char[]
+F|_lock|_lock|_IO_lock_t*|_IO_lock_t*
+F|_offset|_offset|I64|__off64_t
+F|__pad1|__pad1|void*|void*
+F|__pad2|__pad2|void*|void*
+F|__pad3|__pad3|void*|void*
+F|__pad4|__pad4|void*|void*
+F|__pad5|__pad5|U64|size_t
+F|_mode|_mode|I32|int
+F|_unused2|_unused2|U8[]|char[]
+S|FILE|FILEPointer|
+F|_flags|_flags|I32|int
+F|_IO_read_ptr|_IO_read_ptr|U8*|char*
+F|_IO_read_end|_IO_read_end|U8*|char*
+F|_IO_read_base|_IO_read_base|U8*|char*
+F|_IO_write_base|_IO_write_base|U8*|char*
+F|_IO_write_ptr|_IO_write_ptr|U8*|char*
+F|_IO_write_end|_IO_write_end|U8*|char*
+F|_IO_buf_base|_IO_buf_base|U8*|char*
+F|_IO_buf_end|_IO_buf_end|U8*|char*
+F|_IO_save_base|_IO_save_base|U8*|char*
+F|_IO_backup_base|_IO_backup_base|U8*|char*
+F|_IO_save_end|_IO_save_end|U8*|char*
+F|_markers|_markers|_IO_marker*|_IO_marker*
+F|_chain|_chain|_IO_FILE*|_IO_FILE*
+F|_fileno|_fileno|I32|int
+F|_flags2|_flags2|I32|int
+F|_old_offset|_old_offset|I64|__off_t
+F|_cur_column|_cur_column|U16|short unsigned int
+F|_vtable_offset|_vtable_offset|I8|signed char
+F|_shortbuf|_shortbuf|U8[]|char[]
+F|_lock|_lock|_IO_lock_t*|_IO_lock_t*
+F|_offset|_offset|I64|__off64_t
+F|__pad1|__pad1|void*|void*
+F|__pad2|__pad2|void*|void*
+F|__pad3|__pad3|void*|void*
+F|__pad4|__pad4|void*|void*
+F|__pad5|__pad5|U64|size_t
+F|_mode|_mode|I32|int
+F|_unused2|_unused2|U8[]|char[]
+S|__FILE|__FILEPointer|
+F|_flags|_flags|I32|int
+F|_IO_read_ptr|_IO_read_ptr|U8*|char*
+F|_IO_read_end|_IO_read_end|U8*|char*
+F|_IO_read_base|_IO_read_base|U8*|char*
+F|_IO_write_base|_IO_write_base|U8*|char*
+F|_IO_write_ptr|_IO_write_ptr|U8*|char*
+F|_IO_write_end|_IO_write_end|U8*|char*
+F|_IO_buf_base|_IO_buf_base|U8*|char*
+F|_IO_buf_end|_IO_buf_end|U8*|char*
+F|_IO_save_base|_IO_save_base|U8*|char*
+F|_IO_backup_base|_IO_backup_base|U8*|char*
+F|_IO_save_end|_IO_save_end|U8*|char*
+F|_markers|_markers|_IO_marker*|_IO_marker*
+F|_chain|_chain|_IO_FILE*|_IO_FILE*
+F|_fileno|_fileno|I32|int
+F|_flags2|_flags2|I32|int
+F|_old_offset|_old_offset|I64|__off_t
+F|_cur_column|_cur_column|U16|short unsigned int
+F|_vtable_offset|_vtable_offset|I8|signed char
+F|_shortbuf|_shortbuf|U8[]|char[]
+F|_lock|_lock|_IO_lock_t*|_IO_lock_t*
+F|_offset|_offset|I64|__off64_t
+F|__pad1|__pad1|void*|void*
+F|__pad2|__pad2|void*|void*
+F|__pad3|__pad3|void*|void*
+F|__pad4|__pad4|void*|void*
+F|__pad5|__pad5|U64|size_t
+F|_mode|_mode|I32|int
+F|_unused2|_unused2|U8[]|char[]
+S|typedef __va_list_tag __va_list_tag|typedef __va_list_tag __va_list_tagPointer|
+F|gp_offset|gp_offset|U32|unsigned int
+F|fp_offset|fp_offset|U32|unsigned int
+F|overflow_arg_area|overflow_arg_area|void*|void*
+F|reg_save_area|reg_save_area|void*|void*
+S|wint_t|wint_tPointer|
+S|__mbstate_t|__mbstate_tPointer|
+F|__count|__count|I32|int
+F|__value$__wch|__value.__wch|U32|unsigned int
+F|__value$__wchb|__value.__wchb|U8[]|char[]
+S|mbstate_t|mbstate_tPointer|
+F|__count|__count|I32|int
+F|__value$__wch|__value.__wch|U32|unsigned int
+F|__value$__wchb|__value.__wchb|U8[]|char[]
+S|_Atomic_word|_Atomic_wordPointer|
+S|fmtflags|fmtflagsPointer|
+C|_S_boolalpha
+C|_S_dec
+C|_S_fixed
+C|_S_hex
+C|_S_internal
+C|_S_left
+C|_S_oct
+C|_S_right
+C|_S_scientific
+C|_S_showbase
+C|_S_showpoint
+C|_S_showpos
+C|_S_skipws
+C|_S_unitbuf
+C|_S_uppercase
+C|_S_adjustfield
+C|_S_basefield
+C|_S_floatfield
+C|_S_ios_fmtflags_end
+C|_S_ios_fmtflags_max
+C|_S_ios_fmtflags_min
+S|iostate|iostatePointer|
+C|_S_goodbit
+C|_S_badbit
+C|_S_eofbit
+C|_S_failbit
+C|_S_ios_iostate_end
+C|_S_ios_iostate_max
+C|_S_ios_iostate_min
+S|openmode|openmodePointer|
+C|_S_app
+C|_S_ate
+C|_S_bin
+C|_S_in
+C|_S_out
+C|_S_trunc
+C|_S_ios_openmode_end
+C|_S_ios_openmode_max
+C|_S_ios_openmode_min
+S|seekdir|seekdirPointer|
+C|_S_beg
+C|_S_cur
+C|_S_end
+C|_S_ios_seekdir_end
+S|std|stdPointer|
+S|std$__exception_ptr|std$__exception_ptrPointer|
+S|std$__exception_ptr$exception_ptr|std$__exception_ptr$exception_ptrPointer|
+F|_M_exception_object|_M_exception_object|void*|void*
+S|std$__debug|std$__debugPointer|
+S|std$_Ios_Fmtflags|std$_Ios_FmtflagsPointer|
+C|_S_boolalpha
+C|_S_dec
+C|_S_fixed
+C|_S_hex
+C|_S_internal
+C|_S_left
+C|_S_oct
+C|_S_right
+C|_S_scientific
+C|_S_showbase
+C|_S_showpoint
+C|_S_showpos
+C|_S_skipws
+C|_S_unitbuf
+C|_S_uppercase
+C|_S_adjustfield
+C|_S_basefield
+C|_S_floatfield
+C|_S_ios_fmtflags_end
+C|_S_ios_fmtflags_max
+C|_S_ios_fmtflags_min
+S|std$_Ios_Openmode|std$_Ios_OpenmodePointer|
+C|_S_app
+C|_S_ate
+C|_S_bin
+C|_S_in
+C|_S_out
+C|_S_trunc
+C|_S_ios_openmode_end
+C|_S_ios_openmode_max
+C|_S_ios_openmode_min
+S|std$_Ios_Iostate|std$_Ios_IostatePointer|
+C|_S_goodbit
+C|_S_badbit
+C|_S_eofbit
+C|_S_failbit
+C|_S_ios_iostate_end
+C|_S_ios_iostate_max
+C|_S_ios_iostate_min
+S|std$_Ios_Seekdir|std$_Ios_SeekdirPointer|
+C|_S_beg
+C|_S_cur
+C|_S_end
+C|_S_ios_seekdir_end
+S|std$ios_base|std$ios_basePointer|
+S|std$ios_base$Init|std$ios_base$InitPointer|
+S|tm|tmPointer|
+F|tm_sec|tm_sec|I32|int
+F|tm_min|tm_min|I32|int
+F|tm_hour|tm_hour|I32|int
+F|tm_mday|tm_mday|I32|int
+F|tm_mon|tm_mon|I32|int
+F|tm_year|tm_year|I32|int
+F|tm_wday|tm_wday|I32|int
+F|tm_yday|tm_yday|I32|int
+F|tm_isdst|tm_isdst|I32|int
+F|tm_gmtoff|tm_gmtoff|I64|long int
+F|tm_zone|tm_zone|U8*|const char*
+S|__gnu_cxx|__gnu_cxxPointer|
+S|__gnu_cxx$__numeric_traits_integer<int>|__gnu_cxx$__numeric_traits_integer<int>Pointer|
+S|__gnu_cxx$__numeric_traits_floating<float>|__gnu_cxx$__numeric_traits_floating<float>Pointer|
+S|__gnu_cxx$__numeric_traits_floating<double>|__gnu_cxx$__numeric_traits_floating<double>Pointer|
+S|__gnu_cxx$__numeric_traits_floating<long double>|__gnu_cxx$__numeric_traits_floating<long double>Pointer|
+S|__gnu_cxx$__numeric_traits_integer<long unsigned int>|__gnu_cxx$__numeric_traits_integer<long unsigned int>Pointer|
+S|__gnu_cxx$__numeric_traits_integer<char>|__gnu_cxx$__numeric_traits_integer<char>Pointer|
+S|__gnu_cxx$__numeric_traits_integer<short int>|__gnu_cxx$__numeric_traits_integer<short int>Pointer|
+S|__gnu_cxx$__numeric_traits_integer<long int>|__gnu_cxx$__numeric_traits_integer<long int>Pointer|
+S|__gnu_debug|__gnu_debugPointer|
+S|lconv|lconvPointer|
+F|decimal_point|decimal_point|U8*|char*
+F|thousands_sep|thousands_sep|U8*|char*
+F|grouping|grouping|U8*|char*
+F|int_curr_symbol|int_curr_symbol|U8*|char*
+F|currency_symbol|currency_symbol|U8*|char*
+F|mon_decimal_point|mon_decimal_point|U8*|char*
+F|mon_thousands_sep|mon_thousands_sep|U8*|char*
+F|mon_grouping|mon_grouping|U8*|char*
+F|positive_sign|positive_sign|U8*|char*
+F|negative_sign|negative_sign|U8*|char*
+F|int_frac_digits|int_frac_digits|U8|char
+F|frac_digits|frac_digits|U8|char
+F|p_cs_precedes|p_cs_precedes|U8|char
+F|p_sep_by_space|p_sep_by_space|U8|char
+F|n_cs_precedes|n_cs_precedes|U8|char
+F|n_sep_by_space|n_sep_by_space|U8|char
+F|p_sign_posn|p_sign_posn|U8|char
+F|n_sign_posn|n_sign_posn|U8|char
+F|int_p_cs_precedes|int_p_cs_precedes|U8|char
+F|int_p_sep_by_space|int_p_sep_by_space|U8|char
+F|int_n_cs_precedes|int_n_cs_precedes|U8|char
+F|int_n_sep_by_space|int_n_sep_by_space|U8|char
+F|int_p_sign_posn|int_p_sign_posn|U8|char
+F|int_n_sign_posn|int_n_sign_posn|U8|char
+S|__int32_t|__int32_tPointer|
+S|div_t|div_tPointer|
+F|quot|quot|I32|int
+F|rem|rem|I32|int
+S|ldiv_t|ldiv_tPointer|
+F|quot|quot|I64|long int
+F|rem|rem|I64|long int
+S|lldiv_t|lldiv_tPointer|
+F|quot|quot|I64|long long int
+F|rem|rem|I64|long long int
+S|__compar_fn_t|__compar_fn_tPointer|
+S|_G_fpos64_t|_G_fpos64_tPointer|
+F|__pos|__pos|I64|__off64_t
+F|__state|__state|__mbstate_t|__mbstate_t
+S|fpos_t|fpos_tPointer|
+F|__pos|__pos|I64|__off64_t
+F|__state|__state|__mbstate_t|__mbstate_t
+S|wctype_t|wctype_tPointer|
+S|wctrans_t|wctrans_tPointer|
 S|E|EPointer|
 C|E1
 C|E2
@@ -10,8 +307,8 @@ S|A|APointer|
 F|x|x|U16*|uint16_t*
 F|y|y|U16|uint16_t
 S|SOA|SOAPointer|
-F|a|a|U8[]|uint8_t[]
-F|b|b|U16[][]|uint16_t[][]
+F|a|a|U8[]|unsigned char[]
+F|b|b|U16[][]|short unsigned int[][]
 S|IPv4|IPv4Pointer|
 F|ihl|ihl|U8:4|uint8_t:4
 F|version|version|U8:4|uint8_t:4
@@ -62,19 +359,19 @@ F|blue|blue|U8|uint8_t
 S|Uniondata1|Uniondata1Pointer|
 F|i8|i8|U16|uint16_t
 F|f16|f16|U32|uint32_t
-F|arrI8|arrI8|U8[]|uint8_t[]
+F|arrI8|arrI8|U8[]|unsigned char[]
 S|Uniondata2|Uniondata2Pointer|
 F|i16|i16|U16|uint16_t
 F|f32|f32|U32|uint32_t
-F|arrI8|arrI8|U8[]|uint8_t[]
+F|arrI8|arrI8|U8[]|unsigned char[]
 S|Uniondata3|Uniondata3Pointer|
 F|i16|i16|U16|uint16_t
 F|f32|f32|U32|uint32_t
-F|arrI8|arrI8|U8[]|uint8_t[]
+F|arrI8|arrI8|U8[]|unsigned char[]
 S|Uniondata4|Uniondata4Pointer|
 F|i16|i16|U16|uint16_t
 F|f32|f32|U32|uint32_t
-F|arrI8|arrI8|U8[]|uint8_t[]
+F|arrI8|arrI8|U8[]|unsigned char[]
 S|Unionjob|UnionjobPointer|
 F|name|name|U8[]|char[]
 F|salary|salary|float|float
@@ -86,7 +383,7 @@ C|THING2
 C|THING3
 S|MyNamespace$Q|MyNamespace$QPointer|
 F|d|d|U16|uint16_t
-F|e|e|U16[][]|uint16_t[][]
+F|e|e|U16[][]|short unsigned int[][]
 S|MyNamespace$RGBColourV2|MyNamespace$RGBColourV2Pointer|
 F|red|red|U8|uint8_t
 F|green|green|U8|uint8_t
@@ -94,7 +391,7 @@ F|blue|blue|U8|uint8_t
 S|MyNamespace$Uniondata5|MyNamespace$Uniondata5Pointer|
 F|i16|i16|U16|uint16_t
 F|f32|f32|U32|uint32_t
-F|arrI8|arrI8|U8[]|uint8_t[]
+F|arrI8|arrI8|U8[]|unsigned char[]
 S|MyNamespace$InnerNamespace|MyNamespace$InnerNamespacePointer|
 S|MyNamespace$InnerNamespace$TypeInInnerNamespace|MyNamespace$InnerNamespace$TypeInInnerNamespacePointer|
 F|h|h|U16|uint16_t
@@ -106,24 +403,34 @@ F|data|data|I64|int64_t
 C|ENUM1
 C|ENUM2
 C|ENUM3
+F|innerEnum|innerEnum|MyClass$InnerEnum|MyClass$InnerEnum
 F|Z|Z|MyClass$Z|MyClass$Z
 F|instanceOfZ|instanceOfZ|MyClass$Z|MyClass$Z
 S|MyClass$MyNestedClass|MyClass$MyNestedClassPointer|
 F|d|d|I32|int
+S|MyClass$InnerEnum|MyClass$InnerEnumPointer|
+C|ENUM_A
+C|ENUM_B
+C|ENUM_C
 S|MyClass$Z|MyClass$ZPointer|
 F|g|g|U64|uint64_t
-F|h|h|U16[][]|uint16_t[][]
+F|h|h|U16[][]|short unsigned int[][]
 S|S1|S1Pointer|
+F|a|a|IDATA|IDATA
+S|T1|T1Pointer|
 F|a|a|IDATA|IDATA
 S|S2|S2Pointer|
 F|b|b|IDATA|IDATA
 F|b2|b2|S1|S1
 S|T2|T2Pointer|
-F|c|c|struct S2|struct S2
+F|c|c|S2|S2
+S|T3|T3Pointer|
+F|b|b|IDATA|IDATA
+F|b2|b2|S1|S1
 S|T4|T4Pointer|
 F|d|d|T2|T2
-F|e|e|struct S2|struct S2
-F|f|f|struct S2*|T3
+F|e|e|S2|S2
+F|f|f|S2*|T3
 S|MyEnum|MyEnumPointer|
 C|something1
 C|something2
@@ -141,11 +448,10 @@ F|length|length|I64|int64_t
 F|width|width|I64|int64_t
 F|height|height|I64|int64_t
 S|Foo|FooPointer|
-F|staticTest|staticTest|I32|int
 F|data|data|UDATA|uintptr_t
 F|data2|data2|I32|const int
 S|HasVoidStarField|HasVoidStarFieldPointer|
-F|voidStar|voidStar|FunctionPointer*|FunctionPointer*
+F|voidStar|voidStar|void*|void*
 S|UnionFieldType|UnionFieldTypePointer|
 F|i|i|I32|int32_t
 F|s|s|I16|int16_t
@@ -155,14 +461,20 @@ F|unionField2|unionField2|UnionFieldType|UnionFieldType
 S|S3|S3Pointer|
 F|q|q|U8|volatile uint8_t
 F|r|r|U8|const uint8_t
+S|pS3|pS3Pointer|
+F|q|q|U8|volatile uint8_t
+F|r|r|U8|const uint8_t
 S|Vehicle|VehiclePointer|
 F|speed|speed|double|double
 S|Toy|ToyPointer|
 F|durability|durability|I32|int
-S|MatchboxCar|MatchboxCarPointer|Toy
+S|MatchboxCar|MatchboxCarPointer|Vehicle
 F|hasWheels|hasWheels|I32|int
+S|FunctionPointer|FunctionPointerPointer|
+S|INT|INTPointer|
+S|INT_ARRAY|INT_ARRAYPointer|
 S|StructWithFunctionPointer|StructWithFunctionPointerPointer|
-F|functionPointer|functionPointer|FunctionPointer*|FunctionPointer
+F|functionPointer|functionPointer|void*|FunctionPointer
 F|i|i|I32**[][]|INT_ARRAY
 S|S4|S4Pointer|
 F|i|i|I32|int
@@ -174,12 +486,6 @@ S|Outer|OuterPointer|
 F|innerField1$ui8|innerField1.ui8|U8|uint8_t
 F|innerField2$i16|innerField2.i16|I16|int16_t
 F|innerField3$innerStruct|innerField3.innerStruct|Outer$$InnerStruct|Outer$$InnerStruct
-S|Outer$$InnerStruct|Outer$$InnerStructPointer|
-F|i32|i32|I32|int32_t
-S|OuterClassWithDifferentName1|OuterClassWithDifferentName1Pointer|
-F|instanceOfInnerClassWithSameName|instanceOfInnerClassWithSameName|OuterClassWithDifferentName1$InnerClassWithSameName|OuterClassWithDifferentName1$InnerClassWithSameName
-S|OuterClassWithDifferentName1$InnerClassWithSameName|OuterClassWithDifferentName1$InnerClassWithSameNamePointer|
-F|g|g|double|double
 S|OuterClassWithDifferentName2|OuterClassWithDifferentName2Pointer|
 F|instanceOfInnerClassWithSameName|instanceOfInnerClassWithSameName|OuterClassWithDifferentName2$InnerClassWithSameName|OuterClassWithDifferentName2$InnerClassWithSameName
 S|OuterClassWithDifferentName2$InnerClassWithSameName|OuterClassWithDifferentName2$InnerClassWithSameNamePointer|
@@ -190,16 +496,16 @@ F|imaginary|imaginary|I32|int
 S|Complex<double>|Complex<double>Pointer|
 F|real|real|double|double
 F|imaginary|imaginary|double|double
+S|UDATA2|UDATA2Pointer|
 S|SArrayWithTypedefType|SArrayWithTypedefTypePointer|
-F|arrayWithTypedefType|arrayWithTypedefType|U32[]|UDATA2[]
+F|arrayWithTypedefType|arrayWithTypedefType|U32[]|unsigned int[]
+S|OuterClassWithDifferentName1|OuterClassWithDifferentName1Pointer|
+F|instanceOfInnerClassWithSameName|instanceOfInnerClassWithSameName|OuterClassWithDifferentName1$InnerClassWithSameName|OuterClassWithDifferentName1$InnerClassWithSameName
+S|OuterClassWithDifferentName1$InnerClassWithSameName|OuterClassWithDifferentName1$InnerClassWithSameNamePointer|
+F|g|g|double|double
 S|SNoLengthArray|SNoLengthArrayPointer|
 F|numElements|numElements|I32|int
 F|intArr|intArr|I32[]|int[]
-S|TestFileInSubDirConstants|TestFileInSubDirConstantsPointer|
-C|SEAHORSE
-C|TEST_FLAG
-C|TEST_FLAG2
-C|TEST_FLAG_UNDEF
 S|TestHeaderConstants|TestHeaderConstantsPointer|
 C|COW
 S|MapToTypeTest1|MapToTypeTest1Pointer|
@@ -213,6 +519,9 @@ S|MapToTypeTest4|MapToTypeTest4Pointer|
 C|myMapToTypeMacro4
 S|TestConstants|TestConstantsPointer|
 C|dolphin
-C|fish
 C|octopus
 C|whale
+S|TestFileInSubDirConstants|TestFileInSubDirConstantsPointer|
+C|SEAHORSE
+C|TEST_FLAG2
+C|TEST_FLAG_UNDEF

--- a/ddr/test/expected_output/xi32/superset.out
+++ b/ddr/test/expected_output/xi32/superset.out
@@ -141,7 +141,6 @@ F|length|length|I64|int64_t
 F|width|width|I64|int64_t
 F|height|height|I64|int64_t
 S|Foo|FooPointer|
-F|staticTest|staticTest|I32|int
 F|data|data|UDATA|uintptr_t
 F|data2|data2|I32|const int
 S|HasVoidStarField|HasVoidStarFieldPointer|

--- a/ddr/test/map_to_type/map_to_type.hpp
+++ b/ddr/test/map_to_type/map_to_type.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,9 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-/*
- * @ddr_namespace: map_to_type=MapToTypeTest1
- */
+/*@ddr_namespace: map_to_type=MapToTypeTest1*/
 
 #define myMapToTypeMacro1a 13
 #define myMapToTypeMacro1b 14
@@ -29,7 +27,6 @@
 /* @ddr_namespace: default */
 
 #define myMapToTypeMacro2 23
-
 
 /*
  * @ddr_namespace: map_to_type=MapToTypeTest3

--- a/ddr/test/sample1.cpp
+++ b/ddr/test/sample1.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,37 +38,39 @@ struct A {
 	uint16_t *x;
 	uint16_t y;
 };
-struct A instanceOfA = {0, 1};
+
+struct A instanceOfA = { 0, 1 };
 
 struct SOA {
 	uint8_t a[10];
 	uint16_t b[10][10];
 };
-struct SOA instanceOfSOA = {{0}, {0}};
+
+struct SOA instanceOfSOA = { { 0 }, { 0 } };
 
 struct IPv4 {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-	uint8_t ihl:4;
-	uint8_t version:4;
+	uint8_t ihl :4;
+	uint8_t version :4;
 #elif __BYTE_ORDER == __BIG_ENDIAN
-	uint8_t version:4;
-	uint8_t ihl:4;
+	uint8_t version :4;
+	uint8_t ihl :4;
 #endif
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-	uint8_t ecn:2;
-	uint8_t dscp:6;
+	uint8_t ecn :2;
+	uint8_t dscp :6;
 #elif __BYTE_ORDER == __BIG_ENDIAN
-	unsigned int ecn:2;
-	unsigned int dscp:6;
+	unsigned int ecn :2;
+	unsigned int dscp :6;
 #endif
 	uint16_t tot_len;
 	uint16_t id;
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-	uint16_t fragOff:13;
-	uint16_t flags:3;
+	uint16_t fragOff :13;
+	uint16_t flags :3;
 #elif __BYTE_ORDER == __BIG_ENDIAN
-	uint16_t fragOff:3;
-	uint16_t flags:13;
+	uint16_t fragOff :3;
+	uint16_t flags :13;
 #endif
 	uint8_t ttl;
 	uint8_t protocol;
@@ -76,19 +78,22 @@ struct IPv4 {
 	uint32_t saddr;
 	uint32_t daddr;
 };
-struct IPv4 instanceOfIPv4 = {0};
+
+struct IPv4 instanceOfIPv4 = { 0 };
 
 struct C {
 	uint32_t x;
 	uint32_t y;
 };
-struct C instanceOfC = {0, 0};
+
+struct C instanceOfC = { 0, 0 };
 
 struct D {
 	struct C xy;
 	uint32_t z;
 };
-struct D instanceOfD = {{0, 0}, 0};
+
+struct D instanceOfD = { { 0, 0 }, 0 };
 
 struct UDPPacket {
 	struct IPv4 ipHeader;
@@ -97,29 +102,33 @@ struct UDPPacket {
 	uint16_t length;
 	uint16_t checksum;
 };
+
 struct UDPPacket instanceOfUDPPacket;
 
 struct F {
-	uint16_t x:4;
-	uint16_t y:8;
-	uint16_t z:4;
+	uint16_t x :4;
+	uint16_t y :8;
+	uint16_t z :4;
 };
-struct F instanceOfF = {0};
+
+struct F instanceOfF = { 0 };
 
 struct G {
 	uint16_t x :10;
 	uint16_t y :1;
 	uint16_t z :7;
 };
-struct G instanceOfG = {0};
+
+struct G instanceOfG = { 0 };
 
 struct H {
-	uint16_t a:6;
-	uint16_t b:5;
-	uint16_t c:5;
+	uint16_t a :6;
+	uint16_t b :5;
+	uint16_t c :5;
 	uint16_t d;
 };
-struct H instanceOfH = {0};
+
+struct H instanceOfH = { 0 };
 
 struct Empty {};
 struct Empty instanceOfEmpty;
@@ -155,6 +164,7 @@ union Uniondata1 {
 	uint32_t f16;
 	uint8_t  arrI8[1];
 };
+
 union Uniondata1 instanceOfUniondata1;
 
 union Uniondata2 {
@@ -162,6 +172,7 @@ union Uniondata2 {
 	uint32_t f32;
 	uint8_t arrI8[3];
 };
+
 union Uniondata2 instanceOfUniondata2;
 
 union Uniondata3 {
@@ -169,6 +180,7 @@ union Uniondata3 {
 	uint32_t f32;
 	uint8_t arrI8[4];
 };
+
 union Uniondata3 instanceOfUniondata3;
 
 union Uniondata4 {
@@ -176,6 +188,7 @@ union Uniondata4 {
 	uint32_t f32;
 	uint8_t arrI8[5];
 };
+
 union Uniondata4 instanceOfUniondata4;
 
 union Unionjob {
@@ -183,6 +196,7 @@ union Unionjob {
 	float salary;
 	int worker_no;
 };
+
 union Unionjob instanceOfUnionjob;
 
 // 5. Types defined in a namespace
@@ -232,6 +246,7 @@ namespace MyNamespace
 		TypeInInnerNamespace instanceOfTypeInInnerNamespace;
 	}
 }
+
 MyNamespace::Q instanceOfQ;
 MyNamespace::RGBColourV2 instanceOfRGBColourV2;
 MyNamespace::UDATA instanceOfUDATA;
@@ -299,7 +314,6 @@ main(int argc, char *argv[])
 
 	volume = box2.getVolume();
 	std::cout << "Volume: box2: " << volume << std::endl;
-
 
 	RGBColour rgb1;
 	RGBColour rgb2;

--- a/ddr/test/sample2.cpp
+++ b/ddr/test/sample2.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,8 +66,8 @@ public:
 	typedef unsigned short USDATA;
 	uint64_t getData() { return (data + Z.g * (USDATA)Z.h[7][2] + ENUM_A2); }
 };
-MyClass instanceOfMyClass;
 
+MyClass instanceOfMyClass;
 
 // 7. typedef
 // - typedef'ed primitive
@@ -80,29 +80,33 @@ IDATA instanceOfIDATA;
 typedef struct S1 {
 	IDATA a;
 } T1;
-T1 instanceOfT1 = {0};
+
+T1 instanceOfT1 = { 0 };
 
 // - typedef where the name matches the struct tag
 typedef struct S2 {
 	IDATA b;
 	S1 b2;
 } S2;
-S2 instanceOfS2 = {0, {0}};
+
+S2 instanceOfS2 = { 0, { 0 } };
 
 // - typedef there there is no struct tag
 typedef struct {
 	S2 c;
 } T2;
-T2 instanceOfT2 = {{0, {0}}};
+
+T2 instanceOfT2 = { { 0, { 0 } } };
 
 /* Type without struct name at beginning used as a field. */
-typedef S2 * T3 ;
+typedef S2 *T3;
 typedef struct {
 	T2 d;
 	S2 e;
 	T3 f;
 } T4;
-T4 instanceOfT4 = {{{0, {0}}}, {0, {0}}, NULL};
+
+T4 instanceOfT4 = { { { 0, { 0 } } }, { 0, { 0 } }, NULL };
 
 // - typedef'ed enum
 typedef enum {
@@ -113,6 +117,7 @@ typedef enum {
 	something5,
 	somethingN
 } MyEnum;
+
 MyEnum instanceOfEnum;
 
 // - typedef'ed union
@@ -123,6 +128,7 @@ typedef union {
 		uint32_t lo_ipv6;
 	} s;
 } Ip;
+
 Ip instanceOfIp;
 
 // 8. Fields of classes or structs
@@ -169,6 +175,7 @@ public:
 typedef struct HasVoidStarField {
 	void *voidStar;
 } HasVoidStarField;
+
 HasVoidStarField instanceOfHasVoidStarField;
 
 typedef union UnionFieldType {
@@ -180,6 +187,7 @@ typedef struct HasUnionField {
 	union UnionFieldType unionField1;
 	UnionFieldType unionField2;
 } HasUnionField;
+
 HasUnionField instanceOfHasUnionField;
 
 // 9. Simple numeric macros
@@ -257,7 +265,7 @@ sample2()
 
 	int w = 5;
 
-	std::cout << "max(w++y z++): " << std::endl;
+	std::cout << "max(w++ y++): " << std::endl;
 	y = 10;
 	z = MAX(w++, y++);
 

--- a/ddr/test/sample3.cpp
+++ b/ddr/test/sample3.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,12 +28,13 @@ struct S3 {
 	//const field
 	const uint8_t r;
 };
-struct S3 instanceOfS3 = {1, 4};
 
-//typedef of pointer type
+struct S3 instanceOfS3 = { 1, 4 };
+
+// typedef of pointer type
 typedef S3 *pS3;
 
-//multiple inheritance
+// multiple inheritance
 class Vehicle
 {
 public:
@@ -52,21 +53,25 @@ class MatchboxCar : public Vehicle, public Toy
 {
 public:
 	int hasWheels;
-	MatchboxCar(int hasWheelsIn, double speedIn, int durabilityIn) : Vehicle(speedIn), Toy(durabilityIn), hasWheels(hasWheelsIn) {}
+	MatchboxCar(int hasWheelsIn, double speedIn, int durabilityIn)
+		: Vehicle(speedIn), Toy(durabilityIn), hasWheels(hasWheelsIn)
+	{
+	}
 };
 
 /* Function pointer */
 typedef void VOID;
-typedef VOID* (*FunctionPointer)();
+typedef VOID *(*FunctionPointer)();
 
 /* Array and pointer typedef test */
-typedef int * INT[2];
-typedef INT * INT_ARRAY[10];
+typedef int *INT[2];
+typedef INT *INT_ARRAY[10];
 
 struct StructWithFunctionPointer {
 	FunctionPointer functionPointer;
 	INT_ARRAY i;
 };
+
 struct StructWithFunctionPointer structFunctionPointer;
 
 //struct with base types
@@ -77,9 +82,9 @@ struct S4 {
 	char c;
 	bool b;
 };
-struct S4 instanceOfS4 = {0, 1L, 3.8, 'c', true};
+struct S4 instanceOfS4 = { 0, 1L, 3.8, 'c', true };
 
-//Multiple untagged struct definitions inside a scope.
+// Multiple untagged struct definitions inside a scope.
 struct Outer {
 	struct {
 		uint8_t ui8;
@@ -94,9 +99,10 @@ struct Outer {
 		InnerStruct innerStruct;
 	} innerField3;
 };
-struct Outer instanceOfOuter = {{2}, {4}, {{6}}};
 
-//Two different class's with inner class's with the same name.
+struct Outer instanceOfOuter = { { 2 }, { 4 }, { { 6 } } };
+
+// Two different classes with inner classes of the same name.
 class OuterClassWithDifferentName1
 {
 private:
@@ -104,10 +110,13 @@ private:
 	{
 	public:
 		double g;
+		virtual void nop();
 	};
 	InnerClassWithSameName instanceOfInnerClassWithSameName;
 public:
+	virtual void nop();
 };
+
 OuterClassWithDifferentName1 instanceOfOuterClassWithDifferentName1;
 
 class OuterClassWithDifferentName2
@@ -121,6 +130,7 @@ private:
 	InnerClassWithSameName instanceOfInnerClassWithSameName;
 public:
 };
+
 OuterClassWithDifferentName2 instanceOfOuterClassWithDifferentName2;
 
 //Template class
@@ -135,17 +145,19 @@ public:
 		imaginary = imaginaryIn;
 	}
 };
-Complex <int> instanceOfComplex1(100, 75);
-Complex <double> instanceOfComplex2(64.829, 23.42);
 
-//Array field with base type defined in a typedef
+Complex<int> instanceOfComplex1(100, 75);
+Complex<double> instanceOfComplex2(64.829, 23.42);
+
+// Array field with base type defined in a typedef
 typedef unsigned int UDATA2;
 UDATA2 instanceOfUDATA2;
 
 struct SArrayWithTypedefType {
 	UDATA2 arrayWithTypedefType[12];
 };
-struct SArrayWithTypedefType instanceOfSArrayWithTypedefType = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}};
+
+struct SArrayWithTypedefType instanceOfSArrayWithTypedefType = { { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 } };
 
 void
 sample3()
@@ -168,3 +180,6 @@ sample3()
 
 	std::cout << "functionPointer: " << structFunctionPointer.functionPointer << std::endl;
 }
+
+void OuterClassWithDifferentName1::nop() {}
+void OuterClassWithDifferentName1::InnerClassWithSameName::nop() {}

--- a/ddr/test/sample4.c
+++ b/ddr/test/sample4.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,11 +21,12 @@
 
 #include <stdio.h>
 
-//Array without a length
+// Array without a length
 struct SNoLengthArray {
 	int numElements;
 	int intArr[];
 };
+
 struct SNoLengthArray instanceOfSNoLengthArray;
 
 void

--- a/ddr/tools/blob_reader/blob_reader.cpp
+++ b/ddr/tools/blob_reader/blob_reader.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -164,13 +164,12 @@ main(int argc, char *argv[])
 	}
 	fclose(fd);
 
-
 	/* Read strings */
 	{
 		printf("\n== STRINGS ==\n");
 
-		const uint8_t *const stringDataStart = blobBuffer + sizeof(blobHdrV1) + blobHdrV1.structDataSize;
-		const uint8_t *const stringDataEnd = stringDataStart + blobHdrV1.stringTableDataSize;
+		const uint8_t * const stringDataStart = blobBuffer + sizeof(blobHdrV1) + blobHdrV1.structDataSize;
+		const uint8_t * const stringDataEnd = stringDataStart + blobHdrV1.stringTableDataSize;
 		const uint8_t *currentString = stringDataStart;
 		unsigned int stringNum = 1; /* Numbers the strings in the printed list */
 
@@ -260,7 +259,7 @@ main(int argc, char *argv[])
 		sort(structs.begin(), structs.end(), compareStructs);
 
 		printf("\n== STRUCTS ==\n");
-		for (size_t i = 0; i < structs.size(); i += 1) {
+		for (size_t i = 0; i < structs.size(); ++i) {
 			Structure *builtStruct = structs[i];
 			printf("\nStruct name: %.*s\n",
 				   builtStruct->nameLength,
@@ -280,7 +279,7 @@ main(int argc, char *argv[])
 				   (unsigned long int)builtStruct->constants.size());
 
 			/* Print fields in the struct */
-			for (size_t j = 0; j < builtStruct->fields.size(); j += 1) {
+			for (size_t j = 0; j < builtStruct->fields.size(); ++j) {
 				Field *field = builtStruct->fields[j];
 
 				printf(" Field declaredName: %.*s\n",
@@ -294,7 +293,7 @@ main(int argc, char *argv[])
 			}
 
 			/* Print consts in the struct */
-			for (size_t j = 0; j < builtStruct->constants.size(); j += 1) {
+			for (size_t j = 0; j < builtStruct->constants.size(); ++j) {
 				Constant *constant = builtStruct->constants[j];
 
 				printf(" Constant name: %.*s\n",

--- a/ddr/tools/getmacros
+++ b/ddr/tools/getmacros
@@ -1,7 +1,7 @@
-#! /bin/bash
+#!/bin/bash
 
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,26 +21,38 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+debug=1
+
+# Regular expressions used to process the defines and namespace annotations.
+# These assume that all whitespace has been replaced by space characters.
+id='[A-Za-z_][A-Za-z0-9_]*' # matches an identifier
+default_regex="@ddr_namespace: *default"
+map_to_type_regex="@ddr_namespace: *map_to_type="
+flag_define_regex="^ *# *define +${id} *($|//|/\*)"
+flag_undef_regex="^ *# *undef +${id} *($|//|/\*)"
+value_define_regex="^ *# *define +${id} +[^ ].*($|//|/\*)"
+include_guard_regex=".*_[Hh]([Pp][Pp])?_? *($|//|/\*)"
+
 ##
-# Create a list of all cpp, hpp, c, and h files that have a simple (non function) macro within them.
+# Create a list of all c, h, cpp and hpp files that have simple (non function) macros within them.
 ##
 get_all_annotated_files() {
-	local annotated_files=$(grep -rlE "@ddr_(namespace|options): " ${scan_dir} | grep -e '\.[ch]pp$' -e '\.[ch]$')
+	local annotated_files=$(find ${scan_dir} -type f | grep -E -e '\.[ch](pp)?$' | sort | xargs -d '\n' grep -lE '@ddr_(namespace|options):')
 	echo "${annotated_files[@]}"
 }
 
 get_ddr_options() {
 	# Check the file for "@ddr_options" or use the default settings.
-	if grep -qE "@ddr_options: valuesonly" ${f}; then
+	if grep -qE "@ddr_options: *valuesonly" ${f}; then
 		addValues=1
 		addFlags=0
-	elif grep -qE "@ddr_options: buildflagsonly" ${f}; then
+	elif grep -qE "@ddr_options: *buildflagsonly" ${f}; then
 		addValues=0
 		addFlags=1
-	elif grep -qE "@ddr_options: valuesandbuildflags" ${f}; then
+	elif grep -qE "@ddr_options: *valuesandbuildflags" ${f}; then
 		addValues=1
 		addFlags=1
-	elif grep -qE "@ddr_namespace: (default|map_to_type=.*)" ${f}; then
+	elif grep -qE "@ddr_namespace: *(default|map_to_type=)" ${f}; then
 		addValues=1
 		addFlags=0
 	else
@@ -49,38 +61,28 @@ get_ddr_options() {
 	fi
 }
 
-end_previous_namespace() {
-	if [[ 0 -ne ${#namespace} ]]; then
-		namespace=""
-	fi
-}
-
 begin_new_namespace() {
 	temp_macro_file=${f}
-	echo "@TYPE_${namespace}" >> ${temp_macro_file}
+	echo "@TYPE_${namespace}" >> "${temp_macro_file}"
 }
 
-set_map_to_type_namespace() {
+end_previous_namespace() {
+	namespace=''
+}
+
+set_default_namespace() {
 	end_previous_namespace
-	# Strip off everything on the line up to the'='.
-	namespace=${line##*map_to_type=}
-	# Remove everything after comma (version info).
-	namespace=${namespace%,*}
-	# Remove everything after white space space (line may end in " */", for example).
-	namespace=${namespace% *}
-	namespace=${namespace%	*}
+	# Remove directory and extension; append 'Constants'.
+	namespace=$(echo ${f} | sed -e 's|^.*/||' -e 's|\..*$||' -e 's|\(.\)|\U\1|' -e 's|$|Constants|')
 
 	# Echo the type name into the output file.
 	begin_new_namespace
 }
 
-set_default_namespace() {
+set_map_to_type_namespace() {
 	end_previous_namespace
-	# Remove directory info.
-	namespace=${f##*/}
-	# Remove file extension.
-	namespace=${namespace%.*}
-	namespace=$(echo "${namespace}Constants" | sed 's/\(.\)/\U\1/')
+	# Extract the type name.
+	namespace=$(echo "${line}" | sed -e "s|^.*map_to_type=\(${id}\).*$|\1|")
 
 	# Echo the type name into the output file.
 	begin_new_namespace
@@ -92,8 +94,7 @@ define_flag_macro() {
 		if [[ 0 -eq ${#namespace} ]]; then
 			set_default_namespace
 		fi
-		macro=$(echo "${line}" | awk '{print $2'})
-		echo "@MACRO_${macro} 1" >> "${temp_macro_file}"
+		echo "${line}" | sed -e "s|^ *# *define  *\(${id}\).*$|#ifdef \1\n@MACRO_\1 1\n#endif|" >> "${temp_macro_file}"
 	fi
 }
 
@@ -102,8 +103,7 @@ undef_flag_macro() {
 		set_default_namespace
 	fi
 	# Print a constant of 0 to the macro file.
-	macro=$(echo "${line}" | awk '{print $2'})
-	echo "@MACRO_${macro} 0" >> "${temp_macro_file}"
+	echo "${line}" | sed -e "s|^ *# *undef  *\(${id}\).*$|#ifndef \1\n@MACRO_\1 0\n#endif|" >> "${temp_macro_file}"
 }
 
 define_value_macro() {
@@ -111,14 +111,13 @@ define_value_macro() {
 		set_default_namespace
 	fi
 	# Print the macro.
-	macro=$(echo ${line} | awk '{print $2}')
-	echo "@MACRO_${macro} ${macro}" >> "${temp_macro_file}"
+	echo "${line}" | sed -e "s|^ *# *define  *\(${id}\) .*$|#ifdef \1\n@MACRO_\1 \1\n#endif|" >> "${temp_macro_file}"
 }
 
 ##
 # For each file, create another file with all the macro names in it. This file
-# Will include the source file, and be used to find macro values by running the
-# c pre processor on it. The results are added to the macroList file containing
+# will include the source file, and be used to find macro values by running the
+# C preprocessor on it. The results are added to the macroList file containing
 # all macro info. The map to type policy associates all of the macros from a file
 # with the type specified in the top of the header.
 ##
@@ -132,49 +131,45 @@ parse_namespace_policy_files() {
 		# Find ddr_options or use the default.
 		get_ddr_options
 
-		if [[ 1 == ${addFlags} || 1 == ${addValues} ]]; then
-			# gather qualifying macro definitions
-			IFS=$'\n'
-			macro_list=$(awk '/@ddr_namespace: (map_to_type=|default)/{print}/^[ 	]*#(define|undef)[ 	]+[A-Za-z_][A-Za-z0-9_]*/{print}' ${f})
+		if [ ${addFlags} -ne 0 -o ${addValues} -ne 0 ]; then
+			if [ $debug -ne 0 ]; then
+				echo "Processing constants in '${f}' ..."
+			fi
 
-			# backup the original file
-			cp ${f} ${f}.orig
+			# backup the original file (preserving its timestamp)
+			mv ${f} ${f}.orig
+			cp ${f}.orig ${f}
 
 			# Inject repeated include guard and file delimiter
 			(( filenum++ ))
 			echo >> ${f}
-			echo "#ifndef DDRGEN_F${filenum}_GUARD" >> ${f}
-			echo "#define DDRGEN_F${filenum}_GUARD" >> ${f}
+			echo "#ifndef DDRGEN_F${filenum}_GUARD_H" >> ${f}
+			echo "#define DDRGEN_F${filenum}_GUARD_H" >> ${f}
 			echo "@DDRFILE_BEGIN ${f}" >> ${f}
 
-			for line in ${macro_list}; do
-				# Regex's used to process the defines and namespace annotations.
-				# The script was not happy on Windows if the regex's are in the if statements.
-				map_to_type_regex="(@ddr_namespace: map_to_type=)"
-				default_regex="(@ddr_namespace: default)"
-				flag_define_regex="^[ 	]*\#define[ 	]+[A-Za-z_][A-Za-z0-9_]*[ 	]*($|\/\/|\/\*)"
-				flag_undef_regex="^[ 	]*\#undef[ 	]+[A-Za-z_][A-Za-z0-9_]*[ 	]*($|\/\/|\/\*)"
-				value_define_regex="^[ 	]*#define[ 	]+[A-Za-z_][A-Za-z0-9_]*[^(][ 	]+.+($|\/\/|\/\*)"
-				include_guard_regex="((.*_h)|(.*_hpp)|(.*_h_)|(.*_hpp_))([ \t]*($|\/\/|\/\*))"
-
-				# Remove trailing whitespace from lines. This clears line endings.
-				line="$(echo -e "${line}" | sed -e 's/[[:space:]]*$//')"
-
-				if [[ ${line} =~ ${map_to_type_regex} ]]; then
-					# Change namespaces to specified pseudostructure.
-					set_map_to_type_namespace
-				elif [[ ${line} =~ ${default_regex} ]]; then
+			# Gather qualifying macro definitions.
+			# We use sed to replace tabs with spaces and trim trailing spaces
+			# to simplify patterns for grep and this script.
+			sed -e 's/\t/ /g' -e 's/ *$//' < ${f} \
+			| grep -E \
+				-e '@ddr_namespace: *(default|map_to_type=)' \
+				-e '^ *# *(define|undef) +[A-Za-z_]' \
+			| while read -r line; do
+				if [[ ${line} =~ ${default_regex} ]]; then
 					# Change namespaces to "<FilenameConstants>".
 					set_default_namespace
-				elif [[ ${line} =~ ${flag_define_regex} && 1 == ${addFlags} ]]; then
-					# Print a define flag as a constant of 1.
-					define_flag_macro
-				elif [[ ${line} =~ ${flag_undef_regex} && 1 == ${addFlags} ]]; then
-					# Print an undef flag as a constant of 0.
-					undef_flag_macro
-				elif [[ ${line} =~ ${value_define_regex} && 1 == ${addValues} ]]; then
+				elif [[ ${line} =~ ${map_to_type_regex} ]]; then
+					# Change namespaces to specified pseudostructure.
+					set_map_to_type_namespace
+				elif [[ ${addValues} -ne 0 && ${line} =~ ${value_define_regex} ]]; then
 					# Print a value define.
 					define_value_macro
+				elif [[ ${addFlags} -ne 0 && ${line} =~ ${flag_define_regex} ]]; then
+					# Print a define flag as a constant of 1.
+					define_flag_macro
+				elif [[ ${addFlags} -ne 0 && ${line} =~ ${flag_undef_regex} ]]; then
+					# Print an undef flag as a constant of 0.
+					undef_flag_macro
 				fi
 			done
 			end_previous_namespace
@@ -187,30 +182,30 @@ parse_namespace_policy_files() {
 }
 
 restore_annotated_files() {
+	echo "Restoring annotated files ..."
 	for f in "${annotated_files[@]}"; do
 		# Find ddr_options or use the default.
 		get_ddr_options
 
-		if [[ 1 == ${addFlags} || 1 == ${addValues} ]]; then
-			# restore the original file
+		if [ ${addFlags} -ne 0 -o ${addValues} -ne 0 ]; then
+			# restore the original file (retaining its timestamp)
 			if [[ -e ${f}.orig ]]; then
-				cp ${f}.orig ${f}
-				rm ${f}.orig
+				rm -f ${f}
+				mv ${f}.orig ${f}
 			fi
 		fi
 	done
 }
 
-# On ctrl-c we want to restore any annotated files, and then exit
+# On Ctrl-C we want to restore any annotated files, and then exit
 trap_int() {
-	echo "Ctrl-c detected, exiting ..."
-	echo "Restoring annotated files ..."
+	echo "Ctrl-C detected, exiting ..."
 	restore_annotated_files
 	exit
 }
 
 main() {
-	# trap ctrl-c and call trap_int()
+	# trap Ctrl-C and call trap_int()
 	trap "trap_int" INT TERM
 
 	annotated_files=( $(get_all_annotated_files) )
@@ -221,22 +216,18 @@ main() {
 	echo "Annotating source files containing macros ..."
 	# Deal with specific policies.
 	parse_namespace_policy_files
-	
 
 	# preprocess annotated source code
 	if [[ $(command -v gmake) ]]; then
-		gmake --ignore-errors -C ${scan_dir} ddrgen
+		make=gmake
 	else
-		make --ignore-errors -C ${scan_dir} ddrgen
+		make=make
 	fi
+	${make} --ignore-errors --keep-going -C ${scan_dir} ddrgen
 
 	echo "Scraping anotations from preprocessed code ..."
-	local preproc_files=$(grep -rl -e @MACRO_ -e @TYPE_ ${scan_dir} | grep '\.i$')
-	if [[ 0 -ne ${#preproc_files} ]]; then
-		grep -h -e @DDRFILE -e @MACRO_ -e @TYPE_ ${preproc_files} > ${macroList_file}
-	fi
+	find ${scan_dir} -type f -name '*.i' | sort | xargs -d '\n' grep -hE -e '^@(DDRFILE|MACRO|TYPE)_' > ${macroList_file}
 
-	echo "Restoring annotated files ..."
 	restore_annotated_files
 }
 

--- a/doc/ddr.md
+++ b/doc/ddr.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2017 IBM Corp. and others
+Copyright (c) 2016, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -10,7 +10,7 @@ is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following
 Secondary Licenses when the conditions for such availability set
 forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-General Public License, version 2 with the GNU Classpath 
+General Public License, version 2 with the GNU Classpath
 Exception [1] and GNU General Public License, version 2 with the
 OpenJDK Assembly Exception [2].
 
@@ -31,7 +31,7 @@ OMR must be configured to enable the DDR component. As of writing, this is not
 the default. DDR will be built after the main files are built.
 
 ```sh
-./configure --enable-debug --enable-DDR CPPFLAGS=-I/usr/include/libdwarf
+bash configure --enable-debug --enable-DDR CPPFLAGS=-I/usr/include/libdwarf
 make
 ```
 
@@ -41,15 +41,15 @@ How to run new ddrgen on the test samples:
 
 1. Run the macros script from the top directory:
    ```sh
-   ./ddr/tools/getmacros "ddr/test"
+   bash ddr/tools/getmacros ddr/test
    ```
 2. Run ddrgen with the files to scan and macro list as parameters
    ```sh
-   ./ddrgen ./ddrgentest --macrolist ./macroList
+   ./ddrgen ddrgentest --macrolist ddr/test/macroList --blob blob.dat --superset superset.out
    ```
 3. Print the generated blob
    ```sh
-   ./blob_reader blob.dat >blob.dat.strings
+   ./blob_reader blob.dat > blob.dat.strings
    ```
 4. Compare the output to the expected output. For linux x86 (Note that ubuntu has slightly different results):
    ```sh
@@ -77,4 +77,3 @@ You need to call a special makefile, which will run ddrgen on your project.
 ```sh
 make -f omr/ddr_artifacts.mk TOP_SRCDIR=. DBG_FILE_LIST=./<filelist>
 ```
-


### PR DESCRIPTION
This is in support of https://github.com/eclipse/openj9/issues/378.

Fixes & improvements
* blacklist pattern matching
* close list files
* avoid typedef cycles
* write proper enum size to blob
* handle CR/LF line-ends reading a list files
* pass const references
* favour constructor use over assignment
* formatting
* improve safety
* mark constructors explicit as appropriate
* improve DEBUGPRINTF and ERRMSG macros and use consistent format
* remove redundant or unnecessary #includes
* add constructor for Dwarf_Attribute_s
* add Dwarf_Attribute_s._flag
* add dwarf_formflag() for OSX
* omit static fields from expected superset.out
* improve handling of vtable pointers
* improve 'getmacros' script (and don't let it change timestamps)
* use 'find' to avoid scanning unintersting files
* pull regex definitions out of the inner loop
* fix references to ddr/tools/getmacros
* improve test code
* add an example of map_to_type= without following whitespace
* improve namespace handling
* improve getmacros script
* replace use of 'awk' with 'sed'
* fix @MACRO emissions
* tighten API of ddrgen
* fix validation that macro values are constant
* streamline MacroTool
* fix constant evaluation (including numeric prefixes like '0x')
* fix problem reading macrolist
* use const types where appropriate
* use canonical type expressions
* make as many *.i files as possible
* be careful constructing name to type map for macros
* implicitly blacklist illegal type names
* remove overloading in TypeVisitor
* allow writing of blob and superset independently
* simplify blacklist handling
* make reading blacklist more robust
* fix override support
* fix handling of #undef by getmacros
* ignore linkage_name DWARF attribute
* add ClassType::_isComplete
* construct all fields explicitly
* relocate constants to J9HashtableConstants
* repeat structure for typedef with distinct name

ddrgen
* consider macros in ClassType
* fix Type::renameFieldsAndMacros
* don't require values for enum literals
* don't trim trailing *[] from override value
* generalize support for opaque types
* include typedef with distinct name
* new strategy for eliminating duplicate types
* remove special handling for CLimits
* remove unused _offset field in Modifiers
* reset modifiers with field type override

Blob generation
* don't duplicate fields in blob
* extract common code
* propagate failure to parent process

getmacros
* fix handling of ddr_options: valuesandbuildflags
* improve include guard detection
* fix constant handling

would previously map to the following
(independent of whether A was defined or not)
```
@MACRO_A_DEFINED A_DEFINED 1
@MACRO_A_DEFINED A_DEFINED 0
```