### PR TITLE
Enable DDR on Windows

### DIFF
--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -28,10 +28,10 @@
 #include <vector>
 
 #if defined(WIN32) || defined(WIN64)
-/* windows.h defined uintptr_t.  Ignore its definition */
+/* windows.h defines UDATA: Ignore its definition. */
 #define UDATA UDATA_win_
 #include "dia2.h"
-#undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
+#undef UDATA /* this is safe because our UDATA is a typedef, not a macro */
 #endif
 
 #include "ddr/ir/ClassUDT.hpp"
@@ -53,8 +53,7 @@ typedef struct PostponedType
 	string name;
 } PostponedType;
 
-
-class PdbScanner: public Scanner
+class PdbScanner : public Scanner
 {
 public:
 	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir,
@@ -65,7 +64,7 @@ private:
 	unordered_map<string, Type *> _typeMap;
 	vector<PostponedType> _postponedFields;
 
-	void addType(Type *type, bool addToIR);
+	void addType(UDT *type, NamespaceUDT *outerUDT);
 	DDR_RC addFieldMember(IDiaSymbol *symbol, ClassUDT *udt);
 	DDR_RC setBaseType(IDiaSymbol *typeSymbol, Type **type);
 	DDR_RC setBaseTypeFloat(ULONGLONG ulLen, Type **type);
@@ -81,20 +80,18 @@ private:
 
 	DDR_RC addChildrenSymbols(IDiaSymbol *symbol, enum SymTagEnum symTag, NamespaceUDT *outerUDT);
 	DDR_RC addEnumMembers(IDiaSymbol *diaSymbol, EnumUDT *e);
-	DDR_RC createClassUDT(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
+	DDR_RC createClassUDT(IDiaSymbol *symbol, ClassUDT **newClass, NamespaceUDT *outerUDT);
 	DDR_RC createEnumUDT(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
 	DDR_RC createTypedef(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
 	DDR_RC loadDataFromPdb(const wchar_t *filename, IDiaDataSource **diaDataSource, IDiaSession **diaSession, IDiaSymbol **diaSymbol);
 	DDR_RC setSuperClassName(IDiaSymbol *symbol, ClassUDT *newUDT);
-	void getNamespaceFromName(string *name, NamespaceUDT **outerUDT);
-	DDR_RC getName(IDiaSymbol *symbol, string *name);
-	DDR_RC getSize(IDiaSymbol *symbol, ULONGLONG *size);
-	Type *getType(string s);
-	string getUDTname(UDT *u);
+	void getNamespaceFromName(const string &name, NamespaceUDT **outerUDT);
+	static DDR_RC getName(IDiaSymbol *symbol, string *name);
+	static string getSimpleName(const string &name);
+	static DDR_RC getSize(IDiaSymbol *symbol, ULONGLONG *size);
+	Type *getType(const string &name);
 	void initBaseTypeList();
 	DDR_RC updatePostponedFieldNames();
-	void renameAnonymousTypes();
-	void renameAnonymousType(Type *type, ULONGLONG *unnamedTypeCount);
 };
 
 #endif /* PDBSCANNER_HPP */

--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -398,7 +398,9 @@ isNeededBy(UDT *type, const vector<Field *> &fields)
 {
 	bool referenced = true;
 
-	if (type->isAnonymousType()) {
+	if (type->_blacklisted) {
+		referenced = false;
+	} else if (type->isAnonymousType()) {
 		referenced = false;
 		for (vector<Field *>::const_iterator it = fields.begin(); it != fields.end(); ++it) {
 			if ((*it)->_fieldType == type) {
@@ -640,7 +642,7 @@ BlobBuildVisitor::visitNamespace(NamespaceUDT *ns) const
 		for (vector<UDT *>::const_iterator it = ns->_subUDTs.begin(); it != ns->_subUDTs.end(); ++it) {
 			UDT *nested = *it;
 
-			if (!nested->isAnonymousType()) {
+			if (!nested->_blacklisted && !nested->isAnonymousType()) {
 				rc = nested->acceptVisitor(builder);
 				if (DDR_RC_OK != rc) {
 					break;
@@ -984,7 +986,7 @@ BlobEnumerateVisitor::visitNamespace(NamespaceUDT *type) const
 		for (vector<UDT *>::const_iterator it = type->_subUDTs.begin(); it != type->_subUDTs.end(); ++it) {
 			UDT *nested = *it;
 
-			if (!nested->isAnonymousType()) {
+			if (!nested->_blacklisted && !nested->isAnonymousType()) {
 				rc = nested->acceptVisitor(*this);
 				if (DDR_RC_OK != rc) {
 					break;

--- a/ddr/lib/ddr-blobgen/java/genSuperset.cpp
+++ b/ddr/lib/ddr-blobgen/java/genSuperset.cpp
@@ -569,6 +569,11 @@ SupersetVisitor::visitComposite(ClassType *type, Type *superClass) const
 		for (vector<UDT *>::const_iterator it = type->_subUDTs.begin();
 				(DDR_RC_OK == rc) && (it != type->_subUDTs.end()); ++it) {
 			UDT *nested = *it;
+
+			if (nested->_blacklisted) {
+				continue;
+			}
+
 			bool includeSubUDT = true;
 
 			if (nested->isAnonymousType()) {
@@ -644,7 +649,7 @@ SupersetVisitor::visitNamespace(NamespaceUDT *type) const
 				(DDR_RC_OK == rc) && (v != type->_subUDTs.end()); ++v) {
 			UDT *nested = *v;
 
-			if (!nested->isAnonymousType()) {
+			if (!nested->_blacklisted && !nested->isAnonymousType()) {
 				rc = nested->acceptVisitor(*this);
 			}
 		}

--- a/ddr/lib/ddr-ir/TypePrinter.cpp
+++ b/ddr/lib/ddr-ir/TypePrinter.cpp
@@ -72,7 +72,7 @@ DDR_RC
 TypePrinter::visitType(Type *type) const
 {
 	printIndent();
-	printf("type '%s' size(%zu)\n", type->_name.c_str(), type->_sizeOf);
+	printf("type '%s' size(%lu)\n", type->_name.c_str(), (unsigned long)type->_sizeOf);
 	return DDR_RC_OK;
 }
 
@@ -80,10 +80,10 @@ DDR_RC
 TypePrinter::visitClass(ClassUDT *type) const
 {
 	printIndent();
-	printf("%s '%s' size(%zu)",
+	printf("%s '%s' size(%lu)",
 			type->_isClass ? "class" : "struct",
 			type->_name.c_str(),
-			type->_sizeOf);
+			(unsigned long)type->_sizeOf);
 	if (NULL != type->_superClass) {
 		printf(":  %s", type->_superClass->_name.c_str());
 	}
@@ -108,7 +108,7 @@ DDR_RC
 TypePrinter::visitEnum(EnumUDT *type) const
 {
 	printIndent();
-	printf("enum '%s' size(%zu) {\n", type->_name.c_str(), type->_sizeOf);
+	printf("enum '%s' size(%lu) {\n", type->_name.c_str(), (unsigned long)type->_sizeOf);
 
 	{
 		const TypePrinter indented(this);
@@ -155,7 +155,7 @@ DDR_RC
 TypePrinter::visitUnion(UnionUDT *type) const
 {
 	printIndent();
-	printf("union '%s' size(%zu) {\n", type->_name.c_str(), type->_sizeOf);
+	printf("union '%s' size(%lu) {\n", type->_name.c_str(), type->_sizeOf);
 
 	{
 		const TypePrinter indented(this);

--- a/ddr/tools/getmacros
+++ b/ddr/tools/getmacros
@@ -166,11 +166,14 @@ parse_namespace_policy_files() {
 
 			# Gather qualifying macro definitions.
 			# We use sed to replace tabs with spaces and trim trailing spaces
-			# to simplify patterns for grep and this script.
-			sed -e 's|\t| |g' -e 's| *$||' < ${f} \
-			| grep -E \
-				-e '@ddr_namespace: *(default|map_to_type=)' \
-				-e '^ *# *(define|undef) +[A-Za-z_]' \
+			# to simplify patterns for this script; it also filters out the
+			# bulk of irrelevant content.
+			sed -n < ${f} \
+				-e 's|\t| |g' \
+				-e 's| *$||' \
+				-e '/@ddr_namespace:/p' \
+				-e '/^ *# *define /p' \
+				-e '/^ *# *undef /p' \
 			| while read -r line; do
 				if [[ ${line} =~ ${default_regex} ]]; then
 					set_default_namespaces

--- a/gc/base/HeapRegionDescriptor.hpp
+++ b/gc/base/HeapRegionDescriptor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@
 class MM_MemoryPool;
 class MM_MemorySubSpace;
 class MM_HeapRegionManager;
+class MM_HeapRegionManagerTarok;
 class MM_EnvironmentBase;
 /**
  * Base abstract class for heap region descriptors.

--- a/gc/base/MemorySubSpace.hpp
+++ b/gc/base/MemorySubSpace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-
 #if !defined(MEMORYSUBSPACE_HPP_)
 #define MEMORYSUBSPACE_HPP_
 
@@ -34,6 +33,7 @@
 #include "MemorySpacesAPI.h"
 #include "ModronAssertions.h"
 
+class GC_MemorySubSpaceRegionIterator;
 class MM_AllocateDescription;
 class MM_AllocationContext;
 class MM_Collector;

--- a/gc/include/omrmm.hdf
+++ b/gc/include/omrmm.hdf
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	Copyright (c) 2014, 2016 IBM Corp. and others
+Copyright (c) 2014, 2018 IBM Corp. and others
 
-	This program and the accompanying materials are made available under
-	the terms of the Eclipse Public License 2.0 which accompanies this
-	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-	or the Apache License, Version 2.0 which accompanies this distribution and
-	is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-	This Source Code may also be made available under the following
-	Secondary Licenses when the conditions for such availability set
-	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-	General Public License, version 2 with the GNU Classpath 
-	Exception [1] and GNU General Public License, version 2 with the
-	OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-	[1] https://www.gnu.org/software/classpath/license.html
-	[2] http://openjdk.java.net/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
 
-	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 <interface>
 	<publicHeader>../../include_core/mmomrhook.h</publicHeader>
@@ -27,7 +27,6 @@
 	<description>Memory manager OMR hookable events</description>
 
 	<declarations>
-
 /*
  * @ddr_namespace: default
  */
@@ -35,8 +34,9 @@
 #include "omr.h"
 #include "objectdescription.h"
 
-typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uintptr_t componentType);
+struct MM_CommonGCData;
 
+typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uintptr_t componentType);
 	</declarations>
 
 	<event>
@@ -51,10 +51,10 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uintptr_t" name="globalGCCount" description="the count of global gc's" />
 		<data type="uintptr_t" name="localGCCount" description="the count of local gc's" />
 		<data type="uintptr_t" name="systemGC" description="flag to indicate if an explicit GC request" />
-		<data type="uintptr_t" name="aggressive" description="flag to indicate if this is a aggressive collect" /> 
+		<data type="uintptr_t" name="aggressive" description="flag to indicate if this is a aggressive collect" />
 		<data type="uintptr_t" name="bytesRequested" description="number of bytes requested" />
 	</event>
-	
+
 	<event>
 		<name>J9HOOK_MM_OMR_GLOBAL_GC_END</name>
 		<description>
@@ -132,7 +132,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 	<event>
 		<name>J9HOOK_MM_OMR_OOM_DUE_TO_SOFTMX</name>
 		<description>
-			Triggered when an OOM is about to occur due to the current softmx 
+			Triggered when an OOM is about to occur due to the current softmx
 		</description>
 		<struct>MM_SoftmxOOMEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
@@ -142,7 +142,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uintptr_t" name="currentSoftMX" description="The current value for softMX" />
 		<data type="uintptr_t" name="bytesRequired" description="The amount needed to expand by to avoid OOM" />
 	</event>
-	
+
 		<event>
 		<name>J9HOOK_MM_OMR_COMPACT_END</name>
 		<description>
@@ -153,7 +153,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="uintptr_t" name="eventid" description="unique identifier for event" />
 	</event>
-	
+
 	<event>
 		<name>J9HOOK_MM_OMR_GC_CYCLE_START</name>
 		<description>
@@ -166,7 +166,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="struct MM_CommonGCData*" name="commonData" description="common heap data" />
 		<data type="uintptr_t" name="cycleType" description="the type of cycle" />
 	</event>
-	
+
 	<event>
 		<name>J9HOOK_MM_OMR_GC_CYCLE_CONTINUE</name>
 		<description>
@@ -194,7 +194,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uintptr_t" name="cycleType" description="the type of cycle" />
 		<data type="condYieldFromGCFunctionPtr" name="condYieldFromGCFunction" description="Pointer to GC conditional yield function" />
 	</event>
-	
+
 		<event>
 		<name>J9HOOK_MM_OMR_INITIALIZED</name>
 		<description>
@@ -202,7 +202,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		</description>
 		<struct>MM_InitializedEvent</struct>
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
-		<data type="uint64_t" name="timestamp" description="time of event" />		
+		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="const char*" name="gcPolicy" description="-Xgcpolicy value" />
 		<data type="uintptr_t" name="concurrentScavenger" description="Scavenger running Concurrently flag" />
 		<data type="uintptr_t" name="maxHeapSize" description="-Xmx value" />
@@ -228,7 +228,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uintptr_t" name="regionCount" description="total heap region count" />
 		<data type="uintptr_t" name="arrayletLeafSize" description="arraylet leaf size" />
 	</event>
-	
+
 	<event>
 		<name>J9HOOK_MM_OMR_VERBOSE_GC_OUTPUT</name>
 		<description>
@@ -239,7 +239,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="const char*" name="string" description="the string output by verbose GC" />
 	</event>
-	
+
 	<event>
 		<name>J9HOOK_MM_OMR_EXCESSIVEGC_RAISED</name>
 		<description>
@@ -256,7 +256,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="float" name="triggerPercent" description="Minimum percentage which needs to be reclaimed; otherwise OOM raised" />
 		<data type="uintptr_t" name="excessiveLevel" description="The level of excessive gc, only fail to allocate on fatal level" />
 	</event>
-	
+
 	<event>
 		<name>J9HOOK_MM_OMR_OBJECT_DELETE</name>
 		<description>Report the deletion of an object. Hooking this event can significantly impact GC times.</description>
@@ -264,8 +264,8 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="struct OMR_VMThread *" name="currentThread" description="the current thread" />
 		<data type="omrobjectptr_t" name="object" description="the object which has been deleted." />
 		<data type="void*" name="heap" description="an opaque pointer to the heap the object belongs to" />
-	</event>	
-	
+	</event>
+
 	<event>
 		<name>J9HOOK_MM_OMR_OBJECT_RENAME</name>
 		<description>Report the relocation of an object. Hooking this event can significantly impact GC times.</description>
@@ -273,6 +273,6 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="struct OMR_VMThread *" name="currentThread" description="the current thread" />
 		<data type="omrobjectptr_t" name="oldObject" description="the old pointer to the object." />
 		<data type="omrobjectptr_t" name="newObject" description="the new pointer to the object." />
-	</event>	
+	</event>
 
 </interface>

--- a/omrmakefiles/rules.mk
+++ b/omrmakefiles/rules.mk
@@ -200,15 +200,6 @@ define CLEAN_COMMAND
 -$(RM) $(OBJECTS) $(OBJECTS:$(OBJEXT)=.i) *.d
 endef
 
-ifeq (win,$(OMR_HOST_OS))
-define DDR_C_COMMAND
-$(CC) $(CFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -P $< -Fi $@
-endef
-
-define DDR_CPP_COMMAND
-$(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -P $< -Fi $@
-endef
-else
 define DDR_C_COMMAND
 $(CC) $(CFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -E $< | sed -n -e '/^@/p' > $@
 endef
@@ -216,7 +207,6 @@ endef
 define DDR_CPP_COMMAND
 $(CC) $(CPPFLAGS) $(MODULE_CPPFLAGS) $(GLOBAL_CPPFLAGS) -E $< | sed -n -e '/^@/p' > $@
 endef
-endif
 
 ###
 ### Platform-Specific Options

--- a/thread/win32/dllmain.c
+++ b/thread/win32/dllmain.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,14 +25,13 @@
  * @ingroup Thread
  */
 
-
 #include <windows.h>
 #include <stdlib.h>
 #include "omrcfg.h"
 #include "omrcomp.h"
 #include "omrmutex.h"
-#include "thrtypes.h"
 #include "thrdsup.h"
+#include "thrtypes.h"
 
 extern void omrthread_init(J9ThreadLibrary *lib);
 extern void omrthread_shutdown(void);
@@ -50,21 +49,22 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserve
  * @return TRUE on success, FALSE on failure.
  */
 BOOL APIENTRY
-DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+DllMain(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
+	omrthread_library_t lib = NULL;
 
 	switch (ul_reason_for_call) {
-	case DLL_PROCESS_ATTACH: {
-		omrthread_library_t lib;
-
-		/* Disable DLL_THREAD_ATTACH and DLL_THREAD_DETACH notifications for WIN32*/
+	case DLL_PROCESS_ATTACH:
+		/* Disable DLL_THREAD_ATTACH and DLL_THREAD_DETACH notifications for WIN32. */
 		DisableThreadLibraryCalls(hModule);
 		lib = GLOBAL_DATA(default_library);
 		omrthread_init(lib);
 		return lib->initStatus == 1;
-	}
 	case DLL_PROCESS_DETACH:
 		omrthread_shutdown();
+		break;
+	default:
+		break;
 	}
 
 	return TRUE;


### PR DESCRIPTION
Most of the changes here are to `PdbSCanner`, the Windows-specific debug information extraction code:
* avoid premature typedef expansion
* fix handling of blacklisted types and namespaces
* add explicit cases for char and wchar_t (treat char as unsigned like other platforms)
* capture values of literals
* fix handling of anonymous types and namespaces
* fix postponed type resolution
* fix handling of nested blacklisted types
* fix nested anonymous enum types (promote literals of anonymous enum to enclosing scope)
* removed duplicate, unused getName() function
* removed redundant getUDTname() function
* removed renameAnonymousTypes() functions which are no longer useful
* add MSDIA120 to the list of supported libraries
* remove broken progress reporting
* general cleanup surrounding error conditions and propagation of errors
* fix printing of type sizes (Visual Studio doesn't support printf format "%zu")
* merge grep filtering into sed script
* use the same DDR commands on all platforms

Constant discover script `getmacros` doesn't work well with mutual including header files - needed to adjust the include order in dllmain.c to avoid losing constants from thrtypes.h.

Some clean up was required to GC header files that were missing proper forward declarations.
