### PR TITLE
Fixing CR instruction handling on PPC

### DIFF
--- a/compiler/p/codegen/OMRRealRegister.cpp
+++ b/compiler/p/codegen/OMRRealRegister.cpp
@@ -186,7 +186,14 @@ OMR::Power::RealRegister::setRegisterFieldRA(uint32_t *instruction)
    else
       *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RA;
    }
-
+void
+OMR::Power::RealRegister::setRegisterFieldRB(uint32_t *instruction)
+  {
+      if (self()->isConditionRegister())
+        *instruction |= fullRegBinaryEncodings[_registerNumber] << (pos_RB + 2);
+      else
+         *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RB;
+  }
 void
 OMR::Power::RealRegister::setRegisterFieldXS(uint32_t *instruction)
    {

--- a/compiler/p/codegen/OMRRealRegister.hpp
+++ b/compiler/p/codegen/OMRRealRegister.hpp
@@ -110,10 +110,7 @@ class OMR_EXTENSIBLE RealRegister : public OMR::RealRegister
 
    void setRegisterFieldRA(uint32_t *instruction);
 
-   void setRegisterFieldRB(uint32_t *instruction)
-      {
-      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RB;
-      }
+   void setRegisterFieldRB(uint32_t *instruction);
 
    void setRegisterFieldRC(uint32_t *instruction)
       {


### PR DESCRIPTION
Prior, instructions that required CR registers were not correctly processed. An offset is needed to handle CR registers. This commit includes enabling handling for 1 Target, 2 Source Register Immediate instructions to be correctly formulated.

The implementation of the function needs to be moved from the corresponding .hpp file to the .cpp. This was necessary to determine that the register used to construct the instruction is a CR.

Signed-off-by: Alen Badel <Alen.Badel@ibm.com>