### PR TITLE
Killing default Memory Space

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -53,17 +53,6 @@
 void
 MM_Configuration::kill(MM_EnvironmentBase* env)
 {
-	MM_GCExtensionsBase *ext = env->getExtensions();
-
-	/* DefaultMemorySpace needs to be killed before
-	 * ext->heap is freed in MM_Configuration::tearDown. */
-	if (NULL != ext->heap) {
-		MM_MemorySpace *modronMemorySpace = ext->heap->getDefaultMemorySpace();
-		if  (NULL != modronMemorySpace) {
-			modronMemorySpace->kill(env);
-		}
-		ext->heap->setDefaultMemorySpace(NULL);
-	}
 	tearDown(env);
 	env->getForge()->free(this);
 }
@@ -96,6 +85,16 @@ void
 MM_Configuration::tearDown(MM_EnvironmentBase* env)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
+
+	/* DefaultMemorySpace needs to be killed before
+	 * ext->heap is freed in MM_Configuration::tearDown. */
+	if (NULL != extensions->heap) {
+		MM_MemorySpace *modronMemorySpace = extensions->heap->getDefaultMemorySpace();
+		if  (NULL != modronMemorySpace) {
+			modronMemorySpace->kill(env);
+		}
+		extensions->heap->setDefaultMemorySpace(NULL);
+	}
 
 	/* referenceChainWalkerMarkMap must be destroyed before Memory Manager is killed */
 	if (NULL != extensions->referenceChainWalkerMarkMap) {

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -253,7 +253,11 @@ bool
 MM_GCExtensionsBase::isConcurrentScavengerInProgress()
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	return scavenger->isConcurrentInProgress();
+	if (NULL != scavenger) {
+		return scavenger->isConcurrentInProgress();
+	} else {
+		return false;
+	}
 #else
 	return false;
 #endif


### PR DESCRIPTION
Move the destruction of default Memory Space from kill() to teardown()
of base Configuration class.

Firstly, kill() should not be doing anything more than just calling the
destructor (teardown() method), and destroying the backing memory
(free() method).

Secondly, and more imporantly, doing it in kill() before teardown, would
do it too early, before specific teardown of Configuration subclasses
would be not be complete. For example
ConfigurationGenerational::tearDown would want to set scavenger pointer
in extensions to NULL before Scavenger instance is destroyed (inderectly
by MemorySpace and SubSpaceSemiSpace)  

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>