### PR TITLE
Clang: disable unused private field and function

### DIFF
--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -100,7 +100,7 @@ macro(omr_toolconfig_global_setup)
 	# FIXME: disable several warnings while compiling with CLang.
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		omr_append_flags(CMAKE_C_FLAGS -Wno-error=unused-command-line-argument -Wno-error=comment -Wno-error=deprecated)
-		omr_append_flags(CMAKE_CXX_FLAGS -Wno-error=unused-command-line-argument -Wno-error=comment -Wno-error=deprecated)
+		omr_append_flags(CMAKE_CXX_FLAGS -Wno-error=unused-command-line-argument -Wno-error=comment -Wno-error=deprecated -Wno-unused-private-field -Wno-unused-function)
 	endif()
 
 	# Hack up output dir to fix dll dependency issues on windows


### PR DESCRIPTION
There are many warnings `unused-private-field` about the
`OMRNode::NodeExtensionStore::_flag` appear during compilation
with clang as well as some false positive warnings `unused-function`
about the `isJ9()` function (the function is used!) do. To suppress the
warnings, the `-no-unused-private-field -no-unused-function` command
line was added to clang in the MSVC toolchain configuration.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>