### PR TITLE
CMake: Enable exception handling

### DIFF
--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,6 +71,17 @@ endif(OMR_ENV_DATA64)
 
 # Configure the platform dependent library for multithreading
 set(OMR_PLATFORM_THREAD_LIBRARY Ws2_32.lib)
+
+# TR_CXX_COMPILE_OPTIONS are appended to CMAKE_CXX_FLAGS, and so apply only to
+# C++ file compilation
+list(APPEND TR_CXX_COMPILE_OPTIONS
+	/EHsc   # Enable exception handling (Clang doesn't enable exception handling by default)
+)
+
+# TR_C_COMPILE_OPTIONS are appended to CMAKE_C_FLAGS, and so apply only to
+# C file compilation
+list(APPEND TR_C_COMPILE_OPTIONS
+)
 
 macro(omr_toolconfig_global_setup)
 	# Make sure we are building without incremental linking

--- a/include_core/OMR_Agent.hpp
+++ b/include_core/OMR_Agent.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -136,6 +136,11 @@ private:
 	void *operator new(size_t size, void *memoryPtr)
 	{
 		return memoryPtr;
+	}
+
+	void operator delete(void *agent, void *memoryPtr)
+	{
+		destroyAgent(static_cast<OMR_Agent *>(agent));
 	}
 
 	static omr_error_t onPreForkDefault(void);

--- a/omr/OMR_Agent.cpp
+++ b/omr/OMR_Agent.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -139,7 +139,8 @@ OMR_Agent::createAgent(OMR_VM *vm, char const *arg)
 
 	if (NULL != arg) {
 		OMRPORT_ACCESS_FROM_OMRVM(vm);
-		newAgent = (OMR_Agent *)omrmem_allocate_memory(sizeof(*newAgent), OMRMEM_CATEGORY_VM);
+		newAgent = static_cast<OMR_Agent *>(omrmem_allocate_memory(sizeof(*newAgent),
+				OMRMEM_CATEGORY_VM));
 		if (NULL != newAgent) {
 			new(newAgent) OMR_Agent(vm, arg);
 			if (INITIALIZED != newAgent->_state) {


### PR DESCRIPTION
Clang/LLVM isn't able to compile the compilator's code when exception handling
is not enabled:

```
error: cannot use 'throw' with exceptions disabled
       throw Exception();
```

Warning C4291:

```
..\omr\OMR_Agent.cpp(145): warning C4291: 'void *OMR_Agent::operator
new(::size_t,void *)': no matching operator delete found; memory will
not be freed if initialization throws an exception
omr\include_core\OMR_Agent.hpp(136): note: see declaration of
'OMR_Agent::operator new'
```

has also been fixed.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>