### PR TITLE
Share result temps for primitive return values

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3329,7 +3329,7 @@ TR::TreeTop * OMR_InlinerUtil::storeValueInATemp(
              value->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer()))
          isInternalPointer = true;
 
-      if ((value->isNotCollected() && dataType != TR::Aggregate) || isIndirect)
+      if ((value->isNotCollected() && dataType == TR::Address) || isIndirect)
          {
          TR::SymbolReference *valueRef;
          if (tempSymRef!=NULL)


### PR DESCRIPTION
Starting in ade5a1cc, isNotCollected() returns true for primitives,
which causes this conditional to assign them all fresh temporaries.