### PR TITLE
Scan RS concurrently

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -93,7 +93,7 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 	if (!rememberedSet.initialize(env, OMR::GC::AllocationCategory::REMEMBERED_SET)) {
 		goto failed;
 	}
-	rememberedSet.setGrowSize(J9_SCV_REMSET_SIZE);
+	rememberedSet.setGrowSize(OMR_SCV_REMSET_SIZE);
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 #if defined(J9MODRON_USE_CUSTOM_SPINLOCKS)

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,7 +55,7 @@ MM_EnvironmentStandard::initialize(MM_GCExtensionsBase *extensions)
 	_scavengerRememberedSet.count = 0;
 	_scavengerRememberedSet.fragmentCurrent = NULL;
 	_scavengerRememberedSet.fragmentTop = NULL;
-	_scavengerRememberedSet.fragmentSize = (uintptr_t)J9_SCV_REMSET_FRAGMENT_SIZE;
+	_scavengerRememberedSet.fragmentSize = (uintptr_t)OMR_SCV_REMSET_FRAGMENT_SIZE;
 	_scavengerRememberedSet.parentList = &extensions->rememberedSet;
 #endif
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -257,6 +257,9 @@ public:
 	void fixupObjectScan(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	bool fixupSlot(GC_SlotObject *slotObject);
 	bool fixupSlotWithoutCompression(volatile omrobjectptr_t *slotPtr);
+	
+	void scavengeRememberedSetListIndirect(MM_EnvironmentStandard *env);
+	void scavengeRememberedSetListDirect(MM_EnvironmentStandard *env);
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	/**

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -461,9 +461,8 @@ typedef enum {
 
 #define J9_SCV_TENURE_RATIO_LOW 10
 #define J9_SCV_TENURE_RATIO_HIGH 30
-#define J9_SCV_REMSET_MAX 65536
-#define J9_SCV_REMSET_FRAGMENT_SIZE 32
-#define J9_SCV_REMSET_SIZE 16384
+#define OMR_SCV_REMSET_FRAGMENT_SIZE 32
+#define OMR_SCV_REMSET_SIZE 16384
 
 #define J9MODRON_ALLOCATION_MANAGER_HINT_MAX_WALK 20
 


### PR DESCRIPTION
Move the Remembered Set (as roots) scan, partially to the concurrent
phase of Concurrent Scavenger. 

The RS in Scavenger for the most part remembers object Tenure to Nursery
references (direct ones). But it can also remember off-heap structures
that have Nursery references, where the off-heap structure has a proxy
heap object in Tenure (indirect ones). An example being a class object
in Tenure and a matching off-heap class structure in upstream OpenJ9
project.

This change will break the RS scan into two passes. The one where we
scan Indirect references will stay in the STW phase where the rest of
the roots are processed. The pass where scan Direct references is moved
to the concurrent phase. 

Iteration (and popping-up) of RS puddles should still be safe operation,
even though new puddles can be added while RS is still being iterated.
The popping occurs against the previous list, while all the pushing
(whether the ones that have just been processed or the newly added ones
) occurs to the current list. 

Also, there are no races between readers/writters on RS slots - mutator
or other GC scanning threads can only add new slots - never modify the
existing ones.

Moving Indirect pass to concurrent phase is also a possibly, but that
would require that VM employs read barrier of those indirect reference
slots, which ATM is still not the case for the only project using CS -
OpenJ9.

Also doing some minor naming cleanup with RS related constants.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>