### PR TITLE
Add missing TR::InstOpCode helper

### DIFF
--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -317,6 +317,9 @@ TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getAddLogicalThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGRK : TR::InstOpCode::ALRK; }
 
 TR::InstOpCode::Mnemonic
+OMR::Z::InstOpCode::getAddLogicalImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGFI : TR::InstOpCode::ALFI; }
+
+TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getAddLogicalRegRegImmediateOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGHSIK : TR::InstOpCode::ALHSIK; }
 
 TR::InstOpCode::Mnemonic

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -745,6 +745,7 @@ class InstOpCode: public OMR::InstOpCode
    static Mnemonic getAddRegOpCode();
    static Mnemonic getAddThreeRegOpCode();
    static Mnemonic getAddLogicalThreeRegOpCode();
+   static Mnemonic getAddLogicalImmOpCode();
    static Mnemonic getAddLogicalRegRegImmediateOpCode();
    static Mnemonic getSubstractOpCode();
    static Mnemonic getSubstractRegOpCode();


### PR DESCRIPTION
Add a missing TR::InstOpCode helper for Z.
The missing helper is add logical immediate and
returns ALGFI on 64 bit and ALFI on 32 bit computers.

Signed-off-by: Daniel Hong <daniel.hong@live.com>