### PR TITLE
Call configure using the CONFIG_SHELL variable

### DIFF
--- a/run_configure.mk
+++ b/run_configure.mk
@@ -47,6 +47,10 @@ help:
 # Remove all built-in rules
 .SUFFIXES:
 
+
+# Set a default value for CONFIG_SHELL
+CONFIG_SHELL ?= sh
+
 ###
 ### SPEC Specific Configure Arguments
 ###
@@ -128,7 +132,7 @@ clean: clean-environment-variables
 ###
 
 define CONFIGURE_RECIPE
-sh configure --disable-auto-build-flag 'OMRGLUE=$(OMRGLUE)' 'SPEC=$(SPEC)' $(CONFIGURE_ARGS)
+$(CONFIG_SHELL) configure --disable-auto-build-flag 'OMRGLUE=$(OMRGLUE)' 'SPEC=$(SPEC)' $(CONFIGURE_ARGS)
 # Force the timestamps of unchanged files to be updated
 touch $(CONFIGURE_OUTPUT_FILES)
 endef


### PR DESCRIPTION
If CONFIG_SHELL not set, default to 'sh' as before

partial solution to #2567 

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>