### PR TITLE
WIP: Don't sink stores of pd2i* and pd2l* nodes

### DIFF
--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -2460,6 +2460,16 @@ bool TR_SinkStores::treeIsSinkableStore(TR::Node *node, bool sinkIndirectLoads, 
             traceMsg(comp(), "         can't move store of pinning array reference or with UseOnlyAliases\n");
          return false;
          }
+#ifdef J9_PROJECT_SPECIFIC
+      if (node->getOpCode().isStore() && node->getFirstChild()->getOpCode().isBinaryCodedDecimalOp() &&
+              node->getFirstChild()->getOpCode().isConversion() &&
+             (node->getFirstChild()->getOpCode().getDataType() == TR::Int32 || node->getFirstChild()->getOpCode().getDataType() == TR::Int64))
+          {
+          if (trace())
+             traceMsg(comp(), "         can't move store of a BCD Conversion Operation\n");
+          return false;
+          }
+#endif
       }
 
    if (!comp()->cg()->getSupportsJavaFloatSemantics() &&


### PR DESCRIPTION
Sinking stores of pd2i/pd2iOverflow and pd2l/pd2lOverflow breaks the assumption in the z codegen that all such nodes must have a BCDCHKHandlerLabel. This commit prevents Store Sinking from making such transformations and hence breaking this assumption.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>