### PR TITLE
 Modify shutdown sequence to fix CS issue

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -52,6 +52,17 @@
 void
 MM_Configuration::kill(MM_EnvironmentBase* env)
 {
+	MM_GCExtensionsBase *ext = env->getExtensions();
+
+	/* DefaultMemorySpace needs to be killed before
+	 * ext->heap is freed in MM_Configuration::tearDown. */
+	if (NULL != ext->heap) {
+		MM_MemorySpace *modronMemorySpace = ext->heap->getDefaultMemorySpace();
+		if  (NULL != modronMemorySpace) {
+			modronMemorySpace->kill(env);
+		}
+		ext->heap->setDefaultMemorySpace(NULL);
+	}
 	tearDown(env);
 	env->getForge()->free(this);
 }

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -525,6 +525,11 @@ public:
 	bool isInlineTLHAllocateEnabled() { return _delegate.isInlineTLHAllocateEnabled(); }
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 
+	/* When a GC thread is created _workUnitIndex is initialized to 0, when a task is started _workUnitIndex is reset to 1.
+	 * _workUnitIndex can be used to check if a GC thread has done any work since it was created.
+	 */
+	MMINLINE bool isGCSlaveThreadActivated() { return _workUnitIndex != 0; }
+
 	MMINLINE uintptr_t getWorkUnitIndex() { return _workUnitIndex; }
 	MMINLINE uintptr_t getWorkUnitToHandle() { return _workUnitToHandle; }
 	MMINLINE void setWorkUnitToHandle(uintptr_t workUnitToHandle) { _workUnitToHandle = workUnitToHandle; }

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -63,6 +63,19 @@ MM_ConfigurationGenerational::newInstance(MM_EnvironmentBase *env)
 	return configuration;
 }
 
+void
+MM_ConfigurationGenerational::tearDown(MM_EnvironmentBase* env)
+{
+	MM_GCExtensionsBase* extensions = env->getExtensions();
+
+	/* Set pointer to scavenger in extensions to NULL
+	 * before Scavenger is teared down as part of clean up of defaultMemorySpace
+	 * in MM_Configuration::tearDown. */
+	extensions->scavenger = NULL;
+
+	MM_ConfigurationStandard::tearDown(env);
+}
+
 MM_MemorySubSpaceSemiSpace *
 MM_ConfigurationGenerational::createSemiSpace(MM_EnvironmentBase *envBase, MM_Heap *heap, MM_Scavenger *scavenger, MM_InitializationParameters *parameters, UDATA numaNode)
 {

--- a/gc/base/standard/ConfigurationGenerational.hpp
+++ b/gc/base/standard/ConfigurationGenerational.hpp
@@ -62,6 +62,7 @@ public:
 	
 protected:
 	MM_MemorySubSpaceSemiSpace *createSemiSpace(MM_EnvironmentBase *envBase, MM_Heap *heap, MM_Scavenger *scavenger, MM_InitializationParameters *parameters, UDATA numaNode = UDATA_MAX);
+	virtual void tearDown(MM_EnvironmentBase* env);
 private:
 	uintptr_t calculateDefaultRegionSize(MM_EnvironmentBase *env);
 };

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -97,8 +97,19 @@ MM_EnvironmentStandard::flushGCCaches()
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (getExtensions()->concurrentScavenger) {
-		if (MUTATOR_THREAD == getThreadType()) {
-			getExtensions()->scavenger->threadFinalReleaseCopyCaches(this, this);
+
+		/* When a GC Slave thread is created, a Thread object is created and is stored to a (Java) ThreadPool structure.
+		 * If this GC Slave thread created during active scavenger cycle and doesn't do any actual work,
+		 * it can still indirectly trigger a read barrier (if it's the first of 'mutator' threads to access ThreadPool),
+		 * and copy ThreadPool instance into its copy cache.
+		 * This special inactive GC thread will have non-empty copy cache at the beginning of the final STW phase of CS cycle,
+		 * and should be treated same as a mutator thread.
+		 */
+		if ((GC_SLAVE_THREAD == getThreadType() && !isGCSlaveThreadActivated()) ||
+				MUTATOR_THREAD == getThreadType()) {
+			if (NULL != getExtensions()->scavenger) {
+				getExtensions()->scavenger->threadFinalReleaseCopyCaches(this, this);
+			}
 		}
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */

--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -322,14 +322,6 @@ OMR_GC_ShutdownHeap(OMR_VM *omrVM)
 			extensions->verboseGCManager = NULL;
 		}
 
-		if ((NULL != extensions) && (NULL != extensions->heap)) {
-			MM_MemorySpace *defaultSpace = extensions->heap->getDefaultMemorySpace();
-			if (NULL != defaultSpace) {
-				defaultSpace->kill(&env);
-				extensions->heap->setDefaultMemorySpace(NULL);
-			}
-		}
-
 		if (NULL != extensions->configuration) {
 			extensions->configuration->kill(&env);
 		}


### PR DESCRIPTION
Fixing two issues with Concurrent Scavenger:
1. Modified shutdown sequence to do Scavenger tear down later in the
sequence; after all of the mutator threads are done. 
2. Added a new case in flushGCCaches to clear a GC Slave thread
copy cache when starting up with many GC
threads and GC slave thread is brought up during active scavenger cycle
but doesn't do any actual work and so is actually acting like a mutator
thread until the next cycle.

Signed-off-by: Evgenia Badyanova <evgeniab@ca.ibm.com>