### PR TITLE
Print data snippet label name log in tracelog

### DIFF
--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -1562,7 +1562,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
          }
       else if (cds)
          {
-         trfprintf(pOutFile, "DATA SNIPPET: ");
+         trfprintf(pOutFile, "Data ");
+         print(pOutFile, cds->getSnippetLabel());
+         trfprintf(pOutFile, ": ");
          auto data = cds->getValue();
          for (auto i = 0; i < cds->getDataSize(); i++)
             {


### PR DESCRIPTION
Data snippet label name is missing in tracelog on X86, adding it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>