### PR TITLE
Add Evaluator for max and min opcodes in Z codegen

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -898,7 +898,7 @@ static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool i
    TR::Register *registerA = cg->gprClobberEvaluate(node->getFirstChild());
    TR::Register *registerB = cg->evaluate(node->getSecondChild());
    // Mask is 4 to pick b when a is Lower for max, 2 to pick b when a is higher for min
-   uint8_t mask = isMax ? 0x4 : 0x2;
+   const uint8_t mask = isMax ? 0x4 : 0x2;
 
    if (node->getOpCodeValue() == TR::imax || node->getOpCodeValue() == TR::imin)
       {

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -893,6 +893,28 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
    return targetRegister;
    }
 
+/**
+ *  \brief
+ *     Compares 2 numbers are returns the greater of the 2.
+ *     ONLY SUPPORTS imax, imin, lmax, lmin
+ *
+ *  \detail
+ *     Uses a load and conditional store to select the correct value.
+ *     ONLY SUPPORTS imax, imin, lmax, lmin
+ *
+ *  \param node
+ *     The node representing a call to max or min.
+ *
+ *  \param cg
+ *     The code generator used to generate the instructions.
+ *
+ *  \param isMax
+ *     Boolean representing the type of function, either a max or min call.
+ *
+ *  \return
+ *     A register containing the return value of the Java call. The return value
+ *     will be the greater or lesser of the 2 children for max and min functions, respectively.
+ */
 static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool isMax)
    {
    TR::Register *registerA = cg->gprClobberEvaluate(node->getFirstChild());

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -953,6 +953,10 @@ static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool i
          cursor->setEndInternalControlFlow();
          }
       }
+   else
+      {
+      TR_ASSERT_FATAL(node->getOpCodeValue(), "Opcode %s cannot be evaluated by maxMinHelper\n", node->getOpCode().getName());
+      }
 
    node->setRegister(registerA);
 


### PR DESCRIPTION
Add evaluator to handle max and min opcodes in Z codegen
The specific opcodes are imax, imin, lmax and lmin.

Signed-off-by: Daniel Hong <daniel.hong@live.com>