### PR TITLE
Fix for missing data snippet in trace log

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -252,7 +252,7 @@ OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator * cg, TR::CodeGenP
 
       traceMsg(comp,"<snippets>");
       comp->getDebug()->print(comp->getOutFile(), cg->getSnippetList());
-      traceMsg(comp,"</snippets>\n");
+      traceMsg(comp,"\n</snippets>\n");
 
       auto iterator = cg->getSnippetList().begin();
       int32_t estimatedSnippetStart = cg->getEstimatedSnippetStart();

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2703,12 +2703,11 @@ TR_Debug::dumpMixedModeDisassembly()
 
       print(pOutFile, inst);
       }
-   trfprintf(pOutFile,"\n");
-   trfprintf(pOutFile,"</instructions>\n");
+   trfprintf(pOutFile,"\n</instructions>\n");
 
    trfprintf(pOutFile,"<snippets>");
    print(pOutFile, _comp->cg()->getSnippetList());
-   trfprintf(pOutFile,"</snippets>\n");
+   trfprintf(pOutFile,"\n</snippets>\n");
    }
 
 

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -798,7 +798,6 @@ public:
    int32_t printIntConstant(TR::FILE *pOutFile, int64_t value, int8_t radix, TR_RegisterSizes size = TR_WordReg, bool padWithZeros = false);
    int32_t printDecimalConstant(TR::FILE *pOutFile, int64_t value, int8_t width, bool padWithZeros);
    int32_t printHexConstant(TR::FILE *pOutFile, int64_t value, int8_t width, bool padWithZeros);
-   int32_t printFPConstant(TR::FILE *pOutFile, void *value, int8_t numBits, bool printAsBytes = false);
    void printInstructionComment(TR::FILE *pOutFile, int32_t tabStops, TR::Instruction *instr);
    void printFPRegisterComment(TR::FILE *pOutFile, TR::Register *target, TR::Register *source);
    void printMemoryReferenceComment(TR::FILE *pOutFile, TR::MemoryReference *mr);

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -105,12 +105,23 @@ TR_Debug::print(TR::FILE *pOutFile, TR::IA32DataSnippet * snippet)
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet));
    printPrefix(pOutFile, NULL, bufferPos, snippet->getDataSize());
 
-   trfprintf(pOutFile, "%s \t%s", snippet->getDataSize() == 8 ?
-                 dqString() :
-                 (snippet->getDataSize() == 4 ?
-                  ddString() :
-                  dwString()),
-                 hexPrefixString());
+   const char* toString;
+   switch (snippet->getDataSize())
+      {
+      case 8:
+         toString = dqString();
+         break;
+      case 4:
+         toString = ddString();
+         break;
+      case 2:
+         toString = dwString();
+         break;
+      default:
+         toString = dbString();
+         break;
+      }
+   trfprintf(pOutFile, "%s \t%s", toString, hexPrefixString());
 
    for (int i=snippet->getDataSize()-1; i >= 0; i--)
      {

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3596,8 +3596,6 @@ void OMR::X86::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * 
       }
    }
 
-#if DEBUG
-
 void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
 
@@ -3607,7 +3605,7 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    TR::IA32DataSnippet              * cursor;
    int32_t                                  size;
 
-   for (int exp=3; exp > 0; exp--)
+   for (int exp=4; exp > 0; exp--)
       {
       size = 1 << exp;
       for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
@@ -3620,7 +3618,6 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
       }
    }
 
-#endif
 #if defined(DEBUG)
 // Dump the instruction before FP register assignment to
 // reveal the virtual registers prior to stack register assignment.

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -521,9 +521,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void dumpPreGPRegisterAssignment(TR::Instruction *);
    void dumpPostGPRegisterAssignment(TR::Instruction *, TR::Instruction *);
 #endif
-#ifdef DEBUG
+
    void dumpDataSnippets(TR::FILE *pOutFile);
-#endif
 
    TR::IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c);
    TR::IA32ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c);

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -1560,10 +1560,18 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
          {
          printIntConstant(pOutFile, (int32_t)disp, 16, TR_WordReg, true);
          }
+      else if (cds)
+         {
+         trfprintf(pOutFile, "DATA SNIPPET: ");
+         auto data = cds->getValue();
+         for (auto i = 0; i < cds->getDataSize(); i++)
+            {
+            trfprintf(pOutFile, "%02x ", 0xff & (unsigned int)(data[i]));
+            }
+         }
       else
          {
-         trfprintf(pOutFile, "FPRCONSTANT");
-         //         printFPConstant(pOutFile, void *value, int8_t numBits);
+         trfprintf(pOutFile, "UNKNOWN DATA");
          }
       }
 
@@ -1731,12 +1739,6 @@ TR_Debug::getImmediateSizeFromInstruction(TR::Instruction  *instr)
       immedSize = TR_WordReg;
 
    return immedSize;
-   }
-
-int32_t
-TR_Debug::printFPConstant(TR::FILE *pOutFile, void *value, int8_t numBits, bool printAsBytes)
-   {
-   return 0;
    }
 
 void


### PR DESCRIPTION
Data snippet was not properly printed in trace
log, fixing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>