### PR TITLE
Fix compile errors and warnings

### DIFF
--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -105,7 +105,7 @@ FEBase<Derived>::allocateRelocationData(TR::Compilation* comp, uint32_t size)
 
 #if defined(OMR_OS_WINDOWS)
    return reinterpret_cast<uint8_t *>(
-         VirtualAlloc(nullptr,
+         VirtualAlloc(NULL,
             size,
             MEM_COMMIT,
             PAGE_READWRITE));

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -60,15 +60,15 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    TR::CodeCacheConfig & config = self()->codeCacheConfig();
    if (segmentSize < config.codeCachePadKB() << 10)
       codeCacheSizeToAllocate = config.codeCachePadKB() << 10;
-   uint8_t *memorySlab = nullptr;
+
 #if defined(OMR_OS_WINDOWS)
-   memorySlab = reinterpret_cast<uint8_t *>(
-         VirtualAlloc(nullptr,
+   auto memorySlab = reinterpret_cast<uint8_t *>(
+         VirtualAlloc(NULL,
             codeCacheSizeToAllocate,
             MEM_COMMIT,
             PAGE_EXECUTE_READWRITE));
 #else
-   memorySlab = reinterpret_cast<uint8_t *>(
+   auto memorySlab = reinterpret_cast<uint8_t *>(
          mmap(NULL,
               codeCacheSizeToAllocate,
               PROT_READ | PROT_WRITE | PROT_EXEC,

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -82,7 +82,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
 
 #if defined(OMR_OS_WINDOWS)
    auto memorySlab = reinterpret_cast<uint8_t *>(
-         VirtualAlloc(nullptr,
+         VirtualAlloc(NULL,
             codeCacheSizeToAllocate,
             MEM_COMMIT,
             PAGE_EXECUTE_READWRITE));

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -2377,7 +2377,7 @@ convertWithMBTOWC(struct OMRPortLibrary *portLibrary, char *inputBuffer, char *o
 #endif /* defined(OMRZTPF) */
 
 	/* reset the shift state */
-	mbtowc(NULL, NULL, 0);
+	J9_IGNORE_RETURNVAL(mbtowc(NULL, NULL, 0));
 
 	while (*walk) {
 		ret = mbtowc(&ch, walk, MB_CUR_MAX);


### PR DESCRIPTION
- Avoid using nullptr as it is not supported on older gcc.
nullptr is available since gcc 4.6.
- Use J9_IGNORE_RETURNVAL to call mbtowc() when its return value
is not required.

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>