### PR TITLE
Configure location of DIA-SDK needed by PdbScanner

### DIFF
--- a/configure
+++ b/configure
@@ -628,6 +628,7 @@ objext
 arlibext
 solibext
 exeext
+DIASDK_HOME
 enable_DDR
 enable_tracegen
 enable_fvtest_agent
@@ -658,6 +659,8 @@ CCLINK
 OMR_CROSS_COMPILE
 OMR_VALGRIND_MEMCHECK
 OMR_GC_IDLE_HEAP_MANAGER
+VS_CL_PATH
+OMR_DIASDK_HOME
 OMRTHREAD_LIB_UNIX
 OMRTHREAD_LIB_ZOS
 OMRTHREAD_LIB_WIN32
@@ -914,7 +917,8 @@ CPPFLAGS
 CPP
 CXX
 CXXFLAGS
-CCC'
+CCC
+OMR_DIASDK_HOME'
 
 
 # Initialize some variables set by options.
@@ -1726,6 +1730,8 @@ Some influential environment variables:
   CPP         C preprocessor
   CXX         C++ compiler command
   CXXFLAGS    C++ compiler flags
+  OMR_DIASDK_HOME
+              The directory where the DIA SDK can be found. (Default: )
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -2924,7 +2930,6 @@ else
   enable_tracegen=yes
 
 fi
-
 
 
 ###
@@ -4360,7 +4365,6 @@ $as_echo "$OMR_TOOLCHAIN" >&6; }
 
 # Default OMRGLUE to example/glue if it was not specified
 OMRGLUE=${OMRGLUE:-"./example/glue"}
-
 
 ## Default Variables
 
@@ -6838,7 +6842,7 @@ fi
 
 
 
-if test "$OMR_CROSS_CONFIGURE" != yes && test "$OMR_PORT_NUMA_SUPPORT" = 1 && test "$OMR_HOST_OS" = linux; then :
+if test "$OMR_CROSS_CONFIGURE" != yes -a "$OMR_PORT_NUMA_SUPPORT" = 1 -a "$OMR_HOST_OS" = linux; then :
 
 fi
 
@@ -7069,10 +7073,122 @@ fi
 
 
 
-if test "x$enable_DDR" = "xyes" && test "$cross_compiling" != "yes" && test "$OMR_HOST_OS" != osx && test "$OMR_HOST_OS" != aix; then :
 
-	# Look for libdwarf
-	for ac_header in dwarf.h libdwarf/dwarf.h libdwarf.h libdwarf/libdwarf.h
+
+if test "$enable_DDR" = yes -a "$cross_compiling" != "yes"; then :
+  case $OMR_HOST_OS in #(
+  aix) :
+     ;; #(
+  osx) :
+     ;; #(
+  win) :
+
+			# a user-supplied path wins
+			DIASDK_HOME="$OMR_DIASDK_HOME"
+			# otherwise if VSINSTALLDIR is set, use the DIA SDK found there
+			if test "x$DIASDK_HOME" = "x" -a "x$VSINSTALLDIR" != "x"; then :
+  DIASDK_HOME="$VSINSTALLDIR/DIA SDK"
+
+fi
+			# next, look relative to the location of the Visual Studio compiler
+			if test "x$DIASDK_HOME" = "x" -a "$OMR_TOOLCHAIN" = msvc; then :
+
+				# Extract the first word of "cl.exe", so it can be a program name with args.
+set dummy cl.exe; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_VS_CL_PATH+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $VS_CL_PATH in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_VS_CL_PATH="$VS_CL_PATH" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_VS_CL_PATH="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+VS_CL_PATH=$ac_cv_path_VS_CL_PATH
+if test -n "$VS_CL_PATH"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $VS_CL_PATH" >&5
+$as_echo "$VS_CL_PATH" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+				if test "x$VS_CL_PATH" != x; then :
+
+					# this should yield .../VC/bin/cl.exe or .../VC/bin/amd64/cl.exe
+					vc_bin_dir=$($as_dirname -- "$VS_CL_PATH" ||
+$as_expr X"$VS_CL_PATH" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
+	 X"$VS_CL_PATH" : 'X\(//\)[^/]' \| \
+	 X"$VS_CL_PATH" : 'X\(//\)$' \| \
+	 X"$VS_CL_PATH" : 'X\(/\)' \| . 2>/dev/null ||
+$as_echo X"$VS_CL_PATH" |
+    sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
+	    s//\1/
+	    q
+	  }
+	  /^X\(\/\/\)[^/].*/{
+	    s//\1/
+	    q
+	  }
+	  /^X\(\/\/\)$/{
+	    s//\1/
+	    q
+	  }
+	  /^X\(\/\).*/{
+	    s//\1/
+	    q
+	  }
+	  s/.*/./; q')
+					diasdk_dir="$vc_bin_dir/../../DIA SDK"
+					if test -f "$diasdk_dir/include/dia2.h"
+						DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"; then :
+
+						diasdk_dir="$vc_bin_dir/../../../DIA SDK"
+						if test -f "$diasdk_dir/include/dia2.h"; then :
+  DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"
+
+fi
+
+
+fi
+
+
+fi
+
+
+fi
+			# fail if none of the above
+			if test "x$DIASDK_HOME" = "x"; then :
+  as_fn_error $? "--enable-DDR requires the DIA SDK; set VSINSTALLDIR or OMR_DIASDK_HOME" "$LINENO" 5
+
+fi
+			# use forward slashes instead of backslashes; remove any duplicate slashes
+			DIASDK_HOME=$(echo "$DIASDK_HOME" | sed -e 's:\\:/:g' -e 's://:/:'g)
+		 ;; #(
+  *) :
+
+			# other host types: look for DWARF support
+			for ac_header in dwarf.h libdwarf/dwarf.h libdwarf.h libdwarf/libdwarf.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -7085,8 +7201,7 @@ fi
 
 done
 
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
 $as_echo_n "checking for library containing dwarf_init... " >&6; }
 if ${ac_cv_search_dwarf_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -7142,7 +7257,7 @@ if test "$ac_res" != no; then :
 
 fi
 
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dwarf_init" >&5
 $as_echo_n "checking for library containing dwarf_init... " >&6; }
 if ${ac_cv_search_dwarf_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -7198,7 +7313,7 @@ if test "$ac_res" != no; then :
 
 fi
 
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing elf_begin" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing elf_begin" >&5
 $as_echo_n "checking for library containing elf_begin... " >&6; }
 if ${ac_cv_search_elf_begin+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -7255,6 +7370,8 @@ if test "$ac_res" != no; then :
 fi
 
 
+	 ;;
+esac
 
 fi
 
@@ -7310,6 +7427,7 @@ if test "x$HOST_CC" = "x"; then :
 fi
 
 CC=$BUILD_CC
+
 
 
 
@@ -8787,5 +8905,4 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,22 +1,22 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
-# 
+# Copyright (c) 2015, 2018 IBM Corp. and others
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#    
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
@@ -132,7 +132,6 @@ AC_ARG_ENABLE([tracegen],
 	[enable_tracegen=yes]
 )
 
-
 ###
 ### Build environment configuration
 ###
@@ -195,7 +194,7 @@ AS_IF([test "x$OMR_TARGET_DATASIZE" != "x"],
 		[OMR_TARGET_DATASIZE=64],
 		[OMR_TARGET_DATASIZE=32]
 	)]
-) 
+)
 AC_MSG_RESULT([$OMR_TARGET_DATASIZE])
 
 AC_MSG_CHECKING([OMR_TOOLCHAIN])
@@ -211,7 +210,6 @@ AC_MSG_RESULT([$OMR_TOOLCHAIN])
 
 # Default OMRGLUE to example/glue if it was not specified
 OMRGLUE=${OMRGLUE:-"./example/glue"}
-
 
 ## Default Variables
 
@@ -265,7 +263,7 @@ exe_output_dir=${exe_output_dir:-"\$(top_srcdir)"}
 
 ############### Enable/Disable auto-build-flag
 # auto-build-flag command line argument controls the setting of build flags
-# that are not explicitly enabled or disabled. 
+# that are not explicitly enabled or disabled.
 #
 # When auto-build-flag is enabled, build flags that are not explicitly enabled
 # or disabled will be set according to the outcome of the <default action>
@@ -281,7 +279,7 @@ exe_output_dir=${exe_output_dir:-"\$(top_srcdir)"}
 AC_ARG_ENABLE([auto-build-flag],
 	AS_HELP_STRING([--enable-auto-build-flag],
 		[Automatically detect the value of build flags that are not explicitly
-     enabled or disabled. (Default: yes)]),
+		enabled or disabled. (Default: yes)]),
 	[],
 	[enable_auto_build_flag=yes]
 )
@@ -346,7 +344,7 @@ AC_DEFUN([OMRCFG_DEFINE_FLAG_ON],
 # OMRCFG_DEFINE_FLAG_OFF(<flag name>, [<value>], [<help message>])
 # where <flag name> is the name of the flag that will be defined in omrcfg.h if
 # --enable-<flag name> is passed to configure. If --enable-<flag-name> is not
-# passed to configure,the the flag is disabled. 
+# passed to configure,the the flag is disabled.
 # $3 is an optional help message.
 #
 AC_DEFUN([OMRCFG_DEFINE_FLAG_OFF],
@@ -471,7 +469,7 @@ OMRCFG_DEFINE_FLAG([OMR_PORT_NUMA_SUPPORT],[],
 	)]
 )
 
-AS_IF([[test "$OMR_CROSS_CONFIGURE" != yes] && [test "$OMR_PORT_NUMA_SUPPORT" = 1] && [test "$OMR_HOST_OS" = linux]],
+AS_IF([test "$OMR_CROSS_CONFIGURE" != yes -a "$OMR_PORT_NUMA_SUPPORT" = 1 -a "$OMR_HOST_OS" = linux],
 	[AC_CHECK_HEADERS_ONCE([numa.h],
 		[],
 		[AC_MSG_ERROR([numa.h was not found. Please install numa-dev])]
@@ -508,15 +506,57 @@ OMRCFG_DEFINE_FLAG([OMRTHREAD_LIB_UNIX],[1],
 	)]
 )
 
-AS_IF([[test "x$enable_DDR" = "xyes"] && [test "$cross_compiling" != "yes"] && [test "$OMR_HOST_OS" != osx] && [test "$OMR_HOST_OS" != aix]],
-	[
-	# Look for libdwarf
-	AC_CHECK_HEADERS([dwarf.h libdwarf/dwarf.h libdwarf.h libdwarf/libdwarf.h])
+AC_ARG_VAR([OMR_DIASDK_HOME],
+	[The directory where the DIA SDK can be found.] (Default: ))
 
-	AC_SEARCH_LIBS([dwarf_init], [dwarf], [], [], [])
-	AC_SEARCH_LIBS([dwarf_init], [dwarf], [], [], [-lelf])
-	AC_SEARCH_LIBS([elf_begin], [elf], [], [], [])
-	]
+AS_IF([test "$enable_DDR" = yes -a "$cross_compiling" != "yes"],
+	[AS_CASE($OMR_HOST_OS,
+		[aix],[],
+		[osx],[],
+		[win],[
+			# a user-supplied path wins
+			DIASDK_HOME="$OMR_DIASDK_HOME"
+			# otherwise if VSINSTALLDIR is set, use the DIA SDK found there
+			AS_IF([test "x$DIASDK_HOME" = "x" -a "x$VSINSTALLDIR" != "x"],
+				[DIASDK_HOME="$VSINSTALLDIR/DIA SDK"]
+			)
+			# next, look relative to the location of the Visual Studio compiler
+			AS_IF([test "x$DIASDK_HOME" = "x" -a "$OMR_TOOLCHAIN" = msvc],
+				[
+				AC_PATH_PROG([VS_CL_PATH],[cl.exe])
+				AS_IF([test "x$VS_CL_PATH" != x],
+					[
+					# this should yield .../VC/bin/cl.exe or .../VC/bin/amd64/cl.exe
+					vc_bin_dir=$(AS_DIRNAME(["$VS_CL_PATH"]))
+					diasdk_dir="$vc_bin_dir/../../DIA SDK"
+					AS_IF([test -f "$diasdk_dir/include/dia2.h"]
+						[DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"],
+						[
+						diasdk_dir="$vc_bin_dir/../../../DIA SDK"
+						AS_IF([test -f "$diasdk_dir/include/dia2.h"],
+							[DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"]
+						)
+						]
+					)
+					]
+				)
+				]
+			)
+			# fail if none of the above
+			AS_IF([test "x$DIASDK_HOME" = "x"],
+				[AC_MSG_ERROR([--enable-DDR requires the DIA SDK; set VSINSTALLDIR or OMR_DIASDK_HOME])]
+			)
+			# use forward slashes instead of backslashes; remove any duplicate slashes
+			DIASDK_HOME=$(echo "$DIASDK_HOME" | sed -e 's:\\:/:g' -e 's://:/:'g)
+		],
+		[
+			# other host types: look for DWARF support
+			AC_CHECK_HEADERS([dwarf.h libdwarf/dwarf.h libdwarf.h libdwarf/libdwarf.h])
+			AC_SEARCH_LIBS([dwarf_init], [dwarf], [], [], [])
+			AC_SEARCH_LIBS([dwarf_init], [dwarf], [], [], [-lelf])
+			AC_SEARCH_LIBS([elf_begin], [elf], [], [], [])
+		]
+	)]
 )
 
 OMRCFG_DEFINE_FLAG_OFF([OMR_GC_IDLE_HEAP_MANAGER])
@@ -567,6 +607,7 @@ AC_SUBST([enable_fvtest])
 AC_SUBST([enable_fvtest_agent])
 AC_SUBST([enable_tracegen])
 AC_SUBST([enable_DDR])
+AC_SUBST([DIASDK_HOME])
 
 AC_SUBST(exeext)
 AC_SUBST(solibext)
@@ -638,4 +679,3 @@ AC_CONFIG_COMMANDS([toolconfigure],
 		[OMR_HOSTCONFIG_ENV="CC= CXX="])])
 
 AC_OUTPUT
-

--- a/ddr/Makefile
+++ b/ddr/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
+# Copyright (c) 2015, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,14 @@ endif
 
 # Make DEBUG_FORMAT visible to src/cmdline_tool/makefile
 export DEBUG_FORMAT
+
+ifeq (win,$(OMR_HOST_OS))
+  ifneq (,$(DIASDK_HOME))
+    # DIASDK_HOME almost certainly has embedded spaces, so we can't just append
+    # to MODULE_INCLUDES; instead, adjust the INCLUDE environment variable.
+    export INCLUDE := $(if $(INCLUDE),$(INCLUDE);)$(DIASDK_HOME)/include
+  endif
+endif
 
 targets = \
   lib \

--- a/ddr/tools/ddrgen/Makefile
+++ b/ddr/tools/ddrgen/Makefile
@@ -53,7 +53,6 @@ endif
 
 ifeq (win,$(OMR_HOST_OS))
   MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
-  MODULE_INCLUDES += $(ddrgen_srcdir)/scanners/pdb/DIA-SDK/include
 endif
 
 ifeq (osx,$(OMR_HOST_OS))

--- a/omrmakefiles/configure.mk.in
+++ b/omrmakefiles/configure.mk.in
@@ -1,19 +1,19 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
-# 
+# Copyright (c) 2015, 2018 IBM Corp. and others
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#    
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
@@ -167,7 +167,6 @@ SOLIBEXT := @solibext@
 ARLIBEXT := @arlibext@
 OBJEXT := @objext@
 
-
 ###
 ### Platform Flags
 ###
@@ -194,6 +193,7 @@ ENABLE_FVTEST_AGENT := @enable_fvtest_agent@
 ENABLE_TRACEGEN := @enable_tracegen@
 
 ENABLE_DDR := @enable_DDR@
+DIASDK_HOME := @DIASDK_HOME@
 
 ###
 ### Global Options


### PR DESCRIPTION
Location of DIA-SDK can be:
- specified explicitly via OMR_DIASDK_HOME configuration variable
- or found relative to cl.exe.

Relocate addition of DIASDK_HOME to include path so it is available for all code of ddr tools.

Simplify compound configure tests.