### PR TITLE
Avoid breaking CFG in redundant goto elimination

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -708,7 +708,12 @@ OMR::Block::changeBranchDestination(TR::TreeTop * newDestination, TR::CFG *cfg, 
    TR::Node * branchNode = self()->getLastRealTreeTop()->getNode();
    TR_ASSERT(branchNode->getOpCode().isBranch(), "OMR::Block::changeBranchDestination: can't find the existing branch node");
 
-   TR::Block * prevDestinationBlock = branchNode->getBranchDestination()->getNode()->getBlock();
+   TR::TreeTop * prevDestinationTree = branchNode->getBranchDestination();
+   if (newDestination == prevDestinationTree)
+      return; // Nothing to do. Stop here so we don't remove the edge.
+
+   TR::Block * prevDestinationBlock = prevDestinationTree->getNode()->getBlock();
+
    branchNode->setBranchDestination(newDestination);
 
    TR::Block * newDestinationBlock = newDestination->getNode()->getBlock();

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -3436,11 +3436,14 @@ int32_t TR_EliminateRedundantGotos::process(TR::TreeTop *startTree, TR::TreeTop 
          continue;
 
       TR::Block *destBlock = block->getSuccessors().front()->getTo()->asBlock();
+      if (destBlock == block)
+         continue; // No point trying to "update" predecessors
+
       TR::CFGEdgeList fixablePreds(comp()->trMemory()->currentStackRegion());
       auto preds = block->getPredecessors();
       for (auto inEdge = preds.begin(); inEdge != preds.end(); ++inEdge)
          {
-         if (((*inEdge)->getFrom() == cfg->getStart()) || ((*inEdge)->getFrom() == block))
+         if ((*inEdge)->getFrom() == cfg->getStart())
             continue;
 
          TR::Block *pred = toBlock((*inEdge)->getFrom());


### PR DESCRIPTION
OMR::Block::changeBranchDestination() deletes the outgoing edge from the
control flow graph (CFG) when the branch already targets newDestination.
This means that an unnecessary call to changeBranchDestination() can
corrupt the CFG.

Redundant goto elimination can make such calls since eb94ed52.

Now changeBranchDestination() will safely ignore these calls, and
redundant goto elimination will avoid making them.