### PR TITLE
Keeping size of LOA is bigger than largeObjectMinimumSize or 0

### DIFF
--- a/gc/base/MemoryPoolLargeObjects.cpp
+++ b/gc/base/MemoryPoolLargeObjects.cpp
@@ -309,7 +309,9 @@ MM_MemoryPoolLargeObjects::resizeLOA(MM_EnvironmentBase* env)
 				spaceDelta = (NULL != newLOABase) ? (uintptr_t)newLOABase - (uintptr_t)_currentLOABase : _loaSize;
 				oldLOARatio = _currentLOARatio;
 
-				if ((_loaSize - spaceDelta) < _memoryPoolLargeObjects->getMinimumFreeEntrySize()) {
+				/* Does this leave a reasonable sized LOA ? */
+				if (!isSizeEnoughForLOA(env, _loaSize - spaceDelta)) {
+					/* No.. make LOA empty as not even big enough for one free chunk of LOA */
 					spaceDelta = _loaSize;
 					_soaSize += spaceDelta;
 					_loaSize = 0;
@@ -490,7 +492,7 @@ MM_MemoryPoolLargeObjects::resetLOASize(MM_EnvironmentBase* env, double newLOARa
 
 		uintptr_t resizeSize = 0;
 		/* Does this leave a reasonable sized LOA ? */
-		if (newLOASize < _extensions->largeObjectMinimumSize) {
+		if (!isSizeEnoughForLOA(env, newLOASize)) {
 			/* No.. make LOA empty as not even big enough for one free chunk */
 			_currentLOARatio = 0;
 			_soaSize = oldAreaSize;

--- a/gc/base/MemoryPoolLargeObjects.hpp
+++ b/gc/base/MemoryPoolLargeObjects.hpp
@@ -115,6 +115,10 @@ private:
 	double resetTargetLOARatio(MM_EnvironmentBase*);
 	void resetLOASize(MM_EnvironmentBase*, double newLOARatio);
 	void redistributeFreeMemory(MM_EnvironmentBase*, uintptr_t newOldAreaSize);
+	bool isSizeEnoughForLOA(MM_EnvironmentBase* env, uintptr_t newOldAreaSize)
+	{
+		return (newOldAreaSize >= _extensions->largeObjectMinimumSize);
+	}
 
 protected:
 public:


### PR DESCRIPTION
	- maintain new LOA size either bigger than largeObjectMinimumSize or 0
during LOA resize(both expand and contract cases), the size, which is
smaller than largeObjectMinimumSize, is meaningless and could
potentially trigger the assertion. 
	- create inline method for minimizing duplicated logic

Signed-off-by: Lin Hu <linhu@ca.ibm.com>