### PR TITLE
Store addressable physical memory in GC_ExtensionsBase

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -102,6 +102,10 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 	excessiveGCStats.endGCTimeStamp = omrtime_hires_clock();
 	excessiveGCStats.lastEndGlobalGCTimeStamp = excessiveGCStats.endGCTimeStamp;
 
+        /* Get usable physical memory from portlibrary. This is used by computeDefaultMaxHeap().
+	 * It can also be used by downstream projects to compute project specific GC parameters.
+	 */
+	usablePhysicalMemory = omrsysinfo_get_addressable_physical_memory();
 
 	computeDefaultMaxHeap(env);
 
@@ -289,16 +293,10 @@ MM_GCExtensionsBase::identityHashDataRemoveRange(MM_EnvironmentBase* env, MM_Mem
 void
 MM_GCExtensionsBase::computeDefaultMaxHeap(MM_EnvironmentBase* env)
 {
-	uint64_t usableMemory = 0;
 	uint64_t memoryToRequest = 0;
 
-	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-
-	/* Initial memory as returned by port library API. */
-	usableMemory = omrsysinfo_get_addressable_physical_memory();
-
 	/* we are going to try to request a slice of half the usable memory */
-	memoryToRequest = (usableMemory / 2);
+	memoryToRequest = (usablePhysicalMemory / 2);
 
 #define J9_PHYSICAL_MEMORY_MAX (uint64_t)(512 * 1024 * 1024)
 #define J9_PHYSICAL_MEMORY_DEFAULT (16 * 1024 * 1024)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -546,6 +546,8 @@ public:
 
 	uintptr_t overflowSafeAllocSize;
 
+	uintptr_t usablePhysicalMemory; /**< Physical memory available to the process */
+
 #if defined(OMR_GC_REALTIME)
 	/* Parameters */
 	uintptr_t RTC_Frequency;


### PR DESCRIPTION
Added a new field 'usablePhysicalMemory' in GC_ExtensionsBase to
store the value returned by omrsysinfo_get_addressable_physical_memory().

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>