### PR TITLE
Add options for jProfiling

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -889,6 +889,10 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
 
    {"jitMethodEntryAlignmentBoundary=",      "C<nnn>\tAlignment boundary (in bytes) for JIT method entry",
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_jitMethodEntryAlignmentBoundary), 0, "F%d"},
+   {"jProfilingLoopRecompThreshold=",      "C<nnn>\tLoop recompilation threshold for jProfiling",
+        TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_jProfilingLoopRecompThreshold), 0, "F%d"},
+   {"jProfilingMethodRecompThreshold=",      "C<nnn>\tMethod invocations for jProfiling body",
+        TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_jProfilingMethodRecompThreshold), 0, "F%d"},
    {"keepBCDWidening",       "O\tstress testing option -- do not remove widening BCD operations", SET_OPTION_BIT(TR_KeepBCDWidening), "F" },
 
    {"labelTargetNOPLimit=", "C<nnn>\t(labelTargetAddress&0xff) > _labelTargetNOPLimit are padded out with NOPs until the next 256 byte boundary",
@@ -2572,6 +2576,8 @@ OMR::Options::jitPreProcess()
 #else
    _jitMethodEntryAlignmentBoundary = 0;
 #endif
+   _jProfilingMethodRecompThreshold = 4000;
+   _jProfilingLoopRecompThreshold = 2000;
    _blockShufflingSequence = "S";
    _delayCompile = 0;
    _largeNumberOfLoops = 6500;

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1944,6 +1944,12 @@ public:
 
    int32_t getJitMethodEntryAlignmentBoundary(TR::CodeGenerator *cg);
    void setJitMethodEntryAlignmentBoundary(int32_t boundary) { _jitMethodEntryAlignmentBoundary = boundary; }
+/**   \brief Returns a threshold on the profiling method invocations to trip recompilation
+ */
+   int32_t getJProfilingMethodRecompThreshold() { return _jProfilingMethodRecompThreshold; }
+/**   \brief Returns a base threshold for loop to trip recompilation
+ */
+   int32_t getJProfilingLoopRecompThreshold() { return _jProfilingLoopRecompThreshold; }
 
    inline static float getMinProfiledCheckcastFrequency() { return _minProfiledCheckcastFrequency/((float)100.0); }
    static bool isQuickstartDetected() { return _quickstartDetected; }
@@ -2411,6 +2417,8 @@ private:
    bool                        _isAOTCompile;
 
    int32_t                     _jitMethodEntryAlignmentBoundary; /* Alignment boundary for JIT method entry */
+   int32_t                     _jProfilingMethodRecompThreshold;
+   int32_t                     _jProfilingLoopRecompThreshold;
    char *                      _blockShufflingSequence;
    int32_t                     _randomSeed;
    TR_MCTLogs *                _logListForOtherCompThreads;


### PR DESCRIPTION
This commits adds following options.

1. jProfilingLoopRecompThreshold : To specify base threshold for loop which will be adjusted as per loop depth and will be compared against raw loop count.
2. jProfilingMethodRecompThrehold : To specify number of method invocations required to trip recompilation of profiling body.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>