### PR TITLE
Create getter for method being compiled

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -424,6 +424,8 @@ public:
    TR::ResolvedMethodSymbol *getMethodSymbol();
    TR_ResolvedMethod *getCurrentMethod();
 
+   TR_ResolvedMethod *getMethodBeingCompiled() { return _method; }
+
    TR::PersistentInfo *getPersistentInfo();
 
    int32_t getCompThreadID() const { return _compThreadID; }


### PR DESCRIPTION
The Compiler object stores the method to be compiled in a field called
_method, but currently there is no way to retrieve it. This commit adds
that ability.