### PR TITLE
Enable DDR on AIX

### DIFF
--- a/ddr/include/ddr/macros/MacroInfo.hpp
+++ b/ddr/include/ddr/macros/MacroInfo.hpp
@@ -35,7 +35,7 @@ private:
 	/* This could be a real type name, or a fake type name representing a
 	 * custom rule associated with a macro, or a name based off of a file.
 	 */
-	const string _typeName;
+	string _typeName;
 
 	/* A list of all macros associated with typeName */
 	set<pair<string, string> > _macros;

--- a/ddr/include/ddr/scanner/dwarf/AixSymbolTableParser.hpp
+++ b/ddr/include/ddr/scanner/dwarf/AixSymbolTableParser.hpp
@@ -50,7 +50,7 @@ const string BUILT_IN_TYPES_THAT_ARE_TYPEDEFS[NUM_BUILT_IN_TYPES + 1] = {"", "",
 "", "", "integer*1", "integer*2", "integer*4", "wchar", "", "", "logical*8", "integer*8", "", "", ""
 };
 const int BUILT_IN_TYPE_SIZES[NUM_BUILT_IN_TYPES +1 ] = {0, 32, 8, 16, 32, 8, 8, 16, 32, 32,
-32, 0, 32, 64, 128, 32, 32, 32, 64, PTR_SIZE, 8, 8, 16, 32, 32, 64, 128,
+32, 0, 32, 64, 128, 32, 8, 32, 64, PTR_SIZE, 8, 8, 16, 32, 32, 64, 128,
 8, 16, 32, 16, 64, 64, 64, 64, 64, 64, 64};
 
 const string START_OF_FILE[3] = {"debug", "3", "FILE"};

--- a/ddr/lib/ddr-scanner/Scanner.cpp
+++ b/ddr/lib/ddr-scanner/Scanner.cpp
@@ -79,7 +79,7 @@ Scanner::checkBlacklistedType(const string &name) const
 	 * with a letter or an underscore.
 	 */
 	if (!name.empty()) {
-		char start = name.front();
+		char start = name[0];
 
 		if (('_' == start)
 				|| (('A' <= start) && (start <= 'I'))

--- a/ddr/tools/getmacros
+++ b/ddr/tools/getmacros
@@ -38,7 +38,7 @@ include_guard_regex=".*_[Hh]([Pp][Pp])?_? *($|//|/\*)"
 # Create a list of all c, h, cpp and hpp files that have simple (non function) macros within them.
 ##
 get_all_annotated_files() {
-	local annotated_files=$(find ${scan_dir} -type f | grep -E -e '\.[ch](pp)?$' | sort | xargs -d '\n' grep -lE '@ddr_(namespace|options):')
+	local annotated_files=$(find ${scan_dir} -type f | grep -E -e '\.[ch](pp)?$' | sort | xargs -L1 grep -lE '@ddr_(namespace|options):')
 	echo "${annotated_files[@]}"
 }
 
@@ -269,7 +269,7 @@ main() {
 	date "+[%F %T] Scraping anotations from preprocessed code ..."
 	find ${scan_dir} -type f -name '*.i' \
 		| sort \
-		| xargs -d '\n' grep -hE -e '^@(DDRFILE|MACRO|TYPE)_' \
+		| xargs -L1 grep -hE -e '^@(DDRFILE|MACRO|TYPE)_' \
 		| awk "${dedup_filter[*]}" \
 		> ${macroList_file}
 

--- a/omrmakefiles/rules.aix.mk
+++ b/omrmakefiles/rules.aix.mk
@@ -128,11 +128,13 @@ endef
 define LINK_C_SHARED_COMMAND
 -$(RM) $@
 $(CCLINKSHARED) -o $@ $(OBJECTS) $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS)
+cp $@ $@.dbg
 endef
 
 define LINK_CXX_SHARED_COMMAND
 -$(RM) $@
 $(CXXLINKSHARED) -o $@ $(OBJECTS) $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS)
+cp $@ $@.dbg
 endef
 
 endif # ARTIFACT_TYPE contains "shared"


### PR DESCRIPTION
This pull request, in conjunction with the corresponding OpenJ9 pull request [#2309](https://github.com/eclipse/openj9/pull/2309), enables DDR on AIX, addressing eclipse/openj9#1769. This PR should be delivered before the
OpenJ9 PR.

The PR includes the following changes:

  * make _typeName field in MacroInfo non const since xlc on AIX fails to generate a copy assignment operator for const strings
  * replace string.front() with array access in Scanner since xlc does not support this method 
  * replace unsupported xargs command on AIX
  * initialize die sibling to NULL in AixSymbolTableParser.cpp
  * in AixSymbolTableParser.cpp, add missing DW_AT_data_member_location to fields parsed
  * fix missing digit in a number matching pattern in AixSymbolTableParser.cpp
  * fix AixSymbolTableParser incorrectly treating bool as 32bits instead of 8 bits
  * Create .dbg files for each of the shared libs on AIX. However, since objcopy does not seem to work properly on AIX, the debug libs are simply direct copies.
  * Generate file list on AIX even though AIX does not provide absolute paths. This allows the file blaclist to work on AIX.
  * Change the blacklist to only exclude top level types, in order to exclude the problematic type names that shows up on AIX. Compiling with this change on AIX and Linux both showed no apparent issues.

Testing was done on the OpenJ9 side. 
