### PR TITLE
Concurrent Scavenger Tenure Age

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3727,7 +3727,7 @@ MM_Scavenger::masterThreadGarbageCollect(MM_EnvironmentBase *envBase, MM_Allocat
 			if(_extensions->scvTenureStrategyAdaptive) {
 				/* Adjust the tenure age based on the percentage of new space used.  Also, avoid / by 0 */
 				uintptr_t newSpaceTotalSize = _activeSubSpace->getActiveMemorySize();
-				uintptr_t newSpaceConsumedSize = newSpaceTotalSize - _activeSubSpace->getActualActiveFreeMemorySize();
+				uintptr_t newSpaceConsumedSize = _extensions->scavengerStats._flipBytes;
 				uintptr_t newSpaceSizeScale = newSpaceTotalSize / 100;
 
 				if((newSpaceConsumedSize < (_extensions->scvTenureRatioLow * newSpaceSizeScale)) && (_extensions->scvTenureAdaptiveTenureAge < OBJECT_HEADER_AGE_MAX)) {


### PR DESCRIPTION
Adaptive scavenger tenure age adjustment strategy change to mitigate
undesired tenure age adjustments for concurrent scavenger.

## Background
Adaptive scavenger tenure age must be adjusted based on the percentage
of new space used. When determining the space used, It not valid to use the
active subspace for concurrent scavenger. The nursery space behaves
in a _“hybrid”_ manner during the concurrent phase of scavenger, where
evacuate and allocate spaces coexist in a single space. Hence, the
active subspace returns an aggregate of allocated space _(from concurrent
allocation)_ and new space used _(bytes flipped)_. This ultimately results
in inconsistent tenure age adjustments between concurrent and
non-concurrent scavenger for the same work loads. That is, tenure age is
observed to be consistently lower _(i.e., survivor rate is higher)_  for
concurrent scavenger for the same work loads. Consequently, concurrent
scavenger tenures more aggressively, triggers more GCs and ultimately
results in increased pause times.

## Fix
Nursery space consumed size is now obtained
from scavenger stats' flip bytes
`(_extensions->scavengerStats._flipBytes)` rather than calculating it from
the active subspace ``` (_activeSubSpace->getActualActiveFreeMemorySize() -
_activeSubSpace->getActiveMemorySize()) ```.

Signed-off-by: Salman Rana <salman.rana@ibm.com>