### PR TITLE
Misc. Machine class cleanup

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -29,7 +29,7 @@
 #include "infra/Assert.hpp"
 
 OMR::ARM64::Machine::Machine(TR::CodeGenerator *cg) :
-   OMR::Machine(cg, NUM_ARM64_GPR, NUM_ARM64_FPR)
+      OMR::Machine(cg)
    {
    _registerFile = (TR::RealRegister **)cg->trMemory()->allocateMemory(sizeof(TR::RealRegister *)*TR::RealRegister::NumRegisters, heapAlloc);
    self()->initializeRegisterFile();
@@ -385,7 +385,7 @@ void OMR::ARM64::Machine::initializeRegisterFile()
                                                  TR::RealRegister::Free,
                                                  TR::RealRegister::v9,
                                                  self()->cg());
- 
+
    _registerFile[TR::RealRegister::v10] = new (self()->cg()->trHeapMemory()) TR::RealRegister(TR_FPR,
                                                  0,
                                                  TR::RealRegister::Free,

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -43,16 +43,17 @@ static void registerCopy(TR::Instruction     *precedingI,
                          TR::RealRegister *sReg,
                          TR::CodeGenerator   *cg);
 
-OMR::ARM::Machine::Machine(TR::CodeGenerator *cg): OMR::Machine(cg, NUM_ARM_GPR, NUM_ARM_FPR)
+OMR::ARM::Machine::Machine(TR::CodeGenerator *cg) :
+      OMR::Machine(cg)
    {
    self()->initializeRegisterFile();
    }
 
 
 TR::RealRegister *OMR::ARM::Machine::findBestFreeRegister(TR_RegisterKinds rk,
-							bool excludeGPR0,
-							bool considerUnlatched,
-							bool isSinglePrecision)
+      bool excludeGPR0,
+      bool considerUnlatched,
+      bool isSinglePrecision)
    {
    int first;
    int last;
@@ -104,7 +105,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
                                                     TR_RegisterKinds    rk,
                                                     TR::RealRegister *forced,
                                                     bool                excludeGPR0,
-                        							bool isSinglePrecision)
+                                                    bool isSinglePrecision)
    {
    TR::Register           *candidates[NUM_ARM_MAXR];
    TR::Compilation *comp = self()->cg()->comp();
@@ -116,7 +117,6 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
    TR_ARMOpCodes          opCode;
    int                    numCandidates = 0;
    int                    first, last;
-   //TR::RealRegister::TR_States crtemp_state;
 
    if (forced != NULL)
       {

--- a/compiler/codegen/OMRMachine.cpp
+++ b/compiler/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,27 +33,3 @@
 
 #include "codegen/Machine.hpp"      // for TR::Machine
 #include "codegen/Machine_inlines.hpp"
-
-uint8_t
-OMR::Machine::getNumberOfGPRs()
-   {
-   return self()->getNumberOfRegisters(TR_GPR);
-   }
-
-uint8_t
-OMR::Machine::getNumberOfFPRs()
-   {
-   return self()->getNumberOfRegisters(TR_FPR);
-   }
-
-uint8_t
-OMR::Machine::setNumberOfGPRs(uint8_t numIntRegs)
-   {
-   return self()->setNumberOfRegisters(TR_GPR,numIntRegs);
-   }
-
-uint8_t
-OMR::Machine::setNumberOfFPRs(uint8_t numFPRegs)
-   {
-   return self()->setNumberOfRegisters(TR_FPR,numFPRegs);
-   }

--- a/compiler/codegen/OMRMachine.hpp
+++ b/compiler/codegen/OMRMachine.hpp
@@ -35,10 +35,8 @@ namespace OMR { typedef OMR::Machine MachineConnector; }
 #include <stdint.h>                            // for uint8_t, uint32_t
 #include "env/TRMemory.hpp"                    // for TR_Memory, etc
 #include "infra/Annotations.hpp"               // for OMR_EXTENSIBLE
-#include "codegen/RegisterConstants.hpp"
 
 namespace TR { class CodeGenerator; }
-namespace TR { class RealRegister; }
 namespace TR { class Machine; }
 
 namespace OMR
@@ -46,69 +44,20 @@ namespace OMR
 
 class OMR_EXTENSIBLE Machine
    {
-   uint8_t _numberRegisters[NumRegisterKinds];
-   TR_GlobalRegisterNumber _firstGlobalRegisterNumber[NumRegisterKinds];
-   TR_GlobalRegisterNumber _lastGlobalRegisterNumber[NumRegisterKinds];
-   TR_GlobalRegisterNumber _lastRealRegisterGlobalRegisterNumber;
-   TR_GlobalRegisterNumber _overallLastGlobalRegisterNumber;
    TR::CodeGenerator *_cg;
 
-   public:
+public:
 
    TR_ALLOC(TR_Memory::Machine)
 
-   Machine() : _lastRealRegisterGlobalRegisterNumber(-1), _overallLastGlobalRegisterNumber(-1)
+   Machine(TR::CodeGenerator *cg) :
+         _cg(cg)
       {
-       for(uint32_t i=0;i<NumRegisterKinds;i++)
-         {
-         _numberRegisters[i]=-1;
-         _firstGlobalRegisterNumber[i]=0;
-         _lastGlobalRegisterNumber[i]=-1;
-         }
-      }
-
-   // TODO: numVRFRegs should probably be explicitly set to 0 instead of defaulting to 0
-   Machine(TR::CodeGenerator *cg, uint8_t numIntRegs, uint8_t numFPRegs, uint8_t numVRFRegs = 0) : _lastRealRegisterGlobalRegisterNumber(-1), _overallLastGlobalRegisterNumber(-1), _cg(cg)
-      {
-       for(uint32_t i=0;i<NumRegisterKinds;i++)
-         {
-         _numberRegisters[i]=0;
-         _firstGlobalRegisterNumber[i]=0;
-         _lastGlobalRegisterNumber[i]=-1;
-         }
-       _numberRegisters[TR_GPR] = numIntRegs;
-       _numberRegisters[TR_FPR] = numFPRegs;
-       _numberRegisters[TR_VRF] = numVRFRegs; // TODO vrf gra : needs this but every platform will need to pass numVRFRegs in
       }
 
    inline TR::Machine * self();
 
    TR::CodeGenerator *cg() {return _cg;}
-
-   uint8_t getNumberOfRegisters(TR_RegisterKinds rk) { return _numberRegisters[rk]; }
-
-   // Lets try and use the genericly named method above. These are only for backward compatibility
-   uint8_t getNumberOfGPRs();
-   uint8_t getNumberOfFPRs();
-
-   // GlobalRegisterNumbers consiste of real registers in the order of assignment preference. All register kinds combined
-   TR_GlobalRegisterNumber getFirstGlobalRegisterNumber(TR_RegisterKinds rk) { return _firstGlobalRegisterNumber[rk]; }
-   TR_GlobalRegisterNumber getLastGlobalRegisterNumber(TR_RegisterKinds rk) { return _lastGlobalRegisterNumber[rk]; }
-   TR_GlobalRegisterNumber getLastRealRegisterGlobalRegisterNumber() { return _lastRealRegisterGlobalRegisterNumber; }
-   TR_GlobalRegisterNumber getLastGlobalRegisterNumber() { return _overallLastGlobalRegisterNumber; }
-   virtual TR::RealRegister *getRealRegister(TR_GlobalRegisterNumber grn) {return NULL; }
-   TR_GlobalRegisterNumber getNextGlobalRegisterNumber() { return (++_overallLastGlobalRegisterNumber); }
-
-   protected:
-   // setters should only be used by specific machine class initializers
-
-   uint8_t setNumberOfRegisters(TR_RegisterKinds rk, uint8_t num) { return (_numberRegisters[rk] = num); }
-   uint8_t setNumberOfGPRs(uint8_t numIntRegs);
-   uint8_t setNumberOfFPRs(uint8_t numFPRegs);
-
-   TR_GlobalRegisterNumber setFirstGlobalRegisterNumber(TR_RegisterKinds rk, TR_GlobalRegisterNumber grn) { return (_firstGlobalRegisterNumber[rk]=grn); }
-   TR_GlobalRegisterNumber setLastGlobalRegisterNumber(TR_RegisterKinds rk, TR_GlobalRegisterNumber grn) { return (_lastGlobalRegisterNumber[rk]=grn); }
-   TR_GlobalRegisterNumber setLastRealRegisterGlobalRegisterNumber(TR_GlobalRegisterNumber grn) { _overallLastGlobalRegisterNumber=grn; return (_lastRealRegisterGlobalRegisterNumber=grn); }
 
    };
 

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -137,10 +137,11 @@ static bool boundNext(TR::Instruction *currentInstruction, int32_t realNum, TR::
    return true;
    }
 
-OMR::Power::Machine::Machine(TR::CodeGenerator *cg): OMR::Machine(cg, NUM_PPC_GPR, NUM_PPC_FPR),
-numLockedGPRs(-1),
-numLockedFPRs(-1),
-numLockedVRFs(-1)
+OMR::Power::Machine::Machine(TR::CodeGenerator *cg) :
+      OMR::Machine(cg),
+   numLockedGPRs(-1),
+   numLockedFPRs(-1),
+   numLockedVRFs(-1)
    {
    _registerFile = (TR::RealRegister **)cg->trMemory()->allocateMemory(sizeof(TR::RealRegister *)*TR::RealRegister::NumRegisters, heapAlloc);
    self()->initializeRegisterFile();

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -182,7 +182,7 @@ OMR::X86::Machine::Machine
    TR::Register **xmmGlobalRegisters,
    uint32_t *globalRegisterNumberToRealRegisterMap
    )
-   : OMR::Machine(cg, numIntRegs, numFPRegs),
+   : OMR::Machine(cg),
    _registerFile(registerFile),
    _registerAssociations(registerAssociations),
    _numGlobalGPRs(numGlobalGPRs),
@@ -190,7 +190,8 @@ OMR::X86::Machine::Machine
    _numGlobalFPRs(numGlobalFPRs),
    _xmmGlobalRegisters(xmmGlobalRegisters),
    _globalRegisterNumberToRealRegisterMap(globalRegisterNumberToRealRegisterMap),
-   _spilledRegistersList(NULL)
+   _spilledRegistersList(NULL),
+   _numGPRs(numIntRegs)
    {
    self()->initializeFPStackRegisterFile();
    _fpTopOfStack = TR_X86FPStackRegister::fpStackEmpty;

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -104,6 +104,11 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::RealRegister  **_registerFile;
    TR::Register         **_registerAssociations;
 
+   /**
+    * Number of general purpose registers
+    */
+   int8_t _numGPRs;
+
    // Floating point stack pseudo-registers: they can be mapped to real
    // registers on demand, based on their relative position from the top of
    // stack marker.
@@ -134,6 +139,8 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    void initializeRegisterFile(const struct TR::X86LinkageProperties&);
    uint32_t* getGlobalRegisterTable(const struct TR::X86LinkageProperties&);
    int32_t getGlobalReg(TR::RealRegister::RegNum reg);
+
+   uint8_t getNumberOfGPRs() { return _numGPRs; }
 
    TR::RealRegister *getX86RealRegister(TR::RealRegister::RegNum regNum)
       {

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -727,7 +727,7 @@ OMR::Z::Machine::getGPRSize()
 //  Constructor
 
 OMR::Z::Machine::Machine(TR::CodeGenerator * cg)
-   : OMR::Machine(cg, NUM_S390_GPR, NUM_S390_FPR, NUM_S390_VRF), _lastGlobalGPRRegisterNumber(-1), _last8BitGlobalGPRRegisterNumber(-1),
+   : OMR::Machine(cg), _lastGlobalGPRRegisterNumber(-1), _last8BitGlobalGPRRegisterNumber(-1),
    _lastGlobalFPRRegisterNumber(-1), _lastGlobalCCRRegisterNumber(-1), _lastVolatileNonLinkGPR(-1), _lastLinkageGPR(-1),
      _lastVolatileNonLinkFPR(-1), _lastLinkageFPR(-1), _firstGlobalAccessRegisterNumber(-1), _lastGlobalAccessRegisterNumber(-1), _globalEnvironmentRegisterNumber(-1), _globalCAARegisterNumber(-1), _globalParentDSARegisterNumber(-1),
     _globalReturnAddressRegisterNumber(-1),_globalEntryPointRegisterNumber(-1)
@@ -5946,42 +5946,6 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
    return cursor;
    }
 
-uint64_t OMR::Z::Machine::filterColouredRegisterConflicts(TR::Register *targetRegister, TR::Register *siblingRegister,
-                                                             TR::Instruction *currInst)
-  {
-  uint64_t mask=0xffffffff;
-  TR::Compilation *comp = self()->cg()->comp();
-  TR::list<TR::Register *> conflictRegs(getTypedAllocator<TR::Register*>(comp->allocator()));
-
-  if(currInst->defsAnyRegister(targetRegister))
-    {
-    currInst->getDefinedRegisters(conflictRegs);
-    for(auto reg = conflictRegs.begin(); reg != conflictRegs.end(); ++reg)
-      {
-      TR::Register *cr=(*reg)->getRealRegister() ? NULL : (*reg)->getAssignedRegister();
-      if (cr && targetRegister != (*reg) && (*reg)->getAssignedRegister() != targetRegister &&
-         (siblingRegister == NULL || (*reg) != siblingRegister))
-         {
-         mask &= ~toRealRegister(cr)->getRealRegisterMask();
-         }
-      }
-    }
-
-  currInst->getUsedRegisters(conflictRegs);
-  for(auto reg = conflictRegs.begin(); reg != conflictRegs.end(); ++reg)
-    {
-    TR::Register *cr=(*reg)->getRealRegister() ? NULL : (*reg)->getAssignedRegister();
-    if (cr && targetRegister != (*reg) && (*reg)->getAssignedRegister() != targetRegister &&
-       (siblingRegister == NULL || (*reg) != siblingRegister))
-       {
-       mask &= ~toRealRegister(cr)->getRealRegisterMask();
-       }
-    }
-
-  return mask;
-
-  }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // OMR::Z::Machine::initializeRegisterFile
@@ -6729,7 +6693,6 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
              }
           }
 
-      self()->setLastRealRegisterGlobalRegisterNumber(p-1);
       self()->setLastGlobalCCRRegisterNumber(p-1);
 
       return _globalRegisterNumberToRealRegisterMap;
@@ -6864,8 +6827,6 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
    _globalRegisterNumberToRealRegisterMap[41] = TR::RealRegister::FPR0;  // volatile and 1st param float
    self()->setLastLinkageFPR(41);
 #endif
-
-   self()->setLastRealRegisterGlobalRegisterNumber(41);
 
    self()->setLastGlobalFPRRegisterNumber(41);        // Index of last global FPR
    self()->setLastGlobalCCRRegisterNumber(41);        // Index of last global CCR
@@ -7048,49 +7009,42 @@ OMR::Z::Machine::releaseLiteralPoolRegister()
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setFirstGlobalAccessRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setFirstGlobalRegisterNumber(TR_AR,reg);
    return _firstGlobalAccessRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setLastGlobalAccessRegisterNumber(TR_GlobalRegisterNumber reg)
     {
-    self()->setLastGlobalRegisterNumber(TR_AR,reg);
     return _lastGlobalAccessRegisterNumber = reg;
     }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setLastGlobalGPRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setLastGlobalRegisterNumber(TR_GPR,reg);
    return _lastGlobalGPRRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setLastGlobalHPRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setLastGlobalRegisterNumber(TR_HPR,reg);
    return _lastGlobalHPRRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setFirstGlobalGPRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setFirstGlobalRegisterNumber(TR_GPR,reg);
    return _firstGlobalGPRRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setFirstGlobalHPRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setFirstGlobalRegisterNumber(TR_HPR,reg);
    return _firstGlobalHPRRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setFirstGlobalFPRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setFirstGlobalRegisterNumber(TR_FPR, reg);
    self()->setFirstOverlappedGlobalFPRRegisterNumber(reg);
    return _firstGlobalFPRRegisterNumber = reg;
    }
@@ -7098,7 +7052,6 @@ OMR::Z::Machine::setFirstGlobalFPRRegisterNumber(TR_GlobalRegisterNumber reg)
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setLastGlobalFPRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setLastGlobalRegisterNumber(TR_FPR,reg);
    self()->setLastOverlappedGlobalFPRRegisterNumber(reg);
    return _lastGlobalFPRRegisterNumber = reg;
    }
@@ -7106,21 +7059,18 @@ OMR::Z::Machine::setLastGlobalFPRRegisterNumber(TR_GlobalRegisterNumber reg)
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setFirstGlobalVRFRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setFirstGlobalRegisterNumber(TR_VRF,reg);
    return _firstGlobalVRFRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setLastGlobalVRFRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setLastGlobalRegisterNumber(TR_VRF,reg);
    return _lastGlobalVRFRegisterNumber = reg;
    }
 
 TR_GlobalRegisterNumber
 OMR::Z::Machine::setLastGlobalCCRRegisterNumber(TR_GlobalRegisterNumber reg)
    {
-   self()->setLastGlobalRegisterNumber(TR_CCR,reg);
    return _lastGlobalCCRRegisterNumber=reg;
    }
 

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -45,7 +45,6 @@ namespace TR { class CodeGenerator; }
 namespace TR { class Instruction; }
 namespace TR { class Register; }
 namespace TR { class RegisterDependencyConditions; }
-namespace TR { namespace Z { class MachineBase; } }
 template <class T> class TR_Stack;
 template <typename ListKind> class List;
 
@@ -70,8 +69,8 @@ template <typename ListKind> class List;
 
 // single byte Immediate field limit
 #define MAX_UNSIGNED_IMMEDIATE_BYTE_VAL    0xFF
-#define MAX_IMMEDIATE_BYTE_VAL   	       127           // 0x7f
-#define MIN_IMMEDIATE_BYTE_VAL  	         -128           // 0x80
+#define MAX_IMMEDIATE_BYTE_VAL             127           // 0x7f
+#define MIN_IMMEDIATE_BYTE_VAL            -128           // 0x80
 
 #define MAX_RELOCATION_VAL              65535
 #define MIN_RELOCATION_VAL             -65536
@@ -82,8 +81,8 @@ template <typename ListKind> class List;
 
 // Immediate field limit
 #define MAX_UNSIGNED_IMMEDIATE_VAL    0xFFFF
-#define MAX_IMMEDIATE_VAL   	       32767         // 0x7fff
-#define MIN_IMMEDIATE_VAL  	      -32768         // 0x8000
+#define MAX_IMMEDIATE_VAL             32767         // 0x7fff
+#define MIN_IMMEDIATE_VAL            -32768         // 0x8000
 
 // LL: Maximum Immediate field limit for Golden Eagle
 #define GE_MAX_IMMEDIATE_VAL          (int64_t)CONSTANT64(0x000000007FFFFFFF)
@@ -245,11 +244,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
       return _registerFile[regNum];
       }
 
-   TR::RealRegister *getRealRegister(TR_GlobalRegisterNumber grn)
-       {
-       return _registerFile[_globalRegisterNumberToRealRegisterMap[grn]];
-       }
-
    uint8_t getGPRSize();
    uint8_t getFPRSize() const { return 8;}
    uint8_t getARSize() const { return 4;}
@@ -267,9 +261,9 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    /** GENERAL INTERFACE for OBTAINING ANY TYPE of REG */
    TR::Register *assignBestRegister(TR::Register    *targetRegister,
-				   TR::Instruction *currInst,
-                                   bool            doBookKeeping,
-                                   uint64_t        availRegMask = 0xffffffff);
+                                    TR::Instruction *currInst,
+                                    bool            doBookKeeping,
+                                    uint64_t        availRegMask = 0xffffffff);
 
 
    // EVENODD PAIR REGISTERS methods
@@ -307,12 +301,11 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::RealRegister* findBestLegalSiblingFPRegister(bool isFirst, uint64_t availRegMask=0x0000ffff);
 
    bool findBestFreeRegisterPair(TR::RealRegister** firstReg, TR::RealRegister** lastReg, TR_RegisterKinds rk,
-				    TR::Instruction* currInst, uint64_t availRegMask=0x0000ffff);
+                                 TR::Instruction* currInst, uint64_t availRegMask=0x0000ffff);
    void    freeBestRegisterPair(TR::RealRegister** firstReg, TR::RealRegister** lastReg, TR_RegisterKinds rk,
-			            TR::Instruction* currInst, uint64_t availRegMask=0x0000ffff);
+                                TR::Instruction* currInst, uint64_t availRegMask=0x0000ffff);
    void    freeBestFPRegisterPair(TR::RealRegister** firstReg, TR::RealRegister** lastReg,
-			            TR::Instruction* currInst, uint64_t availRegMask=0x0000ffff);
-   uint64_t filterColouredRegisterConflicts(TR::Register *targetRegister, TR::Register *siblingRegister, TR::Instruction *currInstr);
+                                  TR::Instruction* currInst, uint64_t availRegMask=0x0000ffff);
 
    // Access Register managed
    TR::RealRegister* findVirtRegInHighWordRegister(TR::Register *virtReg);


### PR DESCRIPTION
* remove deprecated colouring global register allocator functionality
* remove unused cache of register numbers by kind and modify
  architecture constructors

Signed-off-by: Daryl Maier <maier@ca.ibm.com>