### PR TITLE
Correct .gitignore entry for build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-build/
+/build/
 objs/
 CMakeFiles/
 CMakeCache.txt


### PR DESCRIPTION
The entry right now says "build/" but this will match any directory
called "build" including anything below, say, jitbuilder/build . Given
the latter directory is revision controlled, it's not correct for it
to be ignored.

Fix is to use /build/ as the entry (leading slash makes it only apply
to the top level directory in the repo).

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>