### PR TITLE
Use GNU debug symbols on PPC platforms

### DIFF
--- a/omrmakefiles/rules.linux.mk
+++ b/omrmakefiles/rules.linux.mk
@@ -1,19 +1,19 @@
 ###############################################################################
-# Copyright (c) 2015, 2015 IBM Corp. and others
-# 
+# Copyright (c) 2015, 2018 IBM Corp. and others
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#    
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
@@ -57,7 +57,6 @@ ifeq (ppc,$(OMR_HOST_ARCH))
         endif
     endif
 endif
-
 
 # Compile without exceptions
 ifeq (gcc,$(OMR_TOOLCHAIN))
@@ -159,6 +158,9 @@ ifeq (gcc,$(OMR_TOOLCHAIN))
   ifeq (arm,$(OMR_HOST_ARCH))
     USE_GNU_DEBUG:=1
   endif
+  ifeq (ppc,$(OMR_HOST_ARCH))
+    USE_GNU_DEBUG:=1
+  endif
   ifeq (x86,$(OMR_HOST_ARCH))
     USE_GNU_DEBUG:=1
   endif
@@ -253,7 +255,6 @@ ifneq (,$(findstring executable,$(ARTIFACT_TYPE)))
   GLOBAL_LDFLAGS+=$(DEFAULT_LIBS)
 endif
 
-
 ###
 ### Shared Libraries
 ###
@@ -319,7 +320,6 @@ endif # OMR_TOOLCHAIN is not "xlc"
 
 endif # ARTIFACT_TYPE contains "shared"
 
-
 ###
 ### Warning As Errors
 ###
@@ -338,7 +338,6 @@ ifeq ($(OMR_WARNINGS_AS_ERRORS),1)
         GLOBAL_CXXFLAGS+=-Wreturn-type -Werror
     endif
 endif
-
 
 ###
 ### Enhanced Warnings


### PR DESCRIPTION
This is required for DDR support: #378 and makes ppc64le consistent with x86-64.

