### PR TITLE
Added a C wrapper for VM_AtomicSupport::set operation

### DIFF
--- a/include_core/omrutilbase.h
+++ b/include_core/omrutilbase.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,6 +37,20 @@ void issueReadWriteBarrier(void);
 void issueWriteBarrier(void);
 uintptr_t addAtomic(volatile uintptr_t *address, uintptr_t addend);
 uintptr_t subtractAtomic(volatile uintptr_t *address, uintptr_t value);
+
+/**
+ * @brief Store value at memory location. Stores value at memory
+ * location pointed to be address.
+ *
+ * @param[in] address The memory location to be updated
+ * @param[in] value The value to be stored
+ *
+ * @return The value at memory location address
+ *
+ * @note This method can spin indefinitely while attempting to write
+ * the new value.
+ */
+uintptr_t setAtomic(volatile uintptr_t *address, uintptr_t value);
 
 /* ---------------- cas8help.s ---------------- */
 #if !defined(OMR_ENV_DATA64) && (defined(AIXPPC) || defined(LINUXPPC))

--- a/util/omrutil/AtomicFunctions.cpp
+++ b/util/omrutil/AtomicFunctions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 IBM Corp. and others
+ * Copyright (c) 1998, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,4 +63,10 @@ uintptr_t
 subtractAtomic(volatile uintptr_t *address, uintptr_t value)
 {
 	return VM_AtomicSupport::subtract(address, value);
+}
+
+uintptr_t
+setAtomic(volatile uintptr_t *address, uintptr_t value)
+{
+	return VM_AtomicSupport::set(address, value);
 }


### PR DESCRIPTION
C wrapper, setAtomic has been added for VM_AtomicSupport::set operation.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>