### PR TITLE
Define PseudoRealRegisters using new RegDep enum

### DIFF
--- a/compiler/aarch64/codegen/PseudoRegisterEnum.hpp
+++ b/compiler/aarch64/codegen/PseudoRegisterEnum.hpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+

--- a/compiler/arm/codegen/PseudoRegisterEnum.hpp
+++ b/compiler/arm/codegen/PseudoRegisterEnum.hpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+

--- a/compiler/codegen/OMRRealRegister.hpp
+++ b/compiler/codegen/OMRRealRegister.hpp
@@ -58,6 +58,7 @@ class OMR_EXTENSIBLE RealRegister : public TR::Register
       Locked    = 4
       } RegState;
 
+   // All hardware backed registers
    typedef enum
       {
       #include "codegen/RealRegisterEnum.hpp"
@@ -69,6 +70,22 @@ class OMR_EXTENSIBLE RealRegister : public TR::Register
       #include "codegen/RealRegisterMaskEnum.hpp"
 
       } RegMask;
+
+    // PseudoRegisters are the union of all hardware backed registers (ex. GPR0)
+    // and constructs such as TR::RealRegister::NoReg or TR::RealRegister::AssignAny. 
+    // These pseudo registers are used to assign register dependencies during the 
+    // Register Allocation phase. The enum below is meant to hold all pseudo registers.
+    // However, to avoid compilation failures, we cannot include 
+    // codegen/RealRegisterEnum.hpp again. In order to include it twice, these two enums
+    // must be scoped. However, not all of our minimum compiler toolchains support this
+    // feature yet (MSVC 2010). So we only include PseudoRegisterEnum below, and cast any 
+    // RegNum to RegDep when using it to set a register dependency. If MSVC 2010 support is 
+    // no longer required, then this can be cleaned up by using scoped enums instead. An issue
+    // to track this is open here: https://github.com/eclipse/omr/issues/2590 
+    typedef enum
+       {
+       #include "codegen/PseudoRegisterEnum.hpp"
+       } RegDep;
 
 
    protected:

--- a/compiler/p/codegen/PseudoRegisterEnum.hpp
+++ b/compiler/p/codegen/PseudoRegisterEnum.hpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+

--- a/compiler/x/amd64/codegen/PseudoRegisterEnum.hpp
+++ b/compiler/x/amd64/codegen/PseudoRegisterEnum.hpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+

--- a/compiler/x/i386/codegen/PseudoRegisterEnum.hpp
+++ b/compiler/x/i386/codegen/PseudoRegisterEnum.hpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -7098,7 +7098,7 @@ void OMR::Z::CodeGenerator::startInternalControlFlow(TR::Instruction *instr)
         else
           {
           TR::RealRegister::RegNum rr = postConds->getRegisterDependency(i)->getRealRegister();
-          if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::MISC)
+          if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
             r = mach->getS390RealRegister(rr);
           }
         if(r) _internalControlFlowRegisters.push_back(r);
@@ -10142,7 +10142,7 @@ OMR::Z::CodeGenerator::addVMThreadPreCondition(TR::RegisterDependencyConditions 
       //TODO: using addPreConditionIfNotAlreadyInserted() is slower than using addPreCondition()
       //think about changing the name of this method to addVMThreadPreConditionIfNotAlreadyInserted()
       //and add one for addVMThreadPreCondition, which uses deps->addPreCondition()
-      deps->addPreConditionIfNotAlreadyInserted(reg,(TR::RealRegister::RegNum)self()->getVMThreadRegister()->getAssociation());
+      deps->addPreConditionIfNotAlreadyInserted(reg, static_cast<TR::RealRegister::RegDep>(self()->getVMThreadRegister()->getAssociation()));
       }
    return deps;
    }
@@ -10167,7 +10167,7 @@ OMR::Z::CodeGenerator::addVMThreadPostCondition(TR::RegisterDependencyConditions
       //TODO: using addPostConditionIfNotAlreadyInserted() is slower than using addPostCondition()
       //think about changing the name of this method to addVMThreadPostConditionIfNotAlreadyInserted()
       //and add one for addVMThreadPostCondition, which uses deps->addPostCondition()
-      deps->addPostConditionIfNotAlreadyInserted(reg,(TR::RealRegister::RegNum)self()->getVMThreadRegister()->getAssociation());
+      deps->addPostConditionIfNotAlreadyInserted(reg, static_cast<TR::RealRegister::RegDep>(self()->getVMThreadRegister()->getAssociation()));
       }
    return deps;
    }

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -909,7 +909,7 @@ bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
             else
               {
               TR::RealRegister::RegNum rr = dep->getRealRegister();
-              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::MISC)
+              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
                 usedRegs.push_back(machine->getS390RealRegister(rr));
                 }
@@ -942,7 +942,7 @@ bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
             else
               {
               TR::RealRegister::RegNum rr = dep->getRealRegister();
-              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::MISC)
+              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
                 usedRegs.push_back(machine->getS390RealRegister(rr));
                 }
@@ -1030,7 +1030,7 @@ bool OMR::Z::Instruction::getDefinedRegisters(TR::list<TR::Register *> &defedReg
             else
               {
               TR::RealRegister::RegNum rr = dep->getRealRegister();
-              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::MISC)
+              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
                 defedRegs.push_back(machine->getS390RealRegister(rr));
                 }
@@ -1063,7 +1063,7 @@ bool OMR::Z::Instruction::getDefinedRegisters(TR::list<TR::Register *> &defedReg
             else
               {
               TR::RealRegister::RegNum rr = dep->getRealRegister();
-              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::MISC)
+              if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
                 defedRegs.push_back(machine->getS390RealRegister(rr));
                 }

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6035,7 +6035,6 @@ OMR::Z::Machine::initialiseRegisterFile()
 
    // Initialize GPRs
    _registerFile[TR::RealRegister::NoReg] = NULL;
-   _registerFile[TR::RealRegister::SpilledReg] = NULL;
 
    _registerFile[TR::RealRegister::GPR0] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_GPR, 0, TR::RealRegister::Free,
                                                      TR::RealRegister::GPR0, TR::RealRegister::GPR0Mask, self()->cg());

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -1834,6 +1834,13 @@ bool OMR::Z::RegisterDependencyConditions::doesPostConditionExist( TR::Register 
    }
 
 
+bool OMR::Z::RegisterDependencyConditions::addPreConditionIfNotAlreadyInserted(TR::Register *vr,
+                                                                                  TR::RealRegister::RegNum rr,
+                                                                                  uint8_t flag)
+   {
+   return addPreConditionIfNotAlreadyInserted(vr, static_cast<TR::RealRegister::RegDep>(rr), flag);  
+   }
+
 /**
  * Checks for an existing pre-condition for given virtual register.  If found,
  * the flags are updated.  If not found, a new pre-condition is created with
@@ -1845,7 +1852,7 @@ bool OMR::Z::RegisterDependencyConditions::doesPostConditionExist( TR::Register 
  * @sa addPostConditionIfNotAlreadyInserted()
  */
 bool OMR::Z::RegisterDependencyConditions::addPreConditionIfNotAlreadyInserted(TR::Register *vr,
-                                                                                  TR::RealRegister::RegNum rr,
+                                                                                  TR::RealRegister::RegDep rr,
                                                                                   uint8_t flag)
    {
    int32_t pos = -1;
@@ -1863,6 +1870,12 @@ bool OMR::Z::RegisterDependencyConditions::addPreConditionIfNotAlreadyInserted(T
    return false;
    }
 
+bool OMR::Z::RegisterDependencyConditions::addPostConditionIfNotAlreadyInserted(TR::Register *vr,
+                                                                                   TR::RealRegister::RegNum rr,
+                                                                                   uint8_t flag)
+   {
+   return addPostConditionIfNotAlreadyInserted(vr, static_cast<TR::RealRegister::RegDep>(rr), flag);
+   }
 
 /**
  * Checks for an existing post-condition for given virtual register.  If found,
@@ -1875,7 +1888,7 @@ bool OMR::Z::RegisterDependencyConditions::addPreConditionIfNotAlreadyInserted(T
  * @sa addPreConditionIfNotAlreadyInserted()
  */
 bool OMR::Z::RegisterDependencyConditions::addPostConditionIfNotAlreadyInserted(TR::Register *vr,
-                                                                                   TR::RealRegister::RegNum rr,
+                                                                                   TR::RealRegister::RegDep rr,
                                                                                    uint8_t flag)
    {
    int32_t pos = -1;

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -103,6 +103,14 @@ class TR_S390RegisterDependencyGroup
 
    void setDependencyInfo(uint32_t                                  index,
                           TR::Register                              *vr,
+                          TR::RealRegister::RegDep rr,
+                          uint8_t                                   flag)
+     {
+     setDependencyInfo(index, vr, static_cast<TR::RealRegister::RegNum>(rr), flag);
+     }
+
+   void setDependencyInfo(uint32_t                                  index,
+                          TR::Register                              *vr,
                           TR::RealRegister::RegNum rr,
                           uint8_t                                   flag)
       {
@@ -391,6 +399,13 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    void addPreCondition(TR::Register                              *vr,
                         TR::RealRegister::RegNum rr,
                         uint8_t                                   flag = ReferencesDependentRegister)
+       {
+       addPreCondition(vr, static_cast<TR::RealRegister::RegDep>(rr), flag);
+       }
+
+   void addPreCondition(TR::Register                              *vr,
+                        TR::RealRegister::RegDep rr,
+                        uint8_t                                   flag = ReferencesDependentRegister)
       {
       TR_ASSERT(!getIsUsed(), "ERROR: cannot add pre conditions to an used dependency, create a copy first\n");
 
@@ -427,6 +442,13 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
    void addPostCondition(TR::Register                              *vr,
                          TR::RealRegister::RegNum rr,
+                         uint8_t                                   flag = ReferencesDependentRegister)
+      {
+      addPostCondition(vr, static_cast<TR::RealRegister::RegDep>(rr), flag);
+      }
+
+   void addPostCondition(TR::Register                              *vr,
+                         TR::RealRegister::RegDep rr,
                          uint8_t                                   flag = ReferencesDependentRegister)
       {
       TR_ASSERT(!getIsUsed(), "ERROR: cannot add post conditions to an used dependency, create a copy first\n");
@@ -511,8 +533,15 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    bool addPreConditionIfNotAlreadyInserted(TR::Register *vr,
                                             TR::RealRegister::RegNum rr,
 				                                uint8_t flag = ReferencesDependentRegister);
+   bool addPreConditionIfNotAlreadyInserted(TR::Register *vr,
+                                            TR::RealRegister::RegDep rr,
+				                                uint8_t flag = ReferencesDependentRegister);
+
    bool addPostConditionIfNotAlreadyInserted(TR::Register *vr,
                                              TR::RealRegister::RegNum rr,
+				                                 uint8_t flag = ReferencesDependentRegister);                                     
+   bool addPostConditionIfNotAlreadyInserted(TR::Register *vr,
+                                             TR::RealRegister::RegDep rr,
 				                                 uint8_t flag = ReferencesDependentRegister);
 
    TR::RegisterDependencyConditions *clone(TR::CodeGenerator *cg, int32_t additionalRegDeps);

--- a/compiler/z/codegen/PseudoRegisterEnum.hpp
+++ b/compiler/z/codegen/PseudoRegisterEnum.hpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/*
+ * This file will be included within an enum.  Only comments and enumerator
+ * definitions are permitted.
+ */
+
+      EvenOddPair         = LastHPR + 1,      // Assign an even/odd pair to the reg pair
+      LegalEvenOfPair     = LastHPR + 2,      // Assign an even reg that is followed by an unlocked odd register
+      LegalOddOfPair      = LastHPR + 3,      // Assign an odd reg that is preceded by an unlocked even register
+      FPPair              = LastHPR + 4,      // Assign an FP pair to the reg pair
+      LegalFirstOfFPPair  = LastHPR + 5,      // Assign first FP reg of a FP reg Pair
+      LegalSecondOfFPPair = LastHPR + 6,      // Assign second FP reg of a FP reg Pair
+      AssignAny           = LastHPR + 7,      // Assign any register
+      KillVolAccessRegs   = LastHPR + 8,      // Kill all volatile access regs
+      KillVolHighRegs     = LastHPR + 9,      // Kill all volatile access regs
+      MayDefine           = LastHPR + 10,     // This instruction's result should be modelled as live before as this instruction only 'may defines' the register
+      SpilledReg          = LastHPR + 11,     // OOL: Any Spilled register cross OOL sequences
+      ArGprPair           = LastHPR + 12,     // Assign an ar/gpr pair to the reg pair
+      ArOfArGprPair       = LastHPR + 13,     // Assign AR register corresponding to GPR in the second RA pass
+      GprOfArGprPair      = LastHPR + 14,     // Assign GPR register in the first RA pass
+
+      NumRegisters        = LastHPR + 1    // (include noReg)
+

--- a/compiler/z/codegen/RealRegisterEnum.hpp
+++ b/compiler/z/codegen/RealRegisterEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -154,23 +154,4 @@
       HPR15             = HPRBase + 16,
 
       FirstHPR          = HPR0,
-      LastHPR           = HPR15,
-
-      MISC              = LastHPR,
-
-      EvenOddPair         = MISC + 1,      // Assign an even/odd pair to the reg pair
-      LegalEvenOfPair     = MISC + 2,      // Assign an even reg that is followed by an unlocked odd register
-      LegalOddOfPair      = MISC + 3,      // Assign an odd reg that is preceded by an unlocked even register
-      FPPair              = MISC + 4,      // Assign an FP pair to the reg pair
-      LegalFirstOfFPPair  = MISC + 5,      // Assign first FP reg of a FP reg Pair
-      LegalSecondOfFPPair = MISC + 6,      // Assign second FP reg of a FP reg Pair
-      AssignAny           = MISC + 7,      // Assign any register
-      KillVolAccessRegs   = MISC + 8,      // Kill all volatile access regs
-      KillVolHighRegs     = MISC + 9,      // Kill all volatile access regs
-      MayDefine           = MISC + 10,     // This instruction's result should be modelled as live before as this instruction only 'may defines' the register
-      SpilledReg          = MISC + 11,     // OOL: Any Spilled register cross OOL sequences
-      ArGprPair           = MISC + 12,     // Assign an ar/gpr pair to the reg pair
-      ArOfArGprPair       = MISC + 13,     // Assign AR register corresponding to GPR in the second RA pass
-      GprOfArGprPair      = MISC + 14,     // Assign GPR register in the first RA pass
-
-      NumRegisters        = LastHPR + 1    // (include noReg)
+      LastHPR           = HPR15


### PR DESCRIPTION
Certain registers defined inside RealRegisterEnum.hpp are not hardware backed registers
(ex. TR::RealRegister::NumRegisters), but instead are used as hints for the code generator or as dependencies for real registers. This is quite prevalent in the z/codegen.This commit separates these pseudo registers from the real register enum, and updates the APIs where needed. TR::RealRegister::MISC is also deprecated because it represents the same thing as TR::RealRegister::LastHPR.

Closes: #2491
Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>