### PR TITLE
Disable Compiler Time Profiler and ATOE Mapping for zTPF

### DIFF
--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if defined(LINUX)
+#if defined(LINUX) && !defined(OMRZTPF)
 
 #include <sys/wait.h>
 #include <sys/types.h>

--- a/compiler/ras/ILValidationRules.hpp
+++ b/compiler/ras/ILValidationRules.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,10 @@
  *          during the creation of TR::ILValidator.
  *
  */
+
+#ifdef OMRZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
 
 #include "ras/ILValidationStrategies.hpp"
 


### PR DESCRIPTION
z/TPF currently doesn't support the Compiler Time Profiling
like Linux.  Potentially in the future depending on priorities.
Also, z/TPF gets a compilation failure in ILValidationRules
because of ATOE translation mapping for remove.  The guard
macro prevents this for z/TPF only.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>