### PR TITLE
Cleanup travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,22 +52,10 @@ matrix:
       compiler: gcc
     - os: linux
       compiler: clang
+    - os: linux
+      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR="Unix Makefiles"
   include:
     ## Auto tool builds
-    #  32 bit Linux x86
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - libnuma-dev
-            - gcc-multilib
-            - g++-multilib
-      env: SPEC=linux_x86 PLATFORM=amd64-linux-gcc
-    # 64 bit Linux x86
-    - os: linux
-      env: SPEC=linux_x86-64 PLATFORM=amd64-linux64-gcc
     # 64 bit Linux x86 compressed pointers
     - os: linux
       env: SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc
@@ -88,7 +76,7 @@ matrix:
       dist: trusty
     ## CMake builds
     #  Ninja builds
-    #  64 bit Linux x86
+    #  32 bit Linux x86
     - os: linux
       addons:
         apt:
@@ -100,7 +88,9 @@ matrix:
             - libdwarf-dev
             - libelf-dev 
             - ninja-build
-      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja
+            - gcc-multilib
+            - g++-multilib
+      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja CMAKE_DEFINES="-DOMR_ENV_DATA32=ON -DOMR_DDR=OFF -DOMR_JITBUILDER=OFF"
 before_script:
   - ulimit -c unlimited
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/opt/ccache/libexec:$PATH ; fi

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -48,6 +48,7 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <sys/utsname.h>
+#include <inttypes.h>
 #elif defined(AIXPPC)
 #include <sys/ldr.h>
 #include <sys/debug.h>
@@ -1464,7 +1465,7 @@ sigqueue_is_reliable(void)
 	 * will stay zero and we'll consider sigqueue() unreliable.
 	 */
 	if (0 == uname(&sysinfo)) {
-		sscanf(sysinfo.release, "%lu.%lu", &release_major, &release_minor);
+		sscanf(sysinfo.release, "%" SCNuPTR ".%" SCNuPTR, &release_major, &release_minor);
 	}
 
 	/* sigqueue() is sufficiently reliable on newer Linux kernels (version 3.11 and later). */

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -33,7 +33,6 @@ else
 fi
 
 if test "x$BUILD_WITH_CMAKE" = "xyes"; then
-
   if test "x$CMAKE_GENERATOR" = "x"; then
     export CMAKE_GENERATOR="Ninja"
   fi
@@ -46,7 +45,7 @@ if test "x$BUILD_WITH_CMAKE" = "xyes"; then
 
   mkdir build
   cd build
-  time cmake -Wdev -G "$CMAKE_GENERATOR" -C../cmake/caches/Travis.cmake ..
+  time cmake -Wdev -G "$CMAKE_GENERATOR" $CMAKE_DEFINES -C../cmake/caches/Travis.cmake ..
   if test "x$RUN_BUILD" != "xno"; then
     time cmake --build . -- -j $BUILD_JOBS
     if test "x$RUN_TESTS" != "xno"; then
@@ -54,12 +53,9 @@ if test "x$BUILD_WITH_CMAKE" = "xyes"; then
     fi
   fi
 else
-  # Disable ddrgen on 32 bit builds--libdwarf in 32bit is unavailable.
-  if test "x$SPEC" = "xlinux_x86"; then
-    export EXTRA_CONFIGURE_ARGS="--disable-DDR"
-  else
-    export EXTRA_CONFIGURE_ARGS="--enable-DDR"
-  fi
+  # Linux 64 compressed references build and the 	Lint builds do not run in CMake
+  # Remove the Linux 64 compressed references build once the Autotool build infrastructure is retired
+  export EXTRA_CONFIGURE_ARGS="--enable-DDR"
   time make -f run_configure.mk OMRGLUE=./example/glue SPEC="$SPEC" PLATFORM="$PLATFORM"
   if test "x$RUN_BUILD" != "xno"; then
     # Normal build system


### PR DESCRIPTION
Travis builds will now test the following:
1. OSX 64 bit using CMake with Unix Makefiles
2. Linux 32 bit using CMake with Ninja
3. Linux 64 bit compressed references using autotools
4. Linux 64 bit Lint build

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>