### PR TITLE
Change custom-allocated maps to pointers in ilgen/MethodBuilder and ilgen/TypeDictionary

### DIFF
--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -194,33 +194,33 @@ class MethodBuilder : public TR::IlBuilder
    typedef std::map<const char *, TR::SymbolReference *, StrComparator, SymbolMapAllocator> SymbolMap;
 
    // This map should only be accessed inside a compilation via lookupSymbol
-   SymbolMap                   _symbols;
+   SymbolMap                 * _symbols;
 
    typedef TR::typed_allocator<std::pair<const char * const, int32_t>, TR::Region &> ParameterMapAllocator;
    typedef std::map<const char *, int32_t, StrComparator, ParameterMapAllocator> ParameterMap;
-   ParameterMap                _parameterSlot;
+   ParameterMap              * _parameterSlot;
 
    typedef TR::typed_allocator<std::pair<const char * const, TR::IlType *>, TR::Region &> SymbolTypeMapAllocator;
    typedef std::map<const char *, TR::IlType *, StrComparator, SymbolTypeMapAllocator> SymbolTypeMap;
-   SymbolTypeMap               _symbolTypes;
+   SymbolTypeMap             * _symbolTypes;
 
    typedef TR::typed_allocator<std::pair<int32_t const, const char *>, TR::Region &> SlotToSymNameMapAllocator;
    typedef std::map<int32_t, const char *, std::less<int32_t>, SlotToSymNameMapAllocator> SlotToSymNameMap;
-   SlotToSymNameMap            _symbolNameFromSlot;
+   SlotToSymNameMap          * _symbolNameFromSlot;
    
    typedef TR::typed_allocator<const char *, TR::Region &> StringSetAllocator;
    typedef std::set<const char *, StrComparator, StringSetAllocator> ArrayIdentifierSet;
 
    // This set acts as an identifier for symbols which correspond to arrays
-   ArrayIdentifierSet          _symbolIsArray;
+   ArrayIdentifierSet        * _symbolIsArray;
 
    typedef TR::typed_allocator<std::pair<const char * const, void *>, TR::Region &> MemoryLocationMapAllocator;
    typedef std::map<const char *, void *, StrComparator, MemoryLocationMapAllocator> MemoryLocationMap;
-   MemoryLocationMap           _memoryLocations;
+   MemoryLocationMap         * _memoryLocations;
 
    typedef TR::typed_allocator<std::pair<const char * const, TR::ResolvedMethod *>, TR::Region &> FunctionMapAllocator;
    typedef std::map<const char *, TR::ResolvedMethod *, StrComparator, FunctionMapAllocator> FunctionMap;
-   FunctionMap                 _functions;
+   FunctionMap               * _functions;
 
    TR::IlType                ** _cachedParameterTypes;
    const char                * _definingFile;

--- a/compiler/ilgen/TypeDictionary.cpp
+++ b/compiler/ilgen/TypeDictionary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -479,8 +479,8 @@ TypeDictionary::TypeDictionary() :
    _segmentProvider( new(TR::Compiler->persistentAllocator()) TR::SystemSegmentProvider(1 << 16, TR::Compiler->rawAllocator) ),
    _memoryRegion( new(TR::Compiler->persistentAllocator()) TR::Region(*_segmentProvider, TR::Compiler->rawAllocator) ),
    _trMemory( new(TR::Compiler->persistentAllocator()) TR_Memory(*::trPersistentMemory, *_memoryRegion) ),
-   _structsByName(str_comparator, _trMemory->heapMemoryRegion()),
-   _unionsByName(str_comparator, _trMemory->heapMemoryRegion())
+   _structsByName( new StructMap(str_comparator, _trMemory->heapMemoryRegion()) ),
+   _unionsByName( new UnionMap(str_comparator, _trMemory->heapMemoryRegion()) )
    {
    // primitive types
    NoType       = _primitiveType[TR::NoType]                = new (PERSISTENT_NEW) OMR::PrimitiveType("NoType", TR::NoType);
@@ -529,9 +529,11 @@ TypeDictionary::TypeDictionary() :
 TypeDictionary::~TypeDictionary() throw()
    {
    // Cleanup allocations in _memoryRegion *before* its destroyed below (see note in constructor)
-   _structsByName.clear();
-   _unionsByName.clear();
-
+   _structsByName->clear();
+   ::operator delete(_structsByName);
+   _unionsByName->clear();
+   ::operator delete(_unionsByName);
+   // Cleanup the allocators
    _trMemory->~TR_Memory();
    ::operator delete(_trMemory, TR::Compiler->persistentAllocator());
    _memoryRegion->~Region();
@@ -555,10 +557,10 @@ TypeDictionary::LookupUnion(const char *unionName)
 TR::IlType *
 TypeDictionary::DefineStruct(const char *structName)
    {
-   TR_ASSERT_FATAL(_structsByName.find(structName) == _structsByName.end(), "Struct '%s' already exists", structName);
+   TR_ASSERT_FATAL(_structsByName->find(structName) == _structsByName->end(), "Struct '%s' already exists", structName);
 
    StructType *newType = new (PERSISTENT_NEW) StructType(structName);
-   _structsByName.insert(std::make_pair(structName, newType));
+   _structsByName->insert(std::make_pair(structName, newType));
 
    return newType;
    }
@@ -602,10 +604,10 @@ TypeDictionary::CloseStruct(const char *structName)
 TR::IlType *
 TypeDictionary::DefineUnion(const char *unionName)
    {
-   TR_ASSERT_FATAL(_unionsByName.find(unionName) == _unionsByName.end(), "Union '%s' already exists", unionName);
+   TR_ASSERT_FATAL(_unionsByName->find(unionName) == _unionsByName->end(), "Union '%s' already exists", unionName);
    
    UnionType *newType = new (PERSISTENT_NEW) UnionType(unionName, _trMemory);
-   _unionsByName.insert(std::make_pair(unionName, newType));
+   _unionsByName->insert(std::make_pair(unionName, newType));
 
    return newType;
    }
@@ -643,15 +645,15 @@ TypeDictionary::PointerTo(TR::IlType *baseType)
 TR::IlReference *
 TypeDictionary::FieldReference(const char *typeName, const char *fieldName)
    {
-   StructMap::iterator structIterator = _structsByName.find(typeName);
-   if (structIterator != _structsByName.end())
+   StructMap::iterator structIterator = _structsByName->find(typeName);
+   if (structIterator != _structsByName->end())
       {
       StructType *theStruct = structIterator->second;
       return theStruct->getFieldSymRef(fieldName);
       }
 
-   UnionMap::iterator unionIterator = _unionsByName.find(typeName);
-   if (unionIterator != _unionsByName.end())
+   UnionMap::iterator unionIterator = _unionsByName->find(typeName);
+   if (unionIterator != _unionsByName->end())
       {
       UnionType *theUnion = unionIterator->second;
       return theUnion->getFieldSymRef(fieldName);
@@ -665,14 +667,14 @@ void
 TypeDictionary::NotifyCompilationDone()
    {
    // clear all symbol references for fields
-   for (StructMap::iterator it = _structsByName.begin(); it != _structsByName.end(); it++)
+   for (StructMap::iterator it = _structsByName->begin(); it != _structsByName->end(); it++)
       {
       StructType *aStruct = it->second;
       aStruct->clearSymRefs();
       }
 
    // clear all symbol references for union fields
-   for (UnionMap::iterator it = _unionsByName.begin(); it != _unionsByName.end(); it++)
+   for (UnionMap::iterator it = _unionsByName->begin(); it != _unionsByName->end(); it++)
       {
       UnionType *aUnion = it->second;
       aUnion->clearSymRefs();
@@ -682,8 +684,8 @@ TypeDictionary::NotifyCompilationDone()
 OMR::StructType *
 TypeDictionary::getStruct(const char *structName)
    {
-   StructMap::iterator it = _structsByName.find(structName);
-   TR_ASSERT_FATAL(it != _structsByName.end(), "No struct named '%s'", structName);
+   StructMap::iterator it = _structsByName->find(structName);
+   TR_ASSERT_FATAL(it != _structsByName->end(), "No struct named '%s'", structName);
 
    StructType *theStruct = it->second;
    return theStruct;
@@ -692,8 +694,8 @@ TypeDictionary::getStruct(const char *structName)
 OMR::UnionType *
 TypeDictionary::getUnion(const char *unionName)
    {
-   UnionMap::iterator it = _unionsByName.find(unionName);
-   TR_ASSERT_FATAL(it != _unionsByName.end(), "No union named '%s'", unionName);
+   UnionMap::iterator it = _unionsByName->find(unionName);
+   TR_ASSERT_FATAL(it != _unionsByName->end(), "No union named '%s'", unionName);
 
    UnionType *theUnion = it->second;
    return theUnion;

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -428,11 +428,11 @@ protected:
 
    typedef TR::typed_allocator<std::pair<const char * const, OMR::StructType *>, TR::Region &> StructMapAllocator;
    typedef std::map<const char *, OMR::StructType *, StrComparator, StructMapAllocator> StructMap;
-   StructMap          _structsByName;
+   StructMap        * _structsByName;
 
    typedef TR::typed_allocator<std::pair<const char * const, OMR::UnionType *>, TR::Region &> UnionMapAllocator;
    typedef std::map<const char *, OMR::UnionType *, StrComparator, UnionMapAllocator> UnionMap;
-   UnionMap           _unionsByName;
+   UnionMap         * _unionsByName;
 
    // convenience for primitive types
    TR::IlType       * _primitiveType[TR::NumOMRTypes];


### PR DESCRIPTION
The `compiler/ilgen's` `MethodBuilder` and `TypeDictionary` classes
contain a number of class members, maps, that use a custom allocator
(`TR::typed_allocator<...> _memoryRegion`). The allocator itself is
deleted in the destructors of `MethodBuilder` and `TypeDictionary`:

```cpp
_memoryRegion->~Region();
::operator delete(_memoryRegion, TR::Compiler->persistentAllocator());
```

Then, the class destructors automagically invoke the destructors for
member objects: `_structsByName`, `_unionsByName`, `_symbols`, etc.
Eventually, the method `_Node::_Freenode0` of the `_Tree_node` STL
class (std::map is implemented as a tree) for the head node will be
invoked. The method uses the allocator (`_memoryRegion` in our case, the
destroyed yet) to deallocate the head node and, since the allocator has
been destroyed yet in the destructor of the `MethodBuilder` or
`TypeDictionary` class, an access violation error appears:

```
[----------] 2 tests from JITILBuilderTest
[ RUN      ] JITILBuilderTest.ControlFlowTest
unknown file: error: SEH exception with code 0xc0000005 thrown in the
test body.
[  FAILED  ] JITILBuilderTest.ControlFlowTest (351 ms)
```

To avoid the situation, the `map` members of the `MethodBuilder` and
`TypeDictionary` classes are replaced with the pointers to maps and
the allocated memory is explicitly reclaimed in the destructors before
the allocator is being deleted.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>