### PR TITLE
Reverse #2463 'Resolve link issue when using ld'

### DIFF
--- a/fvtest/rastest/cpuLoadAgent.mk
+++ b/fvtest/rastest/cpuLoadAgent.mk
@@ -31,6 +31,10 @@ ifeq (win,$(OMR_HOST_OS))
 	OBJECTS += $(top_srcdir)/omr.res
 endif
 MODULE_INCLUDES += ../util
+ifeq (aix,$(OMR_HOST_OS))
+	MODULE_CFLAGS += -O2
+	MODULE_CXXFLAGS += -O2
+endif
 EXPORT_FUNCTIONS_FILE := omragent.exportlist
 MODULE_STATIC_LIBS += testutil
 

--- a/omrmakefiles/rules.aix.mk
+++ b/omrmakefiles/rules.aix.mk
@@ -106,8 +106,8 @@ ifeq (ld,$(LINKTOOL))
   endif
   GLOBAL_LDFLAGS+=-G -bnoentry -bernotok
   GLOBAL_LDFLAGS+=-bmap:$(MODULE_NAME).map
-  GLOBAL_LDFLAGS+=-bE:$($(MODULE_NAME)_LINKER_EXPORT_SCRIPT) -L/usr/vac/lib
-  GLOBAL_SHARED_LIBS+=c_r C_r m pthread xlopt
+  GLOBAL_LDFLAGS+=-bE:$($(MODULE_NAME)_LINKER_EXPORT_SCRIPT)
+  GLOBAL_SHARED_LIBS+=c_r C_r m pthread 
 else
   ifeq (1,$(OMR_ENV_DATA64))
     GLOBAL_LDFLAGS+=-X64


### PR DESCRIPTION
* change makes assumptions on library path that does not exist for all xlc versions
* lower optimization on cpuLoadAgent test to work with xlc13 without above change

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>