### PR TITLE
Fix XLC compiler issues on Linux and AIX PPC

### DIFF
--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1063,7 +1063,7 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 	int unixSignalNo = mapPortLibSignalToUnix(portLibrarySignalNo);
 	struct sigaction newAction;
 
-	memset(&newAction, 0, sizeof(sigaction));
+	memset(&newAction, 0, sizeof(struct sigaction));
 
 	/* do not block any signals */
 	if (0 != sigemptyset(&newAction.sa_mask)) {


### PR DESCRIPTION
AIX machines are not available for OMR external builds. AIX machines use XLC compiler. The compile failure happened with XLC compiler. Specific compile failure: 

`"./unix/omrsignal.c", line 1066.37: 1506-043 (W) The operand of the sizeof operator is not valid.`

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>