### PR TITLE
Revert "Call configure using the CONFIG_SHELL variable"

### DIFF
--- a/run_configure.mk
+++ b/run_configure.mk
@@ -47,10 +47,6 @@ help:
 # Remove all built-in rules
 .SUFFIXES:
 
-
-# Set a default value for CONFIG_SHELL
-CONFIG_SHELL ?= sh
-
 ###
 ### SPEC Specific Configure Arguments
 ###
@@ -132,7 +128,7 @@ clean: clean-environment-variables
 ###
 
 define CONFIGURE_RECIPE
-$(CONFIG_SHELL) configure --disable-auto-build-flag 'OMRGLUE=$(OMRGLUE)' 'SPEC=$(SPEC)' $(CONFIGURE_ARGS)
+sh configure --disable-auto-build-flag 'OMRGLUE=$(OMRGLUE)' 'SPEC=$(SPEC)' $(CONFIGURE_ARGS)
 # Force the timestamps of unchanged files to be updated
 touch $(CONFIGURE_OUTPUT_FILES)
 endef


### PR DESCRIPTION
Reverts eclipse/omr#2647

Code did not ultimately solve the problem it intended to.  Also the generated configure script will
re-launch itself with $CONFIG_SHELL if set (autoconf documentation indicated that feature was not yet
implemented). 