### PR TITLE
CMake: Fix DDR on Windows building using Clang

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -79,3 +79,13 @@ set(PASM_FLAGS -x assembler-with-cpp -E -P)
 
 set(SPP_CMD ${CMAKE_C_COMPILER})
 set(SPP_FLAGS -x assembler-with-cpp -E -P)
+
+# Configure the platform dependent library for multithreading
+# We dont actually have a clang config and use gnu on non-Windows,
+# so we have to detect Apple Clang here.
+# see ../../OmrDetectSystemInformation.cmake
+if(CMAKE_C_COMPILER_ID MATCHES "^(Apple)?Clang$")
+	set(OMR_PLATFORM_THREAD_LIBRARY pthread)
+else()
+	set(OMR_PLATFORM_THREAD_LIBRARY -pthread)
+endif()

--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -69,6 +69,9 @@ elseif(OMR_ENV_DATA32)
 	)
 endif(OMR_ENV_DATA64)
 
+# Configure the platform dependent library for multithreading
+set(OMR_PLATFORM_THREAD_LIBRARY Ws2_32.lib)
+
 macro(omr_toolconfig_global_setup)
 	# Make sure we are building without incremental linking
 	omr_remove_flags(CMAKE_EXE_LINKER_FLAGS    /INCREMENTAL)

--- a/cmake/modules/platform/toolcfg/verify.cmake
+++ b/cmake/modules/platform/toolcfg/verify.cmake
@@ -20,3 +20,4 @@
 #############################################################################
 
 omr_assert(WARNING TEST DEFINED OMR_WARNING_AS_ERROR_FLAG)
+omr_assert(FATAL_ERROR TEST DEFINED OMR_PLATFORM_THREAD_LIBRARY)

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -96,3 +96,6 @@ list(APPEND TR_C_COMPILE_OPTIONS
 
 set(SPP_CMD ${CMAKE_C_COMPILER})
 set(SPP_FLAGS -E -P)
+
+# Configure the platform dependent library for multithreading
+set(OMR_PLATFORM_THREAD_LIBRARY -lpthread)

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -315,14 +315,4 @@ target_link_libraries(j9thrstatic
 	omrutil
 )
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-	target_link_libraries(j9thrstatic -pthread)
-elseif(CMAKE_C_COMPILER_ID MATCHES "^(Apple)?Clang$")
-	target_link_libraries(j9thrstatic pthread)
-elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-	target_link_libraries(j9thrstatic Ws2_32.lib)
-elseif(CMAKE_C_COMPILER_ID STREQUAL "XL")
-	target_link_libraries(j9thrstatic -lpthread)
-else()
-	message(FATAL_ERROR "OMR: Unknown compiler ID: '${CMAKE_C_COMPILER_ID}'")
-endif()
+target_link_libraries(j9thrstatic ${OMR_PLATFORM_THREAD_LIBRARY})


### PR DESCRIPTION
When `clang-cl` is used as a C/C++ compiler on Windows to build OMR, CMake attempts to link `DDR` with the `pthread` library and the following error appears:

```bash
lld-link: error: could not open pthread.lib: no such file or directory
```

This commit fixes the error.

In order to improve code readability, a refactoring of system information detection was applied: a new CMake variable is introduced: `OMR_PLATFORM_THREAD_LIBRARY`. A corresponding value is assigned to the variable in a `cmake/modules/platform/toolcfg/${OMR_TOOLCONFIG}` file. This refactoring allows developers just to include the platform dependent thread library to a `target_link_libraries` invocation if the developed component should be linked with the thread library.

**Warning:** The following code is put to `gnu.cmake`:

```cmake
# we dont actually have a clang config and use gnu on non-Windows,
# so we have to detect Apple Clang here.
# see ../../OmrDetectSystemInformation.cmake
if(CMAKE_C_COMPILER_ID MATCHES "^(Apple)?Clang$")
       set(THREAD_LIBRARY pthread)
else()
       set(THREAD_LIBRARY -pthread)
endif()
```

This code should work on all non-Windows platforms when `clang` is used since we have no `clang.cmake` - a file with `Clang` config. I've tried to build `OMR` on Linux using `Clang 5` but builds fail - no working linker configuration, so even the `tracegen` tool hasn't been linked. I think a separated configuration for `Clang` is required.

Tested on `gcc/Linux` and `Clang/Windows` as well as `MSVC/Windows` **Must be tested** on `XLC` and `Clang/MacOS X`.

Closes: #2377
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>