### PR TITLE
Fix slow allocation of memory

### DIFF
--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -344,8 +344,16 @@ findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS sta
 	BOOLEAN dataCorrupt = FALSE;
 	BOOLEAN matchFound = FALSE;
 
+	/*
+	 * The caller provides start and end addresses that constrain a non-null
+	 * address that can be returned by this function. Internally, however,
+	 * this function operates on ranges which are inclusive of the space
+	 * requested by the caller: the allowed range must be initialized taking
+	 * this difference into account by adding the requested block size to the
+	 * end address.
+	 */
 	AddressRange allowedRange;
-	addressRange_Init(&allowedRange, start, end);
+	addressRange_Init(&allowedRange, start, end + byteAmount);
 
 	AddressRange lastAvailableRange;
 	addressRange_Init(&lastAvailableRange, NULL, NULL);

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -299,7 +299,7 @@ addressRange_IsValid(AddressRange *range)
 static uintptr_t
 addressRange_Width(AddressRange *range)
 {
-	Assert_PRT_true(TRUE == addressRange_IsValid(range));
+	Assert_PRT_true(addressRange_IsValid(range));
 	return range->end - range->start;
 }
 
@@ -386,12 +386,12 @@ findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS sta
 					lineBuf[lineCursor - 1] = '\0';
 				}
 
-				if (TRUE == lineEnd) { /* proc-line-data */
+				if (lineEnd) { /* proc-line-data */
 					AddressRange currentMmapRange;
 					addressRange_Init(&currentMmapRange, NULL, NULL);
 					Assert_PRT_true(lineBuf[lineCursor - 1] == '\0');
 
-					if (TRUE == gotEOF) {
+					if (gotEOF) {
 						/* We reach the end of the file. */
 						addressRange_Init(&currentMmapRange, (ADDRESS)(uintptr_t)(-1), (ADDRESS)(uintptr_t)(-1));
 					} else {
@@ -444,7 +444,7 @@ findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS sta
 
 						/* check if the free block has intersection with the allowed range */
 						haveIntersect = addressRange_Intersect(&allowedRange, &freeRange, &intersectAvailable);
-						if (TRUE == haveIntersect) {
+						if (haveIntersect) {
 							uintptr_t intersectSize = addressRange_Width(&intersectAvailable);
 #if defined(OMRVMEM_DEBUG)
 							printf("intersection %p-%p\n", intersectAvailable.start, intersectAvailable.end);
@@ -463,11 +463,11 @@ findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS sta
 				} /* end proc-line-data */
 			} while (readCursor < bytesRead); /* end proc-chars-loop */
 
-			if ((FALSE == reverse) && (TRUE == matchFound)) {
+			if ((FALSE == reverse) && matchFound) {
 				break;
 			}
 
-			if (TRUE == (gotEOF | dataCorrupt)) {
+			if (gotEOF || dataCorrupt) {
 				break;
 			}
 		} /* end read-file-loop */
@@ -476,11 +476,11 @@ findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS sta
 		dataCorrupt = TRUE;
 	}
 
-	if (TRUE == dataCorrupt) {
+	if (dataCorrupt) {
 		return NULL;
 	}
 
-	if (TRUE == matchFound) {
+	if (matchFound) {
 		if (FALSE == reverse) {
 			return lastAvailableRange.start;
 		} else {
@@ -1137,7 +1137,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 			}
 		}
 		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
-			((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize)))
+			(codeCacheConsolidationEnabled && (SIXTEEN_M == validPageSize)))
 #endif /* defined(OMR_ENV_DATA64) */
 #endif /* defined(LINUXPPC) */
 		{

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -87,11 +87,11 @@ typedef struct AddressRange {
 	ADDRESS end;
 } AddressRange;
 
-void addressRange_Init(AddressRange *range, ADDRESS start, ADDRESS end);
-BOOLEAN addressRange_Intersect(AddressRange *a, AddressRange *b, AddressRange *result);
-BOOLEAN addressRange_IsValid(AddressRange *range);
-uintptr_t addressRange_Width(AddressRange *range);
-ADDRESS findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS start, ADDRESS end, uintptr_t byteAmount, BOOLEAN reverse);
+static void addressRange_Init(AddressRange *range, ADDRESS start, ADDRESS end);
+static BOOLEAN addressRange_Intersect(AddressRange *a, AddressRange *b, AddressRange *result);
+static BOOLEAN addressRange_IsValid(AddressRange *range);
+static uintptr_t addressRange_Width(AddressRange *range);
+static ADDRESS findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS start, ADDRESS end, uintptr_t byteAmount, BOOLEAN reverse);
 
 static void *getMemoryInRangeForLargePages(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, key_t addressKey, OMRMemCategory *category, uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t pageSize, uintptr_t mode);
 static void *getMemoryInRangeForDefaultPages(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, OMRMemCategory *category, uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode);
@@ -100,13 +100,13 @@ static BOOLEAN isStrictAndOutOfRange(void *memoryPointer, void *startAddress, vo
 static BOOLEAN rangeIsValid(struct J9PortVmemIdentifier *identifier, void *address, uintptr_t byteAmount);
 static void *reserveLargePages(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, OMRMemCategory *category, uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t pageSize, uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode);
 
-void *default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
+static void *default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
 #if defined(OMR_PORT_NUMA_SUPPORT)
 static void port_numa_interleave_memory(struct OMRPortLibrary *portLibrary, void *start, uintptr_t size);
 #endif /* OMR_PORT_NUMA_SUPPORT */
-void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category);
+static void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category);
 static uintptr_t get_hugepages_info(struct OMRPortLibrary *portLibrary, vmem_hugepage_info_t *page_info);
-int get_protectionBits(uintptr_t mode);
+static int get_protectionBits(uintptr_t mode);
 
 #if defined(OMR_PORT_NUMA_SUPPORT)
 /*
@@ -248,7 +248,7 @@ initializeNumaGlobals(struct OMRPortLibrary *portLibrary)
  * @param void* 		start	[in] 	The start address of the range
  * @param void*  		end		[in]	The end address of the range
  */
-void
+static void
 addressRange_Init(AddressRange *range, ADDRESS start, ADDRESS end)
 {
 	range->start = start;
@@ -264,7 +264,7 @@ addressRange_Init(AddressRange *range, ADDRESS start, ADDRESS end)
  *
  * Returns TRUE if they have intersection.
  */
-BOOLEAN
+static BOOLEAN
 addressRange_Intersect(AddressRange *a, AddressRange *b, AddressRange *result)
 {
 	result->start = a->start > b->start ? a->start : b->start;
@@ -281,7 +281,7 @@ addressRange_Intersect(AddressRange *a, AddressRange *b, AddressRange *result)
  *
  * Returns TRUE if range's start < end.
  */
-BOOLEAN
+static BOOLEAN
 addressRange_IsValid(AddressRange *range)
 {
 	return (range->end > range->start) ? TRUE : FALSE;
@@ -296,7 +296,7 @@ addressRange_IsValid(AddressRange *range)
  * Caller should make sure the input parameter 'range' is valid,
  * otherwise, unexpected value may be returned.
  */
-uintptr_t
+static uintptr_t
 addressRange_Width(AddressRange *range)
 {
 	Assert_PRT_true(TRUE == addressRange_IsValid(range));
@@ -317,7 +317,7 @@ addressRange_Width(AddressRange *range)
  *
  * returns the address available.
  */
-ADDRESS
+static ADDRESS
 findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary, ADDRESS start, ADDRESS end, uintptr_t byteAmount, BOOLEAN reverse)
 {
 	BOOLEAN dataCorrupt = FALSE;
@@ -907,7 +907,8 @@ get_hugepages_info(struct OMRPortLibrary *portLibrary, vmem_hugepage_info_t *pag
 
 	return 1;
 }
-void *
+
+static void *
 default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	/* This function is cloned in J9SourceUnixJ9VMem (omrvmem_reserve_memory).
@@ -984,7 +985,7 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
  * @param[in] allocator Constant describing how the virtual memory was allocated.
  * @param[in] category Memory allocation category
  */
-void
+static void
 update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category)
 {
 	identifier->address = address;
@@ -997,7 +998,7 @@ update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *han
 	identifier->category = category;
 }
 
-int
+static int
 get_protectionBits(uintptr_t mode)
 {
 	int protectionFlags = 0;

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,6 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
-
 
 #include "omrport.h"
 #include "omrportpriv.h"
@@ -350,7 +349,7 @@ addressRange_Width(AddressRange* range)
  * @param ADDRESS 		start			[in] The start address allowed, see also @param end
  * @param ADDRESS 		end				[in] The end address allowed, see also @param start.
  * 											 The returned memory address should be within the range defined by the @param start and the @param end.
- * @param uintptr_t 		byteAmount		[in] The block size required.
+ * @param uintptr_t 	byteAmount		[in] The block size required.
  * @param BOOLEAN 		reverse			[in] Returns the first available memory block when this param equals FALSE, returns the last available memory block when this param equals TRUE
  *
  * returns the address available.
@@ -362,8 +361,16 @@ findAvailableMemoryBlockNoMalloc(struct OMRPortLibrary *portLibrary,
 	BOOLEAN dataCorrupt = FALSE;
 	BOOLEAN matchFound = FALSE;
 
+	/*
+	 * The caller provides start and end addresses that constrain a non-null
+	 * address that can be returned by this function. Internally, however,
+	 * this function operates on ranges which are inclusive of the space
+	 * requested by the caller: the allowed range must be initialized taking
+	 * this difference into account by adding the requested block size to the
+	 * end address.
+	 */
 	AddressRange allowedRange;
-	addressRange_Init(&allowedRange, start, end);
+	addressRange_Init(&allowedRange, start, end + byteAmount);
 
 	AddressRange lastAvailableRange;
 	addressRange_Init(&lastAvailableRange, NULL, NULL);


### PR DESCRIPTION
Some systems (e.g. Windows Subsystem for Linux) ignore the requested allocation address and repeatedly return the same address. When this happens we terminate the loop early to avoid excessive delays.

More recently, we've seen slow startup on z Linux as well. This change helps there too.

This is marked as 'WIP' because we need to understand what, if any, detrimental effects this has.