### PR TITLE
Clean up x/env/OMRCPU class and add missing supportsHLE()

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -107,18 +107,18 @@ namespace TR { class RegisterDependencyConditions; }
 
 TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
-void TR_X86ProcessorInfo::initialize(TR::Compilation *comp)
+void TR_X86ProcessorInfo::initialize()
    {
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
    // To retrieve other information, the VM functions can be called directly.
    //
-   _featureFlags.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags(comp));
-   _featureFlags2.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags2(comp));
-   _featureFlags8.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags8(comp));
+   _featureFlags.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags());
+   _featureFlags2.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags2());
+   _featureFlags8.set(TR::Compiler->target.cpu.getX86ProcessorFeatureFlags8());
 
    // Determine the processor vendor.
    //
-   const char *vendor = TR::Compiler->target.cpu.getX86ProcessorVendorId(comp);
+   const char *vendor = TR::Compiler->target.cpu.getX86ProcessorVendorId();
    if (!strncmp(vendor, "GenuineIntel", 12))
       _vendorFlags.set(TR_GenuineIntel);
    else if (!strncmp(vendor, "AuthenticAMD", 12))
@@ -135,7 +135,7 @@ void TR_X86ProcessorInfo::initialize(TR::Compilation *comp)
 
    // set up the processor family and cache description
 
-   uint32_t _processorSignature = TR::Compiler->target.cpu.getX86ProcessorSignature(comp);
+   uint32_t _processorSignature = TR::Compiler->target.cpu.getX86ProcessorSignature();
 
    if (isGenuineIntel())
       {
@@ -204,7 +204,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    {
 
    bool supportsSSE2 = false;
-   _targetProcessorInfo.initialize(comp);
+   _targetProcessorInfo.initialize();
 
    // Pick a padding table
    //
@@ -225,7 +225,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    //
 
 #if defined(TR_TARGET_X86) && !defined(J9HAMMER)
-   if (_targetProcessorInfo.supportsSSE2() && TR::Compiler->target.cpu.testOSForSSESupport(comp))
+   if (_targetProcessorInfo.supportsSSE2() && TR::Compiler->target.cpu.testOSForSSESupport())
       supportsSSE2 = true;
 #endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
 
@@ -279,7 +279,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    // 32-bit platforms must check the processor and OS.
    // 64-bit platforms unconditionally support prefetching.
    //
-   if (_targetProcessorInfo.supportsSSE() && TR::Compiler->target.cpu.testOSForSSESupport(comp))
+   if (_targetProcessorInfo.supportsSSE() && TR::Compiler->target.cpu.testOSForSSESupport())
 #endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
       {
       self()->setTargetSupportsSoftwarePrefetches();

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -169,6 +169,7 @@ struct TR_X86ProcessorInfo
    bool supportsSelfSnoop()                {return _featureFlags.testAny(TR_SelfSnoop);}
    bool supportsTM()                       {return _featureFlags8.testAny(TR_RTM);}
    bool supportsHyperThreading()           {return _featureFlags.testAny(TR_HyperThreading);}
+   bool supportsHLE()                      {return _featureFlags8.testAny(TR_HLE);}
    bool hasThermalMonitor()                {return _featureFlags.testAny(TR_ThermalMonitor);}
 
    bool supportsMFence()                   {return _featureFlags.testAny(TR_SSE2);}

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -221,7 +221,7 @@ private:
 
    friend class OMR::X86::CodeGenerator;
 
-   void initialize(TR::Compilation *);
+   void initialize();
    };
 
 enum TR_PaddingProperties

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -30,9 +30,6 @@
 TR_X86CPUIDBuffer *
 OMR::X86::CPU::queryX86TargetCPUID()
    {
-#ifdef J9_PROJECT_SPECIFIC
-   return NULL;
-#else
    static TR_X86CPUIDBuffer *buf = NULL;
    auto jitConfig = TR::JitConfig::instance();
 
@@ -71,7 +68,6 @@ OMR::X86::CPU::queryX86TargetCPUID()
       }
 
    return buf;
-#endif
    }
 
 const char *

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,8 +26,9 @@
 #include "env/ProcessorInfo.hpp"
 #include "x/runtime/X86Runtime.hpp"
 
+
 TR_X86CPUIDBuffer *
-OMR::X86::CPU::queryX86TargetCPUID(TR::Compilation *comp)
+OMR::X86::CPU::queryX86TargetCPUID()
    {
 #ifdef J9_PROJECT_SPECIFIC
    return NULL;
@@ -73,46 +74,45 @@ OMR::X86::CPU::queryX86TargetCPUID(TR::Compilation *comp)
 #endif
    }
 
-
 const char *
-OMR::X86::CPU::getX86ProcessorVendorId(TR::Compilation *comp)
+OMR::X86::CPU::getX86ProcessorVendorId()
    {
    static char buf[13];
 
    // Terminate the vendor ID with NULL before returning.
    //
-   strncpy(buf, self()->queryX86TargetCPUID(comp)->_vendorId, 12);
+   strncpy(buf, self()->queryX86TargetCPUID()->_vendorId, 12);
    buf[12] = '\0';
 
    return buf;
    }
 
 uint32_t
-OMR::X86::CPU::getX86ProcessorSignature(TR::Compilation *comp)
+OMR::X86::CPU::getX86ProcessorSignature()
    {
-   return self()->queryX86TargetCPUID(comp)->_processorSignature;
+   return self()->queryX86TargetCPUID()->_processorSignature;
    }
 
 uint32_t
-OMR::X86::CPU::getX86ProcessorFeatureFlags(TR::Compilation *comp)
+OMR::X86::CPU::getX86ProcessorFeatureFlags()
    {
-   return self()->queryX86TargetCPUID(comp)->_featureFlags;
+   return self()->queryX86TargetCPUID()->_featureFlags;
    }
 
 uint32_t
-OMR::X86::CPU::getX86ProcessorFeatureFlags2(TR::Compilation *comp)
+OMR::X86::CPU::getX86ProcessorFeatureFlags2()
    {
-   return self()->queryX86TargetCPUID(comp)->_featureFlags2;
+   return self()->queryX86TargetCPUID()->_featureFlags2;
    }
 
 uint32_t
-OMR::X86::CPU::getX86ProcessorFeatureFlags8(TR::Compilation *comp)
+OMR::X86::CPU::getX86ProcessorFeatureFlags8()
    {
-   return self()->queryX86TargetCPUID(comp)->_featureFlags8;
+   return self()->queryX86TargetCPUID()->_featureFlags8;
    }
 
 bool
-OMR::X86::CPU::testOSForSSESupport(TR::Compilation *comp)
+OMR::X86::CPU::testOSForSSESupport()
    {
    return false;
    }

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -54,14 +54,14 @@ protected:
 
 public:
 
-   TR_X86CPUIDBuffer *queryX86TargetCPUID(TR::Compilation *comp);
-   const char *getX86ProcessorVendorId(TR::Compilation *comp);
-   uint32_t getX86ProcessorSignature(TR::Compilation *comp);
-   uint32_t getX86ProcessorFeatureFlags(TR::Compilation *comp);
-   uint32_t getX86ProcessorFeatureFlags2(TR::Compilation *comp);
-   uint32_t getX86ProcessorFeatureFlags8(TR::Compilation *comp);
+   TR_X86CPUIDBuffer *queryX86TargetCPUID();
+   const char *getX86ProcessorVendorId();
+   uint32_t getX86ProcessorSignature();
+   uint32_t getX86ProcessorFeatureFlags();
+   uint32_t getX86ProcessorFeatureFlags2();
+   uint32_t getX86ProcessorFeatureFlags8();
 
-   bool testOSForSSESupport(TR::Compilation *comp);
+   bool testOSForSSESupport();
 
    };
 


### PR DESCRIPTION
- Remove unused parameter (TR::Compilation *comp)
- Add missing supportsHLE() to TR_X86ProcessorInfo
- Remove J9_PROJECT_SPECIFIC macro in OMR::X86::CPU::queryX86TargetCPUID()

Signed-off-by: Harry Yu <harryyu1994@gmail.com>