### PR TITLE
Fix for incorrect a2i/a2l support on X86 CG

### DIFF
--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -339,13 +339,13 @@ OMR::TreeEvaluator::computeCCEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register *OMR::TreeEvaluator::unImpOpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(false, "Opcode %s is not implemented\n",node->getOpCode().getName());
+   TR_ASSERT_FATAL(false, "Opcode %s is not implemented\n", node->getOpCode().getName());
    return NULL;
    }
 
 TR::Register *OMR::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(false, "badILOp cannot be evaluated");
+   TR_ASSERT_FATAL(false, "badILOp %s cannot be evaluated\n", node->getOpCode().getName());
    return NULL;
    }
 

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -200,7 +200,7 @@
    TR::TreeEvaluator::i2fEvaluator,                     // TR::su2f
    TR::TreeEvaluator::i2dEvaluator,                     // TR::su2d
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::su2a
-   TR::TreeEvaluator::passThroughEvaluator,             // TR::a2i
+   TR::TreeEvaluator::badILOpEvaluator,                 // TR::a2i
    TR::TreeEvaluator::a2lEvaluator,                     // TR::a2l
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::a2b
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::a2s

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -201,7 +201,7 @@
    TR::TreeEvaluator::i2dEvaluator,                     // TR::su2d
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::su2a
    TR::TreeEvaluator::passThroughEvaluator,             // TR::a2i
-   TR::TreeEvaluator::passThroughEvaluator,             // TR::a2l
+   TR::TreeEvaluator::badILOpEvaluator,                 // TR::a2l
    TR::TreeEvaluator::i2bEvaluator,                     // TR::a2b
    TR::TreeEvaluator::i2bEvaluator,                     // TR::a2s
    TR::TreeEvaluator::integerCmpeqEvaluator,            // TR::icmpeq


### PR DESCRIPTION
TR::a2i should only be used on 32-bit;
TR::a2l should only be used on 64-bit;
removing the incorrect supports from their corresponding platforms.

In addition, use TR_ASSERT_FATAL for badILOpEvaluator and unImpOpEvaluator,
ensuring the invalid usage of IL OpCode is always reported.

Issue #2702

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>