### PR TITLE
Fix handling of literals of anonymous enum types

### DIFF
--- a/ddr/include/ddr/blobgen/java/genSuperset.hpp
+++ b/ddr/include/ddr/blobgen/java/genSuperset.hpp
@@ -23,12 +23,12 @@
 #define GENSUPERSET_HPP
 
 #include "ddr/blobgen/genBlob.hpp"
-#include "ddr/ir/Symbol_IR.hpp"
-#include "ddr/std/sstream.hpp"
 #include "ddr/std/unordered_map.hpp"
 
+#include <set>
 #include <string.h>
 
+using std::set;
 using std::string;
 
 class Field;
@@ -46,13 +46,17 @@ private:
 	intptr_t _file;
 	OMRPortLibrary *_portLibrary;
 	bool _printEmptyTypes;
+	string _pendingTypeHeading;
 
 	void initBaseTypedefSet();
 	void convertJ9BaseTypedef(Type *type, string *name);
 	void replaceBaseTypedef(Type *type, string *name);
 	DDR_RC getFieldType(Field *field, string *assembledTypeName, string *simpleTypeName);
+	DDR_RC printType(Type *type, Type *superClass);
+	DDR_RC printPendingType();
 	DDR_RC printFieldMember(Field *field, const string &prefix);
-	void printConstantMember(const string &name);
+	DDR_RC printConstantMember(const string &name);
+	DDR_RC print(const string &text);
 
 	friend class SupersetFieldVisitor;
 	friend class SupersetVisitor;

--- a/ddr/include/ddr/ir/ClassType.hpp
+++ b/ddr/include/ddr/ir/ClassType.hpp
@@ -24,7 +24,6 @@
 
 #include "ddr/ir/NamespaceUDT.hpp"
 
-class EnumMember;
 class Field;
 
 using std::vector;
@@ -34,7 +33,6 @@ class ClassType : public NamespaceUDT
 public:
 	bool _isComplete; /* as opposed to just a forward declaration */
 	vector<Field *> _fieldMembers;
-	vector<EnumMember *> _enumMembers; /* used for anonymous enums*/
 
 	explicit ClassType(size_t size, unsigned int lineNumber = 0);
 	virtual ~ClassType();

--- a/ddr/include/ddr/ir/ClassUDT.hpp
+++ b/ddr/include/ddr/ir/ClassUDT.hpp
@@ -35,7 +35,7 @@ public:
 	explicit ClassUDT(size_t size, bool isClass = true, unsigned int lineNumber = 0);
 	virtual ~ClassUDT();
 
-	virtual string getSymbolKindName();
+	virtual const string &getSymbolKindName() const;
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 

--- a/ddr/include/ddr/ir/EnumUDT.hpp
+++ b/ddr/include/ddr/ir/EnumUDT.hpp
@@ -35,7 +35,7 @@ public:
 	explicit EnumUDT(unsigned int lineNumber = 0);
 	virtual ~EnumUDT();
 
-	virtual string getSymbolKindName();
+	virtual const string &getSymbolKindName() const;
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 

--- a/ddr/include/ddr/ir/NamespaceUDT.hpp
+++ b/ddr/include/ddr/ir/NamespaceUDT.hpp
@@ -25,18 +25,21 @@
 #include "ddr/ir/Macro.hpp"
 #include "ddr/ir/UDT.hpp"
 
+class EnumMember;
+
 class NamespaceUDT : public UDT
 {
 public:
 	std::vector<UDT *> _subUDTs;
 	std::vector<Macro> _macros;
+	vector<EnumMember *> _enumMembers; /* used for anonymous enums */
 
 	explicit NamespaceUDT(unsigned int lineNumber = 0);
 	~NamespaceUDT();
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 	virtual bool insertUnique(Symbol_IR *ir);
-	virtual string getSymbolKindName();
+	virtual const string &getSymbolKindName() const;
 	virtual void addMacro(Macro *macro);
 	virtual std::vector<UDT *> * getSubUDTS();
 	virtual void renameFieldsAndMacros(const FieldOverride &fieldOverride, Type *replacementType);

--- a/ddr/include/ddr/ir/Type.hpp
+++ b/ddr/include/ddr/ir/Type.hpp
@@ -57,7 +57,7 @@ public:
 	bool isAnonymousType() const;
 
 	virtual string getFullName();
-	virtual string getSymbolKindName();
+	virtual const string &getSymbolKindName() const;
 
 	/* Visitor pattern function to allow the scanner/generator/IR to dispatch functionality based on type. */
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);

--- a/ddr/include/ddr/ir/TypePrinter.hpp
+++ b/ddr/include/ddr/ir/TypePrinter.hpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ddr/ir/TypeVisitor.hpp"
+
+#include "ddr/ir/Macro.hpp"
+
+class EnumMember;
+class Field;
+
+#include <vector>
+
+class TypePrinter : public TypeVisitor
+{
+private:
+	const int32_t _flags;
+	const int32_t _indent;
+
+	void printIndent() const;
+	void printFields(const std::vector<Field *> &fields) const;
+	void printLiterals(const std::vector<EnumMember *> &literals) const;
+	void printMacros(const std::vector<Macro> &macros) const;
+
+	explicit TypePrinter(const TypePrinter *outer)
+		: TypeVisitor()
+		, _flags(outer->_flags)
+		, _indent(outer->_indent + 1)
+	{
+	}
+
+public:
+	enum { FIELDS = 1, LITERALS = 2, MACROS = 4 };
+
+	explicit TypePrinter(int32_t flags)
+		: TypeVisitor()
+		, _flags(flags)
+		, _indent(0)
+	{
+	}
+
+	template<typename TypeVector>
+	void
+	printUDTs(const TypeVector &types) const
+	{
+		for (typename TypeVector::const_iterator it = types.begin(); it != types.end(); ++it) {
+			(*it)->acceptVisitor(*this);
+		}
+	}
+
+	virtual DDR_RC visitType(Type *type) const;
+	virtual DDR_RC visitClass(ClassUDT *type) const;
+	virtual DDR_RC visitEnum(EnumUDT *type) const;
+	virtual DDR_RC visitNamespace(NamespaceUDT *type) const;
+	virtual DDR_RC visitTypedef(TypedefUDT *type) const;
+	virtual DDR_RC visitUnion(UnionUDT *type) const;
+};

--- a/ddr/include/ddr/ir/TypedefUDT.hpp
+++ b/ddr/include/ddr/ir/TypedefUDT.hpp
@@ -35,8 +35,7 @@ public:
 	~TypedefUDT();
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
-	virtual bool insertUnique(Symbol_IR *ir);
-	virtual string getSymbolKindName();
+	virtual const string &getSymbolKindName() const;
 	virtual size_t getPointerCount();
 	virtual size_t getArrayDimensions();
 	virtual Type *getBaseType();

--- a/ddr/include/ddr/ir/UnionUDT.hpp
+++ b/ddr/include/ddr/ir/UnionUDT.hpp
@@ -31,7 +31,7 @@ public:
 	virtual ~UnionUDT();
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
-	virtual string getSymbolKindName();
+	virtual const string &getSymbolKindName() const;
 
 	bool operator==(const Type & rhs) const;
 	virtual bool compareToUnion(const UnionUDT &) const;

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -88,7 +88,7 @@ private:
 	DDR_RC getOrCreateNewType(Dwarf_Die die, Dwarf_Half tag, Type **newUDT, NamespaceUDT *outerUDT, bool *isNewType);
 	DDR_RC createNewType(Dwarf_Die die, Dwarf_Half tag, const char *dieName, Type **newUDT);
 	DDR_RC scanClassChildren(NamespaceUDT *newClass, Dwarf_Die die);
-	DDR_RC addEnumMember(Dwarf_Die die, EnumUDT *udt);
+	DDR_RC addEnumMember(Dwarf_Die die, NamespaceUDT *outerUDT, EnumUDT *udt);
 	DDR_RC addClassField(Dwarf_Die die, ClassType *newClass, const string &fieldName);
 	DDR_RC getSuperUDT(Dwarf_Die die, ClassUDT *udt);
 	DDR_RC getTypeInfo(Dwarf_Die die, Dwarf_Die *dieout, string *typeName, Modifiers *modifiers, size_t *typeSize, size_t *bitField);

--- a/ddr/lib/ddr-ir/ClassType.cpp
+++ b/ddr/lib/ddr-ir/ClassType.cpp
@@ -21,25 +21,16 @@
 
 #include "ddr/ir/ClassType.hpp"
 
-#include "ddr/config.hpp"
-
 ClassType::ClassType(size_t size, unsigned int lineNumber)
 	: NamespaceUDT(lineNumber)
 	, _isComplete(false)
 	, _fieldMembers()
-	, _enumMembers()
 {
 	_sizeOf = size;
 }
 
 ClassType::~ClassType()
 {
-	/* enum members may be added to a classType in the case of anonymous enums */
-	for (vector<EnumMember *>::iterator it = _enumMembers.begin(); it != _enumMembers.end(); ++it) {
-		delete *it;
-	}
-	_enumMembers.clear();
-
 	for (vector<Field *>::iterator it = _fieldMembers.begin(); it != _fieldMembers.end(); ++it) {
 		delete *it;
 	}

--- a/ddr/lib/ddr-ir/ClassUDT.cpp
+++ b/ddr/lib/ddr-ir/ClassUDT.cpp
@@ -30,10 +30,13 @@ ClassUDT::~ClassUDT()
 {
 }
 
-string
-ClassUDT::getSymbolKindName()
+const string &
+ClassUDT::getSymbolKindName() const
 {
-	return _isClass ? "class" : "struct";
+	static const string classKind("class");
+	static const string structKind("struct");
+
+	return _isClass ? classKind : structKind;
 }
 
 DDR_RC

--- a/ddr/lib/ddr-ir/EnumUDT.cpp
+++ b/ddr/lib/ddr-ir/EnumUDT.cpp
@@ -21,8 +21,6 @@
 
 #include "ddr/ir/EnumUDT.hpp"
 
-#include "ddr/config.hpp"
-
 EnumUDT::EnumUDT(unsigned int lineNumber)
 	: UDT(4, lineNumber)
 {
@@ -36,10 +34,12 @@ EnumUDT::~EnumUDT()
 	_enumMembers.clear();
 }
 
-string
-EnumUDT::getSymbolKindName()
+const string &
+EnumUDT::getSymbolKindName() const
 {
-	return "enum";
+	static const string enumKind("enum");
+
+	return enumKind;
 }
 
 DDR_RC

--- a/ddr/lib/ddr-ir/Makefile
+++ b/ddr/lib/ddr-ir/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
+# Copyright (c) 2015, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,6 +50,7 @@ OBJECTS = \
   EnumUDT$(OBJEXT) \
   Type$(OBJEXT) \
   TypedefUDT$(OBJEXT) \
+  TypePrinter$(OBJEXT) \
   UDT$(OBJEXT) \
   UnionUDT$(OBJEXT)
 

--- a/ddr/lib/ddr-ir/Members.cpp
+++ b/ddr/lib/ddr-ir/Members.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,4 +21,6 @@
 
 #include "ddr/ir/Members.hpp"
 
-Members::~Members() {}
+Members::~Members()
+{
+}

--- a/ddr/lib/ddr-ir/NamespaceUDT.cpp
+++ b/ddr/lib/ddr-ir/NamespaceUDT.cpp
@@ -21,18 +21,22 @@
 
 #include "ddr/ir/NamespaceUDT.hpp"
 
-#include <stdio.h>
-
 NamespaceUDT::NamespaceUDT(unsigned int lineNumber)
 	: UDT(0, lineNumber)
 	, _subUDTs()
 	, _macros()
+	, _enumMembers()
 {
 }
 
 NamespaceUDT::~NamespaceUDT()
 {
-	for (vector<UDT *>::const_iterator it = this->_subUDTs.begin(); it != this->_subUDTs.end(); ++it) {
+	for (vector<EnumMember *>::iterator it = _enumMembers.begin(); it != _enumMembers.end(); ++it) {
+		delete *it;
+	}
+	_enumMembers.clear();
+
+	for (vector<UDT *>::const_iterator it = _subUDTs.begin(); it != _subUDTs.end(); ++it) {
 		delete *it;
 	}
 	_subUDTs.clear();
@@ -58,10 +62,12 @@ NamespaceUDT::insertUnique(Symbol_IR *ir)
 	return UDT::insertUnique(ir);
 }
 
-string
-NamespaceUDT::getSymbolKindName()
+const string &
+NamespaceUDT::getSymbolKindName() const
 {
-	return "namespace";
+	static const string namespaceKind("namespace");
+
+	return namespaceKind;
 }
 
 void

--- a/ddr/lib/ddr-ir/Type.cpp
+++ b/ddr/lib/ddr-ir/Type.cpp
@@ -44,10 +44,12 @@ Type::getFullName()
 	return _name;
 }
 
-string
-Type::getSymbolKindName()
+const string &
+Type::getSymbolKindName() const
 {
-	return "";
+	static const string typeKind("");
+
+	return typeKind;
 }
 
 DDR_RC
@@ -59,7 +61,7 @@ Type::acceptVisitor(const TypeVisitor &visitor)
 bool
 Type::insertUnique(Symbol_IR *ir)
 {
-	/* No-op: since Types aren't printed, there's no need to check if they're duplicates either */
+	/* No-op: since Types aren't printed, there's no need to check if they're duplicates either. */
 	return false;
 }
 

--- a/ddr/lib/ddr-ir/TypePrinter.cpp
+++ b/ddr/lib/ddr-ir/TypePrinter.cpp
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ddr/ir/TypePrinter.hpp"
+
+#include "ddr/ir/ClassUDT.hpp"
+#include "ddr/ir/EnumUDT.hpp"
+#include "ddr/ir/Field.hpp"
+#include "ddr/ir/TypedefUDT.hpp"
+#include "ddr/ir/UnionUDT.hpp"
+
+void
+TypePrinter::printIndent() const
+{
+	for (int32_t i = _indent; i > 0; --i) {
+		printf("  ");
+	}
+}
+
+void
+TypePrinter::printFields(const std::vector<Field *> &fields) const
+{
+	if (0 != (_flags & FIELDS)) {
+		for (vector<Field *>::const_iterator it = fields.begin(); it != fields.end(); ++it) {
+			printIndent();
+			printf("field '%s'\n", (*it)->_name.c_str());
+		}
+	}
+}
+
+void
+TypePrinter::printLiterals(const std::vector<EnumMember *> &literals) const
+{
+	if (0 != (_flags & LITERALS)) {
+		for (vector<EnumMember *>::const_iterator it = literals.begin(); it != literals.end(); ++it) {
+			printIndent();
+			printf("literal '%s' = %d\n", (*it)->_name.c_str(), (*it)->_value);
+		}
+	}
+}
+
+void
+TypePrinter::printMacros(const std::vector<Macro> &macros) const
+{
+	if (0 != (_flags & MACROS)) {
+		for (vector<Macro>::const_iterator it = macros.begin(); it != macros.end(); ++it) {
+			printIndent();
+			printf("macro '%s' = %s\n", it->_name.c_str(), it->getValue().c_str());
+		}
+	}
+}
+
+DDR_RC
+TypePrinter::visitType(Type *type) const
+{
+	printIndent();
+	printf("type '%s' size(%zu)\n", type->_name.c_str(), type->_sizeOf);
+	return DDR_RC_OK;
+}
+
+DDR_RC
+TypePrinter::visitClass(ClassUDT *type) const
+{
+	printIndent();
+	printf("%s '%s' size(%zu)",
+			type->_isClass ? "class" : "struct",
+			type->_name.c_str(),
+			type->_sizeOf);
+	if (NULL != type->_superClass) {
+		printf(":  %s", type->_superClass->_name.c_str());
+	}
+	printf(" {\n");
+
+	{
+		const TypePrinter indented(this);
+
+		indented.printFields(type->_fieldMembers);
+		indented.printLiterals(type->_enumMembers);
+		indented.printMacros(type->_macros);
+		indented.printUDTs(type->_subUDTs);
+	}
+
+	printIndent();
+	printf("}\n");
+
+	return DDR_RC_OK;
+}
+
+DDR_RC
+TypePrinter::visitEnum(EnumUDT *type) const
+{
+	printIndent();
+	printf("enum '%s' size(%zu) {\n", type->_name.c_str(), type->_sizeOf);
+
+	{
+		const TypePrinter indented(this);
+
+		indented.printLiterals(type->_enumMembers);
+	}
+
+	printIndent();
+	printf("}\n");
+
+	return DDR_RC_OK;
+}
+
+DDR_RC
+TypePrinter::visitNamespace(NamespaceUDT *type) const
+{
+	printIndent();
+	printf("namespace '%s' {\n", type->_name.c_str());
+
+	{
+		const TypePrinter indented(this);
+
+		indented.printLiterals(type->_enumMembers);
+		indented.printMacros(type->_macros);
+		indented.printUDTs(type->_subUDTs);
+	}
+
+	printIndent();
+	printf("}\n");
+
+	return DDR_RC_OK;
+}
+
+DDR_RC
+TypePrinter::visitTypedef(TypedefUDT *type) const
+{
+	printIndent();
+	printf("typedef '%s'\n", type->_name.c_str());
+
+	return DDR_RC_OK;
+}
+
+DDR_RC
+TypePrinter::visitUnion(UnionUDT *type) const
+{
+	printIndent();
+	printf("union '%s' size(%zu) {\n", type->_name.c_str(), type->_sizeOf);
+
+	{
+		const TypePrinter indented(this);
+
+		indented.printFields(type->_fieldMembers);
+		indented.printLiterals(type->_enumMembers);
+		indented.printMacros(type->_macros);
+		indented.printUDTs(type->_subUDTs);
+	}
+
+	printIndent();
+	printf("}\n");
+
+	return DDR_RC_OK;
+}

--- a/ddr/lib/ddr-ir/TypedefUDT.cpp
+++ b/ddr/lib/ddr-ir/TypedefUDT.cpp
@@ -36,17 +36,12 @@ TypedefUDT::acceptVisitor(const TypeVisitor &visitor)
 	return visitor.visitTypedef(this);
 }
 
-bool
-TypedefUDT::insertUnique(Symbol_IR *ir)
+const string &
+TypedefUDT::getSymbolKindName() const
 {
-	// FIXME remove this method?
-	return UDT::insertUnique(ir);
-}
+	static const string typedefKind("");
 
-string
-TypedefUDT::getSymbolKindName()
-{
-	return "";
+	return typedefKind;
 }
 
 size_t

--- a/ddr/lib/ddr-ir/UnionUDT.cpp
+++ b/ddr/lib/ddr-ir/UnionUDT.cpp
@@ -36,10 +36,12 @@ UnionUDT::acceptVisitor(const TypeVisitor &visitor)
 	return visitor.visitUnion(this);
 }
 
-string
-UnionUDT::getSymbolKindName()
+const string &
+UnionUDT::getSymbolKindName() const
 {
-	return "union";
+	static const string unionKind("union");
+
+	return unionKind;
 }
 
 bool

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -48,6 +48,14 @@ DDR_RC getOptions(OMRPortLibrary *portLibrary, int argc, char *argv[], const cha
 	const char **blobFile, const char **overrideListFile, vector<string> *debugFiles, const char **blacklistFile, bool *printEmptyTypes);
 DDR_RC readFileList(OMRPortLibrary *portLibrary, const char *debugFileList, vector<string> *debugFiles);
 
+#undef DEBUG_PRINT_TYPES
+
+#if defined(DEBUG_PRINT_TYPES)
+#include "ddr/ir/TypePrinter.hpp"
+
+static const TypePrinter printer(TypePrinter::FIELDS | TypePrinter::LITERALS | TypePrinter::MACROS);
+#endif /* DEBUG_PRINT_TYPES */
+
 int
 main(int argc, char *argv[])
 {
@@ -102,11 +110,27 @@ main(int argc, char *argv[])
 	Symbol_IR ir;
 	if ((DDR_RC_OK == rc) && !debugFiles.empty()) {
 		rc = scanner.startScan(&portLibrary, &ir, &debugFiles, blacklistFile);
+
+#if defined(DEBUG_PRINT_TYPES)
+		printf("== scan results ==\n");
+		for (vector<Type *>::const_iterator type = ir._types.begin();
+				(DDR_RC_OK == rc) && (type != ir._types.end()); ++type) {
+			(*type)->acceptVisitor(printer);
+		}
+#endif /* DEBUG_PRINT_TYPES */
 	}
 
 	if (DDR_RC_OK == rc) {
 		/* Remove duplicate types. */
 		ir.removeDuplicates();
+
+#if defined(DEBUG_PRINT_TYPES)
+		printf("== after removing duplicates ==\n");
+		for (vector<Type *>::const_iterator type = ir._types.begin();
+				(DDR_RC_OK == rc) && (type != ir._types.end()); ++type) {
+			(*type)->acceptVisitor(printer);
+		}
+#endif /* DEBUG_PRINT_TYPES */
 	}
 
 	/* Read macros. */


### PR DESCRIPTION
Fix
* promote _enumMembers from ClassType to NamespaceUDT
* collect literals of a nested anonymous enum in enclosing namespace

Cleanup
* change signature of Type::getSymbolKindName()
* check that IO operations are successful
* remove unnecessary #include directives
* remove useless method TypedefUDT::insertUnique()
* manage printing type header in JavaSupersetGenerator
* extract common code for visiting class and union types

Addition
* add TypePrinter for debugging (currently disabled)

This should be the final OMR change required to enable https://github.com/eclipse/openj9/issues/378 on Linux.