### PR TITLE
Support for DDR on Linux s390 platforms

### DIFF
--- a/ddr/tools/ddrgen/Makefile
+++ b/ddr/tools/ddrgen/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,7 @@ ifeq (linux,$(OMR_HOST_OS))
     MODULE_SHARED_LIBS += elf
   endif
   ifeq (s390,$(OMR_HOST_ARCH))
-    MODULE_SHARED_LIBS += z
+    MODULE_SHARED_LIBS += elf z
   endif
 endif
 

--- a/omrmakefiles/rules.linux.mk
+++ b/omrmakefiles/rules.linux.mk
@@ -152,16 +152,10 @@ endif
 ### Platform Flags
 ###
 
-## Debugging Infomation
+## Debugging Information
 # Indicate that GNU debug symbols are being used
 ifeq (gcc,$(OMR_TOOLCHAIN))
-  ifeq (arm,$(OMR_HOST_ARCH))
-    USE_GNU_DEBUG:=1
-  endif
-  ifeq (ppc,$(OMR_HOST_ARCH))
-    USE_GNU_DEBUG:=1
-  endif
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter arm ppc s390 x86,$(OMR_HOST_ARCH)))
     USE_GNU_DEBUG:=1
   endif
 endif


### PR DESCRIPTION
Issue: eclipse/openj9#378
* ddrgen needs to link with libelf.so
* produce both .so and .so.dbg files