### PR TITLE
Extend OMR Signal API [Part 2]

### DIFF
--- a/fvtest/porttest/omrsignalTest.cpp
+++ b/fvtest/porttest/omrsignalTest.cpp
@@ -1100,7 +1100,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = "omrsig_test_async_unix_handler";
 	AsyncHandlerInfo handlerInfo;
-	uint32_t setAsyncRC;
+	int32_t setAsyncRC;
 	unsigned int index;
 	omrthread_monitor_t asyncMonitor;
 	intptr_t monitorRC;

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1381,7 +1381,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsignal.c::omrsig_can_protect "omrsig_can_protect"*/
 	int32_t (*sig_can_protect)(struct OMRPortLibrary *portLibrary,  uint32_t flags) ;
 	/** see @ref omrsignal.c::omrsig_set_async_signal_handler "omrsig_set_async_signal_handler"*/
-	uint32_t (*sig_set_async_signal_handler)(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags) ;
+	int32_t (*sig_set_async_signal_handler)(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags) ;
 	/** see @ref omrsignal.c::omrsig_set_single_async_signal_handler "omrsig_set_single_async_signal_handler"*/
 	int32_t (*sig_set_single_async_signal_handler)(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag, void **oldOSHandler) ;
 	/** see @ref omrsignal.c::omrsig_map_os_signal_to_portlib_signal "omrsig_map_os_signal_to_portlib_signal"*/

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1388,6 +1388,8 @@ typedef struct OMRPortLibrary {
 	uint32_t (*sig_map_os_signal_to_portlib_signal)(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue) ;
 	/** see @ref omrsignal.c::omrsig_map_portlib_signal_to_os_signal "omrsig_map_portlib_signal_to_os_signal"*/
 	int32_t (*sig_map_portlib_signal_to_os_signal)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag) ;
+	/** see @ref omrsignal.c::omrsig_register_os_handler "omrsig_register_os_handler"*/
+	int32_t (*sig_register_os_handler)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler) ;
 	/** see @ref omrsignal.c::omrsig_info "omrsig_info"*/
 	uint32_t (*sig_info)(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value) ;
 	/** see @ref omrsignal.c::omrsig_info_count "omrsig_info_count"*/
@@ -1889,6 +1891,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsig_set_single_async_signal_handler(param1,param2,param3,param4) privateOmrPortLibrary->sig_set_single_async_signal_handler(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
 #define omrsig_map_os_signal_to_portlib_signal(param1) privateOmrPortLibrary->sig_map_os_signal_to_portlib_signal(privateOmrPortLibrary, (param1))
 #define omrsig_map_portlib_signal_to_os_signal(param1) privateOmrPortLibrary->sig_map_portlib_signal_to_os_signal(privateOmrPortLibrary, (param1))
+#define omrsig_register_os_handler(param1,param2,param3) privateOmrPortLibrary->sig_register_os_handler(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsig_info(param1,param2,param3,param4,param5) privateOmrPortLibrary->sig_info(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
 #define omrsig_info_count(param1,param2) privateOmrPortLibrary->sig_info_count(privateOmrPortLibrary, (param1), (param2))
 #define omrsig_set_options(param1) privateOmrPortLibrary->sig_set_options(privateOmrPortLibrary, (param1))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -219,6 +219,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsig_set_single_async_signal_handler, /* sig_set_single_async_signal_handler */
 	omrsig_map_os_signal_to_portlib_signal, /* sig_map_os_signal_to_portlib_signal */
 	omrsig_map_portlib_signal_to_os_signal, /* sig_map_portlib_signal_to_os_signal */
+	omrsig_register_os_handler, /* sig_register_os_handler */
 	omrsig_info, /* sig_info */
 	omrsig_info_count, /* sig_info_count */
 	omrsig_set_options, /* sig_set_options */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1065,3 +1065,7 @@ TraceEvent=Trc_PRT_signal_omrsig_set_single_async_signal_handler_user_handler_ad
 TraceExit=Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_set_single_async_signal_handler: Exiting, rc=%d, handler=%p, handler_arg=%p, portlibSignalFlag=0x%X, oldOSHandler=%p"
 
 TraceException=Trc_PRT_signal_mapOSSignalToPortLib_ERROR_unknown_signal Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal: ERROR unknown OS signal=0x%X"
+
+TraceEntry=Trc_PRT_signal_omrsig_register_os_handler_entered Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_register_os_handler: Entered, portLibrarySignalFlag=0x%X, newOSHandler=%p"
+TraceExit=Trc_PRT_signal_omrsig_register_os_handler_exiting Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_register_os_handler: Exiting, rc=%d, portLibrarySignalFlag=0x%X, newOSHandler=%p, oldOSHandler=%p"
+TraceException=Trc_PRT_signal_omrsig_register_os_handler_invalid_portlibSignalFlag Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_register_os_handler: ERROR, portlibSignalFlag=0x%X is either zero or has multiple signal bits set."

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -180,8 +180,11 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
  * entry corresponding to omrsig_handler_fn is removed, and related resources are freed. portlibSignalFlag can only
  * have one signal flag set; otherwise, OMRPORT_SIG_ERROR is returned. One omrsig_handler_fn handler is registered
  * with a signal at any time instead of multiple handlers. When associating a new omrsig_handler_fn with a signal,
- * prior omrsig_handler_fn(s) are dissociated from the signal. The address of the old signal handler function is
- * stored in oldOSHandler. This function supports all signals listed in OMRPORT_SIG_FLAG_SIGALLASYNC.
+ * prior omrsig_handler_fn(s) are dissociated from the signal. This function supports all signals listed in
+ * OMRPORT_SIG_FLAG_SIGALLASYNC.
+ *
+ * The address of the old signal handler function is stored in *oldOSHandler. In case of error or if NULL is provided
+ * for oldOSHandler, then *oldOSHandler is not updated to reflect the old signal handler function.
  *
  * @param[in] portLibrary The port library
  * @param[in] handler the function to call if an asynchronous signal arrives
@@ -229,7 +232,11 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
  * @brief Register a handler with the OS. For an invalid portlibSignalFlag, an error is returned.
  * portlibSignalFlag is invalid: if it is zero or if multiple signal bits are specified or if the
  * specified flag is not supported. If OS fails to register newOSHandler for the specified signal,
- * then an error is returned. In error cases, oldOSHandler won't be updated.
+ * then an error is returned.
+ *
+ * The address of the old signal handler function is stored in *oldOSHandler. In case of error or
+ * if NULL is provided for oldOSHandler, then *oldOSHandler is not updated to reflect the old
+ * signal handler function.
  *
  * This function may override a master handler which was previously set by omrsig_protect or
  * omrsig_set_*_async_signal_handler variant. The records associated with the master handler

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -163,12 +163,12 @@ omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void
  * @note A handler should not do anything to cause the reporting thread to terminate (e.g. call omrthread_exit()) as that may prevent
  *  future signals from being reported.
  *
- * @return 0 on success
+ * @return 0 on success or non-zero on failure
  */
-uint32_t
+int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
-	return 1;
+	return OMRPORT_SIG_ERROR;
 }
 
 

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -172,7 +172,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 }
 
 
-/*
+/**
  * @brief Similar to omrsig_set_async_signal_handler. Refer to omrsig_set_async_signal_handler's description above.
  * A new element is added to the asyncHandlerList for omrsig_handler_fn, and masterASynchSignalHandler is registered
  * with the OS for the signal corresponding to the specified portlibSignalFlag. masterASynchSignalHandler invokes
@@ -197,21 +197,21 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 	return OMRPORT_SIG_ERROR;
 }
 
-/*
+/**
  * @brief Given an OS signal value, return the corresponding port library signal flag.
  *
  * @param[in] portLibrary The port library
  * @param[in] osSignalValue OS signal value
  *
  * @return port library signal flag on success and 0 on failure
-*/
+ */
 uint32_t
 omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue)
 {
 	return 0;
 }
 
-/*
+/**
  * @brief Given a port library signal flag, return the corresponding OS signal value.
  *
  * @param[in] portLibrary The port library

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -547,7 +547,7 @@ extern J9_CFUNC int32_t
 omrsig_set_options(struct OMRPortLibrary *portLibrary, uint32_t options);
 extern J9_CFUNC int32_t
 omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void *fn_arg, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, uintptr_t *result);
-extern J9_CFUNC uint32_t
+extern J9_CFUNC int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags);
 extern J9_CFUNC int32_t
 omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag, void **oldOSHandler);

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -555,6 +555,8 @@ extern J9_CFUNC uint32_t
 omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint32_t osSignalValue);
 extern J9_CFUNC int32_t
 omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag);
+extern J9_CFUNC int32_t
+omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler);
 extern J9_CFUNC uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -384,10 +384,10 @@ omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void 
 	return 0;
 }
 
-uint32_t
+int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
-	uint32_t rc = 0;
+	int32_t rc = 0;
 	J9UnixAsyncHandlerRecord *cursor = NULL;
 	J9UnixAsyncHandlerRecord **previousLink = NULL;
 

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -581,6 +581,12 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
 	return (int32_t)mapPortLibSignalToUnix(portlibSignalFlag);
 }
 
+int32_t
+omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler)
+{
+	return OMRPORT_SIG_ERROR;
+}
+
 /*
  * The full shutdown routine "sig_full_shutdown" overwrites this once we've completed startup
  */

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -575,7 +575,12 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 
 	omrthread_monitor_exit(asyncMonitor);
 
-	Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting(rc, handler, handler_arg, portlibSignalFlag, *oldOSHandler);
+	if (NULL != oldOSHandler) {
+		Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting(rc, handler, handler_arg, portlibSignalFlag, *oldOSHandler);
+	} else {
+		Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting(rc, handler, handler_arg, portlibSignalFlag, NULL);
+	}
+
 	return rc;
 }
 
@@ -625,7 +630,11 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 		omrthread_monitor_exit(registerHandlerMonitor);
 	}
 
-	Trc_PRT_signal_omrsig_register_os_handler_exiting(rc, portlibSignalFlag, newOSHandler, *oldOSHandler);
+	if (NULL != oldOSHandler) {
+		Trc_PRT_signal_omrsig_register_os_handler_exiting(rc, portlibSignalFlag, newOSHandler, *oldOSHandler);
+	} else {
+		Trc_PRT_signal_omrsig_register_os_handler_exiting(rc, portlibSignalFlag, newOSHandler, NULL);
+	}
 
 	return rc;
 }

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -585,7 +585,23 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
 int32_t
 omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler)
 {
-	return OMRPORT_SIG_ERROR;
+	int32_t rc = 0;
+
+	Trc_PRT_signal_omrsig_register_os_handler_entered(portlibSignalFlag, newOSHandler);
+
+	if ((0 == portlibSignalFlag) || !OMR_IS_ONLY_ONE_BIT_SET(portlibSignalFlag)) {
+		/* If portlibSignalFlag is 0 or if portlibSignalFlag has multiple signal bits set, then fail. */
+		Trc_PRT_signal_omrsig_register_os_handler_invalid_portlibSignalFlag(portlibSignalFlag);
+		rc = OMRPORT_SIG_ERROR;
+	} else {
+		omrthread_monitor_enter(registerHandlerMonitor);
+		rc = registerSignalHandlerWithOS(portLibrary, portlibSignalFlag, (unix_sigaction)newOSHandler, oldOSHandler);
+		omrthread_monitor_exit(registerHandlerMonitor);
+	}
+
+	Trc_PRT_signal_omrsig_register_os_handler_exiting(rc, portlibSignalFlag, newOSHandler, *oldOSHandler);
+
+	return rc;
 }
 
 /*
@@ -1108,6 +1124,13 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 {
 	int unixSignalNo = mapPortLibSignalToUnix(portLibrarySignalNo);
 	struct sigaction newAction;
+
+	/* Don't register a handler for unrecognized OS signals.
+	 * Unrecognized OS signals are the ones which aren't included in signalMap.
+	 */
+	if (OMRPORT_SIG_ERROR == unixSignalNo) {
+		return OMRPORT_SIG_ERROR;
+	}
 
 	memset(&newAction, 0, sizeof(struct sigaction));
 

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -401,7 +401,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 			rc = registerMasterHandlers(portLibrary, OMRPORT_SIG_FLAG_SIGXFSZ, OMRPORT_SIG_FLAG_SIGALLASYNC, NULL);
 		} else {
 			Trc_PRT_signal_omrsig_set_async_signal_handler_will_not_set_handler_due_to_Xrs(handler, handler_arg, flags);
-			rc = -1;
+			rc = OMRPORT_SIG_ERROR;
 		}
 	} else {
 		rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLASYNC, NULL);
@@ -410,7 +410,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 
 	if (0 != rc) {
 		Trc_PRT_signal_omrsig_set_async_signal_handler_exiting_did_nothing_possible_error(handler, handler_arg, flags);
-		return OMRPORT_SIG_ERROR;
+		return rc;
 	}
 
 	omrthread_monitor_enter(asyncMonitor);
@@ -451,7 +451,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 			J9UnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 
 			if (NULL == record) {
-				rc = 1;
+				rc = OMRPORT_SIG_ERROR;
 			} else {
 				record->portLib = portLibrary;
 				record->handler = handler;
@@ -550,7 +550,7 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 	if (!foundHandler && (0 != portlibSignalFlag)) {
 		J9UnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 		if (NULL == record) {
-			rc = 1;
+			rc = OMRPORT_SIG_ERROR;
 		} else {
 			record->portLib = portLibrary;
 			record->handler = handler;

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1258,9 +1258,6 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 		}
 	}
 
-	/* CMVC 96193 signalsWithHandlers is checked without acquiring the registerHandlerMonitor */
-	issueWriteBarrier();
-
 	/* Set the portLibrarySignalNo bit in signalsWithHandlers to record successful registration
 	 * of the handler. */
 	signalsWithHandlers |= portLibrarySignalNo;

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -84,9 +84,10 @@ static struct {
 	uint32_t restore;
 }	oldActions[ARRAY_SIZE_SIGNALS];
 
-/* Records the (port library defined) signals for which we have registered a master handler.
- * Access to this must be protected by the masterHandlerMonitor */
-static uint32_t signalsWithMasterHandlers;
+/* Records the (port library defined) signals for which a handler is registered.
+ * Access to this variable must be protected by the registerHandlerMonitor.
+ */
+static uint32_t signalsWithHandlers;
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
 static uint32_t shutDownASynchReporter;
@@ -141,7 +142,7 @@ static pthread_mutex_t wakeUpASyncReporterMutex;
 #endif /* !defined(J9ZOS390) */
 
 static omrthread_monitor_t asyncMonitor;
-static omrthread_monitor_t masterHandlerMonitor;
+static omrthread_monitor_t registerHandlerMonitor;
 static omrthread_monitor_t asyncReporterShutdownMonitor;
 static uint32_t asyncThreadCount;
 static uint32_t attachedPortLibraries;
@@ -326,10 +327,10 @@ omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void 
 
 	if (0 != flagsSignalsOnly) {
 
-		/* Acquire the masterHandlerMonitor and install the handler via registerMasterHandlers. */
-		omrthread_monitor_enter(masterHandlerMonitor);
+		/* Acquire the registerHandlerMonitor and install the handler via registerMasterHandlers. */
+		omrthread_monitor_enter(registerHandlerMonitor);
 		rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLSYNC, NULL);
-		omrthread_monitor_exit(masterHandlerMonitor);
+		omrthread_monitor_exit(registerHandlerMonitor);
 
 		if (0 != rc) {
 			return OMRPORT_SIG_ERROR;
@@ -392,7 +393,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 
 	Trc_PRT_signal_omrsig_set_async_signal_handler_entered(handler, handler_arg, flags);
 
-	omrthread_monitor_enter(masterHandlerMonitor);
+	omrthread_monitor_enter(registerHandlerMonitor);
 
 	if (OMR_ARE_ANY_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)) {
 		/* -Xrs was set, we can't protect against any signals, do not install any handlers except SIGXFSZ*/
@@ -405,7 +406,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 	} else {
 		rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLASYNC, NULL);
 	}
-	omrthread_monitor_exit(masterHandlerMonitor);
+	omrthread_monitor_exit(registerHandlerMonitor);
 
 	if (0 != rc) {
 		Trc_PRT_signal_omrsig_set_async_signal_handler_exiting_did_nothing_possible_error(handler, handler_arg, flags);
@@ -489,7 +490,7 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 		}
 	}
 
-	omrthread_monitor_enter(masterHandlerMonitor);
+	omrthread_monitor_enter(registerHandlerMonitor);
 
 	if (OMR_ARE_ANY_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)) {
 		/* -Xrs was set, we can't protect against any signals, do not install any handlers except SIGXFSZ*/
@@ -502,7 +503,7 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 	} else {
 		rc = registerMasterHandlers(portLibrary, portlibSignalFlag, OMRPORT_SIG_FLAG_SIGALLASYNC, oldOSHandler);
 	}
-	omrthread_monitor_exit(masterHandlerMonitor);
+	omrthread_monitor_exit(registerHandlerMonitor);
 
 	if (0 != rc) {
 		Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting_did_nothing_possible_error(rc, handler, handler_arg, portlibSignalFlag);
@@ -1089,7 +1090,7 @@ masterASynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
  * Register the signal handler with the OS, generally used to register the master signal handlers
  * Not to be confused with omrsig_protect, which registers the user's handler with the port library.
  *
- * Calls to this function must be synchronized using "masterHandlerMonitor".
+ * Calls to this function must be synchronized using "registerHandlerMonitor".
  *
  * The use of this function forces the flags SA_RESTART | SA_SIGINFO | SA_NODEFER to be set for the new signal action
  *
@@ -1199,11 +1200,12 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 		}
 	}
 
-	/* CMVC 96193 signalsWithMasterHandlers is checked without acquiring the masterHandlerMonitor */
+	/* CMVC 96193 signalsWithHandlers is checked without acquiring the registerHandlerMonitor */
 	issueWriteBarrier();
 
-	/* we've successfully registered the master handler for this, record it! */
-	signalsWithMasterHandlers |= portLibrarySignalNo;
+	/* Set the portLibrarySignalNo bit in signalsWithHandlers to record successful registration
+	 * of the handler. */
+	signalsWithHandlers |= portLibrarySignalNo;
 
 	return 0;
 }
@@ -1307,7 +1309,7 @@ addAsyncSignalsToSet(sigset_t *ss)
 /**
  * Registers the master handler for the signals in flags that don't have one.
  *
- * Calls to this function must be synchronized using masterHandlerMonitor.
+ * Calls to this function must be synchronized using registerHandlerMonitor.
  *
  * @param[in] flags the flags that we want signals for
  * @param[in] allowedSubsetOfFlags must be one of OMRPORT_SIG_FLAG_SIGALLSYNC, or
@@ -1386,7 +1388,7 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 	}
 #endif
 
-	if (omrthread_monitor_init_with_name(&masterHandlerMonitor, 0, "portLibrary_omrsig_masterHandler_monitor")) {
+	if (omrthread_monitor_init_with_name(&registerHandlerMonitor, 0, "portLibrary_omrsig_registerHandler_monitor")) {
 		return -1;
 	}
 
@@ -1485,7 +1487,7 @@ destroySignalTools(OMRPortLibrary *portLibrary)
 {
 	omrthread_tls_free(tlsKey);
 	omrthread_tls_free(tlsKeyCurrentSignal);
-	omrthread_monitor_destroy(masterHandlerMonitor);
+	omrthread_monitor_destroy(registerHandlerMonitor);
 	omrthread_monitor_destroy(asyncReporterShutdownMonitor);
 	omrthread_monitor_destroy(asyncMonitor);
 #if !defined(J9ZOS390)
@@ -1508,11 +1510,11 @@ omrsig_set_options(struct OMRPortLibrary *portLibrary, uint32_t options)
 
 		uint32_t anyHandlersInstalled = 0;
 
-		omrthread_monitor_enter(masterHandlerMonitor);
-		if (0 != signalsWithMasterHandlers) {
+		omrthread_monitor_enter(registerHandlerMonitor);
+		if (0 != signalsWithHandlers) {
 			anyHandlersInstalled = 1;
 		}
-		omrthread_monitor_exit(masterHandlerMonitor);
+		omrthread_monitor_exit(registerHandlerMonitor);
 
 		if (anyHandlersInstalled) {
 			Trc_PRT_signal_omrsig_set_options_too_late_handlers_installed(options);
@@ -1528,9 +1530,9 @@ omrsig_set_options(struct OMRPortLibrary *portLibrary, uint32_t options)
 
 		int32_t syncHandlersInstalled = 0;
 
-		omrthread_monitor_enter(masterHandlerMonitor);
+		omrthread_monitor_enter(registerHandlerMonitor);
 
-		if (0 == (signalsWithMasterHandlers & OMRPORT_SIG_FLAG_SIGALLSYNC)) {
+		if (OMR_ARE_NO_BITS_SET(signalsWithHandlers, OMRPORT_SIG_FLAG_SIGALLSYNC)) {
 			/* we haven't installed any synchronous handlers, so it's OK to switch to LE condition handling */
 			portLibrary->sig_protect = omrsig_protect_ceehdlr;
 			portLibrary->sig_info = omrsig_info_ceehdlr;
@@ -1540,7 +1542,7 @@ omrsig_set_options(struct OMRPortLibrary *portLibrary, uint32_t options)
 			syncHandlersInstalled = 1;
 		}
 
-		omrthread_monitor_exit(masterHandlerMonitor);
+		omrthread_monitor_exit(registerHandlerMonitor);
 
 		if (syncHandlersInstalled == 1) {
 			Trc_PRT_signal_omrsig_set_options_too_late_handlers_installed(options);
@@ -1588,7 +1590,8 @@ sig_full_shutdown(struct OMRPortLibrary *portLibrary)
 				OMRSIG_SIGACTION(index, &oldActions[index].action, NULL);
 				/* record that we no longer have a handler installed with the OS for this signal */
 				Trc_PRT_signal_sig_full_shutdown_deregistered_handler_with_OS(portLibrary, index);
-				signalsWithMasterHandlers &= ~mapUnixSignalToPortLib(index, 0);
+				signalsWithHandlers &= ~mapUnixSignalToPortLib(index, 0);
+				oldActions[index].restore = 0;
 			}
 		}
 

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -106,11 +106,10 @@ omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void
 	return 0;
 }
 
-uint32_t
+int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
-
-	uint32_t rc = 0;
+	int32_t rc = 0;
 	J9Win32AsyncHandlerRecord *cursor;
 	J9Win32AsyncHandlerRecord **previousLink;
 

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -198,6 +198,12 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
 }
 
 int32_t
+omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler)
+{
+	return OMRPORT_SIG_ERROR;
+}
+
+int32_t
 omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 {
 	uint32_t supportedFlags = OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -115,7 +115,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 
 	if (OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS & signalOptions) {
 		/* -Xrs was set, do not install any handlers */
-		return 1;
+		return OMRPORT_SIG_ERROR;
 	}
 
 	omrthread_monitor_enter(asyncMonitor);
@@ -153,7 +153,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 			J9Win32AsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 
 			if (record == NULL) {
-				rc = 1;
+				rc = OMRPORT_SIG_ERROR;
 			} else {
 				record->portLib = portLibrary;
 				record->handler = handler;

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -318,6 +318,12 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
 }
 
 int32_t
+omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler)
+{
+	return OMRPORT_SIG_ERROR;
+}
+
+int32_t
 omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 {
 	uint32_t supportedFlags = OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION;

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -237,7 +237,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 
 	if (OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS & signalOptions) {
 		/* -Xrs was set, do not install any handlers */
-		return 1;
+		return OMRPORT_SIG_ERROR;
 	}
 
 	omrthread_monitor_enter(asyncMonitor);
@@ -275,7 +275,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 			J9WinAMD64AsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 
 			if (record == NULL) {
-				rc = 1;
+				rc = OMRPORT_SIG_ERROR;
 			} else {
 				record->portLib = portLibrary;
 				record->handler = handler;

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -228,10 +228,10 @@ omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void 
 	return 0;
 }
 
-uint32_t
+int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
-	uint32_t rc = 0;
+	int32_t rc = 0;
 	J9WinAMD64AsyncHandlerRecord *cursor;
 	J9WinAMD64AsyncHandlerRecord **previousLink;
 

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -457,11 +457,11 @@ omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void
 }
 
 
-uint32_t
+int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handler_fn handler,
 							   void* handler_arg, uint32_t flags)
 {
-	uint32_t rc = 0;
+	int32_t rc = 0;
 	J9UnixAsyncHandlerRecord *cursor;
 	J9UnixAsyncHandlerRecord **previousLink;
 

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -569,6 +569,12 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
 	return OMRPORT_SIG_ERROR;
 }
 
+int32_t
+omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler)
+{
+	return OMRPORT_SIG_ERROR;
+}
+
 /*
  * The full shutdown routine "sig_full_shutdown" overrides this once we've completed startup 
  */

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -479,7 +479,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handl
 			rc = registerMasterHandlers(portLibrary, OMRPORT_SIG_FLAG_SIGXFSZ, OMRPORT_SIG_FLAG_SIGALLASYNC);
 		} else {
 			Trc_PRT_signal_omrsig_set_async_signal_handler_will_not_set_handler_due_to_Xrs(handler, handler_arg, flags);
-			rc = -1;
+			rc = OMRPORT_SIG_ERROR;
 		}
 	} else {
 		rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLASYNC);
@@ -488,7 +488,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handl
 
 	if (0 != rc) {
 		Trc_PRT_signal_omrsig_set_async_signal_handler_exiting_did_nothing_possible_error(handler, handler_arg, flags);
-		return OMRPORT_SIG_ERROR;
+		return rc;
 	}
 	
 	omrthread_monitor_enter(asyncMonitor);
@@ -529,7 +529,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handl
 																				OMR_GET_CALLSITE(),
 																				OMRMEM_CATEGORY_PORT_LIBRARY);
 			if (NULL == record) {
-				rc = 1;
+				rc = OMRPORT_SIG_ERROR;
 			} else {
 				record->portLib = portLibrary;
 				record->handler = handler;


### PR DESCRIPTION
9 new commits have been added to support OMR Signal API extension/improvement.

1) **Add new OMR Signal API: omrsig_register_os_handler**

    omrsig_register_os_handler will register a handler with the OS. Stubs
    have been added for omrsig_register_os_handler.

    On Unix variants, we cache the original OS handler in oldActions while
    registering the first handler with the OS. The original OS handler is
    restored during shutdown.

    If OMRSIG_SIGACTION is called outside OMR, then the original OS handler
    will be overwritten without being cached in oldActions. Subsequently,
    the oldActions may cache a user handler instead of the original OS
    handler. During shutdown, we may not restore the original OS handler
    incorrectly.

    The new API, omrsig_register_os_handler, will let a user register a
    handler with the OS while properly caching the original OS handler. This
    will allow us to properly restore the original OS handler during
    shutdown.

2) **Re-format comments' layout**

3) **Rename signalsWithMasterHandlers and masterHandlerMonitor**

    signalsWithMasterHandlers is used to determine if we have registered a
    handler with a signal. With the introduction of
    omrsig_register_os_handler, a user can register handlers other than the
    master handlers. signalsWithMasterHandlers has been renamed to
    signalsWithHandlers to better represent its purpose.

    masterHandlerMonitor is acquired whenever a handler is registered with
    the OS. Since a user can register any arbitrary handler with the OS
    using omrsig_register_os_handler, masterHandlerMonitor is renamed to
    registerHandlerMonitor to better represent its purpose.

    After restoring the original OS handler in sig_full_shutdown,
    oldActions[index].restore should be reset to 0.

4) **Add implementation of omrsig_register_os_handler [Unix]**

    Implementation of omrsig_register_os_handler has been added in
    unix/omrsignal.c.

    Supporting entry and exit trace points have been added.

    registerSignalHandlerWithOS returns OMRPORT_SIG_ERROR for OS signals
    that are included in signalMap.

5) **Fix omrsig_set_async_signal_handler signature**

    Currently, omrsig_set_async_signal_handler returns an uint32_t.

    But, unix and ztpf implementations of omrsig_set_async_signal_handler
    set return value to OMRPORT_SIG_ERROR (-1).

    In order to allow negative return values,
    omrsig_set_async_signal_handler's signature is changed to return an
    int32_t.

6) **Use error macros instead of undocumented constants for errors**

    In omrsig_set_async_signal_handler and
    omrsig_set_single_async_signal_handler, constants such as 1 and -1 are
    directly used as error codes. Using constants directly leads to
    inconsistency in implementation across platforms.

    Now onwards, omrsig_set_async_signal_handler and
    omrsig_set_single_async_signal_handler will consistently return
    OMRPORT_SIG_ERROR (-1) for error.

7) **Cache info if a master handler is registered with a signal**

    omrsig_protect and omrsig_set_*_async_signal_handler may be invoked
    multiple times. If a master handler is already registered with a signal,
    then we don't want to re-register the master handler with that signal.

    If a master handler is registered with a signal, then this information
    is cached in signalsWithMasterHandlers. The port library signal bit is
    set in signalsWithMasterHandlers.

    When a user overrides the master handler by invoking
    omrsig_register_os_handler, then the port library signal bit is un-set
    in signalsWithMasterHandlers.

    omrsig_set_single_async_signal_handler returns the oldOSHandler. The
    oldOSHandler can be the master handler if the user re-invokes
    omrsig_set_single_async_signal_handler for a signal. So, a user can
    invoke omrsig_register_os_handler using a master handler. In this case,
    we must set signalsWithMasterHandlers bits accordingly in
    omrsig_register_os_handler.

    This allows us to prevent OS calls to re-register master signal
    handlers.

8) **Properly handle NULL values for oldOSHandler**

    omrsig_set_single_async_signal_handler and omrsig_register_os_handler
    have been updated to properly handle NULL values for oldOSHandler.
    Function description has been updated for both of them. A trace point
    was accessing oldOSHandler without a NULL check. A NULL check has been
    added before the trace point accesses oldOSHandler.

9) **Remove unnecessary write barrier**

    At the end of registerSignalHandlerWithOS, a write barrier is issued
    before updating signalsWithHandlers. According to the comment, the write
    barrier is needed since registerHandlerMonitor is not acquired before
    updating signalsWithHandlers at some places.

    It has been confirmed that registerHandlerMonitor is acquired every time
    signalsWithHandlers is accessed. So, the write barrier at the end of
    registerSignalHandlerWithOS is no longer required.

    In sig_full_shutdown, registerHandlerMonitor is not acquired before
    updating signalsWithHandlers. This is an exception since no other code
    should execute when OMR is shutting down.


Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>