### PR TITLE
Wrap omrtrace lib within build flags in OMR_Initialize_VM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,10 +132,13 @@ endif (OMR_EXAMPLE)
 add_subdirectory(thread)
 add_subdirectory(port)
 add_subdirectory(util)
-add_subdirectory(omrtrace)
 add_subdirectory(omr)
 add_subdirectory(third_party)
 add_subdirectory(omrsigcompat)
+
+if(OMR_RAS_TDF_TRACE)
+	add_subdirectory(omrtrace)
+endif(OMR_RAS_TDF_TRACE)
 
 if(OMR_GC)
 	add_subdirectory(gc)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -138,24 +138,26 @@ test_targets += fvtest/porttest/aixbaddep
 endif
 endif
 
+ifeq (1, $(OMR_RAS_TDF_TRACE))
 # RAS Libraries
 main_targets += omrtrace
+# RAS Tests
+test_targets += fvtest/rastest
+endif
 
 # OMR Startup
 main_targets += omr omr/startup
 
-# RAS Tests
-test_targets += fvtest/rastest
-
 # OMR Example Targets
 ifeq (1,$(OMR_EXAMPLE))
 test_targets += example
+main_targets += omrtrace
 endif
 
 # VM Tests
 test_targets += fvtest/vmtest
 
-# List of targets that are needed for the test compil
+# List of targets that are needed for the test compiler and jitbuilder
 compiler_prereqs = port thread util/pool util/omrutil util/avl util/hashtable util/hookable
 
 # Test Compiler
@@ -181,6 +183,7 @@ DO_TEST_TARGET := no
 ifeq (yes,$(ENABLE_FVTEST_AGENT))
 DO_TEST_TARGET := yes
 test_targets := $(test_prereqs)
+main_targets += omrtrace
 test_targets += fvtest/rastest fvtest/util
 endif
 endif

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,7 @@ set(OMR_PORT ON CACHE BOOL "Enable portability library")
 set(OMR_TEST_COMPILER OFF CACHE BOOL "Enable building the test compiler")
 set(OMR_THREAD ON CACHE BOOL "Enable thread library")
 set(OMR_TOOLS ON CACHE BOOL "Enable the native build tools")
+set(OMR_RAS_TDF_TRACE ON CACHE BOOL "Enable trace engine")
 
 ###
 ### Tooling
@@ -107,8 +108,6 @@ set(OMR_GC_VLHGC OFF CACHE BOOL "TODO: Document")
 set(OMR_INTERP_HAS_SEMAPHORES ON CACHE BOOL "TODO: Document")
 set(OMR_INTERP_COMPRESSED_OBJECT_HEADER OFF CACHE BOOL "TODO: Document")
 set(OMR_INTERP_SMALL_MONITOR_SLOT OFF CACHE BOOL "TODO: Document")
-
-set(OMR_RAS_TDF_TRACE ON CACHE BOOL "TODO: Document")
 
 set(OMR_THR_ADAPTIVE_SPIN ON CACHE BOOL "TODO: Document")
 set(OMR_THR_JLM ON CACHE BOOL "TODO: Document")

--- a/omr/startup/omrvmstartup.cpp
+++ b/omr/startup/omrvmstartup.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,7 +73,7 @@ OMR_Initialize(void *languageVM, OMR_VM **vmSlot)
 	 * it is more efficient to call omrthread_attach_ex() before the entire block.
 	 */
 	if (0 != omrthread_attach_ex(&j9self, J9THREAD_ATTR_DEFAULT)) {
-		omrtty_printf("Failed to attach main thread.\n");
+		fprintf(stderr, "Failed to attach main thread.\n");
 		rc = OMR_ERROR_FAILED_TO_ATTACH_NATIVE_THREAD;
 		goto done;
 	}
@@ -338,7 +338,7 @@ OMR_Initialize_VM(OMR_VM **omrVMSlot, OMR_VMThread **omrVMThreadSlot, void *lang
 	 * it is more efficient to call omrthread_attach_ex() before the entire block.
 	 */
 	if (0 != omrthread_attach_ex(&j9self, J9THREAD_ATTR_DEFAULT)) {
-		omrtty_printf("Failed to attach main thread.\n");
+		fprintf(stderr, "Failed to attach main thread.\n");
 		rc = OMR_ERROR_FAILED_TO_ATTACH_NATIVE_THREAD;
 		goto failed;
 	}
@@ -348,6 +348,8 @@ OMR_Initialize_VM(OMR_VM **omrVMSlot, OMR_VMThread **omrVMThreadSlot, void *lang
 		rc = OMR_ERROR_INTERNAL;
 		goto failed;
 	}
+
+	/* omrtty_printf can be used from now on */
 
 	/* Disable port library signal handling. This mechanism disables everything except SIGXFSZ.
 	 * Handling other signals in the port library will interfere with language-specific signal handlers.
@@ -441,6 +443,7 @@ OMR_Initialize_VM(OMR_VM **omrVMSlot, OMR_VMThread **omrVMThreadSlot, void *lang
 	}
 #endif /* OMR_GC */
 
+#if defined(OMR_RAS_TDF_TRACE)
 	{
 		/* Take agent options from OMR_AGENT_OPTIONS */
 		const char *healthCenterOpt = getenv("OMR_AGENT_OPTIONS");
@@ -457,6 +460,7 @@ OMR_Initialize_VM(OMR_VM **omrVMSlot, OMR_VMThread **omrVMThreadSlot, void *lang
 			goto failed;
 		}
 	}
+#endif /* OMR_RAS_TDF_TRACE */
 
 failed:
 	return rc;
@@ -481,6 +485,7 @@ OMR_Shutdown_VM(OMR_VM *omrVM, OMR_VMThread *omrVMThread)
 		}
 #endif /* OMR_GC */
 
+#if defined(OMR_RAS_TDF_TRACE)
 		omr_ras_cleanupMethodDictionary(omrVM);
 
 		omr_ras_cleanupHealthCenter(omrVM, &(omrVM->_hcAgent));
@@ -489,6 +494,7 @@ OMR_Shutdown_VM(OMR_VM *omrVM, OMR_VMThread *omrVMThread)
 		if (OMR_ERROR_NONE != rc) {
 			omrtty_printf("Failed to cleanup trace engine, rc=%d.\n", rc);
 		}
+#endif /* OMR_RAS_TDF_TRACE */
 
 		rc = OMR_Thread_Free(omrVMThread);
 		if (OMR_ERROR_NONE != rc) {


### PR DESCRIPTION
Also, the corresponding wrapping was done in OMR_ShutdownVM. Not
everything that wants to initialize/shutdown OMR components may
want to initialize/shutdown the health center monitoring tools.

Also fixed a potential bug where the port library's omrtty_printf
member was being used before the port library was initialized.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>