### PR TITLE
Change OMR::Options fields from private to protected

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -3783,7 +3783,7 @@ void OMR::Options::openLogFile(int32_t idSuffix)
          fn = filename;
          }
 
-      char *fmodeString = "wb";
+      char *fmodeString = "wb+";
       if (self()->getOption(TR_EnablePIDExtension))
          {
          if (!_suffixLogsFormat)

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -2028,9 +2028,11 @@ private:
    static void     safelyCloseLogs(TR::Options *options, TR_MCTLogs * &closedLogs, TR_FrontEnd * fe);
    static void     closeLogsForOtherCompilationThreads(TR_FrontEnd * fe);
 
+protected:
    void  openLogFile (int32_t idSuffix = -1);
    static void  closeLogFile(TR_FrontEnd *fe, TR::FILE * file);
 
+private:
    // Standard option processing methods
 
    // Set bit(s) defined by "mask" at offset "offset" from the base
@@ -2218,6 +2220,7 @@ private:
    void setDefaultsForDeterministicMode();
    void setMoreAggressiveInlining();
 
+protected:
    static bool           _optionsTablesValidated;
    static TR::OptionTable _jitOptions[];
    static TR::OptionTable _feOptions[];


### PR DESCRIPTION
- need access to OMR::Options private fields in a downstream project

Signed-off-by: Harry Yu <harryyu1994@gmail.com>