### PR TITLE
AArch64: Remove BOM from OMRMachine.cpp

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2018, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under


### PR DESCRIPTION
This commit removes the unnecessary byte order mark (BOM) from
OMRMachine.cpp.

Signed-off-by: knn-k <konno@jp.ibm.com>