### PR TITLE
On linux 390 make sure to target z9-190 as the architecture

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,6 +46,10 @@ else()
 	list(APPEND OMR_PLATFORM_SHARED_LINKER_OPTIONS
 		-m32
 	)
+endif()
+
+if(OMR_HOST_ARCH STREQUAL "s390")
+	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -march=z9-109)
 endif()
 
 # Testarossa build variables. Longer term the distinction between TR and the rest


### PR DESCRIPTION
With the move to CMake some assembly files get assembled using
GCC instead of AS. On Linux 390 some of the instructions used in
the port library assembly files are only supported on newer
architectures so we should set `-march=z9-190`. The compiler
technology is already setting this value for assembler files.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>