### PR TITLE
Fix incorrect usage of TR::Options

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -163,7 +163,7 @@ OMR::ARM::CodeGenerator::CodeGenerator()
       // wrapping-around.
       _maxObjectSizeGuaranteedNotToOverflow = 0x10000000;
       self()->setSupportsDivCheck();
-      if (!self()->comp()->getOptions()->getOption(TR_DisableTraps))
+      if (!self()->comp()->getOption(TR_DisableTraps))
          self()->setHasResumableTrapHandler();
       }
    else
@@ -691,7 +691,7 @@ TR_GlobalRegisterNumber OMR::ARM::CodeGenerator::pickRegister(TR_RegisterCandida
    {
    // Tactical GRA
    // We delegate the decision to use register pressure simulation to common code.
-   // if (!comp()->getOptions()->getOption(TR_DisableRegisterPressureSimulation))
+   // if (!comp()->getOption(TR_DisableRegisterPressureSimulation))
    return OMR::CodeGenerator::pickRegister(regCan, barr, availRegs, highRegisterNumber, candidates);
    // }
    }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -278,7 +278,7 @@ OMR::CodeGenerator::CodeGenerator() :
    _machine = new (self()->trHeapMemory()) TR::Machine(self());
    _disableInternalPointers = self()->comp()->getOption(TR_MimicInterpreterFrameShape) ||
                                self()->comp()->getOptions()->realTimeGC() ||
-                               self()->comp()->getOptions()->getOption(TR_DisableInternalPointers);
+                               self()->comp()->getOption(TR_DisableInternalPointers);
 
    uintptrj_t maxSize = TR::Compiler->vm.getOverflowSafeAllocSize(self()->comp());
    int32_t i;
@@ -862,8 +862,8 @@ OMR::CodeGenerator::use64BitRegsOn32Bit()
       return false;
    else
       {
-      bool longReg = self()->comp()->getOptions()->getOption(TR_Enable64BitRegsOn32Bit);
-      bool longRegHeur = self()->comp()->getOptions()->getOption(TR_Enable64BitRegsOn32BitHeuristic);
+      bool longReg = self()->comp()->getOption(TR_Enable64BitRegsOn32Bit);
+      bool longRegHeur = self()->comp()->getOption(TR_Enable64BitRegsOn32BitHeuristic);
       bool use64BitRegs = (longReg && !longRegHeur && self()->comp()->getJittedMethodSymbol()->mayHaveLongOps()) ||
                           (longReg && longRegHeur && self()->comp()->useLongRegAllocation());
       return use64BitRegs;
@@ -1969,7 +1969,7 @@ OMR::CodeGenerator::convertMultiplyToShift(TR::Node * node)
 bool
 OMR::CodeGenerator::isMemoryUpdate(TR::Node *node)
    {
-   if (self()->comp()->getOptions()->getOption(TR_DisableDirectMemoryOps))
+   if (self()->comp()->getOption(TR_DisableDirectMemoryOps))
       return false;
 
    // See if the given store node can be represented by a direct operation on the
@@ -2950,7 +2950,7 @@ OMR::CodeGenerator::canNullChkBeImplicit(TR::Node *node)
 bool
 OMR::CodeGenerator::canNullChkBeImplicit(TR::Node *node, bool doChecks)
    {
-   if (self()->comp()->getOptions()->getOption(TR_DisableTraps))
+   if (self()->comp()->getOption(TR_DisableTraps))
       return false;
 
    if (!doChecks)

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -405,15 +405,15 @@ compileMethodFromDetails(
             }
 
          if (
-               TR::Options::getCmdLineOptions()->getOption(TR_PerfTool) 
-            || TR::Options::getCmdLineOptions()->getOption(TR_EmitExecutableELFFile)
-            || TR::Options::getCmdLineOptions()->getOption(TR_EmitRelocatableELFFile)
+               compiler.getOption(TR_PerfTool) 
+            || compiler.getOption(TR_EmitExecutableELFFile)
+            || compiler.getOption(TR_EmitRelocatableELFFile)
             )
             {
             TR::CodeCacheManager &codeCacheManager(fe.codeCacheManager());
             TR::CodeGenerator &codeGenerator(*compiler.cg());
             codeCacheManager.registerCompiledMethod(compiler.externalName(), startPC, codeGenerator.getCodeLength());
-            if (TR::Options::getCmdLineOptions()->getOption(TR_EmitRelocatableELFFile))
+            if (compiler.getOption(TR_EmitRelocatableELFFile))
                {
                auto &relocations = codeGenerator.getStaticRelocations();
                for (auto it = relocations.begin(); it != relocations.end(); ++it)
@@ -421,7 +421,7 @@ compileMethodFromDetails(
                   codeCacheManager.registerStaticRelocation(*it);
                   }
                }
-            if (TR::Options::getCmdLineOptions()->getOption(TR_PerfTool))
+            if (compiler.getOption(TR_PerfTool))
                {
                generatePerfToolEntry(startPC, codeGenerator.getCodeEnd(), compiler.signature(), compiler.getHotnessName(compiler.getMethodHotness()));
                }

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -155,7 +155,7 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
       case TR::Symbol::IsResolvedMethod:
          {
          TR::ResolvedMethodSymbol * resolvedMethodSymbol = _symbol->castToResolvedMethodSymbol();
-         if (!TR::Options::getCmdLineOptions()->getOption(TR_EnableHCR))
+         if (!TR::comp()->getOption(TR_EnableHCR))
             {
             switch (resolvedMethodSymbol->getRecognizedMethod())
                {
@@ -352,7 +352,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          {
          TR::ResolvedMethodSymbol * resolvedMethodSymbol = _symbol->castToResolvedMethodSymbol();
 
-         if (!TR::Options::getCmdLineOptions()->getOption(TR_EnableHCR))
+         if (!comp->getOption(TR_EnableHCR))
             {
             switch (resolvedMethodSymbol->getRecognizedMethod())
                {

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3687,7 +3687,7 @@ TR_GlobalRegisterAllocator::findLoopsAndCorrespondingAutos(TR_StructureSubGraphN
          TR_BitVector *symsThatShouldBeAssignedInCurrentLoop = NULL;
 
          bool excludeInvariantsEnabled = comp()->cg()->excludeInvariantsFromGRAEnabled() &&
-                                        (!comp()->getOptions()->getOption(TR_DisableRXusage));
+                                        (!comp()->getOption(TR_DisableRXusage));
 
          if (excludeInvariantsEnabled)
             {
@@ -4817,7 +4817,7 @@ TR_LiveRangeSplitter::TR_LiveRangeSplitter(TR::OptimizationManager *manager)
 
 int32_t TR_LiveRangeSplitter::perform()
    {
-   if (!comp()->getOptions()->getOption(TR_EnableRangeSplittingGRA))
+   if (!comp()->getOption(TR_EnableRangeSplittingGRA))
       return 0;
 
    if (!cg()->prepareForGRA())

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -586,7 +586,7 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
       virtual int32_t getInitialBytecodeSize(TR_ResolvedMethod *feMethod, TR::ResolvedMethodSymbol * methodSymbol, TR::Compilation *comp);
       virtual bool tryToInline(TR_CallTarget *, TR_CallStack *, bool);
       virtual bool inlineMethodEvenForColdBlocks(TR_ResolvedMethod *method);
-      bool aggressiveSmallAppOpts() { return TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts); }
+      bool aggressiveSmallAppOpts() { return comp()->getOption(TR_AggressiveOpts); }
       virtual bool willBeInlinedInCodeGen(TR::RecognizedMethod method);
       virtual bool canInlineMethodWhileInstrumenting(TR_ResolvedMethod *method);
 

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2276,7 +2276,7 @@ bool TR_CompactNullChecks::replaceNullCheckIfPossible(TR::Node *cursorNode, TR::
       if (isEquivalent)
          {
          bool canBeRemoved = true; //comp()->cg()->canNullChkBeImplicit(cursorNode);
-         if (TR::comp()->getOptions()->getOption(TR_DisableTraps) ||
+         if (TR::comp()->getOption(TR_DisableTraps) ||
              TR::Compiler->om.offsetOfObjectVftField() >= comp()->cg()->getNumberBytesReadInaccessible())
            canBeRemoved = false;
 
@@ -5987,7 +5987,7 @@ int8_t TR_Rematerialization::getLoopNestingLevel(int32_t weight)
 
 void TR_Rematerialization::makeEarlyLongRegDecision()
    {
-   if (comp()->getOptions()->getOption(TR_Disable64BitRegsOn32Bit) ||
+   if (comp()->getOption(TR_Disable64BitRegsOn32Bit) ||
        !cg()->supportsLongRegAllocation() ||
        !comp()->getJittedMethodSymbol()->mayHaveLongOps())
       {
@@ -5997,8 +5997,8 @@ void TR_Rematerialization::makeEarlyLongRegDecision()
       return;
       }
 
-   if (!comp()->getOptions()->getOption(TR_Disable64BitRegsOn32Bit) &&
-        comp()->getOptions()->getOption(TR_Disable64BitRegsOn32BitHeuristic))
+   if (!comp()->getOption(TR_Disable64BitRegsOn32Bit) &&
+        comp()->getOption(TR_Disable64BitRegsOn32BitHeuristic))
        {
        comp()->setUseLongRegAllocation(true);
        setLongRegDecision(true);

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -200,7 +200,7 @@ bool TR_LoopVersioner::loopIsWorthVersioning(TR_RegionStructure *naturalLoop)
       }
 
    // if aggressive loop versioner flag is set then run at any optlevel, otherwise only at warm or less
-   bool aggressive = TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning);
+   bool aggressive = comp()->getOption(TR_EnableAggressiveLoopVersioning);
    if (aggressive || comp()->getMethodHotness() <= warm)
       {
       if (naturalLoop->getParent())
@@ -225,7 +225,7 @@ bool TR_LoopVersioner::loopIsWorthVersioning(TR_RegionStructure *naturalLoop)
             }
          }
 
-      bool aggressive = TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning);
+      bool aggressive = comp()->getOption(TR_EnableAggressiveLoopVersioning);
 
       int32_t lvBlockFreqCutoff;
       static const char * b = feGetEnv("TR_LoopVersionerFreqCutoff");
@@ -567,7 +567,7 @@ int32_t TR_LoopVersioner::performWithoutDominators()
          {
          // default hotness threshold
          TR_Hotness hotnessThreshold = hot;
-         if (TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning))
+         if (comp()->getOption(TR_EnableAggressiveLoopVersioning))
             {
             if (trace()) traceMsg(comp(), "aggressiveLoopVersioning: raising hotnessThreshold for conditionalsWillBeEliminated\n");
             hotnessThreshold = maxHotness; // threshold which can't be matched by the > operator
@@ -712,7 +712,7 @@ int32_t TR_LoopVersioner::performWithoutDominators()
    ////if (!_virtualGuardPairs.isEmpty())
    if (!_virtualGuardInfo.isEmpty())
       {
-      bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
+      bool disableLT = comp()->getOption(TR_DisableLoopTransfer);
       if (!disableLT)
          performLoopTransfer();
       }
@@ -3204,7 +3204,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
 
          // If the aggressive loop versioning flag is set, only do the unimportant block test
          // at lower optlevels
-         bool aggressive = TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning);
+         bool aggressive = comp()->getOption(TR_EnableAggressiveLoopVersioning);
 
          static const bool useOuterHeader =
             feGetEnv("TR_loopVersionerUseOuterHeaderForImportance") != NULL;
@@ -3252,7 +3252,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
             )
             {
             isUnimportant = true;
-            if (trace() || comp()->getOptions()->getOption(TR_CountOptTransformations))
+            if (trace() || comp()->getOption(TR_CountOptTransformations))
                {
                for (TR::TreeTop *tt = entryTree; isUnimportant && tt != exitTree; tt = tt->getNextTreeTop())
                   {
@@ -3315,7 +3315,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
          vcount_t visitCount = comp()->incVisitCount(); //@TODO: unsafe API/use pattern
          updateDefinitionsAndCollectProfiledExprs(NULL, currentNode, visitCount, specializedInvariantNodes, invariantNodes, invariantTranslationNodesList, NULL, collectProfiledExprs, nextBlock, warmBranchCount);
 
-         bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
+         bool disableLT = comp()->getOption(TR_DisableLoopTransfer);
          if (!disableLT &&
              currentNode->isTheVirtualGuardForAGuardedInlinedCall() &&
              blocksInWhileLoop.find(currentNode->getBranchDestination()->getNode()->getBlock()))
@@ -3791,7 +3791,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          }
 
       TR::Node *lastTree = nextBlock->getLastRealTreeTop()->getNode();
-      bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
+      bool disableLT = comp()->getOption(TR_DisableLoopTransfer);
       if (!disableLT &&
           lastTree->getOpCode().isIf() &&
           blocksInWhileLoop.find(lastTree->getBranchDestination()->getNode()->getBlock()) &&
@@ -4255,7 +4255,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    TR_Hotness hotnessThreshold = hot;
 
    // If aggressive loop versioning is requested, don't call buildNullCheckComparisonsTree based on hotness
-   if (TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning))
+   if (comp()->getOption(TR_EnableAggressiveLoopVersioning))
       {
       if (trace()) traceMsg(comp(), "aggressiveLoopVersioning: raising hotnessThreshold for buildNullCheckComparisonsTree\n");
       hotnessThreshold = maxHotness; // threshold which can't be matched by the > operator

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1139,7 +1139,7 @@ void OMR::Optimizer::optimize()
          }
       }
 
-   if (TR::Options::getCmdLineOptions()->getOption(TR_EnableDeterministicOrientedCompilation) &&
+   if (comp()->getOption(TR_EnableDeterministicOrientedCompilation) &&
        comp()->isOutermostMethod() &&
        (comp()->getMethodHotness() > cold) &&
        (comp()->getMethodHotness() < scorching))
@@ -1353,13 +1353,13 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
 #ifdef J9_PROJECT_SPECIFIC
       case IfNotClassLoadPhase:
          if (!comp()->getPersistentInfo()->isClassLoadingPhase() ||
-             TR::Options::getCmdLineOptions()->getOption(TR_DontDowngradeToCold))
+             comp()->getOption(TR_DontDowngradeToCold))
             doThisOptimization = true;
          break;
 
       case IfNotClassLoadPhaseAndNotProfiling:
          if ((!comp()->getPersistentInfo()->isClassLoadingPhase() ||
-              TR::Options::getCmdLineOptions()->getOption(TR_DontDowngradeToCold))
+              comp()->getOption(TR_DontDowngradeToCold))
                &&
              (!comp()->isProfilingCompilation() || debug("ignoreIfNotProfiling"))
             )

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -17267,7 +17267,7 @@ TR::Node * arraysetSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier
 TR::Node *bitOpMemSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
    simplifyChildren(node, block, s);
-   if (s->comp()->getOptions()->getOption(TR_ScalarizeSSOps))
+   if (s->comp()->getOption(TR_ScalarizeSSOps))
       {
       }
    return node;

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -54,7 +54,7 @@ OMR::TransformUtil::scalarizeArrayCopy(
    didTransformArrayCopyNode = false;
 
    if ((comp->getOptLevel() == noOpt) ||
-       !comp->getOptions()->getOption(TR_ScalarizeSSOps) ||
+       !comp->getOption(TR_ScalarizeSSOps) ||
        node->getOpCodeValue() != TR::arraycopy ||
        node->getNumChildren() != 3 ||
        comp->requiresSpineChecks() ||

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -480,7 +480,7 @@ bool TR_OrderBlocks::candidateIsBetterSuccessorThanBest(TR::CFGEdge *candidateEd
 
    //if (!_superColdBlockOnly)
    //   {
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling))
+      if (!comp()->getOption(TR_DisableInterpreterProfiling))
          {
          if (candidateEdge->getFrequency() >= 0)
             {

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -965,7 +965,7 @@ TR_RegisterCandidate::processLiveOnEntryBlocks(TR::Block * * blocks, int32_t *bl
          TR_ScratchList<TR_Structure> unreferencedLoops(comp->trMemory());
          TR_ScratchList<TR_Structure> referencedLoops(comp->trMemory());
          if ((numUnreferencedBlocksAtThisFrequency > 0) &&
-             (comp->getOptions()->getOption(TR_EnableRangeSplittingGRA) ||  // move this check above ?
+             (comp->getOption(TR_EnableRangeSplittingGRA) ||  // move this check above ?
               (comp->cg()->areAssignableGPRsScarce())))
             {
             bool seenBlockAtThisFrequency = false;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12744,7 +12744,7 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
                   }
 
               else if ( !vp->comp()->compileRelocatableCode() &&
-                        !(TR::Options::getCmdLineOptions()->getOption(TR_DisableArrayStoreCheckOpts))  &&
+                        !(vp->comp()->getOption(TR_DisableArrayStoreCheckOpts))  &&
                         arrayComponentClass &&
                         objectClass  &&
                         vp->fe()->isInstanceOf(objectClass, arrayComponentClass,true,true)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1910,7 +1910,7 @@ OMR::Power::CodeGenerator::isTargetSnippetOrOutOfLine(TR::Instruction *instr, TR
 
 bool OMR::Power::CodeGenerator::supportsAESInstructions()
    {
-    if ( TR::Compiler->target.cpu.getPPCSupportsAES() && !self()->comp()->getOptions()->getOption(TR_DisableAESInHardware))
+    if ( TR::Compiler->target.cpu.getPPCSupportsAES() && !self()->comp()->getOption(TR_DisableAESInHardware))
       return true;
     else
       return false;
@@ -2452,7 +2452,7 @@ TR_GlobalRegisterNumber OMR::Power::CodeGenerator::pickRegister(TR_RegisterCandi
                                                           TR_GlobalRegisterNumber           &  highRegisterNumber,
                                                           TR_LinkHead<TR_RegisterCandidate> *  candidates)
    {
-   if (!self()->comp()->getOptions()->getOption(TR_DisableRegisterPressureSimulation))
+   if (!self()->comp()->getOption(TR_DisableRegisterPressureSimulation))
       return OMR::CodeGenerator::pickRegister(regCan, barr, availRegs, highRegisterNumber, candidates);
 
 
@@ -3465,14 +3465,14 @@ bool
 OMR::Power::CodeGenerator::getSupportsEncodeUtf16LittleWithSurrogateTest()
    {
    return TR::Compiler->target.cpu.getPPCSupportsVSX() &&
-          !self()->comp()->getOptions()->getOption(TR_DisableSIMDUTF16LEEncoder);
+          !self()->comp()->getOption(TR_DisableSIMDUTF16LEEncoder);
    }
 
 bool
 OMR::Power::CodeGenerator::getSupportsEncodeUtf16BigWithSurrogateTest()
    {
    return TR::Compiler->target.cpu.getPPCSupportsVSX() &&
-          !self()->comp()->getOptions()->getOption(TR_DisableSIMDUTF16BEEncoder);
+          !self()->comp()->getOption(TR_DisableSIMDUTF16BEEncoder);
    }
 
 

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -892,7 +892,7 @@ TR::Register *TR::AMD64SystemLinkage::buildDirectDispatch(
          methodSymRef,
          cg());
 
-      if( TR::Options::getCmdLineOptions()->getOption(TR_EmitRelocatableELFFile) )
+      if (comp()->getOption(TR_EmitRelocatableELFFile))
          {
          LoadRegisterInstruction->setReloKind(TR_NativeMethodAbsolute);
          }

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -48,7 +48,7 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
    OMR::X86::CodeGenerator()
    {
 
-   if (self()->comp()->getOptions()->getOption(TR_DisableTraps))
+   if (self()->comp()->getOption(TR_DisableTraps))
       {
       _numberBytesReadInaccessible  = 0;
       _numberBytesWriteInaccessible = 0;

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1053,14 +1053,14 @@ bool
 OMR::X86::CodeGenerator::getSupportsEncodeUtf16LittleWithSurrogateTest()
    {
    return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() &&
-          !self()->comp()->getOptions()->getOption(TR_DisableSIMDUTF16LEEncoder);
+          !self()->comp()->getOption(TR_DisableSIMDUTF16LEEncoder);
    }
 
 bool
 OMR::X86::CodeGenerator::getSupportsEncodeUtf16BigWithSurrogateTest()
    {
    return TR::CodeGenerator::getX86ProcessorInfo().supportsSSE4_1() &&
-          !self()->comp()->getOptions()->getOption(TR_DisableSIMDUTF16BEEncoder);
+          !self()->comp()->getOption(TR_DisableSIMDUTF16BEEncoder);
    }
 
 bool
@@ -1332,7 +1332,7 @@ OMR::X86::CodeGenerator::performNonLinearRegisterAssignmentAtBranch(
       TR::Instruction *ins =
          generateLabelInstruction(oi->getFirstInstruction(), LABEL, generateLabelSymbol(self()), deps, self());
 
-      if (self()->comp()->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (self()->comp()->getOption(TR_TraceNonLinearRegisterAssigner))
          {
          traceMsg(self()->comp(), "creating LABEL instruction %p for dependencies\n", ins);
          }

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -2017,7 +2017,7 @@ TR_RegisterAssignerState::createDependenciesFromRegisterState(TR_OutlinedInstruc
 
    numDeps += _spilledRegistersList->size();
 
-   if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+   if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
       {
       traceMsg(comp, "createDependenciesFromRegisterState : %d live registers: %d assigned, %d spilled\n",
          numDeps,
@@ -2057,7 +2057,7 @@ TR_RegisterAssignerState::createDependenciesFromRegisterState(TR_OutlinedInstruc
                      {
                      virtReg->decTotalUseCount((*iter)->useCount);
 
-                     if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+                     if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
                         {
                         traceMsg(comp, "Adjusting up register use counts of reg %p (fuc=%d:tuc=%d:mergeFuc=%d) by %d\n",
                         		(*iter)->virtReg, (*iter)->virtReg->getFutureUseCount(), (*iter)->virtReg->getTotalUseCount(), (*iter)->mergeFuc, (*iter)->useCount);
@@ -2078,7 +2078,7 @@ TR_RegisterAssignerState::createDependenciesFromRegisterState(TR_OutlinedInstruc
          //
          virtReg->incFutureUseCount();
 
-         if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+         if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
             {
             traceMsg(comp, "   create ASSIGNED dependency: virtual %p -> %s\n",
                virtReg,
@@ -2102,7 +2102,7 @@ TR_RegisterAssignerState::createDependenciesFromRegisterState(TR_OutlinedInstruc
       //
       (*iter)->incFutureUseCount();
 
-      if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
          {
          traceMsg(comp, "   create SPILLED dependency: virtual %p -> backing storage %p\n",
         		 *iter,
@@ -2178,7 +2178,7 @@ void TR_RegisterAssignerState::dump()
    {
    TR::Compilation *comp = _machine->cg()->comp();
 
-   if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+   if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
       {
       traceMsg(comp, "\nREGISTER ASSIGNER STATE\n=======================\n\nAssigned Live Registers:\n");
 
@@ -2209,7 +2209,7 @@ void OMR::X86::Machine::adjustRegisterUseCountsUp(TR::list<OMR::RegisterUsage*> 
    TR::Compilation *comp = self()->cg()->comp();
    for(auto iter = rul->begin(); iter != rul->end(); ++iter)
       {
-      if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
          {
          traceMsg(comp, "Adjusting UP register use counts of reg %p (fuc=%d:tuc=%d:adjustFuture=%d) by %d -> ",
         		 (*iter)->virtReg, (*iter)->virtReg->getFutureUseCount(), (*iter)->virtReg->getTotalUseCount(), adjustFuture, (*iter)->useCount);
@@ -2220,7 +2220,7 @@ void OMR::X86::Machine::adjustRegisterUseCountsUp(TR::list<OMR::RegisterUsage*> 
       if (adjustFuture)
     	  (*iter)->virtReg->incFutureUseCount((*iter)->useCount);
 
-      if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
          {
          traceMsg(comp, "(fuc=%d:tuc=%d)\n", (*iter)->virtReg->getFutureUseCount(), (*iter)->virtReg->getTotalUseCount());
          }
@@ -2235,7 +2235,7 @@ void OMR::X86::Machine::adjustRegisterUseCountsDown(TR::list<OMR::RegisterUsage*
 
    for(auto iter = rul->begin(); iter != rul->end(); ++iter)
       {
-      if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
          {
          traceMsg(comp, "Adjusting DOWN register use counts of reg %p (fuc=%d:tuc=%d:adjustFuture=%d) by %d -> ",
         		 (*iter)->virtReg, (*iter)->virtReg->getFutureUseCount(), (*iter)->virtReg->getTotalUseCount(), adjustFuture, (*iter)->useCount);
@@ -2246,7 +2246,7 @@ void OMR::X86::Machine::adjustRegisterUseCountsDown(TR::list<OMR::RegisterUsage*
       if (adjustFuture)
     	  (*iter)->virtReg->decFutureUseCount((*iter)->useCount);
 
-      if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+      if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
          {
          traceMsg(comp, "(fuc=%d:tuc=%d)\n", (*iter)->virtReg->getFutureUseCount(), (*iter)->virtReg->getTotalUseCount());
          }

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -767,7 +767,7 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
                virtReg->setAssignedRegister(NULL);
                assignedReg->setState(TR::RealRegister::Free);
 
-               if (comp->getOptions()->getOption(TR_TraceNonLinearRegisterAssigner))
+               if (comp->getOption(TR_TraceNonLinearRegisterAssigner))
                   {
                   cg->traceRegisterAssignment("Generate reload of virt %s due to spillRegIndex dep at inst %p\n",comp->getDebug()->getName(virtReg),currentInstruction);
                   cg->traceRAInstruction(inst);

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -76,7 +76,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
 
    if (TR::Compiler->target.isWindows())
       {
-      if (self()->comp()->getOptions()->getOption(TR_DisableTraps))
+      if (self()->comp()->getOption(TR_DisableTraps))
          {
          _numberBytesReadInaccessible = 0;
          _numberBytesWriteInaccessible = 0;
@@ -109,7 +109,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
       }
    else if (TR::Compiler->target.isLinux())
       {
-      if (self()->comp()->getOptions()->getOption(TR_DisableTraps))
+      if (self()->comp()->getOption(TR_DisableTraps))
          {
          _numberBytesReadInaccessible = 0;
          _numberBytesWriteInaccessible = 0;
@@ -168,7 +168,7 @@ OMR::X86::I386::CodeGenerator::pickRegister(
       TR_GlobalRegisterNumber &highRegisterNumber,
       TR_LinkHead<TR_RegisterCandidate> *candidates)
    {
-   if (!self()->comp()->getOptions()->getOption(TR_DisableRegisterPressureSimulation))
+   if (!self()->comp()->getOption(TR_DisableRegisterPressureSimulation))
       {
       if (self()->comp()->getOption(TR_AssignEveryGlobalRegister))
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -690,7 +690,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
       self()->setSupportsBCDToDFPReduction();
       self()->setSupportsIntDFPConversions();
 
-      if (!comp->getOptions()->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
+      if (!comp->getOption(TR_DisableTraps) && TR::Compiler->vm.hasResumableTrapHandler(comp))
          {
          self()->setHasResumableTrapHandler();
          }
@@ -6129,8 +6129,8 @@ OMR::Z::CodeGenerator::getSupportsEncodeUtf16BigWithSurrogateTest()
    {
    if (self()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
       {
-      return (!self()->comp()->getOptions()->getOption(TR_DisableUTF16BEEncoder) ||
-               (self()->getSupportsVectorRegisters() && !self()->comp()->getOptions()->getOption(TR_DisableSIMDUTF16BEEncoder)));
+      return (!self()->comp()->getOption(TR_DisableUTF16BEEncoder) ||
+               (self()->getSupportsVectorRegisters() && !self()->comp()->getOption(TR_DisableSIMDUTF16BEEncoder)));
       }
 
    return false;

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -4497,7 +4497,7 @@ checkForCandidateBlockForConditionalLoadAndStores(TR::Node* node, TR::CodeGenera
       return NULL;
 
    TR::Compilation *comp = cg->comp();
-   bool noSTOC = comp->getOptions()->getOption(TR_DisableStoreOnCondition);
+   bool noSTOC = comp->getOption(TR_DisableStoreOnCondition);
 
    // Check the nodes within the candidate block to ensure they can all be changed to conditoional loads and stores
    for (TR::TreeTop *tt = candidateBlock->getEntry(); tt != candidateBlock->getExit(); tt = tt->getNextTreeTop())
@@ -11486,7 +11486,7 @@ OMR::Z::TreeEvaluator::treetopEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          {
          case TR::aiadd:
             {
-            if (comp->getOptions()->getOption(TR_TraceCG))
+            if (comp->getOption(TR_TraceCG))
                {
                traceMsg(comp, " found %s [%p] with ref count 1 under treetop, avoiding evaluation into register.\n",
                         node->getFirstChild()->getOpCode().getName(), node->getFirstChild());


### PR DESCRIPTION
- during compilation, the per-method TR::Options should be used instead of the global one
- mostly happens at the Optimizer and Code Generation stage
- simplify comp()->getOptions()->getOption(TR_XXX) to comp()->getOptions(TR_XXX), they are equivalent
- switch _options usage to options in OMRCompilation constructor

Signed-off-by: Harry Yu <harryyu1994@gmail.com>