### PR TITLE
Support An Arbitrarily Low-Overhead Garbage Collector

### DIFF
--- a/gc/base/Collector.hpp
+++ b/gc/base/Collector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 1991, 2017 IBM Corp. and others
+ * (c) Copyright 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,6 +58,8 @@ protected:
 	bool _globalCollector;
 	bool _gcCompleted;
 	bool _isRecursiveGC;
+	bool _disableGC;
+
 	uintptr_t _collectorExpandedSize;
 	uintptr_t _cycleType;
 
@@ -283,6 +285,7 @@ public:
 	virtual	void postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned) {}
 	virtual void forceConcurrentFinish() {}
 	virtual void completeExternalConcurrentCycle(MM_EnvironmentBase *env) {}
+	virtual bool isDisabled(MM_EnvironmentBase *env) { return _disableGC; }
 	/**
 	 * @return pointer to collector/phase specific concurrent stats structure
 	 */
@@ -295,6 +298,7 @@ public:
 		, _globalCollector(false)
 		, _gcCompleted(false)
 		, _isRecursiveGC(false)
+		, _disableGC(false)
 		, _collectorExpandedSize(0)
 		, _cycleType(OMR_GC_CYCLE_TYPE_DEFAULT)
 		, _masterThreadCpuTimeStart(0)

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -922,7 +922,8 @@ MM_MemorySubSpace::systemGarbageCollect(MM_EnvironmentBase* env, uint32_t gcCode
 		return;
 	}
 
-	if (_collector && _usesGlobalCollector) {
+	/* do not launch system gc in -Xgcpolicy:nogc */
+	if (_collector && _usesGlobalCollector && !_collector->isDisabled(env)) {
 		bool invokeGC = true;
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
 		if ((J9MMCONSTANT_EXPLICIT_GC_IDLE_GC == gcCode) && (_extensions->gcOnIdle || _extensions->compactOnIdle)) {

--- a/gc/base/MemorySubSpaceFlat.cpp
+++ b/gc/base/MemorySubSpaceFlat.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -142,15 +142,18 @@ MM_MemorySubSpaceFlat::allocationRequestFailed(MM_EnvironmentBase* env, MM_Alloc
 			return addr;
 		}
 
-		allocateDescription->saveObjects(env);
-		/* The collect wasn't good enough to satisfy the allocate so attempt an aggressive collection */
-		addr = _collector->garbageCollect(env, this, allocateDescription, J9MMCONSTANT_IMPLICIT_GC_AGGRESSIVE, objectAllocationInterface, baseSubSpace, NULL);
-		allocateDescription->restoreObjects(env);
+		/* do not launch aggressive gc in -Xgcpolicy:nogc */
+		if (!_collector->isDisabled(env)) {
+			allocateDescription->saveObjects(env);
+			/* The collect wasn't good enough to satisfy the allocate so attempt an aggressive collection */
+			addr = _collector->garbageCollect(env, this, allocateDescription, J9MMCONSTANT_IMPLICIT_GC_AGGRESSIVE, objectAllocationInterface, baseSubSpace, NULL);
+			allocateDescription->restoreObjects(env);
 
-		reportAllocationFailureEnd(env);
+			reportAllocationFailureEnd(env);
 
-		if (addr) {
-			return addr;
+			if (addr) {
+				return addr;
+			}
 		}
 		/* there was nothing we could do to satisfy the allocate at this level (we will either OOM or attempt a collect at the higher level in our parent) */
 	}

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,6 +217,11 @@ bool
 MM_ParallelGlobalGC::initialize(MM_EnvironmentBase *env)
 {
 	J9HookInterface** mmPrivateHooks = J9_HOOK_INTERFACE(_extensions->privateHookInterface);
+
+	if (gc_policy_nogc == env->getExtensions()->configurationOptions._gcPolicy) {
+		_cycleType = OMR_GC_CYCLE_TYPE_EPSILON;
+		_disableGC = true;
+	}
 
 	_markingScheme = MM_MarkingScheme::newInstance(env);
 	if (NULL == _markingScheme) {
@@ -1081,8 +1086,13 @@ MM_ParallelGlobalGC::internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySu
 {
 	_extensions->globalGCStats.gcCount += 1;
 
-	masterThreadGarbageCollect(env, allocDescription, true, false);
-	
+	/* only try to expand heap instead of garbage collection in -Xgcpolicy:nogc */
+	if (_disableGC) {
+		env->_cycleState->_activeSubSpace->checkResize(env, allocDescription, false);
+		env->_cycleState->_activeSubSpace->performResize(env, allocDescription);
+	} else {
+		masterThreadGarbageCollect(env, allocDescription, true, false);
+	}
 	return true;
 }
 

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -234,6 +234,9 @@ MM_VerboseHandlerOutputStandard::getCycleType(uintptr_t type)
 		break;
 	case OMR_GC_CYCLE_TYPE_SCAVENGE:
 		cycleType = "scavenge";
+		break;
+	case OMR_GC_CYCLE_TYPE_EPSILON:
+		cycleType = "epsilon";
 		break;
 	default:
 		cycleType = "unknown";

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -36,6 +36,7 @@
 #define OMR_GC_POLICY_METRONOME 0x5
 #define OMR_GC_POLICY_OPTAVGPAUSE 0x2
 #define OMR_GC_POLICY_OPTTHRUPUT 0x1
+#define OMR_GC_POLICY_NOGC 0x6
 
 /*
  * list of available GC policies
@@ -46,7 +47,8 @@ typedef enum MM_GCPolicy {
 	gc_policy_optavgpause = OMR_GC_POLICY_OPTAVGPAUSE,
 	gc_policy_gencon = OMR_GC_POLICY_GENCON,
 	gc_policy_balanced = OMR_GC_POLICY_BALANCED,
-	gc_policy_metronome = OMR_GC_POLICY_METRONOME
+	gc_policy_metronome = OMR_GC_POLICY_METRONOME,
+	gc_policy_nogc = OMR_GC_POLICY_NOGC
 } MM_GCPolicy;
 
 #define OMR_GC_WRITE_BARRIER_TYPE_ILLEGAL 0x0
@@ -103,6 +105,7 @@ typedef enum MM_MarkingSchemeScanReason {
 #define OMR_GC_CYCLE_TYPE_DEFAULT     0
 #define OMR_GC_CYCLE_TYPE_GLOBAL      1
 #define OMR_GC_CYCLE_TYPE_SCAVENGE    2
+#define OMR_GC_CYCLE_TYPE_EPSILON	 6
 
 /* Core allocation flags defined for OMR are < OMR_GC_ALLOCATE_OBJECT_LANGUAGE_DEFINED_BASE */
 #define OMR_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE 0x0


### PR DESCRIPTION
	- add gcpolicy:nogc for OpenJ9 to support JEP 318
	- new collector epsilon
	- _disableGC flag in collector, set it is true for gcpolicy:nogc
	- no system gc when _disableGC is true
	- only try to expand heap instead of launching gc 
	when _disableGC is true

Signed-off-by: Lin Hu <linhu@ca.ibm.com>