### PR TITLE
Always set address for startPC symbol reference

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1966,15 +1966,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
    //
    self()->setPrePrologueSize(self()->getBinaryBufferLength());
 
-#ifdef J9_PROJECT_SPECIFIC
-   if ((!self()->comp()->getOptions()->getOption(TR_DisableGuardedCountingRecompilations) && TR::Options::getCmdLineOptions()->allowRecompilation()) ||
-       (self()->comp()->getOptions()->getEnableGPU(TR_EnableGPU) && self()->comp()->hasIntStreamForEach()) ||
-       self()->comp()->isJProfilingCompilation())
-#else
-   if (!self()->comp()->getOptions()->getOption(TR_DisableGuardedCountingRecompilations) &&
-       TR::Options::getCmdLineOptions()->allowRecompilation())
-#endif
-      self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
+   self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
 
    // Generate binary for the rest of the instructions
    //

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6356,10 +6356,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
       if (data.cursorInstruction == data.preProcInstruction)
          {
          self()->setPrePrologueSize(self()->getBinaryBufferCursor() - self()->getBinaryBufferStart());
-         if ((!self()->comp()->getOptions()->getOption(TR_DisableGuardedCountingRecompilations) ||
-              self()->comp()->isJProfilingCompilation()) &&
-             TR::Options::getCmdLineOptions()->allowRecompilation())
-          self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
+         self()->comp()->getSymRefTab()->findOrCreateStartPCSymbolRef()->getSymbol()->getStaticSymbol()->setStaticAddress(self()->getBinaryBufferCursor());
          }
 
       data.cursorInstruction = data.cursorInstruction->getNext();


### PR DESCRIPTION
Remove conditions on Z and X deciding whether to set static address
of startPC symbol reference. The conditions are complicated and error
prone but the benefit is very limited. Better to set the adderess
unconditionally which is what P is doing already.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>