### PR TITLE
Concurrent Card Cleaning Race Condition Fix

### DIFF
--- a/gc/base/MemorySubSpaceGeneric.cpp
+++ b/gc/base/MemorySubSpaceGeneric.cpp
@@ -629,12 +629,7 @@ MM_MemorySubSpaceGeneric::expanded(MM_EnvironmentBase* env, MM_PhysicalSubArena*
 	bool result = heapAddRange(env, this, size, lowAddress, highAddress);
 
 	if (result) {
-		/* Feed the range to the memory pool */
-		_memoryPool->expandWithRange(env, size, lowAddress, highAddress, canCoalesce);
-
-		if (MEMORY_TYPE_OLD == (getTypeFlags() & MEMORY_TYPE_OLD)) {
-			addTenureRange(env, size, lowAddress, highAddress);
-		}
+		addExistingMemory(env, subArena, size, lowAddress, highAddress, canCoalesce);
 	}
 	return result;
 }


### PR DESCRIPTION
Fix for Issue https://github.com/eclipse/omr/issues/2426

Reorder of tenure expansion operations: 

Due to the order in which expansion was done, there was a small period _(time between updating region manager and committing memory)_ where the region manager stored addresses which belonged to uncommitted memory. As a result, the region manager would return uncommitted memory addresses to any operation reading from it during expansion.

- To address this issue, the region manager update is simply delayed until expanded memory is fully committed. More specifically, PhysicalSubArenaVirtualMemoryFlat::expandNoCheck Region Manager resize update is delayed until heapAddRange completes _(ensures expanded memory and structures  have been fully committed)_. Hence, this ensures that card cleaning ranges, determined by the region manager, are indeed valid.

- Heap tuning (tuneToHeap) is moved from collector heapAddRange (ConcurrentGC::heapAddRange) to collector heapReconfigured. This change is required because tuneToHeap reads from the region manager and expects to read new boundary addresses resulting from expansion. However, due to the reorder, the region manager updates after heapAddRange returns. For this reason, heap tuning is moved to headReconfigured, as it is invoked after both heapAddRange and region manager update. 

Signed-off-by: Salman Rana <salman.rana@ibm.com>