### PR TITLE
AArch64: Initial version of OMRCodeGenerator

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
@@ -20,29 +20,175 @@
  *******************************************************************************/
 
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/CodeGenerator_inlines.hpp"
+#include "codegen/GCStackMap.hpp"
 #include "codegen/RegisterConstants.hpp"
 
 OMR::ARM64::CodeGenerator::CodeGenerator() :
-      OMR::CodeGenerator()
+      OMR::CodeGenerator(),
+      _constantData(NULL),
+      _outOfLineCodeSectionList(getTypedAllocator<TR_ARM64OutOfLineCodeSection*>(self()->comp()->allocator()))
    {
+   /*
+    * To be filled
+    */
    }
 
 void
 OMR::ARM64::CodeGenerator::beginInstructionSelection()
    {
+   TR_ASSERT(false, "Not implemented yet.");
    }
 
 void
 OMR::ARM64::CodeGenerator::endInstructionSelection()
    {
+   TR_ASSERT(false, "Not implemented yet.");
    }
 
 void
 OMR::ARM64::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
    {
+   TR_ASSERT(false, "Not implemented yet.");
    }
 
 void
 OMR::ARM64::CodeGenerator::doBinaryEncoding()
    {
+   TR_ASSERT(false, "Not implemented yet.");
+   }
+
+TR::Linkage *OMR::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
+   {
+   TR::Linkage *linkage = NULL;
+   TR_ASSERT(false, "Not implemented yet.");
+   /*
+    * Commented out until TR::ARM64SystemLinkage is implemented
+   switch (lc)
+      {
+      case TR_System:
+         linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());
+         break;
+      default:
+         TR_ASSERT(false, "using system linkage for unrecognized convention %d\n", lc);
+         linkage = new (self()->trHeapMemory()) TR::ARM64SystemLinkage(self());
+      }
+   */
+   self()->setLinkage(lc, linkage);
+   return linkage;
+   }
+
+void OMR::ARM64::CodeGenerator::emitDataSnippets()
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+   /*
+    * Commented out until TR::ConstantDataSnippet is implemented
+   self()->setBinaryBufferCursor(_constantData->emitSnippetBody());
+    */
+   }
+
+bool OMR::ARM64::CodeGenerator::hasDataSnippets()
+   {
+   return (_constantData == NULL) ? false : true;
+   }
+
+int32_t OMR::ARM64::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+   return 0;
+   /*
+    * Commented out until TR::ConstantDataSnippet is implemented
+   return estimatedSnippetStart + _constantData->getLength();
+    */
+   }
+
+
+#ifdef DEBUG
+void OMR::ARM64::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
+   {
+   if (outFile == NULL)
+      return;
+
+   TR_ASSERT(false, "Not implemented yet.");
+   /*
+    * Commented out until TR::ConstantDataSnippet is implemented
+   _constantData->print(outFile);
+    */
+   }
+#endif
+
+
+TR::Instruction *OMR::ARM64::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return NULL;
+   }
+
+
+// different from evaluate in that it returns a clobberable register
+TR::Register *OMR::ARM64::CodeGenerator::gprClobberEvaluate(TR::Node *node)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return NULL;
+   }
+
+
+void OMR::ARM64::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+   }
+
+
+TR_GlobalRegisterNumber OMR::ARM64::CodeGenerator::pickRegister(TR_RegisterCandidate *regCan,
+                                                          TR::Block **barr,
+                                                          TR_BitVector &availRegs,
+                                                          TR_GlobalRegisterNumber &highRegisterNumber,
+                                                          TR_LinkHead<TR_RegisterCandidate> *candidates)
+   {
+   return OMR::CodeGenerator::pickRegister(regCan, barr, availRegs, highRegisterNumber, candidates);
+   }
+
+bool OMR::ARM64::CodeGenerator::allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *regCan, TR::Node *branchNode)
+   {
+   // If return false, processLiveOnEntryBlocks has to dis-qualify any candidates which are referenced
+   // within any CASE of a SWITCH statement.
+   return true;
+   }
+
+int32_t OMR::ARM64::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *node)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return 0;
+   }
+
+int32_t OMR::ARM64::CodeGenerator::getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *node)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return 0;
+   }
+
+int32_t OMR::ARM64::CodeGenerator::getMaximumNumbersOfAssignableGPRs()
+   {
+   return TR::RealRegister::LastGPR - TR::RealRegister::FirstGPR + 1;
+   }
+
+int32_t OMR::ARM64::CodeGenerator::getMaximumNumbersOfAssignableFPRs()
+   {
+   return TR::RealRegister::LastFPR - TR::RealRegister::FirstFPR + 1;
+   }
+
+bool OMR::ARM64::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
+   {
+   return self()->machine()->getARM64RealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
+   }
+
+TR_GlobalRegisterNumber OMR::ARM64::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return 0;
    }


### PR DESCRIPTION
This commit implements the initial version of OMRCodeGenerator files
for aarch64.
This is a part of #2503.

Signed-off-by: knn-k <konno@jp.ibm.com>