### PR TITLE
Deprecate nodeIsDebug node flag

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -5616,22 +5616,6 @@ OMR::Node::divisionCannotOverflow()
    return dividendIsNotMin || divisorIsNotNegativeOne;
    }
 
-
-
-bool
-OMR::Node::isDebug()
-   {
-   return _flags.testAny(nodeIsDebug);
-   }
-
-void
-OMR::Node::setIsDebug(bool v)
-   {
-   _flags.set(nodeIsDebug, v);
-   }
-
-
-
 bool
 OMR::Node::cannotOverflow()
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1011,10 +1011,6 @@ public:
    bool divisionCannotOverflow();
    bool isNonDegenerateArrayCopy();
 
-   // Should not be counted for metrics
-   bool isDebug();
-   void setIsDebug(bool v);
-
    // Flag used by arithmetic int/long operations
    bool cannotOverflow();
    void setCannotOverflow(bool v);
@@ -1812,7 +1808,6 @@ protected:
       visitedForHints                       = 0x00000080, ///< Used only during codegen phase
       nodeIsNonNegative                     = 0x00000100,
       nodeIsNonPositive                     = 0x00000200,
-      nodeIsDebug                           = 0x00000400, ///< Should not be counted for metrics
 
       //---------------------------------------- node specific flags---------------------------------------
 

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -227,13 +227,9 @@ const char *TR::DebugCounter::debugCounterBucketName(TR::Compilation *comp, int3
 TR::Node *TR::DebugCounterBase::createBumpCounterNode(TR::Compilation *comp, TR::Node *deltaNode)
    {
    TR::SymbolReference *symref = getBumpCountSymRef(comp);
-   deltaNode->setIsDebug(true);
    TR::Node *load = TR::Node::createWithSymRef(deltaNode, TR::Compiler->target.is64Bit() ? TR::lload : TR::iload, 0, symref);
-   load->setIsDebug(true);
    TR::Node *add = TR::Node::create(TR::Compiler->target.is64Bit() ? TR::ladd : TR::iadd, 2, load, deltaNode);
-   add->setIsDebug(true);
    TR::Node *store = TR::Node::createWithSymRef(TR::Compiler->target.is64Bit() ? TR::lstore : TR::istore, 1, 1, add, symref);
-   store->setIsDebug(true);
    return store;
    }
 


### PR DESCRIPTION
A quick search through the codebase reveals this flag is not actually
used by anyone so it has no reason to exist.

Fixes: #2299
Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>