### PR TITLE
Merge type size of a forward declaration with a later definition

### DIFF
--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -300,6 +300,10 @@ MergeVisitor::visitNamespace(NamespaceUDT *type) const
 {
 	/* Merge by adding the fields/subtypes of '_other' into 'type'. */
 	NamespaceUDT *other = (NamespaceUDT *)_other;
+	/* This type may be derived from only a forward declaration; if so, update the size now. */
+	if (0 == type->_sizeOf) {
+		type->_sizeOf = other->_sizeOf;
+	}
 	_ir->mergeTypes(type->getSubUDTS(), other->getSubUDTS(), type, _merged);
 	return DDR_RC_OK;
 }


### PR DESCRIPTION
DWARF information corresponding to a forward declaration does not include a size (nor can it).
This change merges the size of a subsequent definition (if found) so the generated blob will have the proper size information.

Issue: eclipse/openj9#378
Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>