### PR TITLE
Add comments to JIT BinaryCommutativeAnalyser files for ARM

### DIFF
--- a/compiler/arm/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/arm/codegen/BinaryCommutativeAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,6 +18,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*
+ * This file is not currently used in ARM JIT
+ */
 
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"

--- a/compiler/arm/codegen/BinaryCommutativeAnalyser.hpp
+++ b/compiler/arm/codegen/BinaryCommutativeAnalyser.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,6 +18,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+/*
+ * This file is not currently used in ARM JIT
+ */
 
 #ifndef ARMBINARYCOMMUTATIVEANALYSER_INCL
 #define ARMBINARYCOMMUTATIVEANALYSER_INCL


### PR DESCRIPTION
BinaryCommutativeAnalyser.hpp and .cpp for ARM are not currently used
from anywhere.  This commit adds comments to those files instead of
removing them entirely from the repository.

Signed-off-by: knn-k <konno@jp.ibm.com>