### PR TITLE
Fix for incorrect evaluation of TR::aladd on X86-32

### DIFF
--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -886,7 +886,12 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
          }
       else if (isMemOp)
          {
-         instr = generateMemRegInstruction(AddMemReg(nodeIs64Bit, isWithCarry), node, tempMR, cg->evaluate(secondChild), cg);
+         TR::Register *reg = cg->evaluate(secondChild);
+         if (reg->getRegisterPair())
+            {
+            reg = reg->getLowOrder();
+            }
+         instr = generateMemRegInstruction(AddMemReg(nodeIs64Bit, isWithCarry), node, tempMR, reg, cg);
          if (debug("traceMemOp"))
             diagnostic("\n*** Node [" POINTER_PRINTF_FORMAT "] inc by var", node);
          }


### PR DESCRIPTION
TR::aladd was incorrectly evaluated on X86-32 by adding address
register to the high register of the offset register pair.
Fixing it by using the low register of the offset register pair.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>