### PR TITLE
VRSb instruction memory reference needs separate index register

### DIFF
--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -3696,6 +3696,12 @@ generateS390MemoryReference(TR::Register * br, int32_t disp, TR::CodeGenerator *
 TR::MemoryReference *
 generateS390MemoryReference(TR::Node * node, TR::CodeGenerator * cg, bool canUseRX)
    {
+   // The TR::MemoryReference(TR::Node*, TR::CodeGenerator*, bool); constructor (below) is made for store or load nodes
+   // that have symbol references.
+   // A symbol reference is needed to adjust memory reference displacement (TR::MemoryReference::calcDisplacement).
+   // If the node has no sym ref, this memory reference's gets a NULL symbol reference, which can lead to crashes in displacement
+   // calculations.
+   TR_ASSERT(node->getOpCode().hasSymbolReference(), "Memory reference generation API needs a node with symbol reference\n");
    return new (cg->trHeapMemory()) TR::MemoryReference(node, cg, canUseRX);
    }
 

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2071,6 +2071,7 @@ TR::Instruction *
 generateVRSbInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * targetReg, TR::Register * sourceReg, TR::MemoryReference * mr,
                         uint8_t mask4 /* 4 bits */)
    {
+   mr->separateIndexRegister(n, cg, true, NULL);
    return new (INSN_HEAP) TR::S390VRSbInstruction(cg, op, n, targetReg, sourceReg, mr, mask4);
    }
 


### PR DESCRIPTION
This pull request contains two commits:

1. The VRSb instruction format does not support index fields.
Fix the generateVRSbInstruction() API so it separates the memory
references index register. 

2.  Add an assert check to make sure the right node is used to generate memory reference. 
The generateS390MemoryReference(TR::Node*, TR::CodeGenerator*,bool)
API uses a constructor that handles load and store nodes with symbol
references. If the node has a no symbol reference, the compiler can crash in binary encoding.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>