### PR TITLE
Rework the Example cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+# TODO: OMR_RTTI flag
+# TODO: Version things
+
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 message(STATUS "Starting with CMake version ${CMAKE_VERSION}")
@@ -66,23 +69,6 @@ add_custom_target(omr_install_tooling
 )
 
 ###
-### Getting the glue target
-###
-set(OMR_GC_GLUE_TARGET "omr_example_gc_glue" CACHE STRING "The gc glue target, must be interface library")
-set(OMR_UTIL_GLUE_TARGET "omr_example_util_glue" CACHE STRING "The util glue target, must be interface library")
-set(OMR_RAS_GLUE_TARGET "omr_example_ras_glue" CACHE STRING "The ras glue target, must be interface library")
-set(OMR_CORE_GLUE_TARGET "omr_example_core_glue" CACHE STRING "The core glue target, must be and interface library")
-
-# TODO should we always be adding this?  Likely only when compiling OMR proper for testing. Otherwise we would want
-# to add the languages glue folder
-add_subdirectory(example/glue)
-
-# TODO: OMR_EXAMPLE flag
-# TODO: OMR_RTTI flag
-
-# TODO: Version things
-
-###
 ### Versions and stuff
 ###
 
@@ -116,6 +102,10 @@ endif()
 configure_file(./omrcfg.CMakeTemplate.h omrcfg.h)
 configure_file(./omrversionstrings.CMakeTemplate.h omrversionstrings.h)
 
+###
+### Native Tooling
+###
+
 if(OMR_TOOLS_IMPORTFILE)
 	include("${OMR_TOOLS_IMPORTFILE}")
 elseif(OMR_TOOLS)
@@ -123,6 +113,21 @@ elseif(OMR_TOOLS)
 else()
 	message(FATAL_ERROR "OMR: Build tools are required. See OMR_TOOLS and OMR_TOOLS_IMPORTFILE")
 endif()
+
+
+###
+### Built-in OMR Applications.
+###
+
+# Each application provides it's own glue, so must be included before subdirectories.
+# The example and om are not yet compatible.
+if (OMR_EXAMPLE)
+	add_subdirectory(example)
+endif (OMR_EXAMPLE)
+
+###
+### Core OMR components
+###
 
 add_subdirectory(thread)
 add_subdirectory(port)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -23,12 +23,18 @@ set(OMR_WARNINGS_AS_ERRORS ON CACHE BOOL "Treat compile warnings as errors")
 set(OMR_ENHANCED_WARNINGS ON CACHE BOOL "Enable enhanced compiler warnings")
 
 ###
+### Built-in OMR Applications
+###
+
+set(OMR_EXAMPLE ON CACHE BOOL "Enable the Example application")
+
+###
 ### Major Feature Flags
 ###
 
 set(OMR_COMPILER OFF CACHE BOOL "Enable the compiler")
 set(OMR_DDR OFF CACHE BOOL "Enable DDR")
-set(OMR_FVTEST OFF CACHE BOOL "Enable the FV Testing.")
+set(OMR_FVTEST ON CACHE BOOL "Enable the FV Testing.")
 set(OMR_GC ON CACHE BOOL "Enable the GC")
 set(OMR_JITBUILDER OFF CACHE BOOL "Enable building JitBuilder")
 set(OMR_OMRSIG ON CACHE BOOL "Enable the OMR signal compatibility library")
@@ -54,6 +60,15 @@ set(OMR_HOOK_LIB "j9hookstatic" CACHE STRING "Name of the hook library to link a
 set(OMR_PORT_LIB "omrport" CACHE STRING "Name of the port library to link against")
 set(OMR_THREAD_LIB "j9thrstatic" CACHE STRING "Name of the thread library to link against")
 set(OMR_TRACE_LIB "omrtrace" CACHE STRING "Name of the trace library to link against")
+
+###
+### Glue library names
+###
+
+set(OMR_GC_GLUE_TARGET "NOTFOUND" CACHE STRING "The gc glue target, must be interface library")
+set(OMR_UTIL_GLUE_TARGET "NOTFOUND" CACHE STRING "The util glue target, must be interface library")
+set(OMR_RAS_GLUE_TARGET "NOTFOUND" CACHE STRING "The ras glue target, must be interface library")
+set(OMR_CORE_GLUE_TARGET "NOTFOUND" CACHE STRING "The core glue target, must be and interface library")
 
 ###
 ### Boolean Feature Flags

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,15 +19,40 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+include(OmrAssert)
+
+omr_assert(TEST OMR_EXAMPLE)
+
+omr_assert(FATAL_ERROR
+	TEST OMR_FVTEST
+	MESSAGE "The example requires OMR_FVTEST=On"
+)
+
+add_library(omr_example_base INTERFACE)
+
+target_include_directories(omr_example_base
+	INTERFACE
+		glue
+)
+
 add_executable(example
 	main.cpp
 )
 
 target_link_libraries(example
-	PRIVATE
-	omrgc
+	omrGtestGlue
+	pugixml
+	omrtestutil
+	omrcore
+	${OMR_HOOK_LIB}
+	${OMR_TRACE_LIB}
+	${OMR_GC_LIB}
+	${OMR_THREAD_LIB}
+	${OMR_PORT_LIB}
 )
 
-add_test(example example)
+# TODO: The example is currently broken.
+# Hashtable iteration appears to be broken, which in turn breaks root marking, and causes the example to spin forever.
+# add_test(example example)
 
 add_subdirectory(glue)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -37,7 +37,6 @@ add_executable(example
 target_link_libraries(example
 	omr_main_function
 	pugixml
-	omrtestutil
 	omrcore
 	${OMR_HOOK_LIB}
 	${OMR_TRACE_LIB}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -23,11 +23,6 @@ include(OmrAssert)
 
 omr_assert(TEST OMR_EXAMPLE)
 
-omr_assert(FATAL_ERROR
-	TEST OMR_FVTEST
-	MESSAGE "The example requires OMR_FVTEST=On"
-)
-
 add_library(omr_example_base INTERFACE)
 
 target_include_directories(omr_example_base
@@ -40,7 +35,7 @@ add_executable(example
 )
 
 target_link_libraries(example
-	omrGtestGlue
+	omr_main_function
 	pugixml
 	omrtestutil
 	omrcore

--- a/example/glue/CMakeLists.txt
+++ b/example/glue/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,13 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+set(OMR_GC_GLUE_TARGET "omr_example_gc_glue" CACHE STRING "The gc glue target, must be interface library" FORCE)
+set(OMR_UTIL_GLUE_TARGET "omr_example_util_glue" CACHE STRING "The util glue target, must be interface library" FORCE)
+set(OMR_RAS_GLUE_TARGET "omr_example_ras_glue" CACHE STRING "The ras glue target, must be interface library" FORCE)
+set(OMR_CORE_GLUE_TARGET "omr_example_core_glue" CACHE STRING "The core glue target, must be and interface library" FORCE)
+
 add_library(omr_example_gc_glue INTERFACE)
+
 target_sources(omr_example_gc_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/CollectorLanguageInterfaceImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/CompactSchemeFixupObject.cpp
@@ -30,43 +36,45 @@ target_sources(omr_example_gc_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/MarkingDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ObjectIterator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/ObjectModelDelegate.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/Profiling.c
 	${CMAKE_CURRENT_SOURCE_DIR}/StartupManagerImpl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/VerboseManagerImpl.cpp
 )
 
-target_include_directories(omr_example_gc_glue INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/..
+target_link_libraries(omr_example_gc_glue
+	INTERFACE
+		omr_example_base
 )
 
 add_library(omr_example_util_glue INTERFACE)
+
 target_sources(omr_example_util_glue INTERFACE
 	${CMAKE_CURRENT_SOURCE_DIR}/UtilGlue.c
 )
 
-target_include_directories(omr_example_util_glue INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/..
-)
-
-add_library(omr_example_core_glue INTERFACE)
-target_sources(omr_example_core_glue INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}/LanguageVMGlue.c
-	${CMAKE_CURRENT_SOURCE_DIR}/omrExampleVM.cpp
-)
-
-target_include_directories(omr_example_core_glue INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/..
+target_link_libraries(omr_example_util_glue
+	INTERFACE
+		omr_example_base
 )
 
 add_library(omr_example_ras_glue INTERFACE)
+
 target_sources(omr_example_ras_glue INTERFACE
+)
+
+target_link_libraries(omr_example_ras_glue
+	INTERFACE
+		omr_example_base
+)
+
+add_library(omr_example_core_glue INTERFACE)
+
+target_sources(omr_example_core_glue INTERFACE
+	${CMAKE_CURRENT_SOURCE_DIR}/LanguageVMGlue.c
+	${CMAKE_CURRENT_SOURCE_DIR}/omrExampleVM.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/Profiling.c
 )
 
-target_include_directories(omr_example_ras_glue INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_SOURCE_DIR}/..
+target_link_libraries(omr_example_core_glue
+	INTERFACE
+		omr_example_base
 )

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -43,7 +43,7 @@
 extern "C" {
 
 int
-testMain(int argc, char ** argv, char **envp)
+omr_main_entry(int argc, char ** argv, char **envp)
 {
 	/* Start up */
 	OMR_VM_Example exampleVM;

--- a/example/makefile
+++ b/example/makefile
@@ -45,16 +45,12 @@ SRCS := $(wildcard *.cpp)
 #
 # Here, OBJECTS is initialized with the list of source files in this directory,
 # and the .cpp file extension is stripped from each filename.
-OBJECTS := $(SRCS:%.cpp=%)
-
-# argmain.cpp is a helper file supplied by the fvtest framework. It defines a
-# portable main() function, which handles conversion of wchar_t or EBCDIC
-# command-line options into OMR's internal string format (UTF-8).
-OBJECTS += argmain
+OBJECTS := $(SRCS:%.cpp=%) main_function
 
 # Append the object file extension (.o or .obj) to each filename.
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 # MODULE_INCLUDES is a special variable that contains additional include paths.
 # These include paths take precedence over include paths specified by the
@@ -69,10 +65,8 @@ MODULE_INCLUDES += \
   $(OMR_GTEST_INCLUDES) \
   ./glue
 
-# Specify the search path for argmain.cpp.
 # OMR_GTEST_DIR is a special variable defined by configure.mk. It contains the
 # location of the googletest source code.
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 # MODULE_STATIC_LIBS is a special variable that contains a list of static
 # libraries needed to build this artifact.

--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -23,6 +23,11 @@ include(OmrAssert)
 
 omr_assert(TEST OMR_FVTEST)
 
+omr_assert(
+	TEST OMR_EXAMPLE
+	MESSAGE "The fv test component relies on the example glue"
+)
+
 add_subdirectory(util)
 
 add_subdirectory(omrGtestGlue)

--- a/fvtest/algotest/main.cpp
+++ b/fvtest/algotest/main.cpp
@@ -24,13 +24,13 @@
 #include "testEnvironment.hpp"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
 PortEnvironment *omrTestEnv;
 
 int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 

--- a/fvtest/algotest/makefile
+++ b/fvtest/algotest/makefile
@@ -25,15 +25,15 @@ include $(top_srcdir)/omrmakefiles/configure.mk
 MODULE_NAME := omralgotest
 ARTIFACT_TYPE := cxx_executable
 
-OBJECTS := argmain main algoTest avltest hashtabletest hooktest pooltest
+OBJECTS := main algoTest avltest hashtabletest hooktest pooltest main_function
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 MODULE_INCLUDES += ../util
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES)
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/fvtest/compilertriltest/main.cpp
+++ b/fvtest/compilertriltest/main.cpp
@@ -22,10 +22,10 @@
 #include "omrTest.h"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
-int testMain(int argc, char **argv, char **envp) {
+int omr_main_entry(int argc, char **argv, char **envp) {
    ::testing::InitGoogleTest(&argc, argv);
    OMREventListener::setDefaultTestListener();
    return RUN_ALL_TESTS();

--- a/fvtest/gctest/main.cpp
+++ b/fvtest/gctest/main.cpp
@@ -23,13 +23,13 @@
 #include "gcTestHelpers.hpp"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
 GCTestEnvironment *gcTestEnv;
 
 int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 

--- a/fvtest/gctest/makefile
+++ b/fvtest/gctest/makefile
@@ -27,12 +27,10 @@ ARTIFACT_TYPE := cxx_executable
 
 # source files in this directory
 SRCS := $(wildcard *.cpp)
-OBJECTS := $(SRCS:%.cpp=%)
-
-# glue and utility source files
-OBJECTS +=\
-  argmain
+OBJECTS := $(SRCS:%.cpp=%) main_function
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 MODULE_INCLUDES += ./configuration $(OMR_PUGIXML_DIR) $(OMR_GTEST_INCLUDES) ../util
 MODULE_INCLUDES += \
@@ -41,8 +39,6 @@ MODULE_INCLUDES += \
   $(OMRGC_IPATH)
 
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS) -DSPEC=$(SPEC)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -20,7 +20,9 @@
 ###############################################################################
 
 add_library(omrGtest STATIC
-	omrGtest.cpp)
+	omrGtest.cpp
+)
+
 target_include_directories(omrGtest
 	PRIVATE
 		${PROJECT_SOURCE_DIR}/third_party/gtest-1.8.0/
@@ -28,6 +30,7 @@ target_include_directories(omrGtest
 	PUBLIC
 		${PROJECT_SOURCE_DIR}/third_party/gtest-1.8.0/include
 )
+
 add_library(omrGtestGlue INTERFACE)
 
 target_include_directories(omrGtestGlue
@@ -35,11 +38,11 @@ target_include_directories(omrGtestGlue
 		.
 )
 
-target_sources(omrGtestGlue INTERFACE
-	${CMAKE_CURRENT_SOURCE_DIR}/argmain.cpp
+target_link_libraries(omrGtestGlue
+	INTERFACE
+		omrGtest
+		omr_main_function
 )
-
-target_link_libraries(omrGtestGlue INTERFACE omrGtest)
 
 #TODO  system thread library should be linked in a more generic way.
 if(NOT OMR_HOST_OS STREQUAL "win")

--- a/fvtest/omrGtestGlue/omrTest.h
+++ b/fvtest/omrGtestGlue/omrTest.h
@@ -139,7 +139,7 @@ public:
 extern "C" {
 #endif
 
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/fvtest/porttest/main.cpp
+++ b/fvtest/porttest/main.cpp
@@ -31,7 +31,7 @@ extern int omrmmap_runTests(struct OMRPortLibrary *portLibrary, char *argv0, cha
 PortTestEnvironment *portTestEnv;
 
 extern "C" int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	bool isChild = false;
 	bool earlyExit = false;
@@ -80,7 +80,7 @@ testMain(int argc, char **argv, char **envp)
 	DETACH_AND_DESTROY_THREADLIBRARY();
 
 	if (earlyExit) {
-		printf("exiting from testMain\n");
+		printf("exiting from omr_main_entry\n");
 		exit(result);
 	}
 

--- a/fvtest/porttest/makefile
+++ b/fvtest/porttest/makefile
@@ -26,7 +26,6 @@ MODULE_NAME := omrporttest
 ARTIFACT_TYPE := cxx_executable
 
 OBJECTS := \
-  argmain \
   fileTest \
   heapTest \
   omrportTest \
@@ -52,7 +51,11 @@ OBJECTS := \
   si_numcpusTest \
   testHelpers \
   testProcessHelpers \
-  vmemTest
+  vmemTest \
+  main_function
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
+
 ifeq (1,$(OMR_OPT_CUDA))
   OBJECTS += \
     cudaBasic \
@@ -74,8 +77,6 @@ OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 MODULE_INCLUDES += $(top_srcdir)/port/common ../util
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES)
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/fvtest/rastest/main.cpp
+++ b/fvtest/rastest/main.cpp
@@ -23,13 +23,13 @@
 #include "rasTestHelpers.hpp"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
 PortEnvironment *rasTestEnv;
 
 int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 	OMREventListener::setDefaultTestListener();

--- a/fvtest/rastest/rastest_include.mk
+++ b/fvtest/rastest/rastest_include.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,17 +19,12 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-GLUE_OBJECTS := \
-  argmain
-
-GLUE_OBJECTS := $(addsuffix $(OBJEXT),$(GLUE_OBJECTS))
-OBJECTS += $(GLUE_OBJECTS)
+OBJECTS += main_function$(OBJEXT)
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES) ../util
 MODULE_INCLUDES += $(OMR_IPATH)
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   j9prtstatic \

--- a/fvtest/sigtest/main.cpp
+++ b/fvtest/sigtest/main.cpp
@@ -25,14 +25,14 @@
 #include "sigTestHelpers.hpp"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
 PortEnvironment *omrTestEnv;
 
 
 int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 	OMREventListener::setDefaultTestListener();

--- a/fvtest/sigtest/makefile
+++ b/fvtest/sigtest/makefile
@@ -25,14 +25,14 @@ include $(top_srcdir)/omrmakefiles/configure.mk
 MODULE_NAME := omrsigtest
 ARTIFACT_TYPE := cxx_executable
 
-OBJECTS := argmain main sigTest sigTestHelpers
+OBJECTS := main sigTest sigTestHelpers main_function
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 MODULE_INCLUDES += ../util
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES)
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/fvtest/threadextendedtest/makefile
+++ b/fvtest/threadextendedtest/makefile
@@ -27,20 +27,20 @@ MODULE_NAME := omrthreadextendedtest
 ARTIFACT_TYPE := cxx_executable
 
 OBJECTS := \
-  argmain \
   processTimeTest \
   threadCpuTimeTest \
   threadExtendedTestHelpers \
   threadExtendedTestMain \
-  timeBaseTest
+  timeBaseTest \
+  main_function
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 MODULE_INCLUDES +=  $(top_srcdir)/fvtest/util
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES)
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/fvtest/threadextendedtest/threadExtendedTestMain.cpp
+++ b/fvtest/threadextendedtest/threadExtendedTestMain.cpp
@@ -25,7 +25,7 @@
 ThreadExtendedTestEnvironment *omrTestEnv;
 
 extern "C" int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 	OMREventListener::setDefaultTestListener();

--- a/fvtest/threadtest/main.cpp
+++ b/fvtest/threadtest/main.cpp
@@ -26,7 +26,7 @@
 ThreadTestEnvironment *omrTestEnv;
 
 extern "C" int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 	OMREventListener::setDefaultTestListener();

--- a/fvtest/threadtest/makefile
+++ b/fvtest/threadtest/makefile
@@ -28,7 +28,6 @@ ARTIFACT_TYPE := cxx_executable
 
 OBJECTS := \
   abortTest \
-  argmain \
   CEnterExit \
   CMonitor \
   createTest \
@@ -42,7 +41,10 @@ OBJECTS := \
   rwMutexTest \
   sanityTest \
   sanityTestHelper \
-  threadTestHelp 
+  threadTestHelp \
+  main_function
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 ifeq (1,$(OMR_THR_FORK_SUPPORT))
   OBJECTS += forkResetTest forkResetRWMutexTest
@@ -53,8 +55,6 @@ OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 MODULE_INCLUDES +=  $(top_srcdir)/fvtest/util
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES) $(top_srcdir)/thread
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/fvtest/tril/test/main.cpp
+++ b/fvtest/tril/test/main.cpp
@@ -22,10 +22,10 @@
 #include "omrTest.h"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
-int testMain(int argc, char **argv, char **envp) {
+int omr_main_entry(int argc, char **argv, char **envp) {
    ::testing::InitGoogleTest(&argc, argv);
    OMREventListener::setDefaultTestListener();
    return RUN_ALL_TESTS();

--- a/fvtest/vmtest/main.cpp
+++ b/fvtest/vmtest/main.cpp
@@ -24,13 +24,13 @@
 #include "testEnvironment.hpp"
 
 extern "C" {
-int testMain(int argc, char **argv, char **envp);
+int omr_main_entry(int argc, char **argv, char **envp);
 }
 
 PortEnvironment *vmTestEnv;
 
 int
-testMain(int argc, char **argv, char **envp)
+omr_main_entry(int argc, char **argv, char **envp)
 {
 	::testing::InitGoogleTest(&argc, argv);
 	OMREventListener::setDefaultTestListener();

--- a/fvtest/vmtest/makefile
+++ b/fvtest/vmtest/makefile
@@ -25,8 +25,11 @@ include $(top_srcdir)/omrmakefiles/configure.mk
 MODULE_NAME := omrvmtest
 ARTIFACT_TYPE := cxx_executable
 
-OBJECTS := main \
-  argmain
+OBJECTS := \
+  main \
+  main_function
+
+vpath main_function.cpp $(top_srcdir)/util/main_function
 
 ifeq (1,$(OMR_THR_FORK_SUPPORT))
   OBJECTS += vmForkTest
@@ -37,8 +40,6 @@ MODULE_INCLUDES += ../util
 MODULE_INCLUDES += $(OMR_GTEST_INCLUDES)
 MODULE_INCLUDES += $(OMR_IPATH)
 MODULE_CXXFLAGS += $(OMR_GTEST_CXXFLAGS)
-
-vpath argmain.cpp $(top_srcdir)/fvtest/omrGtestGlue
 
 MODULE_STATIC_LIBS += \
   omrGtest \

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -20,6 +20,13 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+omr_assert(TEST OMR_GC)
+
+omr_assert(
+	TEST OMR_GC_GLUE_TARGET
+	MESSAGE "OMR_GC_GLUE_TARGET must be set."
+)
+
 omr_add_hookgen(
 	INPUT include/omrmm.hdf
 	PUBLIC_DIR "${omr_BINARY_DIR}"

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -20,6 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+omr_assert(
+	TEST OMR_CORE_GLUE_TARGET
+	MESSAGE "OMR_CORE_GLUE_TARGET must be set. Try using the example with OMR_EXAMPLE=On"
+)
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_tracegen(omrti.tdf)
@@ -65,6 +70,8 @@ if(OMR_GC)
 	)
 
 	target_link_libraries(omrcore
+		PUBLIC
+			omrgc
 		PRIVATE
 			${OMR_CORE_GLUE_TARGET}
 	)

--- a/util/main_function/CMakeLists.txt
+++ b/util/main_function/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2018, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,12 +20,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-if(OMR_HOST_OS STREQUAL "zos")
-	add_subdirectory(a2e)
-endif()
-add_subdirectory(avl)
-add_subdirectory(hashtable)
-add_subdirectory(hookable)
-add_subdirectory(main_function)
-add_subdirectory(omrutil)
-add_subdirectory(pool)
+add_library(omr_main_function INTERFACE)
+
+target_sources(omr_main_function
+	INTERFACE
+		${CMAKE_CURRENT_SOURCE_DIR}/main_function.cpp
+)

--- a/util/main_function/README.md
+++ b/util/main_function/README.md
@@ -1,0 +1,12 @@
+# `omr_main_function`
+
+`omr_main_function` is a static library that helps OMR developers write portable executables. This library defines the `int main()` function, which handles conversion of `wchar_t` or EBCDIC command-line options into OMR's internal string format (UTF-8), before calling out to the user provided `omr_main_entry` function.
+
+## Using omr_main_function
+
+link privately against the `omr_main_function` library. The main entry to your program is now:
+
+```c++
+extern "C" int
+omr_main_entry(int argc, char **argv, char **envp);
+```

--- a/util/main_function/main_function.cpp
+++ b/util/main_function/main_function.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2015 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,6 +18,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+#include "omrcfg.h"
 
 /*
  * Perform platform-specific conversions on (argc, argv) before invoking the generic

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -20,6 +20,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+omr_assert(
+	TEST OMR_UTIL_GLUE_TARGET
+	MESSAGE "OMR_UTIL_GLUE_TARGET must be set."
+)
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 #TODO port following vpath code:


### PR DESCRIPTION
Make the default glue NOTFOUND, and assert that the glue is defined,
whenever it is required. Only use the example glue if OMR_EXAMPLE is on.
OMR_EXAMPLE is on by default.

Compile the example program. We are not able to run example as a test,
due to an old hang.

Signed-off-by: Robert Young <rwy0717@gmail.com>