### PR TITLE
Add matched user-defined placement delete operator through the compiler code

### DIFF
--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -746,10 +746,14 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
    static void   jitPersistentFree(void *mem)                                 {TR_Memory::jitPersistentFree(mem); }
 
 #define TR_PERSISTENT_NEW(a) \
-   void * operator new   (size_t s, PERSISTENT_NEW_DECLARE)   throw()   {return TR_Memory::jitPersistentAlloc(s, a);} \
-   void * operator new[] (size_t s, PERSISTENT_NEW_DECLARE)   throw()   {return TR_Memory::jitPersistentAlloc(s, a);} \
-   void * operator new   (size_t s, TR_PersistentMemory * m)  throw()   {return m->allocatePersistentMemory(s, a);} \
-   void * operator new[] (size_t s, TR_PersistentMemory * m)  throw()   {return m->allocatePersistentMemory(s, a);} \
+   void * operator new    (size_t s, PERSISTENT_NEW_DECLARE)   throw()   { return TR_Memory::jitPersistentAlloc(s, a); } \
+   void operator delete   (void *p, PERSISTENT_NEW_DECLARE)    throw()   { TR_Memory::jitPersistentFree(p); } \
+   void * operator new[]  (size_t s, PERSISTENT_NEW_DECLARE)   throw()   { return TR_Memory::jitPersistentAlloc(s, a); } \
+   void operator delete[] (void *p, PERSISTENT_NEW_DECLARE)    throw()   { TR_Memory::jitPersistentFree(p); } \
+   void * operator new    (size_t s, TR_PersistentMemory * m)  throw()   { return m->allocatePersistentMemory(s, a); } \
+   void operator delete   (void *p, TR_PersistentMemory *m)    throw()   { m->freePersistentMemory(p); } \
+   void * operator new[]  (size_t s, TR_PersistentMemory * m)  throw()   { return m->allocatePersistentMemory(s, a); } \
+   void operator delete[] (void *p, TR_PersistentMemory *m)    throw()   { m->freePersistentMemory(p); } \
    void operator delete  (void *p, size_t s) throw() { TR_ASSERT(false, "Invalid use of operator delete"); }
 
 #define TR_ALLOC_WITHOUT_NEW(a) \
@@ -773,7 +777,8 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
 #define TR_ALLOC_IMPL(a) \
    TR_ALLOC_WITHOUT_NEW(a) \
    TR_PERSISTENT_NEW(a) \
-   void * operator new (size_t s, TR_ArenaAllocator *m)                  {return m->allocate(s);} \
+   void * operator new (size_t s, TR_ArenaAllocator *m) { return m->allocate(s); } \
+   void operator delete(void *p, TR_ArenaAllocator *m) { /* TR_ArenaAllocator contains an empty deallocator */ } \
    void * operator new (size_t s, TR_HeapMemory m, TR_MemoryBase::ObjectType ot = a) { return m.allocate(s,ot); } \
    void operator delete(void *p, TR_HeapMemory m, TR_MemoryBase::ObjectType ot) { return m.deallocate(p); } \
    void * operator new[] (size_t s, TR_HeapMemory m, TR_MemoryBase::ObjectType ot = a) { return m.allocate(s,ot); } \
@@ -792,7 +797,7 @@ TR_HeapMemory::allocate(size_t size, TR_MemoryBase::ObjectType ot)
    void operator delete(void * p, TR::Region &region) { region.deallocate(p); } \
    void * operator new[](size_t size, TR::Region &region) { return region.allocate(size); } \
    void operator delete[](void * p, TR::Region &region) { region.deallocate(p); } \
-   static TrackedPersistentAllocator getPersistentAllocator() { return TrackedPersistentAllocator(); } \
+   static TrackedPersistentAllocator getPersistentAllocator() { return TrackedPersistentAllocator(); }
 
 #define TR_ALLOC(a) \
    typedef TR_TypedPersistentAllocatorBase TrackedPersistentAllocator; \

--- a/compiler/il/NodeExtension.hpp
+++ b/compiler/il/NodeExtension.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,8 +49,14 @@ public:
 
     void * operator new (size_t s, uint16_t arrayElems, TR_NodeExtAllocator & m)
        {
-       s+= (arrayElems-NUM_DEFAULT_ELEMS) * sizeof(uintptr_t);
+       s += (arrayElems - NUM_DEFAULT_ELEMS) * sizeof(uintptr_t);
        return m.allocate(s);
+       }
+
+    void   operator delete(void * ptr, uint16_t arrayElems, TR_NodeExtAllocator & m)
+       {
+       size_t size = sizeof(NodeExtension) + (arrayElems - NUM_DEFAULT_ELEMS) * sizeof(uintptr_t);
+       return m.deallocate(ptr, size);
        }
 
     void   operator delete(void * ptr, size_t s, TR_NodeExtAllocator & m)

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -92,10 +92,22 @@ OMR::Node::operator new(size_t s, TR::NodePool& nodes)
    return (void *) nodes.allocate();
    }
 
+void
+OMR::Node::operator delete(void *node, TR::NodePool& nodes)
+   {
+   nodes.deallocate((TR::Node *) node);
+   }
+
 void *
 OMR::Node::operator new(size_t s, void *ptr) throw()
    {
    return ::operator new(s, ptr);
+   }
+
+void
+OMR::Node::operator delete(void *node, void *ptr) throw()
+   {
+   ::operator delete(node, ptr);
    }
 
 OMR::Node::Node()

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -159,7 +159,9 @@ public:
    ~Node();
 
    void * operator new(size_t s, TR::NodePool & nodePool);
+   void operator delete(void *node, TR::NodePool& nodes);
    void * operator new(size_t s, void *ptr) throw();
+   void operator delete(void *node, void *ptr) throw();
 
    static TR::Node *copy(TR::Node *);
    static TR::Node *copy(TR::Node *, int32_t numChildren);

--- a/compiler/il/OMRTreeTop.cpp
+++ b/compiler/il/OMRTreeTop.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,6 +217,12 @@ OMR::TreeTop::operator new(size_t s, bool trace, TR_Memory * m)
    TR::TreeTop * tt = (TR::TreeTop *)(p + sizeof(void *));
    tt->setLastInstruction(0);
    return tt;
+   }
+
+void
+OMR::TreeTop::operator delete(void *p, bool trace, TR_Memory *m)
+   {
+   m->freeMemory(p, TR_AllocationKind::heapAlloc);
    }
 
 OMR::TreeTop::TreeTop(TR::TreeTop *precedingTreeTop, TR::Node *node, TR::Compilation * c) :

--- a/compiler/il/OMRTreeTop.hpp
+++ b/compiler/il/OMRTreeTop.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,6 +71,7 @@ public:
    static void removeDeadTrees(TR::Compilation * comp, TR::TreeTop* first, TR::TreeTop* last);
 
    void * operator new(size_t s, bool trace, TR_Memory *m);
+   void operator delete(void *ptr, bool trace, TR_Memory *m);
 
    explicit TreeTop(
             TR::Node  *node = NULL,

--- a/compiler/infra/List.hpp
+++ b/compiler/infra/List.hpp
@@ -54,6 +54,13 @@ template <class T> class ListElement
          }
       return rc;
       }
+
+   void operator delete(void *ptr, List<T>& freeList)
+      {
+	  // the freeList was modified during the new operator invocation
+	  operator delete(ptr, freeList.getRegion());
+      }
+
    ListElement(T *p, ListElement<T> *q = NULL) : _pNext(q), _pDatum(p) {}
 
    T *getData()     {return _pDatum;}

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,6 +109,11 @@ class TR_DataFlowAnalysis
 
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((TR_DataFlowAnalysis*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
 

--- a/compiler/optimizer/OMROptimization.hpp
+++ b/compiler/optimizer/OMROptimization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,6 +59,11 @@ class OMR_EXTENSIBLE Optimization: public TR_HasRandomGenerator
 
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((Optimization*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
 

--- a/compiler/optimizer/OMROptimizationManager.hpp
+++ b/compiler/optimizer/OMROptimizationManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,6 +64,11 @@ class OMR_EXTENSIBLE OptimizationManager
 
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((OptimizationManager*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 

--- a/compiler/optimizer/OptimizationPolicy.hpp
+++ b/compiler/optimizer/OptimizationPolicy.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,11 @@ class OptimizationPolicy
    public:
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((OptimizationPolicy*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 

--- a/compiler/optimizer/OptimizationUtil.hpp
+++ b/compiler/optimizer/OptimizationUtil.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,11 @@ class OptimizationUtil
    public:
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((OptimizationUtil*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 

--- a/compiler/optimizer/SinkStores.hpp
+++ b/compiler/optimizer/SinkStores.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,6 +55,11 @@ class TR_LiveOnNotAllPaths
    
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((TR_LiveOnNotAllPaths*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 

--- a/compiler/optimizer/UseDefInfo.hpp
+++ b/compiler/optimizer/UseDefInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,6 +66,11 @@ class TR_UseDefInfo
 
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((TR_UseDefInfo*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() better return the same allocator as used for new */
 

--- a/compiler/optimizer/ValueNumberInfo.hpp
+++ b/compiler/optimizer/ValueNumberInfo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,11 @@ class TR_ValueNumberInfo
   
    static void *operator new(size_t size, TR::Allocator a)
       { return a.allocate(size); }
+   static void  operator delete(void *ptr, TR::Allocator a)
+      {
+      // If there is an exception thrown during construction, the compilation
+      // will be aborted, and all memory associated with that compilation will get freed.
+      }
    static void  operator delete(void *ptr, size_t size)
       { ((TR_ValueNumberInfo*)ptr)->allocator().deallocate(ptr, size); } /* t->allocator() must return the same allocator as used for new */
 

--- a/compiler/runtime/CodeCacheTypes.hpp
+++ b/compiler/runtime/CodeCacheTypes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,8 @@ public:
 
    void *operator new(size_t s, CodeCacheHashEntrySlab *slab) { return slab; }
 
+   void operator delete(void *ptr, CodeCacheHashEntrySlab *slab) { /* do nothing */ }
+
    static CodeCacheHashEntrySlab *allocate(TR::CodeCacheManager *manager, size_t slabSize);
    void free(TR::CodeCacheManager *manager);
 
@@ -112,6 +114,7 @@ public:
    CodeCacheHashTable() { }
 
    void *operator new(size_t s, CodeCacheHashTable *table) { return table; }
+   void operator delete(void *p, CodeCacheHashTable *table) { /* do nothing */ }
 
    static CodeCacheHashTable *allocate(TR::CodeCacheManager *codeCacheManager);
    static size_t hashUnresolvedMethod(void *constPool, int32_t constPoolIndex);

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -91,6 +91,7 @@ public:
    CodeCache() { }
 
    void *operator new(size_t s, TR::CodeCache *cache) { return cache; }
+   void operator delete(void *p, TR::CodeCache *cache) { /* do nothing */ }
 
 
    class CacheCriticalSection : public CriticalSection

--- a/compiler/runtime/OMRCodeCacheMemorySegment.hpp
+++ b/compiler/runtime/OMRCodeCacheMemorySegment.hpp
@@ -55,6 +55,8 @@ public:
 
    void *operator new(size_t size, TR::CodeCacheMemorySegment *segment) { return segment; }
 
+   void operator delete(void *pmem, TR::CodeCacheMemorySegment *segment) { /* do nothing */ }
+
    uint8_t *segmentBase() const  { return _base; }
    uint8_t *segmentAlloc() const { return _alloc; }
    uint8_t *segmentTop() const   { return _top; }

--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,11 @@ class TR_X86RegisterDependencyGroup
          s += (numDependencies-NUM_DEFAULT_DEPENDENCIES)*sizeof(TR::RegisterDependency);
          }
       return m->allocateHeapMemory(s);
+      }
+
+   void operator delete(void *p, int32_t numDependencies, TR_Memory * m)
+      {
+	  m->freeMemory(p, TR_AllocationKind::heapAlloc);
       }
 
    public:


### PR DESCRIPTION
When memory is allocated for an object with operator new, the object's
constructor is called. If the constructor throws an exception, any
memory that was allocated for the object should be deallocated. This
cannot take place unless an operator `delete` function exists that matches
the operator `new`.

The compiler code generates a lot of **C4291** warnings because no placement
form of operator `delete` has been defined that matches the placement form
of operator `new`.

The commit adds missed placement forms of operator `delete` to the
compiler code.