### PR TITLE
Fix crashes with option TR_DisableKnownObjectTable

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1524,7 +1524,8 @@ TR_InlinerBase::createVirtualGuard(
    if (guard->_kind == TR_MutableCallSiteTargetGuard)
       {
       TR::KnownObjectTable *knot = comp()->getOrCreateKnownObjectTable();
-      heuristicTrace(tracer(),"  createVirtualGuard: MutableCallSite.epoch is %p.obj%d (%p.%p)", guard->_mutableCallSiteObject, guard->_mutableCallSiteEpoch, *guard->_mutableCallSiteObject, *knot->getPointerLocation(guard->_mutableCallSiteEpoch));
+      if (knot)
+         heuristicTrace(tracer(),"  createVirtualGuard: MutableCallSite.epoch is %p.obj%d (%p.%p)", guard->_mutableCallSiteObject, guard->_mutableCallSiteEpoch, *guard->_mutableCallSiteObject, *knot->getPointerLocation(guard->_mutableCallSiteEpoch));
       return TR_VirtualGuard::createMutableCallSiteTargetGuard(comp(), calleeIndex, callNode, destination, guard->_mutableCallSiteObject, guard->_mutableCallSiteEpoch);
       }
 

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1147,7 +1147,9 @@ TR::VPConstraint *TR::VPClass::create(OMR::ValuePropagation *vp, TR::VPClassType
    // TR::VPFixedClass combined with JavaLangClassObject location picks out a
    // particular java/lang/Class instance, for which we can have a known
    // object. Inject one here if we don't already have one.
-   if (location != NULL
+   TR::KnownObjectTable *knot = vp->comp()->getOrCreateKnownObjectTable();
+   if (knot
+       && location != NULL
        && location->isJavaLangClassObject() == TR_yes
        && type != NULL
        && type->asFixedClass() != NULL
@@ -1157,7 +1159,6 @@ TR::VPConstraint *TR::VPClass::create(OMR::ValuePropagation *vp, TR::VPClassType
       TR_J9VMBase *fej9 = (TR_J9VMBase *)(vp->comp()->fe());
       uintptrj_t objRefOffs = fej9->getOffsetOfJavaLangClassFromClassField();
       uintptrj_t *objRef = (uintptrj_t*)(type->getClass() + objRefOffs);
-      TR::KnownObjectTable *knot = vp->comp()->getOrCreateKnownObjectTable();
       TR::KnownObjectTable::Index index = knot->getIndexAt(objRef);
       type = TR::VPKnownObject::createForJavaLangClass(vp, index);
       }
@@ -3557,6 +3558,7 @@ TR::VPConstraint *TR::VPKnownObject::intersect1(TR::VPConstraint *other, OMR::Va
       // - we should be looking at the string contents,
       // - known object should be more specific (though it allows null).
       TR::KnownObjectTable *knot = vp->comp()->getKnownObjectTable();
+      TR_ASSERT(knot, "Can't create a TR::VPKnownObject without a known-object table");
       if (getIndex() == knot->getIndexAt((uintptrj_t*)otherConstString->getSymRef()->getSymbol()->castToStaticSymbol()->getStaticAddress()))
          return other; // A const string constraint is more specific than known object
       else

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2161,6 +2161,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
          if (symRef == vp->comp()->getSymRefTab()->findClassFromJavaLangClassSymbolRef())
             {
             TR::KnownObjectTable *knot = vp->comp()->getOrCreateKnownObjectTable();
+            TR_ASSERT(knot, "Can not have a TR::VPKnownObject without a known-object table");
 
                {
                TR::VMAccessCriticalSection constrainIaloadCriticalSection(vp->comp(),
@@ -2212,9 +2213,9 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
           && base->getClass()
           && (!needInitializedCheck || TR::Compiler->cls.isClassInitialized(vp->comp(), base->getClass())))
          {
-         if (symRef == vp->comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef())
+         TR::KnownObjectTable *knot = vp->comp()->getOrCreateKnownObjectTable();
+         if (knot && symRef == vp->comp()->getSymRefTab()->findJavaLangClassFromClassSymbolRef())
             {
-            TR::KnownObjectTable *knot = vp->comp()->getOrCreateKnownObjectTable();
             TR_J9VMBase *fej9 = (TR_J9VMBase *)(vp->comp()->fe());
             TR::KnownObjectTable::Index knownObjectIndex = knot->getIndexAt((uintptrj_t*)(base->getClass() + fej9->getOffsetOfJavaLangClassFromClassField()));
             vp->addBlockOrGlobalConstraint(node,


### PR DESCRIPTION
This commit was written by Omer for JITaaS and is necessary because we use `TR_DisableKnownObjectTable`. Currently the optimizer will crash without a known object table because it does not check for its existence.

Signed-off-by: Noah Weninger <Noah.Weninger@ibm.com>