### PR TITLE
Fix  error: '/*' within block comment for CLang 6.0.0 for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,9 @@ Testing/
 Debug/
 gc/example/Debug/
 omr_test/Debug/
+port/*/omrsyslogmessages.h
+port/*/omrsyslogmessages.rc
+port/*/MSG00001.bin
 port/omrsyslogmessages.h
 port/omrsyslogmessages.rc
 port/MSG00001.bin

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -180,8 +180,8 @@ WIN32_WINNT version constants :
 #define _WIN32_WINNT_WIN7                   0x0601
 #define _WIN32_WINNT_WIN8                   0x0602
 #define _WIN32_WINNT_WINBLUE                0x0603
-#define _WIN32_WINNT_WINTHRESHOLD           0x0A00 /* ABRACADABRA_THRESHOLD * /
-#define _WIN32_WINNT_WIN10                  0x0A00 /* ABRACADABRA_THRESHOLD * /
+#define _WIN32_WINNT_WINTHRESHOLD           0x0A00 / * ABRACADABRA_THRESHOLD * /
+#define _WIN32_WINNT_WIN10                  0x0A00 / * ABRACADABRA_THRESHOLD * /
 */
 
 	if (NULL == PPG_si_osType) {


### PR DESCRIPTION
While the project is being built using CLang as the compiler on Windows, the following error appears:

```
C:\omr\port\win32\omrsysinfo.c(184,52):  error: '/*' within block comment [-Werror,-Wcomment]
#define _WIN32_WINNT_WIN10                  0x0A00 /* ABRACADABRA_THRESHOLD * /
```

It seems the compilator just ignores the `-Wno-comment` flag as well as the `-Wno-error=comment` one.

The following version of the toolchain is used:

```bash
clang-cl --version
clang version 6.0.0 (tags/RELEASE_600/final)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\llvm\bin
```

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>