### PR TITLE
Disable optimizations for max and min on ARM

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -228,6 +228,9 @@ OMR::ARM::CodeGenerator::CodeGenerator()
       {
       self()->setSupportsProfiledInlining();
       }
+
+   // Disable optimizations for max min by default on arm
+   self()->comp()->setOption(TR_DisableMaxMinOptimization);
    }
 
 

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -424,7 +424,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableMarkingOfHotFields",          "O\tdisable marking of Hot Fields",                  SET_OPTION_BIT(TR_DisableMarkingOfHotFields), "F"},
    {"disableMarshallingIntrinsics",       "O\tDisable packed decimal to binary marshalling and un-marshalling optimization. They will not be inlined.", SET_OPTION_BIT(TR_DisableMarshallingIntrinsics), "F"},
    {"disableMaskVFTPointers",             "O\tdisable masking of VFT Pointers",                SET_OPTION_BIT(TR_DisableMaskVFTPointers), "F"},
-   {"disableMaxMinOptimization",          "O\tdisable masking of VFT Pointers",                SET_OPTION_BIT(TR_DisableMaxMinOptimization), "F"},
+   {"disableMaxMinOptimization",          "O\tdisable max and min optimizations",                 SET_OPTION_BIT(TR_DisableMaxMinOptimization), "F"},
    {"disableMccFreeBlockRecycling",       "O\tdo not reuse code cache freed blocks",           SET_OPTION_BIT(TR_DisableFreeCodeCacheBlockRecycling), "F", NOT_IN_SUBSET},
    {"disableMCSBypass",                   "O\tdisable allocating JNI global references to skip some levels of indirection when accessing a MutableCallSite's target MethodHandle in jitted code", SET_OPTION_BIT(TR_DisableMCSBypass), "F"},
    {"disableMergeNew",                    "O\tdisable merge new",                              SET_OPTION_BIT(TR_DisableMergeNew), "F"},


### PR DESCRIPTION
Set the option to disable max and min optimizations to
true by default on ARM.

Signed-off-by: Daniel Hong <daniel.hong@live.com>