### PR TITLE
Deprecate trj9 compiler directory

### DIFF
--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -40,7 +40,7 @@ int jitDebugARM;
 #include "il/Node_inlines.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
-#include "trj9/arm/codegen/ARMHelperCallSnippet.hpp"
+#include "arm/codegen/ARMHelperCallSnippet.hpp"
 #endif
 
 // change the following lines to not get the instruction addr during

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -44,7 +44,7 @@
 #include "il/TreeTop_inlines.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
-#include "trj9/env/CHTable.hpp"                      // for TR_AOTGuardSite, etc
+#include "env/CHTable.hpp"                      // for TR_AOTGuardSite, etc
 #endif
 
 static void lookupScheme1(TR::CodeGenerator *cg, TR::Node *node, bool unbalanced);

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -52,7 +52,7 @@
 #include "il/symbol/StaticSymbol.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
-#include "trj9/env/VMJ9.h"
+#include "env/VMJ9.h"
 #endif
 
 #define LOCK_R14

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,6 @@
 //  NOTE: IF you add opcodes or change the order then you must fix the following
 //        files (at least): ./ILOpCodeProperties.hpp
 //                          compiler/ras/Tree.cpp (2 tables)
-//                          trj9/codegen/CodeGenGPU.cpp
 //                          compiler/optimizer/SimplifierTable.hpp
 //                          compiler/optimizer/ValuePropagationTable.hpp
 //                          compiler/x/amd64/codegen/TreeEvaluatorTable.cpp

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -628,9 +628,7 @@ int32_t OMR::X86::CodeGenerator::getMaximumNumbersOfAssignableGPRs()
 
 /*
  * This method returns TRUE for all the cases we decide NOT to replace the call to CAS
- * with inline assembly.
- * It checks the same condition as inlineCompareAndSwapNative in tr.source/trj9/x/codegen/J9TreeEvaluator.cpp
- * so that GRA and Evaluator should be consistent about whether to inline CAS natives
+ * with inline assembly. The GRA and Evaluator should be consistent about whether to inline CAS natives.
  */
 static bool willNotInlineCompareAndSwapNative(TR::Node *node,
       int8_t size,

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -127,7 +127,7 @@
 
 #if J9_PROJECT_SPECIFIC
 #include "z/codegen/S390Register.hpp"
-#include "trj9/z/codegen/J9S390PrivateLinkage.hpp"
+#include "z/codegen/J9S390PrivateLinkage.hpp"
 #endif
 
 class TR_IGNode;

--- a/fvtest/compilertest/iwyu.mk
+++ b/fvtest/compilertest/iwyu.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ export CXX_PATH?=include-what-you-use
 # differing opinions on that.
 #
 JIT_SRCBASE?=../..
-JIT_OBJBASE?=../../objs/trj9_$(BUILD_CONFIG)
+JIT_OBJBASE?=../../objs/compiler_$(BUILD_CONFIG)
 JIT_DLL_DIR?=$(JIT_OBJBASE)
 
 #


### PR DESCRIPTION
The runtime/compiler/trj9 directory currently serves no purpose as its
parent directory is completely empty. In an effort to simplify the
codebase and closely match the directory layout of OMR we fold this
trj9 directory away so that understanding how OMR and OpenJ9 fit
together with respect to the compiler component is much easier.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>