### PR TITLE
Support exception throw from outlined code on X86

### DIFF
--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -427,13 +427,11 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
 
          // Slow path
          //
-         TR_OutlinedInstructions *slowPath = new (cg->trHeapMemory()) TR_OutlinedInstructions(slowPathLabel, cg);
-         cg->getOutlinedInstructionsList().push_front(slowPath);
-         slowPath->swapInstructionListsWithCompilation();
-         generateLabelInstruction(NULL, LABEL,       slowPathLabel,          cg)->setNode(node);
+         {
+         TR_OutlinedInstructionsGenerator og(slowPathLabel, node, cg);
          generateRegImm64Instruction(MOV8RegImm64, node, treg, DOUBLE_NAN, cg);
-         generateLabelInstruction(      JMP4,        node, endLabel,         cg);
-         slowPath->swapInstructionListsWithCompilation();
+         generateLabelInstruction(JMP4, node, endLabel, cg);
+         }
 
          // Merge point
          //

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -1502,11 +1502,8 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
          generateLabelInstruction(JE4, node, exceptionLabel, cg);
          }
 
-      TR_OutlinedInstructions* exceptionPath = new (cg->trHeapMemory()) TR_OutlinedInstructions(exceptionLabel, cg);
-      cg->getOutlinedInstructionsList().push_front(exceptionPath);
-      exceptionPath->swapInstructionListsWithCompilation();
-
-      generateLabelInstruction(LABEL, node, exceptionLabel, cg);
+      {
+      TR_OutlinedInstructionsGenerator og(exceptionLabel, node, cg);
       // at this point, target is set to -INF and there can only be THREE possible results: -INF, +INF, NaN
       // compare source with ZERO
       generateRegMemInstruction(doubleSource ? UCOMISDRegMem : UCOMISSRegMem,
@@ -1528,7 +1525,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
                                 cg);
 
       generateLabelInstruction(JMP4, node, endLabel, cg);
-      exceptionPath->swapInstructionListsWithCompilation();
+      }
 
       generateLabelInstruction(LABEL, node, endLabel, cg);
       if (longTarget)
@@ -1851,13 +1848,11 @@ TR::Register *OMR::X86::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Code
 
          // Slow path
          //
-         TR_OutlinedInstructions *slowPath = new (cg->trHeapMemory()) TR_OutlinedInstructions(slowPathLabel, cg);
-         cg->getOutlinedInstructionsList().push_front(slowPath);
-         slowPath->swapInstructionListsWithCompilation();
-         generateLabelInstruction(NULL, LABEL,             slowPathLabel,   cg)->setNode(node);
-         generateRegImmInstruction(     MOV4RegImm4, node, treg, FLOAT_NAN, cg);
-         generateLabelInstruction(      JMP4,        node, endLabel,        cg);
-         slowPath->swapInstructionListsWithCompilation();
+         {
+         TR_OutlinedInstructionsGenerator og(slowPathLabel, node, cg);
+         generateRegImmInstruction( MOV4RegImm4, node, treg, FLOAT_NAN, cg);
+         generateLabelInstruction(  JMP4,        node, endLabel,        cg);
+         }
 
          // Merge point
          //

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2016,19 +2016,15 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
    // Create exception table entries for outlined instructions.
    //
-   auto oiIterator = self()->getOutlinedInstructionsList().begin();
-   while (oiIterator != self()->getOutlinedInstructionsList().end())
+   for(auto oiIterator = self()->getOutlinedInstructionsList().begin(); oiIterator != self()->getOutlinedInstructionsList().end(); ++oiIterator)
       {
       uint32_t startOffset = (*oiIterator)->getFirstInstruction()->getBinaryEncoding() - self()->getCodeStart();
       uint32_t endOffset   = (*oiIterator)->getAppendInstruction()->getBinaryEncoding() - self()->getCodeStart();
 
-      TR::Block * block = (*oiIterator)->getBlock();
-      bool      needsETE = (*oiIterator)->getCallNode() && (*oiIterator)->getCallNode()->getSymbolReference()->canCauseGC();
-
-      if (needsETE && block && !block->getExceptionSuccessors().empty())
+      TR::Block* block = (*oiIterator)->getBlock();
+      TR::Node*  node  = (*oiIterator)->getCallNode();
+      if (block && node && !block->getExceptionSuccessors().empty() && node->canGCandExcept())
          block->addExceptionRangeForSnippet(startOffset, endOffset);
-
-      ++oiIterator;
       }
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1782,17 +1782,15 @@ static void arrayCopy16BitPrimitive(TR::Node* node, TR::Register* dstReg, TR::Re
       generateRegMemInstruction(L2RegMem, node, sizeReg, generateX86MemoryReference(srcReg, 0, cg), cg);
       generateMemRegInstruction(S2MemReg, node, generateX86MemoryReference(dstReg, 0, cg), sizeReg, cg);
 
-      TR_OutlinedInstructions* backwardPath = new (cg->trHeapMemory()) TR_OutlinedInstructions(backwardLabel, cg);
-      cg->getOutlinedInstructionsList().push_front(backwardPath);
-      backwardPath->swapInstructionListsWithCompilation();
-      generateLabelInstruction(LABEL, node, backwardLabel, cg);
+      {
+      TR_OutlinedInstructionsGenerator og(backwardLabel, node, cg);
       generateRegMemInstruction(LEARegMem(), node, srcReg, generateX86MemoryReference(srcReg, sizeReg, 0, -2, cg), cg);
       generateRegMemInstruction(LEARegMem(), node, dstReg, generateX86MemoryReference(dstReg, sizeReg, 0, -2, cg), cg);
       generateInstruction(STD, node, cg);
       generateRepMovsInstruction(REPMOVSW, node, sizeReg, NULL, cg);
       generateInstruction(CLD, node, cg);
       generateLabelInstruction(JMP4, node, mainEndLabel, cg);
-      backwardPath->swapInstructionListsWithCompilation();
+      }
       }
    generateLabelInstruction(LABEL, node, mainEndLabel, dependencies, cg);
    }
@@ -1864,17 +1862,15 @@ static void arrayCopyDefault(TR::Node* node, uint8_t elementSize, TR::Register* 
       generateLabelInstruction(JB4, node, backwardLabel, cg);   // jb, skip backward copy setup
       generateRepMovsInstruction(repmovs, node, sizeReg, NULL, cg);
 
-      TR_OutlinedInstructions* backwardPath = new (cg->trHeapMemory()) TR_OutlinedInstructions(backwardLabel, cg);
-      cg->getOutlinedInstructionsList().push_front(backwardPath);
-      backwardPath->swapInstructionListsWithCompilation();
-      generateLabelInstruction(LABEL, node, backwardLabel, cg);
+      {
+      TR_OutlinedInstructionsGenerator og(backwardLabel, node, cg);
       generateRegMemInstruction(LEARegMem(), node, srcReg, generateX86MemoryReference(srcReg, sizeReg, 0, -(intptr_t)elementSize, cg), cg);
       generateRegMemInstruction(LEARegMem(), node, dstReg, generateX86MemoryReference(dstReg, sizeReg, 0, -(intptr_t)elementSize, cg), cg);
       generateInstruction(STD, node, cg);
       generateRepMovsInstruction(repmovs, node, sizeReg, NULL, cg);
       generateInstruction(CLD, node, cg);
       generateLabelInstruction(JMP4, node, mainEndLabel, cg);
-      backwardPath->swapInstructionListsWithCompilation();
+      }
 
       generateLabelInstruction(LABEL, node, mainEndLabel, dependencies, cg);
       }

--- a/compiler/x/codegen/OutlinedInstructions.hpp
+++ b/compiler/x/codegen/OutlinedInstructions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,8 @@ template <typename ListKind> class List;
 
 class TR_OutlinedInstructions
    {
+   friend class TR_OutlinedInstructionsGenerator;
+
    TR::LabelSymbol       *_entryLabel;
    TR::LabelSymbol       *_restartLabel;
    TR::Instruction      *_firstInstruction;
@@ -83,6 +85,11 @@ class TR_OutlinedInstructions
    // problems if some of the trees evaluated are commoned.  Essentially, only
    // do in a TR_OutlinedInstructions what you could have done in a normal
    // in-line internal control flow region.
+   //
+   // NOTE: use this constructor directly is deprecated, for new development,
+   // use TR_OutlinedInstructionsGenerator instead.
+   // TR_OutlinedInstructionsGenerator will setup all necessary information for
+   // gc map and exception table.
    //
    TR_OutlinedInstructions(TR::LabelSymbol *entryLabel, TR::CodeGenerator *cg);
 
@@ -145,4 +152,32 @@ class TR_OutlinedInstructions
    void setRematerializeVMThread() { _rematerializeVMThread = true; }
 
    };
+
+/**
+   @class TR_OutlinedInstructionsGenerator
+   @brief This class is used to switch to outlined code generation in the manner of the RAII idiom.
+
+   The main use of this class is to generate instruction in the outlined code region, for example, cold paths codes.
+*/
+class TR_OutlinedInstructionsGenerator
+   {
+   public:
+
+   /**
+      @brief Switch to outlined code generation.
+
+      @param entryLabel: the entry label of generated outlined code.
+      @param node      : the node of which generated outlined code belongs to.
+      @param cg        : the code generator.
+   */
+   TR_OutlinedInstructionsGenerator(TR::LabelSymbol* entryLabel, TR::Node* node, TR::CodeGenerator* cg);
+   /**
+      @brief Switch back to mainline code generation.
+   */
+   ~TR_OutlinedInstructionsGenerator();
+
+   private:
+   TR_OutlinedInstructions* _oi;
+   };
+
 #endif


### PR DESCRIPTION
GC Map and Exception Table are now properly setup for outlined instructions on X86, so that exception can now be throwed.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>