### PR TITLE
Introduce support for sqrt IL OpCode on X86

### DIFF
--- a/compiler/env/OMRArithEnv.hpp
+++ b/compiler/env/OMRArithEnv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@ namespace OMR { typedef OMR::ArithEnv ArithEnvConnector; }
 #endif
 
 #include <stdint.h>        // for int32_t, int64_t, uint32_t
+#include <cmath>
 #include "infra/Annotations.hpp"
 #include "env/jittypes.h"
 
@@ -48,6 +49,8 @@ class OMR_EXTENSIBLE ArithEnv
 public:
 
    TR::ArithEnv * self();
+
+   template <typename T> inline T fpSquareRoot(T a) { return std::sqrt(a); }
 
    float floatAddFloat(float a, float b);
    float floatSubtractFloat(float a, float b);

--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -10986,7 +10986,7 @@
    {
    /* .opcode               = */ TR::dsqrt,
    /* .name                 = */ "dsqrt",
-   /* .properties1          = */ ILProp1::HasSymbolRef,
+   /* .properties1          = */ 0,
    /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -614,6 +614,8 @@ template <> inline uint32_t Node::getConst<uint32_t>() { return self()->getUnsig
 template <> inline  int32_t Node::getConst< int32_t>() { return self()->getInt(); }
 template <> inline uint64_t Node::getConst<uint64_t>() { return self()->getUnsignedLongInt(); }
 template <> inline  int64_t Node::getConst< int64_t>() { return self()->getLongInt(); }
+template <> inline    float Node::getConst<   float>() { return self()->getFloat(); }
+template <> inline   double Node::getConst<  double>() { return self()->getDouble(); }
 
 template <> inline  uint8_t Node::setConst< uint8_t>( uint8_t b) { return self()->setUnsignedByte(b); }
 template <> inline   int8_t Node::setConst<  int8_t>(  int8_t b) { return self()->setByte(b); }
@@ -623,6 +625,8 @@ template <> inline uint32_t Node::setConst<uint32_t>(uint32_t i) { return self()
 template <> inline  int32_t Node::setConst< int32_t>( int32_t i) { return self()->setInt(i); }
 template <> inline uint64_t Node::setConst<uint64_t>(uint64_t l) { return self()->setUnsignedLongInt(l); }
 template <> inline  int64_t Node::setConst< int64_t>( int64_t l) { return self()->setLongInt(l); }
+template <> inline    float Node::setConst<   float>(   float f) { return self()->setFloat(f); }
+template <> inline   double Node::setConst<  double>(  double d) { return self()->setDouble(d); }
 }
 
 template <class T> T

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -334,7 +334,7 @@ static void setExprInvariant(TR_RegionStructure *region, TR::Node *node)
    }
 
 template <typename T>
-static void foldConstant(TR::Node *node, T value, TR::Simplifier *s, bool anchorChildrenP)
+inline void foldConstant(TR::Node *node, T value, TR::Simplifier *s, bool anchorChildrenP)
    {
    if (!performTransformationSimplifier(node, s)) return;
    if (anchorChildrenP) s->anchorChildren(node, s->_curTree);
@@ -11685,6 +11685,32 @@ TR::Node *sxorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    BINARY_IDENTITY_OP(ShortInt, 0)
 
    return node;
+   }
+
+//---------------------------------------------------------------------
+// Floating point square root
+//
+template <class T>
+inline TR::Node* sqrtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
+   {
+   simplifyChildren(node, block, s);
+   auto child = node->getChild(0);
+   if (child->getOpCode().isLoadConst() &&
+       performTransformation(s->comp(), "%sSimplify sqrt of const child at [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
+      {
+      foldConstant<T>(node, TR::Compiler->arith.fpSquareRoot(child->getConst<T>()), s, false /* !anchorChilren */);
+      }
+   return node;
+   }
+
+TR::Node *fsqrtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
+   {
+   return sqrtSimplifier<float>(node, block, s);
+   }
+
+TR::Node *dsqrtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
+   {
+   return sqrtSimplifier<double>(node, block, s);
    }
 
 //---------------------------------------------------------------------

--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,6 +101,8 @@ TR::Node * ixorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
 TR::Node * lxorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * bxorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * sxorSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
+TR::Node * fsqrtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
+TR::Node * dsqrtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * i2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * i2fSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * i2dSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -740,8 +740,8 @@
    dftSimplifier,           // TR::fnint
    dftSimplifier,           // TR::dnint
 
-   dftSimplifier,           // TR::fsqrt
-   dftSimplifier,           // TR::dsqrt
+   fsqrtSimplifier,         // TR::fsqrt
+   dsqrtSimplifier,         // TR::dsqrt
 
    dftSimplifier,           // TR::getstack
    dftSimplifier,           // TR::dealloca

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -706,8 +706,8 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dint
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::fnint
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dnint
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::fsqrt
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dsqrt
+   TR::TreeEvaluator::fpSqrtEvaluator,                     // TR::fsqrt
+   TR::TreeEvaluator::fpSqrtEvaluator,                     // TR::dsqrt
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dealloca
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::ishfl

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -288,6 +288,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *fpUnaryMaskEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fpReturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fpRemEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fpSqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    // routines for floating point values that can fit in one GPR
    static TR::Register *floatingPointStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -707,8 +707,8 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dint
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::fnint
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dnint
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::fsqrt
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dsqrt
+   TR::TreeEvaluator::fpSqrtEvaluator,                     // TR::fsqrt
+   TR::TreeEvaluator::fpSqrtEvaluator,                     // TR::dsqrt
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::dealloca
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::ishfl

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -226,6 +226,10 @@ signatureCharJ_J_testMethodType  * OpCodesTest::_lAbs = 0;
 signatureCharD_D_testMethodType  * OpCodesTest::_dAbs = 0;
 signatureCharF_F_testMethodType  * OpCodesTest::_fAbs = 0;
 
+//Sqrt
+signatureCharD_D_testMethodType  * OpCodesTest::_dSqrt = 0;
+signatureCharF_F_testMethodType  * OpCodesTest::_fSqrt = 0;
+
 //Load
 signatureCharI_I_testMethodType  *OpCodesTest::_iLoad = 0;
 signatureCharJ_J_testMethodType  *OpCodesTest::_lLoad = 0;

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -568,6 +568,10 @@ class OpCodesTest : public TestDriver
    static signatureCharD_D_testMethodType *_dAbs;
    static signatureCharF_F_testMethodType *_fAbs;
 
+   //Sqrt
+   static signatureCharD_D_testMethodType *_dSqrt;
+   static signatureCharF_F_testMethodType *_fSqrt;
+
    //load
    static signatureCharI_I_testMethodType *_iLoad;
    static signatureCharJ_J_testMethodType *_lLoad;

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -19,8 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include <stdint.h>
-#include <stdio.h>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
 #include "compile/Method.hpp"
 #include "env/jittypes.h"
 #include "gtest/gtest.h"
@@ -103,6 +104,9 @@ X86OpCodesTest::compileUnaryTestMethods()
    compileOpCodeMethod(_dAbs, _numberOfUnaryArgs, TR::dabs, "dAbs", _argTypesUnaryDouble, TR::Double, rc);
    compileOpCodeMethod(_fAbs, _numberOfUnaryArgs, TR::fabs, "fAbs", _argTypesUnaryFloat, TR::Float, rc);
    compileOpCodeMethod(_lAbs, _numberOfUnaryArgs, TR::labs, "lAbs", _argTypesUnaryLong, TR::Int64, rc);
+
+   compileOpCodeMethod(_dSqrt, _numberOfUnaryArgs, TR::dsqrt, "dSqrt", _argTypesUnaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_fSqrt, _numberOfUnaryArgs, TR::fsqrt, "fSqrt", _argTypesUnaryFloat, TR::Float, rc);
 
    compileOpCodeMethod(_lReturn, _numberOfUnaryArgs, TR::lreturn, "lReturn", _argTypesUnaryLong, TR::Int64, rc);
    compileOpCodeMethod(_dReturn, _numberOfUnaryArgs, TR::dreturn, "dReturn", _argTypesUnaryDouble, TR::Double, rc);
@@ -249,7 +253,6 @@ X86OpCodesTest::compileCompareTestMethods()
    compileOpCodeMethod(_ifFcmplt, _numberOfBinaryArgs, TR::iffcmplt, "ifFcmplt", _argTypesBinaryFloat, TR::Int32, rc);
    compileOpCodeMethod(_ifFcmpge, _numberOfBinaryArgs, TR::iffcmpge, "ifFcmpge", _argTypesBinaryFloat, TR::Int32, rc);
    compileOpCodeMethod(_ifFcmple, _numberOfBinaryArgs, TR::iffcmple, "ifFcmple", _argTypesBinaryFloat, TR::Int32, rc);
-
 
    compileOpCodeMethod(_ifScmpeq, _numberOfBinaryArgs, TR::ifscmpeq, "ifScmpeq", _argTypesBinaryShort, TR::Int32, rc);
    compileOpCodeMethod(_ifScmpne, _numberOfBinaryArgs, TR::ifscmpne, "ifScmpne", _argTypesBinaryShort, TR::Int32, rc);
@@ -1514,6 +1517,46 @@ X86OpCodesTest::invokeUnaryTests()
       compileOpCodeMethod(dUnaryCons, 
             _numberOfUnaryArgs, TR::dabs, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
       OMR_CT_EXPECT_EQ(dUnaryCons, abs(doubleDataArray[i]), dUnaryCons(DOUBLE_PLACEHOLDER_1));
+      }
+
+   //fsqrt
+   testCaseNum = sizeof(floatDataArray) / sizeof(floatDataArray[0]);
+   for (uint32_t i = 0; i < testCaseNum; ++i)
+      {
+      union
+         {
+         float    f;
+         uint32_t ui32;
+         } gold, result;
+      gold.f = sqrt(floatDataArray[i]);
+      result.f = _fSqrt(floatDataArray[i]);
+      OMR_CT_EXPECT_EQ(_fSqrt, gold.ui32, result.ui32);
+      sprintf(resolvedMethodName, "fSqrtConst%d", i + 1);
+      compileOpCodeMethod(fUnaryCons, 
+            _numberOfUnaryArgs, TR::fsqrt, resolvedMethodName, _argTypesUnaryFloat, TR::Float, rc, 2, 1, &floatDataArray[i]);
+      gold.f = sqrt(floatDataArray[i]);
+      result.f = fUnaryCons(FLOAT_PLACEHOLDER_1);
+      OMR_CT_EXPECT_EQ(fUnaryCons, gold.ui32, result.ui32);
+      }
+
+   //dsqrt
+   testCaseNum = sizeof(doubleDataArray) / sizeof(doubleDataArray[0]);
+   for (uint32_t i = 0; i < testCaseNum; ++i)
+      {
+      union
+         {
+         double   d;
+         uint64_t ui64;
+         } gold, result;
+      gold.d = sqrt(doubleDataArray[i]);
+      result.d = _dSqrt(doubleDataArray[i]);
+      OMR_CT_EXPECT_EQ(_dSqrt, gold.ui64, result.ui64);
+      sprintf(resolvedMethodName, "dSqrtConst%d", i + 1);
+      compileOpCodeMethod(dUnaryCons, 
+            _numberOfUnaryArgs, TR::dsqrt, resolvedMethodName, _argTypesUnaryDouble, TR::Double, rc, 2, 1, &doubleDataArray[i]);
+      gold.d = sqrt(doubleDataArray[i]);
+      result.d = dUnaryCons(DOUBLE_PLACEHOLDER_1);
+      OMR_CT_EXPECT_EQ(dUnaryCons, gold.ui64, result.ui64);
       }
 
    //lReturn


### PR DESCRIPTION
IL OpCode fsqrt and dsqrt are now supported by X86, including evaluators, simplifiers and tests.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>