### PR TITLE
Fix existing PATH hack for Windows

### DIFF
--- a/run_configure.mk
+++ b/run_configure.mk
@@ -83,7 +83,7 @@ endif
 ifneq (,$(findstring win_x86,$(SPEC)))
   include $(CONFIG_INCL_DIR)/configure_win_x86.mk
   # OMRTODO: this is J9 buildfarm specific code.
-  export PATH:=$(DEV_TOOLS)\jtc-toolchain\java7\windows\mingw-msys\msys\1.0\bin;$(PATH)
+  export PATH:=$(DEV_TOOLS)/jtc-toolchain/java7/windows/mingw-msys/msys/1.0/bin:$(PATH)
 endif
 ifneq (,$(findstring zos_390,$(SPEC)))
   include $(CONFIG_INCL_DIR)/configure_zos_390.mk


### PR DESCRIPTION
The path list separator should be : not ; when running
under a Unix-like environment, otherwise this particular
path that's being added to the start of the list ends up
being prepended to the first path on the list and
invalidating both.

Also change back-slashes to forward-slashes to be
more consistent.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>