### PR TITLE
Implicit master for CS STW

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -521,11 +521,6 @@ public:
 	bool isInlineTLHAllocateEnabled() { return _delegate.isInlineTLHAllocateEnabled(); }
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 
-	/* When a GC thread is created _workUnitIndex is initialized to 0, when a task is started _workUnitIndex is reset to 1.
-	 * _workUnitIndex can be used to check if a GC thread has done any work since it was created.
-	 */
-	MMINLINE bool isGCSlaveThreadActivated() { return _workUnitIndex != 0; }
-
 	MMINLINE uintptr_t getWorkUnitIndex() { return _workUnitIndex; }
 	MMINLINE uintptr_t getWorkUnitToHandle() { return _workUnitToHandle; }
 	MMINLINE void setWorkUnitToHandle(uintptr_t workUnitToHandle) { _workUnitToHandle = workUnitToHandle; }

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -97,16 +97,7 @@ MM_EnvironmentStandard::flushGCCaches()
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (getExtensions()->concurrentScavenger) {
-
-		/* When a GC Slave thread is created, a Thread object is created and is stored to a (Java) ThreadPool structure.
-		 * If this GC Slave thread created during active scavenger cycle and doesn't do any actual work,
-		 * it can still indirectly trigger a read barrier (if it's the first of 'mutator' threads to access ThreadPool),
-		 * and copy ThreadPool instance into its copy cache.
-		 * This special inactive GC thread will have non-empty copy cache at the beginning of the final STW phase of CS cycle,
-		 * and should be treated same as a mutator thread.
-		 */
-		if ((GC_SLAVE_THREAD == getThreadType() && !isGCSlaveThreadActivated()) ||
-				MUTATOR_THREAD == getThreadType()) {
+		if (MUTATOR_THREAD == getThreadType()) {
 			if (NULL != getExtensions()->scavenger) {
 				getExtensions()->scavenger->threadFinalReleaseCopyCaches(this, this);
 			}

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -72,6 +72,12 @@ public:
 	
 	virtual void flushNonAllocationCaches();
 	virtual void flushGCCaches();
+	
+	virtual void initializeGCThread() {
+		/* before a thread turning into a GC one, it shortly acted as a mutator (during thread attach sequence),
+		 * which means it may have allocated or exacuted an object access barrier. */
+		flushGCCaches();
+	}
 
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(OMR_VMThread *omrVMThread) { return static_cast<MM_EnvironmentStandard*>(omrVMThread->_gcOmrVMThreadExtensions); }
 	MMINLINE static MM_EnvironmentStandard *getEnvironment(MM_EnvironmentBase *env) { return static_cast<MM_EnvironmentStandard*>(env); }

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -313,7 +313,7 @@ MM_Scavenger::collectorStartup(MM_GCExtensionsBase* extensions)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavenger) {
-		if (!_masterGCThread.initialize(this)) {
+		if (!_masterGCThread.initialize(this, true, true)) {
 			return false;
 		}
 		if (!_masterGCThread.startup()) {
@@ -4651,6 +4651,8 @@ MM_Scavenger::scavengeComplete(MM_EnvironmentBase *envBase)
 	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_COMPLETE, U_64_MAX, NULL, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
+	Assert_MM_true(_scavengeCacheFreeList.areAllCachesReturned());
+
 	return false;
 }
 
@@ -4777,15 +4779,10 @@ MM_Scavenger::scavengeIncremental(MM_EnvironmentBase *env)
 
 			_concurrentState = concurrent_state_complete;
 
-			if (isBackOutFlagRaised()) {
-				mergeIncrementGCStats(env, false);
-				clearIncrementGCStats(env, false);
-				continue;
-			}
-
-			timeout = true;
+			mergeIncrementGCStats(env, false);
+			clearIncrementGCStats(env, false);
+			continue;
 		}
-			break;
 
 		case concurrent_state_complete:
 		{
@@ -4903,23 +4900,29 @@ MM_Scavenger::workThreadComplete(MM_EnvironmentStandard *env)
 uintptr_t
 MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 {
-	Assert_MM_true(concurrent_state_scan == _concurrentState);
+	if (concurrent_state_scan == _concurrentState) {
+		Assert_MM_true(concurrent_state_scan == _concurrentState || concurrent_state_idle == _concurrentState);
 
-	clearIncrementGCStats(env, false);
+		clearIncrementGCStats(env, false);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, &_forceConcurrentTermination, env->_cycleState);
-	/* Concurrent background task will run with different (typically lower) number of threads. */
-	_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
+		MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, &_forceConcurrentTermination, env->_cycleState);
+		/* Concurrent background task will run with different (typically lower) number of threads. */
+		_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
 
-	/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */
-	_concurrentState = concurrent_state_complete;
-	/* make allocate space non-allocatable to trigger the final GC phase */
-	_activeSubSpace->flip(env, MM_MemorySubSpaceSemiSpace::disable_allocation);
+		/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */
+		_concurrentState = concurrent_state_complete;
+		/* make allocate space non-allocatable to trigger the final GC phase */
+		_activeSubSpace->flip(env, MM_MemorySubSpaceSemiSpace::disable_allocation);
 
-	mergeIncrementGCStats(env, false);
+		mergeIncrementGCStats(env, false);
 
-	/* return the number of bytes scanned since the caller needs to pass it into postConcurrentUpdateStatsAndReport for stats reporting */
-	return scavengeTask.getBytesScanned();
+		/* return the number of bytes scanned since the caller needs to pass it into postConcurrentUpdateStatsAndReport for stats reporting */
+		return scavengeTask.getBytesScanned();
+	} else {
+		/* someone else might have done this phase (and the rest of the cycle), forced in STW, before we even got a chance to run. */
+		Assert_MM_true(concurrent_state_idle == _concurrentState);
+		return 0;
+	}
 }
 
 void MM_Scavenger::preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats)


### PR DESCRIPTION
Stop-the-World Concurrent Scavenger phases of a cycle will now use
implicit master thread (mutator thread that triggered the phase through
Allocation Failure).

MasterGCThread class is modified to now support both implicit and
explicit master GC thread for STW phases. The later (for now) is still
used for Balanced GC (in OpenJ9).

Another optional behavior is whether to acquire or not VM access during
concurrent phase. The default is not to (again, still used by Balanced
GC, during concurrent marking), while CS acquires it (it must because it
moves objects).

The benefit of having implicit master is simpler start/end of a STW
increment, since there is no need for use of assume/relinquish exclusive
access API, which in various ways complicates some corner cases of VM
access synchornization (like hand-off or simultanious safe-access and
exclusive VM access ) with also complex GC scenarios (where two
different STW increments/cycle are executed back to back, like percolate
GC).

Another changes (and simplification) is that the transition from first
STW phase and concurrent phase of a CS cycle will not have the deferred
VM access 'protocol'. Simply, at the end of STW, exclusive VM access
will be released completely (including master GC thread releasing VM
access, instead of deferring the release). Then master GC thread will
simply acquire VM access prior to starting the concurrent phase. No
special tricks or APIs are used. Master GC thread will continue to keep
VM access during the whole concurrent phase, although in future for
fairness, it may occassionally try to release it even before finishing
the phase. So, there is now a gap between first STW and concurrent
phase, where master GC holds neither exclussive VM access nor thread VM
access, and other parties are ok to acquire exclusive VM access (or
safeAccess) at that time (for example to walk heap and replace classes).
The same gap also exists (used to exist even before), between the end of
the concurrent phase and start of the second (last) STW phase. 

Clearly, concurrent phase of CS will continue to use explict master GC
thread.

Another change is a fix to a startup scenario, where explicit master
thread during attach-thread procedure acts as a mutator, and if (rarely)
happens during already active concurrent CS phase, the GC specific
buffers (like barrier ones) would be populated but never flushed (at the
time of flushing the thread would already turn into a GC thread and not
treated properly as a mutator). The fix is to explicitely flush these
buffers after attaching and before really becoming a GC thread. This
used to be a problem only with slave threads, but now that STW phase
runs with implicit master, similar problem occurs while brining up the
explicit master. The old fix is removed, and this new fix is now applied
on both master and slave thread.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>