### PR TITLE
Remove unused coloured register APIs

### DIFF
--- a/compiler/codegen/OMRRegister.cpp
+++ b/compiler/codegen/OMRRegister.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,6 @@ OMR::Register::Register(uint32_t f):
    _backingStorage(NULL),
    _pinningArrayPointer(NULL),
    _assignedRegister(NULL),
-   _colouredRegister(NULL),
    _siblingRegister(NULL),
    _startOfRange(NULL),
    _endOfRange(NULL),
@@ -55,7 +54,6 @@ OMR::Register::Register(TR_RegisterKinds rk):
    _backingStorage(NULL),
    _pinningArrayPointer(NULL),
    _assignedRegister(NULL),
-   _colouredRegister(NULL),
    _siblingRegister(NULL),
    _startOfRange(NULL),
    _endOfRange(NULL),
@@ -74,7 +72,6 @@ OMR::Register::Register(TR_RegisterKinds rk, uint16_t ar):
    _backingStorage(NULL),
    _pinningArrayPointer(NULL),
    _assignedRegister(NULL),
-   _colouredRegister(NULL),
    _siblingRegister(NULL),
    _startOfRange(NULL),
    _endOfRange(NULL),

--- a/compiler/codegen/OMRRegister.hpp
+++ b/compiler/codegen/OMRRegister.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,9 +78,6 @@ class OMR_EXTENSIBLE Register
 
    TR::Register *getAssignedRegister()               {return _assignedRegister;}
    TR::Register *setAssignedRegister(TR::Register *r) {return (_assignedRegister = r);}
-
-   TR::Register *getColouredRegister()               {return _colouredRegister;}
-   TR::Register *setColouredRegister(TR::Register *r) {return (_colouredRegister = r);}
 
    TR::Register *getSiblingRegister()               {return _siblingRegister;}
    TR::Register *setSiblingRegister(TR::Register *r) {return (_siblingRegister = r);}
@@ -200,7 +197,6 @@ class OMR_EXTENSIBLE Register
    TR::AutomaticSymbol       *_pinningArrayPointer;   // pinning array object if containing internal ptr
 
    TR::Register              *_assignedRegister;      // register to which this register is assigned
-   TR::Register              *_colouredRegister;      // register to which this register has been coloured to
    TR::Register              *_siblingRegister;       // Sibling to a register pair
 
    TR::Instruction   *_startOfRange;    // start of live range


### PR DESCRIPTION
Removing getColouredRegister and setColouredRegister from base CodeGen and their references.

Closes: #2467 

Signed-off-by: Shivam Mittal <shivammittal99@gmail.com>