### PR TITLE
Fix compile errors on 32-bit Windows

### DIFF
--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -67,16 +67,16 @@ Symbol_IR::applyOverridesList(OMRPortLibrary *portLibrary, const char *overrides
 	} else {
 		int64_t offset = omrfile_seek(fd, 0, EsSeekEnd);
 		if (-1 != offset) {
-			char *buff = (char *)malloc(offset + 1);
+			char *buff = (char *)malloc((size_t)(offset + 1));
 			if (NULL == buff) {
 				ERRMSG("Unable to allocate memory for file contents: %s", overridesListFile);
 				rc = DDR_RC_ERROR;
 				goto closeFile;
 			}
-			memset(buff, 0, offset + 1);
+			memset(buff, 0, (size_t)(offset + 1));
 			omrfile_seek(fd, 0, EsSeekSet);
 			/* Read each line as a file name. */
-			if (offset == omrfile_read(fd, buff, offset)) {
+			if (offset == omrfile_read(fd, buff, (intptr_t)offset)) {
 				for (char *nextLine = strtok(buff, "\r\n"); NULL != nextLine; nextLine = strtok(NULL, "\r\n")) {
 					string line(nextLine);
 					size_t commentPosition = line.find("#");
@@ -124,13 +124,13 @@ Symbol_IR::applyOverridesFile(OMRPortLibrary *portLibrary, const char *overrides
 	} else {
 		int64_t offset = omrfile_seek(fd, 0, EsSeekEnd);
 		if (-1 != offset) {
-			char *buff = (char *)malloc(offset + 1);
+			char *buff = (char *)malloc((size_t)(offset + 1));
 			if (NULL == buff) {
 				ERRMSG("Unable to allocate memory for file contents: %s", overridesFile);
 				rc = DDR_RC_ERROR;
 				goto closeFile;
 			}
-			memset(buff, 0, offset + 1);
+			memset(buff, 0, (size_t)(offset + 1));
 			omrfile_seek(fd, 0, EsSeekSet);
 
 			/*
@@ -139,7 +139,7 @@ Symbol_IR::applyOverridesFile(OMRPortLibrary *portLibrary, const char *overrides
 			 *   fieldoverride.{StructureName}.{fieldName}={newName}
 			 *   typeoverride.{StructureName}.{fieldName}={newType}"
 			 */
-			if (offset != omrfile_read(fd, buff, offset)) {
+			if (offset != omrfile_read(fd, buff, (intptr_t)offset)) {
 				ERRMSG("Failure reading %s", overridesFile);
 				rc = DDR_RC_ERROR;
 			} else {

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -317,14 +317,14 @@ Options::readFileList(OMRPortLibrary *portLibrary, const char *listFileName, vec
 	} else {
 		int64_t length = omrfile_seek(fd, 0, SEEK_END);
 		if (-1 != length) {
-			char *buff = (char *)malloc(length + 1);
+			char *buff = (char *)malloc((size_t)(length + 1));
 			if (NULL == buff) {
 				ERRMSG("Unable to allocate memory for file contents: %s", listFileName);
 			} else {
-				memset(buff, 0, length + 1);
+				memset(buff, 0, (size_t)(length + 1));
 				omrfile_seek(fd, 0, SEEK_SET);
 
-				if (length != omrfile_read(fd, buff, length)) {
+				if (length != omrfile_read(fd, buff, (intptr_t)length)) {
 					ERRMSG("Failure reading %s", listFileName);
 				} else {
 					const char *delimiters = "\r\n";


### PR DESCRIPTION
Explicit casts are needed on 32-bit platforms where size_t and intptr_t are both narrower than int64_t.