### PR TITLE
Spill target register if it is the only one available

### DIFF
--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -5327,40 +5327,70 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
          }
       else
          {
-         self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+         // if spareReg is still NULL, then it means we did not find any free Reg, and no
+         // other register is available to spill. So we must spill the target register.
 
-         // virtual register is not assigned yet, copy register
-         cursor = self()->registerCopy(currentInstruction, currentTargetVirtualRK, targetRegister, spareReg, self()->cg(), instFlags);
-
-         spareReg->setState(TR::RealRegister::Assigned);
-         spareReg->setAssignedRegister(currentTargetVirtual);
-         currentTargetVirtual->setAssignedRegister(spareReg);
-
-         if (enableHighWordRA && currentTargetVirtual->is64BitReg())
+         // In general if a register is blocked, the virtual register
+         // associated with a target register would have been assigned as part of that instruction.
+         // So we would not do this (i.e. spill the blocked register). However, in this case all
+         // pre-assigned registers in the dependency are blocked before individiual dependencies are coerced
+         // into their respective target registers (inside TR_S390RegisterDependencyGroup::assignRegisters((..)).
+         // In this situation it's possible that the target register of a register dependency is currently
+         // blocked (as in here) and occupied by another virtual register and that there is no other available
+         // register to free.
+         // Hence, we must spill the blocked target reg as it is the only available candidate.
+         if (spareReg == NULL)
             {
-            //TR_ASSERT(targetRegisterHW->getState() == TR::RealRegister::Blocked,
-            //        "currentTargetVirtual is blocked and is fullsize, but the HW is not blocked?");
+            self()->cg()->setRegisterAssignmentFlag(TR_RegisterSpilled);
+            virtualRegister->block();
 
-            spareReg->getHighWordRegister()->setState(TR::RealRegister::Assigned);
-            spareReg->getHighWordRegister()->setAssignedRegister(currentTargetVirtual);
-            targetRegister->getLowWordRegister()->setState(TR::RealRegister::Unlatched);
-            targetRegister->getLowWordRegister()->setAssignedRegister(NULL);
-            targetRegisterHW->setState(TR::RealRegister::Unlatched);
-            targetRegisterHW->setAssignedRegister(NULL);
-            }
-         if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount())
-            {
-            self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
-            self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
+            self()->spillRegister(currentInstruction, currentTargetVirtual);
+            targetRegister->setAssignedRegister(virtualRegister);
+            virtualRegister->setAssignedRegister(targetRegister);
+            targetRegister->setState(TR::RealRegister::Assigned);
+
+            if (targetRegister->isHighWordRegister() && currentTargetVirtual->is64BitReg() &&
+                targetRegister->getRegisterNumber() == spareReg->getHighWordRegister()->getRegisterNumber())
+               doNotRegCopy = true;
+            virtualRegister->unblock();
             }
          else
             {
-            if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+            self()->cg()->traceRegAssigned(currentTargetVirtual, spareReg);
+
+            // virtual register is not assigned yet, copy register
+            cursor = self()->registerCopy(currentInstruction, currentTargetVirtualRK, targetRegister, spareReg, self()->cg(), instFlags);
+
+            spareReg->setState(TR::RealRegister::Assigned);
+            spareReg->setAssignedRegister(currentTargetVirtual);
+            currentTargetVirtual->setAssignedRegister(spareReg);
+
+            if (enableHighWordRA && currentTargetVirtual->is64BitReg())
                {
-               self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+               //TR_ASSERT(targetRegisterHW->getState() == TR::RealRegister::Blocked,
+               //        "currentTargetVirtual is blocked and is fullsize, but the HW is not blocked?");
+
+               spareReg->getHighWordRegister()->setState(TR::RealRegister::Assigned);
+               spareReg->getHighWordRegister()->setAssignedRegister(currentTargetVirtual);
+               targetRegister->getLowWordRegister()->setState(TR::RealRegister::Unlatched);
+               targetRegister->getLowWordRegister()->setAssignedRegister(NULL);
+               targetRegisterHW->setState(TR::RealRegister::Unlatched);
+               targetRegisterHW->setAssignedRegister(NULL);
                }
+            if (virtualRegister->getTotalUseCount() != virtualRegister->getFutureUseCount())
+               {
+               self()->cg()->setRegisterAssignmentFlag(TR_RegisterReloaded);
+               self()->reverseSpillState(currentInstruction, virtualRegister, targetRegister);
+               }
+            else
+               {
+               if (!comp->getOption(TR_DisableOOL) && self()->cg()->isOutOfLineColdPath())
+                  {
+                  self()->cg()->getFirstTimeLiveOOLRegisterList()->push_front(virtualRegister);
+                  }
+               }
+            // spareReg is assigned.
             }
-         // spareReg is assigned.
          }
       }
       // the target reg is assigned


### PR DESCRIPTION
If targetReg's state is blocked and no other registers
are available for spilling, then bypass the blocked state to
spill the blocked register, then reverse spill it back when needed.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>