### PR TITLE
Check number of HCR-triggered recompilation

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1876,6 +1876,12 @@ OMR::Options::Options(
             this->_disabledOptimizations[invariantArgumentPreexistence] = true;
             }
          }
+
+      TR_PersistentMethodInfo methodInfo = bodyInfo->getMethodInfo();
+      if (methodInfo->getReasonForRecompilation() == TR_PersistentMethodInfo::RecompDueToInlinedMethodRedefinition)
+         methodInfo->incrementNumberOfInlinedMethodRedefinition();
+      if (methodInfo->getNumberOfInlinedMethodRedefinition() >= 2)
+         self()->setOption(TR_DisableNextGenHCR);
       }
 #endif
 


### PR DESCRIPTION
If a method has been recompiled due to inlined method redefinition
for more than twice disable nextGenHCR for this method

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>