### PR TITLE
AArch64: Provide some core extensible class stubs

### DIFF
--- a/compiler/aarch64/CMakeLists.txt
+++ b/compiler/aarch64/CMakeLists.txt
@@ -1,0 +1,26 @@
+#################################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+compiler_library(aarch64
+# Target files
+	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRCodeGenerator.cpp
+	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRMachine.cpp
+)

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+﻿/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,27 +19,30 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_CODEGENERATOR_INCL
-#define TR_CODEGENERATOR_INCL
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/RegisterConstants.hpp"
 
-#include "codegen/OMRCodeGenerator.hpp"
-#include "infra/Annotations.hpp"
-
-namespace TR { class Compilation; }
-
-namespace TR
-{
-
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
+OMR::ARM64::CodeGenerator::CodeGenerator() :
+      OMR::CodeGenerator()
    {
-public:
+   }
 
-   /**
-    * @param[in] comp : the TR::Compilaation object
-    */
-   CodeGenerator(TR::Compilation *comp) :
-      OMR::CodeGeneratorConnector() {}
-   };
-}
+void
+OMR::ARM64::CodeGenerator::beginInstructionSelection()
+   {
+   }
 
-#endif
+void
+OMR::ARM64::CodeGenerator::endInstructionSelection()
+   {
+   }
+
+void
+OMR::ARM64::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
+   {
+   }
+
+void
+OMR::ARM64::CodeGenerator::doBinaryEncoding()
+   {
+   }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_ARM64_CODEGENERATOR_INCL
+#define OMR_ARM64_CODEGENERATOR_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_CODEGENERATOR_CONNECTOR
+#define OMR_CODEGENERATOR_CONNECTOR
+namespace OMR { namespace ARM64 { class CodeGenerator; } }
+namespace OMR { typedef OMR::ARM64::CodeGenerator CodeGeneratorConnector; }
+#else
+#error OMR::ARM64::CodeGenerator expected to be a primary connector, but an OMR connector is already defined
+#endif
+
+#include "compiler/codegen/OMRCodeGenerator.hpp"
+
+#include "codegen/RegisterConstants.hpp"
+#include "infra/Annotations.hpp"
+
+namespace OMR
+{
+
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+   {
+
+public:
+
+   CodeGenerator();
+
+   /**
+    * @brief AArch64 hook to begin instruction selection
+    */
+   void beginInstructionSelection();
+
+   /**
+    * @brief AArch64 hook to end instruction selection
+    */
+   void endInstructionSelection();
+
+   /**
+    * @brief AArch64 local register assignment pass
+    *
+    * @param[in] kindsToAssign : mask of register kinds to assign in this pass
+    *
+    * @return : none
+    */
+   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
+
+   /**
+    * @brief AArch64 binary encoding pass
+    */
+   void doBinaryEncoding();
+
+   };
+
+}
+
+}
+
+#endif

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+﻿/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,27 +19,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_CODEGENERATOR_INCL
-#define TR_CODEGENERATOR_INCL
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/Machine.hpp"
 
-#include "codegen/OMRCodeGenerator.hpp"
-#include "infra/Annotations.hpp"
-
-namespace TR { class Compilation; }
-
-namespace TR
-{
-
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
+OMR::ARM64::Machine::Machine(TR::CodeGenerator *cg) :
+      OMR::Machine(cg)
    {
-public:
 
-   /**
-    * @param[in] comp : the TR::Compilaation object
-    */
-   CodeGenerator(TR::Compilation *comp) :
-      OMR::CodeGeneratorConnector() {}
-   };
-}
-
-#endif
+   }

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,27 +19,48 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_CODEGENERATOR_INCL
-#define TR_CODEGENERATOR_INCL
+#ifndef OMR_ARM64_MACHINE_INCL
+#define OMR_ARM64_MACHINE_INCL
 
-#include "codegen/OMRCodeGenerator.hpp"
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
+namespace OMR { namespace ARM64 { class Machine; } }
+namespace OMR { typedef OMR::ARM64::Machine MachineConnector; }
+#else
+#error OMR::ARM64::Machine expected to be a primary connector, but an OMR connector is already defined
+#endif
+
+#include "compiler/codegen/OMRMachine.hpp"
+
 #include "infra/Annotations.hpp"
 
-namespace TR { class Compilation; }
+namespace TR { class CodeGenerator; }
 
-namespace TR
+
+namespace OMR
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE Machine : public OMR::Machine
    {
+
 public:
 
    /**
-    * @param[in] comp : the TR::Compilaation object
+    * @param[in] cg : the TR::CodeGenerator object
     */
-   CodeGenerator(TR::Compilation *comp) :
-      OMR::CodeGeneratorConnector() {}
+   Machine(TR::CodeGenerator *cg);
+
+private:
+
+   TR::CodeGenerator *_cg;
+
    };
 }
-
+}
 #endif

--- a/compiler/aarch64/codegen/OMRRealRegister.hpp
+++ b/compiler/aarch64/codegen/OMRRealRegister.hpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_ARM64_REAL_REGISTER_INCL
+#define OMR_ARM64_REAL_REGISTER_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_REAL_REGISTER_CONNECTOR
+#define OMR_REAL_REGISTER_CONNECTOR
+   namespace OMR { namespace ARM64 { class RealRegister; } }
+   namespace OMR { typedef OMR::ARM64::RealRegister RealRegisterConnector; }
+#else
+   #error OMR::ARM64::RealRegister expected to be a primary connector, but an OMR connector is already defined
+#endif
+
+#include "compiler/codegen/OMRRealRegister.hpp"
+#include "infra/Annotations.hpp"
+
+namespace TR { class CodeGenerator; }
+
+
+namespace OMR
+{
+
+namespace ARM64
+{
+
+class OMR_EXTENSIBLE RealRegister : public OMR::RealRegister
+   {
+protected:
+
+   /**
+    * @param[in] cg : the TR::CodeGenerator object
+    */
+   RealRegister(TR::CodeGenerator *cg) : OMR::RealRegister(cg, NoReg) {}
+
+   /**
+    * @param[in] rk : kind of real register from TR_RegisterKinds
+    * @param[in] w : register weight
+    * @param[in] s : register state from RegState
+    * @param[in] rn : register number from RegNum
+    * @param[in] m : register mask from RegMask
+    * @param[in] cg : the TR::CodeGenerator object
+    */
+   RealRegister(TR_RegisterKinds rk, uint16_t w, RegState s, RegNum rn, RegMask m, TR::CodeGenerator *cg) :
+          OMR::RealRegister(rk, w, s, (uint16_t)0, rn, m, cg) {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/compiler/arm/codegen/OMRMachine.hpp
+++ b/compiler/arm/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,14 +25,12 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
-
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace ARM { class Machine; } }
 namespace OMR { typedef OMR::ARM::Machine MachineConnector; }
-
 #else
-#error OMR::ARM::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::ARM::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRMachine.hpp"

--- a/compiler/codegen/Machine.hpp
+++ b/compiler/codegen/Machine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_MACHINE_INCL
-#define OMR_MACHINE_INCL
+#ifndef TR_MACHINE_INCL
+#define TR_MACHINE_INCL
 
-#include "codegen/OMRMachine.hpp"  // for MachineBaseConnector
+#include "codegen/OMRMachine.hpp"
 
 namespace TR { class CodeGenerator; }
 

--- a/compiler/codegen/OMRMachine.hpp
+++ b/compiler/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,14 +19,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_MACHINE_BASE_INCL
-#define OMR_MACHINE_BASE_INCL
+#ifndef OMR_MACHINE_INCL
+#define OMR_MACHINE_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { class Machine; }
 namespace OMR { typedef OMR::Machine MachineConnector; }
 #endif

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,12 +25,12 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace Power { class Machine; } }
 namespace OMR { typedef OMR::Power::Machine MachineConnector; }
 #else
-#error OMR::Power::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Power::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRMachine.hpp"

--- a/compiler/x/amd64/codegen/OMRMachine.hpp
+++ b/compiler/x/amd64/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,12 +25,12 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace X86 { namespace AMD64 { class Machine; } } }
 namespace OMR { typedef OMR::X86::AMD64::Machine MachineConnector; }
 #else
-#error OMR::X86::AMD64::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::X86::AMD64::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "x/codegen/OMRMachine.hpp"

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,8 +22,8 @@
 #ifndef OMR_X86_MACHINE_INCL
 #define OMR_X86_MACHINE_INCL
 
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace X86 { class Machine; } }
 namespace OMR { typedef OMR::X86::Machine MachineConnector; }
 #endif

--- a/compiler/x/i386/codegen/OMRMachine.hpp
+++ b/compiler/x/i386/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace X86 { namespace I386 { class Machine; } } }
 namespace OMR { typedef OMR::X86::I386::Machine MachineConnector; }
 #else

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,17 +19,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_Z_MACHINEBASE_INCL
-#define OMR_Z_MACHINEBASE_INCL
+#ifndef OMR_Z_MACHINE_INCL
+#define OMR_Z_MACHINE_INCL
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR {namespace Z { class Machine; } }
 namespace OMR { typedef OMR::Z::Machine MachineConnector; }
 #else
-#error OMR::Z::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Z::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRMachine.hpp"


### PR DESCRIPTION
* Stub out some initial AArch64 code generator extensible classes
* Rename Machine class connector macro

Issue: #2348