### PR TITLE
WIP: Virtualized CodeGenerator Hierarchy

### DIFF
--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -339,7 +339,7 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
          node->recursivelyDecReferenceCount();
          }
       else
-         self()->lowerTree(node, tt);
+         lowerTree(node, tt);
       }
 
    if (node->getOpCodeValue() == TR::loadaddr || node->getOpCode().isLoadVarDirect())

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -353,7 +353,7 @@ void OMR::CodeGenerator::lowerTrees()
    // visitCount should not be incremented until it finishes
    //
 
-   self()->preLowerTrees();
+   preLowerTrees();
 
    TR::TreeTop * tt;
    TR::Node * node;
@@ -367,7 +367,7 @@ void OMR::CodeGenerator::lowerTrees()
       TR_ASSERT(node->getVisitCount() != visitCount, "Code Gen: error in lowering trees");
       TR_ASSERT(node->getReferenceCount() == 0, "Code Gen: error in lowering trees");
 
-      self()->lowerTreesPreTreeTopVisit(tt, visitCount);
+      lowerTreesPreTreeTopVisit(tt, visitCount);
 
 
       // First lower the children
@@ -376,10 +376,10 @@ void OMR::CodeGenerator::lowerTrees()
 
       // If the tree needs to be lowered, call the VM to lower it
       //
-      self()->lowerTreeIfNeeded(node, 0, 0, tt);
+      lowerTreeIfNeeded(node, 0, 0, tt);
 
 
-      self()->lowerTreesPostTreeTopVisit(tt, visitCount);
+      lowerTreesPostTreeTopVisit(tt, visitCount);
 
       }
 
@@ -393,7 +393,7 @@ OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vco
 
    parent->setVisitCount(visitCount);
 
-   self()->lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
 
    // Go through the subtrees and lower any nodes that need to be lowered. This
    // involves a call to the VM to replace the trees with other trees.
@@ -407,11 +407,11 @@ OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vco
       if (child->getVisitCount() != visitCount)
          {
          self()->lowerTreesWalk(child, treeTop, visitCount);
-         self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
+         lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
       }
 
-   self()->lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
 
    }
 
@@ -650,7 +650,7 @@ OMR::CodeGenerator::doInstructionSelection()
       self()->getDebug()->setupToDumpTreesAndInstructions("Performing Instruction Selection");
       }
 
-   self()->beginInstructionSelection();
+   beginInstructionSelection();
 
    {
    TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());
@@ -843,7 +843,7 @@ OMR::CodeGenerator::doInstructionSelection()
       self()->getDebug()->roundAddressEnumerationCounters();
       }
 
-   self()->endInstructionSelection();
+   endInstructionSelection();
 
    if (comp->getOption(TR_TraceCG))
       {
@@ -1059,7 +1059,7 @@ OMR::CodeGenerator::getLinkage(TR_LinkageConventions lc)
    if (lc == TR_None)
       return NULL;
    else
-      return _linkages[lc] ? _linkages[lc] : self()->createLinkage(lc);
+      return _linkages[lc] ? _linkages[lc] : createLinkage(lc);
    }
 
 void OMR::CodeGenerator::initializeLinkage()
@@ -1068,8 +1068,8 @@ void OMR::CodeGenerator::initializeLinkage()
    // Allow the project/GlobalCompilationInfo to set the body linkage
    // Expect to call once during initialization
    //
-   linkage = self()->createLinkageForCompilation();
-   linkage = linkage ? linkage : self()->createLinkage(self()->comp()->getJittedMethodSymbol()->getLinkageConvention());
+   linkage = createLinkageForCompilation();
+   linkage = linkage ? linkage : createLinkage(self()->comp()->getJittedMethodSymbol()->getLinkageConvention());
    self()->setLinkage(linkage);
    }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -239,7 +239,8 @@ TR::Node* generatePoisonNode(TR::Compilation *comp, TR::Block *currentBlock, TR:
 namespace OMR
 {
 
-class OMR_EXTENSIBLE CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator
+
    {
    private:
 
@@ -280,29 +281,29 @@ class OMR_EXTENSIBLE CodeGenerator
 
    void uncommonCallConstNodes();
 
-   void preLowerTrees();
+   OMR_API virtual void preLowerTrees();
    void postLowerTrees() {}
 
    TR::TreeTop *lowerTree(TR::Node *root, TR::TreeTop *tt);
    void lowerTrees();
    void lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
-   void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
+   OMR_API virtual void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
-   void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
-   void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
+   OMR_API virtual void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
+   OMR_API virtual void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
 
-   void lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
-   void lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
+   OMR_API virtual void lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
+   OMR_API virtual void lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
-   void lowerTreesPropagateBlockToNode(TR::Node *node);
+   OMR_API virtual void lowerTreesPropagateBlockToNode(TR::Node *node);
 
-   void setUpForInstructionSelection();
-   void doInstructionSelection();
-   void createStackAtlas();
+   OMR_API virtual void setUpForInstructionSelection();
+   OMR_API virtual void doInstructionSelection();
+   OMR_API virtual void createStackAtlas();
 
-   void beginInstructionSelection() {}
-   void endInstructionSelection() {}
+   OMR_API virtual void beginInstructionSelection() {}
+   OMR_API virtual void endInstructionSelection() {}
 
    bool use64BitRegsOn32Bit();
 
@@ -364,12 +365,12 @@ class OMR_EXTENSIBLE CodeGenerator
    void setNextAvailableBlockIndex(int32_t blockIndex) {}
    int32_t getNextAvailableBlockIndex() { return -1; }
 
-   bool supportsMethodEntryPadding() { return true; }
-   bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
-   bool buildInterpreterEntryPoint() { return false; }
-   void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
-   bool supportsUnneededLabelRemoval() { return true; }
-   bool allowSplitWarmAndColdBlocks() { return false; }
+   OMR_API virtual bool supportsMethodEntryPadding() { return true; }
+   OMR_API virtual bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
+   OMR_API virtual bool buildInterpreterEntryPoint() { return false; }
+   OMR_API virtual void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
+   OMR_API virtual bool supportsUnneededLabelRemoval() { return true; }
+   OMR_API virtual bool allowSplitWarmAndColdBlocks() { return false; }
 
    TR_HasRandomGenerator randomizer;
 
@@ -406,7 +407,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
    void prepareNodeForInstructionSelection(TR::Node*node);
    void remapGCIndicesInInternalPtrFormat();
-   void processRelocations();
+   OMR_API virtual void processRelocations();
 
    void findAndFixCommonedReferences();
    void findCommonedReferences(TR::Node*node, TR::TreeTop *treeTop);
@@ -420,7 +421,7 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Hardware profiling
    //
-   void createHWPRecords() {}
+   OMR_API virtual void createHWPRecords() {}
 
    // --------------------------------------------------------------------------
    // Tree evaluation
@@ -452,7 +453,7 @@ class OMR_EXTENSIBLE CodeGenerator
    rcount_t recursivelyDecReferenceCount(TR::Node*node);
    void evaluateChildrenWithMultipleRefCount(TR::Node*node);
 
-   void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp) {}
+   OMR_API virtual void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp) {}
 
    void startUsingRegister(TR::Register *reg);
    void stopUsingRegister(TR::Register *reg);
@@ -480,7 +481,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
 
 
-   TR::Recompilation *allocateRecompilationInfo() { return NULL; }
+   OMR_API virtual TR::Recompilation *allocateRecompilationInfo() { return NULL; }
 
    // --------------------------------------------------------------------------
    // Capabilities
@@ -555,8 +556,8 @@ class OMR_EXTENSIBLE CodeGenerator
    // Linkage
    //
    void initializeLinkage(); // no virt, default, cast
-   TR::Linkage *createLinkage(TR_LinkageConventions lc); // no virt, default, cast
-   TR::Linkage *createLinkageForCompilation();
+   OMR_API virtual TR::Linkage *createLinkage(TR_LinkageConventions lc); // no virt, default, cast
+   OMR_API virtual TR::Linkage *createLinkageForCompilation();
 
    TR::Linkage *getLinkage() {return _bodyLinkage;}
    TR::Linkage *setLinkage(TR::Linkage * l) {return (_bodyLinkage = l);}
@@ -575,7 +576,7 @@ class OMR_EXTENSIBLE CodeGenerator
     * @param method : the recognized method to consider
     * @return true if inlining should be suppressed; false otherwise
     */
-   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method) {return false;}
+   OMR_API virtual bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method) {return false;}
 
    // --------------------------------------------------------------------------
    // Optimizer, not code generator
@@ -765,7 +766,7 @@ class OMR_EXTENSIBLE CodeGenerator
    uint8_t * allocateCodeMemory(uint32_t size, bool isCold, bool isMethodHeaderNeeded=true);
    uint8_t * allocateCodeMemory(uint32_t warmSize, uint32_t coldSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
    void  resizeCodeMemory();
-   void  registerAssumptions() {}
+   OMR_API virtual void  registerAssumptions() {}
 
    static void syncCode(uint8_t *codeStart, uint32_t codeSize);
 
@@ -1045,21 +1046,21 @@ class OMR_EXTENSIBLE CodeGenerator
    void addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info);
    void addStaticRelocation(const TR::StaticRelocation &relocation);
 
-   void addProjectSpecializedRelocation(uint8_t *location,
+   OMR_API virtual void addProjectSpecializedRelocation(uint8_t *location,
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
                                           char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
-   void addProjectSpecializedPairRelocation(uint8_t *location1,
+   OMR_API virtual void addProjectSpecializedPairRelocation(uint8_t *location1,
                                           uint8_t *location2,
                                           uint8_t *target,
                                           TR_ExternalRelocationTargetKind kind,
                                           char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
-   void addProjectSpecializedRelocation(TR::Instruction *instr,
+   OMR_API virtual void addProjectSpecializedRelocation(TR::Instruction *instr,
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
@@ -1081,7 +1082,7 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR_Pair<TR_ResolvedMethod,TR::Instruction> *> &getJNICallSites() { return _jniCallSites; }  // registerAssumptions()
 
    bool needClassAndMethodPointerRelocations() { return false; }
-   bool needRelocationsForStatics() { return false; }
+   OMR_API virtual bool needRelocationsForStatics() { return false; }
 
    // --------------------------------------------------------------------------
    // Snippets
@@ -1173,13 +1174,13 @@ class OMR_EXTENSIBLE CodeGenerator
    // currently can only return a value other than vgdnop for HCR guards
    TR::Instruction* getVirtualGuardForPatching(TR::Instruction *vgdnop);
 
-   void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
-   void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
-   void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
-   void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
-   void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt) { return false; } //J9
+   OMR_API virtual void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
+   OMR_API virtual void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
+   OMR_API virtual void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
+   OMR_API virtual void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
+   OMR_API virtual void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
+   OMR_API virtual bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9
+   OMR_API virtual bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt) { return false; } //J9
 
    // --------------------------------------------------------------------------
    // Unclassified
@@ -1279,7 +1280,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; } // no virt
    bool supportsHighWordFacility() { return false; } // no virt, default, cast
 
-   bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
+   OMR_API virtual bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
 
    // J9 only, move to trj9
    TR_OpaqueClassBlock* getMonClass(TR::Node* monNode);
@@ -1333,7 +1334,7 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::DataType IntJ() { return TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32; }
 
    // will a BCD left shift always leave the sign code unchanged and thus allow it to be propagated through and upwards
-   bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; } // no virt
+   OMR_API virtual bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; } // no virt
 
    bool supportsLengthMinusOneForMemoryOpts() {return false;} // no virt, cast
 

--- a/compiler/infra/Annotations.hpp
+++ b/compiler/infra/Annotations.hpp
@@ -74,8 +74,10 @@
 // OMR_EXTENSIBLE
 #if defined(__clang__) // Only clang is checking this macro for now
 #define OMR_EXTENSIBLE __attribute__((annotate("OMR_Extensible")))
+#deine OMR_API __attribute__((annotate("OMR_API")))
 #else
 #define OMR_EXTENSIBLE
+#define OMR_API
 #endif
 
 // OMR_LIKELY and OMR_UNLIKELY

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1988,7 +1988,7 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
    TR_PPCBinaryEncodingData data;
    data.estimate = 0;
 
-   self()->generateBinaryEncodingPrologue(&data);
+   generateBinaryEncodingPrologue(&data);
 
    bool skipOneReturn = false;
    while (data.cursorInstruction)

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -152,7 +152,7 @@ namespace Power
 
 class CodeGenerator;
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    {
 
    public:
@@ -171,7 +171,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool getSupportsIbyteswap();
 
-   void generateBinaryEncodingPrologue(TR_PPCBinaryEncodingData *data);
+   OMR_API virtual void generateBinaryEncodingPrologue(TR_PPCBinaryEncodingData *data);
 
    void beginInstructionSelection();
    void endInstructionSelection();
@@ -191,7 +191,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void emitDataSnippets();
    bool hasDataSnippets();
 
-   TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
+   OMR_API virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
 
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
@@ -50,7 +50,7 @@ namespace X86
 namespace AMD64
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::X86::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    {
    public:
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1080,7 +1080,7 @@ OMR::X86::CodeGenerator::supportsMergingGuards()
    {
    return self()->getSupportsVirtualGuardNOPing() &&
           self()->comp()->performVirtualGuardNOPing() &&
-          self()->allowGuardMerging();
+          allowGuardMerging();
    }
 
 TR::RealRegister *
@@ -1945,7 +1945,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       int32_t numTrampolinesToReserve = self()->getPicSlotCount() - self()->comp()->getNumReservedIPICTrampolines();
       TR_ASSERT(numTrampolinesToReserve >= 0, "Discrepancy with number of IPIC trampolines to reserve getPicSlotCount()=%d getNumReservedIPICTrampolines()=%d",
          self()->getPicSlotCount(), self()->comp()->getNumReservedIPICTrampolines());
-      self()->reserveNTrampolines(numTrampolinesToReserve);
+      reserveNTrampolines(numTrampolinesToReserve);
       }
 
    self()->setBinaryBufferStart(temp);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -269,7 +269,7 @@ namespace OMR
 namespace X86
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    {
 
    public:
@@ -371,10 +371,10 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     *
     * \return : none
     */
-   void reserveNTrampolines(int32_t numTrampolines) { return; }
+   OMR_API virtual void reserveNTrampolines(int32_t numTrampolines) { return; }
 
    // Note: This leaves the code aligned in the specified manner.
-   TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
+   OMR_API virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
 
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();
@@ -513,7 +513,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool patchableRangeNeedsAlignment(void *cursor, intptrj_t length, intptrj_t boundary, intptrj_t margin=0);
 
-   bool nopsAlsoProcessedByRelocations() { return false; }
+   OMR_API virtual bool nopsAlsoProcessedByRelocations() { return false; }
 
 #if defined(DEBUG)
    void dumpPreFPRegisterAssignment(TR::Instruction *);
@@ -658,7 +658,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    public:
 
-   bool allowGuardMerging() { return false; }
+   OMR_API virtual bool allowGuardMerging() { return false; }
 
    bool enableBetterSpillPlacements()
       {

--- a/compiler/x/i386/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.hpp
@@ -51,7 +51,7 @@ namespace X86
 namespace I386
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::X86::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    {
 
    public:

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -157,7 +157,7 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
 
    parent->setVisitCount(visitCount);
 
-   self()->lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
 
    // Go through the subtrees and lower any nodes that need to be lowered. This
    // involves a call to the VM to replace the trees with other trees.
@@ -171,13 +171,13 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
       if (child->getVisitCount() != visitCount)
          {
          self()->lowerTreesWalk(child, treeTop, visitCount);
-         self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
+         lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
 
       self()->checkIsUnneededIALoad(parent, child, treeTop);
       }
 
-   self()->lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
 
    }
 
@@ -6281,7 +6281,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    static char *disableAlignJITEP = feGetEnv("TR_DisableAlignJITEP");
 
    // Adjust the binary buffer cursor with appropriate padding.
-   if (!disableAlignJITEP && !self()->comp()->compileRelocatableCode() && self()->allowSplitWarmAndColdBlocks())
+   if (!disableAlignJITEP && !self()->comp()->compileRelocatableCode() && allowSplitWarmAndColdBlocks())
       {
       int32_t alignedBase = 256 - self()->getPreprologueOffset();
       int32_t padBase = ( 256 + alignedBase - ((intptrj_t)temp) % 256) % 256;
@@ -11307,7 +11307,7 @@ bool OMR::Z::CodeGenerator::reliesOnAParticularSignEncoding(TR::Node *node)
       return false;
 
    // left shifts do not rely on a clean sign so the only thing to check is if a clean sign property has been propagated thru it (if not then can return false)
-   if (node->getType().isBCD() && op.isLeftShift() && !self()->propagateSignThroughBCDLeftShift(node->getType()))
+   if (node->getType().isBCD() && op.isLeftShift() && !propagateSignThroughBCDLeftShift(node->getType()))
       return false;
 
    if (node->getType().isBCD() && op.isRightShift())

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -199,7 +199,7 @@ namespace OMR
 {
 namespace Z
 {
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    {
 
 public:


### PR DESCRIPTION
* Defined `OMR_API` in _compiler/infra/annotations.hpp_
* Commented out `OMR_EXTENSIBLE` from `CodeGenerator` class declarations
* Removed `self()` from function calls of `CodeGenerator`
This PR is linked to the one from openJ9 achieving the same purpose