### PR TITLE
Allow findOrCreateCPSymbol to take KnownObjectIndex

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1335,7 +1335,7 @@ OMR::SymbolReferenceTable::findOrCreateClassSymbol(
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateCPSymbol(
-   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, TR::DataType dataType, bool resolved, void * dataAddress)
+   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, TR::DataType dataType, bool resolved, void * dataAddress, TR::KnownObjectTable::Index knownObjectIndex)
    {
    TR::StaticSymbol *sym;
    TR_SymRefIterator i(aliasBuilder.cpConstantSymRefs(), self());
@@ -1368,7 +1368,7 @@ OMR::SymbolReferenceTable::findOrCreateCPSymbol(
    sym = TR::StaticSymbol::create(trHeapMemory(),dataType);
    int32_t unresolvedIndex = resolved ? 0 : _numUnresolvedSymbols++;
 
-   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex);
+   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex, knownObjectIndex);
 
    if (resolved)
       sym->setStaticAddress(dataAddress);

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -446,7 +446,7 @@ class SymbolReferenceTable
 
    protected:
 
-   TR::SymbolReference * findOrCreateCPSymbol(TR::ResolvedMethodSymbol *, int32_t, TR::DataType, bool, void *);
+   TR::SymbolReference * findOrCreateCPSymbol(TR::ResolvedMethodSymbol *, int32_t, TR::DataType, bool, void *, TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);
 
    bool shouldMarkBlockAsCold(TR_ResolvedMethod * owningMethod, bool isUnresolvedInCP);
    void markBlockAsCold();

--- a/compiler/il/OMRSymbolReference.cpp
+++ b/compiler/il/OMRSymbolReference.cpp
@@ -136,7 +136,8 @@ OMR::SymbolReference::SymbolReference(
       TR::Symbol *sym,
       mcount_t owningMethodIndex,
       int32_t cpIndex,
-      int32_t unresolvedIndex)
+      int32_t unresolvedIndex,
+      TR::KnownObjectTable::Index knownObjectIndex)
    {
    self()->init(symRefTab,
         symRefTab->assignSymRefNumber(self()),
@@ -145,6 +146,8 @@ OMR::SymbolReference::SymbolReference(
         owningMethodIndex,
         cpIndex,
         unresolvedIndex);
+
+   _knownObjectIndex = knownObjectIndex;
 
    if (sym->isResolvedMethod())
       symRefTab->comp()->registerResolvedMethodSymbolReference(self());

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -119,7 +119,8 @@ public:
                    TR::Symbol *sym,
                    mcount_t owningMethodIndex,
                    int32_t cpIndex,
-                   int32_t unresolvedIndex = 0);
+                   int32_t unresolvedIndex = 0,
+                   TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);
 
    SymbolReference(TR::SymbolReferenceTable *symRefTab,
                    TR::SymbolReference& sr,

--- a/compiler/il/SymbolReference.hpp
+++ b/compiler/il/SymbolReference.hpp
@@ -73,12 +73,14 @@ public:
                    TR::Symbol *sym,
                    mcount_t owningMethodIndex,
                    int32_t cpIndex,
-                   int32_t unresolvedIndex = 0) :
+                   int32_t unresolvedIndex = 0,
+                   TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN) :
       OMR::SymbolReferenceConnector(symRefTab,
                                     sym,
                                     owningMethodIndex,
                                     cpIndex,
-                                    unresolvedIndex) {}
+                                    unresolvedIndex,
+                                    knownObjectIndex) {}
 
    SymbolReference(TR::SymbolReferenceTable *symRefTab,
                    TR::SymbolReference& sr,


### PR DESCRIPTION
Change findOrCreateCPSymbol to take KnownObjectIndex as its last
argument, with the default value being TR::KnownObjectTable::UNKNOWN

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>