### PR TITLE
Eliminate return, reason codes from Return IL nodes

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -3131,44 +3131,6 @@ OMR::Node::getFirstArgumentIndex()
    return 0;
    }
 
-
-
-TR::Node *
-OMR::Node::getReturnReason()
-   {
-   return self()->getReturnCode(true);
-   }
-
-TR::Node *
-OMR::Node::getReturnCode(bool isReason)
-   {
-   TR::Compilation *c = TR::comp();
-   TR::Node *codeChild = NULL;
-   TR::Node *reasonChild = NULL;
-
-   if (!self()->getOpCode().isReturn())
-      return NULL;
-
-   // just return code
-   else if (self()->getOpCodeValue() == TR::ireturn &&
-            self()->getNumChildren() == 1)
-      codeChild = self()->getChild(0);
-
-   // return code and return reason
-   else if ((self()->getOpCodeValue() == TR::Return) &&
-            (self()->getNumChildren() == 2 ||
-             (self()->getNumChildren() == 3 &&
-              self()->getChild(2)->getOpCodeValue() == TR::GlRegDeps)))
-      {
-      codeChild = self()->getChild(0);
-      reasonChild = self()->getChild(1);
-      }
-
-   return isReason ? reasonChild : codeChild;
-   }
-
-
-
 uint32_t
 OMR::Node::getSize()
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -521,9 +521,6 @@ public:
    inline TR::Node *      getArgument(int32_t index);
    inline TR::Node *      getFirstArgument();
 
-   TR::Node *             getReturnCode(bool isReason=false);
-   TR::Node *             getReturnReason();
-
    uint32_t               getSize();
    uint32_t               getRoundedSize();
 

--- a/compiler/ras/IlVerifierHelpers.hpp
+++ b/compiler/ras/IlVerifierHelpers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,9 +71,6 @@ class AllIlVerifier : public TR::IlVerifier
 /**
  * Throws an exception after IL verification. This allows
  * a test to skip codegen, but still verify the optimized IL.
- * Since this exception will cause a different return code to
- * be returned, #getReturnCode can be used to get the actual
- * return code.
  */
 class NoCodegenVerifier : public TR::IlVerifier
    {
@@ -117,15 +114,6 @@ class NoCodegenVerifier : public TR::IlVerifier
     * @return `true` if the verifier was run, otherwise `false`.
     */
    bool hasRun() const { return _hasRun; }
-
-   /**
-    * Get the true return code of a compilation. Since #verify throws an
-    * exception, the compilation does not return the true return code.
-    *
-    * @param result The compilation return code.
-    * @return The true return code.
-    */
-   int32_t getReturnCode() const { return _rc; }
 
    private:
    TR::IlVerifier *_ilVerifier;

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1092,23 +1092,7 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * CAARegister = NULL;
    TR::Linkage * linkage = cg->getS390Linkage();
 
-   // Some asm macros in epilog can kill return code and reason registers.
-   // defer loading constants to avoid caching these values around the macros
-   bool returnCodeDeferred = false;
-   bool returnReasonDeferrred = false;
-   if (linkage->checkEpilogKillsReturnCodeReason())
-      {
-      TR::Node *returnCode = node->getReturnCode();
-      TR::Node *returnReason = node->getReturnReason();
-      if (returnCode && returnCode->getOpCode().isLoadConst())
-         returnCodeDeferred = true;
-      if (returnReason && returnReason->getOpCode().isLoadConst())
-         returnReasonDeferrred = true;
-      }
-
-   if ((node->getOpCodeValue() != TR::Return)
-         && !returnCodeDeferred
-          )
+   if (node->getOpCodeValue() != TR::Return)
       returnValRegister = cg->evaluate(node->getFirstChild());
 
    // GRA needs to tell LRA about the register type

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -397,7 +397,6 @@ enum TR_DispatchType
    virtual void setUsedRegisters(TR::Instruction *instruction, bool *regs, int32_t regsSize);
    virtual bool checkPreservedRegisterUsage(bool *regs, int32_t regsSize);
    virtual void replaceCallWithJumpInstruction(TR::Instruction *callInstruction);
-   virtual bool checkEpilogKillsReturnCodeReason() { return false; }
 
    TR::InstOpCode::Mnemonic getOpCodeForLinkage(TR::Node * child, bool isStore, bool isRegReg);
    TR::InstOpCode::Mnemonic getRegCopyOpCodeForLinkage(TR::Node * child);

--- a/fvtest/compilertest/tests/OptTestDriver.cpp
+++ b/fvtest/compilertest/tests/OptTestDriver.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,7 +72,6 @@ void TestCompiler::OptTestDriver::Verify()
    TR::Optimizer::setMockStrategy(NULL);
 
    ASSERT_EQ(true, noCodegenVerifier.hasRun()) << "Did not run verifiers.";
-   ASSERT_EQ(0, noCodegenVerifier.getReturnCode()) << "One or more verifiers failed.";
    }
 
 /**


### PR DESCRIPTION
Remove OMR::Node::getReturnCode(...) and OMR::Node::getReturnReason(...)
Remove checkEpilogKillsReturnCodeReason() from z/codegen/OMRLinkage.hpp

Closes: #2314 

Signed-off-by: Shivam Mittal <shivammittal99@gmail.com>