### PR TITLE
Implement breakOnEntry on the Z codegen

### DIFF
--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -220,22 +220,30 @@ OMR::Z::InstOpCode::getInstructionLength(TR::InstOpCode::Mnemonic i_opCode)
        case 0x40 :
        case 0x80 : return 4;
        case 0xC0 : return 6;
-       default   : return 0;
+       default:
+          break;
        }
      }
   else // not a real instruction e.g. DC, PSEUDO
      {
      switch(getInstructionFormat(i_opCode))
-       {
-       case DC_FORMAT:
-          {
-          if (i_opCode == DC2)   return 2;
-          else                      return 4;
-          }
-       case PSEUDO : return 0;
-       default     : return 0;
-       }
+        {
+        case E_FORMAT:
+           {
+           return 2;
+           }
+
+        case DC_FORMAT:
+           {
+           return i_opCode == DC2 ? 2 : 4;
+           }
+
+       default:
+          break;
+        }
      }
+
+  return 0;
   }
 
 TR::InstOpCode::Mnemonic

--- a/compiler/z/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeEnum.hpp
@@ -29,6 +29,7 @@
    ASM,                 // ASM WCode Support
    ASSOCREGS,           // Register Association
    BAD,                 // Bad Opcode
+   BREAK,               // Breakpoint (debugger)
    CGFRB,               // Compare and Branch (64-32)
    CGFRJ,               // Compare and Branch Relative (64-32)
    CGFRT,               // Compare and Trap (64-32)

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -56,6 +56,17 @@
    /* .format      = */ PSEUDO,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None
+   },   
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::BREAK,
+   /* .name        = */ "BREAK",
+   /* .description = */ "Breakpoint (debugger)",
+   /* .opcode[0]   = */ 0x00,
+   /* .opcode[1]   = */ 0x01,
+   /* .format      = */ E_FORMAT,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
+   /* .properties  = */ S390OpProp_None
    },
 
    {

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2131,23 +2131,40 @@ TR::Instruction * generateVSIInstruction(
    }
 
 /************************************************************ Misc Instructions ************************************************************/
-TR::Instruction *
-generateS390PseudoInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Node * fenceNode, TR::Instruction * preced)
+TR::Instruction*
+generateS390PseudoInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* n, TR::Node* fenceNode, TR::Instruction* preced)
    {
-   TR::S390PseudoInstruction *instr;
-   TR::Compilation *comp = cg->comp();
+   TR::Instruction* cursor;
+
+   switch (op)
+      {
+      case TR::InstOpCode::PROC:
+         {
+         if (cg->comp()->getOption(TR_EntryBreakPoints))
+            {
+            if (preced)
+               {
+               preced = new (INSN_HEAP) TR::S390EInstruction(TR::InstOpCode::BREAK, n, preced, cg);
+               }
+            else
+               {
+               preced = new (INSN_HEAP) TR::S390EInstruction(TR::InstOpCode::BREAK, n, cg);
+               }
+            }
+         }
+         break;
+      }
 
    if (preced)
-   {
-     instr= new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, preced, cg);
-   }
+      {
+      cursor = new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, preced, cg);
+      }
    else
-   {
-     instr= new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cg);
-   }
+      {
+      cursor = new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cg);
+      }
 
-
-   return instr;
+   return cursor;
    }
 
 TR::Instruction *


### PR DESCRIPTION
Given the analysis done by our friends over at the V8 project the
software breakpoint in GDB as per [1] is encoded as 0x0001. We add a
new BREAK pseudo instruction and generate this software breakpoint so
users can consistently use the breakOnEntry option cross platform.

[1] https://github.com/v8/v8/blob/a062708467a313d64818b5f8a0ac37dae8775959/src/s390/assembler-s390.cc#L611-L614

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>