### PR TITLE
Add stubs for new omrsig functions

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1367,27 +1367,33 @@ typedef struct OMRPortLibrary {
 	const char *(*nls_lookup_message)(struct OMRPortLibrary *portLibrary, uintptr_t flags, uint32_t module_name, uint32_t message_num, const char *default_string) ;
 	/** see @ref omrportcontrol.c::omrport_control "omrport_control"*/
 	int32_t (*port_control)(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t value) ;
-	/** see @ref omrsig.c::omrsig_startup "omrsig_startup"*/
+	/** see @ref omrsignal.c::omrsig_startup "omrsig_startup"*/
 	int32_t (*sig_startup)(struct OMRPortLibrary *portLibrary) ;
-	/** see @ref omrsig.c::omrsig_shutdown "omrsig_shutdown"*/
+	/** see @ref omrsignal.c::omrsig_shutdown "omrsig_shutdown"*/
 	void (*sig_shutdown)(struct OMRPortLibrary *portLibrary) ;
-	/** see @ref omrsig.c::omrsig_protect "omrsig_protect"*/
+	/** see @ref omrsignal.c::omrsig_protect "omrsig_protect"*/
 	int32_t (*sig_protect)(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void *fn_arg, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, uintptr_t *result) ;
-	/** see @ref omrsig.c::omrsig_can_protect "omrsig_can_protect"*/
+	/** see @ref omrsignal.c::omrsig_can_protect "omrsig_can_protect"*/
 	int32_t (*sig_can_protect)(struct OMRPortLibrary *portLibrary,  uint32_t flags) ;
-	/** see @ref omrsig.c::omrsig_set_async_signal_handler "omrsig_set_async_signal_handler"*/
-	uint32_t (*sig_set_async_signal_handler)(struct OMRPortLibrary *portLibrary,  omrsig_handler_fn handler, void *handler_arg, uint32_t flags) ;
-	/** see @ref omrsig.c::omrsig_info "omrsig_info"*/
+	/** see @ref omrsignal.c::omrsig_set_async_signal_handler "omrsig_set_async_signal_handler"*/
+	uint32_t (*sig_set_async_signal_handler)(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags) ;
+	/** see @ref omrsignal.c::omrsig_set_single_async_signal_handler "omrsig_set_single_async_signal_handler"*/
+	void *(*sig_set_single_async_signal_handler)(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag) ;
+	/** see @ref omrsignal.c::omrsig_map_os_signal_to_portlib_signal "omrsig_map_os_signal_to_portlib_signal"*/
+	uint32_t (*sig_map_os_signal_to_portlib_signal)(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue) ;
+	/** see @ref omrsignal.c::omrsig_map_portlib_signal_to_os_signal "omrsig_map_portlib_signal_to_os_signal"*/
+	int32_t (*sig_map_portlib_signal_to_os_signal)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag) ;
+	/** see @ref omrsignal.c::omrsig_info "omrsig_info"*/
 	uint32_t (*sig_info)(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value) ;
-	/** see @ref omrsig.c::omrsig_info_count "omrsig_info_count"*/
+	/** see @ref omrsignal.c::omrsig_info_count "omrsig_info_count"*/
 	uint32_t (*sig_info_count)(struct OMRPortLibrary *portLibrary, void *info, uint32_t category) ;
-	/** see @ref omrsig.c::omrsig_set_options "omrsig_set_options"*/
+	/** see @ref omrsignal.c::omrsig_set_options "omrsig_set_options"*/
 	int32_t (*sig_set_options)(struct OMRPortLibrary *portLibrary, uint32_t options) ;
-	/** see @ref omrsig.c::omrsig_get_options "omrsig_get_options"*/
+	/** see @ref omrsignal.c::omrsig_get_options "omrsig_get_options"*/
 	uint32_t (*sig_get_options)(struct OMRPortLibrary *portLibrary) ;
-	/** see @ref omrsig.c::omrsig_get_current_signal "omrsig_get_current_signal"*/
+	/** see @ref omrsignal.c::omrsig_get_current_signal "omrsig_get_current_signal"*/
 	intptr_t (*sig_get_current_signal)(struct OMRPortLibrary *portLibrary) ;
-	/** see @ref omrsig.c::omrsig_set_reporter_priority "omrsig_set_reporter_priority"*/
+	/** see @ref omrsignal.c::omrsig_set_reporter_priority "omrsig_set_reporter_priority"*/
 	int32_t (*sig_set_reporter_priority)(struct OMRPortLibrary *portLibrary, uintptr_t priority) ;
 	/** see @ref omrfile.c::omrfile_read_text "omrfile_read_text"*/
 	char  *(*file_read_text)(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, intptr_t nbytes) ;
@@ -1874,6 +1880,9 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsig_protect(param1,param2,param3,param4,param5,param6) privateOmrPortLibrary->sig_protect(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5), (param6))
 #define omrsig_can_protect(param1) privateOmrPortLibrary->sig_can_protect(privateOmrPortLibrary, (param1))
 #define omrsig_set_async_signal_handler(param1,param2,param3) privateOmrPortLibrary->sig_set_async_signal_handler(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsig_set_single_async_signal_handler(param1,param2,param3) privateOmrPortLibrary->sig_set_single_async_signal_handler(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsig_map_os_signal_to_portlib_signal(param1) privateOmrPortLibrary->sig_map_os_signal_to_portlib_signal(privateOmrPortLibrary, (param1))
+#define omrsig_map_portlib_signal_to_os_signal(param1) privateOmrPortLibrary->sig_map_portlib_signal_to_os_signal(privateOmrPortLibrary, (param1))
 #define omrsig_info(param1,param2,param3,param4,param5) privateOmrPortLibrary->sig_info(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
 #define omrsig_info_count(param1,param2) privateOmrPortLibrary->sig_info_count(privateOmrPortLibrary, (param1), (param2))
 #define omrsig_set_options(param1) privateOmrPortLibrary->sig_set_options(privateOmrPortLibrary, (param1))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -215,6 +215,9 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsig_protect,  /* sig_protect */
 	omrsig_can_protect, /* sig_can_protect */
 	omrsig_set_async_signal_handler, /* sig_set_async_signal_handler */
+	omrsig_set_single_async_signal_handler, /* sig_set_single_async_signal_handler */
+	omrsig_map_os_signal_to_portlib_signal, /* sig_map_os_signal_to_portlib_signal */
+	omrsig_map_portlib_signal_to_os_signal, /* sig_map_portlib_signal_to_os_signal */
 	omrsig_info, /* sig_info */
 	omrsig_info_count, /* sig_info_count */
 	omrsig_set_options, /* sig_set_options */

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -166,9 +166,57 @@ omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void
  * @return 0 on success
  */
 uint32_t
-omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary,  omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
+omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
 	return 1;
+}
+
+
+/*
+ * @brief Similar to omrsig_set_async_signal_handler. Refer to omrsig_set_async_signal_handler's description above.
+ * Differences: 1) one omrsig_handler_fn handler is registered with a signal at any time instead of multiple handlers.
+ * 2) The old OS handler is returned on success and NULL is returned on failure instead of returning 0 on success and
+ * non-zero on failure. TODO: Add a detailed description once implementation is done.
+ *
+ * @param[in] portLibrary The port library
+ * @param[in] handler the function to call if an asynchronous signal arrives
+ * @param[in] handler_arg the argument to handler
+ * @param[in] portlibSignalFlag port library signal flag
+ *
+ * @return old OS handler on success or NULL on failure
+ */
+void *
+omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag)
+{
+	return NULL;
+}
+
+/*
+ * @brief Given an OS signal value, return the corresponding port library signal flag.
+ *
+ * @param[in] portLibrary The port library
+ * @param[in] osSignalValue OS signal value
+ *
+ * @return port library signal flag on success and 0 on failure
+*/
+uint32_t
+omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue)
+{
+	return 0;
+}
+
+/*
+ * @brief Given a port library signal flag, return the corresponding OS signal value.
+ *
+ * @param[in] portLibrary The port library
+ * @param[in] portlibSignalFlag port library signal flag
+ *
+ * @return OS signal value on success and -1 on failure
+ */
+int32_t
+omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
+{
+	return -1;
 }
 
 /**

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -546,7 +546,13 @@ omrsig_set_options(struct OMRPortLibrary *portLibrary, uint32_t options);
 extern J9_CFUNC int32_t
 omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void *fn_arg, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, uintptr_t *result);
 extern J9_CFUNC uint32_t
-omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary,  omrsig_handler_fn handler, void *handler_arg, uint32_t flags);
+omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags);
+extern J9_CFUNC void *
+omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag);
+extern J9_CFUNC uint32_t
+omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue);
+extern J9_CFUNC int32_t
+omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag);
 extern J9_CFUNC uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -401,7 +401,7 @@ omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void 
 }
 
 uint32_t
-omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary,  omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
+omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
 	uint32_t rc = 0;
 	J9UnixAsyncHandlerRecord *cursor = NULL;
@@ -486,6 +486,24 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary,  omrsig_hand
 
 	Trc_PRT_signal_omrsig_set_async_signal_handler_exiting(handler, handler_arg, flags);
 	return rc;
+}
+
+void *
+omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag)
+{
+	return NULL;
+}
+
+uint32_t
+omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue)
+{
+	return 0;
+}
+
+int32_t
+omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
+{
+	return -1;
 }
 
 /*

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -177,6 +177,24 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 
 	return rc;
 
+}
+
+void *
+omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag)
+{
+	return NULL;
+}
+
+uint32_t
+omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue)
+{
+	return 0;
+}
+
+int32_t
+omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
+{
+	return -1;
 }
 
 int32_t

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -297,6 +297,24 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 	omrthread_monitor_exit(asyncMonitor);
 
 	return rc;
+}
+
+void *
+omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag)
+{
+	return NULL;
+}
+
+uint32_t
+omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue)
+{
+	return 0;
+}
+
+int32_t
+omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
+{
+	return -1;
 }
 
 int32_t

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -549,6 +549,24 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handl
 
 	Trc_PRT_signal_omrsig_set_async_signal_handler_exiting(handler, handler_arg, flags);
 	return rc;
+}
+
+void *
+omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag)
+{
+	return NULL;
+}
+
+uint32_t
+omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue)
+{
+	return 0;
+}
+
+int32_t
+omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
+{
+	return -1;
 }
 
 /*


### PR DESCRIPTION
Stubs have been added for the following new `omrsig` functions:
1) `omrsig_set_single_async_signal_handler`
2) `omrsig_map_os_signal_to_portlib_signal`
3) `omrsig_map_portlib_signal_to_os_signal`

File `omrsig.c` doesn't exist. Instead, functions are defined in 
`omrsignal.c`. Update comments to use `omrsignal.c` instead of 
`omrsig.c`.

OMR Issue: https://github.com/eclipse/omr/issues/2332

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>