### PR TITLE
Add helper functions for ternary select node

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1173,6 +1173,10 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"traceInvariantArgumentPreexistence", "L\ttrace invariable argument preexistence",     TR::Options::traceOptimization, invariantArgumentPreexistence, 0, "P"},
    {"traceIsolatedSE",                  "L\ttrace isolated store elimination",             TR::Options::traceOptimization, isolatedStoreElimination, 0, "P"},
    {"traceIVTT",                        "L\ttrace IV Type transformation",                 TR::Options::traceOptimization, IVTypeTransformation, 0, "P"},
+#ifdef J9_PROJECT_SPECIFIC
+   {"traceJProfilingBlock",             "L\ttrace generation of block frequency counters",               TR::Options::traceOptimization, jProfilingBlock, 0, "P"},
+   {"traceJProfilingValue",             "L\ttrace insertion of jProfiling trees for value profiling",    TR::Options::traceOptimization, jProfilingValue, 0, "P"},
+#endif
    {"traceKnownObjectGraph",            "L\ttrace the relationships between objects in the known-object table", SET_OPTION_BIT(TR_TraceKnownObjectGraph), "P" },
    {"traceLabelTargetNOPs",             "L\ttrace inserting of NOPs before label targets", SET_OPTION_BIT(TR_TraceLabelTargetNOPs), "F"},
    {"traceLastOpt",                     "L\textra tracing for the opt corresponding to lastOptIndex; usually used with traceFull", SET_OPTION_BIT(TR_TraceLastOpt), "F"},

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -423,6 +423,25 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareGreaterOrEquals[] =
    TR::BadILOp,   // TR::Aggregate
    };
 
+TR::ILOpCodes OMR::IL::opCodesForTernarySelect [] =
+   {
+   TR::BadILOp,  // NoType
+   TR::bternary, // Int8
+   TR::sternary, // Int16
+   TR::iternary, // Int32
+   TR::lternary, // Int64
+   TR::fternary, // Float
+   TR::dternary, // Double
+   TR::aternary, // Address
+   TR::BadILOp,   // TR::VectorInt8
+   TR::BadILOp,   // TR::VectorInt16
+   TR::BadILOp,   // TR::VectorInt32
+   TR::BadILOp,   // TR::VectorInt64
+   TR::BadILOp,   // TR::VectorFloat
+   TR::BadILOp,   // TR::VectorDouble
+   TR::BadILOp,   // TR::Aggregate
+   };
+
 static_assert(TR::NumOMRTypes == (sizeof(OMR::IL::opCodesForConst) / sizeof(OMR::IL::opCodesForConst[0])),
               "OMR::IL::opCodesForConst is not the correct size");
 
@@ -542,6 +561,13 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
    return TR::BadILOp;
    }
 
+TR::ILOpCodes
+OMR::IL::opCodeForTernarySelect(TR::DataType dt)
+   {
+   TR_ASSERT(dt < TR::NumOMRTypes, "unexpcted opcode");
+
+   return OMR::IL::opCodesForTernarySelect[dt];
+   }
 
 TR::ILOpCodes
 OMR::IL::opCodeForConst(TR::DataType dt)

--- a/compiler/il/OMRIL.hpp
+++ b/compiler/il/OMRIL.hpp
@@ -64,10 +64,12 @@ class OMR_EXTENSIBLE IL
    static TR::ILOpCodes opCodesForCompareGreaterOrEquals[];
    static TR::ILOpCodes opCodesForIfCompareGreaterThan[];
    static TR::ILOpCodes opCodesForIfCompareGreaterOrEquals[];
+   static TR::ILOpCodes opCodesForTernarySelect[];
 
    TR::ILOpCodes opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode);
    TR::ILOpCodes opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode);
 
+   TR::ILOpCodes opCodeForTernarySelect(TR::DataType dt);
    TR::ILOpCodes opCodeForConst(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectLoad(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectStore(TR::DataType dt);


### PR DESCRIPTION
This PR involved two changes. 
1. Add helper functions to generate ternary select nodes
2. Add tracing options for jProfiling (J9 specific optimization)