### PR TITLE
AArch64: Initial version of RealRegister-related files

### DIFF
--- a/compiler/aarch64/codegen/OMRRealRegister.cpp
+++ b/compiler/aarch64/codegen/OMRRealRegister.cpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/RealRegister.hpp"
+
+const uint8_t OMR::ARM64::RealRegister::fullRegBinaryEncodings[TR::RealRegister::NumRegisters] =
+   {
+      0x00, // NoReg
+      0x00, // x0
+      0x01, // x1
+      0x02, // x2
+      0x03, // x3
+      0x04, // x4
+      0x05, // x5
+      0x06, // x6
+      0x07, // x7
+      0x08, // x8
+      0x09, // x9
+      0x0a, // x10
+      0x0b, // x11
+      0x0c, // x12
+      0x0d, // x13
+      0x0e, // x14
+      0x0f, // x15
+      0x10, // x16
+      0x11, // x17
+      0x12, // x18
+      0x13, // x19
+      0x14, // x20
+      0x15, // x21
+      0x16, // x22
+      0x17, // x23
+      0x18, // x24
+      0x19, // x25
+      0x1a, // x26
+      0x1b, // x27
+      0x1c, // x28
+      0x1d, // x29
+      0x1e, // x30
+      0x1f, // xzr / sp
+      0x00, // v0
+      0x01, // v1
+      0x02, // v2
+      0x03, // v3
+      0x04, // v4
+      0x05, // v5
+      0x06, // v6
+      0x07, // v7
+      0x08, // v8
+      0x09, // v9
+      0x0a, // v10
+      0x0b, // v11
+      0x0c, // v12
+      0x0d, // v13
+      0x0e, // v14
+      0x0f, // v15
+      0x10, // v16
+      0x11, // v17
+      0x12, // v18
+      0x13, // v19
+      0x14, // v20
+      0x15, // v21
+      0x16, // v22
+      0x17, // v23
+      0x18, // v24
+      0x19, // v25
+      0x1a, // v26
+      0x1b, // v27
+      0x1c, // v28
+      0x1d, // v29
+      0x1e, // v30
+      0x1f, // v31
+      0x00  // SpilledReg
+   };

--- a/compiler/aarch64/codegen/OMRRealRegister.hpp
+++ b/compiler/aarch64/codegen/OMRRealRegister.hpp
@@ -47,7 +47,7 @@ namespace ARM64
 
 class OMR_EXTENSIBLE RealRegister : public OMR::RealRegister
    {
-protected:
+   protected:
 
    /**
     * @param[in] cg : the TR::CodeGenerator object
@@ -64,6 +64,85 @@ protected:
     */
    RealRegister(TR_RegisterKinds rk, uint16_t w, RegState s, RegNum rn, RegMask m, TR::CodeGenerator *cg) :
           OMR::RealRegister(rk, w, s, (uint16_t)0, rn, m, cg) {}
+
+   public:
+
+   typedef enum  {
+      pos_RD     = 0,
+      pos_RN     = 5,
+      pos_RM     = 16,
+      pos_RT     = 0,
+      pos_RT2    = 10,
+      pos_RS     = 16,
+      pos_RA     = 10
+   } ARM64OperandPosition;
+
+   /**
+    * @brief Set the RealRegister in the Rd field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRD(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RD;
+      }
+
+   /**
+    * @brief Set the RealRegister in the Rn field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRN(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RN;
+      }
+
+   /**
+    * @brief Set the RealRegister in the Rm field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRM(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RM;
+      }
+
+   /**
+    * @brief Set the RealRegister in the Rt field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRT(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RT;
+      }
+
+   /**
+    * @brief Set the RealRegister in the Rt2 field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRT2(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RT2;
+      }
+
+   /**
+    * @brief Set the RealRegister in the Rs field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRS(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RS;
+      }
+
+   /**
+    * @brief Set the RealRegister in the Ra field of the specified instruction
+    * @param[in] instruction : target instruction
+    */
+   void setRegisterFieldRA(uint32_t *instruction)
+      {
+      *instruction |= fullRegBinaryEncodings[_registerNumber] << pos_RA;
+      }
+
+   private:
+
+   static const uint8_t fullRegBinaryEncodings[NumRegisters];
 
    };
 

--- a/compiler/aarch64/codegen/RealRegister.hpp
+++ b/compiler/aarch64/codegen/RealRegister.hpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_REAL_REGISTER_INCL
+#define TR_REAL_REGISTER_INCL
+
+#include "codegen/OMRRealRegister.hpp"
+
+#include <stddef.h>                       // for NULL
+#include <stdint.h>                       // for uint16_t
+#include "codegen/Register.hpp"           // for Register
+#include "codegen/RegisterConstants.hpp"  // for TR_RegisterKinds
+#include "infra/Assert.hpp"               // for TR_ASSERT
+
+namespace TR { class CodeGenerator; }
+
+namespace TR
+{
+
+class OMR_EXTENSIBLE RealRegister : public OMR::RealRegisterConnector
+   {
+   public:
+
+   RealRegister(TR::CodeGenerator *cg): OMR::RealRegisterConnector(cg) {}
+
+   RealRegister(TR_RegisterKinds rk, uint16_t w, RegState s, RegNum rn, RegMask m, TR::CodeGenerator * cg):
+      OMR::RealRegisterConnector(rk, w, s, rn, m, cg) {}
+
+   RealRegister(TR_RegisterKinds rk, uint16_t w, RegState s, RegNum rn, TR::CodeGenerator *cg):
+      OMR::RealRegisterConnector(rk, w, s, rn, noRegMask, cg) {}
+
+   };
+
+}
+
+inline TR::RealRegister *toRealRegister(TR::Register *r)
+   {
+   TR_ASSERT(r == NULL || r->getRealRegister() != NULL, "trying to convert a non-real register to a real register");
+   return static_cast<TR::RealRegister *>(r);
+   }
+
+#endif

--- a/compiler/aarch64/codegen/RealRegisterEnum.hpp
+++ b/compiler/aarch64/codegen/RealRegisterEnum.hpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+
+      NoReg             = 0,
+      x0                = 1,
+      FirstGPR          = x0,
+      x1                = 2,
+      x2                = 3,
+      x3                = 4,
+      x4                = 5,
+      x5                = 6,
+      x6                = 7,
+      x7                = 8,
+      x8                = 9,
+      x9                = 10,
+      x10               = 11,
+      x11               = 12,
+      x12               = 13,
+      x13               = 14,
+      x14               = 15,
+      x15               = 16,
+      x16               = 17,
+      x17               = 18,
+      x18               = 19,
+      x19               = 20,
+      x20               = 21,
+      x21               = 22,
+      x22               = 23,
+      x23               = 24,
+      x24               = 25,
+      x25               = 26,
+      x26               = 27,
+      x27               = 28,
+      x28               = 29,
+      x29               = 30,
+      x30               = 31,
+      lr                = x30,
+      LastGPR           = x30,
+      LastAssignableGPR = x29,
+      xzr               = 32,
+      sp                = xzr,
+      v0                = 33,
+      FirstFPR          = v0,
+      v1                = 34,
+      v2                = 35,
+      v3                = 36,
+      v4                = 37,
+      v5                = 38,
+      v6                = 39,
+      v7                = 40,
+      v8                = 41,
+      v9                = 42,
+      v10               = 43,
+      v11               = 44,
+      v12               = 45,
+      v13               = 46,
+      v14               = 47,
+      v15               = 48,
+      v16               = 49,
+      v17               = 50,
+      v18               = 51,
+      v19               = 52,
+      v20               = 53,
+      v21               = 54,
+      v22               = 55,
+      v23               = 56,
+      v24               = 57,
+      v25               = 58,
+      v26               = 59,
+      v27               = 60,
+      v28               = 61,
+      v29               = 62,
+      v30               = 63,
+      v31               = 64,
+      LastFPR           = v31,
+      LastAssignableFPR = v31,
+      SpilledReg        = 65,
+      NumRegisters      = SpilledReg + 1

--- a/compiler/aarch64/codegen/RealRegisterMaskEnum.hpp
+++ b/compiler/aarch64/codegen/RealRegisterMaskEnum.hpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+
+      noRegMask = 0x00000000,


### PR DESCRIPTION
This commit implements the initial version of RealRegister-related
files for aarch64.
This is a part of #2465.

Signed-off-by: knn-k <konno@jp.ibm.com>