### PR TITLE
Make memory reference separate index register for PackedDecimal

### DIFF
--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2123,6 +2123,9 @@ TR::Instruction * generateVSIInstruction(
                       TR::MemoryReference    * mr ,
                       uint8_t                  imm3)  /* 8 bits */
    {
+   TR_ASSERT_FATAL(mr != NULL, "NULL memory reference for VSI instruction\n");
+   mr->separateIndexRegister(n, cg, true, NULL);
+
    return new (INSN_HEAP) TR::S390VSIInstruction(cg, op, n, reg, mr, imm3);
    }
 


### PR DESCRIPTION
In memory reference constructor, if the load/store is a packed decimal
load/store and when vector VSI instructions are used, the index register
need to be handled separately by an intermediate LA instruction because
VSI instructions don't support index registers.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>