### PR TITLE
Move uses of snprintf into cpp

### DIFF
--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -58,6 +58,9 @@
 #define TraceEnabled    (comp()->getOption(TR_TraceILGen))
 #define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
 
+#if defined (_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 
 // MethodBuilder is an IlBuilder object representing an entire method /
 // function, so it conceptually has an entry point (though multiple entry
@@ -409,6 +412,18 @@ OMR::MethodBuilder::AppendBuilder(TR::BytecodeBuilder *bb)
    if (_vmState)
       bb->propagateVMState(_vmState);
    addBytecodeBuilderToWorklist(bb);
+   }
+
+void
+OMR::MethodBuilder::DefineLine(const char *line)
+   {
+   snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%s", line);
+   }
+
+void
+OMR::MethodBuilder::DefineLine(int line)
+   {
+   snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%d", line);
    }
 
 void

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -28,10 +28,6 @@
 #include "ilgen/IlBuilder.hpp"
 #include "env/TypedAllocator.hpp"
 
-#if defined (_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 // Maximum length of _definingLine string (including null terminator)
 #define MAX_LINE_NUM_LEN 7
 
@@ -109,15 +105,8 @@ class MethodBuilder : public TR::IlBuilder
 
    void DefineFile(const char *file)                         { _definingFile = file; }
 
-   void DefineLine(const char *line)
-      {
-      snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%s", line);
-      }
-   void DefineLine(int line)
-      {
-      snprintf(_definingLine, MAX_LINE_NUM_LEN * sizeof(char), "%d", line);
-      }
-
+   void DefineLine(const char *line);
+   void DefineLine(int line);
    void DefineName(const char *name);
    void DefineParameter(const char *name, TR::IlType *type);
    void DefineArrayParameter(const char *name, TR::IlType *dt);


### PR DESCRIPTION
Having the uses of snprintf in the header forces the define for
snprintf to be in the header for Windows platforms. Moving limits
the scope of the definition into the cpp.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>