### PR TITLE
Check if the node has been transformed in constrainVCall

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -5311,10 +5311,12 @@ TR::Node *constrainCall(OMR::ValuePropagation *vp, TR::Node *node)
 
    vp->constrainRecognizedMethod(node);
 
-   // Return if the node is not a regular call (xcall/xcalli) anymore
-   if (!node->getOpCode().isCall() || node->getSymbol()->castToMethodSymbol()->isHelper())
+   // Return if the node is not a call anymore
+   if (!node->getOpCode().isCall())
       return node;
 
+   // Symbol might have been changed, get it from node again
+   symbol = node->getSymbol()->castToMethodSymbol();
    if ( symbol )
       {
 #ifdef J9_PROJECT_SPECIFIC
@@ -5729,8 +5731,8 @@ TR::Node *constrainAcall(OMR::ValuePropagation *vp, TR::Node *node)
    {
    constrainCall(vp, node);
 
-   // Return if the node is not a regular call (xcall/xcalli) anymore
-   if (!node->getOpCode().isCall() || node->getSymbol()->castToMethodSymbol()->isHelper())
+   // Return if the node is not a call anymore
+   if (!node->getOpCode().isCall())
       return node;
 
    // This node can be constrained by the return type of the method.

--- a/compiler/optimizer/VPHandlersCommon.cpp
+++ b/compiler/optimizer/VPHandlersCommon.cpp
@@ -332,6 +332,11 @@ static int cacheStringAppend(OMR::ValuePropagation *vp,TR::Node *node)
 TR::Node *constrainVcall(OMR::ValuePropagation *vp, TR::Node *node)
    {
    constrainCall(vp, node);
+
+   // Return if the node is not a call (xcall/xcalli) anymore
+   if (!node->getOpCode().isCall())
+      return node;
+
    // Look for System.arraycopy call. If the node is transformed into an arraycopy
    // re-process it.
    //


### PR DESCRIPTION
This change adds a safety check after the call to constrainCall.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>