### PR TITLE
Fix compiler compilation on Windows (part 1)

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -36,12 +36,18 @@ set(OMR_COMPILER OFF CACHE BOOL "Enable the compiler")
 set(OMR_DDR OFF CACHE BOOL "Enable DDR")
 set(OMR_FVTEST ON CACHE BOOL "Enable the FV Testing.")
 set(OMR_GC ON CACHE BOOL "Enable the GC")
+set(OMR_JIT OFF CACHE BOOL "Enable building the JIT compiler")
 set(OMR_JITBUILDER OFF CACHE BOOL "Enable building JitBuilder")
 set(OMR_OMRSIG ON CACHE BOOL "Enable the OMR signal compatibility library")
 set(OMR_PORT ON CACHE BOOL "Enable portability library")
 set(OMR_TEST_COMPILER OFF CACHE BOOL "Enable building the test compiler")
 set(OMR_THREAD ON CACHE BOOL "Enable thread library")
 set(OMR_TOOLS ON CACHE BOOL "Enable the native build tools")
+
+## OMR_JIT is required for OMR_JITBUILDER and OMR_TEST_COMPILER
+if(OMR_JITBUILDER OR OMR_TEST_COMPILER)
+	set(OMR_JIT ON CACHE BOOL "" FORCE)
+endif()
 
 ###
 ### Tooling

--- a/compiler/codegen/GCStackMap.hpp
+++ b/compiler/codegen/GCStackMap.hpp
@@ -175,6 +175,11 @@ public:
       return m.allocate(s);
       }
 
+   void operator delete(void *gcStackMap, TR_HeapMemory m, uint32_t numberOfSlotsToMap)
+      {
+          m.deallocate(gcStackMap);
+      }
+
    void allocateLiveMonitorBits(TR_Memory * m)
       {
       _liveMonitorBits = (uint8_t *)m->allocateHeapMemory(getMapSizeInBytes());

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,11 +21,15 @@
 
 #include "control/CompileMethod.hpp"
 
+#if defined(OMR_OS_WINDOWS)
+#include <process.h>                           // for _getpid
+#else
+#include <unistd.h>                            // for getpid, intptr_t, etc
+#endif
 #include <exception>                           // for exception
 #include <stdint.h>                            // for int32_t, uint8_t, etc
 #include <stdio.h>                             // for NULL, fprintf, fflush, etc
 #include <string.h>                            // for strlen
-#include <unistd.h>                            // for getpid, intptr_t, etc
 #include "codegen/CodeGenerator.hpp"           // for CodeGenerator
 #include "codegen/FrontEnd.hpp"                // for TR_VerboseLog, etc
 #include "codegen/LinkageConventionsEnum.hpp"
@@ -65,7 +69,11 @@ writePerfToolEntry(void *start, uint32_t size, const char *name)
    if (firstAttempt)
       {
       firstAttempt = false;
+#if defined(OMR_OS_WINDOWS)
+      int jvmPid = _getpid();
+#else
       pid_t jvmPid = getpid();
+#endif
       static const int maxPerfFilenameSize = 15 + sizeof(jvmPid)* 3; // "/tmp/perf-%ld.map"
       char perfFilename[maxPerfFilenameSize] = { 0 };
 

--- a/compiler/cs2/arrayof.h
+++ b/compiler/cs2/arrayof.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1996, 2016 IBM Corp. and others
+ * Copyright (c) 1996, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -481,7 +481,7 @@ template <class AElementType, class Allocator, size_t segmentBits = 8, class Ini
     if (newSize < fNumInitialized) {
       Cursor c(*this);
       for (c.SetTo(newSize); c.Valid(); c.SetToNext())
-        (*c.DerivedElement()).CS2_BASEARDECL::DerivedElement::~DerivedElement();
+        c.DerivedElement()->~DerivedElement();
 
       fNumInitialized = newSize;
       CS2_BASEARDECL::ShrinkTo(newSize);

--- a/compiler/cs2/listof.h
+++ b/compiler/cs2/listof.h
@@ -263,7 +263,7 @@ CS2_LI_DECL::~ListOf() {
   // Destroy the existing elements.
   for (listIndex = 0; listIndex < NumberOfElements(); ++listIndex) {
     typename CS2_AR_DECL::DerivedElement *derivedElement = (typename CS2_AR_DECL::DerivedElement *) & ElementAt(listIndex);
-    derivedElement->CS2_AR_DECL::DerivedElement::~DerivedElement();
+    derivedElement->~DerivedElement();
   }
 }
 
@@ -307,7 +307,7 @@ CS2_LI_DECL &CS2_LI_DECL::operator= (const CS2_LI_DECL &list) {
     // Destroy extra list members
     for (; listIndex < NumberOfElements(); ++listIndex) {
       typename CS2_AR_DECL::DerivedElement *currentElement = CS2_AR_DECL::DerivedElementAt(listIndex);
-      currentElement->CS2_AR_DECL::DerivedElement::~DerivedElement();
+      currentElement->~DerivedElement();
     }
   } else {
     // Copy construct additional list members.
@@ -333,7 +333,7 @@ void CS2_LI_DECL::MakeEmpty (bool freeStorage) {
   // Destroy the existing elements.
   for (listIndex = 0; listIndex < NumberOfElements(); ++listIndex) {
     typename CS2_AR_DECL::DerivedElement *derivedElement = (typename CS2_AR_DECL::DerivedElement *) & ElementAt(listIndex);
-    derivedElement->CS2_AR_DECL::DerivedElement::~DerivedElement();
+    derivedElement->~DerivedElement();
   }
 
   fNextAvailable = 0;

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -20,9 +20,6 @@
  *******************************************************************************/
 
 #include <stddef.h>
-#include <unistd.h> // for getpid
-#include <sys/time.h>
-#include <sys/types.h> // for getpid
 #include "codegen/CodeGenerator.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -948,11 +948,6 @@ namespace TR
 
    typedef CS2::shared_allocator < GlobalSingletonAllocator > GlobalAllocator;
 
-   static GlobalAllocator globalAllocator(const char *name = NULL)
-      {
-      return GlobalAllocator(GlobalSingletonAllocator::instance());
-      }
-
    /*
     * some common CS2 datatypes
     */

--- a/compiler/ilgen/OMRIlGeneratorMethodDetails.hpp
+++ b/compiler/ilgen/OMRIlGeneratorMethodDetails.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,9 @@ protected:
 
    void *operator new(size_t size, TR::IlGeneratorMethodDetails *p){ return (void*) p; }
    void *operator new(size_t size, TR::IlGeneratorMethodDetails &p){ return (void*)&p; }
+   void operator delete(void *pMem, TR::IlGeneratorMethodDetails *p) {};
+   void operator delete(void *pMem, TR::IlGeneratorMethodDetails &p) {};
+   void operator delete(void *pMem, std::size_t size) { ::operator delete(pMem); };
 
    TR::IlVerifier     * _ilVerifier;
    };

--- a/compiler/infra/forward_list.hpp
+++ b/compiler/infra/forward_list.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -150,8 +150,8 @@ public:
       const_iterator &operator =(const const_iterator &other);
       const_iterator &operator ++();
       const_iterator operator ++(int);
-      const_reference operator *() throw();
-      const_pointer operator ->() throw();
+      const_reference operator *() const throw();
+      const_pointer operator ->() const throw();
       friend bool operator ==(const const_iterator &left, const const_iterator &right) { return left._element == right._element; }
       friend bool operator !=(const const_iterator &left, const const_iterator &right) { return !(left == right); }
 
@@ -183,8 +183,8 @@ public:
       iterator &operator =(const iterator &other);
       iterator &operator ++();
       iterator operator ++(int);
-      reference operator *() throw();
-      pointer operator ->() throw();
+      reference operator *() const throw();
+      pointer operator ->() const throw();
       friend bool operator ==(const iterator &left, const iterator &right) { return left._element == right._element; }
       friend bool operator !=(const iterator &left, const iterator &right) { return !(left == right); }
       operator const_iterator() { return const_iterator(_element); }
@@ -660,14 +660,14 @@ TR::forward_list< T, Alloc >::const_iterator::operator ++(int)
 
 template < typename T, typename Alloc >
 typename TR::forward_list< T, Alloc >::const_reference
-TR::forward_list< T, Alloc >::const_iterator::operator *() throw()
+TR::forward_list< T, Alloc >::const_iterator::operator *() const throw()
    {
    return static_cast<const ListElement &>(*_element)._value;
    }
 
 template < typename T, typename Alloc >
 typename TR::forward_list< T, Alloc >::const_pointer
-TR::forward_list< T, Alloc >::const_iterator::operator ->() throw()
+TR::forward_list< T, Alloc >::const_iterator::operator ->() const throw()
    {
    return &static_cast<const ListElement &>(*_element)._value;
    }
@@ -724,14 +724,14 @@ TR::forward_list< T, Alloc >::iterator::operator ++(int)
 
 template < typename T, typename Alloc >
 typename TR::forward_list< T, Alloc >::reference
-TR::forward_list< T, Alloc >::iterator::operator *() throw()
+TR::forward_list< T, Alloc >::iterator::operator *() const throw()
    {
    return static_cast<ListElement &>(*_element)._value;
    }
 
 template < typename T, typename Alloc >
 typename TR::forward_list< T, Alloc >::pointer
-TR::forward_list< T, Alloc >::iterator::operator ->() throw()
+TR::forward_list< T, Alloc >::iterator::operator ->() const throw()
    {
    return &static_cast<ListElement &>(*_element)._value;
    }

--- a/compiler/infra/forward_list.hpp
+++ b/compiler/infra/forward_list.hpp
@@ -472,7 +472,7 @@ TR::forward_list< T, Alloc >::insert_after(iterator position, const value_type &
    {
    ListElement *newElement = _allocator.allocate(1);
    _allocator.construct(newElement, ListElement(position._element->_next, value));
-   position.element->_next = newElement;
+   position._element->_next = newElement;
    }
 
 //template < typename T, typename Alloc >

--- a/fvtest/compilertest/env/FrontEnd.cpp
+++ b/fvtest/compilertest/env/FrontEnd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,6 @@
 #include "env/FrontEnd.hpp"
 
 #include <limits.h>
-#include <math.h>
 #include <stdio.h>
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GCStackAtlas.hpp"

--- a/fvtest/compilertest/tests/LimitFileTest.cpp
+++ b/fvtest/compilertest/tests/LimitFileTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <fstream>
 #include <string>
 #include <sstream>
-#include <unistd.h>
 #include <sys/stat.h>
 
 #include "tests/OMRTestEnv.hpp"

--- a/fvtest/compilertest/tests/LogFileTest.cpp
+++ b/fvtest/compilertest/tests/LogFileTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,7 +26,6 @@
 #include <fstream>
 #include <string>
 #include <sstream>
-#include <unistd.h>
 #include <sys/stat.h>
 
 #include "tests/OMRTestEnv.hpp"

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,7 +21,6 @@
 
 #include <limits.h>
 #include <float.h>
-#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "compile/Compilation.hpp"

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -962,8 +962,8 @@ class OpCodesTest : public TestDriver
    template <typename T> static int32_t compareGE(T a, T b) { return a >= b;}
    template <typename T> static int32_t compareGT(T a, T b) { return a > b;}
    template <typename T> static int32_t compareLE(T a, T b) { return a <= b;}
-   template <typename T> static int32_t comparel(T a, T b) { return std::isnan(a) ? -1 : std::isnan(b) ? -1 : a > b ? 1 : a == b ? 0 : -1 ; }
-   template <typename T> static int32_t compareg(T a, T b) { return std::isnan(a) ? 1 :  std::isnan(b) ? 1 : a > b ? 1 : a == b ? 0 : -1 ; }
+   template <typename T> static int32_t comparel(T a, T b) { return std::isnan(static_cast<long double>(a)) ? -1 : std::isnan(static_cast<long double>(b)) ? -1 : a > b ? 1 : a == b ? 0 : -1 ; }
+   template <typename T> static int32_t compareg(T a, T b) { return std::isnan(static_cast<long double>(a)) ? 1 :  std::isnan(static_cast<long double>(b)) ? 1 : a > b ? 1 : a == b ? 0 : -1 ; }
    template <typename C, typename T> static T ternary(C a, T b, T c) {return a ? b : c;}
    };
 

--- a/fvtest/compilertest/tests/OptTestDriver.cpp
+++ b/fvtest/compilertest/tests/OptTestDriver.cpp
@@ -57,7 +57,7 @@ void TestCompiler::OptTestDriver::makeOptimizationStrategyArray(OptimizationStra
  */
 void TestCompiler::OptTestDriver::Verify()
    {
-   OptimizationStrategy strategy[_optimizations.size() + 1];
+   OptimizationStrategy *strategy = new OptimizationStrategy[_optimizations.size() + 1];
    makeOptimizationStrategyArray(strategy);
    TR::Optimizer::setMockStrategy(strategy);
 
@@ -70,6 +70,7 @@ void TestCompiler::OptTestDriver::Verify()
 
    setIlVerifier(oldVerifier);
    TR::Optimizer::setMockStrategy(NULL);
+   delete[] strategy;
 
    ASSERT_EQ(true, noCodegenVerifier.hasRun()) << "Did not run verifiers.";
    }
@@ -84,13 +85,14 @@ void TestCompiler::OptTestDriver::Verify()
  */
 void TestCompiler::OptTestDriver::VerifyAndInvoke()
    {
-   OptimizationStrategy strategy[_optimizations.size() + 1];
+   OptimizationStrategy *strategy = new OptimizationStrategy[_optimizations.size() + 1];
    makeOptimizationStrategyArray(strategy);
    TR::Optimizer::setMockStrategy(strategy);
 
    RunTest();
 
    TR::Optimizer::setMockStrategy(NULL);
+   delete[] strategy;
    }
 
 /**

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "compile/Method.hpp"

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "compile/Method.hpp"

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "compile/Method.hpp"

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -50,8 +50,6 @@ target_link_libraries(comptest
 	tril
 )
 
-target_compile_options(comptest PRIVATE "-Wno-write-strings")
-
 set_property(TARGET comptest PROPERTY FOLDER fvtest)
 
 add_test(

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -43,7 +43,15 @@ target_link_libraries(triltest
 	omrGtest
 )
 
-target_compile_options(triltest PRIVATE "-Wno-write-strings")
+# The platform specific ${TR_CXX_COMPILE_OPTIONS} and ${TR_C_COMPILE_OPTIONS} compile options
+# should been added, on Windows, for example, these options enable exception handling
+# what is required for Clang.
+target_compile_options(triltest
+	PUBLIC
+		${TR_COMPILE_OPTIONS}
+		$<$<COMPILE_LANGUAGE:CXX>:${TR_CXX_COMPILE_OPTIONS}>
+		$<$<COMPILE_LANGUAGE:C>:${TR_C_COMPILE_OPTIONS}>
+)
 
 set_property(TARGET triltest PROPERTY FOLDER fvtest/tril)
 

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -19,6 +19,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules"
+	${CMAKE_MODULE_PATH})
+
+include(OmrUtility)
+
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 
@@ -26,10 +31,24 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+list(APPEND TRIL_FLEX_FLAGS
+	--yylineno
+	--header-file=${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h
+)
+
+# There is no unistd.h on Windows, so if win_flex.exe is in use,
+# the --wincompat option must be added.
+if(OMR_HOST_OS STREQUAL "win")
+	list(APPEND TRIL_FLEX_FLAGS
+		"--wincompat"
+	)
+endif()
+
+omr_stringify(TRIL_FLEX_OPTIONS ${TRIL_FLEX_FLAGS})
 BISON_TARGET(tril_parser tril.y ${CMAKE_CURRENT_BINARY_DIR}/tril.parser.c)
 FLEX_TARGET(tril_scanner tril.l ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.c
-	COMPILE_FLAGS "--yylineno --header-file=${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h")
-#            DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.h)
+	COMPILE_FLAGS ${TRIL_FLEX_OPTIONS}
+)
 ADD_FLEX_BISON_DEPENDENCY(tril_scanner tril_parser)
 
 if(TRIL_TEST_COMPILER)
@@ -58,7 +77,7 @@ target_include_directories(tril PUBLIC
 
 target_link_libraries(tril PUBLIC 
 	${TRIL_BACKEND_LIB}
-	dl
+	${CMAKE_DL_LIBS}
 )
 
 add_executable(tril_dumper compiler.cpp)
@@ -67,7 +86,15 @@ target_link_libraries(tril_dumper tril)
 add_executable(tril_compiler compiler.cpp)
 target_link_libraries(tril_compiler tril)
 
-target_compile_options(tril PRIVATE "-Wno-write-strings")
+# The platform specific ${TR_CXX_COMPILE_OPTIONS} and ${TR_C_COMPILE_OPTIONS} compile options
+# should been added, on Windows, for example, these options enable exception handling
+# what is required for Clang.
+target_compile_options(tril
+	PUBLIC
+		${TR_COMPILE_OPTIONS}
+		$<$<COMPILE_LANGUAGE:CXX>:${TR_CXX_COMPILE_OPTIONS}>
+		$<$<COMPILE_LANGUAGE:C>:${TR_C_COMPILE_OPTIONS}>
+)
 
 #export(TARGETS tril jitbuilder FILE tril-config.cmake)
 #install(FILES ast.h ilgen.hpp DESTINATION include)

--- a/jitbuilder/release/src/AtomicOperations.cpp
+++ b/jitbuilder/release/src/AtomicOperations.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Call.cpp
+++ b/jitbuilder/release/src/Call.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Conditionals.cpp
+++ b/jitbuilder/release/src/Conditionals.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/ConstString.cpp
+++ b/jitbuilder/release/src/ConstString.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/DotProduct.cpp
+++ b/jitbuilder/release/src/DotProduct.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/FieldAddress.cpp
+++ b/jitbuilder/release/src/FieldAddress.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 #include <assert.h>
 

--- a/jitbuilder/release/src/IterativeFib.cpp
+++ b/jitbuilder/release/src/IterativeFib.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/LinkedList.cpp
+++ b/jitbuilder/release/src/LinkedList.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/LocalArray.cpp
+++ b/jitbuilder/release/src/LocalArray.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Mandelbrot.cpp
+++ b/jitbuilder/release/src/Mandelbrot.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/MatMult.cpp
+++ b/jitbuilder/release/src/MatMult.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/NestedLoop.cpp
+++ b/jitbuilder/release/src/NestedLoop.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/OperandArrayTests.cpp
+++ b/jitbuilder/release/src/OperandArrayTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 #include <stdarg.h>
 

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 #include <stdarg.h>
 

--- a/jitbuilder/release/src/Pointer.cpp
+++ b/jitbuilder/release/src/Pointer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Pow2.cpp
+++ b/jitbuilder/release/src/Pow2.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/RecursiveFib.cpp
+++ b/jitbuilder/release/src/RecursiveFib.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Simple.cpp
+++ b/jitbuilder/release/src/Simple.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/StructArray.cpp
+++ b/jitbuilder/release/src/StructArray.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Switch.cpp
+++ b/jitbuilder/release/src/Switch.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/TransactionalOperations.cpp
+++ b/jitbuilder/release/src/TransactionalOperations.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"

--- a/jitbuilder/release/src/Worklist.cpp
+++ b/jitbuilder/release/src/Worklist.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>
-#include <dlfcn.h>
 #include <errno.h>
 
 #include "Jit.hpp"


### PR DESCRIPTION
The compiler as well as JitBuilder aren't able to be compiled on Windows due to some compilation errors. This PR does the following:

 * Adds Windows-specific includes into CompileMethod (`process.h` vs `unistd.h`)
 * Fixes 'compiler/cs2/listof.h' compilation errors
 * Marks 'forward_list::iterator::*' and '->' as const (and align this to the `std::forward_list` implementation)
 * Fixes element to _element in forward_list.hpp
 * Fixes 'cs2/arrayof.h' compilation errors
 * Fixes compiling the output of `flex` on Windows: the `--wincompat` parameter changes `<unistd.h>` 
    unix include with `<io.h>` windows analog.
 * Removes the unused `dlfcn.h` header from the `jitbuilder/release` C++ files.
 * Removes the unused `math.h` header from the `fvtest/compilertest` C++ files.
 * Removes the unused `unistd.h` header from the `fvtest/compilertest` C++ files.
 * Eliminates an ambiguous call to `std::isnan` in `fvtest/compilertest/tests/OpCodesTest.hpp`.

The PR depends on #2434
