### PR TITLE
Fix blob types for bit fields

### DIFF
--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -915,6 +915,10 @@ JavaBlobGenerator::formatFieldType(Field *field, string *fieldType)
 				stream << "]";
 			}
 			*fieldType += stream.str();
+		} else if (0 != field->_bitField) {
+			stringstream stream;
+			stream << ":" << field->_bitField;
+			*fieldType += stream.str();
 		}
 	}
 


### PR DESCRIPTION
A field
```
int bit : 1;
```
should be described in the blob as having type `int:1` instead of just `int`; this change corrects that.

Issue: eclipse/openj9#378
Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>