### PR TITLE
Fix for malfunctional env var TR_DisableAVX on X86

### DIFF
--- a/compiler/x/runtime/X86Runtime.hpp
+++ b/compiler/x/runtime/X86Runtime.hpp
@@ -80,7 +80,7 @@ inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
          if((6 & _xgetbv(0) != 6) || feGetEnv("TR_DisableAVX")) // '6' = mask for XCR0[2:1]='11b' (XMM state and YMM state are enabled)
             {
             // Unset OSXSAVE if not enabled via CR0
-            pBuffer->_featureFlags2 &= 0x08000000; // OSXSAVE
+            pBuffer->_featureFlags2 &= ~0x08000000; // OSXSAVE
             }
          }
       return true;


### PR DESCRIPTION
TR_DisableAVX was malfunctional since the mask to unset XSAVE bits were incorrect.
Fixing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>