### PR TITLE
Tenure Heap Recycling

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -222,6 +222,8 @@ public:
 
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	MM_Scavenger *scavenger;
+	void *_masterThreadTenureTLHRemainderBase;  /**< base and top pointers of the last unused tenure TLH copy cache, that will be loaded to thread env during master setup */
+	void *_masterThreadTenureTLHRemainderTop;
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
 	J9Pool* environments;
@@ -1219,6 +1221,8 @@ public:
 		, _tenureSize(0)
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		, scavenger(NULL)
+		, _masterThreadTenureTLHRemainderBase(NULL)
+		, _masterThreadTenureTLHRemainderTop(NULL)
 #endif /* OMR_GC_MODRON_SCAVENGER */
 		, environments(NULL)
 #if defined(OMR_GC_CONCURRENT_SWEEP)

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -335,6 +335,19 @@ MM_ParallelGlobalGC::cleanupAfterGC(MM_EnvironmentBase *env, MM_AllocateDescript
 
 	/* Heap size now fixed for next cycle so reset heap statistics */
 	_extensions->heap->resetHeapStatistics(true);
+
+	GC_OMRVMThreadListIterator threadIterator(_extensions->getOmrVM());
+	OMR_VMThread *walkThread = NULL;
+
+	/* Null tenure TLH (Copy Cache) references for all GC slave and Mutator (for concurrent scavenger) threads as the memory will be invalidated on sweep cycle*/
+	while((walkThread = threadIterator.nextOMRVMThread()) != NULL) {
+		MM_EnvironmentStandard *threadEnvironment = MM_EnvironmentStandard::getEnvironment(walkThread);
+		threadEnvironment->_tenureTLHRemainderBase = NULL;
+		threadEnvironment->_tenureTLHRemainderTop = NULL;
+	}
+
+	_extensions->_masterThreadTenureTLHRemainderTop = NULL;
+	_extensions->_masterThreadTenureTLHRemainderBase = NULL;
 }
 
 void

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -145,6 +145,8 @@ public:
 	 * Function members
 	 */
 private:
+	void saveMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
+	void restoreMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
 	void setBackOutFlag(MM_EnvironmentBase *env, BackOutState value);
 	MMINLINE bool isBackOutFlagRaised() { return _extensions->isScavengerBackOutFlagRaised(); }
 	MMINLINE bool shouldAbortScanLoop() {
@@ -359,9 +361,8 @@ public:
 	/**
 	 * Called (typically at the end of GC) to explicitly abandon the TLH remainders (for the calling thread)
 	 */
-	void abandonTLHRemainders(MM_EnvironmentStandard *env);
 	void abandonSurvivorTLHRemainder(MM_EnvironmentStandard *env);
-	void abandonTenureTLHRemainder(MM_EnvironmentStandard *env);
+	void abandonTenureTLHRemainder(MM_EnvironmentStandard *env, bool preserveRemainders = false);
 
 	void reportGCStart(MM_EnvironmentStandard *env);
 	void reportGCEnd(MM_EnvironmentStandard *env);


### PR DESCRIPTION
Changes to preserve TLH remainders (scavenger copy cache) for reserved memory which can be reused for subsequent GCs. That is, references to the base and top of allocated TLH are saved (where appropriate) upon abandon.

This effectively reduces the tenure heap consumption, savings depend on 2 factors:
- Thread count
- Tenuring rate

For this reason, savings vary from negligible to magnitude of order lower tenure consumption rate. For instance, high tenuring (from non-generational workload) and low GC thread count results in lower savings, and opposite, very generational workload (low tenuring rate) with high GC thread count results in high savings.
 
For concurrent scavenger, we obtain additional savings from mutator threads as they create copy caches through a read barrier.
 
Additionally, some simplifications were done - the explicit copy cache flushing at the beginning of the 2nd STW phase of CS cycle was removed as it is already implicity done by VMinterface code

Signed-off-by: Salman Rana <salman.rana@ibm.com>