### PR TITLE
Minimal Signal Changes Part 2 [win64amd]

### DIFF
--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -93,6 +93,18 @@ static struct {
 	{OMRPORT_SIG_FLAG_SIGBREAK, SIGBREAK},
 };
 
+#define ARRAY_SIZE_SIGNALS (NSIG + 1)
+
+typedef void (*win_signal)(int);
+
+/* Store the original signal handler. During shutdown, we need to restore
+ * the signal handler to the original OS handler.
+ */
+static struct {
+	win_signal originalHandler;
+	uint32_t restore;
+} handlerInfo[ARRAY_SIZE_SIGNALS];
+
 static omrthread_monitor_t masterExceptionMonitor;
 
 /* access to this must be synchronized using masterExceptionMonitor */

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -107,6 +107,9 @@ static struct {
 	uint32_t restore;
 } handlerInfo[ARRAY_SIZE_SIGNALS];
 
+/* Keep track of signal counts. */
+static volatile uintptr_t signalCounts[ARRAY_SIZE_SIGNALS] = {0};
+
 static omrthread_monitor_t masterExceptionMonitor;
 
 /* access to this must be synchronized using masterExceptionMonitor */

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -391,7 +391,15 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 BOOLEAN
 omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
 {
-	return FALSE;
+	BOOLEAN rc = FALSE;
+	Trc_PRT_signal_omrsig_is_master_signal_handler_entered(osHandler);
+
+	if (osHandler == (void *)masterASynchSignalHandler) {
+		rc = TRUE;
+	}
+
+	Trc_PRT_signal_omrsig_is_master_signal_handler_exiting(rc);
+	return rc;
 }
 
 int32_t

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -22,6 +22,8 @@
 
 #include <windows.h>
 #include <setjmp.h>
+#include <signal.h>
+
 #include "omrsignal.h"
 #include "omrport.h"
 #include "omrutilbase.h"
@@ -138,6 +140,8 @@ static int32_t runInTryExcept(struct OMRPortLibrary *portLibrary, omrsig_protect
 
 static uint32_t mapOSSignalToPortLib(uint32_t signalNo);
 static int mapPortLibSignalToOSSignal(uint32_t portLibSignal);
+
+static int32_t registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, win_signal handler, void **oldOSHandler);
 
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
@@ -1351,4 +1355,50 @@ mapPortLibSignalToOSSignal(uint32_t portLibSignal)
 
 	Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal(portLibSignal);
 	return OMRPORT_SIG_ERROR;
+}
+
+/**
+ * Register the signal handler with the OS. Calls to this function must be synchronized using
+ * "registerHandlerMonitor". *oldOSHandler points to the old signal handler function. It is only
+ * set if oldOSHandler is non-null. During the first registration, the old signal handler is
+ * stored in handlerInfo[osSignalNo].originalHandler. The original OS handler must be restored
+ * during port library shut down.
+ *
+ * @param[in] portLibrary the OMR port library
+ * @param[in] portLibrarySignalNo the port library signal flag
+ * @param[in] handler the OS handler to register
+ * @param[out] oldOSHandler points to the old OS handler, if oldOSHandler is non-null
+ *
+ * @return 0 upon success, non-zero otherwise.
+ */
+static int32_t
+registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, win_signal handler, void **oldOSHandler)
+{
+    int osSignalNo = mapPortLibSignalToOSSignal(portLibrarySignalNo);
+    win_signal localOldOSHandler = NULL;
+
+    /* Don't register a handler for unrecognized OS signals.
+     * Unrecognized OS signals are the ones which aren't included in signalMap.
+     */
+    if (OMRPORT_SIG_ERROR == osSignalNo) {
+        return OMRPORT_SIG_ERROR;
+    }
+
+    localOldOSHandler = signal(osSignalNo, handler);
+    if (SIG_ERR == localOldOSHandler) {
+        Trc_PRT_signal_registerSignalHandlerWithOS_failed_to_registerHandler(portLibrarySignalNo, osSignalNo, handler);
+        return OMRPORT_SIG_ERROR;
+    }
+
+    Trc_PRT_signal_registerSignalHandlerWithOS_registeredHandler1(portLibrarySignalNo, osSignalNo, handler, localOldOSHandler);
+    if (0 == handlerInfo[osSignalNo].restore) {
+        handlerInfo[osSignalNo].originalHandler = localOldOSHandler;
+        handlerInfo[osSignalNo].restore = 1;
+    }
+
+    if (NULL != oldOSHandler) {
+        *oldOSHandler = (void *)localOldOSHandler;
+    }
+
+    return 0;
 }

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -155,6 +155,7 @@ static int mapPortLibSignalToOSSignal(uint32_t portLibSignal);
 static int32_t registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, win_signal handler, void **oldOSHandler);
 static void updateSignalCount(int osSignalNo);
 static void masterASynchSignalHandler(int osSignalNo);
+static void removeAsyncHandlers(OMRPortLibrary *portLibrary);
 
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
@@ -1293,6 +1294,9 @@ sig_full_shutdown(struct OMRPortLibrary *portLibrary)
 			}
 		}
 
+		/* Remove elements in asyncHandlerList, and free the associated memory. */
+		removeAsyncHandlers(portLibrary);
+
 		omrthread_tls_free(tlsKey);
 		RemoveVectoredExceptionHandler(masterVectoredExceptionHandler);
 		vectoredExceptionHandlerInstalled = 0;
@@ -1507,4 +1511,41 @@ masterASynchSignalHandler(int osSignalNo)
 	 * be registered again after it is invoked.
 	 */
 	signal(osSignalNo, masterASynchSignalHandler);
+}
+
+/**
+ * Remove elements in asyncHandlerList, and free the associated memory.
+ *
+ * @param[in] portLibrary the OMR port library
+ *
+ * @return void
+ */
+static void
+removeAsyncHandlers(OMRPortLibrary *portLibrary)
+{
+	/* clean up the list of async handlers */
+	J9WinAMD64AsyncHandlerRecord *cursor = NULL;
+	J9WinAMD64AsyncHandlerRecord **previousLink = NULL;
+
+	omrthread_monitor_enter(asyncMonitor);
+
+	/* wait until no signals are being reported */
+	while (asyncThreadCount > 0) {
+		omrthread_monitor_wait(asyncMonitor);
+	}
+
+	previousLink = &asyncHandlerList;
+	cursor = asyncHandlerList;
+	while (cursor) {
+		if (cursor->portLib == portLibrary) {
+			*previousLink = cursor->next;
+			portLibrary->mem_free_memory(portLibrary, cursor);
+			cursor = *previousLink;
+		} else {
+			previousLink = &cursor->next;
+ 			cursor = cursor->next;
+ 		}
+	}
+
+	omrthread_monitor_exit(asyncMonitor);
 }


### PR DESCRIPTION
1.  **Add a data structure to store signal handler info [win64amd]**

    We want to restore the signal handlers after the OMR port library
    shutdowns. So, we need to cache the original signal handler.

    handlerInfo is added to store {originalHandler, restore} for every
    signal on win64amd. restore will be set to 1 after the original signal
    handler is cached.

2. **Add registerSignalHandlerWithOS [win64amd]**

    registerSignalHandlerWithOS registers the signal handler with the OS on
    win64amd platform. Also, it caches the original signal handler.

3. **Add registerHandlerMonitor [win64amd]**

    Added registerHandlerMonitor to synchronize calls to
    registerSignalHandlerWithOS.

    initializeSignalTools updated to initialize registerHandlerMonitor, and
    destroySignalTools updated to free registerHandlerMonitor.

    In initializeSignalTools, asyncMonitor and masterExceptionMonitor were
    initialized using the same name, portLibrary_omrsig_async_monitor. Added
    a change to initialize masterExceptionMonitor using the name,
    portLibrary_omrsig_master_exception_monitor.

4. **Add implementation of omrsig_register_os_handler [win64amd]**

    omrsig_register_os_handler registers a signal handler with the OS.

5. **Add wakeUpASyncReporter semaphore [win64amd]**

    wakeUpASyncReporter semaphore will coordinate between master async
    signal handler and async signal reporter thread.

    initializeSignalTools updated to initialize wakeUpASyncReporter, and
    destroySignalTools updated to free wakeUpASyncReporter.

6. **Add signalCounts [win64amd]**

    signalCounts will keep track of unprocessed signals.

7. **Add masterASynchSignalHandler [win64amd]**

    masterASynchSignalHandler updates signalCounts after a signal is
    received, and re-registers masterASynchSignalHandler.

    updateSignalCount is added to update signal counts. Currently, it is
    only invoked from masterASynchSignalHandler. In the future, it will be
    called from consoleCtrlHandler.

8. **Add implementation of omrsig_is_master_signal_handler [win64amd]**

9. **Initialize and clean handlerInfo [win64amd]**

    In omrsig_startup, handlerInfo[osSignalNo].restore is initialized to 0.

    In sig_full_shutdown, handlerInfo[osSignalNo].originalHandler is
    registered with the OS, and handlerInfo[osSignalNo].restore is reset to 0.

10. **Add removeAsyncHandlers [win64amd]**

    removeAsyncHandlers removes the elements in asyncHandlerList, and frees
    the associated memory.

    removeAsyncHandlers is invoked from sig_full_shutdown.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>