### PR TITLE
CMake: refactor jit sources processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ else()
 	message(FATAL_ERROR "OMR: Build tools are required. See OMR_TOOLS and OMR_TOOLS_IMPORTFILE")
 endif()
 
+add_subdirectory(compiler)
 add_subdirectory(thread)
 add_subdirectory(port)
 add_subdirectory(util)

--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -323,51 +323,23 @@ function(create_omr_compiler_library)
 		${COMPILER_OBJECTS}
 	)
 
-	# Populated and then will use target_sources to append to the compiler library.
-	set(CORE_COMPILER_OBJECTS "")
-
-	# Add the contents of the macro to CORE_COMPILER_OBJECTS in this scope.
-	# The library name parameter is currently ignored.
-	macro(compiler_library libraryname)
-		list(APPEND CORE_COMPILER_OBJECTS ${ARGN})
-	endmacro(compiler_library)
-
-	# Instead of a real add_subdirectory we just include the file so everything stays
-	# in the same scope.
-	macro(add_compiler_subdirectory dir)
-		include("${omr_SOURCE_DIR}/compiler/${dir}/CMakeLists.txt")
-	endmacro(add_compiler_subdirectory)
-
-
-	# There's a little bit of a song and dance here
-	# I wonder if it's not better to just have a
-	# unified object list.
-	add_compiler_subdirectory(ras)
-	add_compiler_subdirectory(compile)
-	add_compiler_subdirectory(codegen)
-	add_compiler_subdirectory(control)
-	add_compiler_subdirectory(env)
-	add_compiler_subdirectory(infra)
-	add_compiler_subdirectory(il)
-	add_compiler_subdirectory(optimizer)
-	add_compiler_subdirectory(runtime)
-	add_compiler_subdirectory(ilgen)
-
-	add_compiler_subdirectory(${TR_TARGET_ARCH})
+	# Grab the list of core compiler objects from the global property.
+	# Note: the property is initialized by compiler/CMakeLists.txt
+	get_property(core_compiler_objects GLOBAL PROPERTY OMR_CORE_COMPILER_OBJECTS)
 
 	# Filter out objects requested to be removed by
 	# client project (if any):
 	foreach(object ${COMPILER_FILTER})
 		get_filename_component(abs_filename ${object} ABSOLUTE)
-		list(REMOVE_ITEM CORE_COMPILER_OBJECTS ${abs_filename})
+		list(REMOVE_ITEM core_compiler_objects ${abs_filename})
 	endforeach()
 
 
 
-	omr_inject_object_modification_targets(CORE_COMPILER_OBJECTS ${COMPILER_NAME} ${CORE_COMPILER_OBJECTS})
+	omr_inject_object_modification_targets(core_compiler_objects ${COMPILER_NAME} ${core_compiler_objects})
 
 	# Append to the compiler sources list
-	target_sources(${COMPILER_NAME} PRIVATE ${CORE_COMPILER_OBJECTS})
+	target_sources(${COMPILER_NAME} PRIVATE ${core_compiler_objects})
 
 
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -1,0 +1,56 @@
+###############################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+include(OmrCompilerSupport)
+
+# Add the contents of the macro to CORE_COMPILER_OBJECTS in this scope.
+# The library name parameter is currently ignored.
+macro(compiler_library libraryname)
+	list(APPEND CORE_COMPILER_OBJECTS ${ARGN})
+endmacro(compiler_library)
+
+# Instead of a real add_subdirectory we just include the file so everything stays
+# in the same scope.
+macro(add_compiler_subdirectory dir)
+	include("${omr_SOURCE_DIR}/compiler/${dir}/CMakeLists.txt")
+endmacro(add_compiler_subdirectory)
+
+
+# create an object list which is populated in the subdirectories
+set(CORE_COMPILER_OBJECTS "")
+
+add_compiler_subdirectory(codegen)
+add_compiler_subdirectory(compile)
+add_compiler_subdirectory(control)
+add_compiler_subdirectory(env)
+add_compiler_subdirectory(il)
+add_compiler_subdirectory(ilgen)
+add_compiler_subdirectory(infra)
+add_compiler_subdirectory(optimizer)
+add_compiler_subdirectory(ras)
+add_compiler_subdirectory(runtime)
+
+add_compiler_subdirectory(${TR_TARGET_ARCH})
+
+# Promote the list variable into a global property.
+# That way we dont need to worry about scoping issues.
+set_property(GLOBAL PROPERTY OMR_CORE_COMPILER_OBJECTS ${CORE_COMPILER_OBJECTS})


### PR DESCRIPTION
Currently a list of core jit sources are built up every time a compiler
library is built (test compiler, jitbuilder, tril). With this patch the
list is built only once.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>