### PR TITLE
Add new function: omrsig_is_master_signal_handler

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1391,6 +1391,8 @@ typedef struct OMRPortLibrary {
 	int32_t (*sig_map_portlib_signal_to_os_signal)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag) ;
 	/** see @ref omrsignal.c::omrsig_register_os_handler "omrsig_register_os_handler"*/
 	int32_t (*sig_register_os_handler)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler) ;
+	/** see @ref omrsignal.c::omrsig_is_master_signal_handler "omrsig_is_master_signal_handler"*/
+	BOOLEAN (*sig_is_master_signal_handler)(struct OMRPortLibrary *portLibrary, void *osHandler) ;
 	/** see @ref omrsignal.c::omrsig_info "omrsig_info"*/
 	uint32_t (*sig_info)(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value) ;
 	/** see @ref omrsignal.c::omrsig_info_count "omrsig_info_count"*/
@@ -1893,6 +1895,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsig_map_os_signal_to_portlib_signal(param1) privateOmrPortLibrary->sig_map_os_signal_to_portlib_signal(privateOmrPortLibrary, (param1))
 #define omrsig_map_portlib_signal_to_os_signal(param1) privateOmrPortLibrary->sig_map_portlib_signal_to_os_signal(privateOmrPortLibrary, (param1))
 #define omrsig_register_os_handler(param1,param2,param3) privateOmrPortLibrary->sig_register_os_handler(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsig_is_master_signal_handler(param1) privateOmrPortLibrary->sig_is_master_signal_handler(privateOmrPortLibrary, (param1))
 #define omrsig_info(param1,param2,param3,param4,param5) privateOmrPortLibrary->sig_info(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
 #define omrsig_info_count(param1,param2) privateOmrPortLibrary->sig_info_count(privateOmrPortLibrary, (param1), (param2))
 #define omrsig_set_options(param1) privateOmrPortLibrary->sig_set_options(privateOmrPortLibrary, (param1))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -220,6 +220,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsig_map_os_signal_to_portlib_signal, /* sig_map_os_signal_to_portlib_signal */
 	omrsig_map_portlib_signal_to_os_signal, /* sig_map_portlib_signal_to_os_signal */
 	omrsig_register_os_handler, /* sig_register_os_handler */
+	omrsig_is_master_signal_handler, /* sig_is_master_signal_handler */
 	omrsig_info, /* sig_info */
 	omrsig_info_count, /* sig_info_count */
 	omrsig_set_options, /* sig_set_options */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1069,3 +1069,6 @@ TraceException=Trc_PRT_signal_mapOSSignalToPortLib_ERROR_unknown_signal Group=si
 TraceEntry=Trc_PRT_signal_omrsig_register_os_handler_entered Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_register_os_handler: Entered, portLibrarySignalFlag=0x%X, newOSHandler=%p"
 TraceExit=Trc_PRT_signal_omrsig_register_os_handler_exiting Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_register_os_handler: Exiting, rc=%d, portLibrarySignalFlag=0x%X, newOSHandler=%p, oldOSHandler=%p"
 TraceException=Trc_PRT_signal_omrsig_register_os_handler_invalid_portlibSignalFlag Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_register_os_handler: ERROR, portlibSignalFlag=0x%X is either zero or has multiple signal bits set."
+
+TraceEntry=Trc_PRT_signal_omrsig_is_master_signal_handler_entered Group=signal Overhead=1 Level=3 NoEnv Template="omrsig_is_master_signal_handler: Entered, osHandler=%p"
+TraceExit=Trc_PRT_signal_omrsig_is_master_signal_handler_exiting Group=signal Overhead=1 Level=3 NoEnv Template="omrsig_is_master_signal_handler: Exiting, rc=%d"

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -278,6 +278,21 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 }
 
 /**
+ * Determine if the osHandler is a predefined master signal handler. masterASynchSignalHandler is used for
+ * asynchronous signals and masterSynchSignalHandler is used for synchronous signals.
+ *
+ * @param[in] portLibrary The port library
+ * @param[in] osHandler A signal handler function
+ *
+ * @return TRUE if osHandler is a predefined master handler. Otherwise, return FALSE.
+ */
+BOOLEAN
+omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
+{
+	return FALSE;
+}
+
+/**
  * Determine if the port library is capable of protecting a function from the indicated signals in the indicated way.
  *
  * @param[in] portLibrary The port library

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -557,6 +557,8 @@ extern J9_CFUNC int32_t
 omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag);
 extern J9_CFUNC int32_t
 omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler);
+extern J9_CFUNC BOOLEAN
+omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler);
 extern J9_CFUNC uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -639,6 +639,12 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 	return rc;
 }
 
+BOOLEAN
+omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
+{
+	return FALSE;
+}
+
 /*
  * The full shutdown routine "sig_full_shutdown" overwrites this once we've completed startup
  */

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -642,7 +642,17 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 BOOLEAN
 omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
 {
-	return FALSE;
+	BOOLEAN rc = FALSE;
+	Trc_PRT_signal_omrsig_is_master_signal_handler_entered(osHandler);
+
+	if ((osHandler == (void *)masterSynchSignalHandler)
+		|| (osHandler == (void *)masterASynchSignalHandler)
+	) {
+		rc = TRUE;
+	}
+
+	Trc_PRT_signal_omrsig_is_master_signal_handler_exiting(rc);
+	return rc;
 }
 
 /*

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -202,6 +202,12 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 	return OMRPORT_SIG_ERROR;
 }
 
+BOOLEAN
+omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
+{
+	return FALSE;
+}
+
 int32_t
 omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 {

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -323,6 +323,12 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 	return OMRPORT_SIG_ERROR;
 }
 
+BOOLEAN
+omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
+{
+	return FALSE;
+}
+
 int32_t
 omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 {

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -575,6 +575,12 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 	return OMRPORT_SIG_ERROR;
 }
 
+BOOLEAN
+omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
+{
+	return FALSE;
+}
+
 /*
  * The full shutdown routine "sig_full_shutdown" overrides this once we've completed startup 
  */


### PR DESCRIPTION
1. Add stubs for omrsig_is_master_signal_handler

	omrsig_is_master_signal_handler is a newly added function. It determines
	if a provided OS handler is a predefined master signal handler. 
	There are two master signal handlers: i) masterASynchSignalHandler is
	used for asynchronous signals and ii) masterSynchSignalHandler is used
	for synchronous signals.

2. Add Unix implementation of omrsig_is_master_signal_handler

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>