### PR TITLE
CMake: Fix assembly flags when compiling the jit

### DIFF
--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -254,6 +254,7 @@ macro(set_tr_compile_options)
 	set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} PARENT_SCOPE)
 	# message("[set_tr_compile_options] Set CMAKE_CXX_FLAGS to ${CMAKE_CXX_FLAGS}")
 	# message("[set_tr_compile_options] Set CMAKE_C_FLAGS to ${CMAKE_C_FLAGS}")
+	set(CMAKE_ASM_FLAGS ${TR_ASM_FLAGS} PARENT_SCOPE)
 endmacro(set_tr_compile_options)
 
 # Create an OMR Compiler component

--- a/cmake/modules/platform/arch/x86.cmake
+++ b/cmake/modules/platform/arch/x86.cmake
@@ -42,10 +42,13 @@ if(OMR_ENV_DATA64)
 
 	set(TR_HOST_SUBARCH amd64)
 	set(TR_HOST_BITS    64)
-	set(CMAKE_ASM-ATT_FLAGS "--64 --defsym TR_HOST_X86=1 --defsym TR_HOST_64BIT=1 --defsym BITVECTOR_64BIT=1 --defsym LINUX=1 --defsym TR_TARGET_X86=1 --defsym TR_TARGET_64BIT=1")
+	#TODO the asm flags only work for GNU right now.
+	if(CMAKE_ASM_COMPILER_ID STREQUAL "GNU")
+		set(TR_ASM_FLAGS "-Wa,--64,--defsym,TR_HOST_X86=1,--defsym,TR_HOST_64BIT=1,--defsym,BITVECTOR_64BIT=1,--defsym,LINUX=1,--defsym,TR_TARGET_X86=1,--defsym,TR_TARGET_64BIT=1")
+	endif()
 else()
 	list(APPEND TR_COMPILE_DEFINITIONS -DTR_HOST_32BIT -DTR_TARGET_32BIT)
-	
+
 	set(TR_HOST_SUBARCH i386)
 	set(TR_HOST_BITS    32)
 endif()


### PR DESCRIPTION
No longer use CMAKE_ASM_ATT_FLAGS since we are using ASM not ASM-ATT.
Also put flags into its own variable to prevent polluting flags for
non-OMR components.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>