### PR TITLE
Account for NULL monitor

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -2805,6 +2805,7 @@ interrupt_waiting_thread(omrthread_t self, omrthread_t threadToInterrupt)
 	 * interruptServer thread.
 	 */
 	monitor = threadToInterrupt->monitor;
+	ASSERT(monitor);
 
 	/*
 	 * Holding THREAD_LOCK here prevents threadToInterrupt from exiting monitor_wait.
@@ -3996,6 +3997,7 @@ omrthread_monitor_try_enter_using_threadId(omrthread_monitor_t monitor, omrthrea
 	intptr_t lockAcquired = -1;
 	ASSERT(threadId != 0);
 	ASSERT(threadId == MACRO_SELF());
+	ASSERT(monitor);
 	ASSERT(FREE_TAG != monitor->count);
 
 	/* Are we already the owner? */


### PR DESCRIPTION
In OpenJ9, segmentation fault is observed because calls to
`interrupt_waiting_thread` has `threadToInterrupt->monitor` set to NULL.
Currently, `interrupt_waiting_thread` does not account for NULL 
`threadToInterrupt->monitor`. If `monitor` is NULL, then `interrupt_waiting_thread`
 and `omrthread_monitor_try_enter_using_threadId` should throw an assertion.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>