### PR TITLE
Fetch bitfield width instead of position

### DIFF
--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -624,13 +624,14 @@ PdbScanner::setMemberOffset(IDiaSymbol *symbol, Field *newField)
 				offset = (size_t)loffset;
 			}
 			if (DDR_RC_OK == rc) {
-				DWORD bitposition = 0;
-				hr = symbol->get_bitPosition(&bitposition);
+				ULONGLONG bitwidth = 0;
+				/* For bit-fields, the 'length' is measured in bits. */
+				hr = symbol->get_length(&bitwidth);
 				if (FAILED(hr)) {
 					ERRMSG("get_offset() failed with HRESULT = %08lX", hr);
 					rc = DDR_RC_ERROR;
 				} else {
-					newField->_bitField = bitposition;
+					newField->_bitField = (size_t)bitwidth;
 				}
 			}
 			break;


### PR DESCRIPTION
On Windows, bitfields were not handled properly by DDR.

Consider this declaration found in omrport.h:
```
typedef struct J9Permission {
    uint32_t isUserWriteable : 1;
    uint32_t isUserReadable : 1;
    uint32_t isGroupWriteable : 1;
    uint32_t isGroupReadable : 1;
    uint32_t isOtherWriteable : 1;
    uint32_t isOtherReadable : 1;
    uint32_t : 26; /* future use */
} J9Permission;
```
The description produced by ddrgen corresponded to:
```
uint32_t isUserWriteable;
uint32_t isUserReadable : 1;
uint32_t isGroupWriteable : 2;
uint32_t isGroupReadable : 3;
uint32_t isOtherWriteable : 4;
uint32_t isOtherReadable : 5;
uint32_t : 6;
```
Note the first field is not considered a bitfield at all and all but one of the others are just wrong: This change corrects this.