### PR TITLE
Fix incorrect return value from AtomicFetchAndAdd

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3651,7 +3651,7 @@ TR::Register* OMR::X86::TreeEvaluator::performSimpleAtomicMemoryUpdate(TR::Node*
    TR::Register* result  = cg->allocateRegister();
 
    generateRegRegInstruction(MOVRegReg(), node, result, value, cg);
-   generateMemRegInstruction(op, node, generateX86MemoryReference(address, 0, cg), value, cg);
+   generateMemRegInstruction(op, node, generateX86MemoryReference(address, 0, cg), result, cg);
 
    node->setRegister(result);
    cg->decReferenceCount(node->getChild(0));


### PR DESCRIPTION
AtomicFetchAndAdd returns incorrect result, fixing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>