### PR TITLE
Fix vlog options

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -4801,7 +4801,7 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "hookDetailsClassLoading",
    "hookDetailsClassUnloading",
    "sampleDensity",
-   "profiling"
+   "profiling",
    "JITaaS",
    };
 


### PR DESCRIPTION
verbose={} options was broken causing segmentation fault. This commit fixes that.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>