### PR TITLE
Rename function names and update trace point [unix/omrsignal.c]

### DIFF
--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -623,7 +623,7 @@ TraceExit=Trc_PRT_signal_omrsig_set_async_signal_handler_exiting Group=signal Ov
 TraceEvent=Trc_PRT_signal_omrsig_shutdown_empty_routine Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_shutdown: ERROR, empty shutdown routine indicates omrsig_startup failed, portLibrary=%p"
 TraceEvent=Trc_PRT_signal_omrsig_set_options Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_set_options: options=0x%X"
 TraceEvent=Trc_PRT_signal_omrsig_set_options_too_late_handlers_installed Group=signal Overhead=1 Level=1 NoEnv Template="omrsig_set_options too late, handlers already installed: options=0x%X"
-TraceEvent=Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal: mapPortLibSignalToUnix: ERROR, unknown signal, portLibSignal=0x%X"
+TraceEvent=Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal Obsolete Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal: mapPortLibSignalToUnix: ERROR, unknown signal, portLibSignal=0x%X"
 
 TraceEvent=Trc_PRT_signal_omrsig_asynchSignalReporterThread_going_to_sleep Group=signal Overhead=1 Level=1 NoEnv Template="asynchSignalReporter: going to sleep"
 TraceEvent=Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up Group=signal Overhead=1 Level=1 NoEnv Template="asynchSignalReporter: woken up"

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -224,7 +224,7 @@ static int J9THREAD_PROC asynchSignalReporter(void *userData);
 
 static uint32_t registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, unix_sigaction handler, void **oldOSHandler);
 static uint32_t destroySignalTools(OMRPortLibrary *portLibrary);
-static int mapPortLibSignalToUnix(uint32_t portLibSignal);
+static int mapPortLibSignalToOSSignal(uint32_t portLibSignal);
 static uint32_t countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t category);
 static void sig_full_shutdown(struct OMRPortLibrary *portLibrary);
 static int32_t initializeSignalTools(OMRPortLibrary *portLibrary);
@@ -594,7 +594,7 @@ omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint3
 int32_t
 omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
 {
-	return (int32_t)mapPortLibSignalToUnix(portlibSignalFlag);
+	return (int32_t)mapPortLibSignalToOSSignal(portlibSignalFlag);
 }
 
 int32_t
@@ -740,7 +740,7 @@ runHandlers(uint32_t asyncSignalFlag, int unixSignal)
 
 #if defined(OMRPORT_OMRSIG_SUPPORT)
 	if (OMR_ARE_NO_BITS_SET(signalOptionsGlobal, OMRPORT_SIG_OPTIONS_OMRSIG_NO_CHAIN)) {
-		/* mapPortLibSignalToUnix returns OMRPORT_SIG_ERROR (-1) on unknown mapping */
+		/* mapPortLibSignalToOSSignal returns OMRPORT_SIG_ERROR (-1) on unknown mapping */
 		if (OMRPORT_SIG_ERROR != unixSignal) {
 			omrsig_handler(unixSignal, NULL, NULL);
 		}
@@ -1157,7 +1157,7 @@ masterASynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 static uint32_t
 registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, unix_sigaction handler, void **oldOSHandler)
 {
-	int unixSignalNo = mapPortLibSignalToUnix(portLibrarySignalNo);
+	int unixSignalNo = mapPortLibSignalToOSSignal(portLibrarySignalNo);
 	struct sigaction newAction;
 
 	/* Don't register a handler for unrecognized OS signals.
@@ -1331,7 +1331,7 @@ mapUnixSignalToPortLib(uint32_t signalNo, siginfo_t *sigInfo)
  *         could not be mapped
  */
 static int
-mapPortLibSignalToUnix(uint32_t portLibSignal)
+mapPortLibSignalToOSSignal(uint32_t portLibSignal)
 {
 	uint32_t index = 0;
 

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -1341,7 +1341,8 @@ mapPortLibSignalToUnix(uint32_t portLibSignal)
 			return signalMap[index].unixSignalNo;
 		}
 	}
-	Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal(portLibSignal);
+
+	Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal(portLibSignal);
 	return OMRPORT_SIG_ERROR;
 }
 

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -222,7 +222,7 @@ static void runHandlers(uint32_t asyncSignalFlag, int unixSignal);
 static int J9THREAD_PROC asynchSignalReporter(void *userData);
 #endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
-static uint32_t registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, unix_sigaction handler, void **oldOSHandler);
+static int32_t registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, unix_sigaction handler, void **oldOSHandler);
 static uint32_t destroySignalTools(OMRPortLibrary *portLibrary);
 static int mapPortLibSignalToOSSignal(uint32_t portLibSignal);
 static uint32_t countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t category);
@@ -1154,7 +1154,7 @@ masterASynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
  *
  * @return 0 upon success, non-zero otherwise.
  */
-static uint32_t
+static int32_t
 registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, unix_sigaction handler, void **oldOSHandler)
 {
 	int unixSignalNo = mapPortLibSignalToOSSignal(portLibrarySignalNo);


### PR DESCRIPTION
- **Update trace point in mapPortLibSignalToUnix [unix]**

    Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal is defined as
    a TraceEvent. But, it should be a TraceException. Definition of old
    trace points can't be changed.
    Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal is a
    TraceException. It was added to replace
    Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal. So,
    Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal is replaced
    with Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal.

    Trc_PRT_signal_mapPortLibSignalToUnix_ERROR_unknown_signal is set to
    Obsolete since it is no longer used.

- **Rename mapPortLibSignalToUnix to mapPortLibSignalToOSSignal [unix]**

    Changing function names to be consistent across different platform
    implementations (platform agnostic).

- **Rename mapUnixSignalToPortLib to mapOSSignalToPortLib [unix]**

    Changing function names to be consistent across different platform
    implementations (platform agnostic).

- **Fix return type of registerSignalHandlerWithOS**

    registerSignalHandlerWithOS returns OMRPORT_SIG_ERROR (-1) or 0 so its
    return type should be int32_t instead of uint32_t.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>