### PR TITLE
Prepare redundant goto elim for post-GRA requests

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -702,7 +702,7 @@ OMR::Block::findVirtualGuardBlock(TR::CFG *cfg)
    }
 
 void
-OMR::Block::changeBranchDestination(TR::TreeTop * newDestination, TR::CFG *cfg)
+OMR::Block::changeBranchDestination(TR::TreeTop * newDestination, TR::CFG *cfg, bool callerFixesRegdeps)
    {
 
    TR::Node * branchNode = self()->getLastRealTreeTop()->getNode();
@@ -725,6 +725,9 @@ OMR::Block::changeBranchDestination(TR::TreeTop * newDestination, TR::CFG *cfg)
       }
 
    cfg->removeEdge(prevEdge);
+
+   if (callerFixesRegdeps)
+      return;
 
    int32_t numChildren = branchNode->getNumChildren();
    if (numChildren >0 &&

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -204,7 +204,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    // change the target of the branch in the block, add an edge to the new block,
    // remove the edge from the previous destination block and update any GlRegDep Nodes
    //
-   void changeBranchDestination(TR::TreeTop * newDestination,  TR::CFG *cfg);
+   void changeBranchDestination(TR::TreeTop * newDestination,  TR::CFG *cfg, bool callerFixesRegdeps = false);
 
    TR::Node * findFirstReference(TR::Symbol * sym, vcount_t visitCount);
    void collectReferencedAutoSymRefsIn(TR::Compilation *comp, TR_BitVector *, vcount_t);

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -158,6 +158,7 @@ private:
    void renumberInAncestors(TR_Structure *str, int32_t newNumber);
    void renumberExitEdges(TR_RegionStructure *region, int32_t oldN, int32_t newN);
    void redirectPredecessors(TR::Block *block, TR::Block *destBlock, const TR::CFGEdgeList &preds, bool emptyBlock, bool asyncMessagesFlag);
+   void fixPredecessorRegDeps(TR::Node *regdepsParent, TR::Block *destBlock);
    };
 
 /*

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -157,6 +157,7 @@ private:
    void placeAsyncCheckBefore(TR::TreeTop *);
    void renumberInAncestors(TR_Structure *str, int32_t newNumber);
    void renumberExitEdges(TR_RegionStructure *region, int32_t oldN, int32_t newN);
+   void redirectPredecessors(TR::Block *block, TR::Block *destBlock, const TR::CFGEdgeList &preds, bool asyncMessagesFlag);
    };
 
 /*

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -157,7 +157,7 @@ private:
    void placeAsyncCheckBefore(TR::TreeTop *);
    void renumberInAncestors(TR_Structure *str, int32_t newNumber);
    void renumberExitEdges(TR_RegionStructure *region, int32_t oldN, int32_t newN);
-   void redirectPredecessors(TR::Block *block, TR::Block *destBlock, const TR::CFGEdgeList &preds, bool asyncMessagesFlag);
+   void redirectPredecessors(TR::Block *block, TR::Block *destBlock, const TR::CFGEdgeList &preds, bool emptyBlock, bool asyncMessagesFlag);
    };
 
 /*


### PR DESCRIPTION
Some very late passes of global dead store elimination and dead trees
elimination in openj9 can create opportunities for redundant goto
elimination after GRA (global register allocation). This series updates
redundant goto elimination so that it works on blocks that have register
dependencies, and then makes dead trees elimination request it on
promising blocks. This way it's possible to add an "if enabled" pass of
redundant goto elimination that only looks at blocks where these
opportunities are likely to have been created.