### PR TITLE
AArch64: Stub files of InstOpCode

### DIFF
--- a/compiler/aarch64/codegen/InstOpCode.hpp
+++ b/compiler/aarch64/codegen/InstOpCode.hpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_ARM64_INSTOPCODE_INCL
+#define TR_ARM64_INSTOPCODE_INCL
+
+#include "codegen/OMRInstOpCode.hpp"
+
+namespace TR
+{
+
+class InstOpCode: public OMR::InstOpCodeConnector
+   {
+   public:
+
+   /**
+    * @brief Constructor
+    */
+   InstOpCode() : OMR::InstOpCodeConnector(bad) {}
+   /**
+    * @brief Constructor
+    * @param[in] m : mnemonic
+    */
+   InstOpCode(TR::InstOpCode::Mnemonic m) : OMR::InstOpCodeConnector(m) {}
+   };
+
+}
+#endif

--- a/compiler/aarch64/codegen/OMRInstOpCode.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCode.hpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_ARM64_INSTOPCODE_INCL
+#define OMR_ARM64_INSTOPCODE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_INSTOPCODE_CONNECTOR
+#define OMR_INSTOPCODE_CONNECTOR
+namespace OMR { namespace ARM64 { class InstOpCode; } }
+namespace OMR { typedef OMR::ARM64::InstOpCode InstOpCodeConnector; }
+#else
+#error OMR::ARM64::InstOpCode expected to be a primary connector, but a OMR connector is already defined
+#endif
+
+#include "compiler/codegen/OMRInstOpCode.hpp"
+
+namespace OMR
+{
+
+namespace ARM64
+{
+
+class InstOpCode: public OMR::InstOpCode
+   {
+   protected:
+
+   /**
+    * @brief Constructor
+    */
+   InstOpCode() : OMR::InstOpCode(bad) {}
+   /**
+    * @brief Constructor
+    * @param[in] m : mnemonic
+    */
+   InstOpCode(Mnemonic m) : OMR::InstOpCode(m) {}
+   };
+
+}
+}
+#endif

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum. Only comments and enumerator
+ * definitions are permitted.
+ */
+
+   bad,              // Illegal Opcode
+   label,            // Destination of a jump
+   ARM64LastOp = label,
+   ARM64NumOpCodes = ARM64LastOp + 1,


### PR DESCRIPTION
This commit implements stubs of InstOpCode files for aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>