### PR TITLE
Use compiler defined size_t instead of std::size_t

### DIFF
--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -948,6 +948,11 @@ namespace TR
 
    typedef CS2::shared_allocator < GlobalSingletonAllocator > GlobalAllocator;
 
+   static GlobalAllocator globalAllocator(const char *name = NULL)
+      {
+      return GlobalAllocator(GlobalSingletonAllocator::instance());
+      }
+ 
    /*
     * some common CS2 datatypes
     */

--- a/compiler/ilgen/OMRIlGeneratorMethodDetails.hpp
+++ b/compiler/ilgen/OMRIlGeneratorMethodDetails.hpp
@@ -74,7 +74,7 @@ protected:
    void *operator new(size_t size, TR::IlGeneratorMethodDetails &p){ return (void*)&p; }
    void operator delete(void *pMem, TR::IlGeneratorMethodDetails *p) {};
    void operator delete(void *pMem, TR::IlGeneratorMethodDetails &p) {};
-   void operator delete(void *pMem, std::size_t size) { ::operator delete(pMem); };
+   void operator delete(void *pMem, size_t size) { ::operator delete(pMem); };
 
    TR::IlVerifier     * _ilVerifier;
    };


### PR DESCRIPTION
For extensible classes such as IlGeneratorMethodDetails when overridden
in downstream projects we may encounter compilation issues as the
extended class will look for a suitable delete operator which should be
compatible with the types on the new operator.

size_t and std::size_t however are not compatible for all compilers
(gcc) and will cause errors complaining that no suitable delete
operator was found for the extensible class.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>