### PR TITLE
Fix occasional hang in abortTest::ThreadAbortTest::Waiting

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -3888,11 +3888,13 @@ monitor_enter_three_tier(omrthread_t self, omrthread_monitor_t monitor, BOOLEAN 
 		self->flags &= ~J9THREAD_FLAGM_BLOCKED_ABORTABLE;
 		self->monitor = 0;
 
-		/* Check for abort that may have occurred after we got the monitor. */
-		if (self->flags & J9THREAD_FLAG_ABORTED) {
-			THREAD_UNLOCK(self);
-			monitor_exit(self, monitor);
-			return J9THREAD_INTERRUPTED_MONITOR_ENTER;
+		if (SET_ABORTABLE == isAbortable) {
+			/* Check for abort that may have occurred after we got the monitor. */
+			if (self->flags & J9THREAD_FLAG_ABORTED) {
+				THREAD_UNLOCK(self);
+				monitor_exit(self, monitor);
+				return J9THREAD_INTERRUPTED_MONITOR_ENTER;
+			}
 		}
 		THREAD_UNLOCK(self);
 	}


### PR DESCRIPTION
If the aborted thread has to block on it's monitor during a
monitor enter call the call to monitor enter will incorrectly
fail. The code moved 2 pieces of cleanup into 1 larger if
statement which means the second bit of cleanup is not properly
guarded.  To resolve the issue the second piece of cleanup code
needed to be guarded with the isAbortable check.

Fixes #2113

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>