### PR TITLE
Allow fabricated loadaddr for classes in AOT

### DIFF
--- a/compiler/codegen/OMRAheadOfTimeCompile.hpp
+++ b/compiler/codegen/OMRAheadOfTimeCompile.hpp
@@ -37,6 +37,7 @@ namespace OMR { typedef OMR::AheadOfTimeCompile AheadOfTimeCompileConnector; }
 #include "runtime/Runtime.hpp"      // for TR_ExternalRelocationTargetKind
 
 class TR_Debug;
+namespace TR { class ExternalRelocation; }
 namespace TR { class IteratedExternalRelocation; }
 namespace TR { class AheadOfTimeCompile; }
 
@@ -88,6 +89,11 @@ class OMR_EXTENSIBLE AheadOfTimeCompile
 
    void traceRelocationOffsets(uint8_t *&cursor, int32_t offsetSize, const uint8_t *endOfCurrentRecord, bool isOrderedPair);
 
+   /**
+    * Do project-specific processing of an AOT relocation just before combining
+    * it into an IteratedExternalRelocation.
+    */
+   static void interceptAOTRelocation(TR::ExternalRelocation *relocation) { }
 
    private:
    TR::Compilation *                           _comp;

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -3156,7 +3156,7 @@ void OMR::CodeGenerator::addRelocation(TR::Relocation *r)
       }
    }
 
-void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node)
+void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::AOTRelocationPositionRequest where)
    {
    TR_ASSERT(generatingFileName, "AOT relocation location has improper NULL filename specified");
    if (self()->comp()->compileRelocatableCode())
@@ -3165,18 +3165,33 @@ void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, const char *generat
       genData->file = generatingFileName;
       genData->line = generatingLineNumber;
       genData->node = node;
-      r->setDebugInfo(genData);
-      _aotRelocationList.push_back(r);
+      self()->addAOTRelocation(r, genData, where);
       }
    }
 
-void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo* info)
+void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo* info, TR::AOTRelocationPositionRequest where)
    {
    if (self()->comp()->compileRelocatableCode())
       {
       TR_ASSERT(info, "AOT relocation location does not have associated debug information");
       r->setDebugInfo(info);
-      _aotRelocationList.push_back(r);
+      switch (where)
+         {
+         case TR::AOTRelocationAtFront:
+            _aotRelocationList.push_front(r);
+            break;
+
+         case TR::AOTRelocationAtBack:
+            _aotRelocationList.push_back(r);
+            break;
+
+         default:
+            TR_ASSERT_FATAL(
+               false,
+               "invalid TR::AOTRelocationPositionRequest %d",
+               where);
+            break;
+         }
       }
    }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -231,6 +231,14 @@ class TR_ClobberEvalData
 
    };
 
+namespace TR
+   {
+   enum AOTRelocationPositionRequest
+      {
+      AOTRelocationAtFront,
+      AOTRelocationAtBack,
+      };
+   }
 
 TR::Node* generatePoisonNode(TR::Compilation *comp, TR::Block *currentBlock, TR::SymbolReference *liveAutoSymRef);
 
@@ -1041,8 +1049,8 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR::StaticRelocation>& getStaticRelocations() { return _staticRelocationList; }
 
    void addRelocation(TR::Relocation *r);
-   void addAOTRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node);
-   void addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info);
+   void addAOTRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::AOTRelocationPositionRequest where = TR::AOTRelocationAtBack);
+   void addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info, TR::AOTRelocationPositionRequest where = TR::AOTRelocationAtBack);
    void addStaticRelocation(const TR::StaticRelocation &relocation);
 
    void addProjectSpecializedRelocation(uint8_t *location,

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -156,6 +156,8 @@ uint8_t TR::ExternalRelocation::collectModifier()
 
 void TR::ExternalRelocation::addAOTRelocation(TR::CodeGenerator *codeGen)
    {
+   TR::AheadOfTimeCompile::interceptAOTRelocation(this);
+
    TR::Compilation *comp = codeGen->comp();
    AOTcgDiag0(comp, "TR::ExternalRelocation::addAOTRelocation\n");
    if (comp->getOption(TR_AOT))
@@ -418,11 +420,12 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_ValidateArbitraryClass (50)",
    "TR_EmitClass (51)",
    "TR_JNISpecialTargetAddress (52)",
-   "TR_VirtualRamMethodConst (53)"
+   "TR_VirtualRamMethodConst (53)",
    "TR_InlinedInterfaceMethod (54)",
    "TR_InlinedVirtualMethod (55)",
    "TR_NativeMethodAbsolute (56)",
    "TR_NativeMethodRelative (57)",
+   "TR_ArbitraryClassAddress (58)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/p/codegen/PPCAOTRelocation.cpp
+++ b/compiler/p/codegen/PPCAOTRelocation.cpp
@@ -39,6 +39,15 @@ void TR::PPCPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
    {
    if (cg->comp()->getOption(TR_AOT))
       {
+      // The validation and inlined method ExternalRelocations are added after
+      // binary encoding is finished so that their actual relocation records
+      // will end up at the start. This way other relocations can depend on the
+      // appropriate validations already having completed.
+      //
+      // This relocation may also need to depend on previous validations, but
+      // those are already in the AOT relocation list by this point. Add it at
+      // the beginning to maintain the correct relative ordering.
+
       cg->addAOTRelocation(
          new (cg->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation(
             getSourceInstruction()->getBinaryEncoding(),
@@ -47,7 +56,8 @@ void TR::PPCPairedRelocation::mapRelocation(TR::CodeGenerator *cg)
             getKind(), cg),
          __FILE__,
          __LINE__,
-         getNode());
+         getNode(),
+         TR::AOTRelocationAtFront);
       }
    }
 

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -306,7 +306,8 @@ typedef enum
    TR_InlinedVirtualMethod                = 55,
    TR_NativeMethodAbsolute                = 56,
    TR_NativeMethodRelative                = 57,
-   TR_NumExternalRelocationKinds          = 58,
+   TR_ArbitraryClassAddress               = 58,
+   TR_NumExternalRelocationKinds          = 59,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -114,7 +114,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::X86::MemoryReference
       OMR::X86::MemoryReference::unblockRegisters();
       }
 
-   void addMetaDataForCodeAddressWithLoad(uint8_t *displacementLocation, TR::Instruction *containingInstruction, TR::CodeGenerator *cg);
+   void addMetaDataForCodeAddressWithLoad(uint8_t *displacementLocation, TR::Instruction *containingInstruction, TR::CodeGenerator *cg, TR::SymbolReference *srCopy);
    void addMetaDataForCodeAddressDisplacementOnly(intptrj_t displacement, uint8_t *cursor, TR::CodeGenerator *cg);
 
    protected:


### PR DESCRIPTION
More specifically for classes loaded by the bootstrap class loader,
which are unambiguously identifiable at relocation time.

This allows the JIT compiler to make up references to types about which
it has special knowledge. In particular, it's now possible to create a
loadaddr for java/lang/Class "out of thin air," without a corresponding
constant pool entry available.

At a high level, the appropriate relocations are carried out as follows:

  1. Allow TR_ClassAddress ExternalRelocations to be created without a
  constant pool index.

  2. Before grouping into IteratedExternalRelocations, identify these
  and set their kind to the new TR_ArbitraryClassAddress.

  3. Write the relocation record for TR_ArbitraryClassAddress with the
  same data as would be required for TR_ClassPointer.

  4. Relocate TR_ArbitraryClassAddress by finding the class as though
  for TR_ClassPointer, and then patching the code as though for
  TR_ClassAddress (to deal with materialization sequences).

Note that because the compilation has the class pointer, it must have
been through validateArbitraryClass(). In case the class can't be found
at relocation time, the validation record will cause relocation to fail,
so the value used for missing classes is irrelevant.

Power code generation is updated to generate a materialization sequence
and relocation when it encounters a fabricated class symbol reference in
an AOT (ahead of time) compilation. Previously it used an unresolved
snippet, which requires a constant pool index.