### PR TITLE
Aarch64: Definition of binaryEncodings[]

### DIFF
--- a/compiler/aarch64/codegen/OMRInstOpCode.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCode.hpp
@@ -54,8 +54,24 @@ class InstOpCode: public OMR::InstOpCode
     * @param[in] m : mnemonic
     */
    InstOpCode(Mnemonic m) : OMR::InstOpCode(m) {}
+
+   public:
+
+   typedef uint32_t OpCodeBinaryEntry;
+   static const OpCodeBinaryEntry binaryEncodings[ARM64NumOpCodes];
+
+   /*
+    * @brief Copies binary encoding of the opcode to buffer
+    * @param[in] cursor : instruction cursor
+    * @return instruction cursor
+    */
+   uint8_t *copyBinaryToBuffer(uint8_t *cursor)
+      {
+      *(uint32_t *)cursor = *(uint32_t *)&binaryEncodings[_mnemonic];
+      return cursor;
+      }
    };
 
-}
-}
+} // ARM64
+} // OMR
 #endif


### PR DESCRIPTION
This commit adds the definition of an array binaryEncodings[] in
OMR::ARM64::InstOpCode.

Issue: #2754

Signed-off-by: knn-k <konno@jp.ibm.com>