### PR TITLE
ConcurrentGC STW phase detection for CS

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -52,7 +52,6 @@
 
 class MM_CardTable;
 class MM_ClassLoaderRememberedSet;
-class MM_Collector;
 class MM_CollectorLanguageInterface;
 class MM_CompactGroupPersistentStats;
 class MM_CompressedCardTable;
@@ -61,6 +60,7 @@ class MM_Dispatcher;
 class MM_EnvironmentBase;
 class MM_FrequentObjectsStats;
 class MM_GlobalAllocationManager;
+class MM_GlobalCollector;
 class MM_Heap;
 class MM_HeapMap;
 class MM_HeapRegionManager;
@@ -200,7 +200,7 @@ private:
 protected:
 	OMR_VM* _omrVM;
 	OMR::GC::Forge _forge;
-	MM_Collector* _globalCollector; /**< The global collector for the system */
+	MM_GlobalCollector* _globalCollector; /**< The global collector for the system */
 #if defined(OMR_GC_OBJECT_MAP)
 	MM_ObjectMap *_objectMap;
 #endif /* defined(OMR_GC_OBJECT_MAP) */
@@ -792,8 +792,8 @@ public:
 		}
 	}
 
-	MMINLINE MM_Collector* getGlobalCollector() { return _globalCollector; }
-	MMINLINE void setGlobalCollector(MM_Collector* collector) { _globalCollector = collector; }
+	MMINLINE MM_GlobalCollector* getGlobalCollector() { return _globalCollector; }
+	MMINLINE void setGlobalCollector(MM_GlobalCollector* collector) { _globalCollector = collector; }
 
 #if defined(OMR_GC_OBJECT_MAP)
 	MMINLINE MM_ObjectMap *getObjectMap() { return _objectMap; }

--- a/gc/base/GlobalCollector.hpp
+++ b/gc/base/GlobalCollector.hpp
@@ -65,6 +65,11 @@ public:
 	}
 
 	virtual void yield(MM_EnvironmentBase *env) {};
+	
+	virtual bool isStwCollectionInProgress()
+	{
+		return false;
+	}
 
 	/**
  	 * Perform any collector-specific initialization.

--- a/gc/base/Heap.cpp
+++ b/gc/base/Heap.cpp
@@ -28,7 +28,7 @@
 #include "EnvironmentBase.hpp"
 #include "Forge.hpp"
 #include "GCExtensionsBase.hpp"
-#include "Collector.hpp"
+#include "GlobalCollector.hpp"
 #include "HeapRegionManager.hpp"
 #include "HeapStats.hpp"
 #include "MemorySpace.hpp"
@@ -400,7 +400,7 @@ bool
 MM_Heap::heapAddRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, uintptr_t size, void* lowAddress, void* highAddress)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
-	MM_Collector* globalCollector = extensions->getGlobalCollector();
+	MM_GlobalCollector* globalCollector = extensions->getGlobalCollector();
 
 	bool result = true;
 	if (NULL != globalCollector) {
@@ -420,7 +420,7 @@ bool
 MM_Heap::heapRemoveRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, uintptr_t size, void* lowAddress, void* highAddress, void* lowValidAddress, void* highValidAddress)
 {
 	MM_GCExtensionsBase* extensions = env->getExtensions();
-	MM_Collector* globalCollector = extensions->getGlobalCollector();
+	MM_GlobalCollector* globalCollector = extensions->getGlobalCollector();
 
 	bool result = true;
 	if (NULL != globalCollector) {
@@ -435,7 +435,7 @@ MM_Heap::heapRemoveRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, u
 void
 MM_Heap::heapReconfigured(MM_EnvironmentBase* env)
 {
-	MM_Collector* globalCollector = env->getExtensions()->getGlobalCollector();
+	MM_GlobalCollector* globalCollector = env->getExtensions()->getGlobalCollector();
 
 	if (NULL != globalCollector) {
 		globalCollector->heapReconfigured(env);

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -27,7 +27,7 @@
 #include "EnvironmentBase.hpp"
 #include "Forge.hpp"
 #include "GCExtensionsBase.hpp"
-#include "Collector.hpp"
+#include "GlobalCollector.hpp"
 #include "HeapRegionManager.hpp"
 #include "Math.hpp"
 #include "MemoryManager.hpp"
@@ -340,7 +340,7 @@ MM_HeapVirtualMemory::calculateOffsetFromHeapBase(void* address)
 bool
 MM_HeapVirtualMemory::heapAddRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, uintptr_t size, void* lowAddress, void* highAddress)
 {
-	MM_Collector* globalCollector = env->getExtensions()->getGlobalCollector();
+	MM_GlobalCollector* globalCollector = env->getExtensions()->getGlobalCollector();
 
 	bool result = true;
 	if (NULL != globalCollector) {
@@ -366,7 +366,7 @@ MM_HeapVirtualMemory::heapAddRange(MM_EnvironmentBase* env, MM_MemorySubSpace* s
 bool
 MM_HeapVirtualMemory::heapRemoveRange(MM_EnvironmentBase* env, MM_MemorySubSpace* subspace, uintptr_t size, void* lowAddress, void* highAddress, void* lowValidAddress, void* highValidAddress)
 {
-	MM_Collector* globalCollector = env->getExtensions()->getGlobalCollector();
+	MM_GlobalCollector* globalCollector = env->getExtensions()->getGlobalCollector();
 
 	bool result = true;
 	if (NULL != globalCollector) {

--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -383,7 +383,8 @@ MM_MarkingScheme::markLiveObjectsComplete(MM_EnvironmentBase *env)
 }
 
 MM_WorkPackets *
-MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env) {
+MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env)
+{
 	MM_WorkPackets *workPackets = NULL;
 
 	if (_extensions->isConcurrentMarkEnabled()) {
@@ -397,17 +398,38 @@ MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env) {
 	return workPackets;
 }
 
-
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-bool
-MM_MarkingScheme::isConcurrentMarkInProgress() {
-#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-	uintptr_t mode = ((MM_ConcurrentGC *)_extensions->getGlobalCollector())->getConcurrentGCStats()->getExecutionMode();
-	return (CONCURRENT_ROOT_TRACING <= mode) && (mode < CONCURRENT_EXHAUSTED);
-#else
-	return false;
-#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+void
+MM_MarkingScheme::assertNotForwardedPointer(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
+{
+	/* This is an expensive assert - fetching class slot during marking operation, thus invalidating benefits of leaf optimization.
+	 * TODO: after some soaking remove it!
+	 */
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		MM_ForwardedHeader forwardHeader(objectPtr);
+		omrobjectptr_t forwardPtr = forwardHeader.getNonStrictForwardedObject();
+		/* It is ok to encounter a forwarded object during overlapped concurrent scavenger/marking (or even root scanning),
+		 * but we must do nothing about it (if in backout, STW global phase will recover them).
+		 */
+		Assert_GC_true_with_message3(env, ((NULL == forwardPtr) || (!_extensions->getGlobalCollector()->isStwCollectionInProgress() && _extensions->isConcurrentScavengerInProgress())),
+			"Encountered object %p forwarded to %p (header %p) while Concurrent Scavenger/Marking not in progress\n", objectPtr, forwardPtr, &forwardHeader);
+	}
 }
+
+void
+MM_MarkingScheme::fixupForwardedSlotOutline(GC_SlotObject *slotObject) {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	MM_ForwardedHeader forwardHeader(slotObject->readReferenceFromSlot());
+	omrobjectptr_t forwardPtr = forwardHeader.getNonStrictForwardedObject();
+
+	if ((NULL != forwardPtr) && _extensions->getGlobalCollector()->isStwCollectionInProgress()) {
+		if (forwardHeader.isSelfForwardedPointer()) {
+			forwardHeader.restoreSelfForwardedPointer();
+		} else {
+			slotObject->writeReferenceToSlot(forwardPtr);
+		}
+	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
+}
+
 
 

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -30,11 +30,11 @@
 #include "omrport.h"
 
 #include "AllocateDescription.hpp"
-#include "Collector.hpp"
 #include "EnvironmentBase.hpp"
 #include "Forge.hpp"
 #include "GCCode.hpp"
 #include "GCExtensionsBase.hpp"
+#include "GlobalCollector.hpp"
 #include "Heap.hpp"
 #include "HeapRegionDescriptor.hpp"
 #include "HeapResizeStats.hpp"

--- a/gc/base/MemorySubSpaceUniSpace.cpp
+++ b/gc/base/MemorySubSpaceUniSpace.cpp
@@ -24,8 +24,8 @@
 #include "MemorySubSpaceUniSpace.hpp"
 
 #include "AllocateDescription.hpp"
-#include "Collector.hpp"
 #include "GCExtensionsBase.hpp"
+#include "GlobalCollector.hpp"
 #include "PhysicalSubArena.hpp"
 #include "MemorySpace.hpp"
 

--- a/gc/base/standard/ConcurrentGC.hpp
+++ b/gc/base/standard/ConcurrentGC.hpp
@@ -470,7 +470,7 @@ public:
 	/*
 	 * Return value of _stwCollectionInProgress flag
 	 */
-	MMINLINE bool isStwCollectionInProgress()
+	virtual bool isStwCollectionInProgress()
 	{
 		return _stwCollectionInProgress;
 	}

--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -55,7 +55,7 @@ collectorCreationHelper(OMR_VM *omrVM, MM_EnvironmentBase *env)
 {
 	OMRPORT_ACCESS_FROM_OMRVM(omrVM);
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVM);
-	MM_Collector *globalCollector = extensions->configuration->createGlobalCollector(env);
+	MM_GlobalCollector *globalCollector = extensions->configuration->createGlobalCollector(env);
 	omr_error_t rc = OMR_ERROR_NONE;
 
 	if (NULL == globalCollector) {


### PR DESCRIPTION
At a couple of spots Concurrent Scavenger needs to know if the
overlapping Concurrent GC is in pure concurrent mode or it transitioned
to the final STW phase.

Originally, the *mode* variable was used, but this appears to be not
quite correct: there is a small time hole when mode is
CONCURRENT_FINAL_COLLECTION, while exclusive access has not been
obtained yet, and there is still concurrent marking activity (it would
terminate as soon as the tread realizes the mode has changed).

We now rely on isStwCollectionInProgress() API, which will correctly
return true only if ConcurrentGC operatates while having exclusive
access.

All other changes are non-functional and just shuffling the code to
reduce amount of type casting, break mutual #include dependancy, and
generally make compiler happy.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>