### PR TITLE
Fix _initRanges race with CM and CS

### DIFF
--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -200,7 +200,8 @@ private:
 	MM_ConcurrentCardTable *_cardTable;	/**< pointer to Cards Table */
 	void *_heapBase; 
 	void *_heapAlloc;
-	bool _rebuildInitWork;
+	bool _rebuildInitWorkForAdd; /**< set if heap expansion triggered _initRanges table update */
+	bool _rebuildInitWorkForRemove; /**< set if heap contraction triggered _initRanges table update */
 	bool _retuneAfterHeapResize;
 #if defined(OMR_GC_LARGE_OBJECT_AREA)	
 	MeteringHistory *_meteringHistory;
@@ -215,7 +216,7 @@ private:
 	omrthread_monitor_t _conHelpersActivationMonitor;
 	ConHelperRequest _conHelpersRequest;
 	
-	bool _globalCollectionInProgress;
+	bool _stwCollectionInProgress;  /**< if set, the final STW phase is in progress (mutators not running) */
 	bool _initializeMarkMap;
 	omrthread_monitor_t _initWorkMonitor;
 	omrthread_monitor_t _initWorkCompleteMonitor;
@@ -467,11 +468,11 @@ public:
 	}
 
 	/*
-	 * Return value of _globalCollectionInProgress flag
+	 * Return value of _stwCollectionInProgress flag
 	 */
-	MMINLINE bool isGlobalCollectionInProgress()
+	MMINLINE bool isStwCollectionInProgress()
 	{
-		return _globalCollectionInProgress;
+		return _stwCollectionInProgress;
 	}
 
 	/**
@@ -491,7 +492,8 @@ public:
 		,_cardTable(NULL)
 		,_heapBase(NULL)
 		,_heapAlloc(NULL)
-		,_rebuildInitWork(false)
+		,_rebuildInitWorkForAdd(false)
+		,_rebuildInitWorkForRemove(false)
 		,_retuneAfterHeapResize(false)
 #if defined(OMR_GC_LARGE_OBJECT_AREA)		
 		,_meteringHistory(NULL)
@@ -504,7 +506,7 @@ public:
 		,_conHelpersShutdownCount(0)
 		,_conHelpersActivationMonitor(NULL)
 		,_conHelpersRequest(CONCURRENT_HELPER_WAIT)
-		,_globalCollectionInProgress(false)
+		,_stwCollectionInProgress(false)
 		,_initializeMarkMap(false)
 		,_initWorkMonitor(NULL)
 		,_initWorkCompleteMonitor(NULL)

--- a/gc/base/standard/ConcurrentOverflow.cpp
+++ b/gc/base/standard/ConcurrentOverflow.cpp
@@ -206,7 +206,7 @@ MM_ConcurrentOverflow::clearCardsForNewSpace(MM_EnvironmentStandard *env, MM_Con
 	/* If scavenger is enabled, we are within a global collect, and we have not already done so,
 	 * then we need to clear cards for new space so we can resolve overflow by dirtying cards
 	*/
-    if(_extensions->scavengerEnabled && collector->isGlobalCollectionInProgress()) {
+    if(_extensions->scavengerEnabled && collector->isStwCollectionInProgress()) {
     	/*
     	 *	Should be the only one thread cleaning cards for NEW space
     	 *	If any other thread handling an WP Overflow came here while cleaning is in progress it should wait


### PR DESCRIPTION
_initRanges is a table that drives parallel setting/reseting of Mark Map
in Tenure/Nursery at the begining of Concurrent Marking CM)
cycle/begining STW phase.

In presence of Concurrent Scavenger (CS), that can over lap with CM, and
if Tenure heap expansion occurs (due to failed tenuring), the table will
be updated. 

This change will make the heap expanding thread simply skip the table
update if it senses that init in is progress. The table update is left
for a later, safer point .

BTW, if initializaiton is already in progress, the thread doing heap
expansion will do Mark Map work for the expaned part of the heap (this
part, and deferral of the table update is actually already handled for
standard Scavenger), so it does not really matter if update of
_initRanges occurs just after Mark Map init
work is complete.

This fix has not direct relation with issue reported by
#2426. A few conditions are same
(CM and CS overlapping, CS doing Tenure expansion), but the key
difference is what CM is doing: in this scenario Mark Map initialization
vs Card Table cleaning as in the issue.

Some other minor changes:
- split the deferal flag (_rebuildInitWork) into two flags
(expand/contract) for easier potential future debugging (there is a
nasty case of heap contraction that might be compromised)
- renamed a flag to indicates STW phase of Concurernt Mark

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>