### PR TITLE
Initial three-operand instruction support for X86

### DIFF
--- a/compiler/x/amd64/codegen/OMRRealRegister.hpp
+++ b/compiler/x/amd64/codegen/OMRRealRegister.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -308,6 +308,17 @@ class OMR_EXTENSIBLE RealRegister : public OMR::X86::RealRegister
    void setRegisterFieldInOpcode(uint8_t *opcodeByte)
       {
       *opcodeByte |= _fullRegisterBinaryEncodings[_registerNumber].id; // reg field is in bits 0-2 of opcode
+      }
+
+   /** \brief
+   *    Fill vvvv field in a VEX prefix
+   *
+   *  \param opcodeByte
+   *    The address of VEX prefix byte containing vvvv field
+   */
+   void setRegisterFieldInVEX(uint8_t *opcodeByte)
+      {
+      *opcodeByte ^= ((_fullRegisterBinaryEncodings[_registerNumber].needsRexForByte << 3) | _fullRegisterBinaryEncodings[_registerNumber].id) << 3; // vvvv is in bits 3-6 of last byte of VEX
       }
 
    void setRegisterFieldInModRM(uint8_t *modRMByte)

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -567,6 +567,11 @@ TR::Register *OMR::X86::TreeEvaluator::fpBinaryArithmeticEvaluator(TR::Node     
                                                               bool              isFloat,
                                                               TR::CodeGenerator *cg)
    {
+   static auto Use3OpForFP = (bool)feGetEnv("TR_Use3OpForFP");
+   if (Use3OpForFP)
+      {
+      return TR::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEvaluator(node, cg);
+      }
    // Attempt to use SSE/SSE2 instructions if the CPU supports them, and
    // either neither child is in a register, or at least one of them is
    // already in an XMM register.

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2629,7 +2629,7 @@ bool OMR::X86::CodeGenerator::processInstruction(TR::Instruction *instr, TR_BitV
          if (traceIt)
             traceMsg(self()->comp(), "instr [%p] USES register [%d]\n", x86Instr, srcRegNum);
 
-         int32_t srcRightRegNum = ((TR::RealRegister*)x86Instr->getSourceRightRegister())->getRegisterNumber();
+         int32_t srcRightRegNum = ((TR::RealRegister*)x86Instr->getSource2ndRegister())->getRegisterNumber();
          if (traceIt)
             traceMsg(self()->comp(), "instr [%p] USES register [%d]\n", x86Instr, srcRightRegNum);
 

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -182,7 +182,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    virtual TR::Register *getTargetRegister() { return NULL; }
    virtual TR::Register *getSourceRegister() { return NULL; }
-   virtual TR::Register *getSourceRightRegister() { return NULL; }
+   virtual TR::Register *getSource2ndRegister() { return NULL; }
    virtual TR::MemoryReference *getMemoryReference() { return NULL; }
 
    int32_t getMaxPatchableInstructionLength() { return 10; }

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -215,7 +215,10 @@ uint8_t* OMR::X86::Instruction::generateBinaryEncoding()
       // cursor is NULL when generateOperand() requests to regenerate the binary code, which may happen during encoding of memref with unresolved symbols on 64-bit
       if (cursor)
          {
-         self()->getOpCode().finalize(instructionStart);
+         if (!self()->getSource2ndRegister())
+            {
+            self()->getOpCode().finalize(instructionStart);
+            }
          self()->setBinaryLength(cursor - instructionStart);
          self()->cg()->addAccumulatedInstructionLengthError(self()->getEstimatedBinaryLength() - self()->getBinaryLength());
          return cursor;
@@ -1403,6 +1406,26 @@ uint8_t* TR::X86RegRegInstruction::generateOperand(uint8_t* cursor)
       {
       applySourceRegisterToModRMByte(modRM);
       }
+   return cursor;
+   }
+
+
+// -----------------------------------------------------------------------------
+// TR::X86RegRegRegInstruction:: member functions
+
+uint8_t* TR::X86RegRegRegInstruction::generateOperand(uint8_t* cursor)
+   {
+   TR_ASSERT(getOpCode().info().supportsAVX(), "TR::X86RegRegRegInstruction must be an AVX instruction.");
+   uint8_t *modRM = cursor - 1;
+   if (getOpCode().hasTargetRegisterIgnored() == 0)
+      {
+      applyTargetRegisterToModRMByte(modRM);
+      }
+   if (getOpCode().hasSourceRegisterIgnored() == 0)
+      {
+      applySourceRegisterToModRMByte(modRM);
+      }
+   applySource2ndRegisterToVEX(modRM - 2);
    return cursor;
    }
 

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -115,6 +115,9 @@ TR_Debug::printx(TR::FILE *pOutFile, TR::Instruction  * instr)
       case TR::Instruction::IsRegReg:
          print(pOutFile, (TR::X86RegRegInstruction  *)instr);
          break;
+      case TR::Instruction::IsRegRegReg:
+         print(pOutFile, (TR::X86RegRegRegInstruction  *)instr);
+         break;
       case TR::Instruction::IsRegRegImm:
          print(pOutFile, (TR::X86RegRegImmInstruction  *)instr);
          break;
@@ -1044,14 +1047,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86RegRegRegInstruction  * instr)
    TR_RegisterSizes sourceSize = getSourceSizeFromInstruction(instr);
    if (!(instr->getOpCode().sourceRegIsImplicit() != 0))
       {
-      print(pOutFile, instr->getSourceRegister(), sourceSize);
+      print(pOutFile, instr->getSource2ndRegister(), sourceSize);
       trfprintf(pOutFile, ", ");
+      print(pOutFile, instr->getSourceRegister(), sourceSize);
       }
-
-   if (instr->getOpCodeValue() == SHLD4RegRegCL || instr->getOpCodeValue() <= SHRD4RegRegCL)
-      trfprintf(pOutFile, "cl");
-   else
-      print(pOutFile, instr->getSourceRightRegister(), sourceSize);
 
    printInstructionComment(pOutFile, 2, instr);
    dumpDependencies(pOutFile, instr);
@@ -1065,10 +1064,10 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86RegRegRegInstru
       return;
 
    printRegisterInfoHeader(pOutFile, instr);
-   trfprintf(pOutFile,"    SourceRight       ");
-   printFullRegInfo(pOutFile, instr->getSourceRightRegister());
    trfprintf(pOutFile,"    Source            ");
    printFullRegInfo(pOutFile, instr->getSourceRegister());
+   trfprintf(pOutFile,"    2ndSource         ");
+   printFullRegInfo(pOutFile, instr->getSource2ndRegister());
    trfprintf(pOutFile,"    Target            ");
    printFullRegInfo(pOutFile, instr->getTargetRegister());
 
@@ -1262,7 +1261,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86MemRegRegInstruction  * instr)
    if (instr->getOpCodeValue() == SHLD4MemRegCL || instr->getOpCodeValue() == SHRD4MemRegCL)
       trfprintf(pOutFile, "cl");
    else
-      print(pOutFile, instr->getSourceRightRegister(), sourceSize);
+      print(pOutFile, instr->getSource2ndRegister(), sourceSize);
 
    printInstructionComment(pOutFile, 1, instr);
    printMemoryReferenceComment(pOutFile, instr->getMemoryReference());
@@ -1281,8 +1280,8 @@ TR_Debug::printReferencedRegisterInfo(TR::FILE *pOutFile, TR::X86MemRegRegInstru
       return;
 
    printRegisterInfoHeader(pOutFile, instr);
-   trfprintf(pOutFile,"    SourceRight       ");
-   printFullRegInfo(pOutFile, instr->getSourceRightRegister());
+   trfprintf(pOutFile,"    2ndSource         ");
+   printFullRegInfo(pOutFile, instr->getSource2ndRegister());
    trfprintf(pOutFile,"    Source            ");
    printFullRegInfo(pOutFile, instr->getSourceRegister());
 

--- a/compiler/x/i386/codegen/OMRRealRegister.hpp
+++ b/compiler/x/i386/codegen/OMRRealRegister.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -229,12 +229,22 @@ class OMR_EXTENSIBLE RealRegister : public OMR::X86::RealRegister
          }
       }
 
-
    void setRegisterNumber() { TR_ASSERT(0, "X86 RealRegister doesn't have setRegisterNumber() implementation"); }
 
    void setRegisterFieldInOpcode(uint8_t *opcodeByte)
       {
       *opcodeByte |= _fullRegisterBinaryEncodings[_registerNumber].id; // reg field is in bits 0-2 of opcode
+      }
+
+   /** \brief
+   *    Fill vvvv field in a VEX prefix
+   *
+   *  \param opcodeByte
+   *    The address of VEX prefix byte containing vvvv field
+   */
+   void setRegisterFieldInVEX(uint8_t *opcodeByte)
+      {
+      *opcodeByte ^= ((_fullRegisterBinaryEncodings[_registerNumber].needsRexForByte << 3) | _fullRegisterBinaryEncodings[_registerNumber].id) << 3; // vvvv is in bits 3-6 of last byte of VEX
       }
 
    void setRegisterFieldInModRM(uint8_t *modRMByte)


### PR DESCRIPTION
Introducing support for three-operand instructions. 
RegRegReg instructions with Op/En marked as RVM are now supported.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>