### PR TITLE
Fix intermittent TraceLogTest.stressTraceBufferManagement failure

### DIFF
--- a/fvtest/rastest/traceRecordHelpers.cpp
+++ b/fvtest/rastest/traceRecordHelpers.cpp
@@ -166,7 +166,7 @@ nextTracePoint(PerThreadWrapBuffer *wrapBuffer, const UtTraceRecord *record, Tra
 	uint32_t offset = iter->currentPos;
 	uint32_t tpLength = 0;
 
-	if (iter->currentPos <= record->firstEntry) {
+	if (iter->currentPos < record->firstEntry) {
 		/* currentPos is at or before the start of the data - not possible to continue,
 		 * or the normal exit condition.
 		 */


### PR DESCRIPTION
Fixes issue #2115. Trace points wrapping into the next record by 1 character were skipped by the trace point iterator. It was failing about 1 in 3 times on z/os and now passed 300 consecutive runs.