### PR TITLE
Fix bug in KnowledgeLevel

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3746,15 +3746,15 @@ bool TR_IndirectCallSite::hasFixedTypeArgInfo()
 bool TR_IndirectCallSite::hasResolvedTypeArgInfo()
    {
    return _ecsPrexArgInfo && _ecsPrexArgInfo->get(0) &&
-      _ecsPrexArgInfo->get(0)->classIsPreexistent() && _ecsPrexArgInfo->get(0)->getFixedClass();
+      _ecsPrexArgInfo->get(0)->classIsPreexistent() && _ecsPrexArgInfo->get(0)->getClass();
    }
 
 TR_OpaqueClassBlock* TR_IndirectCallSite::getClassFromArgInfo()
    {
    TR_ASSERT(_ecsPrexArgInfo && _ecsPrexArgInfo->get(0) &&
-         _ecsPrexArgInfo->get(0)->getFixedClass(), "getClassFromArgInfo is NOT guarded by hasFixedTypeArgInfo,hasResolvedTypeArgInfo");
+         _ecsPrexArgInfo->get(0)->getClass(), "getClassFromArgInfo is NOT guarded by hasFixedTypeArgInfo,hasResolvedTypeArgInfo");
 
-   return _ecsPrexArgInfo->get(0)->getFixedClass();
+   return _ecsPrexArgInfo->get(0)->getClass();
    }
 
 bool TR_IndirectCallSite::tryToRefineReceiverClassBasedOnResolvedTypeArgInfo(TR_InlinerBase* inliner)
@@ -6285,11 +6285,11 @@ void TR_InlinerTracer::dumpPrexArgInfo(TR_PrexArgInfo* argInfo)
 
       {
       TR_PrexArgument* arg = argInfo->get(i);
-      if (arg && arg->getFixedClass())
+      if (arg && arg->getClass())
          {
-         char* className = TR::Compiler->cls.classSignature(comp(), arg->getFixedClass(), trMemory());
+         char* className = TR::Compiler->cls.classSignature(comp(), arg->getClass(), trMemory());
          traceMsg( comp(),  "<Argument no=%d address=%p classIsFixed=%d classIsPreexistent=%d class=%p className= %s/>\n",
-         i, arg, arg->classIsFixed(), arg->classIsPreexistent(), arg->getFixedClass(), className);
+         i, arg, arg->classIsFixed(), arg->classIsPreexistent(), arg->getClass(), className);
          }
       else
          {

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -7260,7 +7260,7 @@ int32_t TR_InvariantArgumentPreexistence::perform()
                TR_ASSERT(((*sig == 'L') || (*sig == '[')), "non address argument cannot be fixed/preexistent");
 
                parmInfo.setSymbol(p);
-               TR_OpaqueClassBlock *clazz = arg->getFixedClass();
+               TR_OpaqueClassBlock *clazz = arg->getClass();
                if (clazz)
                   {
                   TR_ASSERT(classIsFixed, "assertion failure");
@@ -7372,7 +7372,7 @@ int32_t TR_InvariantArgumentPreexistence::perform()
                {
                if (arg->classIsFixed())
                   {
-                  symbol->setFixedType(arg->getFixedClass());
+                  symbol->setFixedType(arg->getClass());
                   if (trace())
                      traceMsg(comp(), "PREX:      Parm %d symbol [%p] has fixed type %p\n", index, symbol, symbol->getFixedType());
                   }

--- a/compiler/optimizer/PreExistence.cpp
+++ b/compiler/optimizer/PreExistence.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@ TR_PrexArgument::knowledgeLevel(TR_PrexArgument *pa)
       return NONE;
    else if (pa->hasKnownObjectIndex())
       return KNOWN_OBJECT;
-   else if (pa->getFixedClass())
+   else if (pa->classIsFixed())
       return FIXED_CLASS;
    else if (pa->classIsPreexistent())
       return PREEXISTENT;
@@ -48,7 +48,7 @@ TR_PrexArgument::TR_PrexArgument(
       TR::KnownObjectTable::Index knownObjectIndex,
       TR::Compilation *comp) :
    _classKind(ClassIsUnknown),
-   _fixedClass(0),
+   _class(0),
    _profiledClazz(0),
    _knownObjectIndex(knownObjectIndex)
    {
@@ -58,7 +58,7 @@ TR_PrexArgument::TR_PrexArgument(
 
    if (prexArgumentCriticalSection.hasVMAccess())
       {
-      _fixedClass = TR::Compiler->cls.objectClass(comp, comp->getKnownObjectTable()->getPointer(knownObjectIndex));
+      _class = TR::Compiler->cls.objectClass(comp, comp->getKnownObjectTable()->getPointer(knownObjectIndex));
       _classKind = ClassIsFixed;
       }
 #endif

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -53,7 +53,7 @@ class TR_PrexArgument
          TR_OpaqueClassBlock *profiledClazz = 0,
          bool p = false) :
       _classKind(classKind),
-      _fixedClass(clazz),
+      _class(clazz),
       _profiledClazz(profiledClazz),
       _knownObjectIndex(TR::KnownObjectTable::UNKNOWN)
       { }
@@ -68,7 +68,7 @@ class TR_PrexArgument
    void setClassIsFixed(TR_OpaqueClassBlock *fixedClass=0, TR_OpaqueClassBlock *profiledClazz=0)
       {
       _classKind     = ClassIsFixed;
-      _fixedClass    = fixedClass;
+      _class    = fixedClass;
       _profiledClazz = profiledClazz;
       }
 
@@ -76,7 +76,7 @@ class TR_PrexArgument
 
    bool usedProfiledInfo() { return _profiledClazz != NULL; }
 
-   TR_OpaqueClassBlock *getFixedClass() { return _fixedClass;    }
+   TR_OpaqueClassBlock *getClass() { return _class;    }
    TR_OpaqueClassBlock *getFixedProfiledClass() { return _profiledClazz; }
 
    TR::KnownObjectTable::Index getKnownObjectIndex() { return _knownObjectIndex; }
@@ -89,7 +89,7 @@ class TR_PrexArgument
    // optionally provided - when ClassIsFixed and the type is known to be
    // more specialized and different from the declared type
    //
-   TR_OpaqueClassBlock  *_fixedClass;
+   TR_OpaqueClassBlock  *_class;
    TR_OpaqueClassBlock  *_profiledClazz;
 
    // optionally provided - when ObjectIsKnown


### PR DESCRIPTION
KnowledgeLevel returns FIXED_CLASS if getFixedClass, which returns
_fixedClass, is not null. This wrong because _fixedClass and
getFixedClass() in TR_PrexArgument are used to store and get the class
of the argument regardless of its kind. This change will fix
KnowledgeLevel and use _class and getClass() to avoid misleading.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>