### PR TITLE
[skip ci] Document how to build OMR on Windows using CMake

### DIFF
--- a/doc/BuildingWithCMake.md
+++ b/doc/BuildingWithCMake.md
@@ -54,6 +54,99 @@ CMake can generate build files for a number of backends. You can select the gene
 available generators with `--help`. We recommend using with the `Ninja` generator, when available. More information is
 available [here](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
 
+### Configuring the build on Windows
+
+There are three widely used C/C++ toolchains for Windows: *MSYS2/MinGW*, *Microsoft Visual Studio* and *LLVM/Clang*.
+Let's consider how to use each toolchain to configure and build `OMR` with `CMake`.
+
+#### Common prerequisite
+
+*Perl* must be installed to configure the project. [Strawberry Perl](http://strawberryperl.com/) is absolutely
+suitable for `CMake` on Windows, please do not forget to add the path to `perl.exe` (for example 
+`C:\StrawberryPerl\perl\bin`) to the `PATH` environment variable.
+
+#### Configuring the build for using MSYS2/MinGW
+
+The code of `OMR` uses the Microsoft extension to `C` for supporting *Windows Structured Exception Handling
+([SEH](https://msdn.microsoft.com/library/windows/desktop/ms680657))*. *MinGW* haven't supported it
+for a long time. Some workarounds exist but none of them is suitable to use in production-quality software.
+
+#### Configuring the build for using Visual Studio Build Tools
+
+*Visual Studio Build Tools* is a bundle with a standalone compiler, libraries and scripts to build C++ libraries and
+applications targeting Windows desktop. The [build tools](http://landinghub.visualstudio.com/visual-cpp-build-tools)
+are available for download on Microsoft's website.
+
+The following components of the build tools are recommended to be installed:
+
+ * Windows 10 SDK (>= 10.0.16299.0) for Desktop C++
+ * Visual C++ tools for CMake
+
+**Note:** 
+To use the `NMake` or `Ninja` generator with *Visual C++*, `cmake` must be run from a shell that can use 
+the compiler `cl` from the command line as it described in the document
+[Build C/C++ code on the command line](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line).
+To enable the shell, please run
+`C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat [platform]` where `platform`
+can be one of the following options: `x86_amd64`, `x86_arm uwp`, `x86_arm onecore`, `x64 8.1` or `x64 store 8.1`.
+
+**Note:**
+If you wish to build the `DDR` component, `CMake` should be able to find the path to the `DIA SDK`. There are two ways to specify
+the path:
+
+ * Create the `VSSDK140Install` environment variable and set its value to the path to the *Visual Studio Build Tools* installation,
+for example, `C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools`.
+
+ * Create the `DIASDK` environment variable and set its value to the path to the `DIA SDK` folder itself, for example,
+`C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK`.
+
+Then, to configure the build, let's do this:
+
+```bash
+# always prefer building outside the source tree
+mkdir -p build && cd build
+
+# configure the build using Ninja
+cmake -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl .. -G"Ninja"
+
+# ... or using NMake
+cmake -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl .. -G"NMake Makefiles"
+
+# ... and build it
+cmake --build .
+```
+
+#### Configuring the build for using Clang
+
+*Clang* is released as part of regular *LLVM* releases. You can download the release versions from the
+[LLVM Download Page](http://releases.llvm.org/download.html). *Clang* attempts to be compatible with *MSVC* and provides a
+special version of compiler: `clang-cl`. A good news is here: the compiler can be used to build `OMR` for Windows.
+
+**Note:**
+`clang-cl` requires the same libraries and tools as `MSVC` does, so the
+[previous section](#configuring-the-build-for-using-visual-studio-build-tools) should be taken into account:
+*Visual Studio Build Tools* must be installed and `cmake` must be run from the *Visual Studio Command Prompt* (`vcvarsall.bat`).
+The `PATH` environment variable has to contain the `clang-cl` location.
+
+After preparing the environment, let's do this:
+
+```bash
+# always prefer building outside the source tree
+mkdir -p build && cd build
+
+# configure the build using Ninja
+cmake -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl .. -G"Ninja"
+
+# ... or using NMake
+cmake -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl .. -G"NMake Makefiles"
+
+# ... and build it
+cmake --build .
+```
+
+Please note that `Clang` is more rigorous than `MSVC` and generates much more warnings and occasionally even can not
+compile the code that correctly compiled by using its sibling from Microsoft.
+
 ### Major feature flags
 
 Compilation of major components is controlled with the following On/Off flags:


### PR DESCRIPTION
It's not clear enough how to build OMR on Microsoft Windows. The
following questions appear:

 * Which toolchain to use: there are as least three wide used
   toolchains on the market: MinGW, Visual Studio Build Tools and
   LLVM/Clang so a new developer might be confused a bit why some
   source files won't be compiled by using the picked toolchain.

 * How to get the common prerequisite on the Windows platform, perl,
   that is required to configure and build OMR using CMake.

 * How to specify the picked compiler, linker and generator for CMake
   and more important why does CMake usually can't find the required
   tools ('rc', for example) and standard libraries (kernel32.lib and
   so on).

 * How to let CMake find the path to the DIA SDK that is required to
   build the DDR component.

The answers to these questions are added to 'doc/BuildingWithCMake.md'.

Closes: #2370
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>