### PR TITLE
Fixing dcmplt and dcmpgt Instruction handling on PPC

### DIFF
--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -2010,7 +2010,7 @@ TR::Register *OMR::Power::TreeEvaluator::dcmpltEvaluator(TR::Node *node, TR::Cod
    int64_t imm = 0;
    if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
       {
-      imm = (TR::RealRegister::CRCC_LT <<  TR::RealRegister::pos_RT | TR::RealRegister::CRCC_LT <<  TR::RealRegister::pos_RA | TR::RealRegister::CRCC_SO << TR::RealRegister::pos_RB);
+      imm = (TR::RealRegister::CRCC_GT <<  TR::RealRegister::pos_RT | TR::RealRegister::CRCC_LT <<  TR::RealRegister::pos_RA | TR::RealRegister::CRCC_LT << TR::RealRegister::pos_RB);
       }
    return compareFloatAndSetOrderedBoolean(TR::InstOpCode::blt, TR::InstOpCode::bad, imm, node, cg);
    }
@@ -2025,10 +2025,6 @@ TR::Register *OMR::Power::TreeEvaluator::dcmpgeEvaluator(TR::Node *node, TR::Cod
 TR::Register *OMR::Power::TreeEvaluator::dcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    int64_t imm = 0;
-   if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
-      {
-      imm = (TR::RealRegister::CRCC_GT <<  TR::RealRegister::pos_RT | TR::RealRegister::CRCC_GT <<  TR::RealRegister::pos_RA | TR::RealRegister::CRCC_SO << TR::RealRegister::pos_RB);
-      }
    return compareFloatAndSetOrderedBoolean(TR::InstOpCode::bgt, TR::InstOpCode::bad, imm, node, cg);
    }
 

--- a/compiler/p/codegen/OMRInstOpCode.hpp
+++ b/compiler/p/codegen/OMRInstOpCode.hpp
@@ -128,6 +128,8 @@ class InstOpCode: public OMR::InstOpCode
 
         bool usesCTR() {return (properties[_mnemonic] & PPCOpProp_UsesCtr)!=0;}
 
+        bool isCRLogical() {return (properties[_mnemonic] & PPCOpProp_CRLogical)!=0;}
+
         bool isLongRunningFPOp() {return _mnemonic==fdiv  ||
                                          _mnemonic==fdivs ||
                                          _mnemonic==fsqrt ||

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -120,6 +120,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    bool     isCompare()             {return _opcode.isCompare();}
    bool     isLongRunningFPOp()     {return _opcode.isLongRunningFPOp();}
    bool     isFXMult()              {return _opcode.isFXMult();}
+   bool     isCRLogical()           {return _opcode.isCRLogical();}
 
    virtual bool     isLoad()           {return _opcode.isLoad();}
    virtual bool     isStore()          {return _opcode.isStore();}

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -656,12 +656,6 @@ static void insertMaskField(uint32_t *instruction, TR::InstOpCode::Mnemonic op, 
    // number is strangely encoded in that the low order bit 5 comes first
    // and the high order bits after.  The field is in bit positions 21-26.
 
-   if (op == TR::InstOpCode::cror)
-      {
-      encoding = (((uint32_t) lmask) & 0xffffffff);
-      *instruction |= encoding;
-      return;
-      }
    // For these instructions the immediate is not a mask but a 1-bit immediate operand
    if (op == TR::InstOpCode::cmprb)
       {
@@ -696,9 +690,17 @@ static void insertMaskField(uint32_t *instruction, TR::InstOpCode::Mnemonic op, 
       return;
       }
 
-   TR_ASSERT(lmask, "A mask of 0 cannot be encoded");
-
    TR::InstOpCode       opCode(op);
+
+   if (opCode.isCRLogical())
+      {
+      encoding = (((uint32_t) lmask) & 0xffffffff);
+      *instruction |= encoding;
+      return;
+      }
+
+   TR_ASSERT(lmask, "A mask of 0 cannot be encoded");   
+
    if (opCode.isDoubleWord())
       {
       int bitnum;
@@ -790,6 +792,7 @@ uint8_t *TR::PPCTrg1Src2ImmInstruction::generateBinaryEncoding()
    cursor += PPC_INSTRUCTION_LENGTH;
    setBinaryLength(PPC_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);
+
    return cursor;
    }
 


### PR DESCRIPTION
dcmplt and dcmpgt (Along with fcmpgt and fcmplt) use setbool in order to compare and set the required bit results.

Prior, the sequence setbool expansion was implemented incorrectly. 
-fcmpu compares input arguments, the result is stored in the conditional register (Bits LT,GT,EQ, and SO). 
-setb reads the condition register and set the bit result based on the LT and GT fields.
-setb checks bit set in the LT field will result to the output -1 (or 0xfff) if it's high. 

Therefore, in some situations the result was incorrect. Since when the LT bit is high, the result bit is not set correctly. No matter if dcmplt or dcmpgt is called. 

With this change:
-only with dcmplt and fcmplt , we move LT bit of the condition register to the GT bit. 
-When running dcmpgt and fcmpgt, moving is not needed since we already have the desired state set in the GT bit of the condition register
-The LT bit is now cleared using crxor. 

Now with setb, the result will be based off of GT. setb will set high if GT is high, and low if GT is low. 

The binary encoding for condition register logical instructions were also fixed on PPC. 

Signed-off-by: Alen Badel <Alen.Badel@ibm.com>