### PR TITLE
Change the value of the unneededConv flag

### DIFF
--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -2042,7 +2042,7 @@ protected:
        *     needed because the value the conversion is acting on has been cleansed prior to reaching this evaluation
        *     point.
        */
-      unneededConv                          = 0x00008000, ///< Flag used by TR::x2y
+      unneededConv                          = 0x00000400, ///< Flag used by TR::x2y
       ParentSupportsLazyClobber             = 0x00002000, ///< Tactical x86 codegen flag.  Only when refcount <= 1.  Indicates that parent will consult the register's node count before clobbering it (not just the node's refcount).
 
       // Flag used by float to fixed conversion nodes e.g. f2i/f2pd/d2i/df2i/f2l/d2l/f2s/d2pd etc


### PR DESCRIPTION
The unneededConv flag used by TR::x2y nodes overlaps with the simpleDivCheck flag. During node recreation, flags are copied from the original node to the new node without checking if the flag will be valid for the new node being created. This can cause invalid instructions to be generated if the optimizer transforms an ldiv node of two i2l children to i2l of idiv during treeSimplification. To avoid this, this commit changes the unneededConv node's value so that it doesn't overlap with the simpleDivCheck flag.

Closes: #2297
Signed-off-by: Dhruv Chopra <dhruv.c.chopra@ibm.com>