### PR TITLE
Add missed object alignment to optimum cache size

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -849,7 +849,7 @@ MM_Scavenger::calculateCopyScanCacheSizeForQueueLength(uintptr_t maxCacheSize, u
 	uintptr_t range = maxCacheSize - minCacheSize;
 	uintptr_t cacheSize =  minCacheSize + ((range / threadCount) * (scanCacheCount + 1));
 
-	return cacheSize;
+	return MM_Math::roundToCeiling(_extensions->getObjectAlignmentInBytes(), cacheSize);
 }
 
 /**


### PR DESCRIPTION
calculateCopyScanCacheSizeForQueueLength() can return value which is not
aligned to object alignment. Round output to proper alignment.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>