### PR TITLE
Refactor ucontext header inclusions for z/TPF

### DIFF
--- a/port/ztpf/omrintrospect.c
+++ b/port/ztpf/omrintrospect.c
@@ -26,7 +26,8 @@
  * @brief process introspection support
  */
 #include <pthread.h>
-#include <sys/ucontext.h>
+#include <ucontext.h>
+#include "sys/sigcontext.h"
 #include <sched.h>
 #include <string.h>
 #include <signal.h>

--- a/port/ztpf/omrosdump.c
+++ b/port/ztpf/omrosdump.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,8 +26,6 @@
  * \brief Dump formatting externals referenced from portLibrary
  */
 
-#define ZTPF_NEEDS_GETCONTEXT
-
 #include <signal.h>
 #include <tpf/c_proc.h>
 #include <tpf/c_cinfc.h>
@@ -35,7 +33,6 @@
 #include <tpf/sysapi.h>
 #include <tpf/c_idsprg.h>
 #include <tpf/c_stck.h>
-#include <sys/ucontext.h>
 #include <pthread.h>
 #define OSDUMP_SYMBOLS_ONLY
 

--- a/port/ztpf/omrosdump_helpers.h
+++ b/port/ztpf/omrosdump_helpers.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <tpf/tpfapi.h>
 #include <sys/ucontext.h>
+#include "sys/sigcontext.h"
 
 #ifndef OSDUMP_SYMBOLS_ONLY
 #include "omrport.h"

--- a/port/ztpf/omrsignal_context.c
+++ b/port/ztpf/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,12 +26,8 @@
  * \brief Saves and returns information about signals
  */
 
-#define ZTPF_NEEDS_GETCONTEXT
-
 #include <errno.h>
 #include <string.h>
-#include <sys/ucontext.h>
-#include "sys/sigcontext.h"
 #include <tpf/c_proc.h>
 #include "omrport.h"
 #include "omrsignal_context.h"

--- a/port/ztpf/omrsignal_context.h
+++ b/port/ztpf/omrsignal_context.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,10 +25,10 @@
 #include "omrport.h"
 #include <errno.h>
 #include "omrosdump_helpers.h"
-#include <sys/sigcontext.h>
 
 #include <unistd.h>
 #include <sys/ucontext.h>
+#include "sys/sigcontext.h"
 
 #define MAX_UNIX_SIGNAL_TYPES  MNSIG
 

--- a/port/ztpf/safe_storage.h
+++ b/port/ztpf/safe_storage.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@
 #define _SAFE_STORAGE_H_INCLUDED
 
 #include <tpf/c_proc.h>
-#include <sys/sigcontext.h>
 #include "omrosdump_helpers.h"
 
 /*


### PR DESCRIPTION
This Pull request affects only z/TPF and refactors
ucontext.h header inclusion for some segments
related to dump processing.  The cleanup was
driven by zTPF compiler sysroot cleanup.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>