### PR TITLE
fvtest: Fix comparison between pointers and zero error

### DIFF
--- a/fvtest/porttest/omrfilestreamTest.cpp
+++ b/fvtest/porttest/omrfilestreamTest.cpp
@@ -998,7 +998,7 @@ TEST(PortFileStreamTest, omrfilestream_test_long_file_name)
 
 		/* Reopen the same file, read back what we wrote (verifying the contents), and close the file */
 		fd = omrfile_open(filePathName, EsOpenRead, 0444);
-		if (file < 0) {
+		if (fd < 0) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_open() returned error, expected valid file handle\n", -1);
 			goto unlinkFile;
 		}


### PR DESCRIPTION
When `clang` is used for compilation `fvtest`, the following error occurs:

```bash
..\fvtest\porttest\omrfilestreamTest.cpp(1001,12):  error: ordered
comparison between pointer and zero ('OMRFileStream *' (aka '_iobuf *')
and 'int')
if (file < 0) {
```

It seems the code of `..\fvtest\porttest\omrfilestreamTest.cpp(1001,12)`
contains a typo:

```c
fd = omrfile_open(filePathName, EsOpenRead, 0444);
if (file < 0) { // !!!the typo is here!!!
	outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_open() returned error,
expected valid file handle\n", -1);
	goto unlinkFile;
}
```

The construction `if (file < 0) {` changed to the `if (fd < 0) {` one to
match the 'open the file and check the file descriptor' pattern.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>