### PR TITLE
Fix for incorrect aiadd/aladd support on X86 CG

### DIFF
--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -593,8 +593,8 @@
    TR::TreeEvaluator::fenceEvaluator,                   // TR::fence
    TR::TreeEvaluator::integerAddEvaluator,              // TR::luaddh
    TR::TreeEvaluator::caddEvaluator,                    // TR::cadd
-   TR::TreeEvaluator::integerAddEvaluator,              // TR::aiadd
-   TR::TreeEvaluator::integerAddEvaluator,              // TR::aiuadd
+   TR::TreeEvaluator::badILOpEvaluator,                 // TR::aiadd
+   TR::TreeEvaluator::badILOpEvaluator,                 // TR::aiuadd
    TR::TreeEvaluator::integerAddEvaluator,              // TR::aladd
    TR::TreeEvaluator::integerAddEvaluator,              // TR::aluadd
    TR::TreeEvaluator::integerSubEvaluator,              // TR::lusubh

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -596,8 +596,8 @@
    TR::TreeEvaluator::caddEvaluator,                    // TR::cadd
    TR::TreeEvaluator::integerAddEvaluator,              // TR::aiadd
    TR::TreeEvaluator::integerAddEvaluator,              // TR::aiuadd
-   TR::TreeEvaluator::integerAddEvaluator,              // TR::aladd
-   TR::TreeEvaluator::integerAddEvaluator,              // TR::aluadd
+   TR::TreeEvaluator::badILOpEvaluator,                 // TR::aladd
+   TR::TreeEvaluator::badILOpEvaluator,                 // TR::aluadd
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::lusubh
    TR::TreeEvaluator::csubEvaluator,                    // TR::csub
    TR::TreeEvaluator::integerMulhEvaluator,             // TR::imulh


### PR DESCRIPTION
TR::aiadd should only be used on 32-bit;
TR::aladd should only be used on 64-bit;
removing the incorrect supports from their corresponding platforms.

Issue: #566

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>