### PR TITLE
Upgrade lint job environment on Travis CI to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,13 +77,15 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty
           packages:
             - bison
-            - clang-3.4
-            - libclang-3.4-dev
-            - llvm-3.4
-      env: RUN_LINT=yes RUN_BUILD=no SPEC=linux_x86-64 PLATFORM=amd64-linux64-gcc
-      dist: precise
+            - clang-3.8
+            - libclang-3.8-dev
+            - llvm-3.8
+            - llvm-3.8-dev
+      env: RUN_LINT=yes RUN_BUILD=no SPEC=linux_x86-64 PLATFORM=amd64-linux64-gcc LLVM_CONFIG=llvm-config-3.8 CLANG=clang++-3.8 CXX_PATH=clang++-3.8 CXX=clang++-3.8
+      dist: trusty
     ## CMake builds
     #  Ninja builds
     #  64 bit Linux x86


### PR DESCRIPTION
Currently, the OMRChecker lint job on Travis CI runs
in Precise. It is in the process of being decommisoned,
and the tentative official end of support for Precise
by Travis CI was April 1st 2018. This patch upgrades the
environment to Trusty, and also makes use of clang-3.8
instead of clang-3.4.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

[Travis CI Blog post regarding this matter](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status)