### PR TITLE
Add simplifications for Floating Point nodes

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -68,8 +68,7 @@ TR::Node * bremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
 TR::Node * sremSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * inegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * lnegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * fnegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * dnegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
+TR::Node * fpNegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * bnegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * snegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * constSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -112,8 +112,8 @@
    iremSimplifier,          // TR::iurem
    inegSimplifier,          // TR::ineg
    lnegSimplifier,          // TR::lneg
-   fnegSimplifier,          // TR::fneg
-   dnegSimplifier,          // TR::dneg
+   fpNegSimplifier,         // TR::fneg
+   fpNegSimplifier,         // TR::dneg
    bnegSimplifier,          // TR::bneg
    snegSimplifier,          // TR::sneg
 


### PR DESCRIPTION
This PR is a part of my [GSOC'18 Project](https://summerofcode.withgoogle.com/projects/5175053981843456).

1. Added some simplifications for FP nodes : fadd, fsub, fmul, fneg, dadd, dsub, dmul, dneg.
2. Added Value Propagation constraints : VPFloatConstraint, VPFloatConst, VPFloatRange, VPDoubleConstriant, VPDoubleConst, VPDoubleRange ( #2667 )