### PR TITLE
Prototype inlining support for JitBuilder

### DIFF
--- a/compiler/ilgen/IlInjector.cpp
+++ b/compiler/ilgen/IlInjector.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/ilgen/IlInjector.cpp
+++ b/compiler/ilgen/IlInjector.cpp
@@ -407,7 +407,7 @@ OMR::IlInjector::generateFallThrough()
  * OMR::Node::createWithoutSymRef() instead once it is available publicly.
  * */
 TR::Node *
-OMR::IlInjector::createWithoutSymRef(TR::ILOpCodes opCode, uint16_t numArgs, ...)
+OMR::IlInjector::createWithoutSymRef(TR::ILOpCodes opCode, uint32_t numArgs, ...)
    {
    TR_ASSERT(numArgs > 0, "Must be called with at least one child, but numChildArgs = %d", numArgs);
    va_list args;

--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -128,7 +128,7 @@ public:
    void                           gotoBlock(TR::Block *block);
    void                           branchToBlock(int32_t num) { gotoBlock(_blocks[num]); }
    void                           generateFallThrough();
-   TR::Node                     * createWithoutSymRef(TR::ILOpCodes opCode, uint16_t numArgs, ...);
+   TR::Node                     * createWithoutSymRef(TR::ILOpCodes opCode, uint32_t numArgs, ...);
 
 private:
    void                           validateTargetBlock();

--- a/compiler/ilgen/MethodBuilder.hpp
+++ b/compiler/ilgen/MethodBuilder.hpp
@@ -35,6 +35,12 @@ namespace TR
          MethodBuilder(TR::TypeDictionary *types, TR::VirtualMachineState *vmState)
             : OMR::MethodBuilder(types, vmState)
             { }
+         MethodBuilder(TR::MethodBuilder *callerMB)
+            : OMR::MethodBuilder(callerMB)
+            { }
+         MethodBuilder(TR::MethodBuilder *callerMB, TR::VirtualMachineState *vmState)
+            : OMR::MethodBuilder(callerMB, vmState)
+            { }
       };
 
 } // namespace TR

--- a/compiler/ilgen/OMRBytecodeBuilder.hpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.hpp
@@ -59,8 +59,8 @@ public:
    void AddSuccessorBuilders(uint32_t numBuilders, ...);
    void AddSuccessorBuilder(TR::BytecodeBuilder **b) { AddSuccessorBuilders(1, b); }
 
-   TR::VirtualMachineState *initialVMState()                { return _initialVMState; }
-   TR::VirtualMachineState *vmState()                       { return _vmState; }
+   virtual TR::VirtualMachineState *initialVMState()        { return _initialVMState; }
+   virtual TR::VirtualMachineState *vmState()               { return _vmState; }
    void setVMState(TR::VirtualMachineState *vmState)        { _vmState = vmState; }
 
    void propagateVMState(TR::VirtualMachineState *fromVMState);

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1785,6 +1785,17 @@ OMR::IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, TR::IlVa
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
    }
 
+/*
+ * This service takes a MethodBuilder object as the target and will, for
+ * now, inline the code for that MethodBuilder into the current builder
+ * object. Really, this API does not promise to inline the provided
+ * MethodBuilder object, but this current implementation will inline.
+ * In future, as inlining support moves deeper into the OMR compiler,
+ * this service may or may not inline the provided MethodBuilder.
+ * This particular implementation does not handle VirtualMachineState
+ * propagation well, but does work for simpler examples (code sample
+ * coming in a subsequent commit).
+ */
 TR::IlValue *
 OMR::IlBuilder::Call(TR::MethodBuilder *calleeMB, int32_t numArgs, ...)
    {
@@ -1796,6 +1807,17 @@ OMR::IlBuilder::Call(TR::MethodBuilder *calleeMB, int32_t numArgs, ...)
    return Call(calleeMB, numArgs, argValues);
    }
 
+/*
+ * This service takes a MethodBuilder object as the target and will, for
+ * now, inline the code for that MethodBuilder into the current builder
+ * object. Really, this API does not promise to inline the provided
+ * MethodBuilder object, but this current implementation will inline.
+ * In future, as inlining support moves deeper into the OMR compiler,
+ * this service may or may not inline the provided MethodBuilder.
+ * This particular implementation does not handle VirtualMachineState
+ * propagation well, but does work for simpler examples (code sample
+ * coming in a subsequent commit).
+ */
 TR::IlValue *
 OMR::IlBuilder::Call(TR::MethodBuilder *calleeMB, int32_t numArgs, TR::IlValue **argValues)
    {

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -731,13 +731,13 @@ OMR::IlBuilder::CreateLocalStruct(TR::IlType *structType)
 
 void
 OMR::IlBuilder::StoreIndirect(const char *type, const char *field, TR::IlValue *object, TR::IlValue *value)
-  {
-  TR::SymbolReference *symRef = (TR::SymbolReference*)_types->FieldReference(type, field);
-  TR::DataType fieldType = symRef->getSymbol()->getDataType();
-  TraceIL("IlBuilder[ %p ]::StoreIndirect %s.%s (%d) into (%d)\n", this, type, field, value->getID(), object->getID());
-  TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectStore(fieldType);
-  genTreeTop(TR::Node::createWithSymRef(storeOp, 2, loadValue(object), loadValue(value), 0, symRef));
-  }
+   {
+   TR::SymbolReference *symRef = (TR::SymbolReference*)_types->FieldReference(type, field);
+   TR::DataType fieldType = symRef->getSymbol()->getDataType();
+   TraceIL("IlBuilder[ %p ]::StoreIndirect %s.%s (%d) into (%d)\n", this, type, field, value->getID(), object->getID());
+   TR::ILOpCodes storeOp = comp()->il.opCodeForIndirectStore(fieldType);
+   genTreeTop(TR::Node::createWithSymRef(storeOp, 2, loadValue(object), loadValue(value), 0, symRef));
+   }
 
 TR::IlValue *
 OMR::IlBuilder::Load(const char *name)
@@ -745,6 +745,7 @@ OMR::IlBuilder::Load(const char *name)
    TR::SymbolReference *symRef = lookupSymbol(name);
    TR::Node *valueNode = TR::Node::createLoad(symRef);
    TR::IlValue *returnValue = newValue(symRef->getSymbol()->getDataType(), valueNode);
+   TraceIL("IlBuilder[ %p ]::Load %s into %d from symref %d\n", this, name, returnValue->getID(), symRef->getReferenceNumber());
    return returnValue;
    }
 

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1827,7 +1827,7 @@ OMR::IlBuilder::Call(TR::MethodBuilder *calleeMB, int32_t numArgs, TR::IlValue *
    calleeMB->setInlineSiteIndex(_methodBuilder->getNextInlineSiteIndex());
 
    // set up callee's return builder for return control flows
-   TR::IlBuilder *returnBuilder = OrphanBuilder(); // should really be OrphanByecodeBuilder
+   TR::IlBuilder *returnBuilder = OrphanBuilder();
    calleeMB->setReturnBuilder(returnBuilder);
 
    // get calleeMB ready to be part of this compilation

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -611,7 +611,7 @@ OMR::IlBuilder::Store(const char *varName, TR::IlValue *value)
       _methodBuilder->defineValue(varName, _types->PrimitiveType(value->getDataType()));
    TR::SymbolReference *symRef = lookupSymbol(varName);
 
-   TraceIL("IlBuilder[ %p ]::Store %s %d gets %d\n", this, varName, symRef->getCPIndex(), value->getID());
+   TraceIL("IlBuilder[ %p ]::Store %s %d (%d) gets %d\n", this, varName, symRef->getCPIndex(), symRef->getReferenceNumber(), value->getID());
    storeNode(symRef, loadValue(value));
    }
 

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "env/TRMemory.hpp"    // must precede IlBuilder.hpp to get TR_ALLOC
 #include "ilgen/IlBuilder.hpp"
 
 #include <stdint.h>

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -38,6 +38,7 @@ namespace TR { class IlBuilder; }
 namespace TR { class ResolvedMethodSymbol; } 
 namespace TR { class SymbolReference; }
 namespace TR { class SymbolReferenceTable; }
+namespace TR { class VirtualMachineState; }
 
 namespace TR { class IlType; }
 namespace TR { class TypeDictionary; }
@@ -112,6 +113,10 @@ public:
    virtual TR::MethodBuilder *asMethodBuilder() { return NULL; }
 
    virtual bool isBytecodeBuilder()             { return false; }
+
+   virtual TR::VirtualMachineState *initialVMState()         { return NULL; }
+   virtual TR::VirtualMachineState *vmState()                { return NULL; }
+   virtual void setVMState(TR::VirtualMachineState *vmState) { }
 
    //char *getName();
 

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -232,12 +232,61 @@ public:
 
    // control
    void AppendBuilder(TR::IlBuilder *builder);
+
+   /**
+    * @brief Call a function via a TR::MethodBuilder object, possibly inlining it
+    * @param calleeMB the target function's TR::MethodBuilder object
+    * @param numArgs the number of actual arguments for the method
+    * @param ... arguments to pass to the function, provided as TR::IlValue pointers
+    * @returns the TR::IlValue corresponding to the called function's return value or NULL if return type is None
+    */
    TR::IlValue *Call(TR::MethodBuilder *calleeMB, int32_t numArgs, ...);
+
+   /**
+    * @brief Call a function via a TR::MethodBuilder object, possibly inlining it
+    * @param calleeMB the target function's TR::MethodBuilder object
+    * @param numArgs the number of actual arguments for the method
+    * @param argValues array of arguments to pass to the function
+    * @returns the TR::IlValue corresponding to the called function's return value or NULL if return type is None
+    */
    TR::IlValue *Call(TR::MethodBuilder *calleeMB, int32_t numArgs, TR::IlValue **argValues);
+
+   /**
+    * @brief Call a function via its name using a list of arguments
+    * @param name the name of the target function
+    * @param numArgs the number of actual arguments for the method
+    * @param ... arguments to pass to the function, provided as TR::IlValue pointers
+    * @returns the TR::IlValue corresponding to the called function's return value or NULL if return type is None
+    */
    TR::IlValue *Call(const char *name, int32_t numArgs, ...);
+
+   /**
+    * @brief Call a function via its name using an array of arguments
+    * @param name the name of the target function
+    * @param numArgs the number of actual arguments for the method
+    * @param argValues array of arguments to pass to the function
+    * @returns the TR::IlValue corresponding to the called function's return value or NULL if return type is None
+    */
    TR::IlValue *Call(const char *name, int32_t numArgs, TR::IlValue **argValues);
+
+   /**
+    * @brief Call a function by address using a list of arguments (and providing a name)
+    * @param name the name of the target function (used primarily in logs)
+    * @param numArgs the number of actual arguments for the method
+    * @param ... arguments to pass to the function, provided as TR::IlValue pointers, with the first argument providing the function address
+    * @returns the TR::IlValue corresponding to the called function's return value or NULL if return type is None
+    */
    TR::IlValue *ComputedCall(const char *name, int32_t numArgs, ...);
+
+   /**
+    * @brief Call a function by address using an array of arguments (and providing a name)
+    * @param name the name of the target function
+    * @param numArgs the number of actual arguments for the method
+    * @param argValues array of arguments to pass to the function, with the first argument providing the function address
+    * @returns the TR::IlValue corresponding to the called function's return value or NULL if return type is None
+    */
    TR::IlValue *ComputedCall(const char *name, int32_t numArgs, TR::IlValue **args);
+
    TR::IlValue *genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::IlValue ** paramValues, bool isDirectCall = true);
    void Goto(TR::IlBuilder **dest);
    void Goto(TR::IlBuilder *dest);

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -232,6 +232,8 @@ public:
 
    // control
    void AppendBuilder(TR::IlBuilder *builder);
+   TR::IlValue *Call(TR::MethodBuilder *calleeMB, int32_t numArgs, ...);
+   TR::IlValue *Call(TR::MethodBuilder *calleeMB, int32_t numArgs, TR::IlValue **argValues);
    TR::IlValue *Call(const char *name, int32_t numArgs, ...);
    TR::IlValue *Call(const char *name, int32_t numArgs, TR::IlValue **argValues);
    TR::IlValue *ComputedCall(const char *name, int32_t numArgs, ...);

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -117,7 +117,10 @@ OMR::MethodBuilder::MethodBuilder(TR::TypeDictionary *types, TR::VirtualMachineS
    _allBytecodeBuilders(0),
    _vmState(vmState),
    _bytecodeWorklist(NULL),
-   _bytecodeHasBeenInWorklist(NULL)
+   _bytecodeHasBeenInWorklist(NULL),
+   _inlineSiteIndex(-1),
+   _returnBuilder(NULL),
+   _returnSymbol(NULL)
    {
    _definingLine[0] = '\0';
    }
@@ -139,6 +142,36 @@ TR::MethodBuilder *
 OMR::MethodBuilder::asMethodBuilder()
    {
    return static_cast<TR::MethodBuilder *>(this);
+   }
+
+int32_t
+OMR::MethodBuilder::getNextValueID()
+   {
+   TR::MethodBuilder *caller = callerMethodBuilder();
+   if (caller)
+      // let top most method assign value IDs
+      return caller->getNextValueID();
+
+   return _nextValueID++;
+   }
+
+int32_t
+OMR::MethodBuilder::getNextInlineSiteIndex()
+   {
+   TR::MethodBuilder *caller = callerMethodBuilder();
+   if (caller != NULL)
+      // let top most method assign inlined site indices
+      return caller->getNextInlineSiteIndex();
+
+   return ++_nextInlineSiteIndex;
+   }
+
+TR::MethodBuilder *
+OMR::MethodBuilder::callerMethodBuilder()
+   {
+   if (_returnBuilder == NULL)
+      return NULL;
+   return _returnBuilder->_methodBuilder;
    }
 
 void

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -119,6 +119,7 @@ OMR::MethodBuilder::MethodBuilder(TR::TypeDictionary *types, TR::VirtualMachineS
    _bytecodeWorklist(NULL),
    _bytecodeHasBeenInWorklist(NULL),
    _inlineSiteIndex(-1),
+   _nextInlineSiteIndex(0),
    _returnBuilder(NULL),
    _returnSymbolName(NULL)
    {
@@ -150,6 +151,7 @@ OMR::MethodBuilder::MethodBuilder(TR::MethodBuilder *callerMB, TR::VirtualMachin
    _bytecodeWorklist(NULL),
    _bytecodeHasBeenInWorklist(NULL),
    _inlineSiteIndex(callerMB->getNextInlineSiteIndex()),
+   _nextInlineSiteIndex(0),
    _returnBuilder(NULL),
    _returnSymbolName(NULL)
    {

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -120,9 +120,41 @@ OMR::MethodBuilder::MethodBuilder(TR::TypeDictionary *types, TR::VirtualMachineS
    _bytecodeHasBeenInWorklist(NULL),
    _inlineSiteIndex(-1),
    _returnBuilder(NULL),
-   _returnSymbol(NULL)
+   _returnSymbolName(NULL)
    {
    _definingLine[0] = '\0';
+   }
+
+// used when inlining: 
+OMR::MethodBuilder::MethodBuilder(TR::MethodBuilder *callerMB, TR::VirtualMachineState *vmState)
+   : TR::IlBuilder(asMethodBuilder(), callerMB->typeDictionary()),
+   _methodName("NoName"),
+   _returnType(NoType),
+   _numParameters(0),
+   _symbols(str_comparator, trMemory()->heapMemoryRegion()),
+   _parameterSlot(str_comparator, trMemory()->heapMemoryRegion()),
+   _symbolTypes(str_comparator, trMemory()->heapMemoryRegion()),
+   _symbolNameFromSlot(std::less<int32_t>(), trMemory()->heapMemoryRegion()),
+   _symbolIsArray(str_comparator, trMemory()->heapMemoryRegion()),
+   _memoryLocations(str_comparator, trMemory()->heapMemoryRegion()),
+   _functions(str_comparator, trMemory()->heapMemoryRegion()),
+   _cachedParameterTypes(0),
+   _definingFile(""),
+   _newSymbolsAreTemps(false),
+   _nextValueID(0),
+   _useBytecodeBuilders(false),
+   _countBlocksWorklist(0),
+   _connectTreesWorklist(0),
+   _allBytecodeBuilders(0),
+   _vmState(vmState),
+   _bytecodeWorklist(NULL),
+   _bytecodeHasBeenInWorklist(NULL),
+   _inlineSiteIndex(callerMB->getNextInlineSiteIndex()),
+   _returnBuilder(NULL),
+   _returnSymbolName(NULL)
+   {
+   _definingLine[0] = '\0';
+   initialize(callerMB->_details, callerMB->_methodSymbol, callerMB->_fe, callerMB->_symRefTab);
    }
 
 OMR::MethodBuilder::~MethodBuilder()
@@ -365,6 +397,18 @@ OMR::MethodBuilder::defineSymbol(const char *name, TR::SymbolReference *symRef)
       _methodSymbol->setFirstJitTempIndex(_methodSymbol->getTempIndex());
    }
 
+const char *
+OMR::MethodBuilder::adjustNameForInlinedSite(const char *name)
+   {
+   if (_inlineSiteIndex == -1)
+      return name;
+
+   // prefix with _INL<index>_ and return
+   char *newName = (char *) _comp->trMemory()->allocateHeapMemory((4+10+1+1+strlen(name)) * sizeof(char)); // 4 ("_INL") + max 10 digits + 1 ("_") + original name string + trailing zero
+   sprintf(newName, "_INL%u_%s", _inlineSiteIndex, name);
+   return (const char *)newName;
+   }
+
 TR::SymbolReference *
 OMR::MethodBuilder::lookupSymbol(const char *name)
    {
@@ -385,7 +429,8 @@ OMR::MethodBuilder::lookupSymbol(const char *name)
    TR::DataType primitiveType = symbolType->getPrimitiveType();
 
    ParameterMap::iterator paramSlotsIterator = _parameterSlot.find(name);
-   if (paramSlotsIterator != _parameterSlot.end())
+   // if this MethodBuilder is inlined, even parameters should just be temps
+   if (_inlineSiteIndex == -1 && paramSlotsIterator != _parameterSlot.end())
       {
       int32_t slot = paramSlotsIterator->second;
       symRef = symRefTab()->findOrCreateAutoSymbol(_methodSymbol,
@@ -396,8 +441,14 @@ OMR::MethodBuilder::lookupSymbol(const char *name)
    else
       {
       symRef = symRefTab()->createTemporary(_methodSymbol, primitiveType);
-      symRef->getSymbol()->getAutoSymbol()->setName(name);
+      const char *adjustedName = adjustNameForInlinedSite(name); 
+      symRef->getSymbol()->getAutoSymbol()->setName(adjustedName);
       _symbolNameFromSlot.insert(std::make_pair(symRef->getCPIndex(), name));
+
+      // also do the symbol name mapping in caller so references to parameters can be shown in logs
+      TR::MethodBuilder *callerMB = callerMethodBuilder();
+      if (callerMB)
+         callerMB->_symbolNameFromSlot.insert(std::make_pair(symRef->getCPIndex(), name));
       }
    symRef->getSymbol()->setNotCollected();
 

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -66,8 +66,8 @@ class MethodBuilder : public TR::IlBuilder
    void addToTreeConnectingWorklist(TR::BytecodeBuilder *builder);
    void addToBlockCountingWorklist(TR::BytecodeBuilder *builder);
 
-   TR::VirtualMachineState *vmState()                        { return _vmState; }
-   void setVMState(TR::VirtualMachineState *vmState)         { _vmState = vmState; }
+   virtual TR::VirtualMachineState *vmState()                { return _vmState; }
+   virtual void setVMState(TR::VirtualMachineState *vmState) { _vmState = vmState; }
 
    virtual bool isMethodBuilder()                            { return true; }
    virtual TR::MethodBuilder *asMethodBuilder();

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -57,6 +57,13 @@ class MethodBuilder : public TR::IlBuilder
 
    virtual bool injectIL();
 
+   /**
+    * @brief returns the next index to be used for new values
+    * @returns the next value index
+    * If this method build is an inlined MethodBuilder, then the answer to
+    * this query is delegated to the caller's MethodBuilder, which means
+    * only the top-level MethodBuilder object assigns value IDs.
+    */
    int32_t getNextValueID();
 
    bool usesBytecodeBuilders()                               { return _useBytecodeBuilders; }
@@ -160,34 +167,73 @@ class MethodBuilder : public TR::IlBuilder
     */
    int32_t GetNextBytecodeFromWorklist();
 
+   /**
+    * @brief Override this MethodBuilder's inline site index
+    * @param siteIndex the inline site index to use for this MethodBuilder
+    */
    void setInlineSiteIndex(int32_t siteIndex)
       {
       _inlineSiteIndex = siteIndex;
       }
+
+   /**
+    * @brief returns this MethodBuilder's inline site index
+    * @returns the inlined site index
+    */
    int32_t inlineSiteIndex()
       {
       return _inlineSiteIndex;
       }
+
+   /**
+    * @brief returns the next inline site index to be used for inlined methods
+    * @returns the next inlined site index
+    * If this method build is an inlined MethodBuilder, then the answer to
+    * this query is delegated to the caller's MethodBuilder, which means
+    * only the top-level MethodBuilder object assigns inlined site IDs.
+    */
    int32_t getNextInlineSiteIndex();
 
+   /**
+    * @brief associate a particular IlBuilder object as the return landing pad for this (inlined) MethodBuilder
+    * @param returnBuilder the IlBuilder object to use as a return landing pad
+    */
    void setReturnBuilder(TR::IlBuilder *returnBuilder)
       {
       _returnBuilder = returnBuilder;
       }
+
+   /**
+    * @brief get the return landing pad IlBuilder for this (inlined) MethodBuilder
+    * @returns the return landing pad IlBUilder object
+    */
    TR::IlBuilder *returnBuilder()
       {
       return _returnBuilder;
       }
 
+   /**
+    * @brief set the name of the symbol to use to store the return value from this (inined) MethodBuilder
+    * @param symbolName the name of the symbol to store any return value
+    */
    void setReturnSymbol(const char *symbolName)
       {
       _returnSymbolName = symbolName;
       }
+
+   /**
+    * @brief get the return symbol name to store any return value from this (inlined) MethodBuilder
+    * @returns the return symbol name
+    */
    const char *returnSymbol()
       {
       return _returnSymbolName;
       }
 
+   /*
+    * @brief If this is an inlined MethodBuilder, return the MethodBuilder that directly inlined it
+    * @returns the directly inlining MethodBuilder or NULL if no MethodBuilder inlined this one
+    */
    TR::MethodBuilder *callerMethodBuilder();
 
    protected:
@@ -195,6 +241,11 @@ class MethodBuilder : public TR::IlBuilder
    virtual bool connectTrees();
    TR_Memory *trMemory() { return memoryManager._trMemory; }
 
+   /*
+    * @brief adjusts a local variable name so that it will be unique to the current inlined site to prevent inlining-induced name aliasing
+    * @param name the original local variable name
+    * @returns an adjusted name that will be unique to the current inlined site
+    */
    const char * adjustNameForInlinedSite(const char *name);
 
    private:

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -57,7 +57,7 @@ class MethodBuilder : public TR::IlBuilder
 
    virtual bool injectIL();
 
-   int32_t getNextValueID()                                  { return _nextValueID++; }
+   int32_t getNextValueID();
 
    bool usesBytecodeBuilders()                               { return _useBytecodeBuilders; }
    void setUseBytecodeBuilders()                             { _useBytecodeBuilders = true; }
@@ -159,7 +159,37 @@ class MethodBuilder : public TR::IlBuilder
     * BytecodeBuilder object.
     */
    int32_t GetNextBytecodeFromWorklist();
-   
+
+   void setInlineSiteIndex(int32_t siteIndex)
+      {
+      _inlineSiteIndex = siteIndex;
+      }
+   int32_t inlineSiteIndex()
+      {
+      return _inlineSiteIndex;
+      }
+   int32_t getNextInlineSiteIndex();
+
+   void setReturnBuilder(TR::IlBuilder *returnBuilder)
+      {
+      _returnBuilder = returnBuilder;
+      }
+   TR::IlBuilder *returnBuilder()
+      {
+      return _returnBuilder;
+      }
+
+   void setReturnSymbol(const char *symbolName)
+      {
+      _returnSymbolName = symbolName;
+      }
+   const char *returnSymbol()
+      {
+      return _returnSymbolName;
+      }
+
+   TR::MethodBuilder *callerMethodBuilder();
+
    protected:
    virtual uint32_t countBlocks();
    virtual bool connectTrees();
@@ -237,6 +267,11 @@ class MethodBuilder : public TR::IlBuilder
 
    TR_BitVector              * _bytecodeWorklist;
    TR_BitVector              * _bytecodeHasBeenInWorklist;
+
+   int32_t                     _inlineSiteIndex;
+   int32_t                     _nextInlineSiteIndex;
+   TR::IlBuilder             * _returnBuilder;
+   const char                * _returnSymbolName;
    };
 
 } // namespace OMR

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -50,7 +50,7 @@ class MethodBuilder : public TR::IlBuilder
    TR_ALLOC(TR_Memory::IlGenerator)
 
    MethodBuilder(TR::TypeDictionary *types, TR::VirtualMachineState *vmState = NULL);
-   MethodBuilder(const MethodBuilder &src);
+   MethodBuilder(TR::MethodBuilder *callerMB, TR::VirtualMachineState *vmState = NULL);
    virtual ~MethodBuilder();
 
    virtual void setupForBuildIL();
@@ -194,6 +194,8 @@ class MethodBuilder : public TR::IlBuilder
    virtual uint32_t countBlocks();
    virtual bool connectTrees();
    TR_Memory *trMemory() { return memoryManager._trMemory; }
+
+   const char * adjustNameForInlinedSite(const char *name);
 
    private:
    // We have MemoryManager as the first member of TypeDictionary, so that

--- a/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
@@ -19,7 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "env/TRMemory.hpp"   // include first to get correct TR_ALLOC definition
 #include "ilgen/VirtualMachineOperandStack.hpp"
+
 #include "ilgen/VirtualMachineRegister.hpp"
 #include "compile/Compilation.hpp"
 #include "il/SymbolReference.hpp"

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -36,6 +36,7 @@ ALL_TESTS = \
             conststring \
             dotproduct \
             fieldaddress \
+            inliningrecfib \
             issupportedtype \
             iterfib \
             linkedlist \
@@ -77,6 +78,7 @@ all_goal: common_goal
 	./conststring
 	./dotproduct
 	./fieldaddress
+	./inliningrecfib
 	./linkedlist
 	./localarray
 	./operandarraytests
@@ -170,6 +172,13 @@ fieldaddress : libjitbuilder.a FieldAddress.o
 	$(CXX) -g -fno-rtti -o $@ FieldAddress.o $(JITBUILDER_LINK_FLAGS)
 
 FieldAddress.o: src/FieldAddress.cpp src/FieldAddress.hpp
+	$(CXX) -o $@ $(CXXFLAGS) $<
+
+
+inliningrecfib : libjitbuilder.a InliningRecFib.o
+	$(CXX) -g -fno-rtti -o $@ InliningRecFib.o $(JITBUILDER_LINK_FLAGS)
+
+InliningRecFib.o: src/InliningRecFib.cpp src/InliningRecFib.hpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
 
 

--- a/jitbuilder/release/src/InliningRecFib.cpp
+++ b/jitbuilder/release/src/InliningRecFib.cpp
@@ -1,0 +1,199 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "InliningRecFib.hpp"
+
+/* Un comment to enable debug output */
+/* #define RFIB_DEBUG_OUTPUT */
+
+static void
+printString(int64_t stringPointer)
+   {
+   #define PRINTSTRING_LINE LINETOSTR(__LINE__)
+   char *strPtr = (char *)stringPointer;
+   fprintf(stderr, "%s", strPtr);
+   }
+
+static void
+printInt32(int32_t value)
+   {
+   #define PRINTINT32_LINE LINETOSTR(__LINE__)
+   fprintf(stderr, "%d", value);
+   }
+
+InliningRecursiveFibonacciMethod::InliningRecursiveFibonacciMethod(TR::TypeDictionary *types, int32_t inlineDepth)
+   : MethodBuilder(types),
+     _inlineDepth(inlineDepth)
+   {
+   defineStuff();
+   }
+
+InliningRecursiveFibonacciMethod::InliningRecursiveFibonacciMethod(InliningRecursiveFibonacciMethod *callerMB)
+   : MethodBuilder(callerMB),
+     _inlineDepth(callerMB->_inlineDepth-1)
+   {
+   defineStuff();
+   }
+
+void
+InliningRecursiveFibonacciMethod::defineStuff()
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("fib");
+   DefineParameter("n", Int32);
+   DefineReturnType(Int32);
+
+   DefineFunction((char *)"printString",
+                  (char *)__FILE__,
+                  (char *)PRINTSTRING_LINE,
+                  (void *)&printString,
+                  NoType,
+                  1,
+                  Int64);
+   DefineFunction((char *)"printInt32",
+                  (char *)__FILE__,
+                  (char *)PRINTINT32_LINE,
+                  (void *)&printInt32,
+                  NoType,
+                  1,
+                  Int32);
+   }
+
+static const char *prefix="fib(";
+static const char *middle=") = ";
+static const char *suffix="\n";
+
+bool
+InliningRecursiveFibonacciMethod::buildIL()
+   {
+   TR::IlBuilder *baseCase=NULL, *recursiveCase=NULL;
+   IfThenElse(&baseCase, &recursiveCase,
+      LessThan(
+         Load("n"),
+         ConstInt32(2)));
+
+   DefineLocal("result", Int32);
+
+   baseCase->Store("result",
+   baseCase->   Load("n"));
+
+   TR::IlValue *nMinusOne =
+   recursiveCase->         Sub(
+   recursiveCase->            Load("n"),
+   recursiveCase->            ConstInt32(1));
+
+   TR::IlValue *fib_nMinusOne;
+   if (_inlineDepth > 0)
+      {
+      // memory leak here, but just an example
+      InliningRecursiveFibonacciMethod *inlineFib = new InliningRecursiveFibonacciMethod(this);
+      fib_nMinusOne = recursiveCase->Call(inlineFib, 1, nMinusOne);
+      }
+   else
+      fib_nMinusOne = recursiveCase->Call("fib", 1, nMinusOne);
+
+   TR::IlValue *nMinusTwo =
+   recursiveCase->         Sub(
+   recursiveCase->            Load("n"),
+   recursiveCase->            ConstInt32(2));
+   
+   TR::IlValue *fib_nMinusTwo;
+   if (_inlineDepth > 0)
+      {
+      // memory leak here, but just an example
+      InliningRecursiveFibonacciMethod *inlineFib = new InliningRecursiveFibonacciMethod(this);
+      fib_nMinusTwo = recursiveCase->Call(inlineFib, 1, nMinusTwo);
+      }
+   else
+      fib_nMinusTwo = recursiveCase->Call("fib", 1, nMinusTwo);
+
+   recursiveCase->Store("result",
+   recursiveCase->   Add(fib_nMinusOne, fib_nMinusTwo));
+
+#if defined(RFIB_DEBUG_OUTPUT)
+   Call("printString", 1,
+      ConstInt64((int64_t)prefix));
+   Call("printInt32", 1,
+      Load("n"));
+   Call("printString", 1,
+      ConstInt64((int64_t)middle));
+   Call("printInt32", 1,
+      Load("result"));
+   Call("printString", 1,
+      ConstInt64((int64_t)suffix));
+#endif
+
+   Return(
+      Load("result"));
+
+   return true;
+   }
+
+int
+main(int argc, char *argv[])
+   {
+   int32_t inliningDepth = 1;   // by default, inline one level of calls
+   if (argc == 2)
+      inliningDepth = atoi(argv[1]);
+
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define relevant types\n");
+   TR::TypeDictionary types;
+
+   printf("Step 3: compile method builder, inlining one level\n");
+   InliningRecursiveFibonacciMethod method(&types, inliningDepth);
+   uint8_t *entry=0;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 4: invoke compiled code\n");
+   RecursiveFibFunctionType *fib = (RecursiveFibFunctionType *)entry;
+   for (int32_t n=0;n < 20;n++)
+      printf("fib(%2d) = %d\n", n, fib(n));
+
+   printf ("Step 5: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/release/src/InliningRecFib.hpp
+++ b/jitbuilder/release/src/InliningRecFib.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/src/InliningRecFib.hpp
+++ b/jitbuilder/release/src/InliningRecFib.hpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef INLINING_RECURSIVEFIB_INCL
+#define INLINING_RECURSIVEFIB_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+namespace TR { class TypeDictionary; }
+
+typedef int32_t (RecursiveFibFunctionType)(int32_t);
+
+class InliningRecursiveFibonacciMethod : public TR::MethodBuilder
+   {
+   public:
+   InliningRecursiveFibonacciMethod(TR::TypeDictionary *types, int32_t inlineDepth);
+   InliningRecursiveFibonacciMethod(InliningRecursiveFibonacciMethod *callerMB);
+
+   virtual bool buildIL();
+
+   private:
+   void defineStuff();
+
+   int32_t _inlineDepth;
+   };
+
+#endif // !defined(INLINING_RECURSIVEFIB_INCL)

--- a/jitbuilder/release/src/IterativeFib.cpp
+++ b/jitbuilder/release/src/IterativeFib.cpp
@@ -31,7 +31,7 @@
 #include "ilgen/MethodBuilder.hpp"
 #include "IterativeFib.hpp"
 
-IterativeFibonnaciMethod::IterativeFibonnaciMethod(TR::TypeDictionary *types)
+IterativeFibonacciMethod::IterativeFibonacciMethod(TR::TypeDictionary *types)
    : MethodBuilder(types)
    {
    DefineLine(LINETOSTR(__LINE__));
@@ -43,7 +43,7 @@ IterativeFibonnaciMethod::IterativeFibonnaciMethod(TR::TypeDictionary *types)
    }
 
 bool
-IterativeFibonnaciMethod::buildIL()
+IterativeFibonacciMethod::buildIL()
    {
    TR::IlBuilder *returnN = NULL;
    IfThen(&returnN,
@@ -97,7 +97,7 @@ main(int argc, char *argv[])
    TR::TypeDictionary types;
 
    printf("Step 3: compile method builder\n");
-   IterativeFibonnaciMethod iterFibMethodBuilder(&types);
+   IterativeFibonacciMethod iterFibMethodBuilder(&types);
    uint8_t *entry=0;
    int32_t rc = compileMethodBuilder(&iterFibMethodBuilder, &entry);
    if (rc != 0)

--- a/jitbuilder/release/src/IterativeFib.hpp
+++ b/jitbuilder/release/src/IterativeFib.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/src/IterativeFib.hpp
+++ b/jitbuilder/release/src/IterativeFib.hpp
@@ -30,10 +30,10 @@ namespace TR { class TypeDictionary; }
 
 typedef int32_t (IterativeFibFunctionType)(int32_t);
 
-class IterativeFibonnaciMethod : public TR::MethodBuilder
+class IterativeFibonacciMethod : public TR::MethodBuilder
    {
    public:
-   IterativeFibonnaciMethod(TR::TypeDictionary *types);
+   IterativeFibonacciMethod(TR::TypeDictionary *types);
    virtual bool buildIL();
    };
 

--- a/jitbuilder/release/src/RecursiveFib.cpp
+++ b/jitbuilder/release/src/RecursiveFib.cpp
@@ -49,7 +49,7 @@ printInt32(int32_t value)
    fprintf(stderr, "%d", value);
    }
 
-RecursiveFibonnaciMethod::RecursiveFibonnaciMethod(TR::TypeDictionary *types)
+RecursiveFibonacciMethod::RecursiveFibonacciMethod(TR::TypeDictionary *types)
    : MethodBuilder(types)
    {
    DefineLine(LINETOSTR(__LINE__));
@@ -80,7 +80,7 @@ static const char *middle=") = ";
 static const char *suffix="\n";
 
 bool
-RecursiveFibonnaciMethod::buildIL()
+RecursiveFibonacciMethod::buildIL()
    {
    TR::IlBuilder *baseCase=NULL, *recursiveCase=NULL;
    IfThenElse(&baseCase, &recursiveCase,
@@ -138,7 +138,7 @@ main(int argc, char *argv[])
    TR::TypeDictionary types;
 
    printf("Step 3: compile method builder\n");
-   RecursiveFibonnaciMethod method(&types);
+   RecursiveFibonacciMethod method(&types);
    uint8_t *entry=0;
    int32_t rc = compileMethodBuilder(&method, &entry);
    if (rc != 0)

--- a/jitbuilder/release/src/RecursiveFib.hpp
+++ b/jitbuilder/release/src/RecursiveFib.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/jitbuilder/release/src/RecursiveFib.hpp
+++ b/jitbuilder/release/src/RecursiveFib.hpp
@@ -30,10 +30,10 @@ namespace TR { class TypeDictionary; }
 
 typedef int32_t (RecursiveFibFunctionType)(int32_t);
 
-class RecursiveFibonnaciMethod : public TR::MethodBuilder
+class RecursiveFibonacciMethod : public TR::MethodBuilder
    {
    public:
-   RecursiveFibonnaciMethod(TR::TypeDictionary *types);
+   RecursiveFibonacciMethod(TR::TypeDictionary *types);
    virtual bool buildIL();
    };
 


### PR DESCRIPTION
Add a new Call service to IlBuilder that provides the target via a MethodBuilder object. The current implementation will inline the code generated by the MethodBuilder object, but forced inlining will not remain the default forever (so treat it like a hint).

The current implementation is an inlining mechanism (no heuristics) mostly at the IlBuilder level. It does not yet use the inliner optimization in the OMR compiler, but the longer term plan is to sink down to the inliner. One distinct drawback of the current implementation is that it does not set up any inline table, so all the code just looks like it is from the method being compiled. Another current drawback is that virtual machine state in the caller will not be taken into account when operations like Commit are invoked in a callee. We need to do some more thinking about how that should really work.

The pull request includes a code sample based on RecursiveFib that can inline to any desired depth. I've tested it to depth 8 (which means it inlines 256 calls). After that the compile time gets too long for quick tests. By default, it will inline just one level of calls (2 calls).

This code is a solid step forward for #2398 .

Note to reviewers: in case it isn't immediately obvious, the first five commits are not actually related to inlining MethodBuilders but are generally good things to do.