### PR TITLE
API to support a mutex and a condition variable

### DIFF
--- a/include_core/omrthread.h
+++ b/include_core/omrthread.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,6 +47,9 @@ typedef intptr_t omrthread_os_errno_t;
 typedef struct J9Thread *omrthread_t;
 typedef struct J9ThreadMonitor *omrthread_monitor_t;
 typedef struct J9Semaphore *j9sem_t;
+
+typedef struct OMRMutex *omrmutex_t;
+typedef struct OMRCondVar *omrcondvar_t;
 
 #include "omrthread_generated.h"
 

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1438,6 +1438,88 @@ omrthread_monitor_pin(omrthread_monitor_t monitor, omrthread_t self);
 */
 void
 omrthread_monitor_unpin(omrthread_monitor_t monitor, omrthread_t self);
+
+/**
+ * @brief Allocate and initialize an OMRMutex. The OMRMutex
+ * needs to be destroyed and freed after usage via
+ * omrthread_mutex_destroy.
+ * @param void
+ * @return pointer to OMRMutex or NULL on failure
+ */
+omrmutex_t
+omrthread_mutex_create(void);
+
+/**
+ * @brief Destroy and free memory related to an OMRMutex.
+ * @param mutex pointer to an OMRMutex
+ * @return void
+ */
+void
+omrthread_mutex_destroy(omrmutex_t mutex);
+
+/**
+ * @brief Allocate and initialize an OMRCondVar. The
+ * OMRCondVar needs to be destroyed and freed after usage via
+ * omrthread_condvar_destroy.
+ * @param void
+ * @return pointer to OMRCondVar or NULL on failure
+ */
+omrcondvar_t
+omrthread_condvar_create(void);
+
+/**
+ * @brief Destroy and free memory related to an OMRCondVar.
+ * @param condVar pointer to an OMRCondVar
+ * @return void
+ */
+void
+omrthread_condvar_destroy(omrcondvar_t condVar);
+
+/**
+ * @brief Acquire an OMRMutex.
+ * @param mutex pointer to an OMRMutex
+ * @return void
+ */
+void
+omrthread_mutex_enter(omrmutex_t mutex);
+
+/**
+ * @brief Release an OMRMutex.
+ * @param mutex pointer to an OMRMutex
+ * @return void
+ */
+void
+omrthread_mutex_exit(omrmutex_t mutex);
+
+/**
+ * @brief Send a signal to a blocked thread. The associated
+ * OMRMutex needs to be acquired before invoking this function.
+ * After invocation, the associated OMRMutex needs to be released.
+ * @param condVar pointer to an OMRCondVar
+ * @return void
+ */
+void
+omrthread_condvar_notify(omrcondvar_t condVar);
+
+/**
+ * @brief Send a signal to all the blocked threads. The associated
+ * OMRMutex needs to be acquired before invoking this function. After
+ * invocation, the associated OMRMutex needs to be released.
+ * @param condVar pointer to an OMRCondVar
+ * @return void
+ */
+void
+omrthread_condvar_notify_all(omrcondvar_t condVar);
+
+/**
+ * @brief Wait on an OMRCondVar. The associated OMRMutex
+ * needs to be acquired before invoking this function. After
+ * invocation, the associated OMRMutex needs to be released.
+ * @param condVar pointer to an OMRCondVar
+ * @return void
+ */
+void
+omrthread_condvar_wait(omrcondvar_t condVar, omrmutex_t mutex);
 
 /* forward struct definition */
 struct J9ThreadLibrary;

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -267,6 +267,16 @@ list(APPEND VPATHS common)
 #@echo omrthread_get_jvm_cpu_usage_info_error_recovery >>$@
 #@echo omrthread_get_category >>$@
 #@echo omrthread_set_category >>$@
+
+#@echo omrthread_mutex_create >>$@
+#@echo omrthread_mutex_destroy >>$@
+#@echo omrthread_condvar_create >>$@
+#@echo omrthread_condvar_destroy >>$@
+#@echo omrthread_mutex_enter >>$@
+#@echo omrthread_mutex_exit >>$@
+#@echo omrthread_condvar_notify >>$@
+#@echo omrthread_condvar_notify_all >>$@
+#@echo omrthread_condvar_wait >>$@
 
 #@# temp for the JIT
 #@echo j9thread_self >>$@

--- a/thread/thread_include.mk
+++ b/thread/thread_include.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2018 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -264,6 +264,16 @@ define WRITE_COMMON_THREAD_EXPORTS
 @echo omrthread_get_jvm_cpu_usage_info_error_recovery >>$@
 @echo omrthread_get_category >>$@
 @echo omrthread_set_category >>$@
+
+@echo omrthread_mutex_create >>$@
+@echo omrthread_mutex_destroy >>$@
+@echo omrthread_condvar_create >>$@
+@echo omrthread_condvar_destroy >>$@
+@echo omrthread_mutex_enter >>$@
+@echo omrthread_mutex_exit >>$@
+@echo omrthread_condvar_notify >>$@
+@echo omrthread_condvar_notify_all >>$@
+@echo omrthread_condvar_wait >>$@
 
 @# temp for the JIT
 @echo j9thread_self >>$@


### PR DESCRIPTION
**Motivation:** OpenJ9 utilizes OMR. OMR has a thread library. Currently,
macros to utilize a mutex and a condition variable can be accessed by
including `thrdsup.h` in the parent project. Including `thrdsup.h` leads
to compilation errors in OpenJ9 on AIX and Windows. So, an API has been
developed to support a mutex and a condition variable without exposing
OMR's internal dependencies (`thrdsup.h`).

Two structs have been added, **OMRMutex** and **OMRCondVar** which are wrappers
for **J9OSMutex** and **J9OSCond** respectively. The definition of these structs
is only visible to functions in `omrthread.c`. Isolating definition of
these structs in `omrthread.c` prevents exposing large system header
files such as `windows.h` outside of OMR.

The API includes the following functions to utilize a mutex and a condition variable:
1) `omrthread_mutex_create`
2) `omrthread_mutex_destroy`
3) `omrthread_condvar_create`
4) `omrthread_condvar_destroy`
5) `omrthread_mutex_enter`
6) `omrthread_mutex_exit`
7) `omrthread_condvar_notify`
8) `omrthread_condvar_notify_all`
9) `omrthread_condvar_wait`

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>