### PR TITLE
z/TPF minor refactoring of physical memory calculation

### DIFF
--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -511,4 +511,8 @@ typedef enum {
 #define METRONOME_DEFAULT_TIME_WINDOW_MICRO 60000
 #endif /* OMR_GC_REALTIME */
 
+#if defined(J9ZTPF)
+#define ZTPF_MEMORY_RESERVE_RATIO .8
+#endif /* defined(J9ZTPF) */
+
 #endif /* OMRGCCONSTS_H_ */

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -46,6 +46,9 @@
 #if defined(OMR_OPT_CUDA)
 #include "omrcuda.h"
 #endif /* OMR_OPT_CUDA */
+#if defined(OMRZTPF)
+#include "omrgcconsts.h"
+#endif /* defined(OMRZTPF) */
 
 #if (defined(LINUX) || defined(RS6000) || defined (OSX))
 #include <unistd.h>


### PR DESCRIPTION
Modified z/TPF physical memory determination to better match
existing omr interfaces.  The update takes advantage of the
recently added omrsysinfo_get_addressable_physical_memory function.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>