### PR TITLE
Fix handling of 'flag' macros

### DIFF
--- a/ddr/tools/getmacros
+++ b/ddr/tools/getmacros
@@ -30,7 +30,7 @@ default_regex="@ddr_namespace: *default"
 map_to_type_regex="@ddr_namespace: *map_to_type="
 flag_define_regex="^ *# *define +${id} *($|//|/\*)"
 flag_undef_regex="^ *# *undef +${id} *($|//|/\*)"
-value_define_regex="^ *# *define +${id} +[^ ].*($|//|/\*)"
+value_define_regex="^ *# *define +${id} +[^ /].*($|//|/\*)"
 include_guard_regex=".*_[Hh]([Pp][Pp])?_? *($|//|/\*)"
 
 ##
@@ -61,57 +61,71 @@ get_ddr_options() {
 	fi
 }
 
-begin_new_namespace() {
-	temp_macro_file=${f}
-	echo "@TYPE_${namespace}" >> "${temp_macro_file}"
+# invoked with the name of desired namespace
+begin_namespace() {
+	old_namespace=${namespace}
+	namespace="${1}"
+	if [ "${namespace}" != "${old_namespace}" ]; then
+		echo "@TYPE_${namespace}" >> "${f}"
+	fi
 }
 
-end_previous_namespace() {
-	namespace=''
+set_default_namespaces() {
+	# Remove directory and extension; make first letter uppercase; append 'Constants'.
+	basename=$(echo ${f} | sed -e 's|^.*/||' -e 's|\..*$||' -e 's|\(.\)|\U\1|')
+	const_space="${basename}Constants"
+	flag_space="${basename}Flags"
 }
 
-set_default_namespace() {
-	end_previous_namespace
-	# Remove directory and extension; append 'Constants'.
-	namespace=$(echo ${f} | sed -e 's|^.*/||' -e 's|\..*$||' -e 's|\(.\)|\U\1|' -e 's|$|Constants|')
-
-	# Echo the type name into the output file.
-	begin_new_namespace
-}
-
-set_map_to_type_namespace() {
-	end_previous_namespace
+set_map_to_type_namespaces() {
 	# Extract the type name.
-	namespace=$(echo "${line}" | sed -e "s|^.*map_to_type=\(${id}\).*$|\1|")
+	typename=$(echo "${line}" | sed -e "s|^.*map_to_type=\(${id}\).*$|\1|")
+	const_space="${typename}"
+	flag_space=$(echo "${typename}" | sed -e 's|Constants$|Flags|')
+}
 
-	# Echo the type name into the output file.
-	begin_new_namespace
+# invoked with the name of the flag macro
+write_flag_macro() {
+	begin_namespace "${const_space}"
+	echo "${1}" | sed -e 's|^\(.*\)$|#ifdef \1\n@MACRO_\1 1\n#else\n@MACRO_\1 0\n#endif|' >> "${f}"
+}
+
+# invoked with the name of the flag macro
+write_flag_defined() {
+	begin_namespace "${flag_space}"
+	echo "${1}" | sed -e 's|^\(.*\)$|#ifdef \1\n@MACRO_\1_DEFINED 1\n#else\n@MACRO_\1_DEFINED 0\n#endif|' >> "${f}"
 }
 
 define_flag_macro() {
 	# Filter include guards and print the macro as a constant.
 	if ! [[ ${line} =~ ${include_guard_regex} ]]; then
-		if [[ 0 -eq ${#namespace} ]]; then
-			set_default_namespace
-		fi
-		echo "${line}" | sed -e "s|^ *# *define  *\(${id}\).*$|#ifdef \1\n@MACRO_\1 1\n#endif|" >> "${temp_macro_file}"
+		# Capture macro name
+		name=$(echo "${line}" | sed -e "s|^ *# *define  *\(${id}\).*$|\1|")
+		write_flag_macro "${name}"
+		write_flag_defined "${name}"
 	fi
 }
 
 undef_flag_macro() {
-	if [[ 0 -eq ${#namespace} ]]; then
-		set_default_namespace
-	fi
-	# Print a constant of 0 to the macro file.
-	echo "${line}" | sed -e "s|^ *# *undef  *\(${id}\).*$|#ifndef \1\n@MACRO_\1 0\n#endif|" >> "${temp_macro_file}"
+	# Capture macro name
+	name=$(echo "${line}" | sed -e "s|^ *# *undef  *\(${id}\).*$|\1|")
+	write_flag_macro "${name}"
+	write_flag_defined "${name}"
 }
 
 define_value_macro() {
-	if [[ 0 -eq ${#namespace} ]]; then
-		set_default_namespace
+	# Capture macro name
+	name=$(echo "${line}" | sed -e "s|^ *# *define  *\(${id}\) .*$|\1|")
+
+	if [ ${addValues} -ne 0 ]; then
+		# Print the macro in the constants space.
+		begin_namespace "${const_space}"
+		echo "${name}" | sed -e "s|^\(.*\)$|#ifdef \1\n@MACRO_\1 \1\n#endif|" >> "${f}"
 	fi
-	# Print the macro.
-	echo "${line}" | sed -e "s|^ *# *define  *\(${id}\) .*$|#ifdef \1\n@MACRO_\1 \1\n#endif|" >> "${temp_macro_file}"
+
+	if [ ${addFlags} -ne 0 ]; then
+		write_flag_defined "${name}"
+	fi
 }
 
 ##
@@ -147,20 +161,21 @@ parse_namespace_policy_files() {
 			echo "#define DDRGEN_F${filenum}_GUARD_H" >> ${f}
 			echo "@DDRFILE_BEGIN ${f}" >> ${f}
 
+			set_default_namespaces
+			namespace=''
+
 			# Gather qualifying macro definitions.
 			# We use sed to replace tabs with spaces and trim trailing spaces
 			# to simplify patterns for grep and this script.
-			sed -e 's/\t/ /g' -e 's/ *$//' < ${f} \
+			sed -e 's|\t| |g' -e 's| *$||' < ${f} \
 			| grep -E \
 				-e '@ddr_namespace: *(default|map_to_type=)' \
 				-e '^ *# *(define|undef) +[A-Za-z_]' \
 			| while read -r line; do
 				if [[ ${line} =~ ${default_regex} ]]; then
-					# Change namespaces to "<FilenameConstants>".
-					set_default_namespace
+					set_default_namespaces
 				elif [[ ${line} =~ ${map_to_type_regex} ]]; then
-					# Change namespaces to specified pseudostructure.
-					set_map_to_type_namespace
+					set_map_to_type_namespaces
 				elif [[ ${addValues} -ne 0 && ${line} =~ ${value_define_regex} ]]; then
 					# Print a value define.
 					define_value_macro
@@ -172,7 +187,6 @@ parse_namespace_policy_files() {
 					undef_flag_macro
 				fi
 			done
-			end_previous_namespace
 
 			# close repeated include guard and file delimiter
 			echo "@DDRFILE_END ${f}" >> ${f}
@@ -228,9 +242,9 @@ main() {
 	# Build an awk filter that removes duplicate information.
 	declare -ar dedup_filter=(
 		'BEGIN { include = 0 }'
-		'/^@DDRFILE_BEGIN / { file[$2] += 1 ; if (file[$2] == 1) { include = 1 } }'
+		'/^@DDRFILE_BEGIN / { if (file[$2] != 1) { file[$2] = 1; include = 1 } }'
 		'{ if (include) { print } }'
-		'/^@DDRFILE_END / { if (include) { print } ; include = 0 }'
+		'/^@DDRFILE_END / { include = 0 }'
 	)
 
 	echo "Scraping anotations from preprocessed code ..."


### PR DESCRIPTION
* fix regular expression for flag definitions so the following is properly recognized
```
    #define FLAG // comment
```
* generate *_DEFINED constants with buildflags option
* manage separate flag and constant namespaces
* put {flag} in the 'Constants' namespace and {flag}_DEFINED in the 'Flags' namespace

Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>