### PR TITLE
Don't build useDef info in LoadExtensions at warm

### DIFF
--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -62,7 +62,7 @@ TR_LoadExtensions::TR_LoadExtensions(TR::OptimizationManager *manager)
 
 int32_t TR_LoadExtensions::perform()
    {
-   if (comp()->getOptLevel() >= warm && !optimizer()->cantBuildGlobalsUseDefInfo())
+   if (comp()->getOptLevel() >= hot && !optimizer()->cantBuildGlobalsUseDefInfo())
       {
       if (!comp()->getFlowGraph()->getStructure())
          {


### PR DESCRIPTION
Building useDef info inside LoadExtensions is an expensive operation and doesn't yield a performance benefit for methods compiled at the warm optimization level. This change will now allow useDef info to only be built by load extensions at hot or higher optimization levels.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>