### PR TITLE
Direct old-to-old-reference callback

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -192,6 +192,7 @@ private:
 	bool _isRememberedSetInOverflow;
 
 	volatile BackOutState _backOutState; /**< set if a thread is unable to copy an object due to lack of free space in both Survivor and Tenure */
+	volatile bool _concurrentGlobalGCInProgress; /**< set to true if concurrent Global GC is in progress */
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool debugConcurrentScavengerPageAlignment; /**< if true allows debug output prints for Concurrent Scavenger Page Alignment logic */
 	uintptr_t concurrentScavengerPageSectionSize; /**< selected section size for Concurrent Scavenger Page */
@@ -962,6 +963,9 @@ public:
 	MMINLINE void setScavengerBackOutState(BackOutState backOutState) { _backOutState = backOutState; }
 	MMINLINE BackOutState getScavengerBackOutState() { return _backOutState; }
 	MMINLINE bool isScavengerBackOutFlagRaised() { return backOutFlagCleared < _backOutState; }
+	
+	MMINLINE bool shouldScavengeNotifyGlobalGCOfOldToOldReference() { return _concurrentGlobalGCInProgress; }
+	MMINLINE void setConcurrentGlobalGCInProgress(bool inProgress) { _concurrentGlobalGCInProgress = inProgress; }
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 	/**
@@ -1196,6 +1200,7 @@ public:
 		, _guaranteedNurseryEnd(NULL)
 		, _isRememberedSetInOverflow(false)
 		, _backOutState(backOutFlagCleared)
+		, _concurrentGlobalGCInProgress(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, debugConcurrentScavengerPageAlignment(false)
 		, concurrentScavengerPageSectionSize(0)

--- a/gc/base/omrmmprivate.hdf
+++ b/gc/base/omrmmprivate.hdf
@@ -734,16 +734,6 @@
 	</event>
 	
 	<event>
-		<name>J9HOOK_MM_PRIVATE_OLD_TO_OLD_REFERENCE_CREATED</name>
-		<description>Triggered when old to old reference is created by GC (Scavenger) </description>
-		<condition>defined (__cplusplus)</condition>
-		<trace-sampling intervals="100" />
-		<struct>MM_OldToOldReferenceCreatedEvent</struct>
-		<data type="struct OMR_VMThread*" name="currentThread" description="the current thread" />
-		<data type="void *" name="objectPtr" description="pointer to the parent object" />
-	</event>	
-	
-	<event>
 		<name>J9HOOK_MM_PRIVATE_REBUILD_FREE_LIST</name>
 		<description>Triggered when a range of memory subspace is emptied out and added to free list</description>
 		<condition>defined (__cplusplus)</condition>

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -319,7 +319,6 @@ private:
 	bool tracingRateDropped(MM_EnvironmentBase *env);
 #if defined(OMR_GC_MODRON_SCAVENGER)	
 	uintptr_t potentialFreeSpace(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
-	static void hookOldToOldReferenceCreated(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
 #endif /*OMR_GC_MODRON_SCAVENGER */	
 	static void hookCardCleanPass2Start(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
 


### PR DESCRIPTION
Bypass hook API tp reduce overhead, mostly by avoiding the hook internal
stats counter (which is using an atomic increment).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>