### PR TITLE
Dead code cleanup in Z codegen

### DIFF
--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -195,13 +195,6 @@ enum TR_S390LinkageConventions
                                  VRFREGINDEX(i) :                                   \
                                  FPREGINDEX(i) :                                    \
                               REGINDEX(i))
-/**
- * 390 Specific linkage relocation types
- */
-enum TR_S390LinkageRelocations
-   {
-   TR_S390RelocXPLinkOffsetToEntryPtMarker = 1 ///<XPLink specific relocation types
-   };
 
 /**
  * Starting special linkage index for linkages that have "special arguments"

--- a/compiler/z/codegen/S390BranchCondNames.cpp
+++ b/compiler/z/codegen/S390BranchCondNames.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/S390BranchCondNames.cpp
+++ b/compiler/z/codegen/S390BranchCondNames.cpp
@@ -91,24 +91,3 @@ const char *BranchConditionToNameMap[TR::InstOpCode::S390NumBranchConditions] =
    "MASK14",
    "MASK15"
    };
-
-
-const char *BranchConditionToNameMap_ForListing[S390_MAX_BRANCH_MASK] =
-{
-    "",         // 0x0
-    "O",        // 0x1
-    "HT",       // 0x2
-    "",         // 0x3
-    "LT",       // 0x4
-    "",         // 0x5
-    "NE",       // 0x6
-    "",         // 0x7
-    "EQ",       // 0x8
-    "",         // 0x9
-    "HE",       // 0xA - same as NL (not less than)
-    "",         // 0xB
-    "LE",       // 0xC - same as NH (not higer than)
-    "",         // 0xD
-    "NO",       // 0xE
-    "UNCOND"    // 0xF
-};

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,39 +75,12 @@
 
 namespace TR { class Block; }
 
-#if defined (J9ZOS390)
-#define GPR_EP " " GPR15 " "
-#else
-#define GPR_EP " " GPR4 " "
-#endif
-
-#define PRINT_START_COMMENT         true
-#define DO_NOT_PRINT_START_COMMENT  false
-
 #define OPCODE_SPACING           8
 
 extern const char *BranchConditionToNameMap[];
 
 /** Need to use this since xlc doesn't seem to understand %hx modifier for fprintf */
 #define maskHalf(val) (0x0000FFFF & (val))
-
-/**
- * Given a value, return a string in binary, max bits = 64
- */
-static char *binary_string(int numbits, int val)
-   {
-   static char b[64];  int z=0,i=0;
-
-   if (numbits > 64) numbits=64;
-   memset(b,0,64);
-   z = 1 << (numbits-1);
-   for (i=0 ; z > 0; i++)
-     {
-     b[i] =  ((val & z) == z) ? '1' : '0';
-     z >>= 1;
-     }
-   return b;
-   }
 
 void
 TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
@@ -588,7 +561,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390IEInstruction * instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s%d,%d", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()), instr->getImmediateField1(), instr->getImmediateField2());
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -716,7 +689,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RIEInstruction * instr)
 
       trfprintf(pOutFile, "%s(mask=0x%1x), ", brCondName, mask );
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
 
    }
@@ -801,7 +774,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390LabelInstruction * instr)
          }
       }
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
 
    trfflush(pOutFile);
    }
@@ -823,7 +796,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390VirtualGuardNOPInstruction * instr)
       {
       trfprintf(pOutFile, ", labelTargetAddr=0x%p", labelLoc);
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
 
    trfflush(pOutFile);
    }
@@ -865,7 +838,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchInstruction * instr)
           }
        }
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -885,7 +858,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchOnCountInstruction * instr)
       {
       trfprintf(pOutFile, ", labelTargetAddr=0x%p", labelLoc);
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
 
    trfflush(pOutFile);
    }
@@ -921,7 +894,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390BranchOnIndexInstruction * instr)
       {
       trfprintf(pOutFile, ", labelTargetAddr=0x%p", labelLoc);
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1011,7 +984,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390PseudoInstruction * instr)
       trfprintf(pOutFile, "; DC <0x%llX>", instr->getCallDescValue());
       trfflush(pOutFile);
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1025,7 +998,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390ImmInstruction * instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%-*s0x%08x", OPCODE_SPACING, getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate());
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1039,7 +1012,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390Imm2Instruction * instr)
    printPrefix(pOutFile, instr);
    // DC looks better in the tracefile than DC2 does....
    trfprintf(pOutFile, "%-*s0x%04x", OPCODE_SPACING, "DC", instr->getSourceImmediate());
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1090,7 +1063,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RegInstruction * instr)
          print(pOutFile, targetRegister);
          }
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
 
    trfflush(pOutFile);
    }
@@ -1148,7 +1121,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRInstruction * instr)
       trfprintf(pOutFile, " \t\t# Call \"%s\"", getName(instr->getNode()->getSymbolReference()));
       }
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1182,7 +1155,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390TranslateInstruction * instr)
       {
       trfprintf(pOutFile, " \t\t# Call \"%s\"", getName(instr->getNode()->getSymbolReference()));
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1217,7 +1190,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRFInstruction * instr)
       {
       trfprintf(pOutFile, " \t\t# Call \"%s\"", getName(instr->getNode()->getSymbolReference()));
       }
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1233,7 +1206,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RRRInstruction * instr)
    print(pOutFile, instr->getRegisterOperand(2));
    trfprintf(pOutFile, ",");
    print(pOutFile, instr->getRegisterOperand(3));
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1251,7 +1224,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RIInstruction * instr)
    if (instr->isImm())
       trfprintf(pOutFile, ",0x%x", maskHalf(imm));
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1316,7 +1289,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RILInstruction * instr)
          }
       }
 
-   printInstructionComment(pOutFile, 1, instr, PRINT_START_COMMENT);
+   printInstructionComment(pOutFile, 1, instr, true);
    trfflush(pOutFile);
    }
 
@@ -1904,7 +1877,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, TR::Instruction * 
    bool fullyMapped = true;
    bool sawWcodeName = false;
    char comments[1024] ;
-   bool firstPrint = PRINT_START_COMMENT;
+   bool firstPrint = true;
    bool useTobeyFormat = true;
 
    // For some indirect loads and stores the _originalSymbolReference
@@ -2083,7 +2056,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference * mr, TR::Instruction * 
      if (regex && TR::SimpleRegex::match(regex, comments))
         {
         trfprintf(pOutFile, "\t ; %s", comments);
-        firstPrint = DO_NOT_PRINT_START_COMMENT;
+        firstPrint = false;
         }
      }
 

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -87,7 +87,6 @@ namespace TR { class Block; }
 #define OPCODE_SPACING           8
 
 extern const char *BranchConditionToNameMap[];
-extern const char *BranchConditionToNameMap_ForListing[];
 
 /** Need to use this since xlc doesn't seem to understand %hx modifier for fprintf */
 #define maskHalf(val) (0x0000FFFF & (val))

--- a/compiler/z/codegen/S390Evaluator.hpp
+++ b/compiler/z/codegen/S390Evaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/z/codegen/S390Evaluator.hpp
+++ b/compiler/z/codegen/S390Evaluator.hpp
@@ -186,12 +186,6 @@ int32_t getVectorElementSize(TR::Node *node);
 int32_t getVectorElementSizeMask(TR::Node *node);
 int32_t getVectorElementSizeMask(int8_t size);
 
-TR::Register * generateS390ComplexCompareBool(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic branchOp,
-                                                TR::InstOpCode::S390BranchCondition branchOpCond);
-void asmNodeBookKeeping(TR::CodeGenerator * cg, TR::Node * node, TR::Node * child, int8_t i, TR::RegisterDependencyConditions * conditions);
-
-
-
 #ifndef _MSC_VER
 // Because these templates are not defined in headers, but the cpp TreeEvaluator.cpp, suppress implicit instantiation
 // using these extern definitions. Unfortunately, Visual Studio likes doing things differently, so for VS, this chunk


### PR DESCRIPTION
- Remove BranchConditionToNameMap_ForListing 
- Remove TR_S390RelocXPLinkOffsetToEntryPtMarker 
- Remove unimplemented evaluators 
- Remove S390Debug deprecated #defines and APIs 

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>