### PR TITLE
WIP: Remove more deprecated Z VMThread reclamation logic

### DIFF
--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -1070,7 +1070,6 @@ public:
    uint32_t getBitRegNum (TR::RealRegister *reg);
 
    void printInstructionComment(TR::FILE *pOutFile, int32_t tabStops, TR::Instruction *instr, bool needsStartComment = false);
-   uint8_t *printLoadVMThreadInstruction(TR::FILE *pOutFile, uint8_t* cursor);
    uint8_t *printRuntimeInstrumentationOnOffInstruction(TR::FILE *pOutFile, uint8_t* cursor, bool isRION, bool isPrivateLinkage = false);
    const char *updateBranchName(const char * opCodeName, const char * brCondName);
 #endif

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -200,22 +200,16 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
       site = comp->addSideEffectNOPSite();
       }
 
-   TR::RegisterDependencyConditions * deps;
+   TR::RegisterDependencyConditions * deps = NULL;
    if (node->getNumChildren() == 3)
       {
       TR::Node * third = node->getChild(2);
       cg->evaluate(third);
       deps = generateRegisterDependencyConditions(cg, third, 0);
       }
-   else
-      {
-      deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions((uint16_t) 0, (uint16_t) 0, cg);
-      }
 
    if(virtualGuard->shouldGenerateChildrenCode())
       cg->evaluateChildrenWithMultipleRefCount(node);
-
-   deps = cg->addVMThreadDependencies(deps, NULL);
 
    generateVirtualGuardNOPInstruction(cg, node, site, deps, node->getBranchDestination()->getNode()->getLabel());
 
@@ -1123,8 +1117,6 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       dependencies= new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 4, cg);
 #endif
 
-   dependencies = cg->addVMThreadPreCondition(dependencies, NULL);
-
    int regDepChildNum = 1;
 
    switch (node->getOpCodeValue())
@@ -1275,10 +1267,7 @@ static inline void generateMergedHCRGuardCodeIfNeeded(TR::Node *node, TR::CodeGe
             {
             TR::LabelSymbol *fallThroughLabel = generateLabelSymbol(cg);
 
-            TR::RegisterDependencyConditions  *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions((uint16_t) 0, (uint16_t) 0, cg);
-
-            deps = cg->addVMThreadDependencies(deps, NULL);
-            TR::Instruction *vgnopInstr = generateVirtualGuardNOPInstruction(cg, node, site, deps, fallThroughLabel, instr ? instr->getPrev() : NULL);
+            TR::Instruction *vgnopInstr = generateVirtualGuardNOPInstruction(cg, node, site, NULL, fallThroughLabel, instr ? instr->getPrev() : NULL);
             vgnopInstr->setNext(instr);
             cg->setAppendInstruction(instr);
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, fallThroughLabel, mergedHCRDeps);
@@ -2391,7 +2380,6 @@ OMR::Z::TreeEvaluator::tableEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
       deps->addPostCondition(selectorReg, TR::RealRegister::AssignAny);
       }
-   deps = cg->addVMThreadPostCondition(deps, NULL);
 
    // Determine if the selector register needs to be sign-extended on a 64-bit system
 
@@ -2946,7 +2934,7 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
                {
                targetRegister = n->getRegister();
                cg->evaluate(reference);
-               
+
                // For concurrent scavenge the source is loaded and shifted by the guarded load, thus we need to use CG
                // here for a non-zero compressedrefs shift value
                if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
@@ -3538,7 +3526,7 @@ TR::InstOpCode::S390BranchCondition OMR::Z::TreeEvaluator::mapBranchConditionToL
          }
          break;
       case TR::InstOpCode::COND_BL:
-         {   
+         {
          return TR::InstOpCode::COND_BNL;
          }
          break;
@@ -3716,9 +3704,9 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          if (trueReg->getRegisterPair() || falseReg->getRegisterPair())
             {
             TR_ASSERT(trueReg->getRegisterPair() && falseReg->getRegisterPair(), "Both (or none) false and true regs should be register pairs");
-            
+
             const bool is64BitRegister = trueReg->getKind() == TR_GPR64 || cg->use64BitRegsOn32Bit();
-            
+
             auto mnemonic = is64BitRegister ? TR::InstOpCode::LOCGR: TR::InstOpCode::LOCR;
 
             generateRRFInstruction(cg, mnemonic, node, trueReg->getHighOrder(), falseReg->getHighOrder(), getMaskForBranchCondition(TR::InstOpCode::COND_BER), true);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -5951,13 +5951,6 @@ OMR::Z::CodeGenerator::deleteInst(TR::Instruction* old)
    }
 
 
-bool
-OMR::Z::CodeGenerator::needsVMThreadDependency()
-   {
-   return false;
-   }
-
-
 void
 OMR::Z::CodeGenerator::doPeephole()
    {
@@ -10101,31 +10094,6 @@ OMR::Z::CodeGenerator::clearHighOrderBits( TR::Node * node, TR::Register * targe
       }
 
    return true;
-   }
-
-TR::RegisterDependencyConditions *
-OMR::Z::CodeGenerator::addVMThreadPreCondition(TR::RegisterDependencyConditions *deps, TR::Register *reg)
-   {
-   return deps;
-   }
-
-TR::RegisterDependencyConditions *
-OMR::Z::CodeGenerator::addVMThreadPostCondition(TR::RegisterDependencyConditions *deps, TR::Register *reg)
-   {
-   return deps;
-   }
-
-TR::RegisterDependencyConditions *
-OMR::Z::CodeGenerator::addVMThreadDependencies(TR::RegisterDependencyConditions *deps, TR::Register *reg)
-   {
-   deps = self()->addVMThreadPreCondition(deps, reg);
-   deps = self()->addVMThreadPostCondition(deps, reg);
-   return deps;
-   }
-
-void
-OMR::Z::CodeGenerator::setVMThreadRequired(bool v)
-   {
    }
 
 bool OMR::Z::CodeGenerator::ilOpCodeIsSupported(TR::ILOpCodes o)

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -874,14 +874,6 @@ public:
 
    void deleteInst(TR::Instruction* old);
 
-   /** For using VM Thread Register as assignable register */
-   bool needsVMThreadDependency();
-
-   TR::RegisterDependencyConditions *addVMThreadPreCondition(TR::RegisterDependencyConditions *deps, TR::Register *reg);
-   TR::RegisterDependencyConditions *addVMThreadPostCondition(TR::RegisterDependencyConditions *deps, TR::Register *reg);
-   TR::RegisterDependencyConditions *addVMThreadDependencies(TR::RegisterDependencyConditions *deps, TR::Register *reg);
-   virtual void setVMThreadRequired(bool v); //override TR::CodeGenerator::setVMThreadRequired
-
    bool ilOpCodeIsSupported(TR::ILOpCodes);
 
    void setUsesZeroBasePtr( bool v = true );

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,6 @@ template <typename ListKind> class List;
 
 #define RefsAndDefsDependentRegister  (ReferencesDependentRegister | DefinesDependentRegister)
 
-#define NUM_VM_THREAD_REG_DEPS 1
 #define NUM_DEFAULT_DEPENDENCIES 1
 
 class TR_S390RegisterDependencyGroup
@@ -294,15 +293,12 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 	_cg(NULL)
       {}
 
-   //VMThread work: implicitly add an extra post condition for a possible vm thread
-   //register post dependency.  Do not need for pre because they are so
-   //infrequent.
    RegisterDependencyConditions(uint16_t numPreConds, uint16_t numPostConds, TR::CodeGenerator *cg)
       : _preConditions(TR_S390RegisterDependencyGroup::create(numPreConds, cg->trMemory())),
-        _postConditions(TR_S390RegisterDependencyGroup::create(numPostConds + NUM_VM_THREAD_REG_DEPS, cg->trMemory())),
+        _postConditions(TR_S390RegisterDependencyGroup::create(numPostConds, cg->trMemory())),
         _numPreConditions(numPreConds),
         _addCursorForPre(0),
-        _numPostConditions(numPostConds + NUM_VM_THREAD_REG_DEPS),
+        _numPostConditions(numPostConds),
         _addCursorForPost(0),
         _isHint(false),
         _isUsed(false),
@@ -313,7 +309,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          {
 	 _preConditions->clearDependencyInfo(i);
 	 }
-      for(int32_t j=0;j<numPostConds + NUM_VM_THREAD_REG_DEPS;j++)
+      for(int32_t j=0;j<numPostConds;j++)
          {
          _postConditions->clearDependencyInfo(j);
          }
@@ -539,7 +535,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 
    bool addPostConditionIfNotAlreadyInserted(TR::Register *vr,
                                              TR::RealRegister::RegNum rr,
-				                                 uint8_t flag = ReferencesDependentRegister);                                     
+				                                 uint8_t flag = ReferencesDependentRegister);
    bool addPostConditionIfNotAlreadyInserted(TR::Register *vr,
                                              TR::RealRegister::RegDep rr,
 				                                 uint8_t flag = ReferencesDependentRegister);

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -176,22 +176,6 @@ OMR::Z::Snippet::getPICBinaryLength(TR::CodeGenerator * cg)
    }
 
 /**
- * Load the vm thread value into GPR13
- * @todo okay to assume that we can destroy previous contents of r13? is register volatile?
- */
-uint8_t *
-OMR::Z::Snippet::generateLoadVMThreadInstruction(TR::CodeGenerator *cg, uint8_t *cursor)
-   {
-   return cursor;
-   }
-
-uint32_t
-OMR::Z::Snippet::getLoadVMThreadInstructionLength(TR::CodeGenerator *cg)
-   {
-   return 0;
-   }
-
-/**
  * Helper method to insert Runtime Instrumentation Hooks RION or RIOFF in snippet
  *
  * @param cg               Code Generator Pointer

--- a/compiler/z/codegen/OMRSnippet.hpp
+++ b/compiler/z/codegen/OMRSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -112,10 +112,6 @@ class OMR_EXTENSIBLE Snippet : public OMR::Snippet
 
    uint8_t *generatePICBinary(TR::CodeGenerator *, uint8_t *, TR::SymbolReference *);
    uint32_t getPICBinaryLength(TR::CodeGenerator *);
-
-   /** Helper method to reload VM Thread into GPR13 */
-   uint8_t *generateLoadVMThreadInstruction(TR::CodeGenerator *cg, uint8_t *cursor);
-   uint32_t getLoadVMThreadInstructionLength(TR::CodeGenerator *cg);
 
    // helper methods to insert Runtime Instrumentation hooks
    uint8_t *generateRuntimeInstrumentationOnOffInstruction(TR::CodeGenerator *cg, uint8_t *cursor, TR::InstOpCode::Mnemonic op, bool isPrivateLinkage = false);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -11954,7 +11954,6 @@ OMR::Z::TreeEvaluator::BBEndEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 #endif
    TR::TreeTop * nextTT = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();
    TR::RegisterDependencyConditions * deps = NULL;
-   deps = cg->addVMThreadDependencies(deps, NULL);
 
    lastInstr = generateS390PseudoInstruction(cg, TR::InstOpCode::FENCE, node, deps,
    TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._endPC));

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -3060,12 +3060,6 @@ TR_Debug::getBitRegNum(TR::RealRegister * reg)
    }
 
 uint8_t *
-TR_Debug::printLoadVMThreadInstruction(TR::FILE *pOutFile, uint8_t* cursor)
-   {
-   return cursor;
-   }
-
-uint8_t *
 TR_Debug::printRuntimeInstrumentationOnOffInstruction(TR::FILE *pOutFile, uint8_t* cursor, bool isRION, bool isPrivateLinkage)
    {
    TR::CodeGenerator * cg = _comp->cg();

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -60,9 +60,6 @@ TR::S390HelperCallSnippet::emitSnippetBody()
 
 
    uint32_t rEP = (uint32_t) cg()->getEntryPointRegister() - 1;
-
-   //load vm thread into gpr13
-   cursor = generateLoadVMThreadInstruction(cg(), cursor);
 
    // Generate RIOFF if RI is supported.
    cursor = generateRuntimeInstrumentationOnOffInstruction(cg(), cursor, TR::InstOpCode::RIOFF);
@@ -152,8 +149,6 @@ TR::S390HelperCallSnippet::getLength(int32_t)
       length += TR::S390CallSnippet::instructionCountForArguments(getNode(), cg());
       }
 
-   length += getLoadVMThreadInstructionLength(cg());
-
    length += getRuntimeInstrumentationOnOffInstructionLength(cg());
 
    return length;
@@ -171,8 +166,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390HelperCallSnippet * snippet)
 
    uint8_t * bufferPos = snippet->getSnippetLabel()->getCodeLocation();
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, "Helper Call Snippet", getName(helperSymRef));
-
-   bufferPos = printLoadVMThreadInstruction(pOutFile, bufferPos);
 
    bufferPos = printRuntimeInstrumentationOnOffInstruction(pOutFile, bufferPos, false); // RIOFF
 

--- a/compiler/z/codegen/S390OutOfLineCodeSection.cpp
+++ b/compiler/z/codegen/S390OutOfLineCodeSection.cpp
@@ -79,8 +79,6 @@ void TR_S390OutOfLineCodeSection::generateS390OutOfLineCodeSectionDispatch()
    //
    swapInstructionListsWithCompilation();
 
-   TR::Compilation *comp = _cg->comp();
-   TR::Register    *vmThreadReg = _cg->getMethodMetaDataRealRegister();
    TR::Instruction  *temp = generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _callNode, _entryLabel);
 
    _cg->incOutOfLineColdPathNestedDepth();


### PR DESCRIPTION
Remove the following and fold code accordingly:

* addVMThreadDependencies, addVMThreadPreCondition, addVMThreadPostCondition
* needsVMThreadDependency
* setVMThreadRequired
* NUM_VM_THREAD_REG_DEPS
* generateLoadVMThreadInstruction, getLoadVMThreadInstructionLength, printLoadVMThreadInstruction

Signed-off-by: Daryl Maier <maier@ca.ibm.com>