### PR TITLE
Fix memory fences on x86

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -224,7 +224,7 @@ public:
 #if defined(J9X86)
 		asm volatile("lock orl $0x0,(%%esp)" ::: "memory");
 #elif defined(J9HAMMER)
-		asm volatile("lock orq $0x0,(%%rsp)" ::: "memory");
+		asm volatile("lock orl $0x0,(%%rsp)" ::: "memory");
 #elif defined(ARM) /* defined(J9HAMMER) */
 		__sync_synchronize();
 #elif defined(AARCH64) /* defined(ARM) */
@@ -233,7 +233,7 @@ public:
 		asm volatile("bcr 15,0":::"memory");
 #else /* defined(S390) */
 		asm volatile("":::"memory");
-#endif /* defined(J9X86) || defined(J9HAMMER) */
+#endif /* defined(J9X86) */
 #elif defined(J9ZOS390)
 		/* Replace this with an inline "bcr 15,0" whenever possible */
 		__fence();
@@ -253,24 +253,20 @@ public:
 	VMINLINE static void
 	writeBarrier()
 	{
+	/* Neither x86 nor S390 require a write barrier - the compiler fence is sufficient */
 #if !defined(ATOMIC_SUPPORT_STUB)
 #if defined(AIXPPC) || defined(LINUXPPC)
 		__lwsync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
 #elif defined(__GNUC__)
-#if defined(J9X86) || defined(J9HAMMER)
-		asm volatile("":::"memory");
-		/* TODO investigate whether or not we should call this
-		asm volatile("sfence" ::: "memory");
-		*/
-#elif defined(ARM) /* defined(J9X86) || defined(J9HAMMER) */
+#if defined(ARM)
 		__sync_synchronize();
 #elif defined(AARCH64) /* defined(ARM) */
 		__asm __volatile ("dmb ishst":::"memory");
 #else /* defined(AARCH64) */
 		asm volatile("":::"memory");
-#endif /* defined(J9X86) || defined(J9HAMMER) */
+#endif /* defined(ARM) */
 #elif defined(J9ZOS390)
 		__fence();
 #endif /* defined(AIXPPC) || defined(LINUXPPC) */
@@ -287,35 +283,20 @@ public:
 	VMINLINE static void
 	readBarrier()
 	{
+	/* Neither x86 nor S390 require a read barrier - the compiler fence is sufficient */
 #if !defined(ATOMIC_SUPPORT_STUB)
 #if defined(AIXPPC) || defined(LINUXPPC)
 		__isync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
-#if defined(J9HAMMER)
-		__faststorefence();
-#else /* J9HAMMER */
-		__asm { lock or dword ptr [esp],0 }
-#endif /* J9HAMMER */
-		_ReadWriteBarrier();
 #elif defined(__GNUC__)
-#if defined(J9X86)
-		asm volatile("lock orl $0x0,(%%esp)" ::: "memory");
-		/* TODO investigate whether or not we should call this instead
-		asm volatile("lfence":::"memory");
-		*/
-#elif defined(J9HAMMER)
-		asm volatile("lock orq $0x0,(%%rsp)" ::: "memory");
-		/* TODO investigate whether or not we should call this instead
-		asm volatile("lfence":::"memory");
-		*/
-#elif defined(ARM) /* defined(J9HAMMER) */
+#if defined(ARM)
 		__sync_synchronize();
 #elif defined(AARCH64) /* defined(ARM) */
 		__asm __volatile ("dmb ishld":::"memory");
 #else /* defined(AARCH64) */
 		asm volatile("":::"memory");
-#endif /* defined(J9X86) || defined(J9HAMMER) */
+#endif /* defined(ARM) */
 #elif defined(J9ZOS390)
 		__fence();
 #endif /* defined(AIXPPC) || defined(LINUXPPC) */


### PR DESCRIPTION
- dword rather than qword is sufficient for readWriteBarrier
- no memory fence is required for readBarrier
- remove lfence/sfence TODOs (not required for normal reads/writes)

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>