### PR TITLE
Fix data type of GC_ExtensionsBase::usablePhysicalMemory

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -293,10 +293,8 @@ MM_GCExtensionsBase::identityHashDataRemoveRange(MM_EnvironmentBase* env, MM_Mem
 void
 MM_GCExtensionsBase::computeDefaultMaxHeap(MM_EnvironmentBase* env)
 {
-	uint64_t memoryToRequest = 0;
-
 	/* we are going to try to request a slice of half the usable memory */
-	memoryToRequest = (usablePhysicalMemory / 2);
+	uint64_t memoryToRequest = (usablePhysicalMemory / 2);
 
 #define J9_PHYSICAL_MEMORY_MAX (uint64_t)(512 * 1024 * 1024)
 #define J9_PHYSICAL_MEMORY_DEFAULT (16 * 1024 * 1024)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -546,7 +546,7 @@ public:
 
 	uintptr_t overflowSafeAllocSize;
 
-	uintptr_t usablePhysicalMemory; /**< Physical memory available to the process */
+	uint64_t usablePhysicalMemory; /**< Physical memory available to the process */
 
 #if defined(OMR_GC_REALTIME)
 	/* Parameters */


### PR DESCRIPTION
GC_ExtensionsBase::usablePhysicalMemory should be of same type as the value
returned by omrsysinfo_get_addressable_physical_memory() which is uint64_t.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>