### PR TITLE
Fix index out-of-bound for _loaFreeRatioHistory[]

### DIFF
--- a/gc/base/MemoryPoolLargeObjects.cpp
+++ b/gc/base/MemoryPoolLargeObjects.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -378,7 +378,7 @@ MM_MemoryPoolLargeObjects::calculateTargetLOARatio(MM_EnvironmentBase* env, uint
 	/*
 	 * shift elements to make room for current loa free Ratio
 	 */
-	for (int i = _extensions->loaFreeHistorySize; i > 0 ; i--){
+	for (int i = _extensions->loaFreeHistorySize - 1; i > 0 ; i--){
 		_loaFreeRatioHistory[i] = _loaFreeRatioHistory[i-1];
 	}
 	if (0 == _loaSize) {


### PR DESCRIPTION
Run with memory check detected malloc'ed memory violation. It relates to
write to _loaFreeRatioHistory[] out-of-bound. This problem was
reproduced locally and it is confirmed that fix solved the issue.

Closed #2381

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>