### PR TITLE
Minimal Signal Changes Part 3 [win64amd]

### DIFF
--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -219,7 +219,7 @@ omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 
 	/* split this up into OMRPORT_SIG_FLAG_SIGALLSYNC and OMRPORT_SIG_FLAG_SIGALLASYNC */
 	if (0 == (signalOptions & OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)) {
-		supportedFlags |= OMRPORT_SIG_FLAG_SIGQUIT | OMRPORT_SIG_FLAG_SIGTERM;
+		supportedFlags |= OMRPORT_SIG_FLAG_SIGBREAK | OMRPORT_SIG_FLAG_SIGTERM;
 	}
 
 	if ((flags & supportedFlags) == flags) {
@@ -604,7 +604,7 @@ consoleCtrlHandler(DWORD dwCtrlType)
 
 	switch (dwCtrlType) {
 	case CTRL_BREAK_EVENT:
-		flags = OMRPORT_SIG_FLAG_SIGQUIT;
+		flags = OMRPORT_SIG_FLAG_SIGBREAK;
 		break;
 	case CTRL_C_EVENT:
 		flags = OMRPORT_SIG_FLAG_SIGINT;
@@ -634,7 +634,7 @@ consoleCtrlHandler(DWORD dwCtrlType)
 				/* Returning TRUE stops control from being passed to the next handler routine. The OS default handler may be the next handler routine.
 				 * The default action of the OS default handler routine is to shut down the process
 				 */
-				if (flags & OMRPORT_SIG_FLAG_SIGQUIT) {
+				if (flags & OMRPORT_SIG_FLAG_SIGBREAK) {
 					/* Continue executing */
 					result = TRUE;
 				}

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -644,15 +644,27 @@ omrsig_get_options(struct OMRPortLibrary *portLibrary)
 }
 
 /**
- * sets the priority of the the async reporting thread
+ * Set the priority of the asynchronous signal reporting thread (asynchSignalReporterThread).
  *
- * In windows, a new thread is created to run the handlers each time a signal is received,
- * so this function does nothing.
-*/
+ * @param[in] portLibrary the OMR port library
+ * @param[in] priority the thread priority
+ *
+ * @return 0 upon success and non-zero upon failure.
+ */
 int32_t
 omrsig_set_reporter_priority(struct OMRPortLibrary *portLibrary, uintptr_t priority)
 {
-	return 0;
+	int32_t result = 0;
+
+	omrthread_monitor_t globalMonitor = omrthread_global_monitor();
+
+	omrthread_monitor_enter(globalMonitor);
+	if (attachedPortLibraries > 0) {
+		result = setReporterPriority(portLibrary, priority);
+	}
+	omrthread_monitor_exit(globalMonitor);
+
+	return result;
 }
 
 intptr_t

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -173,6 +173,7 @@ static void runHandlers(uint32_t asyncSignalFlag);
 #endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
 static int32_t registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t allowedSubsetOfFlags, void **oldOSHandler);
+static int32_t setReporterPriority(OMRPortLibrary *portLibrary, uintptr_t priority);
 
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
@@ -1842,4 +1843,24 @@ registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t all
 	}
 
 	return 0;
+}
+
+/**
+ * Set the thread priority for asynchronous signal reporting thread (asynchSignalReporterThread).
+ *
+ * @param[in] portLibrary the OMR port library
+ * @param[in] priority the thread priority
+ *
+ * @return 0 upon success and non-zero upon failure.
+ */
+static int32_t
+setReporterPriority(OMRPortLibrary *portLibrary, uintptr_t priority)
+{
+	Trc_PRT_signal_setReporterPriority(portLibrary, priority);
+
+	if (NULL == asynchSignalReporterThread) {
+		return OMRPORT_SIG_ERROR;
+	}
+
+	return (int32_t)omrthread_set_priority(asynchSignalReporterThread, priority);
 }

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -295,36 +295,52 @@ int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
 	int32_t rc = 0;
-	J9WinAMD64AsyncHandlerRecord *cursor;
-	J9WinAMD64AsyncHandlerRecord **previousLink;
+	J9WinAMD64AsyncHandlerRecord *cursor = NULL;
+	J9WinAMD64AsyncHandlerRecord **previousLink = NULL;
 
-	if (OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS & signalOptions) {
-		/* -Xrs was set, do not install any handlers */
+	Trc_PRT_signal_omrsig_set_async_signal_handler_entered(handler, handler_arg, flags);
+
+	if (OMR_ARE_ALL_BITS_SET(signalOptions, OMRPORT_SIG_OPTIONS_REDUCED_SIGNALS_ASYNCHRONOUS)) {
+		/* Do not install any handlers if -Xrs is set. */
+		Trc_PRT_signal_omrsig_set_async_signal_handler_will_not_set_handler_due_to_Xrs(handler, handler_arg, flags);
 		return OMRPORT_SIG_ERROR;
+	}
+
+	omrthread_monitor_enter(registerHandlerMonitor);
+	rc = registerMasterHandlers(portLibrary, flags, OMRPORT_SIG_FLAG_SIGALLASYNC, NULL);
+	omrthread_monitor_exit(registerHandlerMonitor);
+
+	if (0 != rc) {
+		Trc_PRT_signal_omrsig_set_async_signal_handler_exiting_did_nothing_possible_error(handler, handler_arg, flags);
+		return rc;
 	}
 
 	omrthread_monitor_enter(asyncMonitor);
 
-	/* wait until no signals are being reported */
+	/* Wait until no signals are being reported. */
 	while (asyncThreadCount > 0) {
 		omrthread_monitor_wait(asyncMonitor);
 	}
 
-	/* is this handler already registered? */
+	/* Is this handler already registered? */
 	previousLink = &asyncHandlerList;
 	cursor = asyncHandlerList;
-	while (cursor) {
+	while (NULL != cursor) {
 		if ((cursor->portLib == portLibrary) && (cursor->handler == handler) && (cursor->handler_arg == handler_arg)) {
-			if (flags == 0) {
+			if (0 == flags) {
+				/* Remove this handler record. */
 				*previousLink = cursor->next;
 				portLibrary->mem_free_memory(portLibrary, cursor);
+				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_removed(handler, handler_arg, flags);
 
-				/* if this is the last handler, unregister the Win32 handler function */
-				if (asyncHandlerList == NULL) {
+				/* If this is the last handler, unregister the handler function. */
+				if (NULL == asyncHandlerList) {
 					SetConsoleCtrlHandler(consoleCtrlHandler, FALSE);
 				}
 			} else {
-				cursor->flags = flags;
+				/* Update the listener with the new flags. */
+				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_added_1(handler, handler_arg, flags);
+				cursor->flags |= flags;
 			}
 			break;
 		}
@@ -332,12 +348,12 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 		cursor = cursor->next;
 	}
 
-	if (cursor == NULL) {
-		/* cursor will only be NULL if we failed to find it in the list */
-		if (flags != 0) {
+	if (NULL == cursor) {
+		/* Cursor will only be NULL if we failed to find it in the list. */
+		if (0 != flags) {
 			J9WinAMD64AsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 
-			if (record == NULL) {
+			if (NULL == record) {
 				rc = OMRPORT_SIG_ERROR;
 			} else {
 				record->portLib = portLibrary;
@@ -346,12 +362,13 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 				record->flags = flags;
 				record->next = NULL;
 
-				/* if this is the first handler, register the Win32 handler function */
-				if (asyncHandlerList == NULL) {
+				/* If this is the first handler, register the handler function. */
+				if (NULL == asyncHandlerList) {
 					SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
 				}
 
-				/* add the new record to the end of the list */
+				/* Add the new record to the end of the list. */
+				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_added_2(handler, handler_arg, flags);
 				*previousLink = record;
 			}
 		}
@@ -359,6 +376,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 
 	omrthread_monitor_exit(asyncMonitor);
 
+	Trc_PRT_signal_omrsig_set_async_signal_handler_exiting(handler, handler_arg, flags);
 	return rc;
 }
 

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -138,6 +138,9 @@ static j9sem_t wakeUpASyncReporter;
 /* Used to synchronize shutdown of asynchSignalReporterThread. */
 static omrthread_monitor_t asyncReporterShutdownMonitor;
 
+/* Used to indicate start and end of asynchSignalReporterThread termination. */
+static uint32_t shutDownASynchReporter;
+
 static uint32_t mapWin32ExceptionToPortlibType(uint32_t exceptionCode);
 static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
 static uint32_t infoForFPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
@@ -1625,21 +1628,50 @@ runHandlers(uint32_t asyncSignalFlag)
 }
 
 /**
- * This is the main body of the asynchSignalReporterThread. It is supposed to execute
- * handlers (J9WinAMD64AsyncHandlerRecord->handler) associated to a signal once a
- * signal is raised.
+ * This is the main body of the asynchSignalReporterThread. It executes handlers
+ * (J9WinAMD64AsyncHandlerRecord->handler) associated to a signal once a signal
+ * is raised.
  *
  * @param[in] userData the user data provided during thread creation
  *
- * @return return statement won't be executed since the thread exits before executing
- *         the return statement
+ * @return the return statement won't be executed since the thread exits before
+ *         executing the return statement
  */
 static int J9THREAD_PROC
 asynchSignalReporter(void *userData)
 {
 	omrthread_set_name(omrthread_self(), "Signal Reporter");
 
-	omrthread_exit(NULL);
+	while (0 == shutDownASynchReporter) {
+		int osSignal = 1;
+		uint32_t asyncSignalFlag = 0;
+
+		/* determine which signal we've been woken up for */
+		for (osSignal = 1; osSignal < ARRAY_SIZE_SIGNALS; osSignal++) {
+			uintptr_t signalCount = signalCounts[osSignal];
+
+			if (signalCount > 0) {
+				asyncSignalFlag = mapOSSignalToPortLib(osSignal);
+				runHandlers(asyncSignalFlag);
+				subtractAtomic(&signalCounts[osSignal], 1);
+				/* j9sem_wait will fall-through for each j9sem_post. We can handle
+				 * one signal at a time. Ultimately, all signals will be handled
+				 * So, break out of the for loop.
+				 */
+				break;
+			}
+		}
+
+		j9sem_wait(wakeUpASyncReporter);
+
+		Trc_PRT_signal_omrsig_asynchSignalReporter_woken_up();
+	}
+
+	omrthread_monitor_enter(asyncReporterShutdownMonitor);
+	shutDownASynchReporter = 0;
+	omrthread_monitor_notify(asyncReporterShutdownMonitor);
+
+	omrthread_exit(asyncReporterShutdownMonitor);
 
 	/* Unreachable. */
 	return 0;


### PR DESCRIPTION
1. **Add thread to execute handlers for asynchronous signals [win64amd]**

    Added asynchSignalReporterThread to execute handlers
    (J9WinAMD64AsyncHandlerRecord->handler) for asynchronous signals.

    asynchSignalReporterThread is initialized/created within
    initializeSignalTools.

    asynchSignalReporter represents the main body of
    asynchSignalReporterThread. Currently, it is a stub which sets the
    thread's name and executes the thread exit code. The main functionality
    of asynchSignalReporter will be added later once required dependencies
    have been introduced.
    Code related to asynchSignalReporterThread is wrapped with
    OMR_PORT_ASYNC_HANDLER flag (similar to the unix implementation).

    omrutil.h has the prototype for createThreadWithCategory.

2. **Add registerMasterHandlers [win64amd]**

    registerMasterHandlers registers a master signal handler for the signals
    specified in flags.

    Currently, win64amd only has a master signal handler for asynchronous
    signals: masterASynchSignalHandler. So, registerMasterHandlers only
    supports masterASynchSignalHandler (OMRPORT_SIG_FLAG_SIGALLASYNC).
    OMRPORT_SIG_FLAG_SIGALLSYNC is not supported on win64amd.

3. **Add asyncReporterShutdownMonitor [win64amd]**

    asyncReporterShutdownMonitor will be used to synchronize shutdown of
    asynchSignalReporterThread.

    initializeSignalTools updated to initialize
    asyncReporterShutdownMonitor, and destroySignalTools updated to destroy
    asyncReporterShutdownMonitor.

4. **Add runHandlers [win64amd]**

    runHandlers executes the associated handlers stored within
    asyncHandlerList for a a port library signal flag. It will be used to
    invoke asynchronous handlers from asynchSignalReporter (main body of
    asynchSignalReporterThread).

5. **Implement asynchSignalReporter [win64amd]**

    Previously, only a stub existed for asynchSignalReporter. An
    implementation for asynchSignalReporter is added. asynchSignalReporter
    executes handlers associated to pending signals (signalCounts[...]). It
    receives notification of a signal via a j9sem_post (from
    masterASynchSignalHandler). For thread shutdown,
    asyncReporterShutdownMonitor is used.

    shutDownASynchReporter is used to indicate start and end of
    asynchSignalReporterThread termination.

6. **Terminate asynchSignalReporterThread in sig_full_shutdown [win64amd]**

    Added code to terminate asynchSignalReporterThread in sig_full_shutdown.
    sig_full_shutdown waits until asynchSignalReporterThread is terminated.

7. **Fix omrsig_set_async_signal_handler [win64amd]**

    i) Properly initialize variables during declaration.

    ii) Add trace points.

    iii) For the specified port library signal flags, register master
    asynchronous handler (masterASynchSignalHandler) with the OS.

    iv) Currently, J9WinAMD64AsyncHandlerRecord->flags is assigned a new
    value which removes previous signal/handler relations. This is incorrect
    and inconsistent with the Unix implementation. When associating signals
    with existing handlers, J9WinAMD64AsyncHandlerRecord->flags must be
    updated using a bit-wise OR so that previous signal/handler relations
    are not impacted.

8. **Add implementation of omrsig_set_single_async_signal_handler [win64amd]**

9. **Update consoleCtrlHandler [win64amd]**

    consoleCtrlHandler is a HandlerRoutine, and it is responsible for
    handling control events.

    i) consoleCtrlHandler only handled three control events. Now,
    consoleCtrlHandler handles all five control events: CTRL_BREAK_EVENT is
    translated to SIGBREAK, CTRL_C_EVENT is translated to SIGINT,
    CTRL_CLOSE_EVENT/CTRL_LOGOFF_EVENT/CTRL_SHUTDOWN_EVENT are translated to
    SIGTERM.

    ii) Before, consoleCtrlHandler invoked the handlers. Now,
    consoleCtrlHandler only increments counters (signalCounts[...]) for
    unprocessed signals, and notifies the asynchSignalReporterThread.

    iii) consoleCtrlHandler (HandlerRoutine) won't be invoked for a signal
    send using the raise(...) function. In case of raise(...), the signal
    handler registered with the OS using signal(...) will be invoked. So,
    consoleCtrlHandler mustn't be used to invoke
    J9WinAMD64AsyncHandlerRecord->handler(s). Now,
    asynchSignalReporterThread is responsible for invoking
    J9WinAMD64AsyncHandlerRecord->handler(s).

10. **Add setReporterPriority [win64amd]**

    setReporterPriority sets the thread priority for
    asynchSignalReporterThread.

11. **Update omrsig_set_reporter_priority [win64amd]**

    asynchSignalReporterThread has been added on win64amd. So,
    omrsig_set_reporter_priority is updated to set the priority of
    asynchSignalReporterThread.

12. **Replace SIGQUIT with SIGBREAK [win32]**

    Currently, the SIGQUIT flag is used for SIGBREAK on Windows. This is
    confusing since SIGQUIT doesn't exist on Windows.

    A unique SIGBREAK flag has been added on Windows. So, the SIGQUIT flag
    is replaced with the new SIGBREAK flag.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>