### PR TITLE
Minimal Signal Changes Part 4 [win64amd]

### DIFF
--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1656,7 +1656,7 @@ removeAsyncHandlers(OMRPortLibrary *portLibrary)
 
 	previousLink = &asyncHandlerList;
 	cursor = asyncHandlerList;
-	while (cursor) {
+	while (NULL != cursor) {
 		if (cursor->portLib == portLibrary) {
 			*previousLink = cursor->next;
 			portLibrary->mem_free_memory(portLibrary, cursor);
@@ -1665,6 +1665,10 @@ removeAsyncHandlers(OMRPortLibrary *portLibrary)
 			previousLink = &cursor->next;
  			cursor = cursor->next;
  		}
+	}
+
+	if (NULL == asyncHandlerList) {
+		SetConsoleCtrlHandler(consoleCtrlHandler, FALSE);
 	}
 
 	omrthread_monitor_exit(asyncMonitor);

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1355,15 +1355,15 @@ destroySignalTools(OMRPortLibrary *portLibrary)
 static int32_t
 initializeSignalTools(OMRPortLibrary *portLibrary)
 {
-	if (omrthread_monitor_init_with_name(&asyncMonitor, 0, "portLibrary_omrsig_async_monitor")) {
+	if (0 != omrthread_monitor_init_with_name(&asyncMonitor, 0, "portLibrary_omrsig_async_monitor")) {
 		goto error;
 	}
 
-	if (omrthread_monitor_init_with_name(&masterExceptionMonitor, 0, "portLibrary_omrsig_master_exception_monitor")) {
+	if (0 != omrthread_monitor_init_with_name(&masterExceptionMonitor, 0, "portLibrary_omrsig_master_exception_monitor")) {
 		goto cleanup1;
 	}
 
-	if (omrthread_monitor_init_with_name(&registerHandlerMonitor, 0, "portLibrary_omrsig_register_handler_monitor")) {
+	if (0 != omrthread_monitor_init_with_name(&registerHandlerMonitor, 0, "portLibrary_omrsig_register_handler_monitor")) {
 		goto cleanup2;
 	}
 
@@ -1371,8 +1371,8 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 		goto cleanup3;
 	}
 
-	if (omrthread_monitor_init_with_name(&asyncReporterShutdownMonitor, 0, "portLibrary_omrsig_asynch_reporter_shutdown_monitor")) {
-			goto cleanup4;
+	if (0 != omrthread_monitor_init_with_name(&asyncReporterShutdownMonitor, 0, "portLibrary_omrsig_asynch_reporter_shutdown_monitor")) {
+		goto cleanup4;
 	}
 
 #if defined(OMR_PORT_ASYNC_HANDLER)


### PR DESCRIPTION
**1) Add createAsyncHandlerRecord for common code [win64amd]**

createAsyncHandlerRecord function creates a new async handler record.
omrsig_set_async_signal_handler and
omrsig_set_single_async_signal_handler have this code in common. Adding
createAsyncHandlerRecord function reduces redundant code.

**2) Move common code into registerMasterHandlers [win64amd]**

omrsig_set_async_signal_handler and
omrsig_set_single_async_signal_handler share common code related to
registering master handlers. The common code has been moved into
registerMasterHandlers.

**3) Update removeAsyncHandlers [win64amd]**

In removeAsyncHandlers, code has been added to remove the HandlerRoutine
(consoleCtrlHandler) during shutdown if asyncHandlerList is empty.

**4) Update initializeSignalTools [win64amd]**

According to coding standards, if statements should check for boolean
expressions instead of integer values. In initializeSignalTools, if
statements have been updated to check for boolean expressions.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>