### PR TITLE
Include MemorySpace.hpp in gc/base/Configure.cpp

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -40,6 +40,7 @@
 #include "OMR_VM.hpp"
 #include "OMR_VMThread.hpp"
 #include "MemoryManager.hpp"
+#include "MemorySpace.hpp"
 #include "ParallelDispatcher.hpp"
 #include "ReferenceChainWalkerMarkMap.hpp"
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)


### PR DESCRIPTION
A recent change requires Configure.cpp to know the full shape
of a MemorySpace object, but Configure.cpp only #include's
MemorySpace.hpp via some other header file. Worse, it may
not include MemorySpace.hpp under some configuration settings.

So let's just explicitly #include it.

Signed-off-buy: Mark Stoodley <mstoodle@ca.ibm.com>