### PR TITLE
Remove the obsolete pdremSelect opCode

### DIFF
--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1385,7 +1385,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,           // TR::pdSetSign
 
    constrainChildren,           // TR::pddivrem
-   constrainChildren,           // TR::pdremSelect
 
    constrainChildren,           // TR::pdModifyPrecision
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1842,15 +1842,7 @@ TR_Debug::printBCDNodeInfo(TR::Node * node, TR_PrettyPrinterString& output)
    {
    if (node->getType().isBCD())
       {
-      if (node->getOpCode().isPackedArithmeticSelect())
-         {
-         output.append(" <prec=%d (len=%d) dividendPrec=%d divisorPrec=%d> ",
-                       node->getDecimalPrecision(),
-                       node->getSize(),
-                       node->getSelectDividendPrecision(),
-                       node->getSelectDivisorPrecision());
-         }
-      else if (node->getOpCode().isStore() ||
+      if (node->getOpCode().isStore() ||
                node->getOpCode().isCall() ||
                node->getOpCode().isLoadConst() ||
                (node->getOpCode().isConversion() && !node->getOpCode().isConversionWithFraction()))
@@ -3510,7 +3502,6 @@ int32_t childTypes[] =
    TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdSetSign
 
    TR::PackedDecimal,                                        // TR::pddivrem
-   TR::PackedDecimal,                                        // TR::pdremSelect
 
    TR::PackedDecimal,                                        // TR::pdModifyPrecision
 


### PR DESCRIPTION
Remove the obsolete pdremSelect opCode from the code base.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>