### PR TITLE
Add .gitattributes for zos platform

### DIFF
--- a/.gitattributes.zos
+++ b/.gitattributes.zos
@@ -1,0 +1,22 @@
+# This .gitattributes file will cause all text files EXCEPT for
+# git's .gitattributes and .gitignore files to be encoded as EBCDIC
+# when cloned using git (from Rocket Software) on z/OS platform.
+#
+# Selected binary files will not be translated at all.
+#
+# The default for text files
+* git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# git's files (which MUST be ASCII)
+.gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+.gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+
+# omr files that need to be encoded as EBCDIC
+*.hdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+*.tdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+
+# Binary files
+*.jpg git-encoding=BINARY working-tree-encoding=BINARY
+*.png git-encoding=BINARY working-tree-encoding=BINARY
+*.gif git-encoding=BINARY working-tree-encoding=BINARY
+*.zip git-encoding=BINARY working-tree-encoding=BINARY

--- a/.gitattributes.zos
+++ b/.gitattributes.zos
@@ -1,6 +1,7 @@
-# This .gitattributes file will cause all text files EXCEPT for
-# git's .gitattributes and .gitignore files to be encoded as EBCDIC
-# when cloned using git (from Rocket Software) on z/OS platform.
+# This .gitattributes file will cause all text files to be converted 
+# to ISO8859-1 including git's .gitattributes and .gitignore files, 
+# execpt for those selected files as defiend below, when cloned using 
+# git (from Rocket Software) on z/OS platform.
 #
 # Selected binary files will not be translated at all.
 #

--- a/.gitattributes.zos
+++ b/.gitattributes.zos
@@ -8,10 +8,6 @@
 # The default for text files
 * git-encoding=iso8859-1 working-tree-encoding=iso8859-1
 
-# git's files (which MUST be ASCII)
-.gitattributes git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-.gitignore git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-
 # omr files that need to be encoded as EBCDIC
 *.hdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047
 *.tdf git-encoding=iso8859-1 working-tree-encoding=ibm-1047


### PR DESCRIPTION
This .gitattributes.zos file will not be picked up by the latest versions of git, so git will not attempt to encode/decode files and current clone/checkout will not be affected.

On a zos platform the openjdk extensions file ./closed/get_j9_source.sh will be modified to copy this .gitattributes.zos file to .git/info/attributes and the files refreshed. This will then encode/decode the files.

Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>