### PR TITLE
WIP Add portlibrary api sysinfo_get_available_memory

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -1100,6 +1100,29 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 }
 
 /**
+ * Test for omrsysinfo_get_available_memory() port library API.
+ */
+TEST(PortSysinfoTest, sysinfo_testAvailableMemory)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "omrsysinfo_testAvailableMemory";
+	uint64_t freeMemory = OMRPORT_MEMINFO_NOT_AVAILABLE;
+
+	reportTestEntry(OMRPORTLIB, testName);
+	portTestEnv->changeIndent(1);
+
+	freeMemory = omrsysinfo_get_available_memory();
+	if (OMRPORT_MEMINFO_NOT_AVAILABLE == freeMemory) {
+		outputErrorMessage(PORTTEST_ERROR_ARGS, "Free memory stat is not available.\n");
+	} else {
+		portTestEnv->log("Free memory: %llu bytes\n", freeMemory);
+	}
+
+	portTestEnv->changeIndent(-1);
+	reportTestExit(OMRPORTLIB, testName);
+}
+
+/**
  * @internal
  * Internal function: Counts up the number of processors that are online as per the
  * records delivered by the port library routine omrsysinfo_get_processor_info().

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1099,6 +1099,8 @@ typedef struct OMRPortLibrary {
 	uint64_t (*sysinfo_get_addressable_physical_memory)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_physical_memory "omrsysinfo_get_physical_memory"*/
 	uint64_t (*sysinfo_get_physical_memory)(struct OMRPortLibrary *portLibrary) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_get_available_memory "omrsysinfo_get_available_memory"*/
+	uint64_t (*sysinfo_get_available_memory)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_OS_version "omrsysinfo_get_OS_version"*/
 	const char  *(*sysinfo_get_OS_version)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_env "omrsysinfo_get_env"*/
@@ -1745,6 +1747,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_destroy_processor_info(param1) privateOmrPortLibrary->sysinfo_destroy_processor_info(privateOmrPortLibrary, (param1))
 #define omrsysinfo_get_addressable_physical_memory() privateOmrPortLibrary->sysinfo_get_addressable_physical_memory(privateOmrPortLibrary)
 #define omrsysinfo_get_physical_memory() privateOmrPortLibrary->sysinfo_get_physical_memory(privateOmrPortLibrary)
+#define omrsysinfo_get_available_memory() privateOmrPortLibrary->sysinfo_get_available_memory(privateOmrPortLibrary)
 #define omrsysinfo_get_OS_version() privateOmrPortLibrary->sysinfo_get_OS_version(privateOmrPortLibrary)
 #define omrsysinfo_get_env(param1,param2,param3) privateOmrPortLibrary->sysinfo_get_env(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsysinfo_get_CPU_architecture() privateOmrPortLibrary->sysinfo_get_CPU_architecture(privateOmrPortLibrary)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -69,6 +69,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_destroy_processor_info, /* sysinfo_destroy_processor_info */
 	omrsysinfo_get_addressable_physical_memory, /* sysinfo_get_addressable_physical_memory */
 	omrsysinfo_get_physical_memory, /* sysinfo_get_physical_memory */
+	omrsysinfo_get_available_memory, /* sysinfo_get_available_memory */
 	omrsysinfo_get_OS_version, /* sysinfo_get_OS_version */
 	omrsysinfo_get_env, /* sysinfo_get_env */
 	omrsysinfo_get_CPU_architecture, /* sysinfo_get_CPU_architecture */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -256,7 +256,8 @@ omrsysinfo_get_addressable_physical_memory(struct OMRPortLibrary *portLibrary)
 
 /**
  * Determine the size of the total physical memory in the system, in bytes.
- * Note that if cgroups limits is enabled (see omrsysinfo_cgroup_enable_limits())
+ * Note that if cgroup memory limits is enabled (using 
+ * omrsysinfo_cgroup_enable_subsystems(OMR_CGROUP_SUBSYSTEM_MEMORY))
  * then this function returns the memory limit imposed by the cgroup,
  * which would be same as the value returned by omrsysinfo_cgroup_get_memlimit().
  *
@@ -269,6 +270,23 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
+/**
+ * Determine the size of the free physical memory in the system, in bytes.
+ * Note that if cgroups limits is enabled (using 
+ * omrsysinfo_cgroup_enable_subsystems(OMR_CGROUP_SUBSYSTEM_MEMORY))
+ * then this function returns min(free memory in host, free memory in cgroup).
+ *
+ * @param[in] portLibrary The port library.
+ *
+ * @return OMRPORT_MEMINFO_NOT_AVAILABLE if the information is unavailable, otherwise total physical memory in bytes.
+ */
+uint64_t
+omrsysinfo_get_available_memory(struct OMRPortLibrary *portLibrary)
+{
+	return OMRPORT_MEMINFO_NOT_AVAILABLE;
+}
+
 /**
  * Determine the process ID of the calling process.
  *
@@ -913,8 +931,9 @@ omrsysinfo_cgroup_are_subsystems_enabled(struct OMRPortLibrary *portLibrary, uin
 
 /**
  * Retrieves the memory limit imposed by the cgroup to which the current process belongs.
- * The caller should ensure port library is enabled to use cgroup limits by calling
- * omrsysinfo_cgroup_enable_limits() before calling this function.
+ * The caller should ensure port library is enabled to use cgroup memory limits by calling
+ * omrsysinfo_cgroup_enable_subsystems(OMR_CGROUP_SUBSYSTEM_MEMORY) with subsystems before 
+ * calling this function.
  * When the fuction returns OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM,
  * value of *limits is unspecified.
  * Note that 'limit' parameter must not be NULL.

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -463,6 +463,8 @@ extern J9_CFUNC uint64_t
 omrsysinfo_get_addressable_physical_memory(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC uint64_t
 omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC uint64_t
+omrsysinfo_get_available_memory(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC uint32_t
 omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, uint64_t *limit);
 extern J9_CFUNC uint32_t

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -806,6 +806,33 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 	return (uint64_t) aMemStatusEx.ullTotalPhys;
 }
 
+uint64_t
+omrsysinfo_get_available_memory(struct OMRPortLibrary *portLibrary)
+{
+	J9MemoryInfo memInfo = {0};
+	uint64_t freeMemory = OMRPORT_MEMINFO_NOT_AVAILABLE;
+	int32_t rc = 0;
+
+	rc = portLibrary->sysinfo_get_memory_info(memInfo);
+
+	if (0 != rc) {
+		goto _end;
+	}
+
+	if (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.availPhysical) {
+		freeMemory = memInfo.availPhysical;
+		if (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.cached) {
+			freeMemory += memInfo.cached;
+		}
+		if (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.buffered) {
+			freeMemory += memInfo.buffered;
+		}
+	}
+
+_end:
+	return freeMemory;
+}
+
 /**
  * PortLibrary shutdown.
  *


### PR DESCRIPTION
Add omrsysinfo_get_available_memory() that returns free memory
available for use. omrsysinfo_get_available_memory() also takes
into account cgroup limits and returns the
minimum of (free memory in cgroup, free memory in host)

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>