### PR TITLE
Make extensible class macro naming more consistent and correct

### DIFF
--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,18 +19,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_ARM_INSTRUCTIONBASE_INCL
-#define OMR_ARM_INSTRUCTIONBASE_INCL
+#ifndef OMR_ARM_INSTRUCTION_INCL
+#define OMR_ARM_INSTRUCTION_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
 #ifndef OMR_INSTRUCTION_CONNECTOR
 #define OMR_INSTRUCTION_CONNECTOR
-   namespace OMR { namespace ARM { class Instruction; } }
-   namespace OMR { typedef OMR::ARM::Instruction InstructionConnector; }
+namespace OMR { namespace ARM { class Instruction; } }
+namespace OMR { typedef OMR::ARM::Instruction InstructionConnector; }
 #else
-   #error OMR::ARM::Instruction expected to be a primary connector, but a OMR connector is already defined
+#error OMR::ARM::Instruction expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRInstruction.hpp"

--- a/compiler/arm/codegen/OMRMachine.hpp
+++ b/compiler/arm/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,14 +25,12 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
-
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace ARM { class Machine; } }
 namespace OMR { typedef OMR::ARM::Machine MachineConnector; }
-
 #else
-#error OMR::ARM::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::ARM::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRMachine.hpp"

--- a/compiler/codegen/ELFRelocationResolver.hpp
+++ b/compiler/codegen/ELFRelocationResolver.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef ELFRELOCATIONRESOLVER_HPP
-#define ELFRELOCATIONRESOLVER_HPP
+#ifndef TR_ELFRELOCATIONRESOLVER_INCL
+#define TR_ELFRELOCATIONRESOLVER_INCL
 
 #pragma once
 
@@ -41,4 +41,4 @@ class OMR_EXTENSIBLE ELFRelocationResolver : public ::OMR::ELFRelocationResolver
 
 #endif /* defined(LINUX) */
 
-#endif // ELFRELOCATIONRESOLVER_HPP
+#endif

--- a/compiler/codegen/Machine.hpp
+++ b/compiler/codegen/Machine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_MACHINE_INCL
-#define OMR_MACHINE_INCL
+#ifndef TR_MACHINE_INCL
+#define TR_MACHINE_INCL
 
-#include "codegen/OMRMachine.hpp"  // for MachineBaseConnector
+#include "codegen/OMRMachine.hpp"
 
 namespace TR { class CodeGenerator; }
 

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_INSTRUCTIONBASE_INCL
-#define OMR_INSTRUCTIONBASE_INCL
+#ifndef OMR_INSTRUCTION_INCL
+#define OMR_INSTRUCTION_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
@@ -297,4 +297,4 @@ class OMR_EXTENSIBLE Instruction
 
 }
 
-#endif /* OMR_INSTRUCTIONBASE_INCL */
+#endif

--- a/compiler/codegen/OMRMachine.hpp
+++ b/compiler/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,14 +19,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_MACHINE_BASE_INCL
-#define OMR_MACHINE_BASE_INCL
+#ifndef OMR_MACHINE_INCL
+#define OMR_MACHINE_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { class Machine; }
 namespace OMR { typedef OMR::Machine MachineConnector; }
 #endif

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,14 +19,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_COMPILATIONBASE_INCL
-#define OMR_COMPILATIONBASE_INCL
+#ifndef OMR_COMPILATION_INCL
+#define OMR_COMPILATION_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_COMPILATIONBASE_CONNECTOR
-#define OMR_COMPILATIONBASE_CONNECTOR
+#ifndef OMR_COMPILATION_CONNECTOR
+#define OMR_COMPILATION_CONNECTOR
 namespace OMR { class Compilation; }
 namespace OMR { typedef OMR::Compilation CompilationConnector; }
 #endif

--- a/compiler/p/codegen/Instruction.hpp
+++ b/compiler/p/codegen/Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_INSTRUCTION_INCL
-#define OMR_INSTRUCTION_INCL
+#ifndef TR_INSTRUCTION_INCL
+#define TR_INSTRUCTION_INCL
 
 #include "codegen/OMRInstruction.hpp"
 

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_POWER_CODEGENERATORBASE_INCL
-#define OMR_POWER_CODEGENERATORBASE_INCL
+#ifndef OMR_POWER_CODEGENERATOR_INCL
+#define OMR_POWER_CODEGENERATOR_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
@@ -30,7 +30,7 @@
 namespace OMR { namespace Power { class CodeGenerator; } }
 namespace OMR { typedef OMR::Power::CodeGenerator CodeGeneratorConnector; }
 #else
-#error OMR::Power::CodeGenerator expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Power::CodeGenerator expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRCodeGenerator.hpp"

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_POWER_INSTRUCTIONBASE_INCL
-#define OMR_POWER_INSTRUCTIONBASE_INCL
+#ifndef OMR_POWER_INSTRUCTION_INCL
+#define OMR_POWER_INSTRUCTION_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
@@ -30,7 +30,7 @@
 namespace OMR { namespace Power { class Instruction; } }
 namespace OMR { typedef OMR::Power::Instruction InstructionConnector; }
 #else
-#error OMR::Power::Instruction expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Power::Instruction expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRInstruction.hpp"

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,12 +25,12 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace Power { class Machine; } }
 namespace OMR { typedef OMR::Power::Machine MachineConnector; }
 #else
-#error OMR::Power::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Power::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRMachine.hpp"

--- a/compiler/p/runtime/OMRCodeCacheConfig.hpp
+++ b/compiler/p/runtime/OMRCodeCacheConfig.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,11 +25,14 @@
 /*
  * The following #defines and typedefs must appear before any #includes in this file
  */
-#ifndef OMR_CODECACHECONFIG_COMPOSED
-#define OMR_CODECACHECONFIG_COMPOSED
+#ifndef OMR_CODECACHECONFIG_CONNECTOR
+#define OMR_CODECACHECONFIG_CONNECTOR
 namespace OMR { namespace Power { class CodeCacheConfig; } }
 namespace OMR { typedef Power::CodeCacheConfig CodeCacheConfigConnector; }
+#else
+#error OMR::Power::CodeCacheConfig expected to be a primary connector, but an OMR connector is already defined
 #endif
+
 
 #include "compiler/runtime/OMRCodeCacheConfig.hpp"
 
@@ -49,4 +52,4 @@ class OMR_EXTENSIBLE CodeCacheConfig : public OMR::CodeCacheConfig
 } // namespace POWER
 } // namespace OMR
 
-#endif // defined(OMR_POWER_CODECACHECONFIG_IMPL)
+#endif

--- a/compiler/runtime/CodeCacheManager.hpp
+++ b/compiler/runtime/CodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_CODECACHEMANAGER_INCL
-#define OMR_CODECACHEMANAGER_INCL
+#ifndef TR_CODECACHEMANAGER_INCL
+#define TR_CODECACHEMANAGER_INCL
 
 #include "runtime/OMRCodeCacheManager.hpp"
 

--- a/compiler/runtime/CodeCacheMemorySegment.hpp
+++ b/compiler/runtime/CodeCacheMemorySegment.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,8 +30,8 @@
 namespace TR
 {
 
-#ifndef TR_CODECACHEMEMORYSEGMENT_COMPOSED
-#define TR_CODECACHEMEMORYSEGMENT_COMPOSED
+#ifndef TR_CODECACHEMEMORYSEGMENT_CONNECTOR
+#define TR_CODECACHEMEMORYSEGMENT_CONNECTOR
 
 class OMR_EXTENSIBLE CodeCacheMemorySegment : public OMR::CodeCacheMemorySegmentConnector
    {

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,20 +22,19 @@
 #ifndef OMR_CODECACHE_INCL
 #define OMR_CODECACHE_INCL
 
-#include "env/defines.h"                    // for HOST_OS, OMR_LINUX, etc
-
 /*
  * The following #defines and typedefs must appear before any #includes in this file
  */
 
-#ifndef OMR_CODECACHE_COMPOSED
-#define OMR_CODECACHE_COMPOSED
+#ifndef OMR_CODECACHE_CONNECTOR
+#define OMR_CODECACHE_CONNECTOR
 namespace OMR { class CodeCache; }
 namespace OMR { typedef CodeCache CodeCacheConnector; }
 #endif
 
 #include <stddef.h>                            // for size_t
 #include <stdint.h>                            // for uint8_t, int32_t, etc
+#include "env/defines.h"                       // for HOST_OS, OMR_LINUX, etc
 #include "il/DataTypes.hpp"                    // for TR_YesNoMaybe
 #include "infra/CriticalSection.hpp"           // for CriticalSection
 #include "runtime/CodeCacheConfig.hpp"         // for CodeCacheConfig

--- a/compiler/runtime/OMRCodeCacheConfig.hpp
+++ b/compiler/runtime/OMRCodeCacheConfig.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,8 +26,8 @@
  * The following #define and typedef must appear before any #includes in this file
  */
 
-#ifndef OMR_CODECACHECONFIG_COMPOSED
-#define OMR_CODECACHECONFIG_COMPOSED
+#ifndef OMR_CODECACHECONFIG_CONNECTOR
+#define OMR_CODECACHECONFIG_CONNECTOR
 namespace OMR { class CodeCacheConfig; }
 namespace OMR { typedef CodeCacheConfig CodeCacheConfigConnector; }
 #endif

--- a/compiler/runtime/OMRCodeCacheMemorySegment.hpp
+++ b/compiler/runtime/OMRCodeCacheMemorySegment.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_CODECACHEMEMORYSEGMEN_INCL
-#define OMR_CODECACHEMEMORYSEGMEN_INCL
+#ifndef OMR_CODECACHEMEMORYSEGMENT_INCL
+#define OMR_CODECACHEMEMORYSEGMENT_INCL
 
 /*
  * The following #defines and typedefs must appear before any #includes in this file
  */
 
-#ifndef OMR_CODECACHEMEMORYSEGMENT_COMPOSED
-#define OMR_CODECACHEMEMORYSEGMENT_COMPOSED
+#ifndef OMR_CODECACHEMEMORYSEGMENT_CONNECTOR
+#define OMR_CODECACHEMEMORYSEGMENT_CONNECTOR
 namespace OMR { class CodeCacheMemorySegment; }
 namespace OMR { typedef CodeCacheMemorySegment CodeCacheMemorySegmentConnector; }
 #endif
@@ -75,4 +75,4 @@ public:
 
 }
 
-#endif // OMR_CODECACHEMEMORYSEGMEN_INCL
+#endif

--- a/compiler/x/amd64/codegen/OMRMachine.hpp
+++ b/compiler/x/amd64/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,12 +25,12 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace X86 { namespace AMD64 { class Machine; } } }
 namespace OMR { typedef OMR::X86::AMD64::Machine MachineConnector; }
 #else
-#error OMR::X86::AMD64::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::X86::AMD64::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "x/codegen/OMRMachine.hpp"

--- a/compiler/x/codegen/Instruction.hpp
+++ b/compiler/x/codegen/Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_INSTRUCTION_INCL
-#define OMR_INSTRUCTION_INCL
+#ifndef TR_INSTRUCTION_INCL
+#define TR_INSTRUCTION_INCL
 
 #include "codegen/OMRInstruction.hpp"
 

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_X86_INSTRUCTIONBASE_INCL
-#define OMR_X86_INSTRUCTIONBASE_INCL
+#ifndef OMR_X86_INSTRUCTION_INCL
+#define OMR_X86_INSTRUCTION_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
@@ -30,7 +30,7 @@
 namespace OMR { namespace X86 { class Instruction; } }
 namespace OMR { typedef OMR::X86::Instruction InstructionConnector; }
 #else
-#error OMR::X86::Instruction expected to be a primary connector, but a OMR connector is already defined
+#error OMR::X86::Instruction expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRInstruction.hpp"

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,8 +22,8 @@
 #ifndef OMR_X86_MACHINE_INCL
 #define OMR_X86_MACHINE_INCL
 
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace X86 { class Machine; } }
 namespace OMR { typedef OMR::X86::Machine MachineConnector; }
 #endif

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 namespace OMR { namespace X86 { class CPU; } }
 namespace OMR { typedef OMR::X86::CPU CPUConnector; }
 #else
-#error OMR::X86::CPU expected to be a primary connector, but a OMR connector is already defined
+#error OMR::X86::CPU expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include <stdint.h>
@@ -69,4 +69,4 @@ public:
 
 }
 
-#endif /* OMR_X86_CPU_BASE_INCL */
+#endif

--- a/compiler/x/i386/codegen/OMRMachine.hpp
+++ b/compiler/x/i386/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,8 +25,8 @@
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR { namespace X86 { namespace I386 { class Machine; } } }
 namespace OMR { typedef OMR::X86::I386::Machine MachineConnector; }
 #else

--- a/compiler/z/codegen/Instruction.hpp
+++ b/compiler/z/codegen/Instruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_INSTRUCTION_INCL
-#define OMR_INSTRUCTION_INCL
+#ifndef TR_INSTRUCTION_INCL
+#define TR_INSTRUCTION_INCL
 
 #include "codegen/OMRInstruction.hpp"
 

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_Z_INSTRUCTIONBASE_INCL
-#define OMR_Z_INSTRUCTIONBASE_INCL
+#ifndef OMR_Z_INSTRUCTION_INCL
+#define OMR_Z_INSTRUCTION_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
@@ -30,7 +30,7 @@
 namespace OMR { namespace Z { class Instruction; } }
 namespace OMR { typedef OMR::Z::Instruction InstructionConnector; }
 #else
-#error OMR::Z::Instruction expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Z::Instruction expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRInstruction.hpp"
@@ -471,4 +471,4 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
 }
 
-#endif /* OMR_Z_INSTRUCTIONBASE_INCL */
+#endif

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -739,4 +739,4 @@ private:
 }
 }
 
-#endif /* S390LINKAGEBASE_INCL */
+#endif

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,17 +19,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_Z_MACHINEBASE_INCL
-#define OMR_Z_MACHINEBASE_INCL
+#ifndef OMR_Z_MACHINE_INCL
+#define OMR_Z_MACHINE_INCL
 /*
  * The following #define and typedef must appear before any #includes in this file
  */
-#ifndef OMR_MACHINEBASE_CONNECTOR
-#define OMR_MACHINEBASE_CONNECTOR
+#ifndef OMR_MACHINE_CONNECTOR
+#define OMR_MACHINE_CONNECTOR
 namespace OMR {namespace Z { class Machine; } }
 namespace OMR { typedef OMR::Z::Machine MachineConnector; }
 #else
-#error OMR::Z::Machine expected to be a primary connector, but a OMR connector is already defined
+#error OMR::Z::Machine expected to be a primary connector, but an OMR connector is already defined
 #endif
 
 #include "compiler/codegen/OMRMachine.hpp"

--- a/jitbuilder/codegen/CodeGenerator.hpp
+++ b/jitbuilder/codegen/CodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,8 +20,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TEST_CODEGENERATOR_INCL
-#define TEST_CODEGENERATOR_INCL
+#ifndef TR_CODEGENERATOR_INCL
+#define TR_CODEGENERATOR_INCL
 
 #include "codegen/JBCodeGenerator.hpp"
 


### PR DESCRIPTION
* Fix concrete extensible class macro names
* Fix extensible class connector macros (remove COMPOSED)
* Fix extensible class connector macros (remove BASE)