### PR TITLE
Optimized Simplifier related to abs/neg

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -74,8 +74,7 @@ TR::Node * bnegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
 TR::Node * snegSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * constSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * lconstSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * iabsSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * labsSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
+TR::Node * ilfdabsSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * lshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * bshlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -117,11 +117,10 @@
    bnegSimplifier,          // TR::bneg
    snegSimplifier,          // TR::sneg
 
-
-   iabsSimplifier,           // TR::iabs
-   labsSimplifier,           // TR::labs
-   dftSimplifier,            // TR::fabs   todo
-   dftSimplifier,            // TR::dabs   todo
+   ilfdabsSimplifier,       // TR::iabs
+   ilfdabsSimplifier,       // TR::labs
+   ilfdabsSimplifier,       // TR::fabs
+   ilfdabsSimplifier,       // TR::dabs
 
    ishlSimplifier,          // TR::ishl
    lshlSimplifier,          // TR::lshl

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(comptest
 	ILValidatorTest.cpp
 	ArithmeticTest.cpp
 	ShiftAndRotateTest.cpp
+	SimplifierFoldAbsNegTest.cpp
 	SimplifierFoldAndTest.cpp
 	IfxcmpgeReductionTest.cpp
 	VectorTest.cpp

--- a/fvtest/compilertriltest/SimplifierFoldAbsNegTest.cpp
+++ b/fvtest/compilertriltest/SimplifierFoldAbsNegTest.cpp
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <cmath>
+#include "JitTest.hpp"
+#include "default_compiler.hpp"
+#include "il/Node.hpp"
+#include "infra/ILWalk.hpp"
+#include "ras/IlVerifier.hpp"
+#include "ras/IlVerifierHelpers.hpp"
+#include "SharedVerifiers.hpp" //for NoAndIlVerifier
+
+template <typename T> char* prefixForType();
+template <> char* prefixForType<int32_t>() { return "i"; }
+template <> char* prefixForType<int64_t>() { return "l"; }
+template <> char* prefixForType<  float>() { return "f"; }
+template <> char* prefixForType< double>() { return "d"; }
+
+template <typename T> char* nameForType();
+template <> char* nameForType<int32_t>() { return "Int32" ; }
+template <> char* nameForType<int64_t>() { return "Int64" ; }
+template <> char* nameForType<  float>() { return "Float" ; }
+template <> char* nameForType< double>() { return "Double"; }
+
+std::vector<int32_t> iTestData = { 0, 1, 2, -1, -2, 99999, -99999, std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::min() };
+std::vector<int64_t> lTestData = { 0, 1, 2, -1, -2, 99999, -99999, std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::min() };
+std::vector<  float> fTestData = { 0, 1, 2, -1, -2, 3.14, -3.14, std::numeric_limits<float>::min(), std::numeric_limits<float>::min() };
+std::vector< double> dTestData = { 0, 1, 2, -1, -2, 3.14, -3.14, std::numeric_limits<double>::min(), std::numeric_limits<double>::min() };
+
+template <typename T> std::vector<T> dataForType();
+template <> std::vector<int32_t> dataForType<int32_t>() { return iTestData; }
+template <> std::vector<int64_t> dataForType<int64_t>() { return lTestData; }
+template <> std::vector<  float> dataForType<  float>() { return fTestData; }
+template <> std::vector< double> dataForType< double>() { return dTestData; }
+
+class SimplifierFoldAbsNegTestIlVerifierBase : public TR::IlVerifier
+   {
+   public:
+   int32_t verify(TR::ResolvedMethodSymbol *sym)
+      {
+      for(TR::PreorderNodeIterator iter(sym->getFirstTreeTop(), sym->comp()); iter.currentTree(); ++iter)
+         {
+         int32_t rtn = verifyNode(iter.currentNode());
+         if(rtn)
+            return rtn;
+         }
+      return 0;
+      }
+   protected:
+      virtual int32_t verifyNode(TR::Node *node) = 0;
+   };
+
+/**
+ * Test Fixture for SimplifierFoldAbsNegTest that
+ * selects only the relevant opts for the test case
+ */
+template <typename T>
+class SimplifierFoldAbsNegTest : public TRTest::JitOptTest
+   {
+
+   public:
+   SimplifierFoldAbsNegTest()
+      {
+      /* Add an optimization.
+       * You can add as many optimizations as you need, in order,
+       * using `addOptimization`, or add a group using
+       * `addOptimizations(omrCompilationStrategies[warm])`.
+       * This could also be done in test cases themselves.
+       */
+      addOptimization(OMR::treeSimplification);
+      }
+
+   };
+
+typedef ::testing::Types<int32_t, int64_t, float, double> Types;
+TYPED_TEST_CASE(SimplifierFoldAbsNegTest, Types);
+
+
+class NoAbsAbsIlVerifier : public SimplifierFoldAbsNegTestIlVerifierBase
+   {
+   protected:
+   virtual int32_t verifyNode(TR::Node *node)
+      {
+      return node->getOpCode().isAbs() && node->getChild(0)->getOpCode().isAbs();
+      }
+   };
+
+/*
+ * method(T parameter)
+ *   return abs(abs(parameter));
+ */
+TYPED_TEST(SimplifierFoldAbsNegTest, FoldAbsAbs) {
+    char inputTrees[256];
+    std::snprintf(inputTrees, sizeof(inputTrees), "(method return=%s args=[%s]    "
+                                                  " (block                        "
+                                                  "  (%sreturn                    "
+                                                  "   (%sabs                      "
+                                                  "    (%sabs (%sload parm=0))))))",
+                  nameForType<TypeParam>(), nameForType<TypeParam>(),
+                  prefixForType<TypeParam>(), prefixForType<TypeParam>(), prefixForType<TypeParam>(), prefixForType<TypeParam>());
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+    NoAbsAbsIlVerifier verifier;
+
+    ASSERT_EQ(0, compiler.compileWithVerifier(&verifier)) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam(*)(TypeParam)>();
+
+    // Invoke the compiled method, and assert the output is correct.
+    for (auto test : dataForType<TypeParam>()) {
+        EXPECT_EQ(std::abs(test), entry_point(test));
+    }
+}
+
+
+class NoAbsNegIlVerifier : public SimplifierFoldAbsNegTestIlVerifierBase
+   {
+   protected:
+   virtual int32_t verifyNode(TR::Node *node)
+      {
+      return node->getOpCode().isAbs() && node->getChild(0)->getOpCode().isNeg();
+      }
+   };
+
+/*
+ * method(T parameter)
+ *   return abs(neg(parameter));
+ */
+TYPED_TEST(SimplifierFoldAbsNegTest, FoldAbsNeg) {
+    char inputTrees[256];
+    std::snprintf(inputTrees, sizeof(inputTrees), "(method return=%s args=[%s]    "
+                                                  " (block                        "
+                                                  "  (%sreturn                    "
+                                                  "   (%sabs                      "
+                                                  "    (%sneg (%sload parm=0))))))",
+                  nameForType<TypeParam>(), nameForType<TypeParam>(),
+                  prefixForType<TypeParam>(), prefixForType<TypeParam>(), prefixForType<TypeParam>(), prefixForType<TypeParam>());
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+    NoAbsNegIlVerifier verifier;
+
+    ASSERT_EQ(0, compiler.compileWithVerifier(&verifier)) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam(*)(TypeParam)>();
+
+    // Invoke the compiled method, and assert the output is correct.
+    for (auto test : dataForType<TypeParam>()) {
+        EXPECT_EQ(std::abs(test), entry_point(test));
+    }
+}
+
+
+class NoNegNegIlVerifier : public SimplifierFoldAbsNegTestIlVerifierBase
+   {
+   protected:
+   virtual int32_t verifyNode(TR::Node *node)
+      {
+      return node->getOpCode().isNeg() && node->getChild(0)->getOpCode().isNeg();
+      }
+   };
+
+/*
+ * method(T parameter)
+ *   return neg(neg(parameter));
+ */
+TYPED_TEST(SimplifierFoldAbsNegTest, FoldNegNeg) {
+    char inputTrees[256];
+    std::snprintf(inputTrees, sizeof(inputTrees), "(method return=%s args=[%s]    "
+                                                  " (block                        "
+                                                  "  (%sreturn                    "
+                                                  "   (%sneg                      "
+                                                  "    (%sneg (%sload parm=0))))))",
+                  nameForType<TypeParam>(), nameForType<TypeParam>(),
+                  prefixForType<TypeParam>(), prefixForType<TypeParam>(), prefixForType<TypeParam>(), prefixForType<TypeParam>());
+
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+    NoNegNegIlVerifier verifier;
+
+    ASSERT_EQ(0, compiler.compileWithVerifier(&verifier)) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<TypeParam(*)(TypeParam)>();
+
+    // Invoke the compiled method, and assert the output is correct.
+    for (auto test : dataForType<TypeParam>()) {
+        EXPECT_EQ(test, entry_point(test));
+    }
+}


### PR DESCRIPTION
Simplified following patterns:
```
1.
node foo                         node foo
   [ilfd]abs                  =>    non-negative node bar
      non-negative node bar
node foo                         node foo
   [ilfd]abs                  =>    [ilfd]neg
      negative node bar                negative node bar
 * Note that transformation of [fd]abs is default off *
2.
node foo                         node foo
   [ilfd]abs                  =>    [ilfd]abs
      [ilfd]abs                        node bar
         node bar
3.
node foo                         node foo
   [ilfd]abs                  =>    [ilfd]abs
      [ilfd]neg                        node bar
         node bar
4.
node foo                         node foo
   dneg                       =>    node bar
      dneg
         node bar
```
Signed-off-by: Victor Ding <dvictor@ca.ibm.com>