### PR TITLE
Initial changes to refactor snapshot at the beginning barrier

### DIFF
--- a/example/glue/ConcurrentMarkingDelegate.hpp
+++ b/example/glue/ConcurrentMarkingDelegate.hpp
@@ -198,6 +198,17 @@ public:
 	MMINLINE void signalThreadsToTraceStacks(MM_EnvironmentBase *env) { }
 
 	/**
+	 * Once concurrent tracing has started, mutator threads must activate the appropriate
+	 * write barrier(s) to trigger whenever a reference-value field is updated, until a GC cycle is started.
+	 */
+	MMINLINE bool signalThreadsToActivateWriteBarrier(MM_EnvironmentBase *env)
+	{
+		return true;
+	}
+
+
+	/**
+	 * TODO SATB: remove later, renamed to signalThreadsToDeactivateWriteBarrier
 	 * Once concurrent tracing has started, mutator threads must dirty cards at the appropriate
 	 * write barrier(s) whenever a reference-value field is updated, until a GC cycle is started.
 	 */
@@ -211,6 +222,13 @@ public:
 	 * dirtying cards once a GC has started.
 	 */
 	MMINLINE void signalThreadsToStopDirtyingCards(MM_EnvironmentBase *env) { }
+
+
+	/**
+	 * This can be used to optimize the concurrent write barrier(s) by conditioning threads to stop
+	 * triggering barriers once a GC has started.
+	 */
+	MMINLINE void signalThreadsToDeactivateWriteBarrier(MM_EnvironmentBase *env) { }
 
 	/**
 	 * Informational. Will be called when concurrent tracing has completed and card cleaning has started.

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -236,10 +236,13 @@ if(OMR_GC_MODRON_STANDARD)
 				base/standard/ConcurrentCompleteTracingTask.cpp
 				base/standard/ConcurrentFinalCleanCardsTask.cpp
 				base/standard/ConcurrentGC.cpp
+				base/standard/ConcurrentGCIncrementalUpdate.cpp
+				base/standard/ConcurrentGCSATB.cpp
 				base/standard/ConcurrentOverflow.cpp
 				base/standard/ConcurrentPrepareCardTableTask.cpp
 				base/standard/ConcurrentSafepointCallback.cpp
 				base/standard/WorkPacketsConcurrent.cpp
+				base/standard/WorkPacketsSATB.cpp
 				
 				stats/ConcurrentGCStats.cpp
 		)

--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -93,6 +93,22 @@ public:
 	bool initializeHeapRegionDescriptor(MM_EnvironmentBase *env, MM_HeapRegionDescriptor *region) { return _delegate.initializeHeapRegionDescriptorExtension(env, region); }
 	void teardownHeapRegionDescriptor(MM_EnvironmentBase *env, MM_HeapRegionDescriptor *region) { _delegate.teardownHeapRegionDescriptorExtension(env, region); }
 
+	MMINLINE MM_GCWriteBarrierType getBarrierType() { return _writeBarrierType; }
+
+	MMINLINE bool
+	isSnapshotAtTheBeginningBarrierEnabled()
+	{
+		return (getBarrierType() == gc_modron_wrtbar_satb_and_oldcheck) ||
+				(getBarrierType() == gc_modron_wrtbar_satb);
+	}
+
+	MMINLINE bool
+	isIncrementalUpdateBarrierEnabled()
+	{
+		return (getBarrierType() == gc_modron_wrtbar_cardmark_and_oldcheck) ||
+				(getBarrierType() == gc_modron_wrtbar_cardmark);
+	}
+
 	/**
 	 * Delegated method to determine when to start tracking heap fragmentation, which should be inhibited
 	 * until the heap has grown to a stable operational size.

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -70,6 +70,7 @@ class MM_ReferenceChainWalkerMarkMap;
 class MM_RememberedSetCardBucket;
 #if defined(OMR_GC_STACCATO)
 class MM_RememberedSetWorkPackets;
+class MM_RememberedSetSATB;
 #endif /* OMR_GC_STACCATO */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 class MM_Scavenger;
@@ -162,6 +163,7 @@ public:
 	bool _forceOptionConcurrentMark; /**< true if Concurrent Mark option is forced in command line */
 	bool _forceOptionConcurrentSweep; /**< true if Concurrent Sweep option is forced in command line */
 	bool _forceOptionLargeObjectArea; /**< true if Large Object Area option is forced in command line */
+	bool _forceOptionWriteBarrierSATB; /**< Set with -Xgc:snapshotAtTheBeginningBarrier */
 
 	MM_ConfigurationOptions()
 		: MM_BaseNonVirtual()
@@ -170,6 +172,7 @@ public:
 		, _forceOptionConcurrentMark(false)
 		, _forceOptionConcurrentSweep(false)
 		, _forceOptionLargeObjectArea(false)
+		, _forceOptionWriteBarrierSATB(false)
 	{
 		_typeId = __FUNCTION__;
 	}
@@ -250,7 +253,9 @@ public:
 	MM_SublistPool rememberedSet;
 #endif /* OMR_GC_MODRON_SCAVENGER */
 #if defined(OMR_GC_STACCATO)
+	// TODO: SATB remove staccatoRememberedSet after initial SATB changes are merged
 	MM_RememberedSetWorkPackets* staccatoRememberedSet; /**< The Staccato remembered set used for the write barrier */
+	MM_RememberedSetSATB* sATBBarrierRememberedSet; /**< The snapshot at the beginning barrier remembered set used for the write barrier */
 #endif /* OMR_GC_STACCATO */
 	ModronLnrlOptions lnrlOptions;
 
@@ -1231,6 +1236,7 @@ public:
 		, gcmetadataPageFlags(OMRPORT_VMEM_PAGE_FLAG_NOT_USED)
 #if defined(OMR_GC_STACCATO)
 		, staccatoRememberedSet(NULL)
+		, sATBBarrierRememberedSet(NULL)
 #endif /* OMR_GC_STACCATO */
 
 		, heapBaseForBarrierRange0(NULL)

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Modron_Standard
+ */
+
+#include "omrcfg.h"
+
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+
+#define J9_EXTERNAL_TO_VM
+
+#include "mmprivatehook.h"
+#include "modronbase.h"
+#include "modronopt.h"
+#include "ModronAssertions.h"
+#include "omr.h"
+
+#include <string.h>
+
+#include "ConcurrentGCIncrementalUpdate.hpp"
+#include "ConcurrentCardTableForWC.hpp"
+
+/**
+ * Create new instance of ConcurrentGCIncrementalUpdate object.
+ *
+ * @return Reference to new MM_ConcurrentGCIncrementalUpdate object or NULL
+ */
+MM_ConcurrentGCIncrementalUpdate *
+MM_ConcurrentGCIncrementalUpdate::newInstance(MM_EnvironmentBase *env)
+{
+	MM_ConcurrentGCIncrementalUpdate *concurrentGC =
+			(MM_ConcurrentGCIncrementalUpdate *)env->getForge()->allocate(sizeof(MM_ConcurrentGCIncrementalUpdate),
+					OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	if (NULL != concurrentGC) {
+		new(concurrentGC) MM_ConcurrentGCIncrementalUpdate(env);
+		if (!concurrentGC->initialize(env)) {
+			concurrentGC->kill(env);
+			concurrentGC = NULL;
+		}
+	}
+
+	return concurrentGC;
+}
+
+/**
+ * Destroy instance of an ConcurrentGCIncrementalUpdate object.
+ *
+ */
+void
+MM_ConcurrentGCIncrementalUpdate::kill(MM_EnvironmentBase *env)
+{
+	tearDown(env);
+	env->getForge()->free(this);
+}
+
+
+/* Teardown a ConcurrentGCIncrementalUpdate object
+* Destroy referenced objects and release
+* all allocated storage before ConcurrentGCIncrementalUpdate object is freed.
+*/
+void
+MM_ConcurrentGCIncrementalUpdate::tearDown(MM_EnvironmentBase *env)
+{
+	/* ..and then tearDown our super class */
+	MM_ConcurrentGC::tearDown(env);
+}
+
+/**
+ * Initialize a new ConcurrentGCIncrementalUpdate object.
+ * Instantiate card table and concurrent RAS objects(if required) and initialize all
+ * monitors required by concurrent. Allocate and initialize the concurrent helper thread
+ * table.
+ *
+ * @return TRUE if initialization completed OK;FALSE otheriwse
+ */
+bool
+MM_ConcurrentGCIncrementalUpdate::initialize(MM_EnvironmentBase *env)
+{
+	J9HookInterface** mmPrivateHooks = J9_HOOK_INTERFACE(_extensions->privateHookInterface);
+
+	if (!MM_ConcurrentGC::initialize(env)) {
+		goto error_no_memory;
+	}
+
+	if (!createCardTable(env)) {
+		goto error_no_memory;
+	}
+
+	/* Register on any hook we are interested in */
+	(*mmPrivateHooks)->J9HookRegisterWithCallSite(mmPrivateHooks, J9HOOK_MM_PRIVATE_CARD_CLEANING_PASS_2_START, hookCardCleanPass2Start, OMR_GET_CALLSITE(), (void *)this);
+
+	return true;
+
+	error_no_memory:
+	return false;
+}
+
+bool
+MM_ConcurrentGCIncrementalUpdate::heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress)
+{
+	bool clearCards = (CONCURRENT_OFF < _stats.getExecutionMode()) && subspace->isConcurrentCollectable();
+
+	/* Expand any superclass structures including mark bits*/
+	bool result = MM_ConcurrentGC::heapAddRange(env, subspace, size, lowAddress, highAddress);
+
+	if (result) {
+		/* expand the card table */
+		result = ((MM_ConcurrentCardTable *)_cardTable)->heapAddRange(env, subspace, size, lowAddress, highAddress, clearCards);
+		if (!result) {
+			/* Expansion of Concurrent Card Table has failed
+			 * ParallelGlobalGC expansion must be reversed
+			 */
+			MM_ParallelGlobalGC::heapRemoveRange(env, subspace, size, lowAddress, highAddress, NULL, NULL);
+		}
+	}
+
+	_heapAlloc = _extensions->heap->getHeapTop();
+
+	return result;
+}
+
+/**
+ * Hook function called when an the 2nd pass over card table to clean cards starts.
+ * This is a wrapper into the non-static MM_ConcurrentGCIncrementalUpdate::recordCardCleanPass2Start
+ */
+void
+MM_ConcurrentGCIncrementalUpdate::hookCardCleanPass2Start(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData)
+{
+	MM_CardCleanPass2StartEvent* event = (MM_CardCleanPass2StartEvent *)eventData;
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(event->currentThread);
+
+	((MM_ConcurrentGCIncrementalUpdate *)userData)->recordCardCleanPass2Start(env);
+
+	/* Boost the trace rate for the 2nd card cleaning pass */
+}
+
+void
+MM_ConcurrentGCIncrementalUpdate::recordCardCleanPass2Start(MM_EnvironmentBase *env)
+{
+	_pass2Started = true;
+
+	/* Record how mush work we did before pass 2 KO */
+	_totalTracedAtPass2KO = _stats.getTraceSizeCount() + _stats.getConHelperTraceSizeCount();
+	_totalCleanedAtPass2KO = _stats.getCardCleanCount() + _stats.getConHelperCardCleanCount();
+
+	/* ..and boost tracing rate from here to end of cycle so we complete pass 2 ASAP */
+	_allocToTraceRate *= _allocToTraceRateCardCleanPass2Boost;
+}
+
+bool
+MM_ConcurrentGCIncrementalUpdate::createCardTable(MM_EnvironmentBase *env)
+{
+	bool result = false;
+
+	Assert_MM_true(NULL == _cardTable);
+	Assert_MM_true(NULL == _extensions->cardTable);
+
+#if defined(AIXPPC) || defined(LINUXPPC)
+	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
+
+	if ((uintptr_t)omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) > 1 ) {
+		_cardTable = MM_ConcurrentCardTableForWC::newInstance(env, _extensions->getHeap(), _markingScheme, this);
+	} else
+#endif /* AIXPPC || LINUXPPC */
+	{
+		_cardTable = MM_ConcurrentCardTable::newInstance(env, _extensions->getHeap(), _markingScheme, this);
+	}
+
+	if(NULL != _cardTable) {
+		result = true;
+		/* Set card table address in GC Extensions */
+		_extensions->cardTable = _cardTable;
+	}
+
+	return result;
+}
+
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.hpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.hpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(CONCURRENTGCINCREMENTALUPDATE_HPP_)
+#define CONCURRENTGCINCREMENTALUPDATE_HPP_
+
+#include "omrcfg.h"
+#include "modronopt.h"
+
+#include "omr.h"
+#include "OMR_VM.hpp"
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+
+#include "ConcurrentGC.hpp"
+
+
+/**
+ * @todo Provide class documentation
+ * @ingroup GC_Modron_Standard
+ */
+class MM_ConcurrentGCIncrementalUpdate : public MM_ConcurrentGC
+{
+	/*
+	 * Data members
+	 */
+private:
+
+	/**
+	 * Creates Concurrent Card Table
+	 * @param env current thread environment
+	 * @return true if table is created
+	 */
+	bool createCardTable(MM_EnvironmentBase *env);
+	static void hookCardCleanPass2Start(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
+	void recordCardCleanPass2Start(MM_EnvironmentBase *env);
+
+public:
+	
+	/*
+	 * Function members
+	 */
+
+protected:
+	bool initialize(MM_EnvironmentBase *env);
+	void tearDown(MM_EnvironmentBase *env);
+public:
+	virtual uintptr_t getVMStateID() { return J9VMSTATE_GC_COLLECTOR_CONCURRENTGC; };
+	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, uintptr_t size, void *lowAddress, void *highAddress);
+
+	static MM_ConcurrentGCIncrementalUpdate *newInstance(MM_EnvironmentBase *env);
+	virtual void kill(MM_EnvironmentBase *env);
+
+	MM_ConcurrentGCIncrementalUpdate(MM_EnvironmentBase *env)
+		: MM_ConcurrentGC(env)
+		{
+			_typeId = __FUNCTION__;
+		}
+
+	friend class MM_ConcurrentCardTableForWC;
+};
+
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+
+#endif /* CONCURRENTGCINCREMENTALUPDATE_HPP_ */

--- a/gc/base/standard/ConcurrentGCSATB.cpp
+++ b/gc/base/standard/ConcurrentGCSATB.cpp
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Modron_Standard
+ */
+
+#include "omrcfg.h"
+
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+
+#define J9_EXTERNAL_TO_VM
+
+#include "mmprivatehook.h"
+#include "modronbase.h"
+#include "modronopt.h"
+#include "ModronAssertions.h"
+#include "omr.h"
+
+#include <string.h>
+
+#include "ConcurrentGCSATB.hpp"
+#include "AllocateDescription.hpp"
+
+/**
+ * Create new instance of ConcurrentGCIncrementalUpdate object.
+ *
+ * @return Reference to new MM_ConcurrentGCSATB object or NULL
+ */
+MM_ConcurrentGCSATB *
+MM_ConcurrentGCSATB::newInstance(MM_EnvironmentBase *env)
+{
+	MM_ConcurrentGCSATB *concurrentGC =
+			(MM_ConcurrentGCSATB *)env->getForge()->allocate(sizeof(MM_ConcurrentGCSATB),
+					OMR::GC::AllocationCategory::FIXED, OMR_GET_CALLSITE());
+	if (NULL != concurrentGC) {
+		new(concurrentGC) MM_ConcurrentGCSATB(env);
+		if (!concurrentGC->initialize(env)) {
+			concurrentGC->kill(env);
+			concurrentGC = NULL;
+		}
+	}
+
+	return concurrentGC;
+}
+
+/**
+ * Destroy instance of an ConcurrentGCIncrementalUpdate object.
+ *
+ */
+void
+MM_ConcurrentGCSATB::kill(MM_EnvironmentBase *env)
+{
+	tearDown(env);
+	env->getForge()->free(this);
+}
+
+
+/**
+ * Teardown a MM_ConcurrentGCSATB object
+ * Destroy referenced objects and release
+ * all allocated storage before MM_ConcurrentGCSATB object is freed.
+ */
+void
+MM_ConcurrentGCSATB::tearDown(MM_EnvironmentBase *env)
+{
+	/* ..and then tearDown our super class */
+	MM_ConcurrentGC::tearDown(env);
+}
+
+void
+MM_ConcurrentGCSATB::reportConcurrentHalted(MM_EnvironmentBase *env)
+{}
+
+uintptr_t
+MM_ConcurrentGCSATB::localMark(MM_EnvironmentBase *env, uintptr_t sizeToTrace)
+{
+	omrobjectptr_t objectPtr;
+	uintptr_t gcCount = _extensions->globalGCStats.gcCount;
+
+	env->_workStack.reset(env, _markingScheme->getWorkPackets());
+	Assert_MM_true(env->_cycleState == NULL);
+	Assert_MM_true(CONCURRENT_OFF < _stats.getExecutionMode());
+	Assert_MM_true(_concurrentCycleState._referenceObjectOptions == MM_CycleState::references_default);
+	env->_cycleState = &_concurrentCycleState;
+
+	uintptr_t sizeTraced = 0;
+	while(NULL != (objectPtr = (omrobjectptr_t)env->_workStack.popNoWait(env))) {
+		/* Check for array scanPtr..if we find one ignore it*/
+		if ((uintptr_t)objectPtr & PACKET_ARRAY_SPLIT_TAG){
+			continue;
+		} else {
+			/* Else trace the object */
+			sizeTraced += _markingScheme->scanObject(env, objectPtr, SCAN_REASON_PACKET, (sizeToTrace - sizeTraced));
+		}
+
+		/* Have we done enough tracing ? */
+		if(sizeTraced >= sizeToTrace) {
+			break;
+		}
+
+		/* Before we do any more tracing check to see if GC is waiting */
+		if (env->isExclusiveAccessRequestWaiting()) {
+			/* suspend con helper thread for pending GC */
+			uintptr_t conHelperRequest = switchConHelperRequest(CONCURRENT_HELPER_MARK, CONCURRENT_HELPER_WAIT);
+			Assert_MM_true(CONCURRENT_HELPER_MARK != conHelperRequest);
+			break;
+		}
+	}
+
+	/* Pop the top of the work packet if its a partially processed array tag */
+	if ( ((uintptr_t)((omrobjectptr_t)env->_workStack.peek(env))) & PACKET_ARRAY_SPLIT_TAG) {
+		env->_workStack.popNoWait(env);
+	}
+
+	/* STW collection should not occur while localMark is working */
+	Assert_MM_true(gcCount == _extensions->globalGCStats.gcCount);
+
+	flushLocalBuffers(env);
+	env->_cycleState = NULL;
+
+	return sizeTraced;
+}
+
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */

--- a/gc/base/standard/ConcurrentGCSATB.hpp
+++ b/gc/base/standard/ConcurrentGCSATB.hpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(CONCURRENTGCSATB_HPP_)
+#define CONCURRENTGCSATB_HPP_
+
+#include "omrcfg.h"
+#include "modronopt.h"
+
+#include "omr.h"
+#include "OMR_VM.hpp"
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+
+#include "ConcurrentGC.hpp"
+
+
+/**
+ * @todo Provide class documentation
+ * @ingroup GC_Modron_Standard
+ */
+class MM_ConcurrentGCSATB : public MM_ConcurrentGC
+{
+	/*
+	 * Data members
+	 */
+private:
+
+public:
+	
+	/*
+	 * Function members
+	 */
+
+protected:
+	void tearDown(MM_EnvironmentBase *env);
+	void virtual reportConcurrentHalted(MM_EnvironmentBase *env);
+	uintptr_t virtual localMark(MM_EnvironmentBase *env, uintptr_t sizeToTrace);
+
+public:
+	virtual uintptr_t getVMStateID() { return J9VMSTATE_GC_COLLECTOR_CONCURRENTGC; };
+	static MM_ConcurrentGCSATB *newInstance(MM_EnvironmentBase *env);
+	virtual void kill(MM_EnvironmentBase *env);
+
+	MM_ConcurrentGCSATB(MM_EnvironmentBase *env)
+		: MM_ConcurrentGC(env)
+		{
+			_typeId = __FUNCTION__;
+		}
+};
+
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+
+#endif /* CONCURRENTGCSATB_HPP_ */

--- a/gc/base/standard/ConcurrentSafepointCallback.cpp
+++ b/gc/base/standard/ConcurrentSafepointCallback.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,7 @@ MM_ConcurrentSafepointCallback::requestCallback(MM_EnvironmentBase *env)
 	 * be a no-op.
 	 *
 	 * To optimize card table maintenance, language can implement this and
-	 * call MM_CollectorLanguageInterface::signalThreadsToDirtyCards() here.
+	 * call MM_CollectorLanguageInterface::signalThreadsToActivateWriteBarrier() here.
 	 */
 }
 

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,8 @@
 #include "ConfigurationStandard.hpp"
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
-#include "ConcurrentGC.hpp"
+#include "ConcurrentGCIncrementalUpdate.hpp"
+#include "ConcurrentGCSATB.hpp"
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 #include "ConcurrentSweepGC.hpp"
@@ -119,7 +120,11 @@ MM_ConfigurationStandard::createGlobalCollector(MM_EnvironmentBase* env)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 	if (extensions->concurrentMark) {
-		return MM_ConcurrentGC::newInstance(env);
+		if (isSnapshotAtTheBeginningBarrierEnabled()) {
+			return MM_ConcurrentGCSATB::newInstance(env);
+		} else {
+			return MM_ConcurrentGCIncrementalUpdate::newInstance(env);
+		}
 	}
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 #if defined(OMR_GC_CONCURRENT_SWEEP)

--- a/gc/base/standard/ConfigurationStandard.hpp
+++ b/gc/base/standard/ConfigurationStandard.hpp
@@ -89,12 +89,20 @@ private:
 		MM_GCExtensionsBase* extensions = env->getExtensions();
 		if (extensions->isScavengerEnabled()) {
 			if (extensions->isConcurrentMarkEnabled()) {
-				writeBarrierType = gc_modron_wrtbar_cardmark_and_oldcheck;
+				if (extensions->configurationOptions._forceOptionWriteBarrierSATB) {
+					writeBarrierType = gc_modron_wrtbar_satb_and_oldcheck;
+				} else {
+					writeBarrierType = gc_modron_wrtbar_cardmark_and_oldcheck;
+				}
 			} else {
 				writeBarrierType = gc_modron_wrtbar_oldcheck;
 			}
 		} else if (extensions->isConcurrentMarkEnabled()) {
-			writeBarrierType = gc_modron_wrtbar_cardmark;
+			if (extensions->configurationOptions._forceOptionWriteBarrierSATB) {
+				writeBarrierType = gc_modron_wrtbar_satb;
+			} else {
+				writeBarrierType = gc_modron_wrtbar_cardmark;
+			}
 		}
 		return writeBarrierType;
 	}

--- a/gc/base/standard/RememberedSetSATB.cpp
+++ b/gc/base/standard/RememberedSetSATB.cpp
@@ -1,0 +1,311 @@
+
+/*******************************************************************************
+ * Copyright (c) 1991, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "omrcfg.h"
+
+#if defined(OMR_GC_REALTIME)
+
+#include "Debug.hpp"
+#include "RememberedSetSATB.hpp"
+#include "WorkPackets.hpp"
+
+/**
+ * Object creation and destruction 
+ *
+ */
+
+/**
+ * Create a new instance the MM_RememberedSetSATB class
+ *
+ * @param workPackets The workPackets 
+ */
+MM_RememberedSetSATB *
+MM_RememberedSetSATB::newInstance(MM_EnvironmentBase *env, MM_WorkPacketsSATB *workPackets)
+{
+	MM_RememberedSetSATB *rememberedSet;
+	
+	rememberedSet = (MM_RememberedSetSATB *)env->getForge()->allocate(sizeof(MM_RememberedSetSATB), MM_AllocationCategory::WORK_PACKETS, J9_GET_CALLSITE());
+	if (NULL != rememberedSet) {
+		new(rememberedSet) MM_RememberedSetSATB(env, workPackets);
+		if (!rememberedSet->initialize(env)) {
+			rememberedSet->kill(env);
+			rememberedSet = NULL;
+		}
+	}
+	return rememberedSet;
+}
+
+/**
+ * Kill the RememberedSetWorkPackets instance
+ */
+void
+MM_RememberedSetSATB::kill(MM_EnvironmentBase *env)
+{
+	tearDown(env);
+	env->getForge()->free(this);
+}
+
+/**
+ * Initialize the MM_RememberedSetSATB class.
+ */
+bool
+MM_RememberedSetSATB::initialize(MM_EnvironmentBase *env)
+{
+	return true;
+}
+
+/**
+ * Teardown the MM_RememberedSetSATB class.
+ */
+void
+MM_RememberedSetSATB::tearDown(MM_EnvironmentBase *env)
+{	
+}
+
+/**
+ * Initialize a fragment to a "null" state such that the first store into it will cause a
+ * fragment refresh.
+ * @param fragment The fragment to initialize.
+ */
+void
+MM_RememberedSetSATB::initializeFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment)
+{
+	fragment->fragmentAlloc = NULL;
+	fragment->fragmentTop = NULL;
+	fragment->fragmentStorage = NULL;
+	
+	/* The initial values of the following fields were chosen to ensure the local fragment
+	 * index isn't initialized to the J9GC_REMEMBERED_SET_RESERVED_INDEX, since depending
+	 * on when the fragment is initialized, it could be interpreted as meaning the double
+	 * barrier is active, which isn't the case. Other than that, there is no requirement
+	 * for the initial value of these fields. Eg: If the initial values happen to
+	 * correspond to the global index, this isn't a problem since the fragment won't be
+	 * used because it is considered full and of size 0. 
+	 */
+	fragment->localFragmentIndex = (J9GC_REMEMBERED_SET_RESERVED_INDEX + 1);
+	fragment->preservedLocalFragmentIndex = (J9GC_REMEMBERED_SET_RESERVED_INDEX + 1);
+	fragment->fragmentParent = &_rememberedSetStruct;
+}
+
+/**
+ * Stores a value in the alloc position of the fragment and increments the alloc pointer.
+ * @param fragment The fragment in which the value should be stored.
+ * @param value The value to store in the fragment. 
+ */
+void
+MM_RememberedSetSATB::storeInFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment, UDATA* value)
+{
+	if (!isFragmentValid(env, fragment)) {
+		if (!refreshFragment(env, fragment)) {
+			_workPackets->overflowItem(env, (void *)value, OVERFLOW_TYPE_BARRIER);
+			return;
+		}
+	}
+	
+	assume(isFragmentValid(env, fragment), "Refreshed fragment invalid.");
+	*(*(fragment->fragmentAlloc)) = (UDATA) value;
+	(*(fragment->fragmentAlloc))++;
+}
+
+/**
+ * Determines if the fragment is valid or not. A valid fragment is defined as a non-full
+ * fragment with a local fragment ID that matches the global fragment ID.
+ * @param fragment The fragment to validate. 
+ */
+bool
+MM_RememberedSetSATB::isFragmentValid(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment)
+{
+	if (fragment->fragmentStorage == NULL) {
+		return false;
+	}
+	if (*fragment->fragmentAlloc == *fragment->fragmentTop) {
+		return false;
+	}
+	return (getLocalFragmentIndex(env, fragment) == getGlobalFragmentIndex(env));
+}
+
+/**
+ * Saves the local fragment index but ensures any inline JIT code that uses the fragment
+ * will see a difference in the fragment indexes and force the JIT to go out-of-line.
+ * @param fragment The fragment to preserve the index for.
+ */
+void
+MM_RememberedSetSATB::preserveLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment)
+{
+	assume((fragment->localFragmentIndex != J9GC_REMEMBERED_SET_RESERVED_INDEX), "Attempt to preserve an already preserved fragment index.");
+	fragment->preservedLocalFragmentIndex = fragment->localFragmentIndex;
+	fragment->localFragmentIndex = J9GC_REMEMBERED_SET_RESERVED_INDEX;
+}
+
+/**
+ * Restores the localFragmentIndex such that JIT code may use the fragment directly.
+ * @param fragment The fragment to restore.
+ */
+void
+MM_RememberedSetSATB::restoreLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment)
+{
+	assume((fragment->localFragmentIndex == J9GC_REMEMBERED_SET_RESERVED_INDEX), "Attempt to restore a non-preserved fragment index.");
+	fragment->localFragmentIndex = fragment->preservedLocalFragmentIndex;
+}
+
+/**
+ * Saves the global fragment index but ensures any inline JIT code that uses any fragment
+ * will see a difference in the fragment indexes and force the JIT to go out-of-line.
+ */
+void
+MM_RememberedSetSATB::preserveGlobalFragmentIndex(MM_EnvironmentBase* env)
+{
+	assume((_rememberedSetStruct.globalFragmentIndex != J9GC_REMEMBERED_SET_RESERVED_INDEX), "Attempt to preserve an already preserved global index.");
+	_rememberedSetStruct.preservedGlobalFragmentIndex = _rememberedSetStruct.globalFragmentIndex;
+	_rememberedSetStruct.globalFragmentIndex = J9GC_REMEMBERED_SET_RESERVED_INDEX;
+}
+
+/**
+ * Restores the global fragment index such that JIT inline code may use the fragments directly.
+ */
+void
+MM_RememberedSetSATB::restoreGlobalFragmentIndex(MM_EnvironmentBase* env)
+{
+	assume((_rememberedSetStruct.globalFragmentIndex == J9GC_REMEMBERED_SET_RESERVED_INDEX), "Attempt to restore a non-preserved global index.");
+	_rememberedSetStruct.globalFragmentIndex = _rememberedSetStruct.preservedGlobalFragmentIndex;
+}
+
+/**
+ * @return the actual value corresponding to the fragment index, preserved or not.
+ */
+UDATA
+MM_RememberedSetSATB::getLocalFragmentIndex(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment)
+{
+	/* There should be no synchronization required based on the following assumptions:
+	 * 1) The thread starting the GC will call preserveLocalFragmentIndex on all threads "atomically".
+	 * 2) Any other write to the fragment will be done by the thread owning the fragment.
+	 * 3) All fragment reads are done by the thread owning the fragment. 
+	 */
+	UDATA localIndex = fragment->localFragmentIndex;
+	if (J9GC_REMEMBERED_SET_RESERVED_INDEX == localIndex) {
+		return fragment->preservedLocalFragmentIndex;
+	}
+	return fragment->localFragmentIndex;
+}
+
+/**
+ * @return the actual value corresponding to the global index, preserved or not.
+ */
+UDATA
+MM_RememberedSetSATB::getGlobalFragmentIndex(MM_EnvironmentBase* env)
+{
+	/* There should be no synchronization required based on the following assumptions:
+	 * 1) The global fragment index is modified by the thread that iterates over the remembered set
+	 *    and the thread that completes the GC cycle, but there will be a call to the ragged barrier
+	 *    between those 2 events.
+	 * 2) Reading an out of date global ID in a thread is safe until the ragged barrier is notified
+	 *    that the particular thread has hit the barrier.
+	 */
+	UDATA globalIndex = _rememberedSetStruct.globalFragmentIndex;
+	if (J9GC_REMEMBERED_SET_RESERVED_INDEX == globalIndex) {
+		return _rememberedSetStruct.preservedGlobalFragmentIndex;
+	}
+	return globalIndex;
+}
+
+/**
+ * Increments the global fragment index such that all fragments will be refreshed before
+ * storing into them.
+ * 
+ * This method assumes external synchronization will be used to ensure all threads have
+ * noticed their caches have been flushed. Ie: it's the callers responsibility to call
+ * the ragged barrier after calling this method.
+ */
+void
+MM_RememberedSetSATB::flushFragments(MM_EnvironmentBase* env)
+{
+	/* If the next index corresponds to the reserved index, skip over it. */
+	UDATA nextIndex = (getGlobalFragmentIndex(env) + 1);
+	if (J9GC_REMEMBERED_SET_RESERVED_INDEX != nextIndex) {
+		setGlobalIndex(env, nextIndex);
+	} else {
+		setGlobalIndex(env, nextIndex + 1);
+	}
+}
+
+/**
+ * Sets the appropriate global index depending on whether or not the global index
+ * is preserved.
+ * @param indexValue The new value the global index should take.
+ */
+void
+MM_RememberedSetSATB::setGlobalIndex(MM_EnvironmentBase* env, UDATA indexValue)
+{
+	if (J9GC_REMEMBERED_SET_RESERVED_INDEX == _rememberedSetStruct.globalFragmentIndex) {
+		_rememberedSetStruct.preservedGlobalFragmentIndex = indexValue;
+	} else {
+		_rememberedSetStruct.globalFragmentIndex = indexValue;
+	} 
+}
+
+/**
+ * Refresh the fragment.
+ * 
+ * @Note that the refresh fragment mustn't blindly update the localFragmentIndex, 
+ * it must determine which of the localFragmentFlushID or preservedFragmentFlushID 
+ * is to be updated.
+ */
+bool
+MM_RememberedSetSATB::refreshFragment(MM_EnvironmentBase *env, J9VMGCRememberedSetFragment* fragment)
+{
+	MM_Packet *packet = NULL;
+	bool result = false;
+	
+	packet = _workPackets->getBarrierPacket(env);
+	MM_Packet *oldPacket = (MM_Packet *)fragment->fragmentStorage;
+		
+	if ((NULL != oldPacket) && (getLocalFragmentIndex(env, fragment) == getGlobalFragmentIndex(env)) && (*fragment->fragmentTop == *fragment->fragmentAlloc)) {
+		_workPackets->removePacketFromInUseList(env, oldPacket);
+		_workPackets->putFullPacket(env, oldPacket);
+	}
+	
+	if (J9GC_REMEMBERED_SET_RESERVED_INDEX == fragment->localFragmentIndex) {
+		fragment->preservedLocalFragmentIndex = getGlobalFragmentIndex(env);
+	} else {
+		fragment->localFragmentIndex = getGlobalFragmentIndex(env);
+	}
+    fragment->fragmentParent = &_rememberedSetStruct;
+	
+	if (NULL != packet) {
+		fragment->fragmentAlloc = packet->getCurrentAddr(env);
+		fragment->fragmentTop = packet->getTopAddr(env);
+		fragment->fragmentStorage = (void *)packet;
+	    
+	    _workPackets->putInUsePacket(env, packet);
+	    
+	    result = true;
+	} else {
+		fragment->fragmentAlloc = NULL;
+		fragment->fragmentTop = NULL;
+		fragment->fragmentStorage = NULL;
+	}
+	
+	return result;
+}
+
+#endif /* defined(OMR_GC_REALTIME) */

--- a/gc/base/standard/RememberedSetSATB.hpp
+++ b/gc/base/standard/RememberedSetSATB.hpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#if !defined(REMEMBEREDSETSATB_HPP_)
+#define REMEMBEREDSETSATB_HPP_
+
+#if defined(OMR_GC_REALTIME)
+
+#include "WorkPacketsSATB.hpp"
+#include "BaseNonVirtual.hpp"
+
+class EnvironmentModron;
+
+class MM_RememberedSetSATB : public MM_BaseNonVirtual
+{
+/* Data members & types */
+public:
+	J9VMGCRememberedSet _rememberedSetStruct; /**< The VM-readable struct containing the remembered set "global" indexes. */
+protected:
+private:
+	MM_WorkPacketsSATB *_workPackets; /**< The workPackets struct used as backing store for the rememberedSet */
+
+/* Methods */
+public:
+	/* Constructors & destructors */
+	static MM_RememberedSetSATB *newInstance(MM_EnvironmentBase *env, MM_WorkPacketsSATB *workPackets);
+	void kill(MM_EnvironmentBase *env);
+	
+	MM_RememberedSetSATB(MM_EnvironmentBase *env, MM_WorkPacketsSATB *workPackets) :
+		MM_BaseNonVirtual(),
+		_workPackets(workPackets)
+	{
+		_typeId = __FUNCTION__;
+		/* Initializing the global fragment index to the reserved index means the GC starts
+		 * with the barrier disabled. The preservedGlobalFragmentIndex must be initialized
+		 * to any non-reserved value so that the call to MM_StaccatoGC::enableWriteBarrier which
+		 * in turns restores the globalFragmentIndex from the preservedGlobalFragmentIndex actually
+		 * restores a valid, non-reserved value.
+		 */
+		_rememberedSetStruct.globalFragmentIndex = J9GC_REMEMBERED_SET_RESERVED_INDEX;
+		_rememberedSetStruct.preservedGlobalFragmentIndex = J9GC_REMEMBERED_SET_RESERVED_INDEX + 1; 
+	};
+	
+	/* New methods */
+	void initializeFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment); /* "Nulls" out a fragment. */
+	void storeInFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment, UDATA* value); /* This guarantees the store will occur, but a new fragment may be fetched. */
+	bool isFragmentValid(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment);
+	void preserveLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment); /* Called by the code that enables the double-barrier. */
+	void restoreLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment); /* Called by the root scanner to disable the double-barrier. */
+	void preserveGlobalFragmentIndex(MM_EnvironmentBase* env); /* Called by the code that disables the barrier. */
+	void restoreGlobalFragmentIndex(MM_EnvironmentBase* env); /* Called by the code that enables the barrier. */
+	/* Used to determine if the staccato write barrier is enabled. */
+	MMINLINE bool
+	isGlobalFragmentIndexPreserved(MM_EnvironmentBase* env)
+	{
+		return (J9GC_REMEMBERED_SET_RESERVED_INDEX == _rememberedSetStruct.globalFragmentIndex);
+	}
+	void flushFragments(MM_EnvironmentBase* env); /* Ensures all fragments will be seen as invalid next time they are accessed. */
+	bool refreshFragment(MM_EnvironmentBase *env, J9VMGCRememberedSetFragment* fragment);
+	
+protected:
+	bool initialize(MM_EnvironmentBase *env);
+	void tearDown(MM_EnvironmentBase *env);
+	UDATA getLocalFragmentIndex(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment);
+	UDATA getGlobalFragmentIndex(MM_EnvironmentBase* env);
+	
+private:
+	void setGlobalIndex(MM_EnvironmentBase* env, UDATA indexValue); /* Increments the appropriate global index (global or preserved). */
+};
+#endif /* defined(OMR_GC_REALTIME) */
+#endif /* REMEMBEREDSETSATB_HPP_ */
+

--- a/gc/base/standard/WorkPacketsSATB.cpp
+++ b/gc/base/standard/WorkPacketsSATB.cpp
@@ -1,0 +1,243 @@
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "omrthread.h"
+
+#if defined(OMR_GC_REALTIME)
+
+#include "WorkPacketsSATB.hpp"
+
+#include "Debug.hpp"
+#include "GCExtensions.hpp"
+#include "IncrementalOverflow.hpp"
+
+/**
+ * Instantiate a MM_WorkPacketsSATB
+ * @param mode type of packets (used for getting the right overflow handler)
+ * @return pointer to the new object
+ */
+MM_WorkPacketsSATB *
+MM_WorkPacketsSATB::newInstance(MM_EnvironmentBase *env)
+{
+	MM_WorkPacketsSATB *workPackets;
+	
+	workPackets = (MM_WorkPacketsSATB *)env->getForge()->allocate(sizeof(MM_WorkPacketsSATB), MM_AllocationCategory::WORK_PACKETS, J9_GET_CALLSITE());
+	if (workPackets) {
+		new(workPackets) MM_WorkPacketsSATB(env);
+		if (!workPackets->initialize(env)) {
+			workPackets->kill(env);
+			workPackets = NULL;	
+		}
+	}
+	
+	return workPackets;
+}
+
+/**
+ * Initialize a MM_WorkPacketsSATB object
+ * @return true on success, false otherwise
+ */
+bool
+MM_WorkPacketsSATB::initialize(MM_EnvironmentBase *env)
+{
+	if (!MM_WorkPackets::initialize(env)) {
+		return false;
+	}
+
+	if (0 == MM_GCExtensions::getExtensions(_extensions)->overflowCacheCount) {
+		/* If the user has not specified a value for overflowCacheCount
+		 * set it to be 5% of the packet slot count.
+		 */
+		MM_GCExtensions::getExtensions(_extensions)->overflowCacheCount = (UDATA)(_slotsInPacket * 0.05);
+	}
+
+	if (!_inUseBarrierPacketList.initialize(env)) {
+		return false;
+	}
+		
+	return true;
+}
+
+/**
+ * Destroy the resources a MM_WorkPacketsSATB is responsible for
+ */
+void
+MM_WorkPacketsSATB::tearDown(MM_EnvironmentBase *env)
+{
+	MM_WorkPackets::tearDown(env);
+
+	_inUseBarrierPacketList.tearDown(env);
+}
+
+/**
+ * Create the overflow handler
+ */
+MM_WorkPacketOverflow *
+MM_WorkPacketsSATB::createOverflowHandler(MM_EnvironmentBase *env, MM_WorkPackets *wp)
+{
+	return MM_IncrementalOverflow::newInstance(env, wp);
+}
+
+/**
+ * Return an empty packet for barrier processing.
+ * If the emptyPacketList is empty then overflow a full packet.
+ */
+MM_Packet *
+MM_WorkPacketsSATB::getBarrierPacket(MM_EnvironmentBase *env)
+{
+	MM_Packet *barrierPacket = NULL;
+
+	/* Check the free list */
+	barrierPacket = getPacket(env, &_emptyPacketList);
+	if(NULL != barrierPacket) {
+		return barrierPacket;
+	}
+
+	barrierPacket = getPacketByAdddingWorkPacketBlock(env);
+	if (NULL != barrierPacket) {
+		return barrierPacket;
+	}
+
+	/* Adding a block of packets failed so move on to overflow processing */
+	return getPacketByOverflowing(env);
+}
+
+/**
+ * Get a packet by overflowing a full packet or a barrierPacket
+ *
+ * @return pointer to a packet, or NULL if no packets could be overflowed
+ */
+MM_Packet *
+MM_WorkPacketsSATB::getPacketByOverflowing(MM_EnvironmentBase *env)
+{
+	MM_Packet *packet = NULL;
+
+	if (NULL != (packet = getPacket(env, &_fullPacketList))) {
+		/* Attempt to overflow a full mark packet.
+		 * Move the contents of the packet to overflow.
+		 */
+		emptyToOverflow(env, packet, OVERFLOW_TYPE_WORKSTACK);
+
+		omrthread_monitor_enter(_inputListMonitor);
+
+		/* Overflow was created - alert other threads that are waiting */
+		if(_inputListWaitCount > 0) {
+			omrthread_monitor_notify(_inputListMonitor);
+		}
+		omrthread_monitor_exit(_inputListMonitor);
+	} else {
+		/* Try again to get a packet off of the emptyPacketList as another thread
+		 * may have emptied a packet.
+		 */
+		packet = getPacket(env, &_emptyPacketList);
+	}
+
+	return packet;
+}
+
+/**
+ * Put the packet on the inUseBarrierPacket list.
+ * @param packet the packet to put on the list
+ */
+void
+MM_WorkPacketsSATB::putInUsePacket(MM_EnvironmentBase *env, MM_Packet *packet)
+{
+	_inUseBarrierPacketList.push(env, packet);
+}
+
+void
+MM_WorkPacketsSATB::removePacketFromInUseList(MM_EnvironmentBase *env, MM_Packet *packet)
+{
+	_inUseBarrierPacketList.remove(packet);
+}
+
+void
+MM_WorkPacketsSATB::putFullPacket(MM_EnvironmentBase *env, MM_Packet *packet)
+{
+	_fullPacketList.push(env, packet);
+}
+
+/**
+ * Move all of the packets from the inUse list to the processing list
+ * so they are available for processing.
+ */
+void
+MM_WorkPacketsSATB::moveInUseToNonEmpty(MM_EnvironmentBase *env)
+{
+	MM_Packet *head, *tail;
+	UDATA count;
+	bool didPop;
+
+	/* pop the inUseList */
+	didPop = _inUseBarrierPacketList.popList(&head, &tail, &count);
+	/* push the values from the inUseList onto the processingList */
+	if (didPop) {
+		_nonEmptyPacketList.pushList(head, tail, count);
+	}
+}
+
+/**
+ * Return the heap capactify factor used to determine how many packets to create
+ *
+ * @return the heap capactify factor
+ */
+float
+MM_WorkPacketsSATB::getHeapCapacityFactor(MM_EnvironmentBase *env)
+{
+	/* Increase the factor for staccato since more packets are required */
+	return (float)0.008;
+}
+
+/**
+ * Get an input packet from the current overflow handler
+ *
+ * @return a packet if one is found, NULL otherwise
+ */
+MM_Packet *
+MM_WorkPacketsSATB::getInputPacketFromOverflow(MM_EnvironmentBase *env)
+{
+	MM_Packet *overflowPacket;
+
+	/* Staccato spec cannot loop here as all packets may currently be on
+	 * the InUseBarrierList.  If all packets are on the InUseBarrierList then this
+	 * would turn into an infinite busy loop.
+	 * while(!_overflowHandler->isEmpty()) {
+	 */
+	if(!_overflowHandler->isEmpty()) {
+		if(NULL != (overflowPacket = getPacket(env, &_emptyPacketList))) {
+
+			_overflowHandler->fillFromOverflow(env, overflowPacket);
+
+			if(overflowPacket->isEmpty()) {
+				/* If we didn't end up filling the packet with anything, don't return it and try again */
+				putPacket(env, overflowPacket);
+			} else {
+				return overflowPacket;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+#endif /* OMR_GC_REALTIME */

--- a/gc/base/standard/WorkPacketsSATB.hpp
+++ b/gc/base/standard/WorkPacketsSATB.hpp
@@ -1,0 +1,77 @@
+
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(WORKPACKETSSATB_HPP_)
+#define WORKPACKETSSATB_HPP_
+
+#if defined(OMR_GC_REALTIME)
+
+#include "EnvironmentBase.hpp"
+#include "WorkPackets.hpp"
+
+class MM_IncrementalOverflow;
+
+class MM_WorkPacketsSATB : public MM_WorkPackets
+{
+protected:
+	MM_PacketList _inUseBarrierPacketList;  /**< List for packets currently being used for the remembered set*/
+
+public:
+	static MM_WorkPacketsSATB *newInstance(MM_EnvironmentBase *env);
+	
+	virtual bool initialize(MM_EnvironmentBase *env);
+	virtual void tearDown(MM_EnvironmentBase *env);
+	
+	MM_IncrementalOverflow *getIncrementalOverflowHandler() const { return (MM_IncrementalOverflow*)_overflowHandler; }
+	
+
+	MMINLINE bool inUsePacketsAvailable(MM_EnvironmentBase *env) { return !_inUseBarrierPacketList.isEmpty();}
+
+	virtual MM_Packet *getBarrierPacket(MM_EnvironmentBase *env);
+	virtual void putInUsePacket(MM_EnvironmentBase *env, MM_Packet *packet);
+	virtual void removePacketFromInUseList(MM_EnvironmentBase *env, MM_Packet *packet);
+	virtual void putFullPacket(MM_EnvironmentBase *env, MM_Packet *packet);
+
+	void moveInUseToNonEmpty(MM_EnvironmentBase *env);
+
+	/**
+	 * Create a MM_WorkPacketsRealtime object.
+	 */
+	MM_WorkPacketsSATB(MM_EnvironmentBase *env) :
+		MM_WorkPackets(env)
+		, _inUseBarrierPacketList(NULL)
+	{
+		_typeId = __FUNCTION__;
+	};
+
+protected:
+	virtual MM_WorkPacketOverflow *createOverflowHandler(MM_EnvironmentBase *env, MM_WorkPackets *workPackets);
+	virtual MM_Packet *getPacketByOverflowing(MM_EnvironmentBase *env);
+	virtual float getHeapCapacityFactor(MM_EnvironmentBase *env);
+	virtual MM_Packet *getInputPacketFromOverflow(MM_EnvironmentBase *env);
+
+private:
+};
+#endif /* OMR_GC_REALTIME */
+#endif /* WORKPACKETSSATB_HPP_ */
+

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -59,7 +59,9 @@ typedef enum MM_GCPolicy {
 #define OMR_GC_WRITE_BARRIER_TYPE_CARDMARK_INCREMENTAL 0x5
 #define OMR_GC_WRITE_BARRIER_TYPE_CARDMARK_AND_OLDCHECK 0x6
 #define OMR_GC_WRITE_BARRIER_TYPE_REALTIME 0x7
+#define OMR_GC_WRITE_BARRIER_TYPE_SATB 0x7
 #define OMR_GC_WRITE_BARRIER_TYPE_COUNT 0x8
+#define OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK 0x9
 
 #define OMR_GC_READ_BARRIER_TYPE_ILLEGAL 0x0
 #define OMR_GC_READ_BARRIER_TYPE_NONE 0x1
@@ -75,7 +77,9 @@ typedef enum MM_GCWriteBarrierType {
 	gc_modron_wrtbar_cardmark = OMR_GC_WRITE_BARRIER_TYPE_CARDMARK,
 	gc_modron_wrtbar_cardmark_incremental = OMR_GC_WRITE_BARRIER_TYPE_CARDMARK_INCREMENTAL,
 	gc_modron_wrtbar_cardmark_and_oldcheck = OMR_GC_WRITE_BARRIER_TYPE_CARDMARK_AND_OLDCHECK,
-	gc_modron_wrtbar_realtime = OMR_GC_WRITE_BARRIER_TYPE_REALTIME,
+	gc_modron_wrtbar_satb = OMR_GC_WRITE_BARRIER_TYPE_SATB,
+	gc_modron_wrtbar_satb_and_oldcheck = OMR_GC_WRITE_BARRIER_TYPE_SATB_AND_OLDCHECK,
+	gc_modron_wrtbar_realtime = OMR_GC_WRITE_BARRIER_TYPE_SATB,
 	gc_modron_wrtbar_count = OMR_GC_WRITE_BARRIER_TYPE_COUNT
 } MM_GCWriteBarrierType;
 


### PR DESCRIPTION
SATB barrier is used in metronome gc policy. We would like to enable it
for other gc polices under option -Xgc:snapshotAtTheBeginningBarrier.
These are initial changes to add the option and start decoupling barrier
code from metronome gc.

Signed-off-by: Evgenia Badyanova <evgeniab@ca.ibm.com>