### PR TITLE
Wrap memory allocators in a struct

### DIFF
--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -177,11 +177,23 @@ class MethodBuilder : public TR::IlBuilder
    protected:
    virtual uint32_t countBlocks();
    virtual bool connectTrees();
+   TR_Memory *trMemory() { return memoryManager._trMemory; }
 
    private:
-   TR::SegmentProvider *_segmentProvider;
-   TR::Region *_memoryRegion;
-   TR_Memory *_trMemory;
+   // We have MemoryManager as the first member of TypeDictionary, so that
+   // it is the last one to get destroyed and all objects allocated using
+   // MemoryManager->_memoryRegion may be safely destroyed in the destructor.
+   typedef struct MemoryManager
+      {
+      MemoryManager();
+      ~MemoryManager();
+
+      TR::SegmentProvider *_segmentProvider;
+      TR::Region *_memoryRegion;
+      TR_Memory *_trMemory;
+      } MemoryManager;
+
+   MemoryManager memoryManager;
 
    // These values are typically defined outside of a compilation
    const char                * _methodName;

--- a/compiler/ilgen/TypeDictionary.hpp
+++ b/compiler/ilgen/TypeDictionary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -240,7 +240,7 @@ public:
    TR::IlType *PointerTo(TR::DataType baseType)  { return PointerTo(_primitiveType[baseType]); }
 
    TR::IlReference *FieldReference(const char *typeName, const char *fieldName);
-   TR_Memory *trMemory() { return _trMemory; }
+   TR_Memory *trMemory() { return memoryManager._trMemory; }
 
    //TR::IlReference *ArrayReference(TR::IlType *arrayType);
 
@@ -420,9 +420,20 @@ public:
    void NotifyCompilationDone();
 
 protected:
-   TR::SegmentProvider *_segmentProvider;
-   TR::Region *_memoryRegion;
-   TR_Memory *_trMemory;
+   // We have MemoryManager as the first member of TypeDictionary, so that
+   // it is the last one to get destroyed and all objects allocated using
+   // MemoryManager->_memoryRegion may be safely destroyed in the destructor.
+   typedef struct MemoryManager
+      {
+      MemoryManager();
+      ~MemoryManager();
+
+      TR::SegmentProvider *_segmentProvider;
+      TR::Region *_memoryRegion;
+      TR_Memory *_trMemory;
+      } MemoryManager;
+
+   MemoryManager memoryManager;
 
    typedef bool (*StrComparator)(const char *, const char *);
 


### PR DESCRIPTION
The `compiler/ilgen's` `MethodBuilder` and `TypeDictionary` classes
contain a number of class members, maps, that use a custom allocator
(`TR::typed_allocator<...> _memoryRegion`). The allocator itself is
deleted in the destructors of `MethodBuilder` and `TypeDictionary`:

```cpp
_memoryRegion->~Region();
::operator delete(_memoryRegion, TR::Compiler->persistentAllocator());
```

Then, the class destructors automagically invokes the destructors for
member objects: `_structsByName`, `_unionsByName`, `_symbols`, etc.
Eventually, the method `_Node::_Freenode0` of the `_Tree_node` STL
class (std::map is implemented as a tree) for the head node will be
invoked. The method uses the allocator (`_memoryRegion` in our case,
the destroyed yet) to deallocate the head node and, since the allocator
has been destroyed yet in the destructor of the `MethodBuilder` or
`TypeDictionary` class, an access violation error appears:

```
[----------] 2 tests from JITILBuilderTest
[ RUN      ] JITILBuilderTest.ControlFlowTest
unknown file: error: SEH exception with code 0xc0000005 thrown in the
test body.
[  FAILED  ] JITILBuilderTest.ControlFlowTest (351 ms)
```

To avoid the situation, the memory allocators `TR::SegmentProvider`,
`TR::Region` and `TR_Memory` are wrapped in a struct and the struct is
defined as the first member of `MethodBuilder` and `TypeDictionary`
classes respectively, so that it is the last one to get destroyed.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>