### PR TITLE
AArch64: Initial version of ARM64BinaryEncoding.cpp

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "codegen/ARM64ConditionCode.hpp"
+#include "codegen/ARM64Instruction.hpp"
+#include "codegen/CodeGenerator.hpp"
+
+uint8_t *OMR::ARM64::Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+int32_t OMR::ARM64::Instruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   return currentEstimate + self()->getEstimatedBinaryLength();
+   }
+
+uint8_t *TR::ARM64ImmInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   *(int32_t *)cursor = (int32_t)getSourceImmediate();
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64LabelInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   TR::LabelSymbol *label = getLabelSymbol();
+
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return cursor;
+   }
+
+int32_t TR::ARM64LabelInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return currentEstimate + getEstimatedBinaryLength();
+   }
+
+uint8_t *TR::ARM64ConditionalBranchInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   TR::LabelSymbol *label = getLabelSymbol();
+
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return cursor;
+   }
+
+int32_t TR::ARM64ConditionalBranchInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   TR_ASSERT(false, "Not implemented yet.");
+
+   return currentEstimate + getEstimatedBinaryLength();
+   }
+
+uint8_t *TR::ARM64AdminInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+
+   TR_ASSERT(false, "Not implemented yet.");
+
+   setBinaryLength(0);
+   setBinaryEncoding(instructionStart);
+
+   return instructionStart;
+   }
+
+int32_t TR::ARM64AdminInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(0);
+   return currentEstimate;
+   }
+
+uint8_t *TR::ARM64Trg1Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1ImmInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertImmediateField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1Src1Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1Src1ImmInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertImmediateField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1Src2Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertSource2Register(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1MemInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   cursor = getMemoryReference()->generateBinaryEncoding(this, cursor, cg());
+   setBinaryLength(cursor - instructionStart);
+   setBinaryEncoding(instructionStart);
+   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
+   return cursor;
+   }
+
+int32_t TR::ARM64Trg1MemInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(*cg()));
+   return currentEstimate + getEstimatedBinaryLength();
+   }
+
+uint8_t *TR::ARM64MemInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   cursor = getMemoryReference()->generateBinaryEncoding(this, cursor, cg());
+   setBinaryLength(cursor - instructionStart);
+   setBinaryEncoding(instructionStart);
+   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
+   return cursor;
+   }
+
+int32_t TR::ARM64MemInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(*cg()));
+   return(currentEstimate + getEstimatedBinaryLength());
+   }
+
+uint8_t *TR::ARM64MemSrc1Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertSource1Register(toARM64Cursor(cursor));
+   cursor = getMemoryReference()->generateBinaryEncoding(this, cursor, cg());
+   setBinaryLength(cursor - instructionStart);
+   setBinaryEncoding(instructionStart);
+   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
+   return cursor;
+   }
+
+int32_t TR::ARM64MemSrc1Instruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(*cg()));
+   return(currentEstimate + getEstimatedBinaryLength());
+   }

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -306,6 +306,13 @@ class ARM64LabelInstruction : public TR::Instruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
 class ARM64DepLabelInstruction : public ARM64LabelInstruction
@@ -468,6 +475,13 @@ class ARM64ConditionalBranchInstruction : public ARM64LabelInstruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
 class ARM64DepConditionalBranchInstruction : public ARM64ConditionalBranchInstruction
@@ -602,6 +616,13 @@ class ARM64AdminInstruction : public TR::Instruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
 class ARM64Trg1Instruction : public TR::Instruction
@@ -877,6 +898,15 @@ class ARM64Trg1Src1ImmInstruction : public ARM64Trg1Src1Instruction
    uint32_t setSourceImmediate(uint32_t si) {return (_source1Immediate = si);}
 
    /**
+    * @brief Sets immediate field in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertImmediateField(uint32_t *instruction)
+      {
+      *instruction |= ((_source1Immediate & 0xfff) << 10); /* imm12 */
+      }
+
+   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */
@@ -1053,6 +1083,13 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
 class ARM64MemInstruction : public TR::Instruction
@@ -1128,6 +1165,12 @@ class ARM64MemInstruction : public TR::Instruction
     */
    virtual uint8_t *generateBinaryEncoding();
 
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
 class ARM64MemSrc1Instruction : public ARM64MemInstruction
@@ -1203,6 +1246,13 @@ class ARM64MemSrc1Instruction : public ARM64MemInstruction
     * @return instruction cursor
     */
    virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
 } // TR

--- a/compiler/aarch64/codegen/Instruction.hpp
+++ b/compiler/aarch64/codegen/Instruction.hpp
@@ -61,4 +61,11 @@ class OMR_EXTENSIBLE Instruction : public OMR::InstructionConnector
 
 #include "codegen/OMRInstruction_inlines.hpp"
 
+/**
+ * @brief Type cast for instruction cursor
+ * @param[in] i : instruction cursor
+ * @return instruction cursor
+ */
+inline uint32_t *toARM64Cursor(uint8_t *i) { return (uint32_t *)i; }
+
 #endif


### PR DESCRIPTION
This commit implements the initial version of ARM64BinaryEncoding.cpp
for instruction classes defined in ARM64Instruction.hpp.

Signed-off-by: knn-k <konno@jp.ibm.com>