### PR TITLE
Fix checks when printing RS Instructions

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -5857,7 +5857,7 @@ TR_S390Peephole::perform()
 
                   bool instrMatch =
                         (cast_na->getFirstRegister() == cast_nb->getFirstRegister()) &&
-                        (!cast_na->hasMask()) && (!cast_nb->hasMask()) &&
+                        (!cast_na->hasMaskImmediate()) && (!cast_nb->hasMaskImmediate()) &&
                         (cast_na->getMemoryReference() == NULL) && (cast_nb->getMemoryReference() == NULL);
 
                   if (instrMatch)

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1411,7 +1411,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
 
-   if (instr->hasImmediate())
+   if (instr->hasSourceImmediate())
       {
       if (instr->getRegisterOperand(1)->getRegisterPair())
          {
@@ -1429,7 +1429,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
 
       trfprintf(pOutFile, ",%d", instr->getSourceImmediate());
       }
-   else if (instr->hasMask())
+   else if (instr->hasMaskImmediate())
       {
       print(pOutFile, instr->getFirstRegister());
       trfprintf(pOutFile, ",0x%1x,", instr->getMaskImmediate());

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1411,7 +1411,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()));
 
-   if (instr->getSourceImmediate())
+   if (instr->hasImmediate())
       {
       if (instr->getRegisterOperand(1)->getRegisterPair())
          {
@@ -1429,7 +1429,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RSInstruction * instr)
 
       trfprintf(pOutFile, ",%d", instr->getSourceImmediate());
       }
-   else if (instr->getMaskImmediate())
+   else if (instr->hasMask())
       {
       print(pOutFile, instr->getFirstRegister());
       trfprintf(pOutFile, ",0x%1x,", instr->getMaskImmediate());

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -2550,9 +2550,11 @@ class S390RSInstruction : public TR::S390RegInstruction
 
    int16_t                 _sourceImmediate;
    int8_t                  _maskImmediate;
-   /// _hasMaskImmediate evaluates to true if a value for the _maskImmediate field has been specified, false otherwise
+   /// Set to true if a mask value was specified during the construction of this object, indicating an RS instruction of RS-b format 
+   /// where the third operand is a mask
    bool                    _hasMaskImmediate;
-   /// _hasSourceImmediate evaluates to true if a value for the _sourceImmediate field has been specified, false otherwise
+   /// Set to true if a mask value was specified during the construction of this object, indicating an RS instruction of RS-b format 
+   /// where the third operand is a mask
    bool                    _hasSourceImmediate;
    int8_t                  _idx;
    Kind                    _kind;
@@ -2852,9 +2854,11 @@ class S390RSInstruction : public TR::S390RegInstruction
    uint32_t setSourceImmediate(uint32_t si) {return _sourceImmediate = si;}
    uint32_t getMaskImmediate()              {return _maskImmediate;}
    uint32_t setMaskImmediate(uint32_t mi)   {return _maskImmediate = mi;}
-   /// Returns true if a value for the _maskImmediate field was specified, false otherwise
+   /// Determines whether a mask value was specified during the construction of this object, indicating an RS instruction of RS-b format 
+   /// where the third operand is a mask
    bool     hasMaskImmediate()              {return _hasMaskImmediate;}
-   /// Returns true if a value for the _sourceImmediate field was specified, false otherwise
+   /// Determines whether a mask value was specified during the construction of this object, indicating an RS instruction of RS-b format 
+   /// where the third operand is a mask
    bool     hasSourceImmediate()            {return _hasSourceImmediate;}
 
    TR::Register* getFirstRegister() { return isTargetPair()? S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -2551,6 +2551,7 @@ class S390RSInstruction : public TR::S390RegInstruction
    int16_t                 _sourceImmediate;
    int8_t                  _maskImmediate;
    bool                    _hasMask;
+   bool                    _hasImmediate;
    int8_t                  _idx;
    Kind                    _kind;
 
@@ -2567,7 +2568,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register      *treg,
                         uint32_t          imm,
                         TR::CodeGenerator *cg)
-           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2582,7 +2583,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRS),
-             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false)
+             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2596,7 +2597,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         uint32_t          imm,
                         TR::RegisterDependencyConditions *_conditions,
                         TR::CodeGenerator *cg)
-           : S390RegInstruction(op, n, treg, _conditions, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, _conditions, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
 
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
@@ -2613,7 +2614,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, _conditions, precedingInstruction, cg), _kind(IsRS),
-             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false)
+             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2627,7 +2628,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register             *treg,
                         TR::MemoryReference  *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2647,7 +2648,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg),
-             _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+             _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2669,7 +2670,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg),
-             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _kind(IsRS)
+             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _hasImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2690,7 +2691,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
            : S390RegInstruction(op, n, treg, cg),
-             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _kind(IsRS)
+             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _hasImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2709,7 +2710,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register             *lreg,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, freg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, freg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(lreg);
@@ -2729,7 +2730,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, freg, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, freg, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
       {
 
       if (getOpCode().setsOperand2())
@@ -2750,7 +2751,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::RegisterPair         *regp,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
      {
      useSourceMemoryReference(mf);
      setupThrowsImplicitNullPointerException(n,mf);
@@ -2764,7 +2765,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2779,7 +2780,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::RegisterPair         *regp2,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
 
      {
      if (getOpCode().setsOperand2())
@@ -2799,7 +2800,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(regp2);
@@ -2818,7 +2819,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register      *sreg,
                         uint32_t          imm,
                         TR::CodeGenerator *cg)
-           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
         {
         if (getOpCode().setsOperand2())
            useTargetRegister(sreg);
@@ -2834,7 +2835,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg),
-             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _kind(IsRS)
+             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
         {
         if (getOpCode().setsOperand2())
            useTargetRegister(sreg);
@@ -2850,6 +2851,7 @@ class S390RSInstruction : public TR::S390RegInstruction
    uint32_t getMaskImmediate()              {return _maskImmediate;}
    uint32_t setMaskImmediate(uint32_t mi)   {return _maskImmediate = mi;}
    bool     hasMask()                       {return _hasMask;}
+   bool     hasImmediate()                  {return _hasImmediate;}
 
    TR::Register* getFirstRegister() { return isTargetPair()? S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }
    TR::Register* getLastRegister()  { return isTargetPair()? S390RegInstruction::getLastRegister()  : getRegisterOperand(2); }

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -2550,7 +2550,9 @@ class S390RSInstruction : public TR::S390RegInstruction
 
    int16_t                 _sourceImmediate;
    int8_t                  _maskImmediate;
+   /// _hasMaskImmediate evaluates to true if a value for the _maskImmediate field has been specified, false otherwise
    bool                    _hasMaskImmediate;
+   /// _hasSourceImmediate evaluates to true if a value for the _sourceImmediate field has been specified, false otherwise
    bool                    _hasSourceImmediate;
    int8_t                  _idx;
    Kind                    _kind;
@@ -2850,7 +2852,9 @@ class S390RSInstruction : public TR::S390RegInstruction
    uint32_t setSourceImmediate(uint32_t si) {return _sourceImmediate = si;}
    uint32_t getMaskImmediate()              {return _maskImmediate;}
    uint32_t setMaskImmediate(uint32_t mi)   {return _maskImmediate = mi;}
+   /// Returns true if a value for the _maskImmediate field was specified, false otherwise
    bool     hasMaskImmediate()              {return _hasMaskImmediate;}
+   /// Returns true if a value for the _sourceImmediate field was specified, false otherwise
    bool     hasSourceImmediate()            {return _hasSourceImmediate;}
 
    TR::Register* getFirstRegister() { return isTargetPair()? S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -2550,8 +2550,8 @@ class S390RSInstruction : public TR::S390RegInstruction
 
    int16_t                 _sourceImmediate;
    int8_t                  _maskImmediate;
-   bool                    _hasMask;
-   bool                    _hasImmediate;
+   bool                    _hasMaskImmediate;
+   bool                    _hasSourceImmediate;
    int8_t                  _idx;
    Kind                    _kind;
 
@@ -2568,7 +2568,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register      *treg,
                         uint32_t          imm,
                         TR::CodeGenerator *cg)
-           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(true), _kind(IsRS)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2583,7 +2583,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg), _kind(IsRS),
-             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true)
+             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(true)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2597,7 +2597,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         uint32_t          imm,
                         TR::RegisterDependencyConditions *_conditions,
                         TR::CodeGenerator *cg)
-           : S390RegInstruction(op, n, treg, _conditions, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, _conditions, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(true), _kind(IsRS)
 
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
@@ -2614,7 +2614,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, _conditions, precedingInstruction, cg), _kind(IsRS),
-             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true)
+             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(true)
       {
       // 1 Register is specified - If it is not a register pair, make sure instruction doesn't take a range (i.e. STM).
       TR_ASSERT(treg->getRegisterPair() || !getOpCode().usesRegRangeForTarget(),
@@ -2628,7 +2628,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register             *treg,
                         TR::MemoryReference  *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2648,7 +2648,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg),
-             _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+             _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2670,7 +2670,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg),
-             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _hasImmediate(false), _kind(IsRS)
+             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMaskImmediate(true), _hasSourceImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2691,7 +2691,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
            : S390RegInstruction(op, n, treg, cg),
-             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMask(true), _hasImmediate(false), _kind(IsRS)
+             _sourceImmediate(0), _maskImmediate(mask), _idx(-1), _hasMaskImmediate(true), _hasSourceImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2710,7 +2710,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register             *lreg,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, freg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, freg, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(lreg);
@@ -2730,7 +2730,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, freg, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, freg, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
       {
 
       if (getOpCode().setsOperand2())
@@ -2751,7 +2751,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::RegisterPair         *regp,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
      {
      useSourceMemoryReference(mf);
      setupThrowsImplicitNullPointerException(n,mf);
@@ -2765,7 +2765,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
       {
       useSourceMemoryReference(mf);
       setupThrowsImplicitNullPointerException(n,mf);
@@ -2780,7 +2780,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::RegisterPair         *regp2,
                         TR::MemoryReference      *mf,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
 
      {
      if (getOpCode().setsOperand2())
@@ -2800,7 +2800,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::MemoryReference      *mf,
                         TR::Instruction          *precedingInstruction,
                         TR::CodeGenerator        *cg)
-           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(false), _kind(IsRS)
+           : S390RegInstruction(op, n, regp, precedingInstruction, cg), _sourceImmediate(0), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(false), _kind(IsRS)
       {
       if (getOpCode().setsOperand2())
          useTargetRegister(regp2);
@@ -2819,7 +2819,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Register      *sreg,
                         uint32_t          imm,
                         TR::CodeGenerator *cg)
-           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
+           : S390RegInstruction(op, n, treg, cg), _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(true), _kind(IsRS)
         {
         if (getOpCode().setsOperand2())
            useTargetRegister(sreg);
@@ -2835,7 +2835,7 @@ class S390RSInstruction : public TR::S390RegInstruction
                         TR::Instruction   *precedingInstruction,
                         TR::CodeGenerator *cg)
            : S390RegInstruction(op, n, treg, precedingInstruction, cg),
-             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMask(false), _hasImmediate(true), _kind(IsRS)
+             _sourceImmediate(imm), _maskImmediate(0), _idx(-1), _hasMaskImmediate(false), _hasSourceImmediate(true), _kind(IsRS)
         {
         if (getOpCode().setsOperand2())
            useTargetRegister(sreg);
@@ -2850,8 +2850,8 @@ class S390RSInstruction : public TR::S390RegInstruction
    uint32_t setSourceImmediate(uint32_t si) {return _sourceImmediate = si;}
    uint32_t getMaskImmediate()              {return _maskImmediate;}
    uint32_t setMaskImmediate(uint32_t mi)   {return _maskImmediate = mi;}
-   bool     hasMask()                       {return _hasMask;}
-   bool     hasImmediate()                  {return _hasImmediate;}
+   bool     hasMaskImmediate()              {return _hasMaskImmediate;}
+   bool     hasSourceImmediate()            {return _hasSourceImmediate;}
 
    TR::Register* getFirstRegister() { return isTargetPair()? S390RegInstruction::getFirstRegister() : getRegisterOperand(1); }
    TR::Register* getLastRegister()  { return isTargetPair()? S390RegInstruction::getLastRegister()  : getRegisterOperand(2); }


### PR DESCRIPTION
The getSourceImmediate() API is being used incorrectly inside `TR_Debug::print(TR::FILE*,TR::S390RSInstruction*)`. The purpose of the query here is to check if _sourceImmediate is set. However, if it is set to 0, then the query evaluates as false. This can cause errors and crashes due to printing. This commit adds a new query to check if `_sourceImmediate` has been set, and cleans up the print function to correctly use the `hasMask()` query as well.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>