### PR TITLE
Apply MFENCE and CLFLUSH in patchFence16 on X86-32

### DIFF
--- a/compiler/x/runtime/X86Runtime.hpp
+++ b/compiler/x/runtime/X86Runtime.hpp
@@ -30,9 +30,7 @@
 #define cpuidex(CPUInfo, EAXValue, ECXValue) __cpuidex(CPUInfo, EAXValue, ECXValue)
 #else
 #include <cpuid.h>
-#ifdef TR_HOST_64BIT
 #include <emmintrin.h>
-#endif
 #define cpuid(CPUInfo, EAXValue)             __cpuid(EAXValue, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3])
 #define cpuidex(CPUInfo, EAXValue, ECXValue) __cpuid_count(EAXValue, ECXValue, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3])
 inline unsigned long long _xgetbv(unsigned int ecx)
@@ -111,12 +109,10 @@ inline bool AtomicCompareAndSwap(volatile uint16_t* ptr, uint16_t old_val, uint1
 
 inline void patchingFence16(void* addr)
    {
-#ifdef TR_HOST_64BIT
    _mm_mfence();
    _mm_clflush(addr);
    _mm_clflush(static_cast<char*>(addr)+8);
    _mm_mfence();
-#endif
    }
 
 #endif

--- a/fvtest/compilertest/build/toolcfg/gnu/common.mk
+++ b/fvtest/compilertest/build/toolcfg/gnu/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,13 +116,14 @@ CX_OPTFLAG?=$(CX_DEFAULTOPT)
 CX_FLAGS_PROD+=$(CX_OPTFLAG)
 
 ifeq ($(HOST_ARCH),x)
+    CX_FLAGS+=-mfpmath=sse -msse -msse2 -fno-strict-aliasing -fno-math-errno -fno-rounding-math -fno-trapping-math -fno-signaling-nans
     ifeq ($(HOST_BITS),32)
-        CX_FLAGS+=-m32 -fpic -fno-strict-aliasing
+        CX_FLAGS+=-m32 -fpic
     endif
     
     ifeq ($(HOST_BITS),64)
         CX_DEFINES+=J9HAMMER
-        CX_FLAGS+=-m64 -fPIC -fno-strict-aliasing
+        CX_FLAGS+=-m64 -fPIC
     endif
 endif
 

--- a/jitbuilder/build/toolcfg/gnu/common.mk
+++ b/jitbuilder/build/toolcfg/gnu/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -145,12 +145,12 @@ ifeq ($(HOST_ARCH),p)
 endif
 
 ifeq ($(PLATFORM),amd64-linux-gcc)
-    CX_FLAGS+=-m32 -fpic -fno-strict-aliasing
+    CX_FLAGS+=-m32 -fpic -fno-strict-aliasing -mfpmath=sse -msse -msse2 -fno-math-errno -fno-rounding-math -fno-trapping-math -fno-signaling-nans
 endif
 
 ifeq ($(PLATFORM),amd64-linux64-gcc)
     CX_DEFINES+=J9HAMMER
-    CX_FLAGS+=-m64 -fPIC -fno-strict-aliasing
+    CX_FLAGS+=-m64 -fPIC -fno-strict-aliasing -mfpmath=sse -msse -msse2 -fno-math-errno -fno-rounding-math -fno-trapping-math -fno-signaling-nans
 endif
 
 ifeq ($(PLATFORM),ppc64-linux64-gcc)


### PR DESCRIPTION
Memory fences and cache line flushes are missing in
patchFence16() on X86-32. Fixing it.

Closes #2323

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>