### PR TITLE
Remove more VMThread reclamation logic

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -977,27 +977,6 @@ OMR::CodeGenerator::canClobberNodesRegister(
 void
 OMR::CodeGenerator::setVMThreadRequired(bool v)
    {
-   if (_liveRegisters[TR_GPR])
-      {
-      if (v)
-         {
-         if (self()->incVMThreadLiveCount() == 1)
-            {
-            _liveRegisters[TR_GPR]->addRegister(_vmThreadRegister);
-            _flags1.set(VMThreadRequired, true);
-            }
-         }
-      else
-         {
-         TR_ASSERT(_vmThreadRegister->isLive(), "Tried to remove the vmThread from live list, but wasn't live\n");
-         TR_ASSERT(_vmThreadLiveCount != 0, "Tried to underflow the VMThread register live count\n");
-         if (self()->decVMThreadLiveCount() == 0)
-            {
-            _flags1.set(VMThreadRequired, false);
-            _liveRegisters[TR_GPR]->registerIsDead(_vmThreadRegister);
-            }
-         }
-      }
    }
 
 bool

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -185,7 +185,6 @@ OMR::CodeGenerator::CodeGenerator() :
       _ialoadUnneeded(self()->comp()->trMemory()),
      _symRefTab(self()->comp()->getSymRefTab()),
      _vmThreadRegister(NULL),
-     _vmThreadLiveCount(0),
      _vmThreadSpillInstr(NULL),
      _stackAtlas(NULL),
      _methodStackMap(NULL),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -800,9 +800,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR::RealRegister *getRealVMThreadRegister() {return _realVMThreadRegister;}
    void setRealVMThreadRegister(TR::RealRegister *defvmtr) {_realVMThreadRegister = defvmtr;}
-   uint32_t getVMThreadLiveCount() {return _vmThreadLiveCount;}
-   uint32_t decVMThreadLiveCount() {return (--_vmThreadLiveCount);}
-   uint32_t incVMThreadLiveCount() {return (++_vmThreadLiveCount);}
 
    TR::Instruction *getVMThreadSpillInstruction() {return _vmThreadSpillInstr;}
    void setVMThreadSpillInstruction(TR::Instruction *i);
@@ -1879,7 +1876,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    int32_t _lowestSavedReg;
 
-   uint32_t _vmThreadLiveCount;
    uint32_t _largestOutgoingArgSize;
 
    uint32_t _estimatedCodeLength;

--- a/compiler/il/symbol/OMRLabelSymbol.cpp
+++ b/compiler/il/symbol/OMRLabelSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,6 @@ OMR::LabelSymbol::LabelSymbol() :
    _codeLocation(NULL),
    _estimatedCodeLocation(0),
    _snippet(NULL),
-   _vmThreadRestoringLabel(NULL),
    _directlyTargeted(false)
    {
    self()->setIsLabel();
@@ -87,8 +86,7 @@ OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen) :
    _instruction(NULL),
    _codeLocation(NULL),
    _estimatedCodeLocation(0),
-   _snippet(NULL),
-   _vmThreadRestoringLabel(NULL)
+   _snippet(NULL)
    {
    self()->setIsLabel();
 
@@ -102,8 +100,7 @@ OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb) :
    _instruction(NULL),
    _codeLocation(NULL),
    _estimatedCodeLocation(0),
-   _snippet(NULL),
-   _vmThreadRestoringLabel(NULL)
+   _snippet(NULL)
    {
    self()->setIsLabel();
 

--- a/compiler/il/symbol/OMRLabelSymbol.hpp
+++ b/compiler/il/symbol/OMRLabelSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,9 +100,6 @@ public:
    TR::Snippet * getSnippet()               { return _snippet; }
    TR::Snippet * setSnippet(TR::Snippet *s) { return (_snippet = s); }
 
-   TR::LabelSymbol * getVMThreadRestoringLabel()                    { return _vmThreadRestoringLabel; }
-   TR::LabelSymbol * setVMThreadRestoringLabel(TR::LabelSymbol *ls) { return (_vmThreadRestoringLabel = ls); }
-
    void setDirectlyTargeted() { _directlyTargeted = true; }
    TR_YesNoMaybe isTargeted();
 
@@ -115,8 +112,6 @@ private:
    int32_t            _estimatedCodeLocation;
 
    TR::Snippet *      _snippet;
-
-   TR::LabelSymbol *  _vmThreadRestoringLabel; ///< For late edge splitting
 
    bool               _directlyTargeted;
 

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -384,9 +384,6 @@ public:
    inline void setEndInternalControlFlow();
    inline bool isEndInternalControlFlow();
 
-   inline void setVMThreadLive();
-   inline bool isVMThreadLive();
-
    inline void setInternalControlFlowMerge();
    inline bool isInternalControlFlowMerge();
 
@@ -534,7 +531,7 @@ public:
       StartInternalControlFlow     = 0x40000000,
       EndInternalControlFlow       = 0x20000000,
       // Available                 = 0x10000000,
-      IsVMThreadLive               = 0x08000000, // reg assigner has determined that vmthread must be in the proper register at this label
+      // Available                 = 0x08000000,
       // Available                 = 0x04000000,
       InternalControlFlowMerge     = 0x02000000, // mainline merge label for OOL instructions
       EndOfColdInstructionStream   = 0x01000000,

--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -565,18 +565,6 @@ bool
 OMR::Symbol::isEndInternalControlFlow()
    {
    return self()->isLabel() && !self()->isGlobalLabel() && _flags.testAny(EndInternalControlFlow) && !self()->isGlobalLabel();
-   }
-
-void
-OMR::Symbol::setVMThreadLive()
-   {
-   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(IsVMThreadLive);
-   }
-
-bool
-OMR::Symbol::isVMThreadLive()
-   {
-   return self()->isLabel() && _flags.testAny(IsVMThreadLive);
    }
 
 void

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -118,7 +118,6 @@ namespace TR { class X86PaddingInstruction;                }
 namespace TR { class X86AlignmentInstruction;              }
 namespace TR { class X86BoundaryAvoidanceInstruction;      }
 namespace TR { class X86PatchableCodeAlignmentInstruction; }
-namespace TR { class X86RestoreVMThreadInstruction;        }
 namespace TR { class X86FenceInstruction;                  }
 namespace TR { class X86VirtualGuardNOPInstruction;        }
 namespace TR { class X86ImmInstruction;                    }
@@ -750,7 +749,6 @@ public:
    void print(TR::FILE *, TR::X86AlignmentInstruction *);
    void print(TR::FILE *, TR::X86BoundaryAvoidanceInstruction *);
    void print(TR::FILE *, TR::X86PatchableCodeAlignmentInstruction *);
-   void print(TR::FILE *, TR::X86RestoreVMThreadInstruction *);
    void print(TR::FILE *, TR::X86FenceInstruction *);
 #ifdef J9_PROJECT_SPECIFIC
    void print(TR::FILE *, TR::X86VirtualGuardNOPInstruction *);

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -278,7 +278,6 @@ bool OMR::X86::TreeEvaluator::analyseAddForLEA(TR::Node *node, TR::CodeGenerator
              firstChild->getSymbolReference()->getSymbol()->isMethodMetaData())
             {
             baseRegister = cg->getMethodMetaDataRegister();
-            cg->setVMThreadRequired(true);
             offset += firstChild->getSymbolReference()->getOffset();
             }
          else

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1381,9 +1381,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpeqEvaluator(TR::Node *node, T
             cg->evaluate(firstChild);
             cg->evaluate(secondChild);
 
-            cg->setVMThreadRequired(true);
             generateConditionalJumpInstruction(JO4, node, cg, true);
-            cg->setVMThreadRequired(false);
 
             cg->decReferenceCount(firstChild);
             cg->decReferenceCount(secondChild);
@@ -1403,9 +1401,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpeqEvaluator(TR::Node *node, T
 
       TR::TreeEvaluator::compareIntegersForEquality(node, cg);
 
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JE4, node, cg, true);
-      cg->setVMThreadRequired(false);
       return NULL;
       }
    }
@@ -1483,9 +1479,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
             cg->evaluate(firstChild);
             cg->evaluate(secondChild);
 
-            cg->setVMThreadRequired(true);
             generateConditionalJumpInstruction(JNO4, node, cg, true);
-            cg->setVMThreadRequired(false);
 
             cg->decReferenceCount(firstChild);
             cg->decReferenceCount(secondChild);
@@ -1527,13 +1521,9 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
              generateMemImmInstruction(TEST4MemImm4, node, sourceMR, ( ((int32_t)-1) << node->getFirstChild()->getSecondChild()->getInt() ), cg);
              }
 
-         cg->setVMThreadRequired(true);
-
          TR::X86LabelInstruction *instr = generateConditionalJumpInstruction(JNE4, node, cg, true);
          if (insertMergedHCRGuard)
             generateMergedHCRGuardCodeIfNeeded(node, cg, instr);
-
-         cg->setVMThreadRequired(false);
 
          cg->recursivelyDecReferenceCount(node->getFirstChild());
          cg->decReferenceCount(node->getSecondChild());
@@ -1541,7 +1531,6 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
          }
 
       TR::TreeEvaluator::compareIntegersForEquality(node, cg);
-      cg->setVMThreadRequired(true);
 
       // If this is a guard that has not been NOPed, then
       // it might need to be registered in our internal data structures
@@ -1565,7 +1554,6 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
       if (insertMergedHCRGuard)
          generateMergedHCRGuardCodeIfNeeded(node, cg, instr);
 
-      cg->setVMThreadRequired(false);
       return NULL;
       }
    }
@@ -1659,16 +1647,12 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpltEvaluator(TR::Node *node, T
          TR::TreeEvaluator::generateLAddOrSubForOverflowCheck(node, cg)
        : TR::TreeEvaluator::generateIAddOrSubForOverflowCheck(node, cg))
       {
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JO4, node, cg, true);
-      cg->setVMThreadRequired(false);
       }
    else
       {
       TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JL4, node, cg, true);
-      cg->setVMThreadRequired(false);
       }
    return NULL;
    }
@@ -1679,16 +1663,12 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgeEvaluator(TR::Node *node, T
          TR::TreeEvaluator::generateLAddOrSubForOverflowCheck(node, cg)
        : TR::TreeEvaluator::generateIAddOrSubForOverflowCheck(node, cg))
       {
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JNO4, node, cg, true);
-      cg->setVMThreadRequired(false);
       }
    else
       {
       TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JGE4, node, cg, true);
-      cg->setVMThreadRequired(false);
       }
    return NULL;
    }
@@ -1696,54 +1676,42 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgeEvaluator(TR::Node *node, T
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JG4, node, cg, true);
-   cg->setVMThreadRequired(false);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JLE4, node, cg, true);
-   cg->setVMThreadRequired(false);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JB4, node, cg, true);
-   cg->setVMThreadRequired(false);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JAE4, node, cg, true);
-   cg->setVMThreadRequired(false);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JA4, node, cg, true);
-   cg->setVMThreadRequired(false);
    return NULL;
    }
 
 TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(JBE4, node, cg, true);
-   cg->setVMThreadRequired(false);
    return NULL;
    }
 
@@ -2429,8 +2397,6 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
 
    TR::LabelSymbol *label = node->getBranchDestination()->getNode()->getLabel();
 
-   cg->setVMThreadRequired(true);
-
    TR::Instruction *vgnopInstr = generateVirtualGuardNOPInstruction(node, site, deps, label, cg);
    TR::Instruction *patchPoint = cg->getVirtualGuardForPatching(vgnopInstr);
 
@@ -2450,8 +2416,6 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          generatePatchableCodeAlignmentInstruction(TR::X86PatchableCodeAlignmentInstruction::spinLoopAtomicRegions, vgnopInstr, cg);
          }
       }
-
-   cg->setVMThreadRequired(false);
 
    cg->recursivelyDecReferenceCount(node->getFirstChild());
    cg->recursivelyDecReferenceCount(node->getSecondChild());

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -496,7 +496,6 @@ OMR::X86::CodeGenerator::CodeGenerator() :
    _dependentDiscardableRegisters(getTypedAllocator<TR::Register*>(TR::comp()->allocator())),
    _clobberingInstructions(getTypedAllocator<TR::ClobberingInstruction*>(TR::comp()->allocator())),
    _outlinedInstructionsList(getTypedAllocator<TR_OutlinedInstructions*>(TR::comp()->allocator())),
-   _deferredSplits(getTypedAllocator<TR::X86LabelInstruction*>(TR::comp()->allocator())),
    _flags(0)
    {
    _clobIterator = _clobberingInstructions.begin();
@@ -3548,94 +3547,6 @@ OMR::X86::CodeGenerator::patchableRangeNeedsAlignment(void *cursor, intptrj_t le
 TR_X86ScratchRegisterManager *OMR::X86::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {
    return new (self()->trHeapMemory()) TR_X86ScratchRegisterManager(capacity, self());
-   }
-
-void OMR::X86::CodeGenerator::clearDeferredSplits()
-   {
-   if (_internalControlFlowNestingDepth == 0)
-      {
-      _deferredSplits.clear();
-      }
-   else
-      {
-      // Whatever made us think it was safe to clear deferred splits would be
-      // uncertain inside internal control flow, so do nothing.
-      }
-   }
-
-void OMR::X86::CodeGenerator::performDeferredSplits()
-   {
-   for (auto li = _deferredSplits.begin(); li != _deferredSplits.end(); ++li)
-      {
-      TR::LabelSymbol *newLabelSymbol = self()->splitLabel((*li)->getLabelSymbol());
-      (*li)->setLabelSymbol(newLabelSymbol);
-      }
-
-   _deferredSplits.clear();
-   }
-
-void
-OMR::X86::CodeGenerator::processDeferredSplits(bool clear)
-   {
-   if (clear)
-      self()->clearDeferredSplits();
-   else
-      self()->performDeferredSplits();
-   }
-
-TR::LabelSymbol *OMR::X86::CodeGenerator::splitLabel(TR::LabelSymbol *targetLabel, TR::X86LabelInstruction *instructionToDefer)
-   {
-   TR::Instruction *instr = targetLabel->getInstruction();
-   TR_ASSERT(instr, "splitLabel only works on a label from a TR::Instruction");
-
-   // See if we can defer splitting this label until we know for sure that
-   // ebp won't contain the vmthread
-   //
-   TR::X86LabelInstruction *labelInstr = instr->getIA32LabelInstruction();
-   TR::RealRegister *ebp = self()->machine()->getX86RealRegister(self()->getProperties().getMethodMetaDataRegister());
-   if (instructionToDefer && !ebp->getAssignedRegister()
-      && performTransformation(self()->comp(), "O^O LATE EDGE SPLITTING: Defer splitting %s for %s\n", self()->getDebug()->getName(targetLabel), self()->getDebug()->getName(instructionToDefer)))
-      {
-      TR_ASSERT(instructionToDefer->getOpCode().isBranchOp() && instructionToDefer->getLabelSymbol() == targetLabel,
-         "instructionToDefer must be a branch to targetLabel");
-
-      // Just because ebp is not assigned to anything doesn't mean the value
-      // sitting in it can't possibly be the vmthread register.  There's still
-      // a chance that the last value in ebp was indeed the vmthread register.
-      // Defer the decision to split until we find out for sure that we've
-      // assigned something else to ebp.
-      //
-      self()->addDeferredSplit(instructionToDefer);
-      return targetLabel;
-      }
-
-   // Add another target label instruction if there isn't one already
-   //
-   if (!targetLabel->getVMThreadRestoringLabel())
-      {
-      TR::LabelSymbol *newLabel = generateLabelSymbol(self());
-      targetLabel->setVMThreadRestoringLabel(newLabel);
-      newLabel->setInstruction(generateLabelInstruction(targetLabel->getInstruction()->getPrev(), LABEL, newLabel, self()));
-      self()->generateDebugCounter(targetLabel->getInstruction(), "cg.lateSplitEdges", 1, TR::DebugCounter::Exorbitant);
-      }
-
-   // Conservatively store ebp in the prologue just in case any of these split labels decide they need to load it
-   // That decision will occur at binary encoding time, at which point it's too late to do anything about it.
-   // TODO: This is wasteful.  Come up with something better.
-   //
-   TR::Register *vmThreadVirtualReg = self()->getVMThreadRegister();
-   if (vmThreadVirtualReg->getBackingStorage() == NULL)
-      {
-      // copied from RegisterDependency.cpp
-      vmThreadVirtualReg->setBackingStorage(self()->allocateVMThreadSpill());
-      self()->getSpilledIntRegisters().push_front(vmThreadVirtualReg);
-      }
-
-   // Set spill instruction to the "spill in prolog" value.
-   //
-   self()->setVMThreadSpillInstruction((TR::Instruction *)0xffffffff);
-
-   return targetLabel->getVMThreadRestoringLabel();
    }
 
 bool

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -405,15 +405,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR_X86ScratchRegisterManager *generateScratchRegisterManager(int32_t capacity=7);
 
-   // Late edge splitting
-   //
-   void addDeferredSplit(TR::X86LabelInstruction *branch){ _deferredSplits.push_front(branch); }
-   int32_t hasDeferredSplits(){ return !_deferredSplits.empty(); }
-   void clearDeferredSplits();
-   void performDeferredSplits();
-   void processDeferredSplits(bool clear);
-   TR::LabelSymbol *splitLabel(TR::LabelSymbol *targetLabel, TR::X86LabelInstruction *instructionToDefer=NULL);
-
    bool supportsConstantRematerialization();
    bool supportsLocalMemoryRematerialization();
    bool supportsStaticMemoryRematerialization();
@@ -624,7 +615,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::list<TR::Register*>               _dependentDiscardableRegisters;
    TR::list<TR::ClobberingInstruction*>  _clobberingInstructions;
    std::list<TR::ClobberingInstruction*, TR::typed_allocator<TR::ClobberingInstruction*, TR::Allocator> >::iterator _clobIterator;
-   TR::list<TR::X86LabelInstruction*>    _deferredSplits;
    TR::list<TR_OutlinedInstructions*>   _outlinedInstructionsList;
 
    RegisterAssignmentDirection     _assignmentDirection;

--- a/compiler/x/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/x/codegen/OMRInstructionKindEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,5 +72,4 @@ IsNotExtended,
             IsMemRegReg,
             IsFPMemReg,
       IsFPCompareEval,
-      IsRestoreVMThread,
       IsFfsdPPSRecord,

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -249,21 +249,6 @@ OMR::X86::Machine::findBestFreeGPRegister(TR::Instruction   *currentInstruction,
    bool useRegisterInterferences = self()->cg()->enableRegisterInterferences() ? true : false;
    bool useRegisterWeights = self()->cg()->enableRegisterWeights() ? true : false;
 
-   if (!debug("disableForceVMThreadToEBP") && virtReg == self()->cg()->getVMThreadRegister())
-      {
-      // Reg assigner gets confused if the virtual vmthread GPR gets a register other than ebp
-
-      // If the vmThread register is free then assign it straightaway.
-      //
-      if (_registerFile[TR::RealRegister::ebp]->getState() == TR::RealRegister::Free || _registerFile[TR::RealRegister::ebp]->getState() == TR::RealRegister::Unlatched)
-         {
-         return _registerFile[TR::RealRegister::ebp];
-         }
-
-      diagnostic("Refusing to give a free register for vmthread\n");
-      return NULL;
-      }
-
    if (useRegisterAssociations &&
        virtReg->getAssociation() != TR::RealRegister::NoReg &&
        self()->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)virtReg->getAssociation()) == virtReg &&
@@ -511,67 +496,44 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
       bestDistances[i] = 0;
       }
 
-   if (!debug("disableForceVMThreadToEBP") && (virtReg == self()->cg()->getVMThreadRegister()))
+   // Identify all spillable candidates of the appropriate register type.
+   //
+   for (i = first; i <= last; i++)
       {
-      // Reg assigner gets confused if vmthread gets a register other than ebp
-      TR_ASSERT(_registerFile[TR::RealRegister::ebp]->getState() == TR::RealRegister::Assigned, "ebp must be spillable for vmthread");
-      diagnostic("Forcing use of ebp for vmthread\n");
-      candidates[0] = self()->getX86RealRegister(TR::RealRegister::ebp)->getAssignedRegister();
-      numCandidates = 1;
-      }
-   else
-      {
-
-      //cannot spill when inside an internal control flow
-      if(false)
-      TR_ASSERT(!self()->cg()->insideInternalControlFlow(), "The instruction %p from %s, should not be inside an Internal Control Flow with a depth of %d with a safe depth of %d\n", currentInstruction, currentInstruction->getNode()->getOpCode().getName(), self()->cg()->internalControlFlowNestingDepth(), self()->cg()->internalControlFlowSafeNestingDepth());
-
-      // Identify all spillable candidates of the appropriate register type.
+      // Don't consider registers that can't be assigned.
       //
-      for (i = first; i <= last; i++)
+      if (_registerFile[i]->getState() == TR::RealRegister::Locked)
          {
-         // Don't consider registers that can't be assigned.
-         //
-         if (_registerFile[i]->getState() == TR::RealRegister::Locked)
-            {
-            continue;
-            }
-
-         realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
-
-         if (i == TR::RealRegister::ebp && (interference & TR::RealRegister::ebpMask) && realReg->getAssignedRegister() == self()->cg()->getVMThreadRegister())
-            {
-            // The interference to the VM thread register is absolute.  Don't consider the thread
-            // register as a spillable candidate if it interferes.
-            continue;
-            }
-
-         if (realReg->getState() == TR::RealRegister::Assigned)
-            {
-            candidates[numCandidates++] = realReg->getAssignedRegister();
-            if (targetRegister == i)
-               {
-               if (useRegisterInterferences && (interference & (1 << (i-1)))) // TODO:AMD64: Use the proper mask value
-                  bestRegisters[InterferingTarget] = realReg->getAssignedRegister();
-               else
-                  bestRegisters[NonInterferingTarget] = realReg->getAssignedRegister();
-               }
-            }
+         continue;
          }
 
-      if (numCandidates == 0)
-         {
-         // If we are trying to find a suitable spill register for a virtual that currently occupies a
-         // register required in a register dependency, there may not be any suitable spill
-         // candidates if all available real registers are requested in the register dependency.  In
-         // such a case, where our virtual need not be in a register across the dependency, choose the
-         // virtual itself as a spill candidate.
-         //
-         TR_ASSERT(considerVirtAsSpillCandidate,
-                 "freeBestGPRegister(): could not find any GPR spill candidates for %s\n", self()->getDebug()->getName(virtReg));
+      realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
 
-         bestRegister = virtReg;
+      if (realReg->getState() == TR::RealRegister::Assigned)
+         {
+         candidates[numCandidates++] = realReg->getAssignedRegister();
+         if (targetRegister == i)
+            {
+            if (useRegisterInterferences && (interference & (1 << (i-1)))) // TODO:AMD64: Use the proper mask value
+               bestRegisters[InterferingTarget] = realReg->getAssignedRegister();
+            else
+               bestRegisters[NonInterferingTarget] = realReg->getAssignedRegister();
+            }
          }
+      }
+
+   if (numCandidates == 0)
+      {
+      // If we are trying to find a suitable spill register for a virtual that currently occupies a
+      // register required in a register dependency, there may not be any suitable spill
+      // candidates if all available real registers are requested in the register dependency.  In
+      // such a case, where our virtual need not be in a register across the dependency, choose the
+      // virtual itself as a spill candidate.
+      //
+      TR_ASSERT(considerVirtAsSpillCandidate,
+              "freeBestGPRegister(): could not find any GPR spill candidates for %s\n", self()->getDebug()->getName(virtReg));
+
+      bestRegister = virtReg;
       }
 
    // From all the spillable candidates identified, choose the most appropriate based on
@@ -896,19 +858,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
 
       TR_BackingStore *location = NULL;
       int32_t offset = 0;
-      if (bestRegister == self()->cg()->getVMThreadRegister())
-         {
-         if (bestRegister->getBackingStorage() == NULL)
-            {
-            location = self()->cg()->allocateVMThreadSpill();
-            self()->cg()->setVMThreadSpillInstruction((TR::Instruction *)0xffffffff);
-            }
-         else
-            {
-            location = bestRegister->getBackingStorage(); // note: vmthread is never spilled to a slot's second half
-            }
-         }
-      else if ((bestRegister->getKind() == TR_FPR))
+      if ((bestRegister->getKind() == TR_FPR))
          {
          if (bestRegister->getBackingStorage())
             {
@@ -1047,126 +997,113 @@ TR::RealRegister *OMR::X86::Machine::reverseGPRSpillState(TR::Instruction     *c
 
    TR_BackingStore *location = spilledRegister->getBackingStorage();
 
-   if (spilledRegister != self()->cg()->getVMThreadRegister())
+   // If the virtual register has better spill placement info, see if the spill
+   // can be moved to later in the instruction stream
+   //
+   if (self()->cg()->enableBetterSpillPlacements())
       {
-      // If the virtual register has better spill placement info, see if the spill
-      // can be moved to later in the instruction stream
+      if (spilledRegister->hasBetterSpillPlacement())
+         {
+         TR::Instruction *betterInstruction = self()->cg()->findBetterSpillPlacement(spilledRegister, targetRegister->getRegisterNumber());
+         if (betterInstruction)
+            {
+            self()->cg()->setRegisterAssignmentFlag(TR_HasBetterSpillPlacement);
+            currentInstruction = betterInstruction;
+            }
+         }
+
+      self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
+      }
+
+   if (self()->cg()->getUseNonLinearRegisterAssigner())
+      {
+      self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+      }
+
+   self()->cg()->getSpilledIntRegisters().remove(spilledRegister);
+
+   if (self()->cg()->enableRematerialisation())
+      {
+      self()->cg()->reactivateDependentDiscardableRegisters(spilledRegister);
+
+      // A store is not necessary if the register can be rematerialised.
       //
-      if (self()->cg()->enableBetterSpillPlacements())
+      if (spilledRegister->getRematerializationInfo() &&
+          spilledRegister->getRematerializationInfo()->isRematerialized())
          {
-         if (spilledRegister->hasBetterSpillPlacement())
+         if (debug("dumpRemat"))
             {
-            TR::Instruction *betterInstruction = self()->cg()->findBetterSpillPlacement(spilledRegister, targetRegister->getRegisterNumber());
-            if (betterInstruction)
-               {
-               self()->cg()->setRegisterAssignmentFlag(TR_HasBetterSpillPlacement);
-               currentInstruction = betterInstruction;
-               }
+            diagnostic("---> Avoiding storing %s rematerializable register %s to memory in %s\n",
+                        self()->getDebug()->toString(spilledRegister->getRematerializationInfo()),
+                        self()->getDebug()->getName(spilledRegister),
+                        comp->signature());
             }
 
-         self()->cg()->removeBetterSpillPlacementCandidate(targetRegister);
+         return targetRegister;
          }
+      }
 
-      if (self()->cg()->getUseNonLinearRegisterAssigner())
+   TR::MemoryReference *tempMR = generateX86MemoryReference(location->getSymbolReference(), spilledRegister->isSpilledToSecondHalf()? 4 : 0, self()->cg());
+   TR::Instruction        *instr  = NULL;
+
+   if (spilledRegister->getKind() == TR_FPR)
+      {
+      instr = new (self()->cg()->trHeapMemory())
+         TR::X86MemRegInstruction(
+            currentInstruction,
+            spilledRegister->isSinglePrecision() ? MOVSSMemReg : MOVSDMemReg,
+            tempMR,
+            targetRegister, self()->cg());
+
+      // Do not add a freed spill slot back onto the free list if the list is locked.
+      // This is to enforce re-use of the same spill slot for a virtual register
+      // while assigning non-linear control flow regions.
+      //
+      self()->cg()->freeSpill(location, spilledRegister->isSinglePrecision()? 4:8, spilledRegister->isSpilledToSecondHalf()? 4:0);
+      if (!self()->cg()->isFreeSpillListLocked())
          {
-         self()->cg()->getSpilledRegisterList()->remove(spilledRegister);
+         spilledRegister->setBackingStorage(NULL);
          }
+      }
+   else if (spilledRegister->getKind() == TR_VRF)
+      {
+      instr = new (self()->cg()->trHeapMemory())
+         TR::X86MemRegInstruction(
+            currentInstruction,
+            MOVDQUMemReg,
+            tempMR,
+            targetRegister, self()->cg());
 
-      self()->cg()->getSpilledIntRegisters().remove(spilledRegister);
-
-      if (self()->cg()->enableRematerialisation())
+      // Do not add a freed spill slot back onto the free list if the list is locked.
+      // This is to enforce re-use of the same spill slot for a virtual register
+      // while assigning non-linear control flow regions.
+      //
+      self()->cg()->freeSpill(location, 16, 0);
+      if (!self()->cg()->isFreeSpillListLocked())
          {
-         self()->cg()->reactivateDependentDiscardableRegisters(spilledRegister);
-
-         // A store is not necessary if the register can be rematerialised.
-         //
-         if (spilledRegister->getRematerializationInfo() &&
-             spilledRegister->getRematerializationInfo()->isRematerialized())
-            {
-            if (debug("dumpRemat"))
-               {
-               diagnostic("---> Avoiding storing %s rematerializable register %s to memory in %s\n",
-                           self()->getDebug()->toString(spilledRegister->getRematerializationInfo()),
-                           self()->getDebug()->getName(spilledRegister),
-                           comp->signature());
-               }
-
-            return targetRegister;
-            }
+         spilledRegister->setBackingStorage(NULL);
          }
-
-      TR::MemoryReference *tempMR = generateX86MemoryReference(location->getSymbolReference(), spilledRegister->isSpilledToSecondHalf()? 4 : 0, self()->cg());
-      TR::Instruction        *instr  = NULL;
-
-      if (spilledRegister->getKind() == TR_FPR)
-         {
-         instr = new (self()->cg()->trHeapMemory())
-            TR::X86MemRegInstruction(
-               currentInstruction,
-               spilledRegister->isSinglePrecision() ? MOVSSMemReg : MOVSDMemReg,
-               tempMR,
-               targetRegister, self()->cg());
-
-         // Do not add a freed spill slot back onto the free list if the list is locked.
-         // This is to enforce re-use of the same spill slot for a virtual register
-         // while assigning non-linear control flow regions.
-         //
-         self()->cg()->freeSpill(location, spilledRegister->isSinglePrecision()? 4:8, spilledRegister->isSpilledToSecondHalf()? 4:0);
-         if (!self()->cg()->isFreeSpillListLocked())
-            {
-            spilledRegister->setBackingStorage(NULL);
-            }
-         }
-      else if (spilledRegister->getKind() == TR_VRF)
-         {
-         instr = new (self()->cg()->trHeapMemory())
-            TR::X86MemRegInstruction(
-               currentInstruction,
-               MOVDQUMemReg,
-               tempMR,
-               targetRegister, self()->cg());
-
-         // Do not add a freed spill slot back onto the free list if the list is locked.
-         // This is to enforce re-use of the same spill slot for a virtual register
-         // while assigning non-linear control flow regions.
-         //
-         self()->cg()->freeSpill(location, 16, 0);
-         if (!self()->cg()->isFreeSpillListLocked())
-            {
-            spilledRegister->setBackingStorage(NULL);
-            }
-         }
-      else
-         {
-         instr = new (self()->cg()->trHeapMemory())
-            TR::X86MemRegInstruction(
-               currentInstruction,
-               SMemReg(),
-               tempMR,
-               targetRegister, self()->cg());
-         // Do not add a freed spill slot back onto the free list if the list is locked.
-         // This is to enforce re-use of the same spill slot for a virtual register
-         // while assigning non-linear control flow regions.
-         //
-         self()->cg()->freeSpill(location, TR::Compiler->om.sizeofReferenceAddress(), spilledRegister->isSpilledToSecondHalf()? 4:0);
-         if (!self()->cg()->isFreeSpillListLocked())
-            {
-            spilledRegister->setBackingStorage(NULL);
-            }
-         }
-
-      self()->cg()->traceRAInstruction(instr);
       }
    else
       {
-      self()->cg()->setVMThreadSpillInstruction(currentInstruction);
-      if (self()->getDebug())
+      instr = new (self()->cg()->trHeapMemory())
+         TR::X86MemRegInstruction(
+            currentInstruction,
+            SMemReg(),
+            tempMR,
+            targetRegister, self()->cg());
+      // Do not add a freed spill slot back onto the free list if the list is locked.
+      // This is to enforce re-use of the same spill slot for a virtual register
+      // while assigning non-linear control flow regions.
+      //
+      self()->cg()->freeSpill(location, TR::Compiler->om.sizeofReferenceAddress(), spilledRegister->isSpilledToSecondHalf()? 4:0);
+      if (!self()->cg()->isFreeSpillListLocked())
          {
-         self()->cg()->traceRegisterAssignment("VMThread spill instruction is now %s\n",
-                                      (self()->cg()->getVMThreadSpillInstruction() == (TR::Instruction *)0xffffffff) ?
-                                      "sentinel" : self()->getDebug()->getName(self()->cg()->getVMThreadSpillInstruction()));
+         spilledRegister->setBackingStorage(NULL);
          }
       }
+
+   self()->cg()->traceRAInstruction(instr);
 
    return targetRegister;
    }

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1226,9 +1226,6 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction          *cur
          currentTargetVirtual->setAssignedRegister(currentAssignedRegister);
          self()->cg()->traceRegAssigned(currentTargetVirtual, currentAssignedRegister);
          self()->cg()->traceRAInstruction(instr);
-
-         if (toRealRegister(currentAssignedRegister)->getRegisterNumber() == self()->cg()->getProperties().getMethodMetaDataRegister())
-            self()->cg()->processDeferredSplits(currentTargetVirtual == self()->cg()->getVMThreadRegister());
          }
       else
          {
@@ -1260,9 +1257,6 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction          *cur
             self()->cg()->traceRegAssigned(currentTargetVirtual, candidate);
             self()->cg()->traceRAInstruction(instr);
             self()->cg()->resetRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
-
-            if (candidate->getRegisterNumber() == self()->cg()->getProperties().getMethodMetaDataRegister())
-               self()->cg()->processDeferredSplits(currentTargetVirtual == self()->cg()->getVMThreadRegister());
             }
 
          if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount())
@@ -1286,10 +1280,6 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction          *cur
    targetRegister->setAssignedRegister(virtualRegister);
    virtualRegister->setAssignedRegister(targetRegister);
    virtualRegister->setAssignedAsByteRegister(false);
-
-   if (registerNumber == self()->cg()->getProperties().getMethodMetaDataRegister())
-      self()->cg()->processDeferredSplits(virtualRegister == self()->cg()->getVMThreadRegister());
-
    }
 
 void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction          *currentInstruction,
@@ -1487,8 +1477,6 @@ void OMR::X86::Machine::coerceXMMRegisterAssignment(TR::Instruction          *cu
             self()->cg()->traceRegAssigned(currentTargetVirtual, candidate);
             self()->cg()->traceRAInstruction(instr);
             self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled); // the spill (if any) has been traced
-            if (candidate->getRegisterNumber() == self()->cg()->getProperties().getMethodMetaDataRegister())
-               self()->cg()->processDeferredSplits(currentTargetVirtual == self()->cg()->getVMThreadRegister());
             }
 
          if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount())
@@ -1553,9 +1541,6 @@ void OMR::X86::Machine::coerceGPRegisterAssignment(TR::Instruction   *currentIns
    candidate->setAssignedRegister(virtualRegister);
    virtualRegister->setAssignedRegister(candidate);
    virtualRegister->setAssignedAsByteRegister(false);
-
-   if (candidate->getRegisterNumber() == self()->cg()->getProperties().getMethodMetaDataRegister())
-      self()->cg()->processDeferredSplits(virtualRegister == self()->cg()->getVMThreadRegister());
 
    self()->cg()->traceRegAssigned(virtualRegister, candidate);
    }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -224,7 +224,6 @@ OMR::X86::MemoryReference::MemoryReference(
             if (symbol->isMethodMetaData())
                {
                _baseRegister = cg->getMethodMetaDataRegister();
-               cg->setVMThreadRequired(true);
                }
 
             rcount_t refCount = base->getReferenceCount();
@@ -254,7 +253,6 @@ OMR::X86::MemoryReference::MemoryReference(
             else
                {
                _baseRegister = cg->getMethodMetaDataRegister();
-               cg->setVMThreadRequired(true);
                }
             _baseNode = NULL;
             }
@@ -310,7 +308,6 @@ OMR::X86::MemoryReference::initialize(
    if (symbol->isMethodMetaData())
       {
       _baseRegister = cg->getMethodMetaDataRegister();
-      cg->setVMThreadRequired(true);
       }
    else if (symbol->isRegisterMappedSymbol())
       {
@@ -419,9 +416,6 @@ OMR::X86::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
 
    if (_baseRegister != NULL)
       {
-      if (_baseRegister == vmThreadReg)
-         cg->setVMThreadRequired(false);
-
       if (_baseNode != NULL)
          cg->decReferenceCount(_baseNode);
       else if (_baseRegister != vmThreadReg)
@@ -430,9 +424,6 @@ OMR::X86::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
 
    if (_indexRegister != NULL)
       {
-      if (_indexRegister == vmThreadReg)
-         cg->setVMThreadRequired(false);
-
       if (_indexNode != NULL)
          cg->decReferenceCount(_indexNode);
       else if (_indexRegister != vmThreadReg)
@@ -447,16 +438,12 @@ OMR::X86::MemoryReference::stopUsingRegisters(TR::CodeGenerator *cg)
    TR::Register *vmThreadReg = cg->getVMThreadRegister();
    if (_baseRegister != NULL)
       {
-      if (_baseRegister == vmThreadReg)
-         cg->setVMThreadRequired(false);
-      else
+      if (_baseRegister != vmThreadReg)
          cg->stopUsingRegister(_baseRegister);
       }
    if (_indexRegister != NULL)
       {
-      if (_indexRegister == vmThreadReg)
-         cg->setVMThreadRequired(false);
-      else
+      if (_indexRegister != vmThreadReg)
          cg->stopUsingRegister(_indexRegister);
       }
    }
@@ -695,7 +682,6 @@ OMR::X86::MemoryReference::populateMemoryReference(
                else
                   {
                   _indexRegister = cg->getMethodMetaDataRegister();
-                  cg->setVMThreadRequired(true);
                   }
                _indexNode = NULL;
                }
@@ -710,7 +696,6 @@ OMR::X86::MemoryReference::populateMemoryReference(
                else
                   {
                   _baseRegister = cg->getMethodMetaDataRegister();
-                  cg->setVMThreadRequired(true);
                   }
                _baseNode = NULL;
                }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -113,9 +113,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifxcmpoEvaluator(TR::Node *node, TR::Code
    else
       generateRegRegInstruction(CMPRegReg(nodeIs64Bit), node, rs1, rs2, cg);
 
-   cg->setVMThreadRequired(true);
    generateConditionalJumpInstruction(reverseBranch ? JNO4 : JO4, node, cg, true);
-   cg->setVMThreadRequired(false);
 
    cg->decReferenceCount(node->getFirstChild());
    cg->decReferenceCount(node->getSecondChild());
@@ -2258,8 +2256,6 @@ void OMR::X86::TreeEvaluator::genArithmeticInstructionsForOverflowCHK(TR::Node *
             break;
          }
       }
-
-   cg->setVMThreadRequired(true);
    }
 
 TR::Register *OMR::X86::TreeEvaluator::overflowCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2274,7 +2270,6 @@ TR::Register *OMR::X86::TreeEvaluator::overflowCHKEvaluator(TR::Node *node, TR::
    TR::Block *overflowCatchBlock = TR::TreeEvaluator::getOverflowCatchBlock(node, cg);
    TR::TreeEvaluator::genArithmeticInstructionsForOverflowCHK(node, cg);
    generateLabelInstruction(opcode, node, overflowCatchBlock->getEntry()->getNode()->getLabel(), cg);
-   cg->setVMThreadRequired(false);
    cg->decReferenceCount(node->getFirstChild());
    return NULL;
    }
@@ -4032,8 +4027,6 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
          node->setLabel(label);
          }
 
-      cg->setVMThreadRequired(true);
-
       static bool doAlign = (feGetEnv("TR_DoNotAlignLoopEntries") == NULL);
       static bool alwaysAlignLoops = (feGetEnv("TR_AlwaysAlignLoopEntries") != NULL);
       if (doAlign && !block->isCold() && block->firstBlockInLoop() &&
@@ -4054,7 +4047,6 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
 
       node->getLabel()->setInstruction(inst);
       block->setFirstInstruction(inst);
-      cg->setVMThreadRequired(false);
 
       // If this is the first BBStart of the method, its GlRegDeps determine
       // where parameters should be placed.

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -148,12 +148,8 @@ TR::RealRegister *assignGPRegister(TR::Instruction   *instr,
    assignedRegister->setState(TR::RealRegister::Assigned, virtReg->isPlaceholderReg());
    cg->traceRegAssigned(virtReg, assignedRegister);
 
-   if (assignedRegister->getRegisterNumber() == cg->getProperties().getMethodMetaDataRegister())
-      cg->processDeferredSplits(virtReg == cg->getVMThreadRegister());
-
    return assignedRegister;
    }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86LabelInstruction:: member functions
@@ -236,7 +232,6 @@ void TR::X86LabelInstruction::assignOutlinedInstructions(
       oi->assignRegisters(kindsToBeAssigned, generateVFPSaveInstruction(getPrev(), cg()));
    }
 
-
 // Take the now-assigned register dependencies from this instruction and replicate
 // them on the outlined instruction branch instruction.
 //
@@ -265,7 +260,6 @@ void TR::X86LabelInstruction::addPostDepsToOutlinedInstructionsBranch()
 #endif
       }
    }
-
 
 void TR::X86LabelInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
@@ -416,7 +410,6 @@ void TR::X86LabelInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FenceInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -433,7 +426,6 @@ TR::X86FenceInstruction::X86FenceInstruction(TR::Instruction   *precedingInstruc
    : TR::Instruction(op, precedingInstruction, cg), _fenceNode(node)
    {
    }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86ImmInstruction:: member functions
@@ -496,7 +488,6 @@ TR::X86ImmInstruction  *TR::X86ImmInstruction::getIA32ImmInstruction()
    return this;
    }
 #endif
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86ImmSnippetInstruction:: member functions
@@ -660,8 +651,7 @@ TR::X86RegInstruction::X86RegInstruction(TR::Instruction                      *p
 TR::X86RegInstruction  *TR::X86RegInstruction::getIA32RegInstruction()
    {
    return this;
-}
-
+   }
 
 bool TR::X86RegInstruction::refsRegister(TR::Register *reg)
    {
@@ -767,7 +757,6 @@ void TR::X86RegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86RegRegInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -813,7 +802,6 @@ TR::X86RegRegInstruction::X86RegRegInstruction(TR::Instruction                  
    {
    useRegister(sreg);
    }
-
 
 bool TR::X86RegRegInstruction::refsRegister(TR::Register *reg)
    {
@@ -990,10 +978,6 @@ void TR::X86RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
          assignedSecondRegister->setAssignedRegister(secondRegister);
          assignedSecondRegister->setState(TR::RealRegister::Assigned, secondRegister->isPlaceholderReg());
          cg()->traceRegAssigned(secondRegister, assignedSecondRegister);
-
-         if (toRealRegister(assignedSecondRegister)->getRegisterNumber() == cg()->getProperties().getMethodMetaDataRegister())
-            cg()->processDeferredSplits(secondRegister == cg()->getVMThreadRegister());
-
          }
       else if (secondRequestedRegSize == TR_ByteReg)
          {
@@ -1187,7 +1171,6 @@ TR::X86RegImmSymInstruction::autoSetReloKind()
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86RegRegImmInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -1211,7 +1194,6 @@ TR::X86RegRegImmInstruction::X86RegRegImmInstruction(TR::Instruction   *precedin
    : TR::X86RegRegInstruction(sreg, treg, op, precedingInstruction, cg), _sourceImmediate(imm)
    {
    }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86RegRegRegInstruction:: member functions
@@ -1263,7 +1245,6 @@ TR::X86RegRegRegInstruction::X86RegRegRegInstruction(TR::Instruction            
    {
    useRegister(srreg);
    }
-
 
 bool TR::X86RegRegRegInstruction::refsRegister(TR::Register *reg)
    {
@@ -1508,13 +1489,11 @@ void TR::X86RegRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssi
       }
    }
 
-
 void padUnresolvedReferenceInstruction(TR::Instruction *instr, TR::MemoryReference *mr, TR::CodeGenerator *cg)
    {
    mr->getUnresolvedDataSnippet()->setDataReferenceInstruction(instr);
    generateBoundaryAvoidanceInstruction(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8, instr, cg);
    }
-
 
 void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, int32_t barrier, TR::Instruction *inst, TR::MemoryReference *mr, TR::Register *srcReg, TR::MemoryReference *anotherMr)
    {
@@ -1605,6 +1584,7 @@ void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, in
          generateLabelInstruction(fenceInst, LABEL, doneLabel, deps, cg);
 
    }
+
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86MemInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -1686,8 +1666,6 @@ TR::X86MemInstruction::X86MemInstruction(TR_X86OpCodes                       op,
       }
 
    }
-
-
 
 bool TR::X86MemInstruction::refsRegister(TR::Register *reg)
    {
@@ -1810,30 +1788,6 @@ void TR::X86MemTableInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssig
    // Call inherited logic
    //
    TR::X86MemInstruction::assignRegisters(kindsToBeAssigned);
-
-   // Late edge splitting
-   //
-   if (cg()->getProperties().getMethodMetaDataRegister())
-      {
-      TR::RealRegister    *ebp = cg()->machine()->getX86RealRegister(cg()->getProperties().getMethodMetaDataRegister());
-      bool ebpIsVMThreadRegister = ebp->getAssignedRegister() == cg()->getVMThreadRegister();
-
-      if (!ebpIsVMThreadRegister)
-         {
-         // Split edges of tableswitch that don't have ebp dependencies
-         // Note: we don't both
-         //
-         for (ncount_t i = 0; i < getNumRelocations(); i++)
-            {
-            TR::LabelRelocation *relocation = getRelocation(i);
-            TR::LabelSymbol *targetLabel = relocation->getLabel();
-            if (targetLabel->getInstruction())
-               {
-               relocation->setLabel(cg()->splitLabel(targetLabel));
-               }
-            }
-         }
-      }
    }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1866,7 +1820,6 @@ TR::X86CallMemInstruction::X86CallMemInstruction(TR_X86OpCodes                  
    {
    }
 
-
 void TR::X86CallMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
    aboutToAssignRegDeps();
@@ -1898,7 +1851,6 @@ void TR::X86CallMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssign
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86MemImmInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -1923,7 +1875,6 @@ TR::X86MemImmInstruction::X86MemImmInstruction(TR::Instruction        *preceding
    {
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86MemImmSymInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -1947,9 +1898,6 @@ TR::X86MemImmSymInstruction::X86MemImmSymInstruction(TR::Instruction        *pre
    : TR::X86MemImmInstruction(imm, mr, op, precedingInstruction, cg), _symbolReference(sr)
    {
    }
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86MemRegInstruction:: member functions
@@ -1996,7 +1944,6 @@ TR::X86MemRegInstruction::X86MemRegInstruction(TR::Instruction                  
    {
    useRegister(sreg);
    }
-
 
 bool TR::X86MemRegInstruction::refsRegister(TR::Register *reg)
    {
@@ -2193,7 +2140,6 @@ void TR::X86MemRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86MemRegImmInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -2284,6 +2230,7 @@ bool TR::X86MemRegRegInstruction::refsRegister(TR::Register *reg)
 
    return false;
    }
+
 //check refsRegister
 bool TR::X86MemRegRegInstruction::usesRegister(TR::Register *reg)
    {
@@ -2498,7 +2445,6 @@ TR::X86RegMemInstruction::X86RegMemInstruction(TR::Instruction                  
       padUnresolvedReferenceInstruction(this, mr, cg);
       }
    }
-
 
 bool TR::X86RegMemInstruction::refsRegister(TR::Register *reg)
    {
@@ -2914,7 +2860,6 @@ void TR::X86FPST0ST1RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToB
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPSTiST0RegRegInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -3006,7 +2951,6 @@ void TR::X86FPSTiST0RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToB
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPST0STiRegRegInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -3095,7 +3039,6 @@ void TR::X86FPST0STiRegRegInstruction::assignRegisters(TR_RegisterKinds kindsToB
          }
       }
    }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPArithmeticRegRegInstruction:: member functions
@@ -3193,7 +3136,6 @@ void TR::X86FPArithmeticRegRegInstruction::assignRegisters(TR_RegisterKinds kind
          }
       }
    }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPCompareRegRegInstruction:: member functions
@@ -3439,7 +3381,6 @@ bool TR::X86FPCompareRegRegInstruction::swapOperands()
    return true;
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPCompareEvalInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -3679,8 +3620,6 @@ TR_X86OpCodes getBranchOrSetOpCodeForFPComparison(TR::ILOpCodes cmpOp, bool useF
 
    return op;
    }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86FPRemainderRegRegInstruction:: member functions
@@ -3955,7 +3894,6 @@ void TR::X86FPRegMemInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssig
       }
    }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // TR_IA32VFPxxx member functions
 ////////////////////////////////////////////////////////////////////////////////
@@ -4026,7 +3964,6 @@ void TR::X86BoundaryAvoidanceInstruction::assignRegisters(TR_RegisterKinds kinds
       }
    }
 
-
 int32_t
 TR::X86BoundaryAvoidanceInstruction::betterPadLength(
       int32_t oldPadLength,
@@ -4035,10 +3972,6 @@ TR::X86BoundaryAvoidanceInstruction::betterPadLength(
    {
    return oldPadLength + (int32_t)cg()->alignment(unaccommodatedRegionStart, _boundarySpacing); // cast explicitly
    }
-
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::AMD64RegImm64SymInstruction:: member functions
@@ -4066,7 +3999,6 @@ TR::AMD64RegImm64SymInstruction::AMD64RegImm64SymInstruction(TR::Instruction    
    autoSetReloKind();
    }
 
-
 void
 TR::AMD64RegImm64SymInstruction::autoSetReloKind()
    {
@@ -4078,7 +4010,6 @@ TR::AMD64RegImm64SymInstruction::autoSetReloKind()
    else
       setReloKind(-1);
    }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Generate methods
@@ -4264,7 +4195,6 @@ generateAlignmentInstruction(TR::Instruction *precedingInstruction, uint8_t boun
    return new (cg->trHeapMemory()) TR::X86AlignmentInstruction(precedingInstruction, boundary, margin, cg);
    }
 
-
 TR::X86LabelInstruction  *
 generateLabelInstruction(TR_X86OpCodes   op,
                          TR::Node        * node,
@@ -4336,7 +4266,6 @@ generateLongLabelInstruction(TR_X86OpCodes     op,
    return instr;
    }
 
-
 TR::X86LabelInstruction  *
 generateLabelInstruction(TR_X86OpCodes     opCode,
                          TR::Node           *node,
@@ -4361,7 +4290,6 @@ generateLabelInstruction(TR_X86OpCodes     opCode,
 
    return instr;
    }
-
 
 static TR_AtomicRegion longBranchAtomicRegions[] =
    {
@@ -4441,7 +4369,6 @@ generateConditionalJumpInstruction(
    return inst;
    }
 
-
 TR::X86FenceInstruction  *
 generateFenceInstruction(TR_X86OpCodes op, TR::Node * node, TR::Node * fenceNode, TR::CodeGenerator *cg)
    {
@@ -4479,7 +4406,6 @@ bool TR::X86VirtualGuardNOPInstruction::usesRegister(TR::Register *reg)
 bool TR::X86VirtualGuardNOPInstruction::defsRegister(TR::Register *reg) { return usesRegister(reg); }
 bool TR::X86VirtualGuardNOPInstruction::refsRegister(TR::Register *reg) { return usesRegister(reg); }
 #endif
-
 
 TR::X86RegImmInstruction  *
 generateRegImmInstruction(TR_X86OpCodes                       op,
@@ -4663,7 +4589,6 @@ generateHelperCallInstruction(TR::Node * node, TR_RuntimeHelper index, TR::Regis
          cg);
    }
 
-
 void
 TR::X86VFPCallCleanupInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
@@ -4674,7 +4599,6 @@ TR::X86VFPCallCleanupInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssi
 
    OMR::X86::Instruction::assignRegisters(kindsToBeAssigned);
    }
-
 
 TR::X86VFPSaveInstruction  *generateVFPSaveInstruction(TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
    {
@@ -4735,7 +4659,6 @@ TR::X86VFPCallCleanupInstruction *generateVFPCallCleanupInstruction(int32_t adju
    {
    return new (cg->trHeapMemory()) TR::X86VFPCallCleanupInstruction(adjustment, node, cg);
    }
-
 
 TR::X86FPRegInstruction  *
 generateFPRegInstruction(TR_X86OpCodes op, TR::Node * node, TR::Register * reg, TR::CodeGenerator *cg)

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -434,14 +434,6 @@ TR::X86FenceInstruction::X86FenceInstruction(TR::Instruction   *precedingInstruc
    {
    }
 
-////////////////////////////////////////////////////////////////////////////////
-// TR::X86RestoreVMThreadInstruction:: member functions
-////////////////////////////////////////////////////////////////////////////////
-
-TR::X86RestoreVMThreadInstruction::X86RestoreVMThreadInstruction(TR_X86OpCodes op, TR::Node *node, TR::CodeGenerator *cg)
-   : TR::Instruction(node, op, cg)
-   {
-   }
 
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86ImmInstruction:: member functions
@@ -4370,12 +4362,6 @@ generateLabelInstruction(TR_X86OpCodes     opCode,
    return instr;
    }
 
-TR::X86RestoreVMThreadInstruction  *
-generateRestoreVMThreadInstruction(TR::Node          *node,
-                                   TR::CodeGenerator *cg)
-   {
-   return new (cg->trHeapMemory()) TR::X86RestoreVMThreadInstruction(RestoreVMThread, node, cg);
-   }
 
 static TR_AtomicRegion longBranchAtomicRegions[] =
    {

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -501,24 +501,6 @@ class X86FenceInstruction : public TR::Instruction
    virtual uint8_t *generateBinaryEncoding();
 
    virtual void addMetaDataForCodeAddress(uint8_t *cursor);
-
-   };
-
-
-class X86RestoreVMThreadInstruction : public TR::Instruction
-   {
-   public:
-
-   X86RestoreVMThreadInstruction(TR_X86OpCodes    op,
-                                     TR::Node          *n,
-                                     TR::CodeGenerator *cg);
-
-   virtual char *description() { return "X86RestoreVMThread"; }
-
-   virtual Kind getKind() { return IsRestoreVMThread; }
-   virtual uint8_t *generateBinaryEncoding();
-   virtual int32_t  estimateBinaryLength(int32_t currentEstimate);
-   virtual uint8_t  getBinaryLengthLowerBound();
 
    };
 
@@ -2969,8 +2951,6 @@ TR::X86MemInstruction  * generateMemInstruction(TR_X86OpCodes                   
 
 TR::X86MemTableInstruction * generateMemTableInstruction(TR_X86OpCodes op, TR::Node *node, TR::MemoryReference *mr, ncount_t numEntries, TR::CodeGenerator *cg);
 TR::X86MemTableInstruction * generateMemTableInstruction(TR_X86OpCodes op, TR::Node *node, TR::MemoryReference *mr, ncount_t numEntries, TR::RegisterDependencyConditions *deps, TR::CodeGenerator *cg);
-
-TR::X86RestoreVMThreadInstruction  *generateRestoreVMThreadInstruction(TR::Node *, TR::CodeGenerator *);
 
 TR::X86RegImmInstruction  * generateRegImmInstruction(TR::Instruction *, TR_X86OpCodes op, TR::Register * reg1, int32_t imm, TR::CodeGenerator *cg, int32_t reloKind=TR_NoRelocation);
 TR::X86RegMemInstruction  * generateRegMemInstruction(TR::Instruction *, TR_X86OpCodes op, TR::Register * reg1, TR::MemoryReference  * mr, TR::CodeGenerator *cg);

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -695,50 +695,6 @@ uint8_t *TR::X86FenceInstruction::generateBinaryEncoding()
    }
 
 
-// -----------------------------------------------------------------------------
-// TR::X86RestoreVMThreadInstruction:: member functions
-
-int32_t TR::X86RestoreVMThreadInstruction::estimateBinaryLength(int32_t currentEstimate)
-   {
-   if (TR::Compiler->target.is64Bit())
-      setEstimatedBinaryLength(9);
-   else
-      setEstimatedBinaryLength(7);
-   return currentEstimate + getEstimatedBinaryLength();
-   }
-
-uint8_t TR::X86RestoreVMThreadInstruction::getBinaryLengthLowerBound()
-   {
-   if (TR::Compiler->target.is64Bit())
-      return 9;
-   else
-      return 7;
-   }
-
-uint8_t *TR::X86RestoreVMThreadInstruction::generateBinaryEncoding()
-   {
-   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
-   uint8_t *cursor           = instructionStart;
-
-   if (TR::Compiler->target.is64Bit())
-      {
-      // mov  rbp,qword ptr fs:[00000000h] ; 64 48 8B 2C 25 00 00 00 00
-      *cursor++ = 0x64; *cursor++ = 0x48; *cursor++ = 0x8b; *cursor++ = 0x2c; *cursor++ = 0x25;
-      *cursor++ = 0x00; *cursor++ = 0x00; *cursor++ = 0x00; *cursor++ = 0x00;
-      }
-   else
-      {
-      // mov ebp,dword ptr fs:[0] ; 64 8b 2d 00 00 00 00
-      *cursor++ = 0x64; *cursor++ = 0x8b; *cursor++ = 0x2d;
-      *cursor++ = 0x00; *cursor++ = 0x00; *cursor++ = 0x00; *cursor++ = 0x00;
-      }
-
-   setBinaryLength(cursor - instructionStart);
-   setBinaryEncoding(instructionStart);
-   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
-   return cursor;
-   }
-
 #ifdef J9_PROJECT_SPECIFIC
 // -----------------------------------------------------------------------------
 // TR::X86VirtualGuardNOPInstruction

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -95,9 +95,6 @@ TR_Debug::printx(TR::FILE *pOutFile, TR::Instruction  * instr)
       case TR::Instruction::IsFence:
          print(pOutFile, (TR::X86FenceInstruction  *)instr);
          break;
-      case TR::Instruction::IsRestoreVMThread:
-         print(pOutFile, (TR::X86RestoreVMThreadInstruction  *)instr);
-         break;
       case TR::Instruction::IsImm:
          print(pOutFile, (TR::X86ImmInstruction  *)instr);
          break;
@@ -447,21 +444,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86AlignmentInstruction  * instr)
    trfflush(pOutFile);
    }
 
-void
-TR_Debug::print(TR::FILE *pOutFile, TR::X86RestoreVMThreadInstruction  * instr)
-   {
-   if (pOutFile == NULL)
-      return;
-
-   printPrefix(pOutFile, instr);
-   if (instr->getBinaryEncoding())
-      {
-      trfprintf(pOutFile, "mov ebp, dword ptr fs:[0]\t\t;%sRestoreVMThread ",
-                    commentString());
-      }
-
-   trfflush(pOutFile);
-   }
 
 void
 TR_Debug::printBoundaryAvoidanceInfo(TR::FILE *pOutFile, TR::X86BoundaryAvoidanceInstruction  * instr)

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -230,7 +230,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
          deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
          deps->stopAddingConditions();
 
-         cg->setVMThreadRequired(true);
          generateLabelInstruction(highOrderBranchOp, node, destinationLabel, deps, cg);
          generateLabelInstruction(JNE4, node, doneLabel, deps, cg);
          compareGPRegisterToImmediate(node, cmpRegister->getLowOrder(), lowValue, cg);
@@ -238,7 +237,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
          }
       else
          {
-         cg->setVMThreadRequired(true);
          generateLabelInstruction(highOrderBranchOp, node, destinationLabel, cg);
          generateLabelInstruction(JNE4, node, doneLabel, cg);
          compareGPRegisterToImmediate(node, cmpRegister->getLowOrder(), lowValue, cg);
@@ -266,7 +264,6 @@ void OMR::X86::I386::TreeEvaluator::compareLongsForOrder(
 
       cg->decReferenceCount(firstChild);
       cg->decReferenceCount(secondChild);
-      cg->setVMThreadRequired(false);
       }
    else
       {
@@ -3372,9 +3369,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             generateRegRegInstruction(OR4RegReg, node, targetRegister, cmpRegister->getHighOrder(), cg);
             }
 
-         cg->setVMThreadRequired(true);
          generateConditionalJumpInstruction(JE4, node, cg, needVMThreadDep);
-         cg->setVMThreadRequired(false);
 
          if (targetNeedsToBeExplicitlyStopped)
             {
@@ -3393,7 +3388,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
          cmpRegister = cg->evaluate(firstChild);
          generateLabelInstruction(LABEL, node, startLabel, cg);
          compareGPRegisterToConstantForEquality(node, lowValue, cmpRegister->getLowOrder(), cg);
-         cg->setVMThreadRequired(true);
 
          // Evaluate the global register dependencies and emit the branches by hand;
          // we cannot call generateConditionalJumpInstruction() here because we need
@@ -3425,7 +3419,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             }
 
          generateLabelInstruction(LABEL, node, doneLabel, deps, cg);
-         cg->setVMThreadRequired(false);
 
          if (!popRegisters.isEmpty())
             {
@@ -3514,9 +3507,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             generateRegRegInstruction(OR4RegReg, node, targetRegister, cmpRegister->getHighOrder(), cg);
             }
 
-         cg->setVMThreadRequired(true);
          generateConditionalJumpInstruction(JNE4, node, cg, needVMThreadDep);
-         cg->setVMThreadRequired(false);
 
          if (targetNeedsToBeExplicitlyStopped)
             {
@@ -3527,8 +3518,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
          {
          cmpRegister = cg->evaluate(firstChild);
          compareGPRegisterToConstantForEquality(node, lowValue, cmpRegister->getLowOrder(), cg);
-
-         cg->setVMThreadRequired(true);
 
          // Evaluate the global register dependencies and emit the branches by hand;
          // we cannot call generateConditionalJumpInstruction() here because we need
@@ -3563,8 +3552,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);
             generateLabelInstruction(JNE4, node, destinationLabel, needVMThreadDep, cg);
             }
-
-         cg->setVMThreadRequired(false);
          }
 
       cg->decReferenceCount(firstChild);
@@ -3582,9 +3569,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpltEvaluator(TR::Node *node, T
    {
    if (generateLAddOrSubForOverflowCheck(node, cg))
       {
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JO4, node, cg, true);
-      cg->setVMThreadRequired(false);
       }
    else
       {
@@ -3599,9 +3584,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpgeEvaluator(TR::Node *node, T
    {
    if (generateLAddOrSubForOverflowCheck(node, cg))
       {
-      cg->setVMThreadRequired(true);
       generateConditionalJumpInstruction(JNO4, node, cg, true);
-      cg->setVMThreadRequired(false);
       }
    else
       {


### PR DESCRIPTION
* Remove calls to setVMThreadRequired from x86
* Remove OMR::Symbol isVMThreadLive flag
* Remove vmThreadLiveCount from OMR::CodeGenerator
* Remove obsolete OMR::X86::Instruction RestoreVMThreadInstruction
* Remove deferred edge splitting vmThread optimization from x86
* Remove VMThreadRestoringLabel field from LabelSymbol
* Remove specialty VMThread assignment logic from x86 register assigner