### PR TITLE
added api to read the cgroup subsystem file and get value

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -397,6 +397,18 @@ typedef enum J9VMemMemoryQuery {
 	OMRPORT_VMEM_PROCESS_EnsureWideEnum = 0x1000000
 } J9VMemMemoryQuery;
 
+#if defined(LINUX)
+
+typedef struct OMRCgroupEntry {
+	int32_t hierarchyId; /**< cgroup hierarch ID*/
+	char *subsystem; /**< name of the subsystem*/
+	char *cgroup; /**< name of the cgroup*/
+	uint64_t flag; /**< a bit-wise flag of type OMR_CGROUP_SUBSYSTEM_* representing the cgroup*/
+	struct OMRCgroupEntry *next; /**< pointer to next OMRCgroupEntry*/
+} OMRCgroupEntry;
+
+#endif /* defined(LINUX) */
+
 /**
  * @name Virtual Memory Options
  * Flags used to create bitmap indicating vmem options
@@ -1038,7 +1050,8 @@ typedef struct OMROSKernelInfo {
 /* bitwise flags indicating cgroup subsystems supported by portlibrary */
 #define OMR_CGROUP_SUBSYSTEM_CPU ((uint64_t)0x1)
 #define OMR_CGROUP_SUBSYSTEM_MEMORY ((uint64_t)0x2)
-#define OMR_CGROUP_SUBSYSTEM_ALL (OMR_CGROUP_SUBSYSTEM_CPU | OMR_CGROUP_SUBSYSTEM_MEMORY)
+#define OMR_CGROUP_SUBSYSTEM_CPUSET ((uint64_t)0x4)
+#define OMR_CGROUP_SUBSYSTEM_ALL (OMR_CGROUP_SUBSYSTEM_CPU | OMR_CGROUP_SUBSYSTEM_MEMORY | OMR_CGROUP_SUBSYSTEM_CPUSET)
 
 struct OMRPortLibrary;
 typedef struct J9Heap J9Heap;
@@ -1507,6 +1520,12 @@ typedef struct OMRPortLibrary {
 	int32_t (*sysinfo_cgroup_get_memlimit)(struct OMRPortLibrary *portLibrary, uint64_t *limit);
 	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_is_memlimit_set "omrsysinfo_cgroup_is_memlimit_set"*/
 	BOOLEAN (*sysinfo_cgroup_is_memlimit_set)(struct OMRPortLibrary *portLibrary);
+	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_get_handle_subsystem_file "omrsysinfo_cgroup_get_handle_subsystem_file"*/
+	intptr_t (*sysinfo_cgroup_get_handle_subsystem_file)(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName);
+	/** see @ref omrsysinfo.c::omrsysinfo_get_cgroup_subsystem_list "omrsysinfo_get_cgroup_subsystem_list"*/
+	struct OMRCgroupEntry *(*sysinfo_get_cgroup_subsystem_list)(struct OMRPortLibrary *portLibrary);
+	/** see @ref omrsysinfo.c::omrsysinfo_is_running_in_container "omrsysinfo_is_running_in_container"*/
+	int32_t (*sysinfo_is_running_in_container)(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer);
 	/** see @ref omrport.c::omrport_init_library "omrport_init_library"*/
 	int32_t (*port_init_library)(struct OMRPortLibrary *portLibrary, uintptr_t size) ;
 	/** see @ref omrport.c::omrport_startup_library "omrport_startup_library"*/
@@ -1962,6 +1981,9 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_cgroup_are_subsystems_enabled(param1) privateOmrPortLibrary->sysinfo_cgroup_are_subsystems_enabled(privateOmrPortLibrary, param1)
 #define omrsysinfo_cgroup_get_memlimit(param1) privateOmrPortLibrary->sysinfo_cgroup_get_memlimit(privateOmrPortLibrary, param1)
 #define omrsysinfo_cgroup_is_memlimit_set() privateOmrPortLibrary->sysinfo_cgroup_is_memlimit_set(privateOmrPortLibrary)
+#define omrsysinfo_cgroup_get_handle_subsystem_file(param1,param2) privateOmrPortLibrary->sysinfo_cgroup_get_handle_subsystem_file(privateOmrPortLibrary, param1, param2)
+#define omrsysinfo_get_cgroup_subsystem_list() privateOmrPortLibrary->sysinfo_get_cgroup_subsystem_list(privateOmrPortLibrary)
+#define omrsysinfo_is_running_in_container(param1) privateOmrPortLibrary->sysinfo_is_running_in_container(privateOmrPortLibrary, param1)
 #define omrintrospect_startup() privateOmrPortLibrary->introspect_startup(privateOmrPortLibrary)
 #define omrintrospect_shutdown() privateOmrPortLibrary->introspect_shutdown(privateOmrPortLibrary)
 #define omrintrospect_set_suspend_signal_offset(param1) privateOmrPortLibrary->introspect_set_suspend_signal_offset(privateOmrPortLibrary, param1)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -270,6 +270,9 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_cgroup_are_subsystems_enabled, /* sysinfo_cgroup_are_subsystems_enabled */
 	omrsysinfo_cgroup_get_memlimit, /* sysinfo_cgroup_get_memlimit */
 	omrsysinfo_cgroup_is_memlimit_set, /* sysinfo_cgroup_is_memlimit_set */
+	omrsysinfo_cgroup_get_handle_subsystem_file, /* sysinfo_cgroup_get_handle_subsystem_file */
+	omrsysinfo_get_cgroup_subsystem_list, /* sysinfo_get_cgroup_entry_list */
+	omrsysinfo_is_running_in_container, /* sysinfo_is_running_in_container */
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -935,4 +935,50 @@ BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 {
 	return FALSE;
+}
+
+/**
+ * Gets the file descriptor by opening the file passed as a param fileName with PortLibrary file_open API.
+ * Caller should be using "omrfile_close" (Port Library API) to close the file descriptor after calling this API.
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @param[in] subsystemFlag for checking the index of the subsystem
+ *
+ * @param[in] fileName pointer to cgroup subsystem filename
+ *
+ * @return file descriptor of file on success and OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM on failure
+ */
+intptr_t
+omrsysinfo_cgroup_get_handle_subsystem_file(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName)
+{
+	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
+}
+
+/**
+ * Gets the list of subsystems available
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @return OMRCgroupEntry struct pointer of the linked list if available, NULL otherwise
+ */
+struct OMRCgroupEntry *
+omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
+{
+	return NULL;
+}
+
+/**
+ * States if JVM is running in a container
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @param[in] inContainer BOOLEAN pointer to state running in container or not
+ *
+ * @return 0 on success and OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM on failure
+ */
+int32_t
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
+{
+	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -533,6 +533,12 @@ extern J9_CFUNC int32_t
 omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *limit);
 extern J9_CFUNC BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC intptr_t
+omrsysinfo_cgroup_get_handle_subsystem_file(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName);
+extern J9_CFUNC struct OMRCgroupEntry *
+omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC int32_t
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer);
 
 /* J9SourceJ9Signal*/
 extern J9_CFUNC int32_t

--- a/port/unix_include/omrcgroup.h
+++ b/port/unix_include/omrcgroup.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,13 +23,6 @@
 #define omrcgroup_h
 
 #if defined(LINUX)
-
-typedef struct OMRCgroupEntry {
-	int32_t hierarchyId; /**< cgroup hierarch ID*/
-	char *subsystem; /**< name of the subsystem*/
-	char *cgroup; /**< name of the cgroup*/
-	struct OMRCgroupEntry *next; /**< pointer to next OMRCgroupEntry*/
-} OMRCgroupEntry;
 
 /**
  * Stores memory usage statistics of the cgroup. These stats are collected from the files present

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1670,4 +1670,22 @@ BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 {
 	return FALSE;
+}
+
+intptr_t
+omrsysinfo_cgroup_get_handle_subsystem_file(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName)
+{
+	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
+}
+
+struct OMRCgroupEntry *
+omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
+{
+	return NULL;
+}
+
+int32_t
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
+{
+	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 }


### PR DESCRIPTION
Changes have been done to add api's in OMR Port Library

    omrsysinfo_get_handle_cgroup_subsystem_file:
    To get the file pointer of the cgroup subsystem file
    omrsysinfo_cgroup_is_running_in_container :
    To add the status about running in container
    omrsysinfo__get_cgroup_entry_list
    To get the Linked List which has the Cgroup Subsystem details

These API's can be used to read the Cgroup subsystem file, to check if it is running in a container and also to get the Cgroup Subsystem details from the list

Signed-off-by: bharathappali <bharath.appali@gmail.com>