### PR TITLE
Fix tril's Xcall related tests

### DIFF
--- a/fvtest/compilertriltest/CallTest.cpp
+++ b/fvtest/compilertriltest/CallTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,8 +28,8 @@ int32_t oracleBoracle(int32_t x) { return x + 1123; } // Randomish number to avo
 
 TEST_F(CallTest, icallOracle) { 
     char inputTrees[200] = {0};
-    const auto format_string = "(method return=Int32 args=[Int32] (block (ireturn (icall address=%p args=[Int32] (iload parm=0)) )  ))";
-    std::snprintf(inputTrees, 200, format_string, &oracleBoracle);
+    const auto format_string = "(method return=Int32 args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] (iload parm=0)) )  ))";
+    std::snprintf(inputTrees, 200, format_string, reinterpret_cast<uintmax_t>(&oracleBoracle));
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,27 +57,27 @@ typedef ::testing::Types<int32_t, int64_t, float, double> InputTypes;
 TYPED_TEST_CASE(LinkageTest, InputTypes);
 
 TYPED_TEST(LinkageTest, InvalidLinkageTest) { 
-   char inputTrees[200] = {0};
-   const auto format_string = "(method return=Int32  args=[Int32] (block (ireturn (icall address=%p args=[Int32] linkage=noexist  (iload parm=0)) )  ))"; 
-   std::snprintf(inputTrees, 200, format_string, static_cast<TypeParam (*)(TypeParam)>(passThrough<TypeParam>)); 
+    char inputTrees[200] = {0};
+    const auto format_string = "(method return=Int32  args=[Int32] (block (ireturn (icall address=0x%jX args=[Int32] linkage=noexist  (iload parm=0)) )  ))";
+    std::snprintf(inputTrees, 200, format_string, reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam)>(passThrough<TypeParam>)));
 
-   auto trees = parseString(inputTrees);
-   ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+    auto trees = parseString(inputTrees);
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
 
 #ifdef TR_TARGET_X86
-   Tril::DefaultCompiler compiler{trees};
-   ASSERT_NE(0, compiler.compile()) << "Compilation succeeded unexpectedly\n" << "Input trees: " << inputTrees;
+    Tril::DefaultCompiler compiler{trees};
+    ASSERT_NE(0, compiler.compile()) << "Compilation succeeded unexpectedly\n" << "Input trees: " << inputTrees;
 #endif
 }
 
 TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
     char inputTrees[200] = {0};
-    const auto format_string = "(method return=%s args=[%s] (block (%sreturn (%scall address=%p args=[%s] linkage=system (%sload parm=0)) )  ))";
+    const auto format_string = "(method return=%s args=[%s] (block (%sreturn (%scall address=0x%jX args=[%s] linkage=system (%sload parm=0)) )  ))";
     std::snprintf(inputTrees, 200, format_string, TypeToString<TypeParam>::type, // Return
                                                   TypeToString<TypeParam>::type, //Args
                                                   TypeToString<TypeParam>::prefix, //return
                                                   TypeToString<TypeParam>::prefix, //call
-                                                  static_cast<TypeParam (*)(TypeParam)>(passThrough<TypeParam>),//address
+                                                  reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam)>(passThrough<TypeParam>)),//address
                                                   TypeToString<TypeParam>::type, //args
                                                   TypeToString<TypeParam>::prefix //load
                                                   );
@@ -108,7 +108,7 @@ T fourthArg(T a, T b, T c, T d) { return d; }
 
 TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
     char inputTrees[400] = {0};
-    const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=%p args=[%s,%s,%s,%s] linkage=system"
+    const auto format_string = "(method return=%s args=[%s,%s,%s,%s] (block (%sreturn (%scall address=0x%jX args=[%s,%s,%s,%s] linkage=system"
                                  " (%sload parm=0)"
                                  " (%sload parm=1)"
                                  " (%sload parm=2)"
@@ -121,7 +121,7 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
                                                   TypeToString<TypeParam>::type,   // Args
                                                   TypeToString<TypeParam>::prefix, // return
                                                   TypeToString<TypeParam>::prefix, // call
-                                                  static_cast<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>(fourthArg<TypeParam>),// address
+                                                  reinterpret_cast<uintmax_t>(static_cast<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>(fourthArg<TypeParam>)),// address
                                                   TypeToString<TypeParam>::type,   // args
                                                   TypeToString<TypeParam>::type,   // args
                                                   TypeToString<TypeParam>::type,   // args

--- a/fvtest/tril/tril/ast.cpp
+++ b/fvtest/tril/tril/ast.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,7 @@
  *******************************************************************************/
 
 #include "ast.hpp"
+#include "omrcfg.h"
 #include <stdlib.h>
 #include <string>
 
@@ -100,7 +101,11 @@ const ASTNode* findNodeByNameInTree(const ASTNode* tree, const char* name) {
 
 void printASTValueUnion(FILE* file, const ASTValue* value) {
     switch (value->getType()) {
+#if defined(OMR_ENV_DATA64)
+        case ASTValue::Integer: fprintf(file, "%llu", value->getInteger()); break;
+#else
         case ASTValue::Integer: fprintf(file, "%lu", value->getInteger()); break;
+#endif /* OMR_ENV_DATA64 */
         case ASTValue::FloatingPoint: fprintf(file, "%f", value->getFloatingPoint()); break;
         case ASTValue::String: fprintf(file, "\"%s\"", value->getString()); break;
         default: fprintf(file, "{bad arg type %d}", value->getType());

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,6 +20,7 @@
  *******************************************************************************/
 
 #include "ilgen.hpp"
+#include "omrcfg.h"
 #include "compiler_util.hpp"
 
 #include "il/Block.hpp"
@@ -260,11 +261,15 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
            return NULL;
         }
 
-         TraceIL("  is call with target %s", addressArg);
         /* I don't want to extend the ASTValue type system to include pointers at this moment,
          * so for now, we do the reinterpret_cast to pointer type from long
          */
-        const auto targetAddress = reinterpret_cast<void*>(addressArg->getValue()->get<long>()); 
+#if defined(OMR_ENV_DATA64)
+        TraceIL("  is call with target 0x%016llX", addressArg->getValue()->get<uintptr_t>());
+#else
+        TraceIL("  is call with target 0x%08lX", addressArg->getValue()->get<uintptr_t>());
+#endif /* OMR_ENV_DATA64 */
+        const auto targetAddress = reinterpret_cast<void*>(addressArg->getValue()->get<uintptr_t>());
 
         /* To generate a call, will create a ResolvedMethodSymbol, but we need to know the 
          * signature. The return type is intuitable from the call node, but the arguments 


### PR DESCRIPTION
Tril parses hexadecimal numbers if and only if they start with the `0x`
prefix. Unfortunately, some C/C++ compilers put the prefix for the `%p`
format specifier (so, they translate `%p` to something like
`0x0123456789ABCDEF`) while others don't. If the `0x` prefix is absent
before the address attribute value of the `Xcall` node, tril
interprets leading digits as a decimal number and the rest starting from
not a digital symbol (A,B,C,D,E or F) as an anonymous attribute. As a
result, the formed `Xcall` node will try to invoke a function by a wrong
address and an Access Violation Error appears.

The commit fixes the problem explicitly adding the `0x` prefix before the
format specifier in all code for `Xcall` tests. Output for the ilgen trace
of the `Xcall` opcode is fixed too.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>