### PR TITLE
Replace CARD_SIZE & CARD_SIZE_SHIFT with macros

### DIFF
--- a/gc/include/omrmodroncore.h
+++ b/gc/include/omrmodroncore.h
@@ -38,10 +38,11 @@
  */
 typedef U_8 Card;
 
-enum {
-	CARD_SIZE_SHIFT	= 9,	/* base2 log of CARD_SIZE, used to change division into shift */
-	CARD_SIZE = 512	/* size of a "card" of the heap - in a sense:  the granule of deferred mark map update */
-};
+/* base2 log of CARD_SIZE, used to change division into shift */
+#define CARD_SIZE_SHIFT 9
+
+/* size of a "card" of the heap - in a sense:  the granule of deferred mark map update */
+#define CARD_SIZE 512
 
 /*
  * The following definitions are duplicated in j9modron.h.
@@ -72,7 +73,7 @@ enum {
 /**
  * The following definitions are duplicated in j9modron.h.
  * Both versions of each definition must match exactly.
- * 
+ *
  * #defines representing the vmState that should be set during various GC activities
  * @note J9VMSTATE_GC is the "major mask" representing a "GC" activity - we OR in a minor mask
  * representing the specific activity.


### PR DESCRIPTION
ddrgen associates literals of anonymous enums with the
enclosing scope. As there is no such scope in the case of
CARD_SIZE & CARD_SIZE_SHIFT these literals are not captured.
As macros they will be included in the superset & blob.

In support of https://github.com/eclipse/openj9/issues/378.