### PR TITLE
Add .gitattributes file to allow correct format of files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# This .gitattributes file will cause all text files EXCEPT for
+# git's .gitattributes and .gitignore files to be encoded as EBCDIC.
+# Selected binary files will not be translated at all.
+# The default for text files
+* git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# git's files (which MUST be ASCII)
+.gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+.gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+*.hdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+*.tdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+
+# Binary files
+*.jpg git-encoding=BINARY working-tree-encoding=BINARY
+*.png git-encoding=BINARY working-tree-encoding=BINARY
+*.gif git-encoding=BINARY working-tree-encoding=BINARY
+*.zip git-encoding=BINARY working-tree-encoding=BINARY

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,17 @@
 # This .gitattributes file will cause all text files EXCEPT for
-# git's .gitattributes and .gitignore files to be encoded as EBCDIC.
+# git's .gitattributes and .gitignore files to be encoded as EBCDIC
+# when cloned using git (from Rocket Software) on z/OS platform.
+#
 # Selected binary files will not be translated at all.
+#
 # The default for text files
 * git-encoding=iso8859-1 working-tree-encoding=iso8859-1
 
 # git's files (which MUST be ASCII)
 .gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
 .gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# omr files that need to be encoded as EBCDIC
 *.hdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
 *.tdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
 


### PR DESCRIPTION
when they are download on z/OS system by Rocket Software's
Git program. These changes are needed when building OMR
within OpenJDK with OpenJ9

Signed-off-by: Steve Groeger <groeges@uk.ibm.com>