### PR TITLE
Read Barrier on collected reference dereference

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -318,15 +318,6 @@ TR_FrontEnd::getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *, int3
    return -1;
    }
 
-
-TR_OpaqueClassBlock *
-TR_FrontEnd::getClassFromStatic(void *p)
-   {
-   notImplemented("getClassFromStatic");
-   return 0;
-   }
-
-
 TR_OpaqueMethodBlock *
 TR_FrontEnd::getInlinedCallSiteMethod(TR_InlinedCallSite *ics)
    {

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -211,7 +211,6 @@ public:
 
    // to J9
    virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
-   virtual TR_OpaqueClassBlock * getClassFromStatic(void *p);
    virtual int32_t getStringLength(uintptrj_t objectPointer);
 
    // Null-terminated.  bufferSize >= 1+getStringUTF8Length(objectPointer).  Returns buffer just for convenience.

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1933,10 +1933,10 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
                                                                    TR::VMAccessCriticalSection::tryToAcquireVMAccess);
          if (!symRef->isUnresolved() && getStaticNameCriticalSection.acquiredVMAccess())
             {
-            uintptrj_t *stringLocation = (uintptrj_t*)sym->castToStaticSymbol()->getStaticAddress();
+            uintptrj_t stringLocation = (uintptrj_t)sym->castToStaticSymbol()->getStaticAddress();
             if (stringLocation)
                {
-               uintptrj_t string = *stringLocation;
+               uintptrj_t string = comp()->fej9()->getStaticReferenceFieldAtAddress(stringLocation);
                length = comp()->fej9()->getStringUTF8Length(string);
                contents = (char*)comp()->trMemory()->allocateMemory(length+1, stackAlloc, TR_MemoryBase::UnknownType);
                comp()->fej9()->getStringUTF8(string, contents, length+1);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6121,7 +6121,8 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
                   auto loadMnemonic = TR::InstOpCode::BAD;
 
                   if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() &&
-                      node->getOpCodeValue() == TR::aloadi &&
+                      ((node->getOpCodeValue() == TR::aloadi) ||
+                       (node->getOpCodeValue() == TR::aload && node->getSymbol()->isStatic())) &&
                       tempReg->containsCollectedReference())
                      {
                      if (comp->useCompressedPointers() &&


### PR DESCRIPTION
The compiler must use read barriers when dereferencing collected references.