### PR TITLE
Add tracking of persistent memory in containers

### DIFF
--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -488,6 +488,9 @@ public:
 
    TR::PersistentInfo * getPersistentInfo() { return &_persistentInfo; }
 
+   void printMemStats();
+   void printMemStatsToVlog();
+
    uintptr_t _signature;        // eyecatcher
 
    friend class TR_Memory;

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -503,6 +503,65 @@ public:
 
 extern TR_PersistentMemory * trPersistentMemory;
 
+class TR_TypedPersistentAllocatorBase
+   {
+public:
+
+   void *allocate(size_t size, void * hint = 0)
+      {
+      return trPersistentMemory->allocatePersistentMemory(size, TR_MemoryBase::UnknownType);
+      }
+   void deallocate(void * p, size_t sizeHint = 0) throw()
+      {
+      trPersistentMemory->freePersistentMemory(p);
+      }
+
+   friend bool operator ==(const TR_TypedPersistentAllocatorBase &left, const TR_TypedPersistentAllocatorBase &right)
+      {
+      return &left == &right;
+      }
+   friend bool operator !=(const TR_TypedPersistentAllocatorBase &left, const TR_TypedPersistentAllocatorBase &right)
+      {
+      return !operator ==(left, right);
+      }
+
+   // Enable automatic conversion into a form compatible with C++ standard library containers
+   template<typename T> operator TR::typed_allocator<T, TR_TypedPersistentAllocatorBase& >()
+      {
+      return TR::typed_allocator<T, TR_TypedPersistentAllocatorBase& >(*this);
+      }
+   };
+
+template <TR_MemoryBase::ObjectType O>
+class TR_TypedPersistentAllocator : public TR_TypedPersistentAllocatorBase
+   {
+public:
+
+   void *allocate(size_t size, void * hint = 0)
+      {
+      return trPersistentMemory->allocatePersistentMemory(size, O);
+      }
+   void deallocate(void * p, size_t sizeHint = 0) throw()
+      {
+      trPersistentMemory->freePersistentMemory(p);
+      }
+
+   friend bool operator ==(const TR_TypedPersistentAllocator<O> &left, const TR_TypedPersistentAllocator<O> &right)
+      {
+      return &left == &right;
+      }
+   friend bool operator !=(const TR_TypedPersistentAllocator<O> &left, const TR_TypedPersistentAllocator<O> &right)
+      {
+      return !operator ==(left, right);
+      }
+
+   // Enable automatic conversion into a form compatible with C++ standard library containers
+   template<typename T> operator TR::typed_allocator<T, TR_TypedPersistentAllocator<O>& >()
+      {
+      return TR::typed_allocator<T, TR_TypedPersistentAllocator<O>& >(*this);
+      }
+   };
+
 class TR_MemoryAllocationType
    {
 protected:
@@ -705,7 +764,7 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
    TR_PERSISTENT_ALLOC_WITHOUT_NEW(a) \
    TR_PERSISTENT_NEW(a)
 
-#define TR_ALLOC(a) \
+#define TR_ALLOC_IMPL(a) \
    TR_ALLOC_WITHOUT_NEW(a) \
    TR_PERSISTENT_NEW(a) \
    void * operator new (size_t s, TR_ArenaAllocator *m)                  {return m->allocate(s);} \
@@ -727,7 +786,15 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
    void operator delete(void * p, TR::Region &region) { region.deallocate(p); } \
    void * operator new[](size_t size, TR::Region &region) { return region.allocate(size); } \
    void operator delete[](void * p, TR::Region &region) { region.deallocate(p); } \
+   static TrackedPersistentAllocator getPersistentAllocator() { return TrackedPersistentAllocator(); } \
 
+#define TR_ALLOC(a) \
+   typedef TR_TypedPersistentAllocatorBase TrackedPersistentAllocator; \
+   TR_ALLOC_IMPL(a) \
+
+#define TR_ALLOC_SPECIALIZED(a) \
+   typedef TR_TypedPersistentAllocator<a> TrackedPersistentAllocator; \
+   TR_ALLOC_IMPL(a) \
 
 class TRPersistentMemoryAllocator
    {
@@ -1159,6 +1226,12 @@ typedef CS2::arena_allocator  <65536, TR::Allocator> TR_ArenaAllocator;
  * reduce the verbosity involved in declaring a typed_allocator
  * everytime we need an stl object.
  */
+template <typename T, class Alloc>
+static inline TR::typed_allocator<T, Alloc> getTypedAllocator(Alloc al)
+{
+   TR::typed_allocator<T, Alloc> ta(al);
+   return ta;
+}
 
 template <typename T>
 static inline TR::typed_allocator<T, TR::Allocator> getTypedAllocator(TR::Allocator al)

--- a/compiler/env/TRPersistentMemory.cpp
+++ b/compiler/env/TRPersistentMemory.cpp
@@ -39,6 +39,7 @@ namespace TR { class Compilation; }
 namespace TR { class PersistentInfo; }
 
 extern TR::Monitor *memoryAllocMonitor;
+extern const char * objectName[];
 
 namespace TR
    {
@@ -72,4 +73,27 @@ TR_PersistentMemory::TR_PersistentMemory(
    _persistentAllocator(TR::ref(persistentAllocator)),
    _totalPersistentAllocations()
    {
+   }
+
+void
+TR_PersistentMemory::printMemStats()
+   {
+   fprintf(stderr, "TR_PersistentMemory Stats:\n");
+   for (uint32_t i = 0; i < TR_MemoryBase::NumObjectTypes; i++)
+      {
+      fprintf(stderr, "\t_totalPersistentAllocations[%s]=%lu\n", objectName[i], (unsigned long)_totalPersistentAllocations[i]);
+      }
+   fprintf(stderr, "\n");
+   }
+
+void
+TR_PersistentMemory::printMemStatsToVlog()
+   {
+   TR_VerboseLog::vlogAcquire();
+   TR_VerboseLog::writeLine(TR_Vlog_MEMORY, "TR_PersistentMemory Stats:");
+   for (uint32_t i = 0; i < TR_MemoryBase::NumObjectTypes; i++)
+      {
+      TR_VerboseLog::writeLine(TR_Vlog_MEMORY, "\t_totalPersistentAllocations[%s]=%lu", objectName[i], (unsigned long)_totalPersistentAllocations[i]);
+      }
+   TR_VerboseLog::vlogRelease();
    }

--- a/compiler/env/TypedAllocator.hpp
+++ b/compiler/env/TypedAllocator.hpp
@@ -124,7 +124,7 @@ class typed_allocator : public typed_allocator<void, Alloc>
       typed_allocator<void, untyped_allocator>::deallocate(p, n * sizeof(value_type));
       }
 
-   static void construct(pointer p, const_reference prototype) { new(p) value_type(prototype); }
+   static void construct(pointer p, const_reference prototype) { ::new(p) value_type(prototype); }
    static void destroy(pointer p) { p->~value_type(); }
 
    static size_type max_size() throw()


### PR DESCRIPTION
In the scenario where there is a need to add a class such as the following:
```
class Test
   {
public:
   Test(uintptr_t f1, uintptr_t f2)
      : _field1(f1),
        _field2(f2)
      { }

   uintptr_t _field1;
   uintptr_t _field2;
   };
```
into an STL container such as `std::list`. currently there's no way to know how much total persistent memory is used for `Test`. With this commit it is now possible to do so:

1. Add (or replace the existing `TR_ALLOC` with) `TR_ALLOC_SPECIALIZED` with the appropriate `TR_MemoryBase::ObjectType` enum value to the class definition
2. Declare and use the list, eg:
```
typedef TR::list<Test, Test::TrackedPersistentAllocator> TestList;
TestList myList(getTypedAllocator<Test, Test::TrackedPersistentAllocator>(Test::getPersistentAllocator()));
```

Because there is a concern of dll size increase and so since we don't necessarily want to replace all uses of `TR_ALLOC` with `TR_ALLOC_SPECIALIZED`, when you do step 2 above with an object that has a `TR_ALLOC` in its class definition, the allocation is attributed to `TR_MemoryBase::UnknownType` via a non templated class.