### PR TITLE
Remove unnecessary includes of omr.h in compiler

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -68,9 +68,6 @@ namespace OMR { typedef OMR::Compilation CompilationConnector; }
 #include "ras/DebugCounter.hpp"               // for TR_DebugCounter, etc
 #include "ras/ILValidationStrategies.hpp"
 
-
-#include "omr.h"
-
 #include "il/symbol/ResolvedMethodSymbol.hpp"
 
 

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -54,7 +54,6 @@
 #include "ilgen/IlGeneratorMethodDetails.hpp"
 #include "infra/Assert.hpp"                    // for TR_ASSERT
 #include "ras/Debug.hpp"                       // for createDebugObject, etc
-#include "omr.h"
 #include "env/SystemSegmentProvider.hpp"
 #include "env/DebugSegmentProvider.hpp"
 #include "runtime/CodeCacheManager.hpp"


### PR DESCRIPTION
In 2 different files in the compiler, omr.h is included,
but not used at all.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>