### PR TITLE
Add userSpecifiedCPUs count for overriding number of CPUs

### DIFF
--- a/fvtest/porttest/si_numcpusTest.cpp
+++ b/fvtest/porttest/si_numcpusTest.cpp
@@ -184,7 +184,7 @@ TEST(PortSysinfoTest, sysinfo_numcpus_test4)
  * Measure run time for getting number of CPUs 10000 times.
  *
  * @param[in] portLibrary The port library under test
- * @param[in] type The type of CPU number to query (physical, bound, entitled, target).
+ * @param[in] type The type of CPU number to query (physical, bound, target).
  *
  * @return TEST_PASSED on success, TEST_FAILED on failure
  */
@@ -215,9 +215,6 @@ int omrsysinfo_numcpus_runTime(OMRPortLibrary *portLibrary, uintptr_t type)
 		break;
 	case OMRPORT_CPU_BOUND:
 		testType = "bound";
-		break;
-	case OMRPORT_CPU_ENTITLED:
-		testType = "entitled";
 		break;
 	case OMRPORT_CPU_TARGET:
 		testType = "target";

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -628,8 +628,7 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_CPU_PHYSICAL 1
 #define OMRPORT_CPU_ONLINE 2
 #define OMRPORT_CPU_BOUND 3
-#define OMRPORT_CPU_ENTITLED 4
-#define OMRPORT_CPU_TARGET 5
+#define OMRPORT_CPU_TARGET 4
 
 #define OMRPORT_SL_FOUND  0
 #define OMRPORT_SL_NOT_FOUND  1
@@ -1464,8 +1463,8 @@ typedef struct OMRPortLibrary {
 	intptr_t (*sysinfo_get_cwd)(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_tmp "omrsysinfo_get_tmp"*/
 	intptr_t (*sysinfo_get_tmp)(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen, BOOLEAN ignoreEnvVariable) ;
-	/** see @ref omrsysinfo.c::omrsysinfo_get_number_CPUs_by_type "omrsysinfo_get_number_CPUs_by_type"*/
-	void (*sysinfo_set_number_entitled_CPUs)(struct OMRPortLibrary *portLibrary, uintptr_t number) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_set_number_user_specified_CPUs "omrsysinfo_set_number_user_specified_CPUs"*/
+	void (*sysinfo_set_number_user_specified_CPUs)(struct OMRPortLibrary *portLibrary, uintptr_t number) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_open_file_count "omrsysinfo_get_open_file_count"*/
 	int32_t (*sysinfo_get_open_file_count)(struct OMRPortLibrary *portLibrary, uint64_t *count) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_os_description "omrsysinfo_get_os_description"*/
@@ -1767,7 +1766,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_env_iterator_init(param1,param2,param3) privateOmrPortLibrary->sysinfo_env_iterator_init(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsysinfo_env_iterator_hasNext(param1) privateOmrPortLibrary->sysinfo_env_iterator_hasNext(privateOmrPortLibrary, (param1))
 #define omrsysinfo_env_iterator_next(param1,param2) privateOmrPortLibrary->sysinfo_env_iterator_next(privateOmrPortLibrary, (param1), (param2))
-#define omrsysinfo_set_number_entitled_CPUs(param1) privateOmrPortLibrary->sysinfo_set_number_entitled_CPUs(privateOmrPortLibrary, (param1))
+#define omrsysinfo_set_number_user_specified_CPUs(param1) privateOmrPortLibrary->sysinfo_set_number_user_specified_CPUs(privateOmrPortLibrary,(param1))
 #define omrfile_startup() privateOmrPortLibrary->file_startup(privateOmrPortLibrary)
 #define omrfile_shutdown() privateOmrPortLibrary->file_shutdown(privateOmrPortLibrary)
 #define omrfile_write(param1,param2,param3) privateOmrPortLibrary->file_write(privateOmrPortLibrary, (param1), (param2), (param3))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -256,7 +256,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_get_number_CPUs_by_type, /* sysinfo_get_number_CPUs_by_type */
 	omrsysinfo_get_cwd, /* sysinfo_get_cwd */
 	omrsysinfo_get_tmp, /* sysinfo_get_tmp */
-	omrsysinfo_set_number_entitled_CPUs, /* sysinfo_set_number_entitled_CPUs */
+	omrsysinfo_set_number_user_specified_CPUs, /* sysinfo_set_number_user_specified_CPUs */
 	omrsysinfo_get_open_file_count, /* sysinfo_get_open_file_count */
 	omrsysinfo_get_os_description, /* sysinfo_get_os_description */
 	omrsysinfo_os_has_feature, /* sysinfo_os_has_feature */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -863,8 +863,8 @@ TraceException=Trc_PRT_sysinfo_get_number_CPUs_by_type_invalidType Group=sysinfo
 TraceEvent=Trc_PRT_sysinfo_get_number_CPUs_by_type_platformNotSupported Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_get_number_CPUs_by_type: Platform not supported."
 TraceEntry=Trc_PRT_sysinfo_get_number_CPUs_by_type_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_get_number_CPUs_by_type: Function entered."
 TraceExit=Trc_PRT_sysinfo_get_number_CPUs_by_type_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_get_number_CPUs_by_type: Exiting function - Type %d returned %d."
-TraceEntry=Trc_PRT_sysinfo_set_number_entitled_CPUs_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_set_number_entitled_CPUs: Function entered."
-TraceExit=Trc_PRT_sysinfo_set_number_entitled_CPUs_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_set_number_entitled_CPUs: Exiting function. Entitled CPUs set to %d."
+TraceEntry=Trc_PRT_sysinfo_set_number_user_specified_CPUs_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_set_number_user_specified_CPUs: Function entered."
+TraceExit=Trc_PRT_sysinfo_set_number_user_specified_CPUs_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_set_number_user_specified_CPUs: Exiting function. User-specified CPUs set to %d."
 TraceException=Trc_PRT_sysinfo_get_number_CPUs_by_type_failedOnline Group=sysinfo Overhead=1 Level=1 NoEnv Template="omrsysinfo_get_number_CPUs_by_type: Error: Could not get online CPUs - %s%d"
 
 TraceEntry=Trc_PRT_sysinfo_get_limit_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="omrsysinfo_get_limit: resourceID = %d"
@@ -1077,4 +1077,3 @@ TraceException=Trc_PRT_readCgroupFile_fgets_failed Group=sysinfo Overhead=1 Leve
 TraceException=Trc_PRT_isRunningInContainer_fgets_failed Group=sysinfo Overhead=1 Level=3 NoEnv Template="isRunningInContainer: unexpected format of file %s with errno=%d"
 
 TraceException=Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal Group=signal Overhead=1 Level=3 NoEnv Template="omrsignal: mapPortLibSignalToOSSignal: ERROR, unknown signal, portLibSignal=0x%X" 
- 

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -28,19 +28,17 @@
 #include "omrport.h"
 #include <string.h>
 
-
-
 /**
- * Sets the number of entitled CPUs, which is specified by the user.
- *
+ * Sets the number of user-specified CPUs, value which overrides all other forms of CPU detection
+ * in omrsysinfo_get_number_CPUs_by_type for type OMRPORT_CPU_TARGET.
+ * 
  * @param[in] portLibrary The port library.
- * @param[in] number Number of entitled CPUs.
+ * @param[in] number Number of user-specified CPUs.
  */
 void
-omrsysinfo_set_number_entitled_CPUs(struct OMRPortLibrary *portLibrary, uintptr_t number)
+omrsysinfo_set_number_user_specified_CPUs(struct OMRPortLibrary *portLibrary, uintptr_t number)
 {
-	portLibrary->portGlobals->entitledCPUs = number;
-	return;
+	portLibrary->portGlobals->userSpecifiedCPUs = number;
 }
 
 /**
@@ -144,8 +142,8 @@ omrsysinfo_get_executable_name(struct OMRPortLibrary *portLibrary, const char *a
  * 	- OMRPORT_CPU_PHYSICAL: Number of physical CPU's on this machine
  * 	- OMRPORT_CPU_ONLINE: Number of online CPU's on this machine
  * 	- OMRPORT_CPU_BOUND: Number of physical CPU's bound to this process
- * 	- OMRPORT_CPU_ENTITLED: Number of CPU's the user has specified should be used by the process
- * 	- OMRPORT_CPU_TARGET: Number of CPU's that should be used by the process. This is OMR_MIN(BOUND, ENTITLED).
+ * 	- OMRPORT_CPU_TARGET: Number of CPU's that should be used by the process. This is normally BOUND, but is 
+ *    overridden by portLibrary->portGlobals->userSpecifiedCPUs if it is set.
  *
  * @param[in] portLibrary The port library.
  * @param[in] type Flag to indicate the information type (see function description).
@@ -154,7 +152,6 @@ omrsysinfo_get_executable_name(struct OMRPortLibrary *portLibrary, const char *a
  * 			Returns 0 if:
  * 			 - Physical failed (error)
  * 			 - Bound failed (error)
- * 			 - Entitled is disabled
  * 			 - For target if bound failed (error)
  */
 uintptr_t
@@ -171,9 +168,6 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		break;
 	case OMRPORT_CPU_BOUND:
 		toReturn = 0;
-		break;
-	case OMRPORT_CPU_ENTITLED:
-		toReturn = portLibrary->portGlobals->entitledCPUs;
 		break;
 	case OMRPORT_CPU_TARGET:
 		toReturn = 0;

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -125,7 +125,7 @@ typedef struct OMRPortLibraryGlobalData {
 #endif
 	uintptr_t vmemAdviseOSonFree;					/** For softmx to determine whether OS should be advised of freed vmem */
 	uintptr_t vectorRegsSupportOn;				/* Turn on vector regs support */
-	uintptr_t entitledCPUs;							/** Number of entitled CPUs */
+	uintptr_t userSpecifiedCPUs;						/* Number of user-specified CPUs */
 #if defined(OMR_OPT_CUDA)
 	J9CudaGlobalData cudaGlobals;
 #endif /* OMR_OPT_CUDA */
@@ -504,7 +504,7 @@ omrsysinfo_env_iterator_next(struct OMRPortLibrary *portLibrary, J9SysinfoEnvIte
 extern J9_CFUNC intptr_t
 omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9SysinfoCPUTime *cpuTime);
 extern J9_CFUNC void
-omrsysinfo_set_number_entitled_CPUs(struct OMRPortLibrary *portLibrary, uintptr_t number);
+omrsysinfo_set_number_user_specified_CPUs(struct OMRPortLibrary *portLibrary, uintptr_t number);
 extern J9_CFUNC intptr_t
 omrsysinfo_get_cwd(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen);
 extern J9_CFUNC intptr_t

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -54,12 +54,11 @@ typedef struct CopyEnvToBufferArgs {
 #endif
 
 void
-omrsysinfo_set_number_entitled_CPUs(struct OMRPortLibrary *portLibrary, uintptr_t number)
+omrsysinfo_set_number_user_specified_CPUs(struct OMRPortLibrary *portLibrary, uintptr_t number)
 {
-	Trc_PRT_sysinfo_set_number_entitled_CPUs_Entered();
-	portLibrary->portGlobals->entitledCPUs = number;
-	Trc_PRT_sysinfo_set_number_entitled_CPUs_Exit(number);
-	return;
+	Trc_PRT_sysinfo_set_number_user_specified_CPUs_Entered();
+	portLibrary->portGlobals->userSpecifiedCPUs = number;
+	Trc_PRT_sysinfo_set_number_user_specified_CPUs_Exit(number);
 }
 
 /**
@@ -621,16 +620,12 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 
 		break;
 	}
-	case OMRPORT_CPU_ENTITLED:
-		toReturn = portLibrary->portGlobals->entitledCPUs;
-		break;
 	case OMRPORT_CPU_TARGET: {
-		uintptr_t entitled = portLibrary->portGlobals->entitledCPUs;
-		uintptr_t bound = omrsysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_BOUND);
-		if (entitled != 0 && entitled < bound) {
-			toReturn = entitled;
+		uintptr_t specified = portLibrary->portGlobals->userSpecifiedCPUs;
+		if (0 < specified) {
+			toReturn = specified;
 		} else {
-			toReturn = bound;
+			toReturn = portLibrary->sysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_BOUND);
 		}
 		break;
 	}


### PR DESCRIPTION
This change adds functionality for overriding the number of CPUs
returned by `omrsysinfo_get_number_CPUs_by_type` for the
`OMRPORT_CPU_TARGET` type. This is implemented as a port library
global and can be set through a port library function.

Since this functionality fulfills the needs that were previously
satisfied by the `OMRPORT_CPU_ENTITLED` type, this change also
removes entitled CPU count altogether. User-specified CPUs is now the only
CPU count set by the user.

This change is to satisfy the need for this functionality, as
discussed in eclipse/openj9#1166.

Issue: eclipse/openj9#1166.
Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>