### PR TITLE
WIP: Virtualized CodeGenerator Hierarchy

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -654,7 +654,7 @@ void OMR::ARM::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
 /* @@
 bool OMR::ARM::CodeGenerator::canNullChkBeImplicit(TR::Node *node)
    {
-   return self()->canNullChkBeImplicit(node, true);
+   return canNullChkBeImplicit(node, true);
    }
 */
 

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -308,7 +308,7 @@ OMR::CodeGenerator::buildGCMapForInstruction(TR::Instruction *instr)
 
    // Build the register map
    //
-   self()->buildRegisterMapForInstruction(map);
+   buildRegisterMapForInstruction(map);
    return map;
    }
 

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -156,7 +156,7 @@ OMR::CodeGenerator::buildGCMapsForInstructionAndSnippet(TR::Instruction *instr)
 
       // The info bits are encoded in the register mask on the instruction (if there are any).
       //
-      map->maskRegistersWithInfoBits(instr->getGCRegisterMask(), self()->getRegisterMapInfoBitsMask());
+      map->maskRegistersWithInfoBits(instr->getGCRegisterMask(), getRegisterMapInfoBitsMask());
       instr->setGCMap(map);
       }
 

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -339,7 +339,7 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
          node->recursivelyDecReferenceCount();
          }
       else
-         self()->lowerTree(node, tt);
+         lowerTree(node, tt);
       }
 
    if (node->getOpCodeValue() == TR::loadaddr || node->getOpCode().isLoadVarDirect())

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -97,7 +97,7 @@
 void
 OMR::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount)
    {
-   self()->lowerTreesPropagateBlockToNode(parent);
+   lowerTreesPropagateBlockToNode(parent);
 
    static const char * disableILMulPwr2Opt = feGetEnv("TR_DisableILMulPwr2Opt");
 

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1677,7 +1677,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
          int8_t lri = rcSymbol->getParmSymbol()->getLinkageRegisterIndex();
          if (lri >= 0)
             {
-            linkageRegister = self()->getLinkageGlobalRegisterNumber(lri, dtype);
+            linkageRegister = getLinkageGlobalRegisterNumber(lri, dtype);
             }
          }
       if (linkageRegister == -1)
@@ -1876,7 +1876,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
          int8_t lri = rcSymbol->getParmSymbol()->getLinkageRegisterIndex();
          if (lri >= 0)
             {
-            linkageRegister = self()->getLinkageGlobalRegisterNumber(lri, rcSymbol->getDataType());
+            linkageRegister = getLinkageGlobalRegisterNumber(lri, rcSymbol->getDataType());
             }
          }
       if (debug("tracePickRegister") || self()->comp()->getOptions()->trace(OMR::tacticalGlobalRegisterAllocator))

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1727,7 +1727,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
                {
                if (!remainingRegisters.isSet(i))
                   {
-                  TR_GlobalRegisterNumber highWordReg = self()->getGlobalHPRFromGPR(i);
+                  TR_GlobalRegisterNumber highWordReg = getGlobalHPRFromGPR(i);
                   if (self()->traceSimulateTreeEvaluation())
                      {
                      traceMsg(self()->comp(), "            %s is not available, rejecting %s\n",

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1903,7 +1903,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
           || dtype == TR::DecimalLongDouble
 #endif
           )
-         preservedRegisters = self()->getGlobalFPRsPreservedAcrossCalls();
+         preservedRegisters = getGlobalFPRsPreservedAcrossCalls();
       else
          preservedRegisters = self()->getGlobalGPRsPreservedAcrossCalls();
       if (debug("tracePickRegister") || self()->comp()->getOptions()->trace(OMR::tacticalGlobalRegisterAllocator))

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1905,7 +1905,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
           )
          preservedRegisters = getGlobalFPRsPreservedAcrossCalls();
       else
-         preservedRegisters = self()->getGlobalGPRsPreservedAcrossCalls();
+         preservedRegisters = getGlobalGPRsPreservedAcrossCalls();
       if (debug("tracePickRegister") || self()->comp()->getOptions()->trace(OMR::tacticalGlobalRegisterAllocator))
          {
          traceMsg(self()->comp(), "pickRegister:\tPreserved register info is %spresent\n", preservedRegisters? "" : "NOT ");

--- a/compiler/codegen/CodeGenerator.hpp
+++ b/compiler/codegen/CodeGenerator.hpp
@@ -30,7 +30,7 @@ namespace TR { class Compilation; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGeneratorConnector
    {
 public:
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -665,7 +665,7 @@ OMR::CodeGenerator::doInstructionSelection()
          {
          TR::Block *block = node->getBlock();
          self()->setCurrentEvaluationBlock(block);
-         self()->setCurrentBlockIndex(block->getNumber());
+         setCurrentBlockIndex(block->getNumber());
 
          if (!block->isExtensionOfPreviousBlock())
             {
@@ -1123,7 +1123,7 @@ bool OMR::CodeGenerator::supportsInternalPointers()
    if (_disableInternalPointers)
       return false;
 
-   return self()->internalPointerSupportImplemented();
+   return internalPointerSupportImplemented();
    }
 
 
@@ -2223,7 +2223,7 @@ OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnipp
 
    if (hasDataSnippets())
       {
-      estimatedSnippetStart = self()->setEstimatedLocationsForDataSnippetLabels(estimatedSnippetStart);
+      estimatedSnippetStart = setEstimatedLocationsForDataSnippetLabels(estimatedSnippetStart);
       }
 
    return estimatedSnippetStart;

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1231,7 +1231,7 @@ OMR::CodeGenerator::opCodeIsNoOp(TR::ILOpCode &opCode)
    if (TR::ILOpCode::isOpCodeAnImplicitNoOp(opCode))
       return true;
 
-   return self()->opCodeIsNoOpOnThisPlatform(opCode);
+   return opCodeIsNoOpOnThisPlatform(opCode);
    }
 
 
@@ -2702,7 +2702,7 @@ OMR::CodeGenerator::isMaterialized(TR::Node * node)
    else
       return false;
 
-   return self()->shouldValueBeInACommonedNode(value);
+   return shouldValueBeInACommonedNode(value);
    }
 
 bool

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2251,6 +2251,7 @@ OMR::CodeGenerator::emitSnippets()
 
    retVal = self()->getBinaryBufferCursor();
 
+
    // Emit constant data snippets last.
    //
    if (hasDataSnippets())
@@ -2810,7 +2811,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(TR::Instruction *curso
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, aggregatedCounters);
 
-   return self()->generateDebugCounterBump(cursor, aggregatedCounters, 1, NULL);
+   return generateDebugCounterBump(cursor, aggregatedCounters, 1, NULL);
    }
 
 TR::Instruction *OMR::CodeGenerator::generateDebugCounter(TR::Instruction *cursor, const char *name, TR::Register *deltaReg, int8_t fidelity, int32_t staticDelta)
@@ -2832,7 +2833,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(TR::Instruction *curso
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, counter);
 
-   return self()->generateDebugCounterBump(cursor, counter, deltaReg, NULL);
+   return generateDebugCounterBump(cursor, counter, deltaReg, NULL);
    }
 
 TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::RegisterDependencyConditions &cond, int32_t delta, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor)
@@ -2856,7 +2857,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, aggregatedCounters);
 
-   return self()->generateDebugCounterBump(cursor, aggregatedCounters, 1, &cond);
+   return generateDebugCounterBump(cursor, aggregatedCounters, 1, &cond);
    }
 
 TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::Register *deltaReg, TR::RegisterDependencyConditions &cond, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor)
@@ -2878,7 +2879,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, counter);
 
-   return self()->generateDebugCounterBump(cursor, counter, deltaReg, &cond);
+   return generateDebugCounterBump(cursor, counter, deltaReg, &cond);
    }
 
 TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR_ScratchRegisterManager &srm, int32_t delta, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor)
@@ -2902,7 +2903,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR_S
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, aggregatedCounters);
 
-   return self()->generateDebugCounterBump(cursor, aggregatedCounters, 1, srm);
+   return generateDebugCounterBump(cursor, aggregatedCounters, 1, srm);
    }
 
 TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::Register *deltaReg, TR_ScratchRegisterManager &srm, int8_t fidelity, int32_t staticDelta, TR::Instruction *cursor)
@@ -2924,7 +2925,7 @@ TR::Instruction *OMR::CodeGenerator::generateDebugCounter(const char *name, TR::
    if (TR::DebugCounter::relocatableDebugCounter(self()->comp()))
       self()->comp()->mapStaticAddressToCounter(symref, counter);
 
-   return self()->generateDebugCounterBump(cursor, counter, deltaReg, srm);
+   return generateDebugCounterBump(cursor, counter, deltaReg, srm);
    }
 
 // Records the use of a single virtual register.

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -581,13 +581,13 @@ OMR::CodeGenerator::setUpForInstructionSelection()
 void
 OMR::CodeGenerator::uncommonCallConstNodes()
    {
-   TR::Compilation* comp = comp();
-   if(comp->getOption(TR_TraceCG))
+   TR::Compilation* compilation = comp();
+   if(compilation->getOption(TR_TraceCG))
       {
-      traceMsg(comp, "Performing uncommon call constant nodes\n");
+      traceMsg(compilation, "Performing uncommon call constant nodes\n");
       }
 
-   TR::NodeChecklist checklist(comp);
+   TR::NodeChecklist checklist(compilation);
 
    for (TR::TreeTop* tt = comp()->getStartTree(); tt; tt = tt->getNextTreeTop())
       {
@@ -598,9 +598,9 @@ OMR::CodeGenerator::uncommonCallConstNodes()
           TR::Node* callNode = node->getFirstChild();
           if(checklist.contains(callNode))
              {
-             if(comp->getOption(TR_TraceCG))
+             if(compilation->getOption(TR_TraceCG))
                 {
-                traceMsg(comp, "Skipping previously visited call node %d\n", callNode->getGlobalIndex());
+                traceMsg(compilation, "Skipping previously visited call node %d\n", callNode->getGlobalIndex());
                 }
              continue;
              }
@@ -616,7 +616,7 @@ OMR::CodeGenerator::uncommonCallConstNodes()
                 {
                 if(comp()->getOption(TR_TraceCG))
                    {
-                   traceMsg(comp, "Uncommon const node %X [n%dn]\n",
+                   traceMsg(compilation, "Uncommon const node %X [n%dn]\n",
                             paramNode, paramNode->getGlobalIndex());
                    }
 
@@ -633,20 +633,20 @@ OMR::CodeGenerator::uncommonCallConstNodes()
 void
 OMR::CodeGenerator::doInstructionSelection()
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
 
-   setNextAvailableBlockIndex(comp->getFlowGraph()->getNextNodeNumber() + 1);
+   setNextAvailableBlockIndex(compilation->getFlowGraph()->getNextNodeNumber() + 1);
 
    // Set default value for pre-prologue size
    //
    setPrePrologueSize(0);
 
-   if (comp->getOption(TR_TraceCG))
+   if (compilation->getOption(TR_TraceCG))
       {
       diagnostic("\n<selection>");
       }
 
-   if (comp->getOption(TR_TraceCG) || debug("traceGRA"))
+   if (compilation->getOption(TR_TraceCG) || debug("traceGRA"))
       {
       getDebug()->setupToDumpTreesAndInstructions("Performing Instruction Selection");
       }
@@ -657,9 +657,9 @@ OMR::CodeGenerator::doInstructionSelection()
    TR::StackMemoryRegion stackMemoryRegion(*trMemory());
 
    TR_BitVector *liveLocals = getLiveLocals();
-   TR_BitVector nodeChecklistBeforeDump(comp->getNodeCount(), trMemory(), stackAlloc, growable);
+   TR_BitVector nodeChecklistBeforeDump(compilation->getNodeCount(), trMemory(), stackAlloc, growable);
 
-   for (TR::TreeTop *tt = comp->getStartTree(); tt; tt = getCurrentEvaluationTreeTop()->getNextTreeTop())
+   for (TR::TreeTop *tt = compilation->getStartTree(); tt; tt = getCurrentEvaluationTreeTop()->getNextTreeTop())
       {
       TR::Instruction *prevInstr = getAppendInstruction();
       TR::Node *node = tt->getNode();
@@ -714,13 +714,13 @@ OMR::CodeGenerator::doInstructionSelection()
 
       setLiveLocals(liveLocals);
 
-      if (comp->getOption(TR_TraceCG) || debug("traceGRA"))
+      if (compilation->getOption(TR_TraceCG) || debug("traceGRA"))
          {
          // any evaluator that handles multiple trees will need to dump
          // the others
          getDebug()->saveNodeChecklist(nodeChecklistBeforeDump);
          getDebug()->dumpSingleTreeWithInstrs(tt, NULL, true, false, true, true);
-         traceMsg(comp, "\n------------------------------\n");
+         traceMsg(compilation, "\n------------------------------\n");
          }
 
       setCurrentEvaluationTreeTop(tt);
@@ -731,7 +731,7 @@ OMR::CodeGenerator::doInstructionSelection()
       //
       evaluate(node);
 
-      if (comp->getOption(TR_TraceCG) || debug("traceGRA"))
+      if (compilation->getOption(TR_TraceCG) || debug("traceGRA"))
          {
          TR::Instruction *lastInstr = getAppendInstruction();
          tt->setLastInstruction(lastInstr == prevInstr ? 0 : lastInstr);
@@ -800,21 +800,21 @@ OMR::CodeGenerator::doInstructionSelection()
             }
          }
 
-      if (comp->getOption(TR_TraceCG) || debug("traceGRA"))
+      if (compilation->getOption(TR_TraceCG) || debug("traceGRA"))
          {
          getDebug()->restoreNodeChecklist(nodeChecklistBeforeDump);
          if (tt == getCurrentEvaluationTreeTop())
             {
-            traceMsg(comp, "------------------------------\n");
+            traceMsg(compilation, "------------------------------\n");
             getDebug()->dumpSingleTreeWithInstrs(tt, prevInstr->getNext(), true, true, true, false);
             }
          else
             {
             // dump all the trees that the evaluator handled
-            traceMsg(comp, "------------------------------");
+            traceMsg(compilation, "------------------------------");
             for (TR::TreeTop *dumptt = tt; dumptt != getCurrentEvaluationTreeTop()->getNextTreeTop(); dumptt = dumptt->getNextTreeTop())
                {
-               traceMsg(comp, "\n");
+               traceMsg(compilation, "\n");
                getDebug()->dumpSingleTreeWithInstrs(dumptt, NULL, true, false, true, false);
                }
 
@@ -822,7 +822,7 @@ OMR::CodeGenerator::doInstructionSelection()
             getDebug()->dumpSingleTreeWithInstrs(tt, prevInstr->getNext(), false, true, false, false);
             }
 
-         trfflush(comp->getOutFile());
+         trfflush(compilation->getOutFile());
          }
       }
 
@@ -834,9 +834,9 @@ OMR::CodeGenerator::doInstructionSelection()
 #endif
    } // scope of the stack memory region
 
-   if (comp->getOption(TR_TraceCG) || debug("traceGRA"))
+   if (compilation->getOption(TR_TraceCG) || debug("traceGRA"))
       {
-      comp->incVisitCount();
+      compilation->incVisitCount();
       }
 
    if (getDebug())
@@ -846,7 +846,7 @@ OMR::CodeGenerator::doInstructionSelection()
 
    endInstructionSelection();
 
-   if (comp->getOption(TR_TraceCG))
+   if (compilation->getOption(TR_TraceCG))
       {
       diagnostic("</selection>\n");
       }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2707,7 +2707,7 @@ OMR::CodeGenerator::isMaterialized(TR::Node * node)
 bool
 OMR::CodeGenerator::canNullChkBeImplicit(TR::Node *node)
    {
-   return self()->canNullChkBeImplicit(node, false);
+   return canNullChkBeImplicit(node, false);
    }
 
 bool

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2221,7 +2221,7 @@ OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnipp
       estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);
       }
 
-   if (self()->hasDataSnippets())
+   if (hasDataSnippets())
       {
       estimatedSnippetStart = self()->setEstimatedLocationsForDataSnippetLabels(estimatedSnippetStart);
       }
@@ -2253,7 +2253,7 @@ OMR::CodeGenerator::emitSnippets()
 
    // Emit constant data snippets last.
    //
-   if (self()->hasDataSnippets())
+   if (hasDataSnippets())
       {
       self()->emitDataSnippets();
       }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -629,7 +629,7 @@ OMR::CodeGenerator::doInstructionSelection()
    {
    TR::Compilation *comp = self()->comp();
 
-   self()->setNextAvailableBlockIndex(comp->getFlowGraph()->getNextNodeNumber() + 1);
+   setNextAvailableBlockIndex(comp->getFlowGraph()->getNextNodeNumber() + 1);
 
    // Set default value for pre-prologue size
    //
@@ -1151,7 +1151,7 @@ uint16_t OMR::CodeGenerator::getNumberOfGlobalGPRs()
 int32_t OMR::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block)
    {
    TR::Node *node = block->getLastRealTreeTop()->getNode();
-   return self()->getMaximumNumberOfGPRsAllowedAcrossEdge(node);
+   return getMaximumNumberOfGPRsAllowedAcrossEdge(node);
    }
 
 
@@ -1345,7 +1345,7 @@ bool OMR::CodeGenerator::areAssignableGPRsScarce()
    static char *c1 = feGetEnv("TR_ScarceGPRsThreshold");
    if (c1)
       threshold = atoi(c1);
-      return (self()->getMaximumNumbersOfAssignableGPRs() <= threshold);
+      return (getMaximumNumbersOfAssignableGPRs() <= threshold);
    }
 
 // J9
@@ -2250,7 +2250,6 @@ OMR::CodeGenerator::emitSnippets()
       }
 
    retVal = self()->getBinaryBufferCursor();
-
 
    // Emit constant data snippets last.
    //

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -645,7 +645,7 @@ OMR::CodeGenerator::doInstructionSelection()
       self()->getDebug()->setupToDumpTreesAndInstructions("Performing Instruction Selection");
       }
 
-   self()->beginInstructionSelection();
+   beginInstructionSelection();
 
    {
    TR::StackMemoryRegion stackMemoryRegion(*self()->trMemory());
@@ -2266,7 +2266,7 @@ OMR::CodeGenerator::lookUpSnippet(int32_t snippetKind, TR::SymbolReference *symR
    {
    for (auto iterator = _snippetList.begin(); iterator != _snippetList.end(); ++iterator)
       {
-      if (self()->isSnippetMatched(*iterator, snippetKind, symRef))
+      if (isSnippetMatched(*iterator, snippetKind, symRef))
          return (*iterator)->getSnippetLabel();
       }
    return NULL;

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1049,7 +1049,7 @@ OMR::CodeGenerator::getLinkage(TR_LinkageConventions lc)
    if (lc == TR_None)
       return NULL;
    else
-      return _linkages[lc] ? _linkages[lc] : self()->createLinkage(lc);
+      return _linkages[lc] ? _linkages[lc] : createLinkage(lc);
    }
 
 void OMR::CodeGenerator::initializeLinkage()
@@ -1058,8 +1058,8 @@ void OMR::CodeGenerator::initializeLinkage()
    // Allow the project/GlobalCompilationInfo to set the body linkage
    // Expect to call once during initialization
    //
-   linkage = self()->createLinkageForCompilation();
-   linkage = linkage ? linkage : self()->createLinkage(self()->comp()->getJittedMethodSymbol()->getLinkageConvention());
+   linkage = createLinkageForCompilation();
+   linkage = linkage ? linkage : createLinkage(self()->comp()->getJittedMethodSymbol()->getLinkageConvention());
    self()->setLinkage(linkage);
    }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -362,7 +362,7 @@ void OMR::CodeGenerator::lowerTrees()
       TR_ASSERT(node->getVisitCount() != visitCount, "Code Gen: error in lowering trees");
       TR_ASSERT(node->getReferenceCount() == 0, "Code Gen: error in lowering trees");
 
-      self()->lowerTreesPreTreeTopVisit(tt, visitCount);
+      lowerTreesPreTreeTopVisit(tt, visitCount);
 
 
       // First lower the children

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -367,7 +367,7 @@ void OMR::CodeGenerator::lowerTrees()
 
       // First lower the children
       //
-      self()->lowerTreesWalk(node, tt, visitCount);
+      lowerTreesWalk(node, tt, visitCount);
 
       // If the tree needs to be lowered, call the VM to lower it
       //
@@ -401,7 +401,7 @@ OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vco
       //
       if (child->getVisitCount() != visitCount)
          {
-         self()->lowerTreesWalk(child, treeTop, visitCount);
+         lowerTreesWalk(child, treeTop, visitCount);
          self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
       }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -295,7 +295,7 @@ OMR::CodeGenerator::CodeGenerator() :
    }
 
 void
-OMR::CodeGenerator::continueConstruction()
+OMR::CodeGenerator::initializeConstruction()
    {
    return;
    }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -371,7 +371,7 @@ void OMR::CodeGenerator::lowerTrees()
 
       // If the tree needs to be lowered, call the VM to lower it
       //
-      self()->lowerTreeIfNeeded(node, 0, 0, tt);
+      lowerTreeIfNeeded(node, 0, 0, tt);
 
 
       self()->lowerTreesPostTreeTopVisit(tt, visitCount);
@@ -402,7 +402,7 @@ OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vco
       if (child->getVisitCount() != visitCount)
          {
          lowerTreesWalk(child, treeTop, visitCount);
-         self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
+         lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
       }
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -388,7 +388,7 @@ OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vco
 
    parent->setVisitCount(visitCount);
 
-   self()->lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
 
    // Go through the subtrees and lower any nodes that need to be lowered. This
    // involves a call to the VM to replace the trees with other trees.

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -294,6 +294,12 @@ OMR::CodeGenerator::CodeGenerator() :
    self()->setIsLeafMethod();
    }
 
+void
+OMR::CodeGenerator::continueConstruction()
+   {
+   return;
+   }
+
 TR_StackMemory
 OMR::CodeGenerator::trStackMemory()
    {

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -348,7 +348,7 @@ void OMR::CodeGenerator::lowerTrees()
    // visitCount should not be incremented until it finishes
    //
 
-   self()->preLowerTrees();
+   preLowerTrees();
 
    TR::TreeTop * tt;
    TR::Node * node;
@@ -374,7 +374,7 @@ void OMR::CodeGenerator::lowerTrees()
       lowerTreeIfNeeded(node, 0, 0, tt);
 
 
-      self()->lowerTreesPostTreeTopVisit(tt, visitCount);
+      lowerTreesPostTreeTopVisit(tt, visitCount);
 
       }
 
@@ -406,7 +406,7 @@ OMR::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vco
          }
       }
 
-   self()->lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
 
    }
 
@@ -838,7 +838,7 @@ OMR::CodeGenerator::doInstructionSelection()
       self()->getDebug()->roundAddressEnumerationCounters();
       }
 
-   self()->endInstructionSelection();
+   endInstructionSelection();
 
    if (comp->getOption(TR_TraceCG))
       {
@@ -2255,7 +2255,7 @@ OMR::CodeGenerator::emitSnippets()
    //
    if (hasDataSnippets())
       {
-      self()->emitDataSnippets();
+      emitDataSnippets();
       }
 
    return retVal;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -253,7 +253,7 @@ TR::Node* generatePoisonNode(TR::Compilation *comp, TR::Block *currentBlock, TR:
 namespace OMR
 {
 
-class OMR_EXTENSIBLE CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator
    {
    private:
 
@@ -1127,7 +1127,7 @@ class OMR_EXTENSIBLE CodeGenerator
    // should override these methods if they use constant data snippets.
    //
    void emitDataSnippets() {}
-   bool hasDataSnippets() {return false;}
+   virtual bool hasDataSnippets() {return false;} // no virt, cast
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
    
    // --------------------------------------------------------------------------

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -303,7 +303,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
-   void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
+   virtual void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
    void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
 
    virtual void lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
@@ -552,7 +552,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Capabilities
    //
    virtual bool supports32bitAiadd() {return true;}
-   bool supportsMergingGuards() {return false;}
+   virtual bool supportsMergingGuards() {return false;}
 
    // --------------------------------------------------------------------------
    // Z only
@@ -579,7 +579,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Lower trees
    //
    void rematerializeCmpUnderTernary(TR::Node*node);
-   bool yankIndexScalingOp() {return false;}
+   virtual bool yankIndexScalingOp() {return false;}
 
    void cleanupFlags(TR::Node*node);
 
@@ -921,7 +921,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool is8BitGlobalGPR(TR_GlobalRegisterNumber n) {return n <= _last8BitGlobalGPR;}
 
-   TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type){ return -1; }
+   virtual TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type){ return -1; }
    virtual TR_BitVector *getGlobalGPRsPreservedAcrossCalls(){ return NULL; }
    virtual TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return NULL; }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -663,7 +663,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool opCodeIsNoOp(TR::ILOpCode &opCode);
    virtual bool opCodeIsNoOpOnThisPlatform(TR::ILOpCode &opCode) {return false;}
 
-   bool supportsSinglePrecisionSQRT() {return false;}
+   virtual bool supportsSinglePrecisionSQRT() {return false;}
    bool supportsFusedMultiplyAdd() {return false;}
    bool supportsNegativeFusedMultiplyAdd() {return false;}
 
@@ -923,7 +923,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type){ return -1; }
    TR_BitVector *getGlobalGPRsPreservedAcrossCalls(){ return NULL; }
-   TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return NULL; }
+   virtual TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return NULL; }
 
    int32_t getFirstBit(TR_BitVector &bv);
    TR_GlobalRegisterNumber pickRegister(TR_RegisterCandidate *, TR::Block * *, TR_BitVector & availableRegisters, TR_GlobalRegisterNumber & highRegisterNumber, TR_LinkHead<TR_RegisterCandidate> *candidates);
@@ -1225,10 +1225,10 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::AheadOfTimeCompile *setAheadOfTimeCompile(TR::AheadOfTimeCompile *p) {return (_aheadOfTimeCompile = p);}
 
    // J9, X86
-   bool canTransformUnsafeCopyToArrayCopy() { return false; }
+   virtual bool canTransformUnsafeCopyToArrayCopy() { return false; }
    bool canTransformUnsafeSetMemory() { return false; }
 
-   bool canNullChkBeImplicit(TR::Node *);
+   virtual bool canNullChkBeImplicit(TR::Node *);
    bool canNullChkBeImplicit(TR::Node *, bool doChecks);
 
    virtual bool IsInMemoryType(TR::DataType type) { return false; }
@@ -1295,9 +1295,9 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool bndsChkNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual void setOnDemandLiteralPoolRun(bool answer) {}
-   bool isLiteralPoolOnDemandOn () { return false; }
+   virtual bool isLiteralPoolOnDemandOn () { return false; }
    bool supportsOnDemandLiteralPool() { return false; }
-   bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; }
+   virtual bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; }
    virtual bool supportsHighWordFacility() { return false; }
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
@@ -1377,7 +1377,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void setMappingAutomatics() {_flags1.set(MappingAutomatics);}
 
    bool getSupportsDirectJNICalls() {return _flags1.testAny(SupportsDirectJNICalls);}
-   bool supportsDirectJNICallsForAOT() { return false;}
+   virtual bool supportsDirectJNICallsForAOT() { return false;}
 
    void setSupportsDirectJNICalls() {_flags1.set(SupportsDirectJNICalls);}
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -485,7 +485,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void stopUsingRegister(TR::Register *reg);
 
    virtual void setCurrentBlockIndex(int32_t blockIndex) { }
-   int32_t getCurrentBlockIndex() { return -1; }
+   virtual int32_t getCurrentBlockIndex() { return -1; }
 
    TR::Instruction *lastInstructionBeforeCurrentEvaluationTreeTop()
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -306,14 +306,14 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
    void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
 
-   void lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
+   virtual void lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
    void lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
-   void lowerTreesPropagateBlockToNode(TR::Node *node);
+   virtual void lowerTreesPropagateBlockToNode(TR::Node *node);
 
    virtual void setUpForInstructionSelection();
    void doInstructionSelection();
-   void createStackAtlas();
+   virtual void createStackAtlas();
 
    virtual void beginInstructionSelection() {}
    void endInstructionSelection() {}
@@ -382,8 +382,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
    bool buildInterpreterEntryPoint() { return false; }
    void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
-   bool supportsUnneededLabelRemoval() { return true; }
-   bool allowSplitWarmAndColdBlocks() { return false; }
+   virtual bool supportsUnneededLabelRemoval() { return true; }
+   virtual bool allowSplitWarmAndColdBlocks() { return false; }
 
    TR_HasRandomGenerator randomizer;
 
@@ -1107,7 +1107,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::list<TR_Pair<TR_ResolvedMethod,TR::Instruction> *> &getJNICallSites() { return _jniCallSites; }  // registerAssumptions()
 
    bool needClassAndMethodPointerRelocations() { return false; }
-   bool needRelocationsForStatics() { return false; }
+   virtual bool needRelocationsForStatics() { return false; }
    bool needRelocationsForBodyInfoData() { return false; }
    bool needRelocationsForPersistentInfoData() { return false; }
 
@@ -1194,7 +1194,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // currently can only return a value other than vgdnop for HCR guards
    TR::Instruction* getVirtualGuardForPatching(TR::Instruction *vgdnop);
 
-   void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
+   virtual void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -380,7 +380,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool supportsMethodEntryPadding() { return true; }
    virtual bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
-   bool buildInterpreterEntryPoint() { return false; }
+   virtual bool buildInterpreterEntryPoint() { return false; }
    virtual void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
    virtual bool supportsUnneededLabelRemoval() { return true; }
    virtual bool allowSplitWarmAndColdBlocks() { return false; }
@@ -949,7 +949,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    TR_Array<TR::Register *>& getRegisterArray() {return _registerArray;}
 
-   bool needToAvoidCommoningInGRA() {return false;}
+   virtual bool needToAvoidCommoningInGRA() {return false;}
 
    virtual bool considerTypeForGRA(TR::Node *node) {return true;}
    virtual bool considerTypeForGRA(TR::DataType dt) {return true;}
@@ -1550,7 +1550,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual bool isAddressScaleIndexSupported(int32_t scale) { return false; }
 
-   bool getSupportsConstantOffsetInAddressing(int64_t value);
+   virtual bool getSupportsConstantOffsetInAddressing(int64_t value);
    bool getSupportsConstantOffsetInAddressing() { return _flags3.testAny(SupportsConstantOffsetInAddressing); }
    void setSupportsConstantOffsetInAddressing() { _flags3.set(SupportsConstantOffsetInAddressing); }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -297,7 +297,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void preLowerTrees();
    void postLowerTrees() {}
 
-   TR::TreeTop *lowerTree(TR::Node *root, TR::TreeTop *tt);
+   virtual TR::TreeTop *lowerTree(TR::Node *root, TR::TreeTop *tt);
    void lowerTrees();
    virtual void lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
@@ -311,7 +311,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    void lowerTreesPropagateBlockToNode(TR::Node *node);
 
-   void setUpForInstructionSelection();
+   virtual void setUpForInstructionSelection();
    void doInstructionSelection();
    void createStackAtlas();
 
@@ -447,7 +447,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // --------------------------------------------------------------------------
    // Hardware profiling
    //
-   void createHWPRecords() {}
+   virtual void createHWPRecords() {}
 
    // --------------------------------------------------------------------------
    // Tree evaluation
@@ -479,7 +479,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    rcount_t recursivelyDecReferenceCount(TR::Node*node);
    void evaluateChildrenWithMultipleRefCount(TR::Node*node);
 
-   void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp) {}
+   virtual void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp) {}
 
    void startUsingRegister(TR::Register *reg);
    void stopUsingRegister(TR::Register *reg);
@@ -1071,21 +1071,21 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void addExternalRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info, TR::ExternalRelocationPositionRequest where = TR::ExternalRelocationAtBack);
    void addStaticRelocation(const TR::StaticRelocation &relocation);
 
-   void addProjectSpecializedRelocation(uint8_t *location,
+   virtual void addProjectSpecializedRelocation(uint8_t *location,
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
                                           char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
-   void addProjectSpecializedPairRelocation(uint8_t *location1,
+   virtual void addProjectSpecializedPairRelocation(uint8_t *location1,
                                           uint8_t *location2,
                                           uint8_t *target,
                                           TR_ExternalRelocationTargetKind kind,
                                           char *generatingFileName,
                                           uintptr_t generatingLineNumber,
                                           TR::Node *node) {}
-   void addProjectSpecializedRelocation(TR::Instruction *instr,
+   virtual void addProjectSpecializedRelocation(TR::Instruction *instr,
                                           uint8_t *target,
                                           uint8_t *target2,
                                           TR_ExternalRelocationTargetKind kind,
@@ -1226,7 +1226,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    // J9, X86
    virtual bool canTransformUnsafeCopyToArrayCopy() { return false; }
-   bool canTransformUnsafeSetMemory() { return false; }
+   virtual bool canTransformUnsafeSetMemory() { return false; }
 
    virtual bool canNullChkBeImplicit(TR::Node *);
    bool canNullChkBeImplicit(TR::Node *, bool doChecks);
@@ -1300,7 +1300,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; }
    virtual bool supportsHighWordFacility() { return false; }
 
-   bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
+   virtual bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
 
    // J9 only, move to trj9
    TR_OpaqueClassBlock* getMonClass(TR::Node* monNode);
@@ -1352,7 +1352,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::DataType IntJ() { return TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32; }
 
    // will a BCD left shift always leave the sign code unchanged and thus allow it to be propagated through and upwards
-   bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; }
+   virtual bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; }
 
    virtual bool supportsLengthMinusOneForMemoryOpts() {return false;}
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -419,7 +419,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Code Generator Phases
    //
    void generateCode();
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign) = 0;
+   virtual void doRegisterAssignment(TR_RegisterKinds kindsToAssign) = 0;
    void doBinaryEncoding();
    void doPeephole() { return; }
    bool hasComplexAddressingMode() { return false; }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -583,7 +583,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    void cleanupFlags(TR::Node*node);
 
-   bool shouldYankCompressedRefs() { return false; }
+   virtual bool shouldYankCompressedRefs() { return false; }
    bool materializesHeapBase() { return true; }
    virtual bool canFoldLargeOffsetInAddressing() { return false; }
 
@@ -636,7 +636,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
     * @param method : the recognized method to consider
     * @return true if inlining should be suppressed; false otherwise
     */
-   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
+   virtual bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
    // --------------------------------------------------------------------------
    // Optimizer, not code generator
@@ -1198,7 +1198,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
-   void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
+   virtual void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
    bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9
    bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt) { return false; } //J9
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1645,7 +1645,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    protected:
 
    CodeGenerator();
-   void continueConstruction();
+   void initializeConstruction();
 
    enum // _flags1
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -607,10 +607,10 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::Instruction *generateDebugCounter(const char *name, TR_ScratchRegisterManager &srm, int32_t delta = 1, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL);
    TR::Instruction *generateDebugCounter(const char *name, TR::Register *deltaReg, TR_ScratchRegisterManager &srm, int8_t fidelity = TR::DebugCounter::Undetermined, int32_t staticDelta = 1, TR::Instruction *cursor = NULL);
 
-   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond){ return cursor; }
-   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR::RegisterDependencyConditions *cond){ return cursor; }
-   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm){ return cursor; }
-   TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm){ return cursor; }
+   virtual TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR::RegisterDependencyConditions *cond){ return cursor; }
+   virtual TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR::RegisterDependencyConditions *cond){ return cursor; }
+   virtual TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm){ return cursor; }
+   virtual TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm){ return cursor; }
 
    // --------------------------------------------------------------------------
    // Linkage
@@ -658,8 +658,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    //
    int16_t getMinShortForLongCompareNarrower() { return SHRT_MIN; }
    int8_t getMinByteForLongCompareNarrower() { return SCHAR_MIN; }
-
-   bool branchesAreExpensive() { return true; }
+ 
+   virtual bool branchesAreExpensive() { return true; }
    bool opCodeIsNoOp(TR::ILOpCode &opCode);
    bool opCodeIsNoOpOnThisPlatform(TR::ILOpCode &opCode) {return false;}
 
@@ -668,14 +668,14 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool supportsNegativeFusedMultiplyAdd() {return false;}
 
    bool supportsComplexAddressing() {return false;}
-   bool canBeAffectedByStoreTagStalls() { return false; }
+   virtual bool canBeAffectedByStoreTagStalls() { return false; }
 
    bool isMaterialized(TR::Node *);
    bool shouldValueBeInACommonedNode(int64_t) { return false; }
    bool materializesLargeConstants() { return false; }
 
    bool canUseImmedInstruction(int64_t v) {return false;}
-   bool needsNormalizationBeforeShifts() { return false; }
+   virtual bool needsNormalizationBeforeShifts() { return false; }
 
    uint32_t getNumberBytesReadInaccessible() { return _numberBytesReadInaccessible; }
    uint32_t getNumberBytesWriteInaccessible() { return _numberBytesWriteInaccessible; }
@@ -683,7 +683,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool codegenSupportsUnsignedIntegerDivide() {return false;}
    bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);
 
-   bool codegenSupportsLoadlessBNDCheck() {return false;}
+   virtual bool codegenSupportsLoadlessBNDCheck() {return false;}
 
    // called to determine if multiply decomposition exists in platform codegen so that codegen sequences are used
    // instead of the IL transformed multiplies
@@ -931,8 +931,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR_GlobalRegisterNumber findCoalescenceRegisterForParameter(TR::Node *callNode, TR_RegisterCandidate *rc, uint32_t childIndex, bool *isUnpreferred);
    TR_RegisterCandidate *findUsedCandidate(TR::Node *node, TR_RegisterCandidate *rc, TR_BitVector *visitedNodes);
 
-   bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node * branchNode);
-   void removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters) {}
+   bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node * branchNode); // no virt
+   virtual void removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters) {}
    void setUnavailableRegistersUsage(TR_Array<TR_BitVector>  & liveOnEntryUsage, TR_Array<TR_BitVector>   & liveOnExitUsage) {}
 
    int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
@@ -1127,9 +1127,10 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // should override these methods if they use constant data snippets.
    //
    void emitDataSnippets() {}
-   virtual bool hasDataSnippets() {return false;} // no virt, cast
+   virtual bool hasDataSnippets() {return false;}
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
    
+
    // --------------------------------------------------------------------------
    // Register pressure
    //
@@ -1233,7 +1234,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool IsInMemoryType(TR::DataType type) { return false; }
 
-   bool nodeMayCauseException(TR::Node *node) { return false; }
+   virtual bool nodeMayCauseException(TR::Node *node) { return false; }
 
    // Should these be in codegen?
    bool isSupportedAdd(TR::Node *addr);

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -375,8 +375,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::Instruction *getImplicitExceptionPoint() {return _implicitExceptionPoint;}
    TR::Instruction *setImplicitExceptionPoint(TR::Instruction *p) {return (_implicitExceptionPoint = p);}
 
-   void setNextAvailableBlockIndex(int32_t blockIndex) {}
-   int32_t getNextAvailableBlockIndex() { return -1; }
+   virtual void setNextAvailableBlockIndex(int32_t blockIndex) {}
+   virtual int32_t getNextAvailableBlockIndex() { return -1; }
 
    bool supportsMethodEntryPadding() { return true; }
    bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
@@ -564,9 +564,9 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool AddArtificiallyInflatedNodeToStack(TR::Node* n);
 
    // Used to model register liveness without Future Use Count.
-   bool isInternalControlFlowReg(TR::Register *reg) {return false;}
-   void startInternalControlFlow(TR::Instruction *instr) {}
-   void endInternalControlFlow(TR::Instruction *instr) {}
+   virtual bool isInternalControlFlowReg(TR::Register *reg) {return false;}
+   virtual void startInternalControlFlow(TR::Instruction *instr) {}
+   virtual void endInternalControlFlow(TR::Instruction *instr) {}
 
 
 
@@ -628,7 +628,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // --------------------------------------------------------------------------
    // Optimizer, code generator capabilities
    //
-   int32_t getPreferredLoopUnrollFactor() {return -1;}
+   virtual int32_t getPreferredLoopUnrollFactor() {return -1;}
 
    /**
     * @brief Answers whether the provided recognized method should be inlined by an
@@ -649,7 +649,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool supportsInliningOfIsInstance() {return false;}
    bool supportsPassThroughCopyToNewVirtualRegister() { return false; }
 
-   uint8_t getSizeOfCombinedBuffer() {return 0;}
+   virtual uint8_t getSizeOfCombinedBuffer() {return 0;}
 
    bool doRematerialization() {return false;}
 
@@ -657,7 +657,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Architecture, not code generator
    //
    int16_t getMinShortForLongCompareNarrower() { return SHRT_MIN; }
-   int8_t getMinByteForLongCompareNarrower() { return SCHAR_MIN; }
+   virtual int8_t getMinByteForLongCompareNarrower() { return SCHAR_MIN; }
 
    virtual bool branchesAreExpensive() { return true; }
    bool opCodeIsNoOp(TR::ILOpCode &opCode);
@@ -681,18 +681,18 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    uint32_t getNumberBytesWriteInaccessible() { return _numberBytesWriteInaccessible; }
 
    bool codegenSupportsUnsignedIntegerDivide() {return false;}
-   bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);
+   virtual bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);
 
    virtual bool codegenSupportsLoadlessBNDCheck() {return false;}
 
    // called to determine if multiply decomposition exists in platform codegen so that codegen sequences are used
    // instead of the IL transformed multiplies
-   bool codegenMulDecomposition(int64_t multiplier) {return false;}
+   virtual bool codegenMulDecomposition(int64_t multiplier) {return false;}
 
    // --------------------------------------------------------------------------
    // FrontEnd, not code generator
    //
-   bool getSupportsNewObjectAlignment() { return false; }
+   virtual bool getSupportsNewObjectAlignment() { return false; }
    virtual bool getSupportsTenuredObjectAlignment() { return false; }
    virtual bool isObjectOfSizeWorthAligning(uint32_t size) { return false; }
 
@@ -732,7 +732,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR_GCStackMap *buildGCMapForInstruction(TR::Instruction *instr);
    void buildRegisterMapForInstruction(TR_GCStackMap *map);
    // IA32 only?
-   uint32_t getRegisterMapInfoBitsMask() {return 0;}
+   virtual uint32_t getRegisterMapInfoBitsMask() {return 0;}
 
    // --------------------------------------------------------------------------
    // Method frame building
@@ -933,13 +933,13 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node * branchNode);
    virtual void removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters) {}
-   void setUnavailableRegistersUsage(TR_Array<TR_BitVector>  & liveOnEntryUsage, TR_Array<TR_BitVector>   & liveOnExitUsage) {}
+   virtual void setUnavailableRegistersUsage(TR_Array<TR_BitVector>  & liveOnEntryUsage, TR_Array<TR_BitVector>   & liveOnExitUsage) {}
 
-   int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
+   virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
-   int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
-   int32_t getMaximumNumbersOfAssignableGPRs() { return INT_MAX; }
+   virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
+   virtual int32_t getMaximumNumbersOfAssignableGPRs() { return INT_MAX; }
    int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }
    virtual int32_t getMaximumNumbersOfAssignableVRs()  { return INT_MAX; }
    virtual bool willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR::Compilation *comp){ return true;}
@@ -951,12 +951,12 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool needToAvoidCommoningInGRA() {return false;}
 
-   bool considerTypeForGRA(TR::Node *node) {return true;}
-   bool considerTypeForGRA(TR::DataType dt) {return true;}
-   bool considerTypeForGRA(TR::SymbolReference *symRef) {return true;}
+   virtual bool considerTypeForGRA(TR::Node *node) {return true;}
+   virtual bool considerTypeForGRA(TR::DataType dt) {return true;}
+   virtual bool considerTypeForGRA(TR::SymbolReference *symRef) {return true;}
 
    void enableLiteralPoolRegisterForGRA () {}
-   bool excludeInvariantsFromGRAEnabled() { return false; }
+   virtual bool excludeInvariantsFromGRAEnabled() { return false; }
 
    TR_BitVector *getBlocksWithCalls();
 
@@ -970,7 +970,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::RegisterIterator *setFPRegisterIterator(TR::RegisterIterator *iter) {return (_fpRegisterIterator = iter);}
 
    // X86 only
-   uint32_t estimateBinaryLength(TR::MemoryReference *) { return 0; }
+   virtual uint32_t estimateBinaryLength(TR::MemoryReference *) { return 0; }
 
 #ifdef DEBUG
    static void shutdown(TR_FrontEnd *fe, TR::FILE *logFile);
@@ -1094,15 +1094,15 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
                                           TR::Node *node) {}
 
    void apply8BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label);
-   void apply12BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label, bool isCheckDisp = true);
-   void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label);
-   void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label,int8_t d, bool isInstrOffset = false);
-   void apply24BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
+   virtual void apply12BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label, bool isCheckDisp = true);
+   virtual void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label);
+   virtual void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label,int8_t d, bool isInstrOffset = false);
+   virtual void apply24BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
    void apply16BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
    void apply32BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
    void apply64BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *);
-   void apply32BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
-   void apply32BitLabelTableRelocation(int32_t * cursor, TR::LabelSymbol *);
+   virtual void apply32BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
+   virtual void apply32BitLabelTableRelocation(int32_t * cursor, TR::LabelSymbol *);
 
    TR::list<TR_Pair<TR_ResolvedMethod,TR::Instruction> *> &getJNICallSites() { return _jniCallSites; }  // registerAssumptions()
 
@@ -1129,7 +1129,6 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void emitDataSnippets() {}
    virtual bool hasDataSnippets() {return false;}
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
-   
 
    // --------------------------------------------------------------------------
    // Register pressure
@@ -1173,7 +1172,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // --------------------------------------------------------------------------
    // Register assignment
    //
-   TR_RegisterKinds prepareRegistersForAssignment();
+   virtual TR_RegisterKinds prepareRegistersForAssignment();
    void addToUnlatchedRegisterList(TR::RealRegister *reg);
    void freeUnlatchedRegisters();
 
@@ -1210,7 +1209,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // P now
    virtual bool isRotateAndMask(TR::Node *node) { return false; }
 
-   TR::Instruction *generateNop(TR::Node *node, TR::Instruction *instruction=0, TR_NOPKind nopKind=TR_NOPStandard);
+   virtual TR::Instruction *generateNop(TR::Node *node, TR::Instruction *instruction=0, TR_NOPKind nopKind=TR_NOPStandard);
    bool isOutOfLineHotPath() { TR_ASSERT(0, "isOutOfLineHotPath is only implemented for 390 and ppc"); return false;}
 
    //Rather confusingly not used -only- in BCD related codegen.
@@ -1232,7 +1231,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool canNullChkBeImplicit(TR::Node *);
    bool canNullChkBeImplicit(TR::Node *, bool doChecks);
 
-   bool IsInMemoryType(TR::DataType type) { return false; }
+   virtual bool IsInMemoryType(TR::DataType type) { return false; }
 
    virtual bool nodeMayCauseException(TR::Node *node) { return false; }
 
@@ -1278,7 +1277,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // strictly more information to codegen, which can then generate the best sequence at its
    // discretion, fabricating a loop if necessary. But at least in the case of idiom
    // recognition's MemCpy pattern, we want Design 94472 for this.
-   int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget);
+   virtual int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget);
 
    // TO TransformUtil.  Make platform specific
    int32_t arrayTranslateAndTestMinimumNumberOfIterations();
@@ -1295,7 +1294,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child) { return false; }
    bool bndsChkNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
-   void setOnDemandLiteralPoolRun(bool answer) {}
+   virtual void setOnDemandLiteralPoolRun(bool answer) {}
    bool isLiteralPoolOnDemandOn () { return false; }
    bool supportsOnDemandLiteralPool() { return false; }
    bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; }
@@ -1355,7 +1354,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // will a BCD left shift always leave the sign code unchanged and thus allow it to be propagated through and upwards
    bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; }
 
-   bool supportsLengthMinusOneForMemoryOpts() {return false;}
+   virtual bool supportsLengthMinusOneForMemoryOpts() {return false;}
 
    // Java, likely Z
    bool supportsTrapsInTMRegion() { return true; }
@@ -1508,7 +1507,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool getSupportsAutoSIMD() { return _flags4.testAny(SupportsAutoSIMD);}
    void setSupportsAutoSIMD() { _flags4.set(SupportsAutoSIMD);}
 
-   bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType) { return false; }
+   virtual bool getSupportsOpCodeForAutoSIMD(TR::ILOpCode, TR::DataType) { return false; }
 
    bool removeRegisterHogsInLowerTreesWalk() { return _flags3.testAny(RemoveRegisterHogsInLowerTreesWalk);}
    void setRemoveRegisterHogsInLowerTreesWalk() { _flags3.set(RemoveRegisterHogsInLowerTreesWalk);}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1641,6 +1641,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void resetTrackingInMemoryKilledLoads() {_flags4.reset(TrackingInMemoryKilledLoads);}
 
    void setLmmdFailed() { _lmmdFailed = true;}
+	 
+	 virtual void insertInstructionPrefetches() {};
 
    protected:
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -420,8 +420,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    //
    void generateCode();
    virtual void doRegisterAssignment(TR_RegisterKinds kindsToAssign) = 0;
-   void doBinaryEncoding();
-   void doPeephole() { return; }
+   virtual void doBinaryEncoding() = 0;
+   virtual void doPeephole() { return; }
    bool hasComplexAddressingMode() { return false; }
    void removeUnusedLocals();
 
@@ -667,7 +667,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool supportsFusedMultiplyAdd() {return false;}
    bool supportsNegativeFusedMultiplyAdd() {return false;}
 
-   bool supportsComplexAddressing() {return false;}
+   virtual bool supportsComplexAddressing() {return false;}
    virtual bool canBeAffectedByStoreTagStalls() { return false; }
 
    bool isMaterialized(TR::Node *);
@@ -730,7 +730,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void addToAtlas(TR::Instruction *);
    void buildGCMapsForInstructionAndSnippet(TR::Instruction *instr);
    TR_GCStackMap *buildGCMapForInstruction(TR::Instruction *instr);
-   void buildRegisterMapForInstruction(TR_GCStackMap *map);
+   virtual void buildRegisterMapForInstruction(TR_GCStackMap *map) = 0;
    // IA32 only?
    virtual uint32_t getRegisterMapInfoBitsMask() {return 0;}
 
@@ -845,7 +845,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    uint32_t getGlobalRegister(TR_GlobalRegisterNumber n) {return _globalRegisterTable[n];}
    uint32_t *setGlobalRegisterTable(uint32_t *p) {return (_globalRegisterTable = p);}
 
-   TR_GlobalRegisterNumber getGlobalRegisterNumber(uint32_t realReg) { return -1; }
+   virtual TR_GlobalRegisterNumber getGlobalRegisterNumber(uint32_t realReg) { return -1; }
 
    TR_GlobalRegisterNumber getFirstGlobalGPR() {return 0;}
    TR_GlobalRegisterNumber getLastGlobalGPR()  {return _lastGlobalGPR;}
@@ -857,7 +857,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR_GlobalRegisterNumber setLastGlobalHPR(TR_GlobalRegisterNumber n) {return (_lastGlobalHPR = n);}
 
    virtual TR_GlobalRegisterNumber getGlobalHPRFromGPR (TR_GlobalRegisterNumber n) {return 0;}
-   TR_GlobalRegisterNumber getGlobalGPRFromHPR (TR_GlobalRegisterNumber n) {return 0;}
+   virtual TR_GlobalRegisterNumber getGlobalGPRFromHPR (TR_GlobalRegisterNumber n) {return 0;}
 
    TR_GlobalRegisterNumber getFirstGlobalFPR() {return _lastGlobalGPR + 1;}
    TR_GlobalRegisterNumber setFirstGlobalFPR(TR_GlobalRegisterNumber n) {return (_firstGlobalFPR = n);}
@@ -1435,8 +1435,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool getSupportsArrayTranslateTROT() {return _flags4.testAny(SupportsArrayTranslateTROT);}
    void setSupportsArrayTranslateTROT() {_flags4.set(SupportsArrayTranslateTROT);}
 
-   bool getSupportsEncodeUtf16LittleWithSurrogateTest() { return false; }
-   bool getSupportsEncodeUtf16BigWithSurrogateTest() { return false; }
+   virtual bool getSupportsEncodeUtf16LittleWithSurrogateTest() { return false; }
+   virtual bool getSupportsEncodeUtf16BigWithSurrogateTest() { return false; }
 
    bool supportsZonedDFPConversions() {return _enabledFlags.testAny(SupportsZonedDFPConversions);}
    void setSupportsZonedDFPConversions() {_enabledFlags.set(SupportsZonedDFPConversions);}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -422,7 +422,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void doRegisterAssignment(TR_RegisterKinds kindsToAssign) = 0;
    virtual void doBinaryEncoding() = 0;
    virtual void doPeephole() { return; }
-   bool hasComplexAddressingMode() { return false; }
+   virtual bool hasComplexAddressingMode() { return false; }
    void removeUnusedLocals();
 
    void identifyUnneededByteConvNodes(TR::Node*, TR::TreeTop *, vcount_t, TR::DataType);
@@ -537,7 +537,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    static inline bool isIntrinsicMethodSupported(TR::RecognizedMethod method);
 
 
-   TR::Recompilation *allocateRecompilationInfo() { return NULL; }
+   virtual TR::Recompilation *allocateRecompilationInfo() { return NULL; }
 
    /**
     * @brief This determines if it is necessary to emit a prefetch instruction.

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -419,7 +419,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Code Generator Phases
    //
    void generateCode();
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
+   virtual void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
    void doPeephole() { return; }
    bool hasComplexAddressingMode() { return false; }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -616,8 +616,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Linkage
    //
    void initializeLinkage();
-   TR::Linkage *createLinkage(TR_LinkageConventions lc);
-   TR::Linkage *createLinkageForCompilation();
+   virtual TR::Linkage *createLinkage(TR_LinkageConventions lc);
+   virtual TR::Linkage *createLinkageForCompilation();
 
    TR::Linkage *getLinkage() {return _bodyLinkage;}
    TR::Linkage *setLinkage(TR::Linkage * l) {return (_bodyLinkage = l);}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -656,7 +656,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // --------------------------------------------------------------------------
    // Architecture, not code generator
    //
-   int16_t getMinShortForLongCompareNarrower() { return SHRT_MIN; }
+   virtual int16_t getMinShortForLongCompareNarrower() { return SHRT_MIN; }
    virtual int8_t getMinByteForLongCompareNarrower() { return SCHAR_MIN; }
 
    virtual bool branchesAreExpensive() { return true; }
@@ -926,7 +926,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return NULL; }
 
    int32_t getFirstBit(TR_BitVector &bv);
-   TR_GlobalRegisterNumber pickRegister(TR_RegisterCandidate *, TR::Block * *, TR_BitVector & availableRegisters, TR_GlobalRegisterNumber & highRegisterNumber, TR_LinkHead<TR_RegisterCandidate> *candidates);
+   virtual TR_GlobalRegisterNumber pickRegister(TR_RegisterCandidate *, TR::Block * *, TR_BitVector & availableRegisters, TR_GlobalRegisterNumber & highRegisterNumber, TR_LinkHead<TR_RegisterCandidate> *candidates);
    TR_RegisterCandidate *findCoalescenceForRegisterCopy(TR::Node *node, TR_RegisterCandidate *rc, bool *isUnpreferred);
    TR_GlobalRegisterNumber findCoalescenceRegisterForParameter(TR::Node *callNode, TR_RegisterCandidate *rc, uint32_t childIndex, bool *isUnpreferred);
    TR_RegisterCandidate *findUsedCandidate(TR::Node *node, TR_RegisterCandidate *rc, TR_BitVector *visitedNodes);
@@ -940,7 +940,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
    virtual int32_t getMaximumNumbersOfAssignableGPRs() { return INT_MAX; }
-   int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }
+   virtual int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }
    virtual int32_t getMaximumNumbersOfAssignableVRs()  { return INT_MAX; }
    virtual bool willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR::Compilation *comp){ return true;}
    virtual bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber, TR::DataType) { return true; }
@@ -1195,7 +1195,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR::Instruction* getVirtualGuardForPatching(TR::Instruction *vgdnop);
 
    virtual void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
-   void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
+   virtual void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -856,7 +856,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR_GlobalRegisterNumber getLastGlobalHPR() {return _lastGlobalHPR;}
    TR_GlobalRegisterNumber setLastGlobalHPR(TR_GlobalRegisterNumber n) {return (_lastGlobalHPR = n);}
 
-   TR_GlobalRegisterNumber getGlobalHPRFromGPR (TR_GlobalRegisterNumber n) {return 0;}
+   virtual TR_GlobalRegisterNumber getGlobalHPRFromGPR (TR_GlobalRegisterNumber n) {return 0;}
    TR_GlobalRegisterNumber getGlobalGPRFromHPR (TR_GlobalRegisterNumber n) {return 0;}
 
    TR_GlobalRegisterNumber getFirstGlobalFPR() {return _lastGlobalGPR + 1;}

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -419,7 +419,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Code Generator Phases
    //
    void generateCode();
-   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
+   void doRegisterAssignment(TR_RegisterKinds kindsToAssign) = 0;
    void doBinaryEncoding();
    void doPeephole() { return; }
    bool hasComplexAddressingMode() { return false; }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -301,7 +301,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void lowerTrees();
    virtual void lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
-   void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
+   virtual void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
    void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
    void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
@@ -379,9 +379,9 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual int32_t getNextAvailableBlockIndex() { return -1; }
 
    bool supportsMethodEntryPadding() { return true; }
-   bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
+   virtual bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
    bool buildInterpreterEntryPoint() { return false; }
-   void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
+   virtual void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
    virtual bool supportsUnneededLabelRemoval() { return true; }
    virtual bool allowSplitWarmAndColdBlocks() { return false; }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -935,9 +935,9 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters) {}
    virtual void setUnavailableRegistersUsage(TR_Array<TR_BitVector>  & liveOnEntryUsage, TR_Array<TR_BitVector>   & liveOnExitUsage) {}
 
-   virtual virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
+   virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
-   int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
+   int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }t
    virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
    virtual int32_t getMaximumNumbersOfAssignableGPRs() { return INT_MAX; }
    int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -419,7 +419,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Code Generator Phases
    //
    void generateCode();
-   virtual void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
+   void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
    void doPeephole() { return; }
    bool hasComplexAddressingMode() { return false; }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -551,7 +551,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // --------------------------------------------------------------------------
    // Capabilities
    //
-   bool supports32bitAiadd() {return true;}
+   virtual bool supports32bitAiadd() {return true;}
    bool supportsMergingGuards() {return false;}
 
    // --------------------------------------------------------------------------
@@ -585,7 +585,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool shouldYankCompressedRefs() { return false; }
    bool materializesHeapBase() { return true; }
-   bool canFoldLargeOffsetInAddressing() { return false; }
+   virtual bool canFoldLargeOffsetInAddressing() { return false; }
 
    void insertDebugCounters();
 
@@ -646,7 +646,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool getSupportsProfiledInlining() { return _flags4.testAny(SupportsProfiledInlining);}
    void setSupportsProfiledInlining() { _flags4.set(SupportsProfiledInlining);}
-   bool supportsInliningOfIsInstance() {return false;}
+   virtual bool supportsInliningOfIsInstance() {return false;}
    bool supportsPassThroughCopyToNewVirtualRegister() { return false; }
 
    uint8_t getSizeOfCombinedBuffer() {return 0;}
@@ -658,10 +658,10 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    //
    int16_t getMinShortForLongCompareNarrower() { return SHRT_MIN; }
    int8_t getMinByteForLongCompareNarrower() { return SCHAR_MIN; }
- 
+
    virtual bool branchesAreExpensive() { return true; }
    bool opCodeIsNoOp(TR::ILOpCode &opCode);
-   bool opCodeIsNoOpOnThisPlatform(TR::ILOpCode &opCode) {return false;}
+   virtual bool opCodeIsNoOpOnThisPlatform(TR::ILOpCode &opCode) {return false;}
 
    bool supportsSinglePrecisionSQRT() {return false;}
    bool supportsFusedMultiplyAdd() {return false;}
@@ -671,7 +671,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool canBeAffectedByStoreTagStalls() { return false; }
 
    bool isMaterialized(TR::Node *);
-   bool shouldValueBeInACommonedNode(int64_t) { return false; }
+   virtual bool shouldValueBeInACommonedNode(int64_t) { return false; }
    bool materializesLargeConstants() { return false; }
 
    bool canUseImmedInstruction(int64_t v) {return false;}
@@ -693,11 +693,11 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // FrontEnd, not code generator
    //
    bool getSupportsNewObjectAlignment() { return false; }
-   bool getSupportsTenuredObjectAlignment() { return false; }
-   bool isObjectOfSizeWorthAligning(uint32_t size) { return false; }
+   virtual bool getSupportsTenuredObjectAlignment() { return false; }
+   virtual bool isObjectOfSizeWorthAligning(uint32_t size) { return false; }
 
    // J9
-   int32_t getInternalPtrMapBit() { return 31;}
+   virtual int32_t getInternalPtrMapBit() { return 31;}
 
    uint32_t getMaxObjectSizeGuaranteedNotToOverflow() { return _maxObjectSizeGuaranteedNotToOverflow; }
 
@@ -840,7 +840,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void addSymbolAndDataTypeToMap(TR::Symbol *symbol, TR::DataType dt);
    TR::DataType getDataTypeFromSymbolMap(TR::Symbol *symbol);
 
-   bool prepareForGRA();
+   virtual bool prepareForGRA();
 
    uint32_t getGlobalRegister(TR_GlobalRegisterNumber n) {return _globalRegisterTable[n];}
    uint32_t *setGlobalRegisterTable(uint32_t *p) {return (_globalRegisterTable = p);}
@@ -931,17 +931,17 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    TR_GlobalRegisterNumber findCoalescenceRegisterForParameter(TR::Node *callNode, TR_RegisterCandidate *rc, uint32_t childIndex, bool *isUnpreferred);
    TR_RegisterCandidate *findUsedCandidate(TR::Node *node, TR_RegisterCandidate *rc, TR_BitVector *visitedNodes);
 
-   bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node * branchNode); // no virt
+   virtual bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node * branchNode);
    virtual void removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters) {}
    void setUnavailableRegistersUsage(TR_Array<TR_BitVector>  & liveOnEntryUsage, TR_Array<TR_BitVector>   & liveOnExitUsage) {}
 
    int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
-   int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
+   virtual int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
    int32_t getMaximumNumbersOfAssignableGPRs() { return INT_MAX; }
    int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }
-   int32_t getMaximumNumbersOfAssignableVRs()  { return INT_MAX; }
+   virtual int32_t getMaximumNumbersOfAssignableVRs()  { return INT_MAX; }
    virtual bool willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR::Compilation *comp){ return true;}
    bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber, TR::DataType) { return true; }
 
@@ -1208,7 +1208,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    //
 
    // P now
-   bool isRotateAndMask(TR::Node *node) { return false; }
+   virtual bool isRotateAndMask(TR::Node *node) { return false; }
 
    TR::Instruction *generateNop(TR::Node *node, TR::Instruction *instruction=0, TR_NOPKind nopKind=TR_NOPStandard);
    bool isOutOfLineHotPath() { TR_ASSERT(0, "isOutOfLineHotPath is only implemented for 390 and ppc"); return false;}
@@ -1253,7 +1253,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // to be processed for it to be worth it to execute the 'translate' built-in function
    // arrayTranslateAndTestMinimumNumberOfIterations returns the minimum number of iterations
    // that the loop must run for the transformation to be worthwhile.
-   int32_t arrayTranslateTableRequiresAlignment(bool isByteSource, bool isByteTarget)  { return 0; }
+   virtual int32_t arrayTranslateTableRequiresAlignment(bool isByteSource, bool isByteTarget)  { return 0; }
 
    // These methods used to return a default value of INT_MAX. However, in at least one place,
    // and quite possibly elsewhere, the optimizer tests for
@@ -1291,15 +1291,15 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    // the following functions evaluate whether a codegen for the node or for static
    // symbol reference requires entry in the literal pool
-   bool arithmeticNeedsLiteralFromPool(TR::Node *node) { return false; }
+   virtual bool arithmeticNeedsLiteralFromPool(TR::Node *node) { return false; }
    bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child) { return false; }
    bool bndsChkNeedsLiteralFromPool(TR::Node *node) { return false; }
-   bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
+   virtual bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
    void setOnDemandLiteralPoolRun(bool answer) {}
    bool isLiteralPoolOnDemandOn () { return false; }
    bool supportsOnDemandLiteralPool() { return false; }
    bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; }
-   bool supportsHighWordFacility() { return false; }
+   virtual bool supportsHighWordFacility() { return false; }
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
 
@@ -1368,8 +1368,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    static bool treeContainsCall(TR::TreeTop * treeTop);
 
    // IA32 only?
-   int32_t arrayInitMinimumNumberOfBytes() {return 8;}
-   
+   virtual int32_t arrayInitMinimumNumberOfBytes() {return 8;}
+
    void addCountersToEdges(TR::Block *block);
 
    bool getSupportsBitOpCodes() {return false;}
@@ -1549,7 +1549,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool getSupportsScaledIndexAddressing() { return _flags1.testAny(SupportsScaledIndexAddressing); }
    void setSupportsScaledIndexAddressing() { _flags1.set(SupportsScaledIndexAddressing); }
 
-   bool isAddressScaleIndexSupported(int32_t scale) { return false; }
+   virtual bool isAddressScaleIndexSupported(int32_t scale) { return false; }
 
    bool getSupportsConstantOffsetInAddressing(int64_t value);
    bool getSupportsConstantOffsetInAddressing() { return _flags3.testAny(SupportsConstantOffsetInAddressing); }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -433,7 +433,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    void prepareNodeForInstructionSelection(TR::Node*node);
    void remapGCIndicesInInternalPtrFormat();
-   void processRelocations();
+   virtual void processRelocations();
 
    void findAndFixCommonedReferences();
    void findCommonedReferences(TR::Node*node, TR::TreeTop *treeTop);
@@ -584,7 +584,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void cleanupFlags(TR::Node*node);
 
    virtual bool shouldYankCompressedRefs() { return false; }
-   bool materializesHeapBase() { return true; }
+   virtual bool materializesHeapBase() { return true; }
    virtual bool canFoldLargeOffsetInAddressing() { return false; }
 
    void insertDebugCounters();
@@ -651,7 +651,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual uint8_t getSizeOfCombinedBuffer() {return 0;}
 
-   bool doRematerialization() {return false;}
+   virtual bool doRematerialization() {return false;}
 
    // --------------------------------------------------------------------------
    // Architecture, not code generator
@@ -665,7 +665,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual bool supportsSinglePrecisionSQRT() {return false;}
    virtual bool supportsFusedMultiplyAdd() {return false;}
-   bool supportsNegativeFusedMultiplyAdd() {return false;}
+   virtual bool supportsNegativeFusedMultiplyAdd() {return false;}
 
    virtual bool supportsComplexAddressing() {return false;}
    virtual bool canBeAffectedByStoreTagStalls() { return false; }
@@ -1196,7 +1196,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    virtual void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
-   void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
+   virtual void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    virtual void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
    bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1357,7 +1357,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool supportsLengthMinusOneForMemoryOpts() {return false;}
 
    // Java, likely Z
-   bool supportsTrapsInTMRegion() { return true; }
+   virtual bool supportsTrapsInTMRegion() { return true; }
 
    // Allows a platform code generator to assert that a particular node operation will use 64 bit values
    // that are not explicitly present in the node datatype.

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -484,7 +484,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void startUsingRegister(TR::Register *reg);
    void stopUsingRegister(TR::Register *reg);
 
-   void setCurrentBlockIndex(int32_t blockIndex) { }
+   virtual void setCurrentBlockIndex(int32_t blockIndex) { }
    int32_t getCurrentBlockIndex() { return -1; }
 
    TR::Instruction *lastInstructionBeforeCurrentEvaluationTreeTop()
@@ -647,7 +647,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool getSupportsProfiledInlining() { return _flags4.testAny(SupportsProfiledInlining);}
    void setSupportsProfiledInlining() { _flags4.set(SupportsProfiledInlining);}
    virtual bool supportsInliningOfIsInstance() {return false;}
-   bool supportsPassThroughCopyToNewVirtualRegister() { return false; }
+   virtual bool supportsPassThroughCopyToNewVirtualRegister() { return false; }
 
    virtual uint8_t getSizeOfCombinedBuffer() {return 0;}
 
@@ -672,7 +672,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    bool isMaterialized(TR::Node *);
    virtual bool shouldValueBeInACommonedNode(int64_t) { return false; }
-   bool materializesLargeConstants() { return false; }
+   virtual bool materializesLargeConstants() { return false; }
 
    bool canUseImmedInstruction(int64_t v) {return false;}
    virtual bool needsNormalizationBeforeShifts() { return false; }
@@ -717,7 +717,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // --------------------------------------------------------------------------
    // FE capability, not code generator
    //
-   bool internalPointerSupportImplemented() {return false;}
+   virtual bool internalPointerSupportImplemented() {return false;}
    bool supportsInternalPointers();
 
    // --------------------------------------------------------------------------
@@ -935,7 +935,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters) {}
    virtual void setUnavailableRegistersUsage(TR_Array<TR_BitVector>  & liveOnEntryUsage, TR_Array<TR_BitVector>   & liveOnExitUsage) {}
 
-   virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
+   virtual virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
@@ -1128,7 +1128,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    //
    void emitDataSnippets() {}
    virtual bool hasDataSnippets() {return false;}
-   int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
+   virtual int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
 
    // --------------------------------------------------------------------------
    // Register pressure
@@ -1280,7 +1280,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget);
 
    // TO TransformUtil.  Make platform specific
-   int32_t arrayTranslateAndTestMinimumNumberOfIterations();
+   virtual int32_t arrayTranslateAndTestMinimumNumberOfIterations();
    static int32_t defaultArrayTranslateMinimumNumberOfIterations(const char *methodName);
    static bool useOldArrayTranslateMinimumNumberOfIterations()
       {
@@ -1291,7 +1291,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // the following functions evaluate whether a codegen for the node or for static
    // symbol reference requires entry in the literal pool
    virtual bool arithmeticNeedsLiteralFromPool(TR::Node *node) { return false; }
-   bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child) { return false; }
+   virtual bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child) { return false; }
    bool bndsChkNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual void setOnDemandLiteralPoolRun(bool answer) {}
@@ -1361,7 +1361,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    // Allows a platform code generator to assert that a particular node operation will use 64 bit values
    // that are not explicitly present in the node datatype.
-   bool usesImplicit64BitGPRs(TR::Node *node) { return false; }
+   virtual bool usesImplicit64BitGPRs(TR::Node *node) { return false; }
 
    // General utility?
    static bool treeContainsCall(TR::TreeTop * treeTop);

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -299,7 +299,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    TR::TreeTop *lowerTree(TR::Node *root, TR::TreeTop *tt);
    void lowerTrees();
-   void lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
+   virtual void lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
    void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
@@ -664,7 +664,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool opCodeIsNoOpOnThisPlatform(TR::ILOpCode &opCode) {return false;}
 
    virtual bool supportsSinglePrecisionSQRT() {return false;}
-   bool supportsFusedMultiplyAdd() {return false;}
+   virtual bool supportsFusedMultiplyAdd() {return false;}
    bool supportsNegativeFusedMultiplyAdd() {return false;}
 
    bool supportsComplexAddressing() {return false;}
@@ -937,7 +937,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
-   int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }t
+   virtual int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *) { return INT_MAX; }
    virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block);
    virtual int32_t getMaximumNumbersOfAssignableGPRs() { return INT_MAX; }
    int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }
@@ -955,7 +955,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool considerTypeForGRA(TR::DataType dt) {return true;}
    virtual bool considerTypeForGRA(TR::SymbolReference *symRef) {return true;}
 
-   void enableLiteralPoolRegisterForGRA () {}
+   virtual void enableLiteralPoolRegisterForGRA () {}
    virtual bool excludeInvariantsFromGRAEnabled() { return false; }
 
    TR_BitVector *getBlocksWithCalls();
@@ -1292,7 +1292,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // symbol reference requires entry in the literal pool
    virtual bool arithmeticNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child) { return false; }
-   bool bndsChkNeedsLiteralFromPool(TR::Node *node) { return false; }
+   virtual bool bndsChkNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual void setOnDemandLiteralPoolRun(bool answer) {}
    virtual bool isLiteralPoolOnDemandOn () { return false; }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1645,6 +1645,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    protected:
 
    CodeGenerator();
+   void continueConstruction();
 
    enum // _flags1
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -943,7 +943,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    int32_t getMaximumNumbersOfAssignableFPRs() { return INT_MAX; }
    virtual int32_t getMaximumNumbersOfAssignableVRs()  { return INT_MAX; }
    virtual bool willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR::Compilation *comp){ return true;}
-   bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber, TR::DataType) { return true; }
+   virtual bool isGlobalRegisterAvailable(TR_GlobalRegisterNumber, TR::DataType) { return true; }
 
    bool areAssignableGPRsScarce();
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -315,7 +315,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    void doInstructionSelection();
    void createStackAtlas();
 
-   void beginInstructionSelection() {}
+   virtual void beginInstructionSelection() {}
    void endInstructionSelection() {}
 
    bool use64BitRegsOn32Bit();
@@ -680,7 +680,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    uint32_t getNumberBytesReadInaccessible() { return _numberBytesReadInaccessible; }
    uint32_t getNumberBytesWriteInaccessible() { return _numberBytesWriteInaccessible; }
 
-   bool codegenSupportsUnsignedIntegerDivide() {return false;}
+   virtual bool codegenSupportsUnsignedIntegerDivide() {return false;}
    virtual bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);
 
    virtual bool codegenSupportsLoadlessBNDCheck() {return false;}
@@ -922,7 +922,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    bool is8BitGlobalGPR(TR_GlobalRegisterNumber n) {return n <= _last8BitGlobalGPR;}
 
    TR_GlobalRegisterNumber getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type){ return -1; }
-   TR_BitVector *getGlobalGPRsPreservedAcrossCalls(){ return NULL; }
+   virtual TR_BitVector *getGlobalGPRsPreservedAcrossCalls(){ return NULL; }
    virtual TR_BitVector *getGlobalFPRsPreservedAcrossCalls(){ return NULL; }
 
    int32_t getFirstBit(TR_BitVector &bv);
@@ -1099,8 +1099,8 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label,int8_t d, bool isInstrOffset = false);
    virtual void apply24BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
    void apply16BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
-   void apply32BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
-   void apply64BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *);
+   virtual void apply32BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
+   virtual void apply64BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *);
    virtual void apply32BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
    virtual void apply32BitLabelTableRelocation(int32_t * cursor, TR::LabelSymbol *);
 
@@ -1121,7 +1121,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // Local snippet sharing facility: most RISC platforms can make use of it. The platform
    // specific code generators should override isSnippetMatched if they choose to use it.
    TR::LabelSymbol * lookUpSnippet(int32_t snippetKind, TR::SymbolReference *symRef);
-   bool isSnippetMatched(TR::Snippet *snippet, int32_t snippetKind, TR::SymbolReference *symRef) {return false;}
+   virtual bool isSnippetMatched(TR::Snippet *snippet, int32_t snippetKind, TR::SymbolReference *symRef) {return false;}
 
    // called to emit any constant data snippets.  The platform specific code generators
    // should override these methods if they use constant data snippets.
@@ -1210,7 +1210,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool isRotateAndMask(TR::Node *node) { return false; }
 
    virtual TR::Instruction *generateNop(TR::Node *node, TR::Instruction *instruction=0, TR_NOPKind nopKind=TR_NOPStandard);
-   bool isOutOfLineHotPath() { TR_ASSERT(0, "isOutOfLineHotPath is only implemented for 390 and ppc"); return false;}
+   virtual bool isOutOfLineHotPath() { TR_ASSERT(0, "isOutOfLineHotPath is only implemented for 390 and ppc"); return false;}
 
    //Rather confusingly not used -only- in BCD related codegen.
    //... has leaked into non-BCD code.
@@ -1296,7 +1296,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool constLoadNeedsLiteralFromPool(TR::Node *node) { return false; }
    virtual void setOnDemandLiteralPoolRun(bool answer) {}
    virtual bool isLiteralPoolOnDemandOn () { return false; }
-   bool supportsOnDemandLiteralPool() { return false; }
+   virtual bool supportsOnDemandLiteralPool() { return false; }
    virtual bool supportsDirectIntegralLoadStoresFromLiteralPool() { return false; }
    virtual bool supportsHighWordFacility() { return false; }
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -294,7 +294,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    void uncommonCallConstNodes();
 
-   void preLowerTrees();
+   virtual void preLowerTrees();
    void postLowerTrees() {}
 
    virtual TR::TreeTop *lowerTree(TR::Node *root, TR::TreeTop *tt);
@@ -304,19 +304,19 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void lowerTreeIfNeeded(TR::Node *node, int32_t childNumber, TR::Node *parent, TR::TreeTop *tt);
 
    virtual void lowerTreesPreTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
-   void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
+   virtual void lowerTreesPostTreeTopVisit(TR::TreeTop *tt, vcount_t visitCount);
 
    virtual void lowerTreesPreChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
-   void lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
+   virtual void lowerTreesPostChildrenVisit(TR::Node * parent, TR::TreeTop * treeTop, vcount_t visitCount);
 
    virtual void lowerTreesPropagateBlockToNode(TR::Node *node);
 
    virtual void setUpForInstructionSelection();
-   void doInstructionSelection();
+   virtual void doInstructionSelection();
    virtual void createStackAtlas();
 
    virtual void beginInstructionSelection() {}
-   void endInstructionSelection() {}
+   virtual void endInstructionSelection() {}
 
    bool use64BitRegsOn32Bit();
 
@@ -378,7 +378,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void setNextAvailableBlockIndex(int32_t blockIndex) {}
    virtual int32_t getNextAvailableBlockIndex() { return -1; }
 
-   bool supportsMethodEntryPadding() { return true; }
+   virtual bool supportsMethodEntryPadding() { return true; }
    virtual bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
    virtual bool buildInterpreterEntryPoint() { return false; }
    virtual void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
@@ -401,7 +401,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
       return false;
       }
 
-   bool hasTMEvaluator()    {return false;}
+   virtual bool hasTMEvaluator()    {return false;}
 
    // --------------------------------------------------------------------------
    // Infrastructure
@@ -674,7 +674,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual bool shouldValueBeInACommonedNode(int64_t) { return false; }
    virtual bool materializesLargeConstants() { return false; }
 
-   bool canUseImmedInstruction(int64_t v) {return false;}
+   virtual bool canUseImmedInstruction(int64_t v) {return false;}
    virtual bool needsNormalizationBeforeShifts() { return false; }
 
    uint32_t getNumberBytesReadInaccessible() { return _numberBytesReadInaccessible; }
@@ -798,7 +798,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    uint8_t * allocateCodeMemory(uint32_t size, bool isCold, bool isMethodHeaderNeeded=true);
    uint8_t * allocateCodeMemory(uint32_t warmSize, uint32_t coldSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
    void  resizeCodeMemory();
-   void  registerAssumptions() {}
+   virtual void  registerAssumptions() {}
 
    static void syncCode(uint8_t *codeStart, uint32_t codeSize);
 
@@ -1098,7 +1098,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label);
    virtual void apply16BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol * label,int8_t d, bool isInstrOffset = false);
    virtual void apply24BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
-   void apply16BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
+   virtual void apply16BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
    virtual void apply32BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *, TR::LabelSymbol *, int32_t);
    virtual void apply64BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *);
    virtual void apply32BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
@@ -1106,7 +1106,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    TR::list<TR_Pair<TR_ResolvedMethod,TR::Instruction> *> &getJNICallSites() { return _jniCallSites; }  // registerAssumptions()
 
-   bool needClassAndMethodPointerRelocations() { return false; }
+   virtual bool needClassAndMethodPointerRelocations() { return false; }
    virtual bool needRelocationsForStatics() { return false; }
    bool needRelocationsForBodyInfoData() { return false; }
    bool needRelocationsForPersistentInfoData() { return false; }
@@ -1126,7 +1126,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    // called to emit any constant data snippets.  The platform specific code generators
    // should override these methods if they use constant data snippets.
    //
-   void emitDataSnippets() {}
+   virtual void emitDataSnippets() {}
    virtual bool hasDataSnippets() {return false;}
    virtual int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart) {return 0;}
 
@@ -1197,9 +1197,9 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
    virtual void jitAddPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    virtual void jitAdd32BitPicToPatchOnClassUnload(void *classPointer, void *addressToBePatched) {}
    virtual void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
-   void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
+   virtual void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePatched, bool unresolved = false) {}
    virtual void jitAddUnresolvedAddressMaterializationToPatchOnClassRedefinition(void *firstInstruction) {} //J9
-   bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9
+   virtual bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const TR::Node *forNode) { return false; } //J9
    bool wantToPatchClassPointer(const TR_OpaqueClassBlock *allegedClassPointer, const uint8_t *inCodeAt) { return false; } //J9
 
    // --------------------------------------------------------------------------
@@ -1371,7 +1371,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator
 
    void addCountersToEdges(TR::Block *block);
 
-   bool getSupportsBitOpCodes() {return false;}
+   virtual bool getSupportsBitOpCodes() {return false;}
 
    bool getMappingAutomatics() {return _flags1.testAny(MappingAutomatics);}
    void setMappingAutomatics() {_flags1.set(MappingAutomatics);}

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -186,7 +186,9 @@ OMR::Compilation::getHotnessName(TR_Hotness h)
 
 static TR::CodeGenerator * allocateCodeGenerator(TR::Compilation * comp)
    {
-   return new (comp->trHeapMemory()) TR::CodeGenerator();
+   TR::CodeGenerator* result = new (comp->trHeapMemory()) TR::CodeGenerator();
+   result->continueConstruction();
+   return result;
    }
 
 

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -187,7 +187,7 @@ OMR::Compilation::getHotnessName(TR_Hotness h)
 static TR::CodeGenerator * allocateCodeGenerator(TR::Compilation * comp)
    {
    TR::CodeGenerator* result = new (comp->trHeapMemory()) TR::CodeGenerator();
-   result->continueConstruction();
+   result->initializeConstruction();
    return result;
    }
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1858,7 +1858,7 @@ OMR::Node::duplicateTree_DEPRECATED(bool duplicateChildren)
          }
       else
          {
-         newRoot->setGlobalRegisterNumber(getGlobalRegisterNumber());
+         newRoot->setGlobalRegisterNumber(self()->getGlobalRegisterNumber());
          }
       }
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1858,7 +1858,7 @@ OMR::Node::duplicateTree_DEPRECATED(bool duplicateChildren)
          }
       else
          {
-         newRoot->setGlobalRegisterNumber(self()->getGlobalRegisterNumber());
+         newRoot->setGlobalRegisterNumber(getGlobalRegisterNumber());
          }
       }
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -122,6 +122,12 @@ OMR::Power::CodeGenerator::CodeGenerator() :
      conversionBuffer(NULL),
      _outOfLineCodeSectionList(getTypedAllocator<TR_PPCOutOfLineCodeSection*>(self()->comp()->allocator()))
    {
+   
+   }
+
+void
+OMR::Power::CodeGenerator::continueConstruction()
+   {
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1672,7 +1672,7 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
    TR_PPCBinaryEncodingData data;
    data.estimate = 0;
 
-   self()->generateBinaryEncodingPrologue(&data);
+   generateBinaryEncodingPrologue(&data);
 
    bool skipOneReturn = false;
    while (data.cursorInstruction)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -559,7 +559,7 @@ void OMR::Power::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAss
 
       self()->tracePreRAInstruction(instructionCursor);
 
-      self()->setCurrentBlockIndex(instructionCursor->getBlockIndex());
+      setCurrentBlockIndex(instructionCursor->getBlockIndex());
 
       instructionCursor->assignRegisters(TR_GPR);
 
@@ -1528,7 +1528,7 @@ void OMR::Power::CodeGenerator::doPeephole()
 
    while (instructionCursor)
       {
-      self()->setCurrentBlockIndex(instructionCursor->getBlockIndex());
+      setCurrentBlockIndex(instructionCursor->getBlockIndex());
 
       if ((TR::Compiler->target.cpu.id() == TR_PPCp6) && instructionCursor->isTrap())
          {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -126,7 +126,7 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    }
 
 void
-OMR::Power::CodeGenerator::continueConstruction()
+OMR::Power::CodeGenerator::initializeConstruction()
    {
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -620,13 +620,13 @@ TR::Instruction *OMR::Power::CodeGenerator::generateGroupEndingNop(TR::Node *nod
    {
    if (TR::Compiler->target.cpu.id() >= TR_PPCp6) // handles P7, P8
       {
-      preced = self()->generateNop(node , preced , TR_NOPEndGroup);
+      preced = generateNop(node , preced , TR_NOPEndGroup);
       }
    else
       {
-      preced = self()->generateNop(node , preced);
-      preced = self()->generateNop(node , preced);
-      preced = self()->generateNop(node , preced);
+      preced = generateNop(node , preced);
+      preced = generateNop(node , preced);
+      preced = generateNop(node , preced);
       }
 
    return preced;
@@ -634,7 +634,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateGroupEndingNop(TR::Node *nod
 
 TR::Instruction *OMR::Power::CodeGenerator::generateProbeNop(TR::Node *node , TR::Instruction *preced)
    {
-   preced = self()->generateNop(node , preced , TR_ProbeNOP);
+   preced = generateNop(node , preced , TR_ProbeNOP);
    return preced;
    }
 
@@ -1731,14 +1731,14 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
                {
                if (TR::Compiler->target.cpu.id() >= TR_PPCp6)
                   {
-                  nop = self()->generateNop(data.cursorInstruction->getNode(), data.cursorInstruction->getPrev(), TR_NOPEndGroup); // handles P6, P7
+                  nop = generateNop(data.cursorInstruction->getNode(), data.cursorInstruction->getPrev(), TR_NOPEndGroup); // handles P6, P7
                   nop->setNext(data.cursorInstruction);
                   data.cursorInstruction = nop;
                   uselessFetched++;
                   }
                for (; uselessFetched < 8; uselessFetched++)
                   {
-                  nop = self()->generateNop(data.cursorInstruction->getNode(), data.cursorInstruction->getPrev(), TR_NOPStandard);
+                  nop = generateNop(data.cursorInstruction->getNode(), data.cursorInstruction->getPrev(), TR_NOPStandard);
                   nop->setNext(data.cursorInstruction);
                   data.cursorInstruction = nop;
                   }

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2912,7 +2912,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
       {
       TR::Register *deltaReg = self()->allocateRegister();
       cursor = loadConstant(self(), node, delta, deltaReg, cursor);
-      cursor = self()->generateDebugCounterBump(cursor, counter, deltaReg, cond);
+      cursor = generateDebugCounterBump(cursor, counter, deltaReg, cond);
       if (cond)
          {
          addDependency(cond, deltaReg, TR::RealRegister::NoReg, TR_GPR, self());
@@ -2986,7 +2986,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
       {
       TR::Register *deltaReg = srm.findOrCreateScratchRegister();
       cursor = loadConstant(self(), node, delta, deltaReg, cursor);
-      cursor = self()->generateDebugCounterBump(cursor, counter, deltaReg, srm);
+      cursor = generateDebugCounterBump(cursor, counter, deltaReg, srm);
       srm.reclaimScratchRegister(deltaReg);
       return cursor;
       }

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -118,9 +118,9 @@ OMR::Power::CodeGenerator::CodeGenerator() :
      _stackPtrRegister(NULL),
      _constantData(NULL),
      _blockCallInfo(NULL),
-     _transientLongRegisters(self()->trMemory()),
+     _transientLongRegisters(trMemory()),
      conversionBuffer(NULL),
-     _outOfLineCodeSectionList(getTypedAllocator<TR_PPCOutOfLineCodeSection*>(self()->comp()->allocator()))
+     _outOfLineCodeSectionList(getTypedAllocator<TR_PPCOutOfLineCodeSection*>(comp()->allocator()))
    {
    
    }
@@ -129,39 +129,39 @@ void
 OMR::Power::CodeGenerator::initializeConstruction()
    {
    // Initialize Linkage for Code Generator
-   self()->initializeLinkage();
+   initializeLinkage();
 
    _unlatchedRegisterList =
-      (TR::RealRegister**)self()->trMemory()->allocateHeapMemory(sizeof(TR::RealRegister*)*(TR::RealRegister::NumRegisters + 1));
+      (TR::RealRegister**)trMemory()->allocateHeapMemory(sizeof(TR::RealRegister*)*(TR::RealRegister::NumRegisters + 1));
 
    _unlatchedRegisterList[0] = 0; // mark that list is empty
 
-   _linkageProperties = &self()->getLinkage()->getProperties();
+   _linkageProperties = &getLinkage()->getProperties();
 
    // Set up to collect items for later TOC mapping
    if (TR::Compiler->target.is64Bit())
       {
-      self()->setTrackStatics(new (self()->trHeapMemory()) TR_Array<TR::SymbolReference *>(self()->trMemory()));
-      self()->setTrackItems(new (self()->trHeapMemory()) TR_Array<TR_PPCLoadLabelItem *>(self()->trMemory()));
+      setTrackStatics(new (trHeapMemory()) TR_Array<TR::SymbolReference *>(trMemory()));
+      setTrackItems(new (trHeapMemory()) TR_Array<TR_PPCLoadLabelItem *>(trMemory()));
       }
    else
       {
-      self()->setTrackStatics(NULL);
-      self()->setTrackItems(NULL);
+      setTrackStatics(NULL);
+      setTrackItems(NULL);
       }
 
-   self()->setStackPointerRegister(self()->machine()->getPPCRealRegister(_linkageProperties->getNormalStackPointerRegister()));
-   self()->setMethodMetaDataRegister(self()->machine()->getPPCRealRegister(_linkageProperties->getMethodMetaDataRegister()));
-   self()->setTOCBaseRegister(self()->machine()->getPPCRealRegister(_linkageProperties->getTOCBaseRegister()));
-   self()->getLinkage()->initPPCRealRegisterLinkage();
-   self()->getLinkage()->setParameterLinkageRegisterIndex(self()->comp()->getJittedMethodSymbol());
-   self()->machine()->initREGAssociations();
+   setStackPointerRegister(machine()->getPPCRealRegister(_linkageProperties->getNormalStackPointerRegister()));
+   setMethodMetaDataRegister(machine()->getPPCRealRegister(_linkageProperties->getMethodMetaDataRegister()));
+   setTOCBaseRegister(machine()->getPPCRealRegister(_linkageProperties->getTOCBaseRegister()));
+   getLinkage()->initPPCRealRegisterLinkage();
+   getLinkage()->setParameterLinkageRegisterIndex(comp()->getJittedMethodSymbol());
+   machine()->initREGAssociations();
 
    // Tactical GRA settings.
    //
-   self()->setGlobalGPRPartitionLimit(TR::Machine::getGlobalGPRPartitionLimit());
-   self()->setGlobalFPRPartitionLimit(TR::Machine::getGlobalFPRPartitionLimit());
-   self()->setGlobalRegisterTable(_linkageProperties->getRegisterAllocationOrder());
+   setGlobalGPRPartitionLimit(TR::Machine::getGlobalGPRPartitionLimit());
+   setGlobalFPRPartitionLimit(TR::Machine::getGlobalFPRPartitionLimit());
+   setGlobalRegisterTable(_linkageProperties->getRegisterAllocationOrder());
    _numGPR = _linkageProperties->getNumAllocatableIntegerRegisters();
    _firstGPR = 0;
    _lastGPR = _numGPR - 1;
@@ -172,60 +172,60 @@ OMR::Power::CodeGenerator::initializeConstruction()
    _lastFPR = _firstFPR + _numFPR - 1;
    _firstParmFPR = _linkageProperties->getFirstAllocatableFloatArgumentRegister();
    _lastVolatileFPR = _linkageProperties->getLastAllocatableFloatVolatileRegister();
-   self()->setLastGlobalGPR(_lastGPR);
-   self()->setLast8BitGlobalGPR(_lastGPR);
-   self()->setLastGlobalFPR(_lastFPR);
+   setLastGlobalGPR(_lastGPR);
+   setLast8BitGlobalGPR(_lastGPR);
+   setLastGlobalFPR(_lastFPR);
 
    _numVRF = _linkageProperties->getNumAllocatableVectorRegisters();
-   self()->setFirstGlobalVRF(_lastFPR + 1);
-   self()->setLastGlobalVRF(_lastFPR + _numVRF);
+   setFirstGlobalVRF(_lastFPR + 1);
+   setLastGlobalVRF(_lastFPR + _numVRF);
 
-   self()->setSupportsGlRegDeps();
-   self()->setSupportsGlRegDepOnFirstBlock();
+   setSupportsGlRegDeps();
+   setSupportsGlRegDepOnFirstBlock();
 
    if (TR::Compiler->target.is32Bit())
-      self()->setUsesRegisterPairsForLongs();
+      setUsesRegisterPairsForLongs();
 
-   self()->setPerformsChecksExplicitly();
-   self()->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
+   setPerformsChecksExplicitly();
+   setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
 
-   self()->setEnableRefinedAliasSets();
+   setEnableRefinedAliasSets();
 
    static char * accessStaticsIndirectly = feGetEnv("TR_AccessStaticsIndirectly");
    if (accessStaticsIndirectly)
-      self()->setAccessStaticsIndirectly(true);
+      setAccessStaticsIndirectly(true);
 
    if (!debug("noLiveRegisters"))
       {
-      self()->addSupportedLiveRegisterKind(TR_GPR);
-      self()->addSupportedLiveRegisterKind(TR_FPR);
-      self()->addSupportedLiveRegisterKind(TR_CCR);
-      self()->addSupportedLiveRegisterKind(TR_VSX_SCALAR);
-      self()->addSupportedLiveRegisterKind(TR_VSX_VECTOR);
-      self()->addSupportedLiveRegisterKind(TR_VRF);
+      addSupportedLiveRegisterKind(TR_GPR);
+      addSupportedLiveRegisterKind(TR_FPR);
+      addSupportedLiveRegisterKind(TR_CCR);
+      addSupportedLiveRegisterKind(TR_VSX_SCALAR);
+      addSupportedLiveRegisterKind(TR_VSX_VECTOR);
+      addSupportedLiveRegisterKind(TR_VRF);
 
-      self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_GPR);
-      self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_FPR);
-      self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_CCR);
-      self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_VRF);
-      self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_VSX_SCALAR);
-      self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(self()->comp()), TR_VSX_VECTOR);
+      setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp()), TR_GPR);
+      setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp()), TR_FPR);
+      setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp()), TR_CCR);
+      setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp()), TR_VRF);
+      setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp()), TR_VSX_SCALAR);
+      setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp()), TR_VSX_VECTOR);
       }
 
 
-    self()->setSupportsConstantOffsetInAddressing();
-    self()->setSupportsVirtualGuardNOPing();
-    self()->setSupportsPrimitiveArrayCopy();
-    self()->setSupportsReferenceArrayCopy();
+    setSupportsConstantOffsetInAddressing();
+    setSupportsVirtualGuardNOPing();
+    setSupportsPrimitiveArrayCopy();
+    setSupportsReferenceArrayCopy();
 
     // disabled for now
     //
-    if (self()->comp()->getOption(TR_AggressiveOpts) &&
-        !self()->comp()->getOption(TR_DisableArraySetOpts))
+    if (comp()->getOption(TR_AggressiveOpts) &&
+        !comp()->getOption(TR_DisableArraySetOpts))
        {
-       self()->setSupportsArraySet();
+       setSupportsArraySet();
        }
-    self()->setSupportsArrayCmp();
+    setSupportsArrayCmp();
 
     if (TR::Compiler->target.cpu.getPPCSupportsVSX())
        {
@@ -235,17 +235,17 @@ OMR::Power::CodeGenerator::initializeConstruction()
        static bool disablePPCTROTNoBreak = (feGetEnv("TR_disablePPCTROTNoBreak") != NULL);
 
        if (!disablePPCTRTO)
-          self()->setSupportsArrayTranslateTRTO();
+          setSupportsArrayTranslateTRTO();
 #ifndef __LITTLE_ENDIAN__
        else if (!disablePPCTRTO255)
           setSupportsArrayTranslateTRTO255();
 #endif
 
        if (!disablePPCTROT)
-          self()->setSupportsArrayTranslateTROT();
+          setSupportsArrayTranslateTROT();
 
        if (!disablePPCTROTNoBreak)
-          self()->setSupportsArrayTranslateTROTNoBreak();
+          setSupportsArrayTranslateTROTNoBreak();
        }
 
    _numberBytesReadInaccessible = 0;
@@ -253,13 +253,13 @@ OMR::Power::CodeGenerator::initializeConstruction()
 
    // Poorly named.  Not necessarily Java specific.
    //
-   self()->setSupportsJavaFloatSemantics();
+   setSupportsJavaFloatSemantics();
 
-   self()->setSupportsDivCheck();
-   self()->setSupportsLoweringConstIDiv();
+   setSupportsDivCheck();
+   setSupportsLoweringConstIDiv();
    if (TR::Compiler->target.is64Bit())
-      self()->setSupportsLoweringConstLDiv();
-   self()->setSupportsLoweringConstLDivPower2();
+      setSupportsLoweringConstLDiv();
+   setSupportsLoweringConstLDivPower2();
 
    static bool disableDCAS = (feGetEnv("TR_DisablePPCDCAS") != NULL);
 
@@ -267,63 +267,63 @@ OMR::Power::CodeGenerator::initializeConstruction()
        TR::Compiler->target.is64Bit() &&
        TR::Options::useCompressedPointers())
       {
-      self()->setSupportsDoubleWordCAS();
-      self()->setSupportsDoubleWordSet();
+      setSupportsDoubleWordCAS();
+      setSupportsDoubleWordSet();
       }
 
-   if (self()->is64BitProcessor())
-      self()->setSupportsInlinedAtomicLongVolatiles();
+   if (is64BitProcessor())
+      setSupportsInlinedAtomicLongVolatiles();
 
    // Standard allows only offset multiple of 4
    // TODO: either improves the query to be size-based or gets the offset into a register
    if (TR::Compiler->target.is64Bit())
-      self()->setSupportsAlignedAccessOnly();
+      setSupportsAlignedAccessOnly();
 
    // TODO: distinguishing among OOO and non-OOO implementations
    if (TR::Compiler->target.isSMP())
-      self()->setEnforceStoreOrder();
+      setEnforceStoreOrder();
 
-   if (TR::Compiler->vm.hasResumableTrapHandler(self()->comp()))
-      self()->setHasResumableTrapHandler();
+   if (TR::Compiler->vm.hasResumableTrapHandler(comp()))
+      setHasResumableTrapHandler();
 
-   if (TR::Compiler->target.cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM))
-      self()->setSupportsTM();
+   if (TR::Compiler->target.cpu.getPPCSupportsTM() && !comp()->getOption(TR_DisableTM))
+      setSupportsTM();
 
    // enable LM if hardware supports instructions and running the reduced-pause GC policy
    if (TR::Compiler->target.cpu.getPPCSupportsLM())
-      self()->setSupportsLM();
+      setSupportsLM();
 
-   if(self()->getSupportsTM())
-      self()->setSupportsTMHashMapAndLinkedQueue();
+   if(getSupportsTM())
+      setSupportsTMHashMapAndLinkedQueue();
 
    if (TR::Compiler->target.cpu.getPPCSupportsVMX() && TR::Compiler->target.cpu.getPPCSupportsVSX())
-      self()->setSupportsAutoSIMD();
+      setSupportsAutoSIMD();
 
    static bool disableTMDCAS = (feGetEnv("TR_DisablePPCTMDCAS") != NULL);
-   if (self()->getSupportsTM() && !disableTMDCAS &&
+   if (getSupportsTM() && !disableTMDCAS &&
        TR::Compiler->target.is64Bit() &&
        !TR::Options::useCompressedPointers())
       {
-      self()->setSupportsTMDoubleWordCASORSet();
+      setSupportsTMDoubleWordCASORSet();
       }
 
 
-   if (!self()->comp()->getOption(TR_DisableRegisterPressureSimulation))
+   if (!comp()->getOption(TR_DisableRegisterPressureSimulation))
       {
       for (int32_t i = 0; i < TR_numSpillKinds; i++)
-         _globalRegisterBitVectors[i].init(self()->getNumberOfGlobalRegisters(), self()->trMemory());
+         _globalRegisterBitVectors[i].init(getNumberOfGlobalRegisters(), trMemory());
 
-      for (TR_GlobalRegisterNumber grn=0; grn < self()->getNumberOfGlobalRegisters(); grn++)
+      for (TR_GlobalRegisterNumber grn=0; grn < getNumberOfGlobalRegisters(); grn++)
          {
-         TR::RealRegister::RegNum reg = (TR::RealRegister::RegNum)self()->getGlobalRegister(grn);
-         if (self()->getFirstGlobalGPR() <= grn && grn <= self()->getLastGlobalGPR())
+         TR::RealRegister::RegNum reg = (TR::RealRegister::RegNum)getGlobalRegister(grn);
+         if (getFirstGlobalGPR() <= grn && grn <= getLastGlobalGPR())
             _globalRegisterBitVectors[ TR_gprSpill ].set(grn);
-         else if (self()->getFirstGlobalFPR() <= grn && grn <= self()->getLastGlobalFPR())
+         else if (getFirstGlobalFPR() <= grn && grn <= getLastGlobalFPR())
             _globalRegisterBitVectors[ TR_fprSpill ].set(grn);
 
-         if (!self()->getProperties().getPreserved(reg))
+         if (!getProperties().getPreserved(reg))
             _globalRegisterBitVectors[ TR_volatileSpill ].set(grn);
-         if (self()->getProperties().getIntegerArgument(reg) || self()->getProperties().getFloatArgument(reg))
+         if (getProperties().getIntegerArgument(reg) || getProperties().getFloatArgument(reg))
             _globalRegisterBitVectors[ TR_linkageSpill  ].set(grn);
          }
 
@@ -335,48 +335,48 @@ OMR::Power::CodeGenerator::initializeConstruction()
    int i;
 
    TR_GlobalRegisterNumber globalRegNumbers[TR::RealRegister::NumRegisters];
-   for (i=0; i < self()->getNumberOfGlobalGPRs(); i++)
+   for (i=0; i < getNumberOfGlobalGPRs(); i++)
      {
-     grn = self()->getFirstGlobalGPR() + i;
-     globalRegNumbers[self()->getGlobalRegister(grn)] = grn;
+     grn = getFirstGlobalGPR() + i;
+     globalRegNumbers[getGlobalRegister(grn)] = grn;
      }
-   for (i=0; i < self()->getNumberOfGlobalFPRs(); i++)
+   for (i=0; i < getNumberOfGlobalFPRs(); i++)
      {
-     grn = self()->getFirstGlobalFPR() + i;
-     globalRegNumbers[self()->getGlobalRegister(grn)] = grn;
+     grn = getFirstGlobalFPR() + i;
+     globalRegNumbers[getGlobalRegister(grn)] = grn;
      }
 
    // Initialize linkage reg arrays
-   TR::PPCLinkageProperties linkageProperties = self()->getProperties();
+   TR::PPCLinkageProperties linkageProperties = getProperties();
    for (i=0; i < linkageProperties.getNumIntArgRegs(); i++)
      _gprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getIntegerArgumentRegister(i)];
    for (i=0; i < linkageProperties.getNumFloatArgRegs(); i++)
      _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[linkageProperties.getFloatArgumentRegister(i)];
 
-   if (self()->comp()->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
+   if (comp()->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
       {
-      self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_GPR));
-      self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_FPR));
+      setGPRegisterIterator(new (trHeapMemory()) TR::RegisterIterator(machine(), TR_GPR));
+      setFPRegisterIterator(new (trHeapMemory()) TR::RegisterIterator(machine(), TR_FPR));
       }
 
-   self()->setSupportsProfiledInlining();
+   setSupportsProfiledInlining();
 
-   TR_ResolvedMethod *method = self()->comp()->getJittedMethodSymbol()->getResolvedMethod();
-   TR_ReturnInfo      returnInfo = self()->getLinkage()->getReturnInfoFromReturnType(method->returnType());
-   self()->comp()->setReturnInfo(returnInfo);
+   TR_ResolvedMethod *method = comp()->getJittedMethodSymbol()->getResolvedMethod();
+   TR_ReturnInfo      returnInfo = getLinkage()->getReturnInfoFromReturnType(method->returnType());
+   comp()->setReturnInfo(returnInfo);
    }
 
 uintptrj_t *
 OMR::Power::CodeGenerator::getTOCBase()
     {
-        TR_PPCTableOfConstants *pTOC = toPPCTableOfConstants(self()->comp()->getPersistentInfo()->getPersistentTOC());
+        TR_PPCTableOfConstants *pTOC = toPPCTableOfConstants(comp()->getPersistentInfo()->getPersistentTOC());
         return pTOC->getTOCBase();
     }
 
 TR_PPCScratchRegisterManager*
 OMR::Power::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {
-   return new (self()->trHeapMemory()) TR_PPCScratchRegisterManager(capacity, self());
+   return new (trHeapMemory()) TR_PPCScratchRegisterManager(capacity, self());
    }
 
 // PPC codeGenerator hook for class unloading events
@@ -404,17 +404,17 @@ OMR::Power::CodeGenerator::generateSwitchToInterpreterPrePrologue(
       TR::Instruction *cursor,
       TR::Node *node)
    {
-   TR::Register   *gr0 = self()->machine()->getPPCRealRegister(TR::RealRegister::gr0);
-   TR::ResolvedMethodSymbol *methodSymbol = self()->comp()->getJittedMethodSymbol();
-   TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue, false, false, false);
+   TR::Register   *gr0 = machine()->getPPCRealRegister(TR::RealRegister::gr0);
+   TR::ResolvedMethodSymbol *methodSymbol = comp()->getJittedMethodSymbol();
+   TR::SymbolReference    *revertToInterpreterSymRef = symRefTab()->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue, false, false, false);
    uintptrj_t             ramMethod = (uintptrj_t)methodSymbol->getResolvedMethod()->resolvedMethodAddress();
-   TR::SymbolReference    *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(directToInterpreterHelper(methodSymbol, self()), false, false, false);
+   TR::SymbolReference    *helperSymRef = symRefTab()->findOrCreateRuntimeHelper(directToInterpreterHelper(methodSymbol, self()), false, false, false);
    uintptrj_t             helperAddr = (uintptrj_t)helperSymRef->getMethodAddress();
 
    // gr0 must contain the saved LR; see Recompilation.s
-   cursor = new (self()->trHeapMemory()) TR::PPCTrg1Instruction(TR::InstOpCode::mflr, node, gr0, cursor, self());
-   cursor = self()->getLinkage()->flushArguments(cursor);
-   cursor = generateDepImmSymInstruction(self(), TR::InstOpCode::bl, node, (uintptrj_t)revertToInterpreterSymRef->getMethodAddress(), new (self()->trHeapMemory()) TR::RegisterDependencyConditions(0,0, self()->trMemory()), revertToInterpreterSymRef, NULL, cursor);
+   cursor = new (trHeapMemory()) TR::PPCTrg1Instruction(TR::InstOpCode::mflr, node, gr0, cursor, self());
+   cursor = getLinkage()->flushArguments(cursor);
+   cursor = generateDepImmSymInstruction(self(), TR::InstOpCode::bl, node, (uintptrj_t)revertToInterpreterSymRef->getMethodAddress(), new (trHeapMemory()) TR::RegisterDependencyConditions(0,0, trMemory()), revertToInterpreterSymRef, NULL, cursor);
 
    if (TR::Compiler->target.is64Bit())
       {
@@ -429,8 +429,8 @@ OMR::Power::CodeGenerator::generateSwitchToInterpreterPrePrologue(
       cursor = generateImmInstruction(self(), TR::InstOpCode::dd, node, (int32_t)ramMethod, TR_RamMethod, cursor);
       }
 
-   if (self()->comp()->getOption(TR_EnableHCR))
-      self()->comp()->getStaticHCRPICSites()->push_front(cursor);
+   if (comp()->getOption(TR_EnableHCR))
+      comp()->getStaticHCRPICSites()->push_front(cursor);
 
   if (TR::Compiler->target.is64Bit())
      {
@@ -456,11 +456,11 @@ void
 OMR::Power::CodeGenerator::beginInstructionSelection()
    {
 
-   TR::Node *firstNode = self()->comp()->getStartTree()->getNode();
+   TR::Node *firstNode = comp()->getStartTree()->getNode();
    _returnTypeInfoInstruction = NULL;
-   if ((self()->comp()->getJittedMethodSymbol()->getLinkageConvention() == TR_Private))
+   if ((comp()->getJittedMethodSymbol()->getLinkageConvention() == TR_Private))
       {
-      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::PPCImmInstruction(TR::InstOpCode::dd, firstNode, 0, NULL, self());
+      _returnTypeInfoInstruction = new (trHeapMemory()) TR::PPCImmInstruction(TR::InstOpCode::dd, firstNode, 0, NULL, self());
       }
 
    generateAdminInstruction(self(), TR::InstOpCode::proc, firstNode);
@@ -471,7 +471,7 @@ OMR::Power::CodeGenerator::endInstructionSelection()
    {
    if (_returnTypeInfoInstruction != NULL)
       {
-      _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(self()->comp()->getReturnInfo()));
+      _returnTypeInfoInstruction->setSourceImmediate(static_cast<uint32_t>(comp()->getReturnInfo()));
       }
    }
 
@@ -480,7 +480,7 @@ OMR::Power::CodeGenerator::staticTracking(TR::SymbolReference *symRef)
    {
    if (TR::Compiler->target.is64Bit())
       {
-      TR_Array<TR::SymbolReference *> *symRefArray = self()->getTrackStatics();
+      TR_Array<TR::SymbolReference *> *symRefArray = getTrackStatics();
       int32_t idx;
 
       for (idx=0; idx<symRefArray->size(); idx++)
@@ -497,7 +497,7 @@ OMR::Power::CodeGenerator::itemTracking(
    {
    if (TR::Compiler->target.is64Bit())
       {
-      self()->getTrackItems()->add(new (self()->trHeapMemory()) TR_PPCLoadLabelItem(offset, label));
+      getTrackItems()->add(new (trHeapMemory()) TR_PPCLoadLabelItem(offset, label));
       }
    }
 
@@ -545,25 +545,25 @@ void OMR::Power::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAss
 
    // gprs, fprs, and ccrs are all assigned in backward direction
 
-   TR::Instruction *instructionCursor = self()->getAppendInstruction();
+   TR::Instruction *instructionCursor = getAppendInstruction();
 
    TR::Block *currBlock = NULL;
    TR::Instruction * currBBEndInstr = instructionCursor;
 
-   if (!self()->comp()->getOption(TR_DisableOOL))
+   if (!comp()->getOption(TR_DisableOOL))
       {
-      TR::list<TR::Register*> *spilledRegisterList = new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(self()->comp()->allocator()));
-      self()->setSpilledRegisterList(spilledRegisterList);
+      TR::list<TR::Register*> *spilledRegisterList = new (trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp()->allocator()));
+      setSpilledRegisterList(spilledRegisterList);
       }
 
-   if (self()->getDebug())
-      self()->getDebug()->startTracingRegisterAssignment();
+   if (getDebug())
+      getDebug()->startTracingRegisterAssignment();
 
    while (instructionCursor)
       {
       prevInstruction = instructionCursor->getPrev();
 
-      self()->tracePreRAInstruction(instructionCursor);
+      tracePreRAInstruction(instructionCursor);
 
       setCurrentBlockIndex(instructionCursor->getBlockIndex());
 
@@ -579,25 +579,25 @@ void OMR::Power::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAss
             {
             if (li->getLabelSymbol()->isStartInternalControlFlow())
                {
-               self()->decInternalControlFlowNestingDepth();
+               decInternalControlFlowNestingDepth();
                }
             if (li->getLabelSymbol()->isEndInternalControlFlow())
                {
-               self()->incInternalControlFlowNestingDepth();
+               incInternalControlFlowNestingDepth();
                }
             }
          }
 
-      self()->freeUnlatchedRegisters();
-      self()->buildGCMapsForInstructionAndSnippet(instructionCursor);
+      freeUnlatchedRegisters();
+      buildGCMapsForInstructionAndSnippet(instructionCursor);
 
-      self()->tracePostRAInstruction(instructionCursor);
+      tracePostRAInstruction(instructionCursor);
 
       instructionCursor = prevInstruction;
       }
 
-   if (self()->getDebug())
-      self()->getDebug()->stopTracingRegisterAssignment();
+   if (getDebug())
+      getDebug()->stopTracingRegisterAssignment();
    }
 
 TR::Instruction *OMR::Power::CodeGenerator::generateNop(TR::Node *n, TR::Instruction *preced, TR_NOPKind nopKind)
@@ -617,9 +617,9 @@ TR::Instruction *OMR::Power::CodeGenerator::generateNop(TR::Node *n, TR::Instruc
       }
 
    if (preced)
-      return new (self()->trHeapMemory()) TR::Instruction(nop, n, preced, self());
+      return new (trHeapMemory()) TR::Instruction(nop, n, preced, self());
    else
-      return new (self()->trHeapMemory()) TR::Instruction(nop, n,  self());
+      return new (trHeapMemory()) TR::Instruction(nop, n,  self());
    }
 
 TR::Instruction *OMR::Power::CodeGenerator::generateGroupEndingNop(TR::Node *node , TR::Instruction *preced)
@@ -1525,12 +1525,12 @@ void OMR::Power::CodeGenerator::doPeephole()
    if (disablePeephole)
       return;
 
-   int syncPeepholeWindow = self()->comp()->isOptServer() ? 12 : 6;
+   int syncPeepholeWindow = comp()->isOptServer() ? 12 : 6;
 
-   if (self()->comp()->getOptLevel() == noOpt)
+   if (comp()->getOptLevel() == noOpt)
       return;
 
-   TR::Instruction *instructionCursor = self()->getFirstInstruction();
+   TR::Instruction *instructionCursor = getFirstInstruction();
 
    while (instructionCursor)
       {
@@ -1600,7 +1600,7 @@ void OMR::Power::CodeGenerator::doPeephole()
 
 bool OMR::Power::CodeGenerator::supportsAESInstructions()
    {
-    if ( TR::Compiler->target.cpu.getPPCSupportsAES() && !self()->comp()->getOption(TR_DisableAESInHardware))
+    if ( TR::Compiler->target.cpu.getPPCSupportsAES() && !comp()->getOption(TR_DisableAESInHardware))
       return true;
     else
       return false;
@@ -1630,31 +1630,31 @@ OMR::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    switch (lc)
       {
       case TR_System:
-         linkage = new (self()->trHeapMemory()) TR::PPCSystemLinkage(self());
+         linkage = new (trHeapMemory()) TR::PPCSystemLinkage(self());
          break;
 
       default:
-         linkage = new (self()->trHeapMemory()) TR::PPCSystemLinkage(self());
+         linkage = new (trHeapMemory()) TR::PPCSystemLinkage(self());
       }
 
-   self()->setLinkage(lc, linkage);
+   setLinkage(lc, linkage);
    return linkage;
    }
 
 void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       TR_PPCBinaryEncodingData *data)
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    data->recomp = NULL;
-   data->cursorInstruction = self()->getFirstInstruction();
+   data->cursorInstruction = getFirstInstruction();
    data->preProcInstruction = data->cursorInstruction;
 
    data->jitTojitStart = data->cursorInstruction;
    data->cursorInstruction = NULL;
 
-   self()->getLinkage()->loadUpArguments(data->cursorInstruction);
+   getLinkage()->loadUpArguments(data->cursorInstruction);
 
-   data->cursorInstruction = self()->getFirstInstruction();
+   data->cursorInstruction = getFirstInstruction();
 
    while (data->cursorInstruction && data->cursorInstruction->getOpCodeValue() != TR::InstOpCode::proc)
       {
@@ -1666,11 +1666,11 @@ void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
    if (boundary && (boundary > 4) && ((boundary & (boundary - 1)) == 0))
       {
       comp->getOptions()->setJitMethodEntryAlignmentBoundary(boundary);
-      self()->setPreJitMethodEntrySize(data->estimate);
+      setPreJitMethodEntrySize(data->estimate);
       data->estimate += (boundary - 4);
       }
 
-   self()->getLinkage()->createPrologue(data->cursorInstruction);
+   getLinkage()->createPrologue(data->cursorInstruction);
    }
 
 void OMR::Power::CodeGenerator::doBinaryEncoding()
@@ -1688,7 +1688,7 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
          if (skipOneReturn == false)
             {
             TR::Instruction *temp = data.cursorInstruction->getPrev();
-            self()->getLinkage()->createEpilogue(temp);
+            getLinkage()->createEpilogue(temp);
             if (temp->getNext() != data.cursorInstruction)
                skipOneReturn = true;
             data.cursorInstruction = temp->getNext();
@@ -1702,25 +1702,25 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
       data.cursorInstruction = data.cursorInstruction->getNext();
       }
 
-   data.estimate = self()->setEstimatedLocationsForSnippetLabels(data.estimate);
+   data.estimate = setEstimatedLocationsForSnippetLabels(data.estimate);
    if (data.estimate > 32768)
       {
       data.estimate = identifyFarConditionalBranches(data.estimate, self());
       }
 
-   self()->setEstimatedCodeLength(data.estimate);
+   setEstimatedCodeLength(data.estimate);
 
-   data.cursorInstruction = self()->getFirstInstruction();
+   data.cursorInstruction = getFirstInstruction();
    uint8_t *coldCode = NULL;
-   uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
+   uint8_t *temp = allocateCodeMemory(getEstimatedCodeLength(), 0, &coldCode);
 
-   self()->setBinaryBufferStart(temp);
-   self()->setBinaryBufferCursor(temp);
-   self()->alignBinaryBufferCursor();
+   setBinaryBufferStart(temp);
+   setBinaryBufferCursor(temp);
+   alignBinaryBufferCursor();
 
    bool skipLabel = false;
 
-   bool  isPrivateLinkage = (self()->comp()->getJittedMethodSymbol()->getLinkageConvention() == TR_Private);
+   bool  isPrivateLinkage = (comp()->getJittedMethodSymbol()->getLinkageConvention() == TR_Private);
 
    uint8_t *start = temp;
 
@@ -1731,7 +1731,7 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
          if ((data.cursorInstruction)->isNopCandidate())
             {
             TR::Instruction *nop;
-            uintptrj_t uselessFetched = ((uintptrj_t)self()->getBinaryBufferCursor()/4)%8;
+            uintptrj_t uselessFetched = ((uintptrj_t)getBinaryBufferCursor()/4)%8;
 
             if (uselessFetched >= 8 - data.cursorInstruction->MAX_LOOP_ALIGN_NOPS())
                {
@@ -1757,28 +1757,28 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
             }
          }
 
-      self()->setBinaryBufferCursor(data.cursorInstruction->generateBinaryEncoding());
+      setBinaryBufferCursor(data.cursorInstruction->generateBinaryEncoding());
 
-      self()->addToAtlas(data.cursorInstruction);
+      addToAtlas(data.cursorInstruction);
 
       if (data.cursorInstruction == data.preProcInstruction)
          {
-         self()->setPrePrologueSize(self()->getBinaryBufferCursor() - self()->getBinaryBufferStart() - self()->getJitMethodEntryPaddingSize());
-         self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
+         setPrePrologueSize(getBinaryBufferCursor() - getBinaryBufferStart() - getJitMethodEntryPaddingSize());
+         comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(getBinaryBufferCursor());
          }
 
       data.cursorInstruction = data.cursorInstruction->getNext();
 
       if (isPrivateLinkage && data.cursorInstruction==data.jitTojitStart)
          {
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(self()->comp()->getReturnInfo());
+         uint32_t magicWord = ((getBinaryBufferCursor()-getCodeStart())<<16) | static_cast<uint32_t>(comp()->getReturnInfo());
 
          *(uint32_t *)(data.preProcInstruction->getBinaryEncoding()) = magicWord;
 
 #ifdef J9_PROJECT_SPECIFIC
          if (data.recomp!=NULL && data.recomp->couldBeCompiledAgain())
             {
-            TR_LinkageInfo *lkInfo = TR_LinkageInfo::get(self()->getCodeStart());
+            TR_LinkageInfo *lkInfo = TR_LinkageInfo::get(getCodeStart());
             if (data.recomp->useSampling())
                lkInfo->setSamplingMethodBody();
             else
@@ -1795,20 +1795,20 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
    if (TR::Compiler->target.is64Bit())
       {
       int32_t idx;
-      for (idx=0; idx<self()->getTrackItems()->size(); idx++)
-         TR_PPCTableOfConstants::setTOCSlot(self()->getTrackItems()->element(idx)->getTOCOffset(),
-            (uintptrj_t)self()->getTrackItems()->element(idx)->getLabel()->getCodeLocation());
+      for (idx=0; idx<getTrackItems()->size(); idx++)
+         TR_PPCTableOfConstants::setTOCSlot(getTrackItems()->element(idx)->getTOCOffset(),
+            (uintptrj_t)getTrackItems()->element(idx)->getLabel()->getCodeLocation());
       }
 
    // Create exception table entries for outlined instructions.
    //
-   if (!self()->comp()->getOption(TR_DisableOOL))
+   if (!comp()->getOption(TR_DisableOOL))
       {
-      auto oiIterator = self()->getPPCOutOfLineCodeSectionList().begin();
-      while (oiIterator != self()->getPPCOutOfLineCodeSectionList().end())
+      auto oiIterator = getPPCOutOfLineCodeSectionList().begin();
+      while (oiIterator != getPPCOutOfLineCodeSectionList().end())
          {
-         uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
-         uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
+         uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - getCodeStart();
+         uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - getCodeStart();
 
          TR::Block * block = (*oiIterator)->getBlock();
          bool needsETE = (*oiIterator)->getFirstInstruction()->getNode()->getOpCode().hasSymbolReference() &&
@@ -1827,16 +1827,16 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
 TR::Register *OMR::Power::CodeGenerator::gprClobberEvaluate(TR::Node *node)
    {
 
-   TR::Register *resultReg = self()->evaluate(node);
+   TR::Register *resultReg = evaluate(node);
    TR_ASSERT( resultReg->getKind() == TR_GPR || resultReg->getKind() == TR_FPR , "gprClobberEvaluate() called for non-GPR or non-FPR.");
 
-   if (!self()->canClobberNodesRegister(node))
+   if (!canClobberNodesRegister(node))
       {
       if (TR::Compiler->target.is32Bit() && node->getType().isInt64())
          {
-         TR::Register     *lowReg  = self()->allocateRegister();
-         TR::Register     *highReg = self()->allocateRegister();
-         TR::RegisterPair *longReg = self()->allocateRegisterPair(lowReg, highReg);
+         TR::Register     *lowReg  = allocateRegister();
+         TR::Register     *highReg = allocateRegister();
+         TR::RegisterPair *longReg = allocateRegisterPair(lowReg, highReg);
 
          generateTrg1Src1Instruction(self(), TR::InstOpCode::mr, node,
                                      lowReg,
@@ -1849,7 +1849,7 @@ TR::Register *OMR::Power::CodeGenerator::gprClobberEvaluate(TR::Node *node)
          }
       else
          {
-         TR::Register *targetReg = resultReg->containsCollectedReference() ? self()->allocateCollectedReferenceRegister() : self()->allocateRegister(resultReg->getKind());
+         TR::Register *targetReg = resultReg->containsCollectedReference() ? allocateCollectedReferenceRegister() : allocateRegister(resultReg->getKind());
 
          if (resultReg->containsInternalPointer())
             {
@@ -1943,14 +1943,14 @@ bool OMR::Power::CodeGenerator::canTransformUnsafeSetMemory()
 void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
    {
    TR_InternalPointerMap *internalPtrMap = NULL;
-   TR::GCStackAtlas *atlas = self()->getStackAtlas();
+   TR::GCStackAtlas *atlas = getStackAtlas();
 
    // Build the register map
    //
    for (int i=TR::RealRegister::FirstGPR;
             i<=TR::RealRegister::LastGPR; i++)
       {
-      TR::RealRegister *realReg = self()->machine()->getPPCRealRegister(
+      TR::RealRegister *realReg = machine()->getPPCRealRegister(
               (TR::RealRegister::RegNum)i);
 
       if (realReg->getHasBeenAssignedInMethod())
@@ -1961,7 +1961,7 @@ void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *ma
             if (virtReg->containsInternalPointer())
                {
                if (!internalPtrMap)
-                  internalPtrMap = new (self()->trHeapMemory()) TR_InternalPointerMap(self()->trMemory());
+                  internalPtrMap = new (trHeapMemory()) TR_InternalPointerMap(trMemory());
                internalPtrMap->addInternalPointerPair(virtReg->getPinningArrayPointer(), 31 - (i-1));
                atlas->addPinningArrayPtrForInternalPtrReg(virtReg->getPinningArrayPointer());
                }
@@ -1980,7 +1980,7 @@ int32_t OMR::Power::CodeGenerator::findOrCreateFloatConstant(void *v, TR::DataTy
                              TR::Instruction *n2, TR::Instruction *n3)
    {
    if (_constantData == NULL)
-      _constantData = new (self()->trHeapMemory()) TR::ConstantDataSnippet(self());
+      _constantData = new (trHeapMemory()) TR::ConstantDataSnippet(self());
    return(_constantData->addConstantRequest(v, t, n0, n1, n2, n3, NULL, false));
    }
 
@@ -1990,7 +1990,7 @@ int32_t OMR::Power::CodeGenerator::findOrCreateAddressConstant(void *v, TR::Data
                              TR::Node *node, bool isUnloadablePicSite)
    {
    if (_constantData == NULL)
-      _constantData = new (self()->trHeapMemory()) TR::ConstantDataSnippet(self());
+      _constantData = new (trHeapMemory()) TR::ConstantDataSnippet(self());
    return(_constantData->addConstantRequest(v, t, n0, n1, n2, n3, node, isUnloadablePicSite));
    }
 
@@ -2024,7 +2024,7 @@ bool OMR::Power::CodeGenerator::hasDataSnippets()
 
 void OMR::Power::CodeGenerator::emitDataSnippets()
    {
-   self()->setBinaryBufferCursor(_constantData->emitSnippetBody());
+   setBinaryBufferCursor(_constantData->emitSnippetBody());
    }
 
 int32_t OMR::Power::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
@@ -2061,15 +2061,15 @@ inline static bool callInTree(TR::TreeTop *treeTop)
 
 TR_BitVector *OMR::Power::CodeGenerator::computeCallInfoBitVector()
    {
-   uint32_t         bcount = self()->comp()->getFlowGraph()->getNextNodeNumber();
-   TR_BitVector     bvec, *ebvec = new (self()->trHeapMemory()) TR_BitVector(bcount, self()->trMemory());
+   uint32_t         bcount = comp()->getFlowGraph()->getNextNodeNumber();
+   TR_BitVector     bvec, *ebvec = new (trHeapMemory()) TR_BitVector(bcount, trMemory());
    TR::TreeTop      *pTree, *exitTree;
    TR::Block        *block;
    uint32_t         bnum, btemp;
 
-   bvec.init(bcount, self()->trMemory());
+   bvec.init(bcount, trMemory());
 
-   for (pTree=self()->comp()->getStartTree(); pTree!=NULL; pTree=exitTree->getNextTreeTop())
+   for (pTree=comp()->getStartTree(); pTree!=NULL; pTree=exitTree->getNextTreeTop())
       {
       block = pTree->getNode()->getBlock();
       exitTree = block->getExit();
@@ -2091,7 +2091,7 @@ TR_BitVector *OMR::Power::CodeGenerator::computeCallInfoBitVector()
          }
       }
 
-   for (pTree=self()->comp()->getStartTree(); pTree!=NULL; pTree=exitTree->getNextTreeTop())
+   for (pTree=comp()->getStartTree(); pTree!=NULL; pTree=exitTree->getNextTreeTop())
       {
       block = pTree->getNode()->getBlock();
       exitTree = block->getExit();
@@ -2119,12 +2119,12 @@ void OMR::Power::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Regis
    if (immediateChild && immediateChild->getOpCode().isLoadConst() &&
       (immediateChild->getType().isIntegral() && !immediateChild->getType().isInt64() || immediateChild->getType().isAddress()))
       {
-      self()->simulateSkippedTreeEvaluation(immediateChild, state, summary, 'i');
-      self()->simulateDecReferenceCount(immediateChild, state);
-      self()->simulateTreeEvaluation(node->getFirstChild(), state, summary);
-      self()->simulateDecReferenceCount(node->getFirstChild(), state);
-      self()->simulatedNodeState(node)._childRefcountsHaveBeenDecremented = 1;
-      self()->simulateNodeGoingLive(node, state);
+      simulateSkippedTreeEvaluation(immediateChild, state, summary, 'i');
+      simulateDecReferenceCount(immediateChild, state);
+      simulateTreeEvaluation(node->getFirstChild(), state, summary);
+      simulateDecReferenceCount(node->getFirstChild(), state);
+      simulatedNodeState(node)._childRefcountsHaveBeenDecremented = 1;
+      simulateNodeGoingLive(node, state);
       }
    else
       {
@@ -2138,18 +2138,18 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
                                                           TR_GlobalRegisterNumber           &  highRegisterNumber,
                                                           TR_LinkHead<TR_RegisterCandidate> *  candidates)
    {
-   if (!self()->comp()->getOption(TR_DisableRegisterPressureSimulation))
+   if (!comp()->getOption(TR_DisableRegisterPressureSimulation))
       return OMR::CodeGenerator::pickRegister(regCan, barr, availRegs, highRegisterNumber, candidates);
 
 
-   if (self()->getBlockCallInfo() == NULL)
+   if (getBlockCallInfo() == NULL)
       {
-      self()->setBlockCallInfo(self()->computeCallInfoBitVector());
+      setBlockCallInfo(computeCallInfoBitVector());
       }
 
    uint32_t      firstIndex, lastIndex, lastVolIndex, longLow = 0;
    TR::Symbol     *sym = regCan->getSymbolReference()->getSymbol();
-   TR_BitVector *ebvec = self()->getBlockCallInfo();
+   TR_BitVector *ebvec = getBlockCallInfo();
    TR_BitVectorIterator livec(regCan->getBlocksLiveOnEntry());
    bool          hasCallInPath = false, isParm = sym->isParm(), isAddressType=false, isFloatType=false;
    bool isVector  = false;
@@ -2181,8 +2181,8 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
       case TR::VectorInt32:
       case TR::VectorDouble:
           isVector = true;
-          firstIndex = self()->getFirstGlobalVRF();
-          lastIndex = self()->getLastGlobalVRF();
+          firstIndex = getFirstGlobalVRF();
+          lastIndex = getLastGlobalVRF();
           lastVolIndex = lastIndex;  // TODO: preserved VRF's !!
          break;
 
@@ -2204,7 +2204,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
       int32_t numExtraRegs = 0;
       int32_t maxRegisterPressure = 0;
 
-      vcount_t visitCount = self()->comp()->incVisitCount();
+      vcount_t visitCount = comp()->incVisitCount();
       int32_t maxFrequency = 0;
 
       while (livec.hasMoreElements())
@@ -2235,7 +2235,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
          }
 
       if (!_assignedGlobalRegisters)
-         _assignedGlobalRegisters = new (self()->trStackMemory()) TR_BitVector(self()->comp()->getSymRefCount(), self()->trMemory(), stackAlloc, growable);
+         _assignedGlobalRegisters = new (trStackMemory()) TR_BitVector(comp()->getSymRefCount(), trMemory(), stackAlloc, growable);
 
       bool vmThreadUsed = false;
       bool assigningEDX = false;
@@ -2264,7 +2264,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
                _assignedGlobalRegisters->set(prev->getSymbolReference()->getReferenceNumber());
                }
            }
-        maxRegisterPressure = self()->estimateRegisterPressure(block, visitCount, maxStaticFrequency, maxFrequency, vmThreadUsed, numAssignedGlobalRegs, _assignedGlobalRegisters, regCan->getSymbolReference(), assigningEDX);
+        maxRegisterPressure = estimateRegisterPressure(block, visitCount, maxStaticFrequency, maxFrequency, vmThreadUsed, numAssignedGlobalRegs, _assignedGlobalRegisters, regCan->getSymbolReference(), assigningEDX);
         if (maxRegisterPressure >= _numGPR)
            break;
         }
@@ -2421,7 +2421,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::getLinkageGlobalRegisterNumbe
    TR_GlobalRegisterNumber result;
    if (type == TR::Float || type == TR::Double)
       {
-      if (linkageRegisterIndex >= self()->getProperties()._numFloatArgumentRegisters)
+      if (linkageRegisterIndex >= getProperties()._numFloatArgumentRegisters)
          result = -1;
       else
          result = _fprLinkageGlobalRegisterNumbers[linkageRegisterIndex];
@@ -2430,12 +2430,12 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::getLinkageGlobalRegisterNumbe
       TR_ASSERT(false, "assertion failure");    // TODO
    else
       {
-      if (linkageRegisterIndex >= self()->getProperties()._numIntegerArgumentRegisters)
+      if (linkageRegisterIndex >= getProperties()._numIntegerArgumentRegisters)
          result = -1;
       else
          result = _gprLinkageGlobalRegisterNumbers[linkageRegisterIndex];
       }
-   diagnostic("getLinkageGlobalRegisterNumber(%d, %s) = %d\n", linkageRegisterIndex, self()->comp()->getDebug()->getName(type), result);
+   diagnostic("getLinkageGlobalRegisterNumber(%d, %s) = %d\n", linkageRegisterIndex, comp()->getDebug()->getName(type), result);
    return result;
    }
 
@@ -2535,8 +2535,8 @@ void OMR::Power::CodeGenerator::setRealRegisterAssociation(TR::Register     *reg
    {
    if (!reg->isLive() || realNum == TR::RealRegister::NoReg)
       return;
-   TR::RealRegister *realReg = self()->machine()->getPPCRealRegister(realNum);
-   self()->getLiveRegisters(reg->getKind())->setAssociation(reg, realReg);
+   TR::RealRegister *realReg = machine()->getPPCRealRegister(realNum);
+   getLiveRegisters(reg->getKind())->setAssociation(reg, realReg);
    }
 
 
@@ -2545,7 +2545,7 @@ void OMR::Power::CodeGenerator::addRealRegisterInterference(TR::Register    *reg
    {
    if (!reg->isLive() || realNum == TR::RealRegister::NoReg)
       return;
-   TR::RealRegister *realReg = self()->machine()->getPPCRealRegister(realNum);
+   TR::RealRegister *realReg = machine()->getPPCRealRegister(realNum);
    reg->getLiveRegisterInfo()->addInterference(realReg->getRealRegisterMask());
    }
 
@@ -2774,7 +2774,7 @@ TR_BackingStore * OMR::Power::CodeGenerator::allocateStackSlot()
    ListElement<TR_BackingStore> * tempElement;
    if (conversionBuffer == NULL)
      {
-     conversionBuffer = new (self()->trHeapMemory()) List<TR_BackingStore>(self()->trMemory());
+     conversionBuffer = new (trHeapMemory()) List<TR_BackingStore>(trMemory());
      static const char *TR_ConversionSlots = feGetEnv("TR_ConversionSlots");
      int numSlots = (TR_ConversionSlots == NULL ? 2 : atoi(TR_ConversionSlots));
      for(int i = 0; i < numSlots; i++)
@@ -2783,7 +2783,7 @@ TR_BackingStore * OMR::Power::CodeGenerator::allocateStackSlot()
         }
      tempElement = conversionBuffer->getLastElement();
      tempElement->setNextElement(conversionBuffer->getListHead());
-     conversionBufferIt = new (self()->trHeapMemory()) ListIterator<TR_BackingStore>(conversionBuffer);
+     conversionBufferIt = new (trHeapMemory()) ListIterator<TR_BackingStore>(conversionBuffer);
      }
 
    conversionBufferIt->getNext();
@@ -2794,10 +2794,10 @@ TR_BackingStore * OMR::Power::CodeGenerator::allocateStackSlot()
      }
    else
      {
-     TR::AutomaticSymbol *spillSymbol = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Int64,8);
+     TR::AutomaticSymbol *spillSymbol = TR::AutomaticSymbol::create(trHeapMemory(),TR::Int64,8);
      spillSymbol->setSpillTempAuto();
-     self()->comp()->getMethodSymbol()->addAutomatic(spillSymbol);
-     return tempElement->setData(new (self()->trHeapMemory()) TR_BackingStore(self()->comp()->getSymRefTab(), spillSymbol, 0));
+     comp()->getMethodSymbol()->addAutomatic(spillSymbol);
+     return tempElement->setData(new (trHeapMemory()) TR_BackingStore(comp()->getSymRefTab(), spillSymbol, 0));
      }
    }
 
@@ -2830,8 +2830,8 @@ int32_t OMR::Power::CodeGenerator::getMaximumNumbersOfAssignableVRs()
  */
 bool OMR::Power::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
    {
-   int64_t smallestPos = self()->getSmallestPosConstThatMustBeMaterialized();
-   int64_t largestNeg = self()->getLargestNegConstThatMustBeMaterialized();
+   int64_t smallestPos = getSmallestPosConstThatMustBeMaterialized();
+   int64_t largestNeg = getLargestNegConstThatMustBeMaterialized();
 
    return ((value >= smallestPos) || (value <= largestNeg));
    }
@@ -2874,8 +2874,8 @@ bool OMR::Power::CodeGenerator::isRotateAndMask(TR::Node * node)
 
 TR_PPCOutOfLineCodeSection *OMR::Power::CodeGenerator::findOutLinedInstructionsFromLabel(TR::LabelSymbol *label)
    {
-   auto oiIterator = self()->getPPCOutOfLineCodeSectionList().begin();
-   while (oiIterator != self()->getPPCOutOfLineCodeSectionList().end())
+   auto oiIterator = getPPCOutOfLineCodeSectionList().begin();
+   while (oiIterator != getPPCOutOfLineCodeSectionList().end())
       {
       if ((*oiIterator)->getEntryLabel() == label)
          return *oiIterator;
@@ -2887,8 +2887,8 @@ TR_PPCOutOfLineCodeSection *OMR::Power::CodeGenerator::findOutLinedInstructionsF
 
 TR::Snippet *OMR::Power::CodeGenerator::findSnippetInstructionsFromLabel(TR::LabelSymbol *label)
    {
-   auto snippetIterator = self()->getSnippetList().begin();
-   while(snippetIterator != self()->getSnippetList().end())
+   auto snippetIterator = getSnippetList().begin();
+   while(snippetIterator != getSnippetList().end())
       {
       if ((*snippetIterator)->getSnippetLabel() == label)
          return *snippetIterator;
@@ -2916,14 +2916,14 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
    if (delta > UPPER_IMMED || delta < LOWER_IMMED)
       {
-      TR::Register *deltaReg = self()->allocateRegister();
+      TR::Register *deltaReg = allocateRegister();
       cursor = loadConstant(self(), node, delta, deltaReg, cursor);
       cursor = generateDebugCounterBump(cursor, counter, deltaReg, cond);
       if (cond)
          {
          addDependency(cond, deltaReg, TR::RealRegister::NoReg, TR_GPR, self());
          }
-      self()->stopUsingRegister(deltaReg);
+      stopUsingRegister(deltaReg);
       return cursor;
       }
 
@@ -2931,15 +2931,15 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
    TR_ASSERT(addr, "Expecting a non-null debug counter address");
 
-   TR::Register *addrReg = self()->allocateRegister();
-   TR::Register *counterReg = self()->allocateRegister();
+   TR::Register *addrReg = allocateRegister();
+   TR::Register *counterReg = allocateRegister();
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
    if (cond)
       {
       uint32_t preCondCursor = cond->getAddCursorForPre();
@@ -2949,8 +2949,8 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
       cond->getPostConditions()->getRegisterDependency(postCondCursor)->setExcludeGPR0();
       addDependency(cond, counterReg, TR::RealRegister::NoReg, TR_GPR, self());
       }
-   self()->stopUsingRegister(addrReg);
-   self()->stopUsingRegister(counterReg);
+   stopUsingRegister(addrReg);
+   stopUsingRegister(counterReg);
    return cursor;
    }
 
@@ -2961,15 +2961,15 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
    TR_ASSERT(addr, "Expecting a non-null debug counter address");
 
-   TR::Register *addrReg = self()->allocateRegister();
-   TR::Register *counterReg = self()->allocateRegister();
+   TR::Register *addrReg = allocateRegister();
+   TR::Register *counterReg = allocateRegister();
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
    if (cond)
       {
       uint32_t preCondCursor = cond->getAddCursorForPre();
@@ -2979,8 +2979,8 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
       cond->getPostConditions()->getRegisterDependency(postCondCursor)->setExcludeGPR0();
       addDependency(cond, counterReg, TR::RealRegister::NoReg, TR_GPR, self());
       }
-   self()->stopUsingRegister(addrReg);
-   self()->stopUsingRegister(counterReg);
+   stopUsingRegister(addrReg);
+   stopUsingRegister(counterReg);
    return cursor;
    }
 
@@ -3006,10 +3006,10 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
    srm.reclaimScratchRegister(addrReg);
    srm.reclaimScratchRegister(counterReg);
    return cursor;
@@ -3027,10 +3027,10 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
    cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
    cursor = generateMemSrc1Instruction(self(), TR::InstOpCode::stw, node,
-                                       new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
+                                       new (trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), counterReg, cursor);
    srm.reclaimScratchRegister(addrReg);
    srm.reclaimScratchRegister(counterReg);
    return cursor;
@@ -3039,7 +3039,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
 bool OMR::Power::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
-   return self()->machine()->getPPCRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
+   return machine()->getPPCRealRegister((TR::RealRegister::RegNum)getGlobalRegister(i))->getState() == TR::RealRegister::Free;
    }
 
 
@@ -3052,7 +3052,7 @@ bool OMR::Power::CodeGenerator::supportsSinglePrecisionSQRT()
 int32_t
 OMR::Power::CodeGenerator::getPreferredLoopUnrollFactor()
    {
-   return self()->comp()->getMethodHotness() > warm ? (self()->comp()->isOptServer() ? 12 : 8) : 4;
+   return comp()->getMethodHotness() > warm ? (comp()->isOptServer() ? 12 : 8) : 4;
    }
 
 bool
@@ -3080,7 +3080,7 @@ OMR::Power::CodeGenerator::freeAndResetTransientLongs()
 
    for (num_lReg=0; num_lReg < _transientLongRegisters.size(); num_lReg++)
       {
-      self()->stopUsingRegister(_transientLongRegisters[num_lReg]);
+      stopUsingRegister(_transientLongRegisters[num_lReg]);
       }
 
    _transientLongRegisters.setSize(0);
@@ -3151,14 +3151,14 @@ bool
 OMR::Power::CodeGenerator::getSupportsEncodeUtf16LittleWithSurrogateTest()
    {
    return TR::Compiler->target.cpu.getPPCSupportsVSX() &&
-          !self()->comp()->getOption(TR_DisableSIMDUTF16LEEncoder);
+          !comp()->getOption(TR_DisableSIMDUTF16LEEncoder);
    }
 
 bool
 OMR::Power::CodeGenerator::getSupportsEncodeUtf16BigWithSurrogateTest()
    {
    return TR::Compiler->target.cpu.getPPCSupportsVSX() &&
-          !self()->comp()->getOption(TR_DisableSIMDUTF16BEEncoder);
+          !comp()->getOption(TR_DisableSIMDUTF16BEEncoder);
    }
 
 
@@ -3172,7 +3172,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
    {
 
    bool doAOTRelocation = true;
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
 
    if (tempReg == NULL)
       {
@@ -3182,7 +3182,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          if (typeAddress == -1)
             {
             if (doAOTRelocation)
-               self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+               addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  firstInstruction,
                                  (uint8_t *)value,
                                  (uint8_t *)seqKind,
@@ -3201,7 +3201,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                   recordInfo->data1 = (uintptr_t)node->getSymbolReference();
                   recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                   recordInfo->data3 = (uintptr_t)seqKind;
-                  self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+                  addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)recordInfo,
                                     TR_DataAddress, self()),
@@ -3226,7 +3226,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             else
                {
                if (doAOTRelocation)
-                  self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+                  addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)value,
                                     (uint8_t *)seqKind,
@@ -3246,7 +3246,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
          if (typeAddress == -1)
             {
             if (doAOTRelocation)
-               self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+               addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                  firstInstruction,
                                  (uint8_t *)value,
                                  (uint8_t *)seqKind,
@@ -3260,7 +3260,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             if (typeAddress == TR_RamMethodSequence) // NOTE: 32 bit changed to use TR_RamMethodSequence for ordered pair, hence, we should check this instead
                {
                if (doAOTRelocation)
-                  self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+                  addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)value,
                                     (uint8_t *)seqKind,
@@ -3277,7 +3277,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                   recordInfo->data1 = (uintptr_t)node->getSymbolReference();
                   recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                   recordInfo->data3 = (uintptr_t)seqKind;
-                  self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+                  addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)recordInfo,
                                     TR_DataAddress, self()),
@@ -3302,7 +3302,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
             else
                {
                if (doAOTRelocation)
-                  self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
+                  addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(
                                     firstInstruction,
                                     (uint8_t *)value,
                                     (uint8_t *)seqKind,
@@ -3328,12 +3328,12 @@ OMR::Power::CodeGenerator::loadAddressConstantFixed(
       int16_t typeAddress,
       bool doAOTRelocation)
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    bool isAOT = comp->compileRelocatableCode();
 
    if (TR::Compiler->target.is32Bit())
       {
-      return self()->loadIntConstantFixed(node, (int32_t)value, trgReg, cursor, typeAddress);
+      return loadIntConstantFixed(node, (int32_t)value, trgReg, cursor, typeAddress);
       }
 
    // load a 64-bit constant into a register with a fixed 5 instruction sequence
@@ -3341,7 +3341,7 @@ OMR::Power::CodeGenerator::loadAddressConstantFixed(
    TR::Instruction *firstInstruction;
 
    if (cursor == NULL)
-      cursor = self()->getAppendInstruction();
+      cursor = getAppendInstruction();
 
    if (tempReg == NULL)
       {
@@ -3374,11 +3374,11 @@ OMR::Power::CodeGenerator::loadAddressConstantFixed(
 
    if (doAOTRelocation)
       {
-      self()->addMetaDataForLoadAddressConstantFixed(node, firstInstruction, tempReg, typeAddress, value);
+      addMetaDataForLoadAddressConstantFixed(node, firstInstruction, tempReg, typeAddress, value);
       }
 
    if (temp == NULL)
-      self()->setAppendInstruction(cursor);
+      setAppendInstruction(cursor);
 
    return(cursor);
    }
@@ -3393,7 +3393,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       int32_t value)
    {
 
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
 
    if (typeAddress == TR_DataAddress)
       {
@@ -3401,7 +3401,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       recordInfo->data1 = (uintptr_t)node->getSymbolReference();
       recordInfo->data2 = node ? (uintptr_t)node->getInlinedSiteIndex() : (uintptr_t)-1;
       recordInfo->data3 = orderedPairSequence2;
-      self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
+      addExternalRelocation(new (trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
                                                                                           (uint8_t *)secondInstruction,
                                                                                           (uint8_t *)recordInfo,
                                                                                           (TR_ExternalRelocationTargetKind)TR_DataAddress, self()),
@@ -3422,7 +3422,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = (uintptr_t)value;
       recordInfo->data3 = orderedPairSequence2;
-      self()->addExternalRelocation(new (self()->trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
+      addExternalRelocation(new (trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
                                                                                           (uint8_t *)secondInstruction,
                                                                                           (uint8_t *)recordInfo,
                                                                                           (TR_ExternalRelocationTargetKind)typeAddress, self()),
@@ -3446,21 +3446,21 @@ OMR::Power::CodeGenerator::loadIntConstantFixed(
    TR::Instruction *temp = cursor;
    TR::Instruction *firstInstruction, *secondInstruction;
 
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
 
    if (cursor == NULL)
       {
-      cursor = self()->getAppendInstruction();
+      cursor = getAppendInstruction();
       }
 
    cursor = firstInstruction = generateTrg1ImmInstruction(self(), TR::InstOpCode::lis, node, trgReg, value>>16, cursor);
    cursor = secondInstruction = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::ori, node, trgReg, trgReg, value&0x0000ffff, cursor);
 
-   self()->addMetaDataForLoadIntConstantFixed(node, firstInstruction, secondInstruction, typeAddress, value);
+   addMetaDataForLoadIntConstantFixed(node, firstInstruction, secondInstruction, typeAddress, value);
 
    if (temp == NULL)
       {
-      self()->setAppendInstruction(cursor);
+      setAppendInstruction(cursor);
       }
 
    return(cursor);
@@ -3474,16 +3474,16 @@ OMR::Power::CodeGenerator::addMetaDataFor32BitFixedLoadLabelAddressIntoReg(
       TR::Instruction *firstInstruction,
       TR::Instruction *secondInstruction)
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
 
    TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
    recordInfo->data3 = orderedPairSequence1;
 
-   self()->getAheadOfTimeCompile()->getRelocationList().push_front(new (self()->trHeapMemory()) TR::PPCPairedRelocation
+   getAheadOfTimeCompile()->getRelocationList().push_front(new (trHeapMemory()) TR::PPCPairedRelocation
                         (firstInstruction, secondInstruction, (uint8_t *)recordInfo,
                          TR_AbsoluteMethodAddressOrderedPair, node));
 
-   self()->addRelocation(new (self()->trHeapMemory()) TR::PPCPairedLabelAbsoluteRelocation
+   addRelocation(new (trHeapMemory()) TR::PPCPairedLabelAbsoluteRelocation
                      (firstInstruction, secondInstruction, NULL, NULL, label));
 
    }
@@ -3497,12 +3497,12 @@ OMR::Power::CodeGenerator::addMetaDataFor64BitFixedLoadLabelAddressIntoReg(
       TR::Instruction **q)
    {
 
-   if (!self()->comp()->compileRelocatableCode())
+   if (!comp()->compileRelocatableCode())
       {
-      self()->addRelocation(new (self()->trHeapMemory()) TR::PPCPairedLabelAbsoluteRelocation(q[0], q[1], q[2], q[3], label));
+      addRelocation(new (trHeapMemory()) TR::PPCPairedLabelAbsoluteRelocation(q[0], q[1], q[2], q[3], label));
       }
 
-   self()->addExternalRelocation(new (self()->trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(q[0],
+   addExternalRelocation(new (trHeapMemory()) TR::BeforeBinaryEncodingExternalRelocation(q[0],
                                                                             (uint8_t *)(label),
                                                                             (uint8_t *) (tempReg ? fixedSequence4 : fixedSequence2),
                                                                             TR_FixedSequenceAddress, self()),
@@ -3520,7 +3520,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
       TR::Register *tempReg,
       bool useADDISFor32Bit)
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    if (TR::Compiler->target.is64Bit())
       {
       int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, self());
@@ -3528,15 +3528,15 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
       if (offset != PTOC_FULL_INDEX)
          {
          offset *= 8;
-         self()->itemTracking(offset, label);
+         itemTracking(offset, label);
          if (offset<LOWER_IMMED||offset>UPPER_IMMED)
             {
-            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, self()->getTOCBaseRegister(), self()->hiValue(offset));
-            generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
+            generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addis, node, trgReg, getTOCBaseRegister(), hiValue(offset));
+            generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (trHeapMemory()) TR::MemoryReference(trgReg, LO_VALUE(offset), 8, self()));
             }
          else
             {
-            generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (self()->trHeapMemory()) TR::MemoryReference(self()->getTOCBaseRegister(), offset, 8, self()));
+            generateTrg1MemInstruction(self(),TR::InstOpCode::Op_load, node, trgReg, new (trHeapMemory()) TR::MemoryReference(getTOCBaseRegister(), offset, 8, self()));
             }
          }
       else
@@ -3545,7 +3545,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
 
          fixedSeqMemAccess(self(), node, 0, q, trgReg, trgReg, TR::InstOpCode::addi2, 4, NULL, tempReg);
 
-         self()->addMetaDataFor64BitFixedLoadLabelAddressIntoReg(node, label, tempReg, q);
+         addMetaDataFor64BitFixedLoadLabelAddressIntoReg(node, label, tempReg, q);
          }
       }
    else
@@ -3562,7 +3562,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
          }
       instr2 = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi2 , node, trgReg, trgReg, 0);
 
-      self()->addMetaDataFor32BitFixedLoadLabelAddressIntoReg(node, label, instr1, instr2);
+      addMetaDataFor32BitFixedLoadLabelAddressIntoReg(node, label, instr1, instr2);
       }
 
    return cursor;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1644,7 +1644,7 @@ OMR::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       TR_PPCBinaryEncodingData *data)
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
    data->recomp = NULL;
    data->cursorInstruction = getFirstInstruction();
    data->preProcInstruction = data->cursorInstruction;
@@ -1662,10 +1662,10 @@ void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       data->cursorInstruction = data->cursorInstruction->getNext();
       }
 
-   int32_t boundary = comp->getOptions()->getJitMethodEntryAlignmentBoundary(self());
+   int32_t boundary = compilation->getOptions()->getJitMethodEntryAlignmentBoundary(self());
    if (boundary && (boundary > 4) && ((boundary & (boundary - 1)) == 0))
       {
-      comp->getOptions()->setJitMethodEntryAlignmentBoundary(boundary);
+      compilation->getOptions()->setJitMethodEntryAlignmentBoundary(boundary);
       setPreJitMethodEntrySize(data->estimate);
       data->estimate += (boundary - 4);
       }
@@ -3172,7 +3172,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
    {
 
    bool doAOTRelocation = true;
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
 
    if (tempReg == NULL)
       {
@@ -3197,7 +3197,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                {
                if (doAOTRelocation)
                   {
-                  TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+                  TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)compilation->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
                   recordInfo->data1 = (uintptr_t)node->getSymbolReference();
                   recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                   recordInfo->data3 = (uintptr_t)seqKind;
@@ -3214,13 +3214,13 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                {
                if (doAOTRelocation)
                   {
-                  TR::DebugCounterBase *counter = comp->getCounterFromStaticAddress(node->getSymbolReference());
+                  TR::DebugCounterBase *counter = compilation->getCounterFromStaticAddress(node->getSymbolReference());
                   if (counter == NULL)
                      {
-                     comp->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed\n");
+                     compilation->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed\n");
                      }
 
-                  TR::DebugCounter::generateRelocation(comp, firstInstruction, node, counter, seqKind);
+                  TR::DebugCounter::generateRelocation(compilation, firstInstruction, node, counter, seqKind);
                   }
                }
             else
@@ -3273,7 +3273,7 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                {
                if (doAOTRelocation)
                   {
-                  TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+                  TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)compilation->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
                   recordInfo->data1 = (uintptr_t)node->getSymbolReference();
                   recordInfo->data2 = (uintptr_t)node->getInlinedSiteIndex();
                   recordInfo->data3 = (uintptr_t)seqKind;
@@ -3290,13 +3290,13 @@ OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed(
                {
                if (doAOTRelocation)
                   {
-                  TR::DebugCounterBase *counter = comp->getCounterFromStaticAddress(node->getSymbolReference());
+                  TR::DebugCounterBase *counter = compilation->getCounterFromStaticAddress(node->getSymbolReference());
                   if (counter == NULL)
                      {
-                     comp->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed\n");
+                     compilation->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed\n");
                      }
 
-                  TR::DebugCounter::generateRelocation(comp, firstInstruction, node, counter, seqKind);
+                  TR::DebugCounter::generateRelocation(compilation, firstInstruction, node, counter, seqKind);
                   }
                }
             else
@@ -3328,8 +3328,8 @@ OMR::Power::CodeGenerator::loadAddressConstantFixed(
       int16_t typeAddress,
       bool doAOTRelocation)
    {
-   TR::Compilation *comp = comp();
-   bool isAOT = comp->compileRelocatableCode();
+   TR::Compilation *compilation = comp();
+   bool isAOT = compilation->compileRelocatableCode();
 
    if (TR::Compiler->target.is32Bit())
       {
@@ -3393,11 +3393,11 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       int32_t value)
    {
 
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
 
    if (typeAddress == TR_DataAddress)
       {
-      TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+      TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)compilation->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = (uintptr_t)node->getSymbolReference();
       recordInfo->data2 = node ? (uintptr_t)node->getInlinedSiteIndex() : (uintptr_t)-1;
       recordInfo->data3 = orderedPairSequence2;
@@ -3409,17 +3409,17 @@ OMR::Power::CodeGenerator::addMetaDataForLoadIntConstantFixed(
       }
    else if (typeAddress == TR_DebugCounter)
       {
-      TR::DebugCounterBase *counter = comp->getCounterFromStaticAddress(node->getSymbolReference());
+      TR::DebugCounterBase *counter = compilation->getCounterFromStaticAddress(node->getSymbolReference());
       if (counter == NULL)
          {
-         comp->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed\n");
+         compilation->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::Power::CodeGenerator::addMetaDataForLoadAddressConstantFixed\n");
          }
 
-      TR::DebugCounter::generateRelocation(comp, firstInstruction, secondInstruction, node, counter, orderedPairSequence2);
+      TR::DebugCounter::generateRelocation(compilation, firstInstruction, secondInstruction, node, counter, orderedPairSequence2);
       }
    else if (typeAddress != -1)
       {
-      TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+      TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)compilation->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
       recordInfo->data1 = (uintptr_t)value;
       recordInfo->data3 = orderedPairSequence2;
       addExternalRelocation(new (trHeapMemory()) TR::ExternalOrderedPair32BitRelocation((uint8_t *)firstInstruction,
@@ -3446,7 +3446,7 @@ OMR::Power::CodeGenerator::loadIntConstantFixed(
    TR::Instruction *temp = cursor;
    TR::Instruction *firstInstruction, *secondInstruction;
 
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
 
    if (cursor == NULL)
       {
@@ -3474,9 +3474,9 @@ OMR::Power::CodeGenerator::addMetaDataFor32BitFixedLoadLabelAddressIntoReg(
       TR::Instruction *firstInstruction,
       TR::Instruction *secondInstruction)
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
 
-   TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)comp->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
+   TR_RelocationRecordInformation *recordInfo = ( TR_RelocationRecordInformation *)compilation->trMemory()->allocateMemory(sizeof( TR_RelocationRecordInformation), heapAlloc);
    recordInfo->data3 = orderedPairSequence1;
 
    getAheadOfTimeCompile()->getRelocationList().push_front(new (trHeapMemory()) TR::PPCPairedRelocation
@@ -3520,7 +3520,7 @@ OMR::Power::CodeGenerator::fixedLoadLabelAddressIntoReg(
       TR::Register *tempReg,
       bool useADDISFor32Bit)
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
    if (TR::Compiler->target.is64Bit())
       {
       int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, self());

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -152,7 +152,7 @@ namespace Power
 
 class CodeGenerator;
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    {
 
    public:

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -171,7 +171,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
 
    bool getSupportsIbyteswap();
 
-   void generateBinaryEncodingPrologue(TR_PPCBinaryEncodingData *data);
+   virtual void generateBinaryEncodingPrologue(TR_PPCBinaryEncodingData *data);
 
    void beginInstructionSelection();
    void endInstructionSelection();

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -162,7 +162,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    TR_BackingStore * allocateStackSlot();
 
    CodeGenerator();
-   void continueConstruction();
+   void initializeConstruction();
 
    TR::Linkage *createLinkage(TR_LinkageConventions lc);
 

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -162,6 +162,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    TR_BackingStore * allocateStackSlot();
 
    CodeGenerator();
+   void continueConstruction();
 
    TR::Linkage *createLinkage(TR_LinkageConventions lc);
 

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -512,8 +512,6 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
       DummyLastFlag
       };
 
-   void initialize();
-
    TR_BitVector *computeCallInfoBitVector();
 
 

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -193,7 +193,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    void emitDataSnippets();
    bool hasDataSnippets();
 
-   TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
+   virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node);
 
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -90,7 +90,7 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
    }
 
 void
-OMR::X86::AMD64::CodeGenerator::continueConstruction()
+OMR::X86::AMD64::CodeGenerator::initializeConstruction()
    {
 	// Common X86 initialization
    //

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -86,7 +86,13 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
    if (self()->comp()->getOption(TR_MimicInterpreterFrameShape))
       self()->setMapAutosTo8ByteSlots();
 
-   // Common X86 initialization
+   
+   }
+
+void
+OMR::X86::AMD64::CodeGenerator::continueConstruction()
+   {
+	// Common X86 initialization
    //
    self()->initialize(self()->comp());
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -48,7 +48,7 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
    OMR::X86::CodeGenerator()
    {
 
-   if (self()->comp()->getOption(TR_DisableTraps))
+   if (comp()->getOption(TR_DisableTraps))
       {
       _numberBytesReadInaccessible  = 0;
       _numberBytesWriteInaccessible = 0;
@@ -57,34 +57,34 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
       {
       _numberBytesReadInaccessible  = 4096;
       _numberBytesWriteInaccessible = 4096;
-      self()->setHasResumableTrapHandler();
-      self()->setEnableImplicitDivideCheck();
+      setHasResumableTrapHandler();
+      setEnableImplicitDivideCheck();
       }
 
-   self()->setSupportsDivCheck();
+   setSupportsDivCheck();
 
    static char *c = feGetEnv("TR_disableAMD64ValueProfiling");
    if (c)
-      self()->comp()->setOption(TR_DisableValueProfiling);
+      comp()->setOption(TR_DisableValueProfiling);
 
    static char *accessStaticsIndirectly = feGetEnv("TR_AccessStaticsIndirectly");
    if (accessStaticsIndirectly)
-      self()->setAccessStaticsIndirectly(true);
+      setAccessStaticsIndirectly(true);
 
    static char *alwaysUseTrampolines = feGetEnv("TR_AlwaysUseTrampolines");
    if (alwaysUseTrampolines)
-      self()->setAlwaysUseTrampolines();
+      setAlwaysUseTrampolines();
 
-   self()->setSupportsDoubleWordCAS();
-   self()->setSupportsDoubleWordSet();
+   setSupportsDoubleWordCAS();
+   setSupportsDoubleWordSet();
 
-   self()->setSupportsGlRegDepOnFirstBlock();
-   self()->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
+   setSupportsGlRegDepOnFirstBlock();
+   setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
 
    // Interpreter frame shape requires all autos to occupy an 8-byte slot on 64-bit.
    //
-   if (self()->comp()->getOption(TR_MimicInterpreterFrameShape))
-      self()->setMapAutosTo8ByteSlots();
+   if (comp()->getOption(TR_MimicInterpreterFrameShape))
+      setMapAutosTo8ByteSlots();
 
    
    }
@@ -94,30 +94,30 @@ OMR::X86::AMD64::CodeGenerator::initializeConstruction()
    {
 	// Common X86 initialization
    //
-   self()->initialize(self()->comp());
+   initialize(comp());
 
-   self()->initLinkageToGlobalRegisterMap();
+   initLinkageToGlobalRegisterMap();
 
-   self()->setRealVMThreadRegister(self()->machine()->getX86RealRegister(TR::RealRegister::ebp));
+   setRealVMThreadRegister(machine()->getX86RealRegister(TR::RealRegister::ebp));
 
    // GRA-related initialization is done after calling initialize() so we can
    // use such things as getNumberOfGlobal[FG]PRs().
 
-   _globalGPRsPreservedAcrossCalls.init(self()->getNumberOfGlobalRegisters(), self()->trMemory());
-   _globalFPRsPreservedAcrossCalls.init(self()->getNumberOfGlobalRegisters(), self()->trMemory());
+   _globalGPRsPreservedAcrossCalls.init(getNumberOfGlobalRegisters(), trMemory());
+   _globalFPRsPreservedAcrossCalls.init(getNumberOfGlobalRegisters(), trMemory());
 
    int16_t i;
    TR_GlobalRegisterNumber grn;
-   for (i=0; i < self()->getNumberOfGlobalGPRs(); i++)
+   for (i=0; i < getNumberOfGlobalGPRs(); i++)
       {
-      grn = self()->getFirstGlobalGPR() + i;
-      if (self()->getProperties().isPreservedRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(grn)))
+      grn = getFirstGlobalGPR() + i;
+      if (getProperties().isPreservedRegister((TR::RealRegister::RegNum)getGlobalRegister(grn)))
          _globalGPRsPreservedAcrossCalls.set(grn);
       }
-   for (i=0; i < self()->getNumberOfGlobalFPRs(); i++)
+   for (i=0; i < getNumberOfGlobalFPRs(); i++)
       {
-      grn = self()->getFirstGlobalFPR() + i;
-      if (self()->getProperties().isPreservedRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(grn)))
+      grn = getFirstGlobalFPR() + i;
+      if (getProperties().isPreservedRegister((TR::RealRegister::RegNum)getGlobalRegister(grn)))
          _globalFPRsPreservedAcrossCalls.set(grn);
       }
 
@@ -136,7 +136,7 @@ OMR::X86::AMD64::CodeGenerator::longClobberEvaluate(TR::Node *node)
    {
    TR_ASSERT(TR::Compiler->target.is64Bit(), "assertion failure");
    TR_ASSERT(node->getOpCode().is8Byte() || node->getOpCode().isRef(), "assertion failure");
-   return self()->gprClobberEvaluate(node, MOV8RegReg);
+   return gprClobberEvaluate(node, MOV8RegReg);
    }
 
 TR_GlobalRegisterNumber
@@ -150,22 +150,22 @@ OMR::X86::AMD64::CodeGenerator::getLinkageGlobalRegisterNumber(
 
    if (isFloat)
       {
-      if (linkageRegisterIndex >= self()->getProperties().getNumFloatArgumentRegisters())
+      if (linkageRegisterIndex >= getProperties().getNumFloatArgumentRegisters())
          return -1;
       else
          result = _fprLinkageGlobalRegisterNumbers[linkageRegisterIndex];
       }
    else
       {
-      if (linkageRegisterIndex >= self()->getProperties().getNumIntegerArgumentRegisters())
+      if (linkageRegisterIndex >= getProperties().getNumIntegerArgumentRegisters())
          return -1;
       else
          result = _gprLinkageGlobalRegisterNumbers[linkageRegisterIndex];
       }
 
-   TR::RealRegister::RegNum realReg = self()->getProperties().getArgumentRegister(linkageRegisterIndex, isFloat);
+   TR::RealRegister::RegNum realReg = getProperties().getArgumentRegister(linkageRegisterIndex, isFloat);
 
-   TR_ASSERT(self()->getGlobalRegister(result) == realReg, "Result must be consistent with globalRegisterTable");
+   TR_ASSERT(getGlobalRegister(result) == realReg, "Result must be consistent with globalRegisterTable");
    return result;
    }
 
@@ -180,9 +180,9 @@ OMR::X86::AMD64::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node
       return 1;
 
    if (node->getOpCode().isIf() && node->getFirstChild()->getOpCodeValue() == TR::instanceof)
-      return self()->getNumberOfGlobalGPRs() - 6;
+      return getNumberOfGlobalGPRs() - 6;
    else if(node->getOpCode().isSwitch())
-      return self()->getNumberOfGlobalGPRs() - 3; // A memref in a jump for a MemTable might need a base, index and address register.
+      return getNumberOfGlobalGPRs() - 3; // A memref in a jump for a MemTable might need a base, index and address register.
 
    return INT_MAX;
    }
@@ -194,23 +194,23 @@ OMR::X86::AMD64::CodeGenerator::initLinkageToGlobalRegisterMap()
    int i;
 
    TR_GlobalRegisterNumber globalRegNumbers[TR::RealRegister::NumRegisters];
-   for (i=0; i < self()->getNumberOfGlobalGPRs(); i++)
+   for (i=0; i < getNumberOfGlobalGPRs(); i++)
      {
-     grn = self()->getFirstGlobalGPR() + i;
-     globalRegNumbers[self()->getGlobalRegister(grn)] = grn;
+     grn = getFirstGlobalGPR() + i;
+     globalRegNumbers[getGlobalRegister(grn)] = grn;
      }
 
-   for (i=0; i < self()->getNumberOfGlobalFPRs(); i++)
+   for (i=0; i < getNumberOfGlobalFPRs(); i++)
      {
-     grn = self()->getFirstGlobalFPR() + i;
-     globalRegNumbers[self()->getGlobalRegister(grn)] = grn;
+     grn = getFirstGlobalFPR() + i;
+     globalRegNumbers[getGlobalRegister(grn)] = grn;
      }
 
-   for (i=0; i < self()->getProperties().getNumIntegerArgumentRegisters(); i++)
-     _gprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[self()->getProperties().getIntegerArgumentRegister(i)];
+   for (i=0; i < getProperties().getNumIntegerArgumentRegisters(); i++)
+     _gprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[getProperties().getIntegerArgumentRegister(i)];
 
-   for (i=0; i < self()->getProperties().getNumFloatArgumentRegisters(); i++)
-     _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[self()->getProperties().getFloatArgumentRegister(i)];
+   for (i=0; i < getProperties().getNumFloatArgumentRegisters(); i++)
+     _fprLinkageGlobalRegisterNumbers[i] = globalRegNumbers[getProperties().getFloatArgumentRegister(i)];
    }
 
 bool

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
@@ -50,7 +50,7 @@ namespace X86
 namespace AMD64
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::X86::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    {
    public:
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
@@ -55,6 +55,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    public:
 
    CodeGenerator();
+   void continueConstruction();
 
    virtual TR::Register *longClobberEvaluate(TR::Node *node);
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.hpp
@@ -55,7 +55,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    public:
 
    CodeGenerator();
-   void continueConstruction();
+   void initializeConstruction();
 
    virtual TR::Register *longClobberEvaluate(TR::Node *node);
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1067,7 +1067,7 @@ OMR::X86::CodeGenerator::supportsMergingGuards()
    {
    return self()->getSupportsVirtualGuardNOPing() &&
           self()->comp()->performVirtualGuardNOPing() &&
-          self()->allowGuardMerging();
+          allowGuardMerging();
    }
 
 bool

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -241,7 +241,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
          {
          if (TR::Compiler->target.is64Bit())
             {
-            self()->setSupportsTM(); // disable tm on 32bits for now
+            setSupportsTM(); // disable tm on 32bits for now
             }
          }
       }
@@ -252,24 +252,24 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
 #endif
       )
       {
-      self()->setUseSSEForSinglePrecision();
-      self()->setUseSSEForDoublePrecision();
-      self()->setSupportsAutoSIMD();
-      self()->setSupportsJavaFloatSemantics();
+      setUseSSEForSinglePrecision();
+      setUseSSEForDoublePrecision();
+      setSupportsAutoSIMD();
+      setSupportsJavaFloatSemantics();
       }
 
    // Choose the best XMM double precision load instruction for the target architecture.
    //
-   if (self()->useSSEForDoublePrecision())
+   if (useSSEForDoublePrecision())
       {
       static char *forceMOVLPD = feGetEnv("TR_forceMOVLPDforDoubleLoads");
       if (_targetProcessorInfo.isAuthenticAMD() || forceMOVLPD)
          {
-         self()->setXMMDoubleLoadOpCode(MOVLPDRegMem);
+         setXMMDoubleLoadOpCode(MOVLPDRegMem);
          }
       else
          {
-         self()->setXMMDoubleLoadOpCode(MOVSDRegMem);
+         setXMMDoubleLoadOpCode(MOVSDRegMem);
          }
       }
 
@@ -282,23 +282,23 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    if (_targetProcessorInfo.supportsSSE() && TR::Compiler->target.cpu.testOSForSSESupport(comp))
 #endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
       {
-      self()->setTargetSupportsSoftwarePrefetches();
+      setTargetSupportsSoftwarePrefetches();
       }
 
    // Enable software prefetch of the TLH and configure the TLH prefetching
    // geometry.
    //
    if (((!comp->getOption(TR_DisableTLHPrefetch) && (comp->cg()->getX86ProcessorInfo().isIntelCore2() || comp->cg()->getX86ProcessorInfo().isIntelNehalem())) ||
-       (comp->getOption(TR_TLHPrefetch) && self()->targetSupportsSoftwarePrefetches())))
+       (comp->getOption(TR_TLHPrefetch) && targetSupportsSoftwarePrefetches())))
       {
-      self()->setEnableTLHPrefetching();
+      setEnableTLHPrefetching();
       }
 
-   self()->setGlobalGPRPartitionLimit(self()->machine()->getGlobalGPRPartitionLimit());
-   self()->setGlobalFPRPartitionLimit(self()->machine()->getGlobalFPRPartitionLimit());
-   self()->setLastGlobalGPR(self()->machine()->getLastGlobalGPRRegisterNumber());
-   self()->setLast8BitGlobalGPR(self()->machine()->getLast8BitGlobalGPRRegisterNumber());
-   self()->setLastGlobalFPR(self()->machine()->getLastGlobalFPRRegisterNumber());
+   setGlobalGPRPartitionLimit(machine()->getGlobalGPRPartitionLimit());
+   setGlobalFPRPartitionLimit(machine()->getGlobalFPRPartitionLimit());
+   setLastGlobalGPR(machine()->getLastGlobalGPRRegisterNumber());
+   setLast8BitGlobalGPR(machine()->getLast8BitGlobalGPRRegisterNumber());
+   setLastGlobalFPR(machine()->getLastGlobalFPRRegisterNumber());
    /*
     * GRA does not work with vector registers on 32 bit due to a bug where xmm registers are not being assigned.
     * This disables GRA for vector registers on 32 bit.
@@ -309,37 +309,37 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
 #if 0
    if (TR::Compiler->target.is64Bit())
       {
-      self()->setFirstGlobalVRF(self()->getFirstGlobalFPR());
-      self()->setLastGlobalVRF(self()->getLastGlobalFPR());
+      setFirstGlobalVRF(getFirstGlobalFPR());
+      setLastGlobalVRF(getLastGlobalFPR());
       }
 #endif // closes the if 0.
 
    // Initialize Linkage for Code Generator
-   self()->initializeLinkage();
+   initializeLinkage();
 
-   _linkageProperties = &self()->getLinkage()->getProperties();
+   _linkageProperties = &getLinkage()->getProperties();
 
-   _unlatchedRegisterList = (TR::RealRegister**)self()->trMemory()->allocateHeapMemory(sizeof(TR::RealRegister*)*(TR::RealRegister::NumRegisters + 1));
+   _unlatchedRegisterList = (TR::RealRegister**)trMemory()->allocateHeapMemory(sizeof(TR::RealRegister*)*(TR::RealRegister::NumRegisters + 1));
    _unlatchedRegisterList[0] = 0; // mark that list is empty
 
-   self()->setGlobalRegisterTable(self()->machine()->getGlobalRegisterTable(*_linkageProperties));
+   setGlobalRegisterTable(machine()->getGlobalRegisterTable(*_linkageProperties));
 
-   self()->machine()->initializeRegisterFile(*_linkageProperties);
+   machine()->initializeRegisterFile(*_linkageProperties);
 
-   self()->getLinkage()->copyLinkageInfoToParameterSymbols();
+   getLinkage()->copyLinkageInfoToParameterSymbols();
 
    _switchToInterpreterLabel = NULL;
 
    // Use a virtual frame pointer register.  The real frame pointer register to be used
    // will be substituted based on _vfpState during size estimation.
    //
-   _frameRegister = self()->machine()->getX86RealRegister(TR::RealRegister::vfp);
+   _frameRegister = machine()->getX86RealRegister(TR::RealRegister::vfp);
 
-   TR::Register            *vmThreadRegister = self()->setVMThreadRegister(self()->allocateRegister());
+   TR::Register            *vmThreadRegister = setVMThreadRegister(allocateRegister());
    TR::RealRegister::RegNum vmThreadIndex    = _linkageProperties->getMethodMetaDataRegister();
    if (vmThreadIndex != TR::RealRegister::NoReg)
       {
-      TR::RealRegister *vmThreadReal = self()->machine()->getX86RealRegister(vmThreadIndex);
+      TR::RealRegister *vmThreadReal = machine()->getX86RealRegister(vmThreadIndex);
       vmThreadRegister->setAssignedRegister(vmThreadReal);
       vmThreadRegister->setAssociation(vmThreadIndex);
       vmThreadReal->setAssignedRegister(vmThreadRegister);
@@ -347,78 +347,78 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       }
 
    if (!debug("disableBetterSpillPlacements"))
-      self()->setEnableBetterSpillPlacements();
+      setEnableBetterSpillPlacements();
 
-   self()->setEnableRematerialisation();
-   self()->setEnableRegisterAssociations();
-   self()->setEnableRegisterWeights();
-   self()->setEnableRegisterInterferences();
+   setEnableRematerialisation();
+   setEnableRegisterAssociations();
+   setEnableRegisterWeights();
+   setEnableRegisterInterferences();
 
-   self()->setEnableSinglePrecisionMethods();
+   setEnableSinglePrecisionMethods();
 
    if (!debug("disableRefinedAliasSets"))
-      self()->setEnableRefinedAliasSets();
+      setEnableRefinedAliasSets();
 
    if (!comp->getOption(TR_DisableLiveRangeSplitter))
       comp->setOption(TR_EnableRangeSplittingGRA);
 
-   self()->addSupportedLiveRegisterKind(TR_GPR);
-   self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_GPR);
-   self()->addSupportedLiveRegisterKind(TR_FPR);
-   self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_FPR);
-   self()->addSupportedLiveRegisterKind(TR_VRF);
-   self()->setLiveRegisters(new (self()->trHeapMemory()) TR_LiveRegisters(comp), TR_VRF);
+   addSupportedLiveRegisterKind(TR_GPR);
+   setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp), TR_GPR);
+   addSupportedLiveRegisterKind(TR_FPR);
+   setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp), TR_FPR);
+   addSupportedLiveRegisterKind(TR_VRF);
+   setLiveRegisters(new (trHeapMemory()) TR_LiveRegisters(comp), TR_VRF);
 
    if (!TR::Compiler->om.canGenerateArraylets())
       {
-      self()->setSupportsArrayCmp();
-      self()->setSupportsPrimitiveArrayCopy();
+      setSupportsArrayCmp();
+      setSupportsPrimitiveArrayCopy();
       if (!comp->getOption(TR_DisableArraySetOpts))
          {
-         self()->setSupportsArraySet();
+         setSupportsArraySet();
          }
       static bool disableX86TRTO = (bool)feGetEnv("TR_disableX86TRTO");
       if (!disableX86TRTO)
          {
-         if (self()->getX86ProcessorInfo().supportsSSE4_1())
+         if (getX86ProcessorInfo().supportsSSE4_1())
             {
-            self()->setSupportsArrayTranslateTRTO();
+            setSupportsArrayTranslateTRTO();
             }
          }
       static bool disableX86TROT = (bool)feGetEnv("TR_disableX86TROT");
       if (!disableX86TROT)
          {
-         if (self()->getX86ProcessorInfo().supportsSSE4_1())
+         if (getX86ProcessorInfo().supportsSSE4_1())
             {
-            self()->setSupportsArrayTranslateTROT();
+            setSupportsArrayTranslateTROT();
             }
-         if (self()->getX86ProcessorInfo().supportsSSE2())
+         if (getX86ProcessorInfo().supportsSSE2())
             {
-            self()->setSupportsArrayTranslateTROTNoBreak();
+            setSupportsArrayTranslateTROTNoBreak();
             }
          }
       }
 
-   self()->setSupportsScaledIndexAddressing();
-   self()->setSupportsConstantOffsetInAddressing();
-   self()->setSupportsCompactedLocals();
-   self()->setSupportsGlRegDeps();
-   self()->setSupportsEfficientNarrowIntComputation();
-   self()->setSupportsEfficientNarrowUnsignedIntComputation();
-   self()->setSupportsVirtualGuardNOPing();
+   setSupportsScaledIndexAddressing();
+   setSupportsConstantOffsetInAddressing();
+   setSupportsCompactedLocals();
+   setSupportsGlRegDeps();
+   setSupportsEfficientNarrowIntComputation();
+   setSupportsEfficientNarrowUnsignedIntComputation();
+   setSupportsVirtualGuardNOPing();
 
    // allows [i/l]div to decompose to [i/l]mulh in TreeSimplifier
    //
    static char * enableMulHigh = feGetEnv("TR_X86MulHigh");
    if (enableMulHigh)
       {
-      self()->setSupportsLoweringConstIDiv();
+      setSupportsLoweringConstIDiv();
 
       if (TR::Compiler->target.is64Bit())
-         self()->setSupportsLoweringConstLDiv();
+         setSupportsLoweringConstLDiv();
       }
 
-   self()->setSpillsFPRegistersAcrossCalls(); // TODO:AMD64: Are the preserved XMMRs relevant here?
+   setSpillsFPRegistersAcrossCalls(); // TODO:AMD64: Are the preserved XMMRs relevant here?
 
    // Make a conservative estimate of the boundary over which an executable instruction cannot
    // be patched.
@@ -434,31 +434,31 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       boundary = 8;
       }
 
-   self()->setInstructionPatchAlignmentBoundary(boundary);
+   setInstructionPatchAlignmentBoundary(boundary);
 
    // Smallest code patching boundary that is known to work on all processors we support.
    //
-   self()->setLowestCommonCodePatchingAlignmentBoundary(8);
+   setLowestCommonCodePatchingAlignmentBoundary(8);
 
-   self()->setPicSlotCount(0);
+   setPicSlotCount(0);
 
    if (!comp->getOption(TR_DisableRegisterPressureSimulation))
       {
       for (int32_t i = 0; i < TR_numSpillKinds; i++)
-         _globalRegisterBitVectors[i].init(self()->getNumberOfGlobalRegisters(), comp->trMemory());
+         _globalRegisterBitVectors[i].init(getNumberOfGlobalRegisters(), comp->trMemory());
 
       TR::RealRegister::RegNum vmThreadRealRegisterIndex = _linkageProperties->getMethodMetaDataRegister();
-      for (TR_GlobalRegisterNumber grn=0; grn < self()->getNumberOfGlobalRegisters(); grn++)
+      for (TR_GlobalRegisterNumber grn=0; grn < getNumberOfGlobalRegisters(); grn++)
          {
-         TR::RealRegister::RegNum reg = (TR::RealRegister::RegNum)self()->getGlobalRegister(grn);
-         if (grn < self()->getFirstGlobalFPR())
+         TR::RealRegister::RegNum reg = (TR::RealRegister::RegNum)getGlobalRegister(grn);
+         if (grn < getFirstGlobalFPR())
             _globalRegisterBitVectors[ TR_gprSpill ].set(grn);
          else
             _globalRegisterBitVectors[ TR_fprSpill ].set(grn);
 
-         if (!self()->getProperties().isPreservedRegister(reg))
+         if (!getProperties().isPreservedRegister(reg))
             _globalRegisterBitVectors[ TR_volatileSpill ].set(grn);
-         if (self()->getProperties().isIntegerArgumentRegister(reg) || self()->getProperties().isFloatArgumentRegister(reg))
+         if (getProperties().isIntegerArgumentRegister(reg) || getProperties().isFloatArgumentRegister(reg))
             _globalRegisterBitVectors[ TR_linkageSpill  ].set(grn);
          if (reg == vmThreadRealRegisterIndex)
             _globalRegisterBitVectors[ TR_vmThreadSpill ].set(grn);
@@ -472,15 +472,15 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       }
 
    if (TR::Compiler->target.cpu.isI386())
-      self()->setGenerateMasmListingSyntax();
+      setGenerateMasmListingSyntax();
 
    if (comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRARegisterStates))
       {
-      self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_GPR));
-      self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_FPR));
+      setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_GPR));
+      setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_FPR));
       }
 
-   self()->setSupportsProfiledInlining();
+   setSupportsProfiledInlining();
    }
 
 
@@ -510,7 +510,7 @@ OMR::X86::CodeGenerator::initializeConstruction()
 TR::Linkage *
 OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    TR::Linkage *linkage = NULL;
 
    switch (lc)
@@ -523,17 +523,17 @@ OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
          if (TR::Compiler->target.isLinux() || TR::Compiler->target.isOSX())
             {
 #if defined(TR_TARGET_64BIT)
-            linkage = new (self()->trHeapMemory()) TR::AMD64ABILinkage(self());
+            linkage = new (trHeapMemory()) TR::AMD64ABILinkage(self());
 #else
-            linkage = new (self()->trHeapMemory()) TR::IA32SystemLinkage(self());
+            linkage = new (trHeapMemory()) TR::IA32SystemLinkage(self());
 #endif
             }
          else if (TR::Compiler->target.isWindows())
             {
 #if defined(TR_TARGET_64BIT)
-            linkage = new (self()->trHeapMemory()) TR::AMD64Win64FastCallLinkage(self());
+            linkage = new (trHeapMemory()) TR::AMD64Win64FastCallLinkage(self());
 #else
-            linkage = new (self()->trHeapMemory()) TR::IA32SystemLinkage(self());
+            linkage = new (trHeapMemory()) TR::IA32SystemLinkage(self());
 #endif
             }
          else
@@ -546,14 +546,14 @@ OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
          TR_ASSERT(0, "\nTestarossa error: Illegal linkage convention %d\n", lc);
       }
 
-   self()->setLinkage(lc, linkage);
+   setLinkage(lc, linkage);
    return linkage;
    }
 
 void
 OMR::X86::CodeGenerator::beginInstructionSelection()
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    _returnTypeInfoInstruction = NULL;
    TR::ResolvedMethodSymbol * methodSymbol = comp->getJittedMethodSymbol();
    TR::Recompilation * recompilation = comp->getRecompilationInfo();
@@ -564,47 +564,47 @@ OMR::X86::CodeGenerator::beginInstructionSelection()
       // Return type info will have been generated by recompilation info
       //
       if (methodSymbol->getLinkageConvention() == TR_Private)
-         _returnTypeInfoInstruction = (TR::X86ImmInstruction*)(self()->getAppendInstruction());
+         _returnTypeInfoInstruction = (TR::X86ImmInstruction*)(getAppendInstruction());
 
       if (methodSymbol->getLinkageConvention() == TR_System)
-         _returnTypeInfoInstruction = (TR::X86ImmInstruction*)(self()->getAppendInstruction());
+         _returnTypeInfoInstruction = (TR::X86ImmInstruction*)(getAppendInstruction());
       }
 
    if (methodSymbol->getLinkageConvention() == TR_Private && !_returnTypeInfoInstruction)
       {
       // linkageInfo word
-      if (self()->getAppendInstruction())
+      if (getAppendInstruction())
          _returnTypeInfoInstruction = generateImmInstruction(DDImm4, startNode, 0, self());
       else
-         _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, DDImm4, 0, self());
+         _returnTypeInfoInstruction = new (trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, DDImm4, 0, self());
       }
 
    if (methodSymbol->getLinkageConvention() == TR_System && !_returnTypeInfoInstruction)
       {
       // linkageInfo word
-      if (self()->getAppendInstruction())
+      if (getAppendInstruction())
          _returnTypeInfoInstruction = generateImmInstruction(DDImm4, startNode, 0, self());
       else
-         _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, DDImm4, 0, self());
+         _returnTypeInfoInstruction = new (trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, DDImm4, 0, self());
       }
 
-   if (self()->getAppendInstruction())
+   if (getAppendInstruction())
       generateInstruction(PROCENTRY, startNode, self());
    else
-      new (self()->trHeapMemory()) TR::Instruction(PROCENTRY, (TR::Instruction *)NULL, self());
+      new (trHeapMemory()) TR::Instruction(PROCENTRY, (TR::Instruction *)NULL, self());
 
    // Set the default FPCW to single precision mode if we are allowed to.
    //
-   if (self()->enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
+   if (enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      generateMemInstruction(LDCWMem, startNode, generateX86MemoryReference(self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST), self()), self());
+      generateMemInstruction(LDCWMem, startNode, generateX86MemoryReference(findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST), self()), self());
       }
    }
 
 void
 OMR::X86::CodeGenerator::endInstructionSelection()
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    if (_returnTypeInfoInstruction != NULL)
       {
       TR_ReturnInfo returnInfo = comp->getReturnInfo();
@@ -615,12 +615,12 @@ OMR::X86::CodeGenerator::endInstructionSelection()
 
    // Reset the FPCW in the dummy finally block.
    //
-   if (self()->enableSinglePrecisionMethods() &&
+   if (enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR_ASSERT(self()->getLastCatchAppendInstruction(),
+      TR_ASSERT(getLastCatchAppendInstruction(),
              "endInstructionSelection() ==> Could not find the dummy finally block!\n");
-      generateMemInstruction(self()->getLastCatchAppendInstruction(), LDCWMem, generateX86MemoryReference(self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST), self()), self());
+      generateMemInstruction(getLastCatchAppendInstruction(), LDCWMem, generateX86MemoryReference(findOrCreate2ByteConstant(getLastCatchAppendInstruction()->getNode(), DOUBLE_PRECISION_ROUND_TO_NEAREST), self()), self());
       }
    }
 
@@ -733,7 +733,7 @@ void OMR::X86::CodeGenerator::removeLiveDiscardableRegister(TR::Register * reg)
 
 bool OMR::X86::CodeGenerator::canNullChkBeImplicit(TR::Node * node)
    {
-   return self()->canNullChkBeImplicit(node, true);
+   return canNullChkBeImplicit(node, true);
    }
 
 void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
@@ -747,15 +747,15 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
       TR::ClobberingInstruction  * clob = NULL;
       TR_IGNode                 *IGNodeSym = NULL;
 
-      if (self()->getLocalsIG())
-         IGNodeSym = self()->getLocalsIG()->getIGNodeForEntity(symbol);
+      if (getLocalsIG())
+         IGNodeSym = getLocalsIG()->getIGNodeForEntity(symbol);
 
       // If this instruction clobbers the source of any memory discardable register(s),
       // those registers must be deactivated (marked as non-discardable) after this point.
       // We record which registers are deactivated, so that we can re-activate them when
       // we have assigned registers for this instruction.
-      auto  iterator = self()->getLiveDiscardableRegisters().begin();
-      while (iterator != self()->getLiveDiscardableRegisters().end())
+      auto  iterator = getLiveDiscardableRegisters().begin();
+      while (iterator != getLiveDiscardableRegisters().end())
          {
          TR::Register *registerCursor = *iterator;
          if (registerCursor->getRematerializationInfo()->isRematerializableFromMemory())
@@ -767,20 +767,20 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
                {
                if (!clob)
                   {
-                  clob = new (self()->trHeapMemory()) TR::ClobberingInstruction(instr, self()->trMemory());
-                  self()->addClobberingInstruction(clob);
+                  clob = new (trHeapMemory()) TR::ClobberingInstruction(instr, trMemory());
+                  addClobberingInstruction(clob);
                   }
 
                clob->addClobberedRegister(registerCursor);
-               iterator = self()->getLiveDiscardableRegisters().erase(iterator);
+               iterator = getLiveDiscardableRegisters().erase(iterator);
                registerCursor->resetIsDiscardable();
 
                if (debug("dumpRemat"))
                   {
                   diagnostic("---> Clobbering %s discardable register %s at instruction %p in %s\n",
-                              self()->getDebug()->toString(registerCursor->getRematerializationInfo()),
-                              self()->getDebug()->getName(registerCursor),
-                              instr, self()->comp()->signature());
+                              getDebug()->toString(registerCursor->getRematerializationInfo()),
+                              getDebug()->getName(registerCursor),
+                              instr, comp()->signature());
                   }
                }
 
@@ -788,26 +788,26 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
             //
             else if (IGNodeSym != NULL)
                {
-               TR_IGNode *IGNodeRematSym = self()->getLocalsIG()->getIGNodeForEntity(rmSymRef->getSymbol());
+               TR_IGNode *IGNodeRematSym = getLocalsIG()->getIGNodeForEntity(rmSymRef->getSymbol());
                if ((IGNodeRematSym != NULL) &&
                    (IGNodeSym->getColour() == IGNodeRematSym->getColour()))
                   {
                   if (!clob)
                      {
-                     clob = new (self()->trHeapMemory()) TR::ClobberingInstruction(instr, self()->trMemory());
-                     self()->addClobberingInstruction(clob);
+                     clob = new (trHeapMemory()) TR::ClobberingInstruction(instr, trMemory());
+                     addClobberingInstruction(clob);
                      }
 
                   clob->addClobberedRegister(registerCursor);
-                  iterator = self()->getLiveDiscardableRegisters().erase(iterator);
+                  iterator = getLiveDiscardableRegisters().erase(iterator);
                   registerCursor->resetIsDiscardable();
 
                   if (debug("dumpRemat"))
                      {
                      diagnostic("---> Clobbering %s discardable register %s at instruction %p because of shared slot in %s\n",
-                                 self()->getDebug()->toString(registerCursor->getRematerializationInfo()),
-                                 self()->getDebug()->getName(registerCursor),
-                                 instr, self()->comp()->signature());
+                                 getDebug()->toString(registerCursor->getRematerializationInfo()),
+                                 getDebug()->getName(registerCursor),
+                                 instr, comp()->signature());
                      }
                   }
                else
@@ -823,12 +823,12 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
       // If a register-dependent discardable register depends on any of the deactivated
       // registers, it (and those that depend on it if any) must also be deactivated.
       //
-      if (clob && self()->supportsIndirectMemoryRematerialization())
+      if (clob && supportsIndirectMemoryRematerialization())
          {
          iterator = clob->getClobberedRegisters().begin();
          while (iterator != clob->getClobberedRegisters().end())
             {
-            self()->clobberLiveDependentDiscardableRegisters(clob, *iterator);
+            clobberLiveDependentDiscardableRegisters(clob, *iterator);
             ++iterator;
             }
          }
@@ -842,14 +842,14 @@ void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
 void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR::ClobberingInstruction * clob,
                                                                     TR::Register              * baseReg)
    {
-   TR_Stack<TR::Register *> worklist(self()->trMemory());
+   TR_Stack<TR::Register *> worklist(trMemory());
    worklist.push(baseReg);
 
    while (!worklist.isEmpty())
       {
       baseReg = worklist.pop();
 
-      for (auto iterator = self()->getLiveDiscardableRegisters().begin(); iterator != self()->getLiveDiscardableRegisters().end();)
+      for (auto iterator = getLiveDiscardableRegisters().begin(); iterator != getLiveDiscardableRegisters().end();)
          {
          TR::Register * candidate = *iterator;
          TR_RematerializationInfo * info = candidate->getRematerializationInfo();
@@ -857,15 +857,15 @@ void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR::Clobb
          if (info->isIndirect() && info->getBaseRegister() == baseReg)
             {
             clob->addClobberedRegister(candidate);
-            iterator = self()->getLiveDiscardableRegisters().erase(iterator);
+            iterator = getLiveDiscardableRegisters().erase(iterator);
             candidate->resetIsDiscardable();
             worklist.push(candidate);
 
             if (debug("dumpRemat"))
                {
                diagnostic("---> Clobbering %s discardable register %s at instruction %p in %s\n",
-                           self()->getDebug()->toString(info), self()->getDebug()->getName(candidate), clob->getInstruction(),
-                           self()->comp()->signature());
+                           getDebug()->toString(info), getDebug()->getName(candidate), clob->getInstruction(),
+                           comp()->signature());
                }
             }
          else
@@ -882,24 +882,24 @@ void OMR::X86::CodeGenerator::clobberLiveDependentDiscardableRegisters(TR::Clobb
 //
 void OMR::X86::CodeGenerator::reactivateDependentDiscardableRegisters(TR::Register * baseReg)
    {
-   TR_Stack<TR::Register *> worklist(self()->trMemory());
+   TR_Stack<TR::Register *> worklist(trMemory());
    worklist.push(baseReg);
 
    if (debug("dumpRemat"))
       diagnostic("---> Re-activating rematerializable registers dependent on %s: ",
-                  self()->getDebug()->getName(baseReg));
+                  getDebug()->getName(baseReg));
 
    while (!worklist.isEmpty())
       {
       baseReg = worklist.pop();
 
-      for (auto iterator = self()->getDependentDiscardableRegisters().begin(); iterator != self()->getDependentDiscardableRegisters().end(); ++iterator)
+      for (auto iterator = getDependentDiscardableRegisters().begin(); iterator != getDependentDiscardableRegisters().end(); ++iterator)
          {
          if ((*iterator)->isDiscardable() &&
              (*iterator)->getRematerializationInfo()->getBaseRegister() == baseReg)
             {
             if (debug("dumpRemat"))
-               diagnostic("%s ", self()->getDebug()->getName(*iterator));
+               diagnostic("%s ", getDebug()->getName(*iterator));
 
             (*iterator)->getRematerializationInfo()->setActive();
 
@@ -922,23 +922,23 @@ void OMR::X86::CodeGenerator::reactivateDependentDiscardableRegisters(TR::Regist
 //
 void OMR::X86::CodeGenerator::deactivateDependentDiscardableRegisters(TR::Register * baseReg)
    {
-   TR_Stack<TR::Register *> worklist(self()->trMemory());
+   TR_Stack<TR::Register *> worklist(trMemory());
    worklist.push(baseReg);
 
    if (debug("dumpRemat"))
       diagnostic("---> Deactivating rematerialisable registers dependent on %s: ",
-                  self()->getDebug()->getName(baseReg));
+                  getDebug()->getName(baseReg));
 
    while (!worklist.isEmpty())
       {
       baseReg = worklist.pop();
 
-      for (auto iterator = self()->getDependentDiscardableRegisters().begin(); iterator != self()->getDependentDiscardableRegisters().end(); ++iterator)
+      for (auto iterator = getDependentDiscardableRegisters().begin(); iterator != getDependentDiscardableRegisters().end(); ++iterator)
          {
          if (baseReg == (*iterator)->getRematerializationInfo()->getBaseRegister())
             {
             if (debug("dumpRemat"))
-               diagnostic("%s ", self()->getDebug()->getName(*iterator));
+               diagnostic("%s ", getDebug()->getName(*iterator));
 
             (*iterator)->getRematerializationInfo()->resetActive();
             worklist.push(*iterator);
@@ -989,7 +989,7 @@ OMR::X86::CodeGenerator::getSupportsOpCodeForAutoSIMD(TR::ILOpCode opcode, TR::D
          else
             return false;
       case TR::vmul:
-         if (dt == TR::Float || dt == TR::Double || (dt == TR::Int32 && self()->getX86ProcessorInfo().supportsSSE4_1()))
+         if (dt == TR::Float || dt == TR::Double || (dt == TR::Int32 && getX86ProcessorInfo().supportsSSE4_1()))
             return true;
          else
             return false;
@@ -1046,14 +1046,14 @@ bool
 OMR::X86::CodeGenerator::getSupportsEncodeUtf16LittleWithSurrogateTest()
    {
    return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() &&
-          !self()->comp()->getOption(TR_DisableSIMDUTF16LEEncoder);
+          !comp()->getOption(TR_DisableSIMDUTF16LEEncoder);
    }
 
 bool
 OMR::X86::CodeGenerator::getSupportsEncodeUtf16BigWithSurrogateTest()
    {
    return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() &&
-          !self()->comp()->getOption(TR_DisableSIMDUTF16BEEncoder);
+          !comp()->getOption(TR_DisableSIMDUTF16BEEncoder);
    }
 
 bool
@@ -1071,8 +1071,8 @@ OMR::X86::CodeGenerator::getSupportsBitPermute()
 bool
 OMR::X86::CodeGenerator::supportsMergingGuards()
    {
-   return self()->getSupportsVirtualGuardNOPing() &&
-          self()->comp()->performVirtualGuardNOPing() &&
+   return getSupportsVirtualGuardNOPing() &&
+          comp()->performVirtualGuardNOPing() &&
           allowGuardMerging();
    }
 
@@ -1098,7 +1098,7 @@ OMR::X86::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhe
 TR::RealRegister *
 OMR::X86::CodeGenerator::getMethodMetaDataRegister()
    {
-   return toRealRegister(self()->getVMThreadRegister());
+   return toRealRegister(getVMThreadRegister());
    }
 
 TR::SymbolReference *
@@ -1108,12 +1108,12 @@ OMR::X86::CodeGenerator::getNanoTimeTemp()
       {
       TR::AutomaticSymbol *sym;
 #if defined(LINUX) || defined(OSX)
-      sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,sizeof(struct timeval));
+      sym = TR::AutomaticSymbol::create(trHeapMemory(),TR::Aggregate,sizeof(struct timeval));
 #else
-      sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,8);
+      sym = TR::AutomaticSymbol::create(trHeapMemory(),TR::Aggregate,8);
 #endif
-      self()->comp()->getMethodSymbol()->addAutomatic(sym);
-      _nanoTimeTemp = new (self()->trHeapMemory()) TR::SymbolReference(self()->comp()->getSymRefTab(), sym);
+      comp()->getMethodSymbol()->addAutomatic(sym);
+      _nanoTimeTemp = new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), sym);
       }
    return _nanoTimeTemp;
    }
@@ -1121,7 +1121,7 @@ OMR::X86::CodeGenerator::getNanoTimeTemp()
 bool
 OMR::X86::CodeGenerator::canTransformUnsafeCopyToArrayCopy()
    {
-   return !self()->comp()->getOption(TR_DisableArrayCopyOpts);
+   return !comp()->getOption(TR_DisableArrayCopyOpts);
    }
 
 void OMR::X86::CodeGenerator::saveBetterSpillPlacements(TR::Instruction * branchInstruction)
@@ -1135,7 +1135,7 @@ void OMR::X86::CodeGenerator::saveBetterSpillPlacements(TR::Instruction * branch
 
    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++)
       {
-      realReg = self()->machine()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      realReg = machine()->getX86RealRegister((TR::RealRegister::RegNum)i);
 
       // Skip non-assignable registers
       //
@@ -1165,9 +1165,9 @@ void OMR::X86::CodeGenerator::saveBetterSpillPlacements(TR::Instruction * branch
       if ((*regElement)->containsCollectedReference() || (*regElement)->containsInternalPointer() || (*regElement)->hasBetterSpillPlacement())
          continue;
 
-      self()->traceRegisterAssignment("Saved better spill placement for %R, mask = %x.", *regElement, freeRealRegisters);
+      traceRegisterAssignment("Saved better spill placement for %R, mask = %x.", *regElement, freeRealRegisters);
 
-      TR_BetterSpillPlacement * info = new (self()->trHeapMemory()) TR_BetterSpillPlacement;
+      TR_BetterSpillPlacement * info = new (trHeapMemory()) TR_BetterSpillPlacement;
       info->_virtReg                = *regElement;
       info->_freeRealRegs           = freeRealRegisters;
       info->_branchInstruction      = branchInstruction;
@@ -1190,7 +1190,7 @@ void OMR::X86::CodeGenerator::removeBetterSpillPlacementCandidate(TR::RealRegist
    TR_BetterSpillPlacement * info, * next;
 
    if (_betterSpillPlacements)
-     self()->traceRegisterAssignment("Removed better spill placement candidate %d.", regNum);
+     traceRegisterAssignment("Removed better spill placement candidate %d.", regNum);
 
    for (info = _betterSpillPlacements, next = NULL; info; info = next)
       {
@@ -1211,7 +1211,7 @@ void OMR::X86::CodeGenerator::removeBetterSpillPlacementCandidate(TR::RealRegist
          // placement.
          //
          info->_virtReg->setHasBetterSpillPlacement(false);
-         self()->traceRegisterAssignment("%R is no longer a candidate for better spill placement.", info->_virtReg);
+         traceRegisterAssignment("%R is no longer a candidate for better spill placement.", info->_virtReg);
          }
       }
    }
@@ -1231,12 +1231,12 @@ OMR::X86::CodeGenerator::findBetterSpillPlacement(
    if (info && (info->_freeRealRegs & TR::RealRegister::getRealRegisterMask(virtReg->getKind(), (TR::RealRegister::RegNum)realRegNum)))
       {
       placement = info->_branchInstruction;
-      self()->traceRegisterAssignment("Successful better spill placement for %R at [" POINTER_PRINTF_FORMAT "].", virtReg, placement);
+      traceRegisterAssignment("Successful better spill placement for %R at [" POINTER_PRINTF_FORMAT "].", virtReg, placement);
       }
    else
       {
       placement = NULL;
-      self()->traceRegisterAssignment("Failed better spill placement for %R.", virtReg);
+      traceRegisterAssignment("Failed better spill placement for %R.", virtReg);
       }
 
    // Remove the better spill placement info from the list.
@@ -1261,15 +1261,15 @@ OMR::X86::CodeGenerator::performNonLinearRegisterAssignmentAtBranch(
       TR::X86LabelInstruction *branchInstruction,
       TR_RegisterKinds kindsToBeAssigned)
    {
-   TR::Machine *xm = self()->machine();
-   TR_RegisterAssignerState *branchRAState = new (self()->trHeapMemory()) TR_RegisterAssignerState(xm);
+   TR::Machine *xm = machine();
+   TR_RegisterAssignerState *branchRAState = new (trHeapMemory()) TR_RegisterAssignerState(xm);
 
    // Take a snapshot of the current register assigner state.
    //
    branchRAState->capture();
 
    TR_OutlinedInstructions *oi =
-      self()->findOutlinedInstructionsFromLabel(branchInstruction->getLabelSymbol());
+      findOutlinedInstructionsFromLabel(branchInstruction->getLabelSymbol());
 
    TR_ASSERT(oi, "Could not find OutlinedInstructions from branch label on instr=%p\n", branchInstruction);
 
@@ -1303,9 +1303,9 @@ OMR::X86::CodeGenerator::performNonLinearRegisterAssignmentAtBranch(
       TR::Instruction *ins =
          generateLabelInstruction(oi->getFirstInstruction(), LABEL, generateLabelSymbol(self()), deps, self());
 
-      if (self()->comp()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (comp()->getOption(TR_TraceNonLinearRegisterAssigner))
          {
-         traceMsg(self()->comp(), "creating LABEL instruction %p for dependencies\n", ins);
+         traceMsg(comp(), "creating LABEL instruction %p for dependencies\n", ins);
          }
       }
 
@@ -1340,7 +1340,7 @@ OMR::X86::CodeGenerator::performNonLinearRegisterAssignmentAtBranch(
    // TODO: live registers that are not spilled at this point should have their backing
    // storage returned to the free spill list.
    //
-   self()->unlockFreeSpillList();
+   unlockFreeSpillList();
 
    // Disassociate backing storage that was previously reserved for a spilled virtual if
    // virtual is no longer spilled.  This occurs because the the free spill list was
@@ -1354,15 +1354,15 @@ OMR::X86::CodeGenerator::performNonLinearRegisterAssignmentAtBranch(
 void OMR::X86::CodeGenerator::prepareForNonLinearRegisterAssignmentAtMerge(
       TR::X86LabelInstruction *mergeInstruction)
    {
-   TR::Machine *xm = self()->machine();
-   TR_RegisterAssignerState *ras = new (self()->trHeapMemory()) TR_RegisterAssignerState(xm);
+   TR::Machine *xm = machine();
+   TR_RegisterAssignerState *ras = new (trHeapMemory()) TR_RegisterAssignerState(xm);
 
    // Take a snapshot of the current register assigner state.
    //
    ras->capture();
 
    TR_OutlinedInstructions *oi =
-      self()->findOutlinedInstructionsFromMergeLabel(mergeInstruction->getLabelSymbol());
+      findOutlinedInstructionsFromMergeLabel(mergeInstruction->getLabelSymbol());
 
    TR_ASSERT(oi, "Could not find OutlinedInstructions from merge label on instr=%p\n", mergeInstruction);
 
@@ -1385,7 +1385,7 @@ void OMR::X86::CodeGenerator::prepareForNonLinearRegisterAssignmentAtMerge(
    // become unspilled.  This will ensure a spilled register will receive the
    // same backing store if it is spilled on either path of the control flow.
    //
-   self()->lockFreeSpillList();
+   lockFreeSpillList();
    }
 
 
@@ -1399,7 +1399,7 @@ void OMR::X86::CodeGenerator::processClobberingInstructions(TR::ClobberingInstru
    // for whatever reason, we must deal with them properly for correctness.)
    //
    while (clobInstructionCursor &&
-    (clobInstructionCursor->getInstruction() == instructionCursor) && self()->enableRematerialisation())
+    (clobInstructionCursor->getInstruction() == instructionCursor) && enableRematerialisation())
       {
       auto regIterator = clobInstructionCursor->getClobberedRegisters().begin();
       while (regIterator != clobInstructionCursor->getClobberedRegisters().end())
@@ -1419,8 +1419,8 @@ void OMR::X86::CodeGenerator::processClobberingInstructions(TR::ClobberingInstru
             if (debug("dumpRemat"))
                {
                diagnostic("---> Activating %s discardable register %s at instruction %p in %s\n",
-                           self()->getDebug()->toString(info), self()->getDebug()->getName(*regIterator), instructionCursor,
-                           self()->comp()->signature());
+                           getDebug()->toString(info), getDebug()->getName(*regIterator), instructionCursor,
+                           comp()->signature());
                }
             }
 
@@ -1443,7 +1443,7 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       TR::Instruction *instructionCursor,
       TR::Instruction *appendInstruction)
    {
-   TR::Compilation *comp = self()->comp();
+   TR::Compilation *comp = comp();
    TR::Instruction *prevInstruction;
 
 #ifdef DEBUG
@@ -1452,16 +1452,16 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
    bool dumpPostGP = (debug("dumpGPRA") || debug("dumpGPRA1")) && comp->getOutFile() != NULL;
 #endif
 
-   if (self()->getUseNonLinearRegisterAssigner())
+   if (getUseNonLinearRegisterAssigner())
       {
-      if (!self()->getSpilledRegisterList())
+      if (!getSpilledRegisterList())
          {
-         self()->setSpilledRegisterList(new (self()->trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator())));
+         setSpilledRegisterList(new (trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator())));
          }
       }
 
-   if (self()->getDebug())
-      self()->getDebug()->startTracingRegisterAssignment("backward", kindsToAssign);
+   if (getDebug())
+      getDebug()->startTracingRegisterAssignment("backward", kindsToAssign);
 
    while (instructionCursor && instructionCursor != appendInstruction)
       {
@@ -1471,10 +1471,10 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       if (dumpPreGP)
          {
          origNextInstruction = instructionCursor->getNext();
-         self()->dumpPreGPRegisterAssignment(instructionCursor);
+         dumpPreGPRegisterAssignment(instructionCursor);
          }
 #endif
-      self()->tracePreRAInstruction(instructionCursor);
+      tracePreRAInstruction(instructionCursor);
 
       prevInstruction = instructionCursor->getPrev();
       instructionCursor->assignRegisters(kindsToAssign);
@@ -1484,29 +1484,29 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       {
          if (label->isStartInternalControlFlow())
          {
-         self()->decInternalControlFlowNestingDepth();
+         decInternalControlFlowNestingDepth();
          }
       else if (label->isEndInternalControlFlow())
          {
-         self()->incInternalControlFlowNestingDepth();
+         incInternalControlFlowNestingDepth();
          }
       }
 
-      self()->freeUnlatchedRegisters();
+      freeUnlatchedRegisters();
 
-      self()->buildGCMapsForInstructionAndSnippet(instructionCursor);
+      buildGCMapsForInstructionAndSnippet(instructionCursor);
 
 #ifdef DEBUG
       if (dumpPostGP)
-         self()->dumpPostGPRegisterAssignment(instructionCursor, origNextInstruction);
+         dumpPostGPRegisterAssignment(instructionCursor, origNextInstruction);
 #endif
-      self()->tracePostRAInstruction(instructionCursor);
+      tracePostRAInstruction(instructionCursor);
       TR::ClobberingInstruction * clobInst;
-      if(_clobIterator == self()->getClobberingInstructions().end())
+      if(_clobIterator == getClobberingInstructions().end())
          clobInst = 0;
       else
          clobInst = *_clobIterator;
-      self()->processClobberingInstructions(clobInst, instructionCursor);
+      processClobberingInstructions(clobInst, instructionCursor);
 
       // Skip over any instructions that may have been inserted prior to the
       // current instruction.  Any such instructions will already have real
@@ -1515,8 +1515,8 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       instructionCursor = prevInstruction;
       }
 
-   if (self()->getDebug())
-      self()->getDebug()->stopTracingRegisterAssignment();
+   if (getDebug())
+      getDebug()->stopTracingRegisterAssignment();
    }
 
 
@@ -1527,38 +1527,38 @@ void OMR::X86::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
 
 #if defined(DEBUG)
    TR::Instruction *origPrevInstruction;
-   bool            dumpPreFP = (debug("dumpFPRA") || debug("dumpFPRA0")) && self()->comp()->getOutFile() != NULL;
-   bool            dumpPostFP = (debug("dumpFPRA") || debug("dumpFPRA1")) && self()->comp()->getOutFile() != NULL;
-   bool            dumpPreGP = (debug("dumpGPRA") || debug("dumpGPRA0")) && self()->comp()->getOutFile() != NULL;
-   bool            dumpPostGP = (debug("dumpGPRA") || debug("dumpGPRA1")) && self()->comp()->getOutFile() != NULL;
+   bool            dumpPreFP = (debug("dumpFPRA") || debug("dumpFPRA0")) && comp()->getOutFile() != NULL;
+   bool            dumpPostFP = (debug("dumpFPRA") || debug("dumpFPRA1")) && comp()->getOutFile() != NULL;
+   bool            dumpPreGP = (debug("dumpGPRA") || debug("dumpGPRA0")) && comp()->getOutFile() != NULL;
+   bool            dumpPostGP = (debug("dumpGPRA") || debug("dumpGPRA1")) && comp()->getOutFile() != NULL;
 #endif
 
-   LexicalTimer pt1("total register assignment", self()->comp()->phaseTimer());
+   LexicalTimer pt1("total register assignment", comp()->phaseTimer());
 
    // Assign FPRs in a forward pass
    //
    if (kindsToAssign & TR_X87_Mask)
       {
-      if (self()->getDebug())
-         self()->getDebug()->startTracingRegisterAssignment("forward", TR_X87_Mask);
+      if (getDebug())
+         getDebug()->startTracingRegisterAssignment("forward", TR_X87_Mask);
 
 #if defined(DEBUG)
       if (dumpPreFP || dumpPostFP)
          diagnostic("\n\nFP Register Assignment (forward pass):\n");
 #endif
 
-      LexicalTimer pt2("FP register assignment", self()->comp()->phaseTimer());
+      LexicalTimer pt2("FP register assignment", comp()->phaseTimer());
 
-      self()->setAssignmentDirection(Forward);
-      instructionCursor = self()->getFirstInstruction();
+      setAssignmentDirection(Forward);
+      instructionCursor = getFirstInstruction();
       while (instructionCursor)
          {
-         self()->tracePreRAInstruction(instructionCursor);
+         tracePreRAInstruction(instructionCursor);
 #if defined(DEBUG)
          if (dumpPreFP)
             {
             origPrevInstruction = instructionCursor->getPrev();
-            self()->dumpPreFPRegisterAssignment(instructionCursor);
+            dumpPreFPRegisterAssignment(instructionCursor);
             }
 #endif
          nextInstruction = instructionCursor->getNext();
@@ -1566,44 +1566,44 @@ void OMR::X86::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssig
 
 #if defined(DEBUG)
          if (dumpPostFP)
-            self()->dumpPostFPRegisterAssignment(instructionCursor, origPrevInstruction);
+            dumpPostFPRegisterAssignment(instructionCursor, origPrevInstruction);
 #endif
-         self()->tracePostRAInstruction(instructionCursor);
+         tracePostRAInstruction(instructionCursor);
 
          instructionCursor = nextInstruction;
          }
 
-      if (self()->getDebug())
-         self()->getDebug()->stopTracingRegisterAssignment();
+      if (getDebug())
+         getDebug()->stopTracingRegisterAssignment();
       }
 
    // Use new float/double slots for XMMR spills, to avoid
    // interfering with existing FPR spills.
    //
-   self()->jettisonAllSpills();
+   jettisonAllSpills();
 
 #if defined(DEBUG)
    if (dumpPreGP || dumpPostGP)
       diagnostic("\n\nGP Register Assignment (backward pass):\n");
 #endif
 
-   LexicalTimer pt2("GP register assignment", self()->comp()->phaseTimer());
+   LexicalTimer pt2("GP register assignment", comp()->phaseTimer());
    // Assign GPRs and XMMRs in a backward pass
    //
    kindsToAssign = TR_RegisterKinds(kindsToAssign & (TR_GPR_Mask | TR_FPR_Mask | TR_VRF_Mask));
    if (kindsToAssign)
       {
-      self()->getVMThreadRegister()->setFutureUseCount(self()->getVMThreadRegister()->getTotalUseCount());
-      self()->setAssignmentDirection(Backward);
-      self()->getFrameRegister()->setFutureUseCount(self()->getFrameRegister()->getTotalUseCount());
+      getVMThreadRegister()->setFutureUseCount(getVMThreadRegister()->getTotalUseCount());
+      setAssignmentDirection(Backward);
+      getFrameRegister()->setFutureUseCount(getFrameRegister()->getTotalUseCount());
 
-      if (self()->enableRematerialisation())
-         _clobIterator = self()->getClobberingInstructions().begin();
+      if (enableRematerialisation())
+         _clobIterator = getClobberingInstructions().begin();
 
-      if (self()->enableRegisterAssociations())
-         self()->machine()->setGPRWeightsFromAssociations();
+      if (enableRegisterAssociations())
+         machine()->setGPRWeightsFromAssociations();
 
-      self()->doBackwardsRegisterAssignment(kindsToAssign, self()->getAppendInstruction());
+      doBackwardsRegisterAssignment(kindsToAssign, getAppendInstruction());
       }
    }
 
@@ -1632,11 +1632,11 @@ struct DescendingSortX86DataSnippetByDataSize
    };
 void OMR::X86::CodeGenerator::doBinaryEncoding()
    {
-   LexicalTimer pt1("code generation", self()->comp()->phaseTimer());
+   LexicalTimer pt1("code generation", comp()->phaseTimer());
 
    // Generate fixup code for the interpreter entry point right before PROCENTRY
    //
-   TR::Instruction * procEntryInstruction = self()->getFirstInstruction();
+   TR::Instruction * procEntryInstruction = getFirstInstruction();
    while (procEntryInstruction && procEntryInstruction->getOpCodeValue() != PROCENTRY)
       {
       procEntryInstruction = procEntryInstruction->getNext();
@@ -1645,8 +1645,8 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    TR::Instruction * interpreterEntryInstruction;
    if (TR::Compiler->target.is64Bit())
       {
-      if (self()->comp()->getMethodSymbol()->getLinkageConvention() != TR_System)
-         interpreterEntryInstruction = self()->getLinkage()->copyStackParametersToLinkageRegisters(procEntryInstruction);
+      if (comp()->getMethodSymbol()->getLinkageConvention() != TR_System)
+         interpreterEntryInstruction = getLinkage()->copyStackParametersToLinkageRegisters(procEntryInstruction);
       else
          interpreterEntryInstruction = procEntryInstruction;
 
@@ -1654,7 +1654,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       //
       if (TR::Compiler->target.isSMP())
          {
-         TR::Recompilation * recompilation = self()->comp()->getRecompilationInfo();
+         TR::Recompilation * recompilation = comp()->getRecompilationInfo();
          const TR_AtomicRegion *atomicRegions;
 #ifdef J9_PROJECT_SPECIFIC
          if (recompilation && !recompilation->useSampling())
@@ -1692,12 +1692,12 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // Pass 1: Binary length estimation and prologue creation
    //
 
-   if (self()->comp()->getOption(TR_TraceCG))
+   if (comp()->getOption(TR_TraceCG))
       {
-      traceMsg(self()->comp(), "<proepilogue>\n");
+      traceMsg(comp(), "<proepilogue>\n");
       }
 
-   TR::Instruction * estimateCursor = self()->getFirstInstruction();
+   TR::Instruction * estimateCursor = getFirstInstruction();
    int32_t estimate = 0;
 
    // Estimate the binary length up to PROCENTRY
@@ -1709,13 +1709,13 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       }
 
    /* Set offset for jitted method entry alignment */
-   if (self()->comp()->getRecompilationInfo())
+   if (comp()->getRecompilationInfo())
       {
       TR_ASSERT(estimate >= 3, "Estimate should not be less than 3");
-      self()->setPreJitMethodEntrySize(estimate - 3);
+      setPreJitMethodEntrySize(estimate - 3);
       }
    else
-      self()->setPreJitMethodEntrySize(estimate);
+      setPreJitMethodEntrySize(estimate);
 
    // Create prologue
    //
@@ -1723,7 +1723,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
    // The recompilation prologue
    //
-   TR::Recompilation * recompilation = self()->comp()->getRecompilationInfo();
+   TR::Recompilation * recompilation = comp()->getRecompilationInfo();
    if (recompilation)
       prologueCursor = recompilation->generatePrologue(prologueCursor);
 
@@ -1732,21 +1732,21 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    //
    _vfpResetInstruction = generateVFPSaveInstruction(prologueCursor, self());
 
-   self()->getLinkage()->createPrologue(prologueCursor); // The linkage prologue
+   getLinkage()->createPrologue(prologueCursor); // The linkage prologue
 
    for (TR::Instruction *gcMapCursor = prologueCursor; gcMapCursor != _vfpResetInstruction; gcMapCursor = gcMapCursor->getNext())
       {
       if (gcMapCursor->needsGCMap())
-         gcMapCursor->setGCMap(self()->getStackAtlas()->getParameterMap()->clone(self()->trMemory()));
+         gcMapCursor->setGCMap(getStackAtlas()->getParameterMap()->clone(trMemory()));
       }
 
    /* Adjust estimate based on jitted method entry alignment requirement */
-   uintptr_t boundary = self()->comp()->getOptions()->getJitMethodEntryAlignmentBoundary(self());
+   uintptr_t boundary = comp()->getOptions()->getJitMethodEntryAlignmentBoundary(self());
    if (boundary && (boundary & boundary - 1) == 0)
       estimate += boundary - 1;
 
-   if (self()->comp()->getOption(TR_TraceVFPSubstitution))
-      traceMsg(self()->comp(), "\n<instructions\n"
+   if (comp()->getOption(TR_TraceVFPSubstitution))
+      traceMsg(comp(), "\n<instructions\n"
                                 "\ttitle=\"VFP Substitution\">");
 
    // Estimate instruction length of prologue and remainder of method,
@@ -1805,7 +1805,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
             // Generate epilogue
             //
             TR::Instruction * temp = estimateCursor->getPrev();
-            self()->getLinkage()->createEpilogue(temp);
+            getLinkage()->createEpilogue(temp);
 
             // Resume estimation from the first instruction of the epilogue
             //
@@ -1836,19 +1836,19 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       TR_VFPState prevState = _vfpState;
       estimateCursor->adjustVFPState(&_vfpState, self());
 
-      if (self()->comp()->getOption(TR_TraceVFPSubstitution))
-         self()->getDebug()->dumpInstructionWithVFPState(estimateCursor, &prevState);
+      if (comp()->getOption(TR_TraceVFPSubstitution))
+         getDebug()->dumpInstructionWithVFPState(estimateCursor, &prevState);
 
       if (estimateCursor == _vfpResetInstruction)
-         self()->generateDebugCounter(estimateCursor, "cg.prologues:#instructionBytes", estimate - estimatedPrologueStartOffset, TR::DebugCounter::Expensive);
+         generateDebugCounter(estimateCursor, "cg.prologues:#instructionBytes", estimate - estimatedPrologueStartOffset, TR::DebugCounter::Expensive);
 
       estimateCursor = estimateCursor->getNext();
       }
 
-   if (self()->comp()->getOption(TR_TraceVFPSubstitution))
-      traceMsg(self()->comp(), "\n</instructions>\n");
+   if (comp()->getOption(TR_TraceVFPSubstitution))
+      traceMsg(comp(), "\n</instructions>\n");
 
-   estimate = self()->setEstimatedLocationsForSnippetLabels(estimate);
+   estimate = setEstimatedLocationsForSnippetLabels(estimate);
    // When using copyBinaryToBuffer() to copy the encoding of an instruction we
    // indiscriminatelly copy a whole integer, even if the size of the encoding
    // is less than that. This may cause the write to happen beyond the allocated
@@ -1857,11 +1857,11 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // adjacent block. For this reason it is better to overestimate
    // the allocated size by 4.
    #define OVER_ESTIMATION 4
-   self()->setEstimatedCodeLength(estimate+OVER_ESTIMATION);
+   setEstimatedCodeLength(estimate+OVER_ESTIMATION);
 
-   if (self()->comp()->getOption(TR_TraceCG))
+   if (comp()->getOption(TR_TraceCG))
       {
-      traceMsg(self()->comp(), "</proepilogue>\n");
+      traceMsg(comp(), "</proepilogue>\n");
       }
 
    /////////////////////////////////////////////////////////////////
@@ -1869,55 +1869,55 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // Pass 2: Binary encoding
    //
 
-   if (self()->comp()->getOption(TR_TraceCG))
+   if (comp()->getOption(TR_TraceCG))
       {
-      traceMsg(self()->comp(), "<encode>\n");
+      traceMsg(comp(), "<encode>\n");
       }
 
    uint8_t * coldCode = NULL;
-   uint8_t * temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
+   uint8_t * temp = allocateCodeMemory(getEstimatedCodeLength(), 0, &coldCode);
    TR_ASSERT(temp, "Failed to allocate primary code area.");
 
-   if (TR::Compiler->target.is64Bit() && self()->comp()->getCodeCacheSwitched() && self()->getPicSlotCount() != 0)
+   if (TR::Compiler->target.is64Bit() && comp()->getCodeCacheSwitched() && getPicSlotCount() != 0)
       {
-      int32_t numTrampolinesToReserve = self()->getPicSlotCount() - self()->comp()->getNumReservedIPICTrampolines();
+      int32_t numTrampolinesToReserve = getPicSlotCount() - comp()->getNumReservedIPICTrampolines();
       TR_ASSERT(numTrampolinesToReserve >= 0, "Discrepancy with number of IPIC trampolines to reserve getPicSlotCount()=%d getNumReservedIPICTrampolines()=%d",
-         self()->getPicSlotCount(), self()->comp()->getNumReservedIPICTrampolines());
+         getPicSlotCount(), comp()->getNumReservedIPICTrampolines());
       reserveNTrampolines(numTrampolinesToReserve);
       }
 
-   self()->setBinaryBufferStart(temp);
-   self()->setBinaryBufferCursor(temp);
-   self()->alignBinaryBufferCursor();
+   setBinaryBufferStart(temp);
+   setBinaryBufferCursor(temp);
+   alignBinaryBufferCursor();
 
-   TR::Instruction * cursorInstruction = self()->getFirstInstruction();
+   TR::Instruction * cursorInstruction = getFirstInstruction();
 
    // Generate binary for all instructions before the interpreter entry point
    //
    while (cursorInstruction && cursorInstruction != interpreterEntryInstruction)
       {
-      self()->setBinaryBufferCursor(cursorInstruction->generateBinaryEncoding());
+      setBinaryBufferCursor(cursorInstruction->generateBinaryEncoding());
       cursorInstruction = cursorInstruction->getNext();
       }
 
    // Now we know the buffer size before the entry point
    //
-   self()->setPrePrologueSize(self()->getBinaryBufferLength());
+   setPrePrologueSize(getBinaryBufferLength());
 
-   self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
+   comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(getBinaryBufferCursor());
 
    // Generate binary for the rest of the instructions
    //
    while (cursorInstruction)
       {
-      uint8_t * const instructionStart = self()->getBinaryBufferCursor();
-      self()->setBinaryBufferCursor(cursorInstruction->generateBinaryEncoding());
-      TR_ASSERT(cursorInstruction->getEstimatedBinaryLength() >= self()->getBinaryBufferCursor() - instructionStart,
+      uint8_t * const instructionStart = getBinaryBufferCursor();
+      setBinaryBufferCursor(cursorInstruction->generateBinaryEncoding());
+      TR_ASSERT(cursorInstruction->getEstimatedBinaryLength() >= getBinaryBufferCursor() - instructionStart,
               "Instruction length estimate must be conservatively large (instr=%s, opcode=%s, estimate=%d, actual=%d",
-              self()->getDebug()? self()->getDebug()->getName(cursorInstruction) : "(unknown)",
-              self()->getDebug()? self()->getDebug()->getOpCodeName(&cursorInstruction->getOpCode()) : "(unknown)",
+              getDebug()? getDebug()->getName(cursorInstruction) : "(unknown)",
+              getDebug()? getDebug()->getOpCodeName(&cursorInstruction->getOpCode()) : "(unknown)",
               cursorInstruction->getEstimatedBinaryLength(),
-              self()->getBinaryBufferCursor() - instructionStart);
+              getBinaryBufferCursor() - instructionStart);
 
       if (TR::Compiler->target.is64Bit() &&
           (cursorInstruction->getOpCodeValue() == PROCENTRY))
@@ -1925,9 +1925,9 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
          // A hack to set the linkage info word
          //
          TR_ASSERT(_returnTypeInfoInstruction->getOpCodeValue() == DDImm4, "assertion failure");
-         uint32_t magicWord = ((self()->getBinaryBufferCursor()-self()->getCodeStart())<<16) | static_cast<uint32_t>(self()->comp()->getReturnInfo());
+         uint32_t magicWord = ((getBinaryBufferCursor()-getCodeStart())<<16) | static_cast<uint32_t>(comp()->getReturnInfo());
          uint32_t recompFlag = 0;
-         TR::Recompilation * recomp = self()->comp()->getRecompilationInfo();
+         TR::Recompilation * recomp = comp()->getRecompilationInfo();
 
 #ifdef J9_PROJECT_SPECIFIC
          if (recomp !=NULL && recomp->couldBeCompiledAgain())
@@ -1940,16 +1940,16 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
          *(uint32_t*)(_returnTypeInfoInstruction->getBinaryEncoding()) = magicWord;
          }
 
-      self()->addToAtlas(cursorInstruction);
+      addToAtlas(cursorInstruction);
       cursorInstruction = cursorInstruction->getNext();
       }
 
    // Create exception table entries for outlined instructions.
    //
-   for(auto oiIterator = self()->getOutlinedInstructionsList().begin(); oiIterator != self()->getOutlinedInstructionsList().end(); ++oiIterator)
+   for(auto oiIterator = getOutlinedInstructionsList().begin(); oiIterator != getOutlinedInstructionsList().end(); ++oiIterator)
       {
-      uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
-      uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
+      uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - getCodeStart();
+      uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - getCodeStart();
 
       TR::Block* block = (*oiIterator)->getBlock();
       TR::Node*  node  = (*oiIterator)->getCallNode();
@@ -1961,22 +1961,22 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    // Place an assumption that gcrPatchPointSymbol reference has been updated
    // with the address of the byte to be patched. Otherwise, fail this compilation
    // and retry without GCR.
-   if (self()->comp()->getOption(TR_EnableGCRPatching) &&
-       self()->comp()->getRecompilationInfo() &&
-       self()->comp()->getRecompilationInfo()->getJittedBodyInfo()->getUsesGCR())
+   if (comp()->getOption(TR_EnableGCRPatching) &&
+       comp()->getRecompilationInfo() &&
+       comp()->getRecompilationInfo()->getJittedBodyInfo()->getUsesGCR())
       {
-      void * addrToPatch = self()->comp()->getSymRefTab()->findOrCreateGCRPatchPointSymbolRef()->getSymbol()->getStaticSymbol()->getStaticAddress();
+      void * addrToPatch = comp()->getSymRefTab()->findOrCreateGCRPatchPointSymbolRef()->getSymbol()->getStaticSymbol()->getStaticAddress();
       if (!addrToPatch)
          {
          TR_ASSERT(false, "Must have updated gcrPatchPointSymbol with the correct address by now\n");
-         self()->comp()->failCompilation<TR::GCRPatchFailure>("Must have updated gcrPatchPointSymbol with the correct address by now");
+         comp()->failCompilation<TR::GCRPatchFailure>("Must have updated gcrPatchPointSymbol with the correct address by now");
          }
       }
 #endif
 
-   if (self()->comp()->getOption(TR_TraceCG))
+   if (comp()->getOption(TR_TraceCG))
       {
-      traceMsg(self()->comp(), "</encode>\n");
+      traceMsg(comp(), "</encode>\n");
       }
 
    }
@@ -1984,18 +1984,18 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 // different from evaluate in that it returns a clobberable register
 TR::Register *OMR::X86::CodeGenerator::gprClobberEvaluate(TR::Node * node, TR_X86OpCodes movRegRegOpCode)
    {
-   TR::Register *sourceRegister = self()->evaluate(node);
+   TR::Register *sourceRegister = evaluate(node);
 
    bool canClobber = true;
    if (node->getReferenceCount() > 1)
       canClobber = false;
    else if (sourceRegister->needsLazyClobbering())
-      canClobber = self()->canClobberNodesRegister(node);
+      canClobber = canClobberNodesRegister(node);
 
-   if (self()->comp()->getOption(TR_TraceCG) && sourceRegister->needsLazyClobbering())
-      traceMsg(self()->comp(), "LAZY CLOBBERING: node %s register %s refcount=%d canClobber=%s\n",
-         self()->getDebug()->getName(node),
-         self()->getDebug()->getName(sourceRegister),
+   if (comp()->getOption(TR_TraceCG) && sourceRegister->needsLazyClobbering())
+      traceMsg(comp(), "LAZY CLOBBERING: node %s register %s refcount=%d canClobber=%s\n",
+         getDebug()->getName(node),
+         getDebug()->getName(sourceRegister),
          node->getReferenceCount(),
          canClobber? "true":"false"
          );
@@ -2010,14 +2010,14 @@ TR::Register *OMR::X86::CodeGenerator::gprClobberEvaluate(TR::Node * node, TR_X8
          {
          if (debug("traceClobberedConstantRegisters") && node->getRegister())
             {
-            trfprintf(self()->comp()->getOutFile(),
+            trfprintf(comp()->getOutFile(),
                "CLOBBERING CONSTANT in %s on " POINTER_PRINTF_FORMAT " in %s\n",
-               self()->getDebug()->getName(node->getRegister()), node, self()->comp()->signature());
-            trfflush(self()->comp()->getOutFile());
+               getDebug()->getName(node->getRegister()), node, comp()->signature());
+            trfflush(comp()->getOutFile());
             }
          }
 
-      TR::Register *targetRegister = self()->allocateRegister();
+      TR::Register *targetRegister = allocateRegister();
       generateRegRegInstruction(movRegRegOpCode, node, targetRegister, sourceRegister, self());
       //
       // TODO: Should we do this?
@@ -2031,15 +2031,15 @@ TR::Register *OMR::X86::CodeGenerator::gprClobberEvaluate(TR::Node * node, TR_X8
 TR::Register *OMR::X86::CodeGenerator::intClobberEvaluate(TR::Node * node)
    {
    TR_ASSERT(!node->getOpCode().is8Byte() || node->getOpCode().isRef(), "Non-ref 8bytes must use longClobberEvaluate");
-   TR_ASSERT(!node->getOpCode().isRef() || TR::Compiler->target.is32Bit() || self()->comp()->useCompressedPointers(), "64-bit references must use longClobberEvaluate unless under compression");
-   return self()->gprClobberEvaluate(node, MOV4RegReg);
+   TR_ASSERT(!node->getOpCode().isRef() || TR::Compiler->target.is32Bit() || comp()->useCompressedPointers(), "64-bit references must use longClobberEvaluate unless under compression");
+   return gprClobberEvaluate(node, MOV4RegReg);
    }
 
 TR::Register *OMR::X86::CodeGenerator::shortClobberEvaluate(TR::Node * node)
    {
    TR_ASSERT(!node->getOpCode().is4Byte() && !node->getOpCode().is8Byte(), "Ints/Longs must use int/longClobberEvaluate");
    TR_ASSERT(!(node->getOpCode().isRef() && TR::Compiler->target.is64Bit()), "64-bit references must use longClobberEvaluate");
-   return self()->gprClobberEvaluate(node, MOV2RegReg);
+   return gprClobberEvaluate(node, MOV2RegReg);
    }
 
 TR::Register *OMR::X86::CodeGenerator::floatClobberEvaluate(TR::Node * node)
@@ -2047,8 +2047,8 @@ TR::Register *OMR::X86::CodeGenerator::floatClobberEvaluate(TR::Node * node)
 
    if (node->getReferenceCount() > 1)
       {
-      TR::Register * temp           = self()->evaluate(node);
-      TR::Register * targetRegister = self()->allocateSinglePrecisionRegister(temp->getKind());
+      TR::Register * temp           = evaluate(node);
+      TR::Register * targetRegister = allocateSinglePrecisionRegister(temp->getKind());
 
       if (temp->needsPrecisionAdjustment())
          TR::TreeEvaluator::insertPrecisionAdjustment(temp, node, self());
@@ -2065,7 +2065,7 @@ TR::Register *OMR::X86::CodeGenerator::floatClobberEvaluate(TR::Node * node)
       }
    else
       {
-      return self()->evaluate(node);
+      return evaluate(node);
       }
    }
 
@@ -2074,8 +2074,8 @@ TR::Register *OMR::X86::CodeGenerator::doubleClobberEvaluate(TR::Node * node)
 
    if (node->getReferenceCount() > 1)
       {
-      TR::Register * temp           = self()->evaluate(node);
-      TR::Register * targetRegister = self()->allocateRegister(temp->getKind());
+      TR::Register * temp           = evaluate(node);
+      TR::Register * targetRegister = allocateRegister(temp->getKind());
 
       if (temp->needsPrecisionAdjustment())
          TR::TreeEvaluator::insertPrecisionAdjustment(temp, node, self());
@@ -2092,14 +2092,14 @@ TR::Register *OMR::X86::CodeGenerator::doubleClobberEvaluate(TR::Node * node)
       }
    else
       {
-      return self()->evaluate(node);
+      return evaluate(node);
       }
    }
 
 TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromLabel(TR::LabelSymbol *label)
    {
-   auto oiIterator = self()->getOutlinedInstructionsList().begin();
-   while (oiIterator != self()->getOutlinedInstructionsList().end())
+   auto oiIterator = getOutlinedInstructionsList().begin();
+   while (oiIterator != getOutlinedInstructionsList().end())
       {
       if ((*oiIterator)->getEntryLabel() == label)
          return *oiIterator;
@@ -2111,8 +2111,8 @@ TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromL
 
 TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromMergeLabel(TR::LabelSymbol *label)
    {
-   auto oiIterator = self()->getOutlinedInstructionsList().begin();
-   while (oiIterator != self()->getOutlinedInstructionsList().end())
+   auto oiIterator = getOutlinedInstructionsList().begin();
+   while (oiIterator != getOutlinedInstructionsList().end())
       {
       if ((*oiIterator)->getRestartLabel() == label)
          return (*oiIterator);
@@ -2124,7 +2124,7 @@ TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromM
 
 TR::X86DataSnippet * OMR::X86::CodeGenerator::createDataSnippet(TR::Node * n, void * c, size_t s)
    {
-   auto snippet = new (self()->trHeapMemory()) TR::X86DataSnippet(self(), n, c, s);
+   auto snippet = new (trHeapMemory()) TR::X86DataSnippet(self(), n, c, s);
    _dataSnippetList.push_back(snippet);
    return snippet;
    }
@@ -2148,7 +2148,7 @@ TR::X86ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstantDataSn
 
    // Constant was not found: create a new snippet for it and add it to the constant list.
    //
-   auto snippet = new (self()->trHeapMemory()) TR::X86ConstantDataSnippet(self(), n, c, s);
+   auto snippet = new (trHeapMemory()) TR::X86ConstantDataSnippet(self(), n, c, s);
    _dataSnippetList.push_back(snippet);
    return snippet;
    }
@@ -2170,48 +2170,48 @@ void OMR::X86::CodeGenerator::emitDataSnippets()
    {
    for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
       {
-      self()->setBinaryBufferCursor((*iterator)->emitSnippetBody());
+      setBinaryBufferCursor((*iterator)->emitSnippetBody());
       }
    }
 
 TR::X86ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate2ByteConstant(TR::Node * n, int16_t c)
    {
-   return self()->findOrCreateConstantDataSnippet(n, &c, 2);
+   return findOrCreateConstantDataSnippet(n, &c, 2);
    }
 
 TR::X86ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate4ByteConstant(TR::Node * n, int32_t c)
    {
-   return self()->findOrCreateConstantDataSnippet(n, &c, 4);
+   return findOrCreateConstantDataSnippet(n, &c, 4);
    }
 
 TR::X86ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c)
    {
-   return self()->findOrCreateConstantDataSnippet(n, &c, 8);
+   return findOrCreateConstantDataSnippet(n, &c, 8);
    }
 
 TR::X86ConstantDataSnippet *OMR::X86::CodeGenerator::findOrCreate16ByteConstant(TR::Node * n, void *c)
    {
-   return self()->findOrCreateConstantDataSnippet(n, c, 16);
+   return findOrCreateConstantDataSnippet(n, c, 16);
    }
 
 TR::X86DataSnippet *OMR::X86::CodeGenerator::create2ByteData(TR::Node *n, int16_t c)
    {
-   return self()->createDataSnippet(n, &c, 2);
+   return createDataSnippet(n, &c, 2);
    }
 
 TR::X86DataSnippet *OMR::X86::CodeGenerator::create4ByteData(TR::Node *n, int32_t c)
    {
-   return self()->createDataSnippet(n, &c, 4);
+   return createDataSnippet(n, &c, 4);
    }
 
 TR::X86DataSnippet *OMR::X86::CodeGenerator::create8ByteData(TR::Node *n, int64_t c)
    {
-   return self()->createDataSnippet(n, &c, 8);
+   return createDataSnippet(n, &c, 8);
    }
 
 TR::X86DataSnippet *OMR::X86::CodeGenerator::create16ByteData(TR::Node *n, void *c)
    {
-   return self()->createDataSnippet(n, c, 16);
+   return createDataSnippet(n, c, 16);
    }
 
 static uint32_t registerBitMask(int32_t reg)
@@ -2222,13 +2222,13 @@ static uint32_t registerBitMask(int32_t reg)
 void OMR::X86::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map)
    {
    TR_InternalPointerMap * internalPtrMap = NULL;
-   TR::GCStackAtlas *atlas = self()->getStackAtlas();
+   TR::GCStackAtlas *atlas = getStackAtlas();
    //
    // Build the register map
    //
    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i)
       {
-      TR::RealRegister * reg = self()->machine()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister * reg = machine()->getX86RealRegister((TR::RealRegister::RegNum)i);
       if (reg->getHasBeenAssignedInMethod())
          {
          TR::Register *virtReg = reg->getAssignedRegister();
@@ -2237,7 +2237,7 @@ void OMR::X86::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map
             if (virtReg->containsInternalPointer())
                {
                if (!internalPtrMap)
-                  internalPtrMap = new (self()->trHeapMemory()) TR_InternalPointerMap(self()->trMemory());
+                  internalPtrMap = new (trHeapMemory()) TR_InternalPointerMap(trMemory());
                internalPtrMap->addInternalPointerPair(virtReg->getPinningArrayPointer(), i);
                atlas->addPinningArrayPtrForInternalPtrReg(virtReg->getPinningArrayPointer());
                }
@@ -2269,7 +2269,7 @@ bool OMR::X86::CodeGenerator::allowGlobalRegisterAcrossBranch(TR_RegisterCandida
 bool OMR::X86::CodeGenerator::supportsInliningOfIsInstance()
    {
    static const char *envp = feGetEnv("TR_NINLINEISINSTANCE");
-   return !envp && !self()->comp()->getOption(TR_DisableInlineIsInstance);
+   return !envp && !comp()->getOption(TR_DisableInlineIsInstance);
    }
 
 uint8_t OMR::X86::CodeGenerator::getSizeOfCombinedBuffer()
@@ -2338,7 +2338,7 @@ int32_t OMR::X86::CodeGenerator::branchDisplacementToHelperOrTrampoline(
 
    if (NEEDS_TRAMPOLINE(helperAddress, nextInstructionAddress, self()))
       {
-      helperAddress = self()->fe()->indexedTrampolineLookup(helper->getReferenceNumber(), (void *)(nextInstructionAddress-4));
+      helperAddress = fe()->indexedTrampolineLookup(helper->getReferenceNumber(), (void *)(nextInstructionAddress-4));
       TR_ASSERT(IS_32BIT_RIP(helperAddress, nextInstructionAddress), "Local helper trampoline should be reachable directly.\n");
       }
 
@@ -2359,9 +2359,9 @@ TR::RealRegister::RegNum OMR::X86::CodeGenerator::pickNOPRegister(TR::Instructio
    // We don't do ebp or esp (or r11 or r12 for that matter) because their
    // binary encodings are not always idential to those of the other registers.
 
-   TR::RealRegister * ebx = self()->machine()->getX86RealRegister(TR::RealRegister::ebx);
-   TR::RealRegister * esi = self()->machine()->getX86RealRegister(TR::RealRegister::esi);
-   TR::RealRegister * edi = self()->machine()->getX86RealRegister(TR::RealRegister::edi);
+   TR::RealRegister * ebx = machine()->getX86RealRegister(TR::RealRegister::ebx);
+   TR::RealRegister * esi = machine()->getX86RealRegister(TR::RealRegister::esi);
+   TR::RealRegister * edi = machine()->getX86RealRegister(TR::RealRegister::edi);
 
    int8_t ebxLastDef = 0;
    int8_t esiLastDef = 0;
@@ -2437,10 +2437,10 @@ inline intptrj_t integerConstNodeValue(TR::Node *node, TR::CodeGenerator *cg)
 
 bool OMR::X86::CodeGenerator::nodeIsFoldableMemOperand(TR::Node *node, TR::Node *parent, TR_RegisterPressureState *state)
    {
-   TR_SimulatedNodeState &nodeState = self()->simulatedNodeState(node, state);
+   TR_SimulatedNodeState &nodeState = simulatedNodeState(node, state);
    bool result =
       (node->getOpCode().isLoadVar() || node->getOpCode().isArrayLength()) &&
-      !self()->isCandidateLoad(node, state) &&
+      !isCandidateLoad(node, state) &&
       !nodeState.hasRegister();
 
    if (node->getFutureUseCount() > 1)
@@ -2452,8 +2452,8 @@ bool OMR::X86::CodeGenerator::nodeIsFoldableMemOperand(TR::Node *node, TR::Node 
       //
       if (parent->getOpCode().isBndCheck() && node->getOpCode().isArrayLength() && node->getFutureUseCount() == 2)
          {
-         if (self()->traceSimulateTreeEvaluation() && result)
-            traceMsg(self()->comp(), " bndchk/arraylength");
+         if (traceSimulateTreeEvaluation() && result)
+            traceMsg(comp(), " bndchk/arraylength");
          TR::TreeTop *prevTT = state->_currentTreeTop->getPrevTreeTop();
          if (prevTT)
             {
@@ -2464,8 +2464,8 @@ bool OMR::X86::CodeGenerator::nodeIsFoldableMemOperand(TR::Node *node, TR::Node 
          }
       }
 
-   if (self()->traceSimulateTreeEvaluation() && result)
-      traceMsg(self()->comp(), " %s foldable into %s", self()->getDebug()->getName(node), self()->getDebug()->getName(parent));
+   if (traceSimulateTreeEvaluation() && result)
+      traceMsg(comp(), " %s foldable into %s", getDebug()->getName(node), getDebug()->getName(parent));
    return result;
    }
 
@@ -2476,7 +2476,7 @@ inline bool lookForMemrefInChild(TR::Node *node)
 
 uint8_t OMR::X86::CodeGenerator::nodeResultGPRCount(TR::Node *node, TR_RegisterPressureState *state)
    {
-   TR_ASSERT(!self()->comp()->getOption(TR_DisableRegisterPressureSimulation), "assertion failure");
+   TR_ASSERT(!comp()->getOption(TR_DisableRegisterPressureSimulation), "assertion failure");
 
    // 32-bit integer constants practically never need a register on x86
    //  (includes 64-bit integer constants with high word zero needed to maintain IL correctness)
@@ -2484,7 +2484,7 @@ uint8_t OMR::X86::CodeGenerator::nodeResultGPRCount(TR::Node *node, TR_RegisterP
    if (  node->getOpCode().isLoadConst()
       && (node->getSize() <= 4 || (node->getType().isInt64() && node->isHighWordZero()))
       && (node->getType().isAddress() || node->getType().isIntegral())
-      && !(  self()->simulatedNodeState(node, state)._keepLiveUntil != NULL // Check if parent will become a RegStore that keeps this node live
+      && !(  simulatedNodeState(node, state)._keepLiveUntil != NULL // Check if parent will become a RegStore that keeps this node live
          && state->_currentTreeTop->getNode()->getOpCode().isStoreDirect()
          && state->_currentTreeTop->getNode()->getFirstChild() == node)
       ){
@@ -2499,7 +2499,7 @@ uint8_t OMR::X86::CodeGenerator::nodeResultGPRCount(TR::Node *node, TR_RegisterP
 
 void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_RegisterPressureState * state, TR_RegisterPressureSummary * summary)
    {
-   TR_ASSERT(!self()->comp()->getOption(TR_DisableRegisterPressureSimulation), "assertion failure");
+   TR_ASSERT(!comp()->getOption(TR_DisableRegisterPressureSimulation), "assertion failure");
 
    // Memory operand opportunities
    //
@@ -2531,9 +2531,9 @@ void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Registe
       // We try folding left first because it tends to be better for BNDCHKs.
       // TODO: we should really try folding the higher tree first
       //
-      if (tryFoldingLeft && (clobbersNothing || right->getFutureUseCount() == 1) && self()->nodeIsFoldableMemOperand(left, node, state))
+      if (tryFoldingLeft && (clobbersNothing || right->getFutureUseCount() == 1) && nodeIsFoldableMemOperand(left, node, state))
          toFold = 0;
-      else if ((clobbersNothing || left->getFutureUseCount() == 1) && self()->nodeIsFoldableMemOperand(right, node, state))
+      else if ((clobbersNothing || left->getFutureUseCount() == 1) && nodeIsFoldableMemOperand(right, node, state))
          toFold = 1;
 
       }
@@ -2541,28 +2541,28 @@ void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Registe
    if (toFold != -1) // toFold child can be folded into a memory operand
       {
       int32_t i;
-      TR_SimulatedMemoryReference memref(self()->trMemory());
+      TR_SimulatedMemoryReference memref(trMemory());
 
       // Evaluate children besides toFold
       for (i=0; i < node->getNumChildren(); i++)
          {
          if (i != toFold)
-            self()->simulateTreeEvaluation(node->getChild(i), state, summary);
+            simulateTreeEvaluation(node->getChild(i), state, summary);
          }
 
       // Fold memref child
-      self()->simulateMemoryReference(&memref, node->getChild(toFold), state, summary);
+      simulateMemoryReference(&memref, node->getChild(toFold), state, summary);
 
       // Decrement refcounts
       for (i=0; i < node->getNumChildren(); i++)
-         self()->simulateDecReferenceCount(node->getChild(i), state);
+         simulateDecReferenceCount(node->getChild(i), state);
       memref.simulateDecNodeReferenceCounts(state, self());
-      self()->simulatedNodeState(node)._childRefcountsHaveBeenDecremented = 1;
+      simulatedNodeState(node)._childRefcountsHaveBeenDecremented = 1;
 
       // Go live
-      self()->simulateNodeGoingLive(node, state);
-      if (self()->traceSimulateTreeEvaluation())
-         traceMsg(self()->comp(), " memop");
+      simulateNodeGoingLive(node, state);
+      if (traceSimulateTreeEvaluation())
+         traceMsg(comp(), " memop");
       }
    else
       {
@@ -2590,8 +2590,8 @@ void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Registe
          // Will probably use shifts/adds/etc instead of multiply
          //
          usesMul = false;
-         if (self()->traceSimulateTreeEvaluation())
-            traceMsg(self()->comp(), " nomul");
+         if (traceSimulateTreeEvaluation())
+            traceMsg(comp(), " nomul");
          }
 
       if (usesMul)
@@ -2599,15 +2599,15 @@ void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Registe
          summary->spill(TR_edxSpill, self());
 
          bool candidateDiesHere = false;
-         if (self()->isCandidateLoad(firstChild, candidate)  && firstChild->getFutureUseCount() == 1)
+         if (isCandidateLoad(firstChild, candidate)  && firstChild->getFutureUseCount() == 1)
             candidateDiesHere = true;
-         if (self()->isCandidateLoad(secondChild, candidate) && secondChild->getFutureUseCount() == 1)
+         if (isCandidateLoad(secondChild, candidate) && secondChild->getFutureUseCount() == 1)
             candidateDiesHere = true;
 
          if (candidateDiesHere)
             {
-            if (self()->traceSimulateTreeEvaluation())
-               traceMsg(self()->comp(), " dieshere");
+            if (traceSimulateTreeEvaluation())
+               traceMsg(comp(), " dieshere");
             }
          else
             {
@@ -2617,13 +2617,13 @@ void OMR::X86::CodeGenerator::simulateNodeEvaluation(TR::Node * node, TR_Registe
          // Account for the extra result register that mul/div instructions use
          //
          summary->accumulate(state, self(), 1);
-         if (self()->traceSimulateTreeEvaluation())
-            traceMsg(self()->comp(), " mul:g=%d", summary->_gprPressure);
+         if (traceSimulateTreeEvaluation())
+            traceMsg(comp(), " mul:g=%d", summary->_gprPressure);
          }
       }
    else if ((opCode.isLeftShift() || opCode.isRightShift())
       && !node->getSecondChild()->getOpCode().isLoadConst()
-      && !self()->isCandidateLoad(node->getSecondChild(), candidate))
+      && !isCandidateLoad(node->getSecondChild(), candidate))
       {
       summary->spill(TR_ecxSpill, self());
       }
@@ -2700,8 +2700,8 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
 
       if (_paddingTable->_flags.testAny(TR_X86PaddingTable::registerMatters))
          {
-         TR::RealRegister::RegNum  regIndex  = self()->pickNOPRegister(neighborhood);
-         TR::RealRegister      *reg       = self()->machine()->getX86RealRegister(regIndex);
+         TR::RealRegister::RegNum  regIndex  = pickNOPRegister(neighborhood);
+         TR::RealRegister      *reg       = machine()->getX86RealRegister(regIndex);
          int32_t                  prefixLen = (_paddingTable->_prefixMask & (1<<length))? 1 : 0;
 
          // Target reg
@@ -2756,17 +2756,17 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
          //
          while (length > _paddingTable->_biggestEncoding)
             {
-            cursor = self()->generatePadding(cursor, _paddingTable->_biggestEncoding, neighborhood, properties);
+            cursor = generatePadding(cursor, _paddingTable->_biggestEncoding, neighborhood, properties);
             length -= _paddingTable->_biggestEncoding;
             }
 
          // Generate an instruction for the residue.
          //
-         cursor = self()->generatePadding(cursor, length, neighborhood, properties);
+         cursor = generatePadding(cursor, length, neighborhood, properties);
          }
       }
    // Begin -- Static debug counters to track nop generation
-   if (!recursive && self()->comp()->getOptions()->enableDebugCounters())
+   if (!recursive && comp()->getOptions()->enableDebugCounters())
       {
       if (neighborhood)
          {
@@ -2785,7 +2785,7 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
              (guardNode->isTheVirtualGuardForAGuardedInlinedCall() || guardNode->isHCRGuard() || guardNode->isProfiledGuard() || guardNode->isMethodEnterExitGuard()))
             {
             const char *guardKind;
-            TR_VirtualGuard *vg = self()->comp()->findVirtualGuardInfo(neighborhood->getNode());
+            TR_VirtualGuard *vg = comp()->findVirtualGuardInfo(neighborhood->getNode());
             switch (vg->getKind())
                {
                case TR_NoGuard:
@@ -2819,10 +2819,10 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
                default:
                   guardKind = "Unknown"; break;
                }
-            TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "nopCount/%d/%s/%s", blockFrequency, neighborhood->description(), guardKind));
+            TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "nopCount/%d/%s/%s", blockFrequency, neighborhood->description(), guardKind));
             if (length > 0)
                {
-               TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "nopInst/%d/%s/%s", blockFrequency, neighborhood->description(), guardKind));
+               TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "nopInst/%d/%s/%s", blockFrequency, neighborhood->description(), guardKind));
 
                for (TR::Instruction *ninst = neighborhood->getNext(); ninst; ninst = ninst->getNext())
                   {
@@ -2831,41 +2831,41 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
                      if (guardNode->isHCRGuard() && ninst->getNode() && ninst->getNode()->isHCRGuard() &&
                          guardNode->getBranchDestination() == ninst->getNode()->getBranchDestination())
                         continue;
-                     TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/vgnop", blockFrequency));
+                     TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "vgnopNoPatchReason/%d/vgnop", blockFrequency));
                      break;
                      }
-                  if (self()->comp()->isPICSite(ninst))
+                  if (comp()->isPICSite(ninst))
                      {
-                     TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/staticPIC", blockFrequency));
+                     TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "vgnopNoPatchReason/%d/staticPIC", blockFrequency));
                      break;
                      }
                   if (ninst->isPatchBarrier())
                      {
                      if (ninst->getOpCodeValue() != LABEL)
-                        TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/patchBarrier", blockFrequency));
+                        TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "vgnopNoPatchReason/%d/patchBarrier", blockFrequency));
                      else
-                        TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/controlFlowMerge", blockFrequency));
+                        TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "vgnopNoPatchReason/%d/controlFlowMerge", blockFrequency));
                      break;
                      }
                   if (ninst->getEstimatedBinaryLength() > 0)
                      {
-                     TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "vgnopNoPatchReason/%d/%s_%s", blockFrequency, (guardNode->isHCRGuard() ? "hcr" : "nohcr"), ninst->description()));
+                     TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "vgnopNoPatchReason/%d/%s_%s", blockFrequency, (guardNode->isHCRGuard() ? "hcr" : "nohcr"), ninst->description()));
                      }
                   }
                }
             }
          else
             {
-            TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "nopCount/%d/%s", blockFrequency, neighborhood->description()));
+            TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "nopCount/%d/%s", blockFrequency, neighborhood->description()));
             if (length > 0)
-               TR::DebugCounter::incStaticDebugCounter(self()->comp(), TR::DebugCounter::debugCounterName(self()->comp(), "nopInst/%d/%s", blockFrequency, neighborhood->description()));
+               TR::DebugCounter::incStaticDebugCounter(comp(), TR::DebugCounter::debugCounterName(comp(), "nopInst/%d/%s", blockFrequency, neighborhood->description()));
             }
          }
       else
          {
-         TR::DebugCounter::incStaticDebugCounter(self()->comp(), "nopCount/-1/unknown");
+         TR::DebugCounter::incStaticDebugCounter(comp(), "nopCount/-1/unknown");
          if (length > 0)
-            TR::DebugCounter::incStaticDebugCounter(self()->comp(), "nopInst/-1/unknown");
+            TR::DebugCounter::incStaticDebugCounter(comp(), "nopInst/-1/unknown");
          }
       }
    // End -- Static debug coutners to track nop generation
@@ -2876,19 +2876,19 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
 intptrj_t
 OMR::X86::CodeGenerator::alignment(void *cursor, intptrj_t boundary, intptrj_t margin)
    {
-   return self()->alignment((intptrj_t)cursor, boundary, margin);
+   return alignment((intptrj_t)cursor, boundary, margin);
    }
 
 bool
 OMR::X86::CodeGenerator::patchableRangeNeedsAlignment(void *cursor, intptrj_t length, intptrj_t boundary, intptrj_t margin)
    {
-   intptrj_t toAlign = self()->alignment(cursor, boundary, margin);
+   intptrj_t toAlign = alignment(cursor, boundary, margin);
    return (toAlign > 0 && toAlign < length);
    }
 
 TR_X86ScratchRegisterManager *OMR::X86::CodeGenerator::generateScratchRegisterManager(int32_t capacity)
    {
-   return new (self()->trHeapMemory()) TR_X86ScratchRegisterManager(capacity, self());
+   return new (trHeapMemory()) TR_X86ScratchRegisterManager(capacity, self());
    }
 
 bool
@@ -2905,12 +2905,12 @@ TR::Instruction *OMR::X86::CodeGenerator::generateDebugCounterBump(TR::Instructi
    if (delta == 1)
       return generateMemInstruction(cursor,
          INC4Mem,
-         generateX86MemoryReference(counter->getBumpCountSymRef(self()->comp()), self()),
+         generateX86MemoryReference(counter->getBumpCountSymRef(comp()), self()),
          self());
    else
       return generateMemImmInstruction(cursor,
          (-128 <= delta && delta <= 127)? ADD4MemImms : ADD4MemImm4,
-         generateX86MemoryReference(counter->getBumpCountSymRef(self()->comp()), self()),
+         generateX86MemoryReference(counter->getBumpCountSymRef(comp()), self()),
          delta,
          self());
    }
@@ -2919,7 +2919,7 @@ TR::Instruction *OMR::X86::CodeGenerator::generateDebugCounterBump(TR::Instructi
    {
    if (deltaReg)
       return generateMemRegInstruction(cursor, ADD4MemReg,
-         generateX86MemoryReference(counter->getBumpCountSymRef(self()->comp()), self()),
+         generateX86MemoryReference(counter->getBumpCountSymRef(comp()), self()),
          deltaReg,
          self());
    else
@@ -2950,7 +2950,7 @@ void OMR::X86::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * 
          case TR::tstart:
             {
             int globalRegNum;
-            globalRegNum = self()->machine()->getGlobalReg(TR::RealRegister::eax);
+            globalRegNum = machine()->getGlobalReg(TR::RealRegister::eax);
             TR_ASSERT(globalRegNum != -1, "could not find global reg");
             availableRegisters.reset(globalRegNum);
             break;
@@ -2968,7 +2968,7 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
 
    for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
       {
-      (*iterator)->print(outFile, self()->getDebug());
+      (*iterator)->print(outFile, getDebug());
       }
    }
 
@@ -2978,18 +2978,18 @@ void OMR::X86::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
 //
 void OMR::X86::CodeGenerator::dumpPreFPRegisterAssignment(TR::Instruction * instructionCursor)
    {
-   if (self()->comp()->getOutFile() == NULL)
+   if (comp()->getOutFile() == NULL)
       return;
 
    if (instructionCursor->totalReferencedFPRegisters(self()) > 0)
       {
-      trfprintf(self()->comp()->getOutFile(), "\n<< Pre-FPR assignment for instruction: %p", instructionCursor);
-      self()->getDebug()->print(self()->comp()->getOutFile(), instructionCursor);
-      self()->getDebug()->printReferencedRegisterInfo(self()->comp()->getOutFile(), instructionCursor);
+      trfprintf(comp()->getOutFile(), "\n<< Pre-FPR assignment for instruction: %p", instructionCursor);
+      getDebug()->print(comp()->getOutFile(), instructionCursor);
+      getDebug()->printReferencedRegisterInfo(comp()->getOutFile(), instructionCursor);
 
       if (debug("dumpFPRegStatus"))
          {
-         self()->machine()->printFPRegisterStatus(self()->fe(), self()->comp()->getOutFile());
+         machine()->printFPRegisterStatus(fe(), comp()->getOutFile());
          }
       }
    }
@@ -3000,13 +3000,13 @@ void OMR::X86::CodeGenerator::dumpPreFPRegisterAssignment(TR::Instruction * inst
 void OMR::X86::CodeGenerator::dumpPostFPRegisterAssignment(TR::Instruction * instructionCursor,
                                                         TR::Instruction *origPrevInstruction)
    {
-   if (self()->comp()->getOutFile() == NULL)
+   if (comp()->getOutFile() == NULL)
       return;
 
    if (instructionCursor->totalReferencedFPRegisters(self()) > 0)
       {
       TR::Instruction * prevInstruction = instructionCursor->getPrev();
-      trfprintf(self()->comp()->getOutFile(), "\n>> Post-FPR assignment for instruction: %p", instructionCursor);
+      trfprintf(comp()->getOutFile(), "\n>> Post-FPR assignment for instruction: %p", instructionCursor);
 
       if (prevInstruction == origPrevInstruction) prevInstruction = NULL;
 
@@ -3018,34 +3018,34 @@ void OMR::X86::CodeGenerator::dumpPostFPRegisterAssignment(TR::Instruction * ins
 
       while (prevInstruction && (prevInstruction != instructionCursor))
          {
-         self()->getDebug()->print(self()->comp()->getOutFile(), prevInstruction);
+         getDebug()->print(comp()->getOutFile(), prevInstruction);
          prevInstruction = prevInstruction->getNext();
          }
 
-      self()->getDebug()->print(self()->comp()->getOutFile(), instructionCursor);
-      self()->getDebug()->printReferencedRegisterInfo(self()->comp()->getOutFile(), instructionCursor);
+      getDebug()->print(comp()->getOutFile(), instructionCursor);
+      getDebug()->printReferencedRegisterInfo(comp()->getOutFile(), instructionCursor);
 
       if (debug("dumpFPRegStatus"))
          {
-         self()->machine()->printFPRegisterStatus(self()->fe(), self()->comp()->getOutFile());
+         machine()->printFPRegisterStatus(fe(), comp()->getOutFile());
          }
       }
    }
 
 void OMR::X86::CodeGenerator::dumpPreGPRegisterAssignment(TR::Instruction * instructionCursor)
    {
-   if (self()->comp()->getOutFile() == NULL)
+   if (comp()->getOutFile() == NULL)
       return;
 
    if (instructionCursor->totalReferencedGPRegisters(self()) > 0)
       {
-      trfprintf(self()->comp()->getOutFile(), "\n<< Pre-GPR assignment for instruction: %p", instructionCursor);
-      self()->getDebug()->print(self()->comp()->getOutFile(), instructionCursor);
-      self()->getDebug()->printReferencedRegisterInfo(self()->comp()->getOutFile(), instructionCursor);
+      trfprintf(comp()->getOutFile(), "\n<< Pre-GPR assignment for instruction: %p", instructionCursor);
+      getDebug()->print(comp()->getOutFile(), instructionCursor);
+      getDebug()->printReferencedRegisterInfo(comp()->getOutFile(), instructionCursor);
 
       if (debug("dumpGPRegStatus"))
          {
-         self()->machine()->printGPRegisterStatus(self()->fe(), self()->machine()->registerFile(), self()->comp()->getOutFile());
+         machine()->printGPRegisterStatus(fe(), machine()->registerFile(), comp()->getOutFile());
          }
       }
    }
@@ -3056,26 +3056,26 @@ void OMR::X86::CodeGenerator::dumpPreGPRegisterAssignment(TR::Instruction * inst
 void OMR::X86::CodeGenerator::dumpPostGPRegisterAssignment(TR::Instruction * instructionCursor,
                                                         TR::Instruction *origNextInstruction)
    {
-   if (self()->comp()->getOutFile() == NULL)
+   if (comp()->getOutFile() == NULL)
       return;
 
    if (instructionCursor->totalReferencedGPRegisters(self()) > 0)
       {
-      trfprintf(self()->comp()->getOutFile(), "\n>> Post-GPR assignment for instruction: %p", instructionCursor);
+      trfprintf(comp()->getOutFile(), "\n>> Post-GPR assignment for instruction: %p", instructionCursor);
 
       TR::Instruction * nextInstruction = instructionCursor;
 
       while (nextInstruction && (nextInstruction != origNextInstruction))
          {
-         self()->getDebug()->print(self()->comp()->getOutFile(), nextInstruction);
+         getDebug()->print(comp()->getOutFile(), nextInstruction);
          nextInstruction = nextInstruction->getNext();
          }
 
-      self()->getDebug()->printReferencedRegisterInfo(self()->comp()->getOutFile(), instructionCursor);
+      getDebug()->printReferencedRegisterInfo(comp()->getOutFile(), instructionCursor);
 
       if (debug("dumpGPRegStatus"))
          {
-         self()->machine()->printGPRegisterStatus(self()->fe(), self()->machine()->registerFile(), self()->comp()->getOutFile());
+         machine()->printGPRegisterStatus(fe(), machine()->registerFile(), comp()->getOutFile());
          }
       }
    }
@@ -3085,9 +3085,9 @@ bool
 OMR::X86::CodeGenerator::useSSEFor(TR::DataType type)
    {
    if (type == TR::Float)
-      return self()->useSSEForSinglePrecision();
+      return useSSEForSinglePrecision();
    else if (type == TR::Double)
-      return self()->useSSEForDoublePrecision();
+      return useSSEForDoublePrecision();
    else
       return false;
    }
@@ -3095,7 +3095,7 @@ OMR::X86::CodeGenerator::useSSEFor(TR::DataType type)
 bool
 OMR::X86::CodeGenerator::needToAvoidCommoningInGRA()
    {
-   if (!self()->useSSEForSinglePrecision() && !self()->useSSEForDoublePrecision()) return true;
+   if (!useSSEForSinglePrecision() && !useSSEForDoublePrecision()) return true;
    return false;
    }
 
@@ -3116,7 +3116,7 @@ OMR::X86::CodeGenerator::arrayTranslateAndTestMinimumNumberOfIterations()
    // attempt to transform a loop with the MemCpy pattern. Be more
    // aggressive at scorching, since loops that iterate exactly 8
    // times can appear to iterate slightly less than that.
-   return self()->comp()->getOptLevel() >= scorching ? 4 : 8;
+   return comp()->getOptLevel() >= scorching ? 4 : 8;
    }
 
 TR::Instruction *OMR::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin) {return nullptr;}

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -500,6 +500,12 @@ OMR::X86::CodeGenerator::CodeGenerator() :
    {
    _clobIterator = _clobberingInstructions.begin();
    }
+   
+void
+OMR::X86::CodeGenerator::continueConstruction()
+   {
+   return;
+   }
 
 TR::Linkage *
 OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1877,7 +1877,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       int32_t numTrampolinesToReserve = self()->getPicSlotCount() - self()->comp()->getNumReservedIPICTrampolines();
       TR_ASSERT(numTrampolinesToReserve >= 0, "Discrepancy with number of IPIC trampolines to reserve getPicSlotCount()=%d getNumReservedIPICTrampolines()=%d",
          self()->getPicSlotCount(), self()->comp()->getNumReservedIPICTrampolines());
-      self()->reserveNTrampolines(numTrampolinesToReserve);
+      reserveNTrampolines(numTrampolinesToReserve);
       }
 
    self()->setBinaryBufferStart(temp);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -510,7 +510,7 @@ OMR::X86::CodeGenerator::initializeConstruction()
 TR::Linkage *
 OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
    TR::Linkage *linkage = NULL;
 
    switch (lc)
@@ -553,11 +553,11 @@ OMR::X86::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 void
 OMR::X86::CodeGenerator::beginInstructionSelection()
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
    _returnTypeInfoInstruction = NULL;
-   TR::ResolvedMethodSymbol * methodSymbol = comp->getJittedMethodSymbol();
-   TR::Recompilation * recompilation = comp->getRecompilationInfo();
-   TR::Node * startNode = comp->getStartTree()->getNode();
+   TR::ResolvedMethodSymbol * methodSymbol = compilation->getJittedMethodSymbol();
+   TR::Recompilation * recompilation = compilation->getRecompilationInfo();
+   TR::Node * startNode = compilation->getStartTree()->getNode();
 
    if (recompilation && recompilation->generatePrePrologue() != NULL)
       {
@@ -595,7 +595,7 @@ OMR::X86::CodeGenerator::beginInstructionSelection()
 
    // Set the default FPCW to single precision mode if we are allowed to.
    //
-   if (enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
+   if (enableSinglePrecisionMethods() && compilation->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
       generateMemInstruction(LDCWMem, startNode, generateX86MemoryReference(findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST), self()), self());
       }
@@ -604,10 +604,10 @@ OMR::X86::CodeGenerator::beginInstructionSelection()
 void
 OMR::X86::CodeGenerator::endInstructionSelection()
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
    if (_returnTypeInfoInstruction != NULL)
       {
-      TR_ReturnInfo returnInfo = comp->getReturnInfo();
+      TR_ReturnInfo returnInfo = compilation->getReturnInfo();
 
       // Note: this will get clobbered again in code generation on AMD64
       _returnTypeInfoInstruction->setSourceImmediate(returnInfo);
@@ -616,7 +616,7 @@ OMR::X86::CodeGenerator::endInstructionSelection()
    // Reset the FPCW in the dummy finally block.
    //
    if (enableSinglePrecisionMethods() &&
-       comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
+       compilation->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
       TR_ASSERT(getLastCatchAppendInstruction(),
              "endInstructionSelection() ==> Could not find the dummy finally block!\n");
@@ -1443,20 +1443,20 @@ void OMR::X86::CodeGenerator::doBackwardsRegisterAssignment(
       TR::Instruction *instructionCursor,
       TR::Instruction *appendInstruction)
    {
-   TR::Compilation *comp = comp();
+   TR::Compilation *compilation = comp();
    TR::Instruction *prevInstruction;
 
 #ifdef DEBUG
    TR::Instruction *origNextInstruction;
-   bool dumpPreGP = (debug("dumpGPRA") || debug("dumpGPRA0")) && comp->getOutFile() != NULL;
-   bool dumpPostGP = (debug("dumpGPRA") || debug("dumpGPRA1")) && comp->getOutFile() != NULL;
+   bool dumpPreGP = (debug("dumpGPRA") || debug("dumpGPRA0")) && compilation->getOutFile() != NULL;
+   bool dumpPostGP = (debug("dumpGPRA") || debug("dumpGPRA1")) && compilation->getOutFile() != NULL;
 #endif
 
    if (getUseNonLinearRegisterAssigner())
       {
       if (!getSpilledRegisterList())
          {
-         setSpilledRegisterList(new (trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(comp->allocator())));
+         setSpilledRegisterList(new (trHeapMemory()) TR::list<TR::Register*>(getTypedAllocator<TR::Register*>(compilation->allocator())));
          }
       }
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3112,3 +3112,5 @@ OMR::X86::CodeGenerator::arrayTranslateAndTestMinimumNumberOfIterations()
    // times can appear to iterate slightly less than that.
    return self()->comp()->getOptLevel() >= scorching ? 4 : 8;
    }
+
+TR::Instruction *OMR::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin) {return nullptr;}

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2922,12 +2922,12 @@ TR::Instruction *OMR::X86::CodeGenerator::generateDebugCounterBump(TR::Instructi
 
 TR::Instruction *OMR::X86::CodeGenerator::generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm)
    {
-   return self()->generateDebugCounterBump(cursor, counter, delta, NULL);
+   return generateDebugCounterBump(cursor, counter, delta, NULL);
    }
 
 TR::Instruction *OMR::X86::CodeGenerator::generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm)
    {
-   return self()->generateDebugCounterBump(cursor, counter, deltaReg, NULL);
+   return generateDebugCounterBump(cursor, counter, deltaReg, NULL);
    }
 
 void OMR::X86::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * rc, TR::Block * * blocks, TR_BitVector & availableRegisters)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -502,7 +502,7 @@ OMR::X86::CodeGenerator::CodeGenerator() :
    }
    
 void
-OMR::X86::CodeGenerator::continueConstruction()
+OMR::X86::CodeGenerator::initializeConstruction()
    {
    return;
    }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1792,7 +1792,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
       // Insert epilogue before each RET.
       //
-      if (self()->isReturnInstruction(estimateCursor))
+      if (isReturnInstruction(estimateCursor))
          {
          if (skipOneReturn == false)
             {

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -356,7 +356,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    virtual void reserveNTrampolines(int32_t numTrampolines) { return; }
 
    // Note: This leaves the code aligned in the specified manner.
-   virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin) = 0;
+   virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
 
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -353,7 +353,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
     *
     * \return : none
     */
-   void reserveNTrampolines(int32_t numTrampolines) { return; }
+   virtual void reserveNTrampolines(int32_t numTrampolines) { return; }
 
    // Note: This leaves the code aligned in the specified manner.
    virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin) = 0;

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -585,6 +585,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    protected:
 
    CodeGenerator();
+   void continueConstruction();
 
    // Note: the following should be called by subclasses near the end of their
    // constructors.  This breaks a rather nasty cyclic initialization dependency,

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -493,7 +493,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
 
    bool patchableRangeNeedsAlignment(void *cursor, intptrj_t length, intptrj_t boundary, intptrj_t margin=0);
 
-   bool nopsAlsoProcessedByRelocations() { return false; }
+   virtual bool nopsAlsoProcessedByRelocations() { return false; }
 
 #if defined(DEBUG)
    void dumpPreFPRegisterAssignment(TR::Instruction *);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -268,7 +268,7 @@ namespace OMR
 namespace X86
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    {
 
    public:

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -356,7 +356,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    void reserveNTrampolines(int32_t numTrampolines) { return; }
 
    // Note: This leaves the code aligned in the specified manner.
-   virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
+   virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin) = 0;
 
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -585,7 +585,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    protected:
 
    CodeGenerator();
-   void continueConstruction();
+   void initializeConstruction();
 
    // Note: the following should be called by subclasses near the end of their
    // constructors.  This breaks a rather nasty cyclic initialization dependency,

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -356,7 +356,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    void reserveNTrampolines(int32_t numTrampolines) { return; }
 
    // Note: This leaves the code aligned in the specified manner.
-   TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
+   virtual TR::Instruction *generateSwitchToInterpreterPrePrologue(TR::Instruction *prev, uint8_t alignment, uint8_t alignmentMargin);
 
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
    void emitDataSnippets();

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -670,7 +670,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
 
    public:
 
-   bool allowGuardMerging() { return false; }
+   virtual bool allowGuardMerging() { return false; }
 
    bool enableBetterSpillPlacements()
       {

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1141,10 +1141,10 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
    int32_t growth = 0;
    if (!self()->isForceWideDisplacement())
       {
-      int32_t currentEncodingAllocation = self()->estimateBinaryLength(cg);
+      int32_t currentEncodingAllocation = estimateBinaryLength(cg);
       int32_t currentPatchSize = self()->getBinaryLengthLowerBound(cg);
       _flags.set(MemRef_ForceWideDisplacement);
-      int32_t potentialEncodingGrowth = self()->estimateBinaryLength(cg) - currentPatchSize;
+      int32_t potentialEncodingGrowth = estimateBinaryLength(cg) - currentPatchSize;
       int32_t potentialPatchGrowth = self()->getBinaryLengthLowerBound(cg) - currentEncodingAllocation;
 
       if (potentialPatchGrowth > 0 &&
@@ -1157,7 +1157,7 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
       else
          {
          _flags.reset(MemRef_ForceWideDisplacement);
-         self()->estimateBinaryLength(cg);
+         estimateBinaryLength(cg);
          return OMR::X86::EnlargementResult(0, 0);
          }
       }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -1141,10 +1141,10 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
    int32_t growth = 0;
    if (!self()->isForceWideDisplacement())
       {
-      int32_t currentEncodingAllocation = estimateBinaryLength(cg);
+      int32_t currentEncodingAllocation = self()->estimateBinaryLength(cg);
       int32_t currentPatchSize = self()->getBinaryLengthLowerBound(cg);
       _flags.set(MemRef_ForceWideDisplacement);
-      int32_t potentialEncodingGrowth = estimateBinaryLength(cg) - currentPatchSize;
+      int32_t potentialEncodingGrowth = self()->estimateBinaryLength(cg) - currentPatchSize;
       int32_t potentialPatchGrowth = self()->getBinaryLengthLowerBound(cg) - currentEncodingAllocation;
 
       if (potentialPatchGrowth > 0 &&
@@ -1157,7 +1157,7 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
       else
          {
          _flags.reset(MemRef_ForceWideDisplacement);
-         estimateBinaryLength(cg);
+         self()->estimateBinaryLength(cg);
          return OMR::X86::EnlargementResult(0, 0);
          }
       }

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -60,7 +60,13 @@
 OMR::X86::I386::CodeGenerator::CodeGenerator() :
    OMR::X86::CodeGenerator()
    {
-   // Common X86 initialization
+
+   }
+
+void
+OMR::X86::I386::CodeGenerator::continueConstruction()
+   {
+	// Common X86 initialization
    //
    self()->initialize( self()->comp() );
 
@@ -119,8 +125,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
    static char *dontConsiderAllAutosForGRA = feGetEnv("TR_dontConsiderAllAutosForGRA");
    if (!dontConsiderAllAutosForGRA)
       self()->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
-
-   }
+}
 
 
 TR::Register *

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -68,21 +68,21 @@ OMR::X86::I386::CodeGenerator::initializeConstruction()
    {
 	// Common X86 initialization
    //
-   self()->initialize( self()->comp() );
+   initialize( comp() );
 
-   self()->setUsesRegisterPairsForLongs();
+   setUsesRegisterPairsForLongs();
 
    if (debug("supportsArrayTranslateAndTest"))
-      self()->setSupportsArrayTranslateAndTest();
+      setSupportsArrayTranslateAndTest();
    if (debug("supportsArrayCmp"))
-      self()->setSupportsArrayCmp();
+      setSupportsArrayCmp();
 
-   self()->setSupportsDoubleWordCAS();
-   self()->setSupportsDoubleWordSet();
+   setSupportsDoubleWordCAS();
+   setSupportsDoubleWordSet();
 
    if (TR::Compiler->target.isWindows())
       {
-      if (self()->comp()->getOption(TR_DisableTraps))
+      if (comp()->getOption(TR_DisableTraps))
          {
          _numberBytesReadInaccessible = 0;
          _numberBytesWriteInaccessible = 0;
@@ -91,16 +91,16 @@ OMR::X86::I386::CodeGenerator::initializeConstruction()
          {
          _numberBytesReadInaccessible = 4096;
          _numberBytesWriteInaccessible = 4096;
-         self()->setHasResumableTrapHandler();
-         self()->setEnableImplicitDivideCheck();
+         setHasResumableTrapHandler();
+         setEnableImplicitDivideCheck();
          }
-      self()->setSupportsDivCheck();
-      self()->setJNILinkageCalleeCleanup();
-      self()->setRealVMThreadRegister(self()->machine()->getX86RealRegister(TR::RealRegister::ebp));
+      setSupportsDivCheck();
+      setJNILinkageCalleeCleanup();
+      setRealVMThreadRegister(machine()->getX86RealRegister(TR::RealRegister::ebp));
       }
    else if (TR::Compiler->target.isLinux())
       {
-      if (self()->comp()->getOption(TR_DisableTraps))
+      if (comp()->getOption(TR_DisableTraps))
          {
          _numberBytesReadInaccessible = 0;
          _numberBytesWriteInaccessible = 0;
@@ -109,22 +109,22 @@ OMR::X86::I386::CodeGenerator::initializeConstruction()
          {
          _numberBytesReadInaccessible = 4096;
          _numberBytesWriteInaccessible = 4096;
-         self()->setHasResumableTrapHandler();
-         self()->setEnableImplicitDivideCheck();
+         setHasResumableTrapHandler();
+         setEnableImplicitDivideCheck();
          }
-      self()->setRealVMThreadRegister(self()->machine()->getX86RealRegister(TR::RealRegister::ebp));
-      self()->setSupportsDivCheck();
+      setRealVMThreadRegister(machine()->getX86RealRegister(TR::RealRegister::ebp));
+      setSupportsDivCheck();
       }
    else
       {
       TR_ASSERT(0, "unknown target");
       }
 
-   self()->setSupportsInlinedAtomicLongVolatiles();
+   setSupportsInlinedAtomicLongVolatiles();
 
    static char *dontConsiderAllAutosForGRA = feGetEnv("TR_dontConsiderAllAutosForGRA");
    if (!dontConsiderAllAutosForGRA)
-      self()->setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
+      setConsiderAllAutosAsTacticalGlobalRegisterCandidates();
 }
 
 
@@ -134,10 +134,10 @@ OMR::X86::I386::CodeGenerator::longClobberEvaluate(TR::Node *node)
    TR_ASSERT(node->getOpCode().is8Byte(), "assertion failure");
    if (node->getReferenceCount() > 1)
       {
-      TR::Register     *temp    = self()->evaluate(node);
-      TR::Register     *lowReg  = self()->allocateRegister();
-      TR::Register     *highReg = self()->allocateRegister();
-      TR::RegisterPair *longReg = self()->allocateRegisterPair(lowReg, highReg);
+      TR::Register     *temp    = evaluate(node);
+      TR::Register     *lowReg  = allocateRegister();
+      TR::Register     *highReg = allocateRegister();
+      TR::RegisterPair *longReg = allocateRegisterPair(lowReg, highReg);
 
       generateRegRegInstruction(MOV4RegReg, node, lowReg, temp->getLowOrder(), self());
       generateRegRegInstruction(MOV4RegReg, node, highReg, temp->getHighOrder(), self());
@@ -145,7 +145,7 @@ OMR::X86::I386::CodeGenerator::longClobberEvaluate(TR::Node *node)
       }
    else
       {
-      return self()->evaluate(node);
+      return evaluate(node);
       }
    }
 
@@ -158,9 +158,9 @@ OMR::X86::I386::CodeGenerator::pickRegister(
       TR_GlobalRegisterNumber &highRegisterNumber,
       TR_LinkHead<TR_RegisterCandidate> *candidates)
    {
-   if (!self()->comp()->getOption(TR_DisableRegisterPressureSimulation))
+   if (!comp()->getOption(TR_DisableRegisterPressureSimulation))
       {
-      if (self()->comp()->getOption(TR_AssignEveryGlobalRegister))
+      if (comp()->getOption(TR_AssignEveryGlobalRegister))
          {
          // This is not really necessary except for testing purposes.
          // Conceptually, the common pickRegister code should be free to make
@@ -174,7 +174,7 @@ OMR::X86::I386::CodeGenerator::pickRegister(
          // this code is redundant.  It is only necessary when
          // TR_AssignEveryGlobalRegister is set.
          //
-         availableRegisters -= *self()->getGlobalRegisters(TR_vmThreadSpill, self()->comp()->getMethodSymbol()->getLinkageConvention());
+         availableRegisters -= *getGlobalRegisters(TR_vmThreadSpill, comp()->getMethodSymbol()->getLinkageConvention());
          }
       return OMR::CodeGenerator::pickRegister(rc, allBlocks, availableRegisters, highRegisterNumber, candidates);
       }
@@ -200,7 +200,7 @@ OMR::X86::I386::CodeGenerator::pickRegister(
 
 
    if (!_assignedGlobalRegisters)
-      _assignedGlobalRegisters = new (self()->trStackMemory()) TR_BitVector(self()->comp()->getSymRefCount(), self()->trMemory(), stackAlloc, growable);
+      _assignedGlobalRegisters = new (trStackMemory()) TR_BitVector(comp()->getSymRefCount(), trMemory(), stackAlloc, growable);
 
    if (availableRegisters.get(5))
       return 5; // esi
@@ -213,7 +213,7 @@ OMR::X86::I386::CodeGenerator::pickRegister(
       return 1;
 
 #ifdef J9_PROJECT_SPECIFIC
-   TR::RecognizedMethod rm = self()->comp()->getMethodSymbol()->getRecognizedMethod();
+   TR::RecognizedMethod rm = comp()->getMethodSymbol()->getRecognizedMethod();
    if (rm == TR::java_util_HashtableHashEnumerator_hasMoreElements)
       {
       if (availableRegisters.get(4))
@@ -227,7 +227,7 @@ OMR::X86::I386::CodeGenerator::pickRegister(
       int32_t numExtraRegs = 0;
       int32_t maxRegisterPressure = 0;
 
-      vcount_t visitCount = self()->comp()->incVisitCount();
+      vcount_t visitCount = comp()->incVisitCount();
       TR_BitVectorIterator bvi(rc->getBlocksLiveOnEntry());
       int32_t maxFrequency = 0;
       while (bvi.hasMoreElements())
@@ -289,17 +289,17 @@ OMR::X86::I386::CodeGenerator::pickRegister(
                }
             }
 
-         maxRegisterPressure = self()->estimateRegisterPressure(block, visitCount, maxStaticFrequency, maxFrequency, vmThreadUsed, numAssignedGlobalRegs, _assignedGlobalRegisters, rc->getSymbolReference(), assigningEDX);
+         maxRegisterPressure = estimateRegisterPressure(block, visitCount, maxStaticFrequency, maxFrequency, vmThreadUsed, numAssignedGlobalRegs, _assignedGlobalRegisters, rc->getSymbolReference(), assigningEDX);
 
-         if (maxRegisterPressure >= self()->getMaximumNumbersOfAssignableGPRs())
+         if (maxRegisterPressure >= getMaximumNumbersOfAssignableGPRs())
             break;
          }
 
       // Determine if we can spare any extra registers for this candidate without spilling
       // in any hot (critical) blocks
       //
-      if (maxRegisterPressure < self()->getMaximumNumbersOfAssignableGPRs())
-         numExtraRegs = self()->getMaximumNumbersOfAssignableGPRs() - maxRegisterPressure;
+      if (maxRegisterPressure < getMaximumNumbersOfAssignableGPRs())
+         numExtraRegs = getMaximumNumbersOfAssignableGPRs() - maxRegisterPressure;
 
       //dumpOptDetails("For global register candidate %d reg pressure is %d maxRegs %d numExtraRegs %d\n", rc->getSymbolReference()->getReferenceNumber(), maxRegisterPressure, comp()->cg()->getMaximumNumbersOfAssignableGPRs(), numExtraRegs);
 
@@ -331,7 +331,7 @@ OMR::X86::I386::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node 
       // 1 for jump table base reg, which is not apparent in the trees
       // 1 for ebp when it is needed for the VMThread
       //
-      return self()->getNumberOfGlobalGPRs() - 2;
+      return getNumberOfGlobalGPRs() - 2;
       }
 
    if (node->getOpCode().isIf())
@@ -376,7 +376,7 @@ OMR::X86::I386::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node 
          {
          if (!TR::TreeEvaluator::instanceOfOrCheckCastNeedSuperTest(node->getFirstChild(), self())  &&
              TR::TreeEvaluator::instanceOfOrCheckCastNeedEqualityTest(node->getFirstChild(), self()))
-            return self()->getNumberOfGlobalGPRs() - 4; // ebp plus three other regs if vft masking is enabled
+            return getNumberOfGlobalGPRs() - 4; // ebp plus three other regs if vft masking is enabled
          else
             return 0;
          }
@@ -384,7 +384,7 @@ OMR::X86::I386::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node 
       // All other conditional branches, we usually need one reg for the compare and possibly one for the vmthread
       //return getNumberOfGlobalGPRs() - 1 - (node->isVMThreadRequired()? 1 : 0);
       // vmThread required might be set on a node after GRA has ran
-      return self()->getNumberOfGlobalGPRs() - 2;
+      return getNumberOfGlobalGPRs() - 2;
       }
 
    return INT_MAX;
@@ -394,7 +394,7 @@ OMR::X86::I386::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node 
 bool
 OMR::X86::I386::CodeGenerator::codegenMulDecomposition(int64_t multiplier)
    {
-   bool iMulDecomposeReport = self()->comp()->getOptions()->getTraceSimplifier(TR_TraceMulDecomposition);
+   bool iMulDecomposeReport = comp()->getOptions()->getTraceSimplifier(TR_TraceMulDecomposition);
    bool answer = false;
    if (iMulDecomposeReport)
       diagnostic("\nCodegen was queried for the value of %d, ", (int32_t)multiplier);

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -64,7 +64,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
    }
 
 void
-OMR::X86::I386::CodeGenerator::continueConstruction()
+OMR::X86::I386::CodeGenerator::initializeConstruction()
    {
 	// Common X86 initialization
    //

--- a/compiler/x/i386/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.hpp
@@ -51,7 +51,7 @@ namespace X86
 namespace I386
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::X86::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    {
 
    public:

--- a/compiler/x/i386/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.hpp
@@ -57,6 +57,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    public:
 
    CodeGenerator();
+   void continueConstruction();
 
    virtual TR::Register *longClobberEvaluate(TR::Node *node);
 

--- a/compiler/x/i386/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.hpp
@@ -57,7 +57,7 @@ class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::X86::CodeGenerator
    public:
 
    CodeGenerator();
-   void continueConstruction();
+   void initializeConstruction();
 
    virtual TR::Register *longClobberEvaluate(TR::Node *node);
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -175,7 +175,7 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
       //
       if (child->getVisitCount() != visitCount)
          {
-         self()->lowerTreesWalk(child, treeTop, visitCount);
+         lowerTreesWalk(child, treeTop, visitCount);
          self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -176,7 +176,7 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
       if (child->getVisitCount() != visitCount)
          {
          lowerTreesWalk(child, treeTop, visitCount);
-         self()->lowerTreeIfNeeded(child, childCount, parent, treeTop);
+         lowerTreeIfNeeded(child, childCount, parent, treeTop);
          }
 
       self()->checkIsUnneededIALoad(parent, child, treeTop);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -182,7 +182,7 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
       self()->checkIsUnneededIALoad(parent, child, treeTop);
       }
 
-   self()->lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPostChildrenVisit(parent, treeTop, visitCount);
 
    }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1823,7 +1823,7 @@ OMR::Z::CodeGenerator::isLitPoolFreeForAssignment()
    // If lit on demand is working, we always free up
    // If no lit-on-demand, try to avoid locking up litpool reg anyways
    //
-   if (self()->isLiteralPoolOnDemandOn() || (!self()->comp()->hasNativeCall() && self()->getFirstSnippet() == NULL))
+   if (isLiteralPoolOnDemandOn() || (!self()->comp()->hasNativeCall() && self()->getFirstSnippet() == NULL))
       {
       litPoolRegIsFree = true;
       }
@@ -3693,7 +3693,7 @@ OMR::Z::CodeGenerator::getMaximumNumberOfAssignableGPRs()
    int32_t maxGPRs = 0;
 
 
-   maxGPRs = 12 + (self()->isLiteralPoolOnDemandOn() ? 1 : 0);
+   maxGPRs = 12 + (isLiteralPoolOnDemandOn() ? 1 : 0);
 
    //traceMsg(comp(), " getMaximumNumberOfAssignableGPRs: %d\n",  maxGPRs);
    return maxGPRs;
@@ -3836,7 +3836,7 @@ OMR::Z::CodeGenerator::getMaximumNumbersOfAssignableGPRs()
    {
    return self()->getMaximumNumberOfAssignableGPRs();
 
-   //int32_t maxNumberOfAssignableGPRS = (8 + (self()->isLiteralPoolOnDemandOn() ? 1 : 0));
+   //int32_t maxNumberOfAssignableGPRS = (8 + (isLiteralPoolOnDemandOn() ? 1 : 0));
    //return maxNumberOfAssignableGPRS;
    }
 
@@ -5967,7 +5967,7 @@ OMR::Z::CodeGenerator::genCopyFromLiteralPool(TR::Node *node, int32_t bytesToCop
    TR::Register *litPoolBaseReg = NULL;
    TR::Node *litPoolNode = NULL;
    bool stopUsing = false;
-   if (self()->isLiteralPoolOnDemandOn())
+   if (isLiteralPoolOnDemandOn())
       {
       if (litPoolNode)
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -551,7 +551,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
    }
 
 void
-OMR::Z::CodeGenerator::continueConstruction()
+OMR::Z::CodeGenerator::initializeConstruction()
    {
    TR::Compilation *comp = self()->comp();
    _cgFlags = 0;

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -546,8 +546,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _ccInstruction(NULL),
      _previouslyAssignedTo(self()->comp()->allocator("LocalRA"))
    {
-   TR::Compilation *comp = self()->comp();
-   _cgFlags = 0;
 
    
    }
@@ -555,6 +553,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
 void
 OMR::Z::CodeGenerator::continueConstruction()
    {
+   TR::Compilation *comp = self()->comp();
+   _cgFlags = 0;
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2510,7 +2510,7 @@ OMR::Z::CodeGenerator::prepareRegistersForAssignment()
          }
       }
 
-   TR::Machine* machine = machine();
+   TR::Machine* thisMachine = machine();
 
    // Lock vector registers. This is done for testing purposes and to artificially increase register pressure
    // We go from the end since in most cases, we want to test functionality of the first half i.e 0-15 for overlap with FPR etc
@@ -2518,7 +2518,7 @@ OMR::Z::CodeGenerator::prepareRegistersForAssignment()
        {
        for (int32_t i = TR::RealRegister::LastAssignableVRF; i > (TR::RealRegister::LastAssignableVRF - TR::Options::_numVecRegsToLock); --i)
           {
-          machine->realRegister(static_cast<TR::RealRegister::RegNum>(i))->setState(TR::RealRegister::Locked);
+          thisMachine->realRegister(static_cast<TR::RealRegister::RegNum>(i))->setState(TR::RealRegister::Locked);
           }
        }
 
@@ -2530,36 +2530,36 @@ OMR::Z::CodeGenerator::prepareRegistersForAssignment()
    // count up how many registers are locked for each type
    for (int32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = thisMachine->getS390RealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedGPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = thisMachine->getS390RealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedHPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = thisMachine->getS390RealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedFPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstVRF; i <= TR::RealRegister::LastVRF; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = thisMachine->getS390RealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedVRFs;
       }
 
-   machine->setNumberOfLockedRegisters(TR_GPR, lockedGPRs);
-   machine->setNumberOfLockedRegisters(TR_HPR, lockedHPRs);
-   machine->setNumberOfLockedRegisters(TR_FPR, lockedFPRs);
-   machine->setNumberOfLockedRegisters(TR_VRF, lockedVRFs);
+   thisMachine->setNumberOfLockedRegisters(TR_GPR, lockedGPRs);
+   thisMachine->setNumberOfLockedRegisters(TR_HPR, lockedHPRs);
+   thisMachine->setNumberOfLockedRegisters(TR_FPR, lockedFPRs);
+   thisMachine->setNumberOfLockedRegisters(TR_VRF, lockedVRFs);
 
    return kindsMask;
    }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -549,6 +549,12 @@ OMR::Z::CodeGenerator::CodeGenerator()
    TR::Compilation *comp = self()->comp();
    _cgFlags = 0;
 
+   
+   }
+
+void
+OMR::Z::CodeGenerator::continueConstruction()
+   {
    // Initialize Linkage for Code Generator
    self()->initializeLinkage();
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1335,7 +1335,7 @@ OMR::Z::CodeGenerator::beginInstructionSelection()
    TR::Node * startNode = self()->comp()->getStartTree()->getNode();
    TR::Instruction * cursor = NULL;
 
-   self()->setCurrentBlockIndex(startNode->getBlock()->getNumber());
+   setCurrentBlockIndex(startNode->getBlock()->getNumber());
 
    if (self()->comp()->getJittedMethodSymbol()->getLinkageConvention() == TR_Private)
       {
@@ -2702,7 +2702,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
          self()->comp()->setCurrentBlock(instructionCursor->getNode()->getBlock());
 
       // Main register assignment procedure
-      self()->setCurrentBlockIndex(instructionCursor->getBlockIndex());
+      setCurrentBlockIndex(instructionCursor->getBlockIndex());
       instructionCursor->assignRegisters(TR_GPR);
 
       handleLoadWithRegRanges(instructionCursor, self());

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -615,7 +615,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
          self()->setSupportsHighWordFacility(true);
       }
 
-   self()->setOnDemandLiteralPoolRun(true);
+   setOnDemandLiteralPoolRun(true);
    self()->setGlobalStaticBaseRegisterOn(false);
 
    self()->setGlobalPrivateStaticBaseRegisterOn(false);
@@ -2720,12 +2720,12 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
                {
                _internalControlFlowNestingDepth--;
                if (_internalControlFlowNestingDepth == 0)
-                  self()->endInternalControlFlow(instructionCursor);        // Walking backwards so start is end
+                  endInternalControlFlow(instructionCursor);        // Walking backwards so start is end
                }
             if (li->getLabelSymbol()->isEndInternalControlFlow())
                {
                _internalControlFlowNestingDepth++;
-               self()->startInternalControlFlow(instructionCursor);
+               startInternalControlFlow(instructionCursor);
                }
             }
          }
@@ -3703,7 +3703,7 @@ int32_t
 OMR::Z::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *block)
    {
    TR::Node *node = block->getLastRealTreeTop()->getNode();
-   int32_t num = self()->getMaximumNumberOfGPRsAllowedAcrossEdge(node);
+   int32_t num = getMaximumNumberOfGPRsAllowedAcrossEdge(node);
 
 
    return num >= 0 ?  num : 0;
@@ -5500,7 +5500,7 @@ OMR::Z::CodeGenerator::evaluateLengthMinusOneForMemoryOps(TR::Node *node, bool c
    {
    TR::Register *reg;
 
-   if ((node->getReferenceCount() == 1) && self()->supportsLengthMinusOneForMemoryOpts() &&
+   if ((node->getReferenceCount() == 1) && supportsLengthMinusOneForMemoryOpts() &&
       ((node->getOpCodeValue()==TR::iadd &&
        node->getSecondChild()->getOpCodeValue()==TR::iconst &&
        node->getSecondChild()->getInt() == 1) ||

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6843,7 +6843,7 @@ bool OMR::Z::CodeGenerator::reliesOnAParticularSignEncoding(TR::Node *node)
       return false;
 
    // left shifts do not rely on a clean sign so the only thing to check is if a clean sign property has been propagated thru it (if not then can return false)
-   if (node->getType().isBCD() && op.isLeftShift() && !self()->propagateSignThroughBCDLeftShift(node->getType()))
+   if (node->getType().isBCD() && op.isLeftShift() && !propagateSignThroughBCDLeftShift(node->getType()))
       return false;
 
    if (node->getType().isBCD() && op.isRightShift())

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -3593,7 +3593,7 @@ OMR::Z::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterInde
       }
    else
       {
-      result = self()->getGlobalRegisterNumber(self()->getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1);
+      result = getGlobalRegisterNumber(self()->getS390Linkage()->getIntegerArgumentRegister(linkageRegisterIndex)-1);
       }
 
    return result;

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -839,7 +839,7 @@ OMR::Z::CodeGenerator::getGlobalGPRFromHPR (TR_GlobalRegisterNumber n)
 
 bool OMR::Z::CodeGenerator::prepareForGRA()
    {
-   bool enableHighWordGRA = supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA);
+   bool enableHighWordGRA = supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA);
    bool enableVectorGRA = self()->getSupportsVectorRegisters() && !self()->comp()->getOption(TR_DisableVectorRegGRA);
 
    if (!_globalRegisterTable)
@@ -2596,7 +2596,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
       if (self()->getDebug())
          {
          TR_RegisterKinds rks = (TR_RegisterKinds)(TR_GPR_Mask | TR_FPR_Mask | TR_VRF_Mask);
-         if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA))
+         if (supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA))
             rks = (TR_RegisterKinds) ((int)rks | TR_HPR_Mask);
 
          self()->getDebug()->startTracingRegisterAssignment("backward", rks);
@@ -2605,7 +2605,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
    // pre-pass to set all internal control flow reg deps to 64bit regs
    TR::Instruction * currInst = instructionCursor;
-   if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
+   if (supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
       {
       while (currInst)
          {
@@ -2685,7 +2685,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
       self()->tracePreRAInstruction(instructionCursor);
 
-      if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && !comp()->getOption(TR_DisableHPRUpgrade))
+      if (supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA) && !self()->comp()->getOption(TR_DisableHPRUpgrade))
          {
          TR::Instruction * newInst = self()->upgradeToHPRInstruction(instructionCursor);
          if (newInst)
@@ -2693,7 +2693,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
             instructionCursor = newInst;
             }
          }
-      if (supportsHighWordFacility() && comp()->getOption(TR_DisableHighWordRA))
+      if (supportsHighWordFacility() && self()->comp()->getOption(TR_DisableHighWordRA))
          self()->setAvailableHPRSpillMask(0xffff0000);
 
       prevInstruction = instructionCursor->getPrev();
@@ -4076,7 +4076,7 @@ OMR::Z::CodeGenerator::gprClobberEvaluate(TR::Node * node, bool force_copy, bool
             else
                loadRegOpCode = TR::InstOpCode::LR;
             }
-         if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
+         if (supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
             {
             loadRegOpCode = TR::InstOpCode::getLoadRegOpCodeFromNode(self(), node);
             if (srcRegister->is64BitReg())
@@ -5186,7 +5186,7 @@ OMR::Z::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map)
    TR::GCStackAtlas * atlas = self()->getStackAtlas();
 
 
-   if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA))
+   if (supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA))
       {
       for (int32_t i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; i++)
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -839,7 +839,7 @@ OMR::Z::CodeGenerator::getGlobalGPRFromHPR (TR_GlobalRegisterNumber n)
 
 bool OMR::Z::CodeGenerator::prepareForGRA()
    {
-   bool enableHighWordGRA = self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA);
+   bool enableHighWordGRA = supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA);
    bool enableVectorGRA = self()->getSupportsVectorRegisters() && !self()->comp()->getOption(TR_DisableVectorRegGRA);
 
    if (!_globalRegisterTable)
@@ -2596,7 +2596,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
       if (self()->getDebug())
          {
          TR_RegisterKinds rks = (TR_RegisterKinds)(TR_GPR_Mask | TR_FPR_Mask | TR_VRF_Mask);
-         if (self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA))
+         if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA))
             rks = (TR_RegisterKinds) ((int)rks | TR_HPR_Mask);
 
          self()->getDebug()->startTracingRegisterAssignment("backward", rks);
@@ -2605,7 +2605,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
    // pre-pass to set all internal control flow reg deps to 64bit regs
    TR::Instruction * currInst = instructionCursor;
-   if (self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
+   if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
       {
       while (currInst)
          {
@@ -2685,7 +2685,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
       self()->tracePreRAInstruction(instructionCursor);
 
-      if (self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA) && !self()->comp()->getOption(TR_DisableHPRUpgrade))
+      if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && !comp()->getOption(TR_DisableHPRUpgrade))
          {
          TR::Instruction * newInst = self()->upgradeToHPRInstruction(instructionCursor);
          if (newInst)
@@ -2693,7 +2693,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
             instructionCursor = newInst;
             }
          }
-      if (self()->supportsHighWordFacility() && self()->comp()->getOption(TR_DisableHighWordRA))
+      if (supportsHighWordFacility() && comp()->getOption(TR_DisableHighWordRA))
          self()->setAvailableHPRSpillMask(0xffff0000);
 
       prevInstruction = instructionCursor->getPrev();
@@ -4076,7 +4076,7 @@ OMR::Z::CodeGenerator::gprClobberEvaluate(TR::Node * node, bool force_copy, bool
             else
                loadRegOpCode = TR::InstOpCode::LR;
             }
-         if (self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
+         if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
             {
             loadRegOpCode = TR::InstOpCode::getLoadRegOpCodeFromNode(self(), node);
             if (srcRegister->is64BitReg())
@@ -5186,7 +5186,7 @@ OMR::Z::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map)
    TR::GCStackAtlas * atlas = self()->getStackAtlas();
 
 
-   if (self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA))
+   if (supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA))
       {
       for (int32_t i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; i++)
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -162,7 +162,7 @@ OMR::Z::CodeGenerator::lowerTreesWalk(TR::Node * parent, TR::TreeTop * treeTop, 
 
    parent->setVisitCount(visitCount);
 
-   self()->lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
+   lowerTreesPreChildrenVisit(parent, treeTop, visitCount);
 
    // Go through the subtrees and lower any nodes that need to be lowered. This
    // involves a call to the VM to replace the trees with other trees.
@@ -3231,7 +3231,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    static char *disableAlignJITEP = feGetEnv("TR_DisableAlignJITEP");
 
    // Adjust the binary buffer cursor with appropriate padding.
-   if (!disableAlignJITEP && !self()->comp()->compileRelocatableCode() && self()->allowSplitWarmAndColdBlocks())
+   if (!disableAlignJITEP && !self()->comp()->compileRelocatableCode() && allowSplitWarmAndColdBlocks())
       {
       int32_t alignedBase = 256 - self()->getPreprologueOffset();
       int32_t padBase = ( 256 + alignedBase - ((intptrj_t)temp) % 256) % 256;

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -240,6 +240,7 @@ public:
    void lowerTreesPropagateBlockToNode(TR::Node *node);
 
    CodeGenerator();
+   void continueConstruction();
    TR::Linkage *createLinkage(TR_LinkageConventions lc);
 
    bool anyNonConstantSnippets();

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -508,7 +508,7 @@ public:
    int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *);
    int32_t getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *);
    int32_t getMaximumNumberOfVRFsAllowedAcrossEdge(TR::Node *);
-   int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *);
+   virtual int32_t getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Block *);
 
    int32_t getMaximumNumbersOfAssignableGPRs();
    int32_t getMaximumNumbersOfAssignableFPRs();

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -167,7 +167,7 @@ namespace OMR
 {
 namespace Z
 {
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGenerator
    {
 
 public:

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -240,7 +240,7 @@ public:
    void lowerTreesPropagateBlockToNode(TR::Node *node);
 
    CodeGenerator();
-   void continueConstruction();
+   void initializeConstruction();
    TR::Linkage *createLinkage(TR_LinkageConventions lc);
 
    bool anyNonConstantSnippets();

--- a/fvtest/compilertest/codegen/CodeGenerator.hpp
+++ b/fvtest/compilertest/codegen/CodeGenerator.hpp
@@ -26,7 +26,7 @@
 
 namespace TR
 {
-class OMR_EXTENSIBLE CodeGenerator : public ::TestCompiler::CodeGeneratorConnector
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public ::TestCompiler::CodeGeneratorConnector
    {
    public:
 

--- a/fvtest/compilertest/codegen/TestCodeGenerator.hpp
+++ b/fvtest/compilertest/codegen/TestCodeGenerator.hpp
@@ -37,7 +37,7 @@ namespace TestCompiler { typedef CodeGenerator CodeGeneratorConnector; }
 namespace TestCompiler
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public OMR::CodeGeneratorConnector
    {
    public:
 

--- a/fvtest/compilertest/z/codegen/TestCodeGenerator.hpp
+++ b/fvtest/compilertest/z/codegen/TestCodeGenerator.hpp
@@ -45,7 +45,7 @@ namespace TestCompiler
 namespace Z
 {
 
-class OMR_EXTENSIBLE CodeGenerator : public TestCompiler::CodeGenerator
+class /*OMR_EXTENSIBLE*/ CodeGenerator : public TestCompiler::CodeGenerator
    {
    public:
 


### PR DESCRIPTION
* Commented out `OMR_EXTENSIBLE` from `CodeGenerator` class declarations
* Removed `self()` from function calls of `CodeGenerator`

Since virtualizing the `CodeGenerator` hierarchy requires changes from both, the OMR and OpenJ9, projects this PR is linked to [a related one in openJ9](https://github.com/eclipse/openj9/pull/2087) achieving the same purpose.


Signed-off-by: Samer AL Masri <almasri@ualberta.ca>