### PR TITLE
Add FMA instructions for X86 compiler

### DIFF
--- a/compiler/env/OMRArithEnv.cpp
+++ b/compiler/env/OMRArithEnv.cpp
@@ -151,3 +151,9 @@ OMR::ArithEnv::longMultiplyLong(int64_t a, int64_t b)
    {
    return a * b;
    }
+
+bool
+OMR::ArithEnv::permitsFusedMultiplyAdd()
+    {
+    return true;
+    }

--- a/compiler/env/OMRArithEnv.hpp
+++ b/compiler/env/OMRArithEnv.hpp
@@ -66,6 +66,8 @@ public:
    int64_t longRemainderLong(int64_t a, int64_t b);
    int64_t longDivideLong(int64_t a, int64_t b);
    int64_t longMultiplyLong(int64_t a, int64_t b);
+   
+   bool permitsFusedMultiplyAdd();
    };
 
 }

--- a/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/TreeEvaluatorTable.hpp
@@ -114,8 +114,8 @@
    TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::iurem
    TR::TreeEvaluator::integerNegEvaluator,              // TR::ineg
    TR::TreeEvaluator::integerNegEvaluator,              // TR::lneg
-   TR::TreeEvaluator::fpUnaryMaskEvaluator,             // TR::fneg
-   TR::TreeEvaluator::fpUnaryMaskEvaluator,             // TR::dneg
+   TR::TreeEvaluator::fpNegEvaluator,                   // TR::fneg
+   TR::TreeEvaluator::fpNegEvaluator,                   // TR::dneg
    TR::TreeEvaluator::bnegEvaluator,                    // TR::bneg
    TR::TreeEvaluator::snegEvaluator,                    // TR::sneg
    TR::TreeEvaluator::integerAbsEvaluator,              // TR::iabs

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -433,6 +433,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    bool internalPointerSupportImplemented() {return false;} // no virt
 
    bool supportsSinglePrecisionSQRT() {return true;}
+   bool supportsFusedMultiplyAdd() {return _targetProcessorInfo.supportsFMA() && _targetProcessorInfo.supportsAVX() && getSupportsVectorRegisters();}
+   bool supportsNegativeFusedMultiplyAdd() {return _targetProcessorInfo.supportsFMA() && _targetProcessorInfo.supportsAVX() && getSupportsVectorRegisters();}
 
    bool supportsComplexAddressing();
 

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -281,6 +281,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *fpUnaryMaskEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fpReturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fpRemEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *fpNegEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    // routines for floating point values that can fit in one GPR
    static TR::Register *floatingPointStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/TreeEvaluatorTable.hpp
@@ -114,8 +114,8 @@
    TR::TreeEvaluator::integerDivOrRemEvaluator,         // TR::iurem
    TR::TreeEvaluator::integerNegEvaluator,              // TR::ineg
    TR::TreeEvaluator::integerPairNegEvaluator,         // TR::lneg
-   TR::TreeEvaluator::fpUnaryMaskEvaluator,             // TR::fneg
-   TR::TreeEvaluator::fpUnaryMaskEvaluator,             // TR::dneg
+   TR::TreeEvaluator::fpNegEvaluator,                   // TR::fneg
+   TR::TreeEvaluator::fpNegEvaluator,                   // TR::dneg
    TR::TreeEvaluator::bnegEvaluator,                    // TR::bneg
    TR::TreeEvaluator::snegEvaluator,                    // TR::sneg
    TR::TreeEvaluator::integerAbsEvaluator,              // TR::iabs


### PR DESCRIPTION
Added scalar FMA instructions:

VFMADD132SS, VFMSUB132SS, VFNMADD132SS, VFNMSUB132SS,
VFMADD132SD, VFMSUB132SD, VFNMADD132SD, VFNMSUB132SD

Signed-off-by: Shivam Mittal <shivammittal99@gmail.com>