### PR TITLE
Use the VirtualAlloc API to allocate code cache

### DIFF
--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,7 +20,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#if defined(OMR_OS_WINDOWS)
+#include <windows.h>
+#else
 #include <sys/mman.h>
+#endif /* OMR_OS_WINDOWS */
 #include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/CodeCacheMemorySegment.hpp"
@@ -58,14 +62,16 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    // We should really rely on the port library to allocate memory, but this connection
    // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9
    // where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
-   #if !defined(MAP_ANONYMOUS)
-      #define NO_MAP_ANONYMOUS
-      #if defined(MAP_ANON)
-         #define MAP_ANONYMOUS MAP_ANON
-      #else
-         #error unexpectedly, no MAP_ANONYMOUS or MAP_ANON definition
+   #if !defined(OMR_OS_WINDOWS)
+      #if !defined(MAP_ANONYMOUS)
+         #define NO_MAP_ANONYMOUS
+         #if defined(MAP_ANON)
+            #define MAP_ANONYMOUS MAP_ANON
+         #else
+            #error unexpectedly, no MAP_ANONYMOUS or MAP_ANON definition
+         #endif
       #endif
-   #endif
+   #endif /* OMR_OS_WINDOWS */
 
    // ignore preferredStartAddress for now, since it's NULL anyway
    //   goal would be to allocate code cache segments near the JIT library address
@@ -73,18 +79,27 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    TR::CodeCacheConfig & config = self()->codeCacheConfig();
    if (segmentSize < config.codeCachePadKB() << 10)
       codeCacheSizeToAllocate = config.codeCachePadKB() << 10;
-   uint8_t *memorySlab = (uint8_t *) mmap(NULL,
-                                          codeCacheSizeToAllocate,
-                                          PROT_READ | PROT_WRITE | PROT_EXEC,
-                                          MAP_ANONYMOUS | MAP_PRIVATE,
-                                          0,
-                                          0);
-
+   uint8_t *memorySlab = nullptr;
+#if defined(OMR_OS_WINDOWS)
+   memorySlab = reinterpret_cast<uint8_t *>(
+         VirtualAlloc(nullptr,
+            codeCacheSizeToAllocate,
+            MEM_COMMIT,
+            PAGE_EXECUTE_READWRITE));
+#else
+   memorySlab = reinterpret_cast<uint8_t *>(
+         mmap(NULL,
+              codeCacheSizeToAllocate,
+              PROT_READ | PROT_WRITE | PROT_EXEC,
+              MAP_ANONYMOUS | MAP_PRIVATE,
+              0,
+              0));
    // keep the impact of this fix localized
    #if defined(NO_MAP_ANONYMOUS)
       #undef MAP_ANONYMOUS
       #undef NO_MAP_ANONYMOUS
    #endif
+#endif /* OMR_OS_WINDOWS */
    TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) ((size_t)memorySlab + codeCacheSizeToAllocate - sizeof(TR::CodeCacheMemorySegment));
    new (memSegment) TR::CodeCacheMemorySegment(memorySlab, reinterpret_cast<uint8_t *>(memSegment));
    return memSegment;


### PR DESCRIPTION
JitBuilder, as well as the compiler test infrastructure, use the
`sys/mman.h` memory management api to allocate an executable code cache
for the compiler. Windows doesn't provide the `sys/mman.h` API, so the
`VirtualAlloc` function from the Windows API should be used instead of
`mmap`.

Currently, the method `FEBase<Derived>::allocateRelocationData` (see
`compiler/env/FEBase_t.hpp`) is used only from the
`TR_PPCTableOfConstants` class (so, won't be compiled under Windows) but
in order to compiler the method, the `VirtualAlloc` function are used
there too.

TODO: the use of `VirtualAlloc`/`mmap` has to be replaced with the
`omrvmem_reserve_memory_ex` function from the port library.

The PR depends on #2434

Issue: #1952
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>