### PR TITLE
Use sed instead of grep

### DIFF
--- a/omrmakefiles/rules.mk
+++ b/omrmakefiles/rules.mk
@@ -210,11 +210,11 @@ $(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -P $< -Fi $@
 endef
 else
 define DDR_C_COMMAND
-$(CC) $(CFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -E $< | grep '^@' > $@
+$(CC) $(CFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -E $< | sed -n -e '/^@/p' > $@
 endef
 
 define DDR_CPP_COMMAND
-$(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -E $< | grep '^@' > $@
+$(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -E $< | sed -n -e '/^@/p' > $@
 endef
 endif
 


### PR DESCRIPTION
Unlike grep, sed won't fail if there are no matching lines. Even though make is ignoring such failures, build logs are cluttered with noise like this:

```
../../omrmakefiles/rules.mk:400: recipe for target 'BaseVirtual.i' failed
make[9]: [BaseVirtual.i] Error 1 (ignored)
```

Improves upon https://github.com/eclipse/omr/pull/2366.