### PR TITLE
Minimal Signal Changes Part 1 [win32]

### DIFF
--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -71,6 +71,7 @@ static uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win3
 static intptr_t setCurrentSignal(struct OMRPortLibrary *portLibrary, intptr_t signal);
 
 static uint32_t mapOSSignalToPortLib(uint32_t signalNo);
+static int mapPortLibSignalToOSSignal(uint32_t portLibSignal);
 
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
@@ -207,7 +208,7 @@ omrsig_map_os_signal_to_portlib_signal(struct OMRPortLibrary *portLibrary, uint3
 int32_t
 omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag)
 {
-	return OMRPORT_SIG_ERROR;
+	return (int32_t)mapPortLibSignalToOSSignal(portlibSignalFlag);
 }
 
 int32_t
@@ -777,4 +778,28 @@ mapOSSignalToPortLib(uint32_t signalNo)
 
 	Trc_PRT_signal_mapOSSignalToPortLib_ERROR_unknown_signal(signalNo);
 	return 0;
+}
+
+
+/**
+ * The port library signal flag is converted to the corresponding OS signal number.
+ *
+ * @param portLibSignal the port library signal flag
+ *
+ * @return The corresponding OS signal number or OMRPORT_SIG_ERROR (-1) if the portLibSignal
+ *         can't be mapped.
+ */
+static int
+mapPortLibSignalToOSSignal(uint32_t portLibSignal)
+{
+	uint32_t index = 0;
+
+	for (index = 0; index < sizeof(signalMap) / sizeof(signalMap[0]); index++) {
+		if (signalMap[index].portLibSignalNo == portLibSignal) {
+			return signalMap[index].osSignalNo;
+		}
+	}
+
+	Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal(portLibSignal);
+	return OMRPORT_SIG_ERROR;
 }

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -881,15 +881,27 @@ omrsig_get_options(struct OMRPortLibrary *portLibrary)
 }
 
 /**
- * sets the priority of the the async reporting thread
+ * Set the priority of the asynchronous signal reporting thread (asynchSignalReporterThread).
  *
- * In windows, a new thread is created to run the handlers each time a signal is received,
- * so this function does nothing.
-*/
+ * @param[in] portLibrary the OMR port library
+ * @param[in] priority the thread priority
+ *
+ * @return 0 upon success and non-zero upon failure.
+ */
 int32_t
 omrsig_set_reporter_priority(struct OMRPortLibrary *portLibrary, uintptr_t priority)
 {
-	return 0;
+	int32_t result = 0;
+
+	omrthread_monitor_t globalMonitor = omrthread_global_monitor();
+
+	omrthread_monitor_enter(globalMonitor);
+	if (attachedPortLibraries > 0) {
+		result = setReporterPriority(portLibrary, priority);
+	}
+	omrthread_monitor_exit(globalMonitor);
+
+	return result;
 }
 
 

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -273,7 +273,15 @@ omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibS
 BOOLEAN
 omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler)
 {
-	return FALSE;
+	BOOLEAN rc = FALSE;
+	Trc_PRT_signal_omrsig_is_master_signal_handler_entered(osHandler);
+
+	if (osHandler == (void *)masterASynchSignalHandler) {
+		rc = TRUE;
+	}
+
+	Trc_PRT_signal_omrsig_is_master_signal_handler_exiting(rc);
+	return rc;
 }
 
 int32_t

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -89,6 +89,7 @@ static int mapPortLibSignalToOSSignal(uint32_t portLibSignal);
 
 static int32_t registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySignalNo, win_signal handler, void **oldOSHandler);
 static int32_t initializeSignalTools(OMRPortLibrary *portLibrary);
+static void destroySignalTools(OMRPortLibrary *portLibrary);
 
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
@@ -275,8 +276,7 @@ omrsig_shutdown(struct OMRPortLibrary *portLibrary)
 	omrthread_monitor_enter(globalMonitor);
 
 	if (--attachedPortLibraries == 0) {
-		omrthread_monitor_destroy(asyncMonitor);
-		omrthread_tls_free(tlsKeyCurrentSignal);
+		destroySignalTools(portLibrary);
 	}
 
 	omrthread_monitor_exit(globalMonitor);
@@ -885,4 +885,18 @@ cleanup1:
 	omrthread_monitor_destroy(asyncMonitor);
 error:
 	return OMRPORT_SIG_ERROR;
+}
+
+/**
+ * Destroys the signal tools.
+ *
+ * @param[in] portLibrary the OMR port library
+ *
+ * @return void
+ */
+static void
+destroySignalTools(OMRPortLibrary *portLibrary)
+{
+	omrthread_monitor_destroy(asyncMonitor);
+	omrthread_tls_free(tlsKeyCurrentSignal);
 }

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -34,6 +34,19 @@ typedef struct J9Win32AsyncHandlerRecord {
 	struct J9Win32AsyncHandlerRecord *next;
 } J9Win32AsyncHandlerRecord;
 
+static struct {
+	uint32_t portLibSignalNo;
+	int osSignalNo;
+} signalMap[] = {
+	{OMRPORT_SIG_FLAG_SIGSEGV, SIGSEGV},
+	{OMRPORT_SIG_FLAG_SIGILL, SIGILL},
+	{OMRPORT_SIG_FLAG_SIGFPE, SIGFPE},
+	{OMRPORT_SIG_FLAG_SIGABRT, SIGABRT},
+	{OMRPORT_SIG_FLAG_SIGTERM, SIGTERM},
+	{OMRPORT_SIG_FLAG_SIGINT, SIGINT},
+	{OMRPORT_SIG_FLAG_SIGQUIT, SIGBREAK},
+};
+
 static J9Win32AsyncHandlerRecord *asyncHandlerList;
 static omrthread_monitor_t asyncMonitor;
 static uint32_t asyncThreadCount;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -125,6 +125,8 @@ static int32_t registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flag
 
 static J9Win32AsyncHandlerRecord *createAsyncHandlerRecord(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags);
 
+static int32_t setReporterPriority(OMRPortLibrary *portLibrary, uintptr_t priority);
+
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
 {
@@ -1297,4 +1299,24 @@ createAsyncHandlerRecord(struct OMRPortLibrary *portLibrary, omrsig_handler_fn h
 	}
 
 	return record;
+}
+
+/**
+ * Set the thread priority for asynchronous signal reporting thread (asynchSignalReporterThread).
+ *
+ * @param[in] portLibrary the OMR port library
+ * @param[in] priority the thread priority
+ *
+ * @return 0 upon success and non-zero upon failure.
+ */
+static int32_t
+setReporterPriority(OMRPortLibrary *portLibrary, uintptr_t priority)
+{
+	Trc_PRT_signal_setReporterPriority(portLibrary, priority);
+
+	if (NULL == asynchSignalReporterThread) {
+		return OMRPORT_SIG_ERROR;
+	}
+
+	return (int32_t)omrthread_set_priority(asynchSignalReporterThread, priority);
 }

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -48,6 +48,18 @@ static struct {
 	{OMRPORT_SIG_FLAG_SIGQUIT, SIGBREAK},
 };
 
+#define ARRAY_SIZE_SIGNALS (NSIG + 1)
+
+typedef void (*win_signal)(int);
+
+/* Store the original signal handler. During shutdown, we need to restore
+ * the signal handler to the original OS handler.
+ */
+static struct {
+	win_signal originalHandler;
+	uint32_t restore;
+} handlerInfo[ARRAY_SIZE_SIGNALS];
+
 static J9Win32AsyncHandlerRecord *asyncHandlerList;
 static omrthread_monitor_t asyncMonitor;
 static uint32_t asyncThreadCount;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -254,7 +254,98 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 int32_t
 omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag, void **oldOSHandler)
 {
-	return OMRPORT_SIG_ERROR;
+	int32_t rc = 0;
+	J9Win32AsyncHandlerRecord *cursor = NULL;
+	J9Win32AsyncHandlerRecord **previousLink = NULL;
+	BOOLEAN foundHandler = FALSE;
+
+	Trc_PRT_signal_omrsig_set_single_async_signal_handler_entered(handler, handler_arg, portlibSignalFlag);
+
+	if (0 != portlibSignalFlag) {
+		/* For non-zero portlibSignalFlag, check if only one signal bit is set. Otherwise, fail. */
+		if (!OMR_IS_ONLY_ONE_BIT_SET(portlibSignalFlag)) {
+			Trc_PRT_signal_omrsig_set_single_async_signal_handler_error_multiple_signal_flags_found(portlibSignalFlag);
+			return OMRPORT_SIG_ERROR;
+		}
+	}
+
+	rc = registerMasterHandlers(portLibrary, portlibSignalFlag, OMRPORT_SIG_FLAG_SIGALLASYNC, oldOSHandler);
+	if (0 != rc) {
+		Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting_did_nothing_possible_error(rc, handler, handler_arg, portlibSignalFlag);
+		return rc;
+	}
+
+	omrthread_monitor_enter(asyncMonitor);
+
+	/* Wait until no signals are being reported. */
+	while (asyncThreadCount > 0) {
+		omrthread_monitor_wait(asyncMonitor);
+	}
+
+	/* Is this handler already registered? */
+	previousLink = &asyncHandlerList;
+	cursor = asyncHandlerList;
+	while (NULL != cursor) {
+		if (cursor->portLib == portLibrary) {
+			if ((cursor->handler == handler) && (cursor->handler_arg == handler_arg)) {
+				foundHandler = TRUE;
+				if (0 == portlibSignalFlag) {
+					/* Remove this handler record. */
+					*previousLink = cursor->next;
+					portLibrary->mem_free_memory(portLibrary, cursor);
+					Trc_PRT_signal_omrsig_set_single_async_signal_handler_user_handler_removed(handler, handler_arg, portlibSignalFlag);
+
+					/* If this is the last handler, then unregister the handler function. */
+					if (NULL == asyncHandlerList) {
+						SetConsoleCtrlHandler(consoleCtrlHandler, FALSE);
+					}
+					break;
+				} else {
+					/* Update the listener with the new portlibSignalFlag. */
+					Trc_PRT_signal_omrsig_set_single_async_signal_handler_user_handler_added_1(handler, handler_arg, portlibSignalFlag);
+					cursor->flags |= portlibSignalFlag;
+				}
+			} else {
+				/* Unset the portlibSignalFlag for other handlers. One signal must be associated to only one handler. */
+				cursor->flags &= ~portlibSignalFlag;
+			}
+		}
+		previousLink = &cursor->next;
+		cursor = cursor->next;
+	}
+
+	if (!foundHandler && (0 != portlibSignalFlag)) {
+		J9Win32AsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+
+		if (NULL == record) {
+			rc = OMRPORT_SIG_ERROR;
+		} else {
+			record->portLib = portLibrary;
+			record->handler = handler;
+			record->handler_arg = handler_arg;
+			record->flags = portlibSignalFlag;
+			record->next = NULL;
+
+			/* If this is the first handler, register the handler function. */
+			if (NULL == asyncHandlerList) {
+				SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
+			}
+
+			/* Add the new record to the end of the list. */
+			Trc_PRT_signal_omrsig_set_single_async_signal_handler_user_handler_added_2(handler, handler_arg, portlibSignalFlag);
+			*previousLink = record;
+		}
+	}
+
+	omrthread_monitor_exit(asyncMonitor);
+
+	if (NULL != oldOSHandler) {
+		Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting(rc, handler, handler_arg, portlibSignalFlag, *oldOSHandler);
+	} else {
+		Trc_PRT_signal_omrsig_set_single_async_signal_handler_exiting(rc, handler, handler_arg, portlibSignalFlag, NULL);
+	}
+
+	return rc;
 }
 
 uint32_t

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -115,6 +115,7 @@ static void masterASynchSignalHandler(int osSignalNo);
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
 static int J9THREAD_PROC asynchSignalReporter(void *userData);
+static void runHandlers(uint32_t asyncSignalFlag);
 #endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
 static int32_t registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t allowedSubsetOfFlags, void **oldOSHandler);
@@ -1046,6 +1047,40 @@ masterASynchSignalHandler(int osSignalNo)
 }
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
+/**
+ * Given a port library signal flag, execute the associated handlers stored
+ * within asyncHandlerList (list of J9Win32AsyncHandlerRecord).
+ *
+ * @param asyncSignalFlag port library signal flag
+ *
+ * @return void
+ */
+static void
+runHandlers(uint32_t asyncSignalFlag)
+{
+	J9Win32AsyncHandlerRecord *cursor = NULL;
+
+	/* incrementing the asyncThreadCount will prevent the list from being modified while we use it */
+	omrthread_monitor_enter(asyncMonitor);
+	asyncThreadCount++;
+	omrthread_monitor_exit(asyncMonitor);
+
+	cursor = asyncHandlerList;
+	while (NULL != cursor) {
+		if (OMR_ARE_ANY_BITS_SET(cursor->flags, asyncSignalFlag)) {
+			Trc_PRT_signal_omrsig_asynchSignalReporter_calling_handler(cursor->portLib, asyncSignalFlag, cursor->handler_arg);
+			cursor->handler(cursor->portLib, asyncSignalFlag, NULL, cursor->handler_arg);
+		}
+		cursor = cursor->next;
+	}
+
+	omrthread_monitor_enter(asyncMonitor);
+	if (--asyncThreadCount == 0) {
+		omrthread_monitor_notify_all(asyncMonitor);
+	}
+	omrthread_monitor_exit(asyncMonitor);
+}
+
 /**
  * This is the main body of the asynchSignalReporterThread. It is supposed to execute
  * handlers (J9Win32AsyncHandlerRecord->handler) associated to a signal once a

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -235,7 +235,27 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
 int32_t
 omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler)
 {
-	return OMRPORT_SIG_ERROR;
+	int32_t rc = 0;
+
+	Trc_PRT_signal_omrsig_register_os_handler_entered(portlibSignalFlag, newOSHandler);
+
+	if ((0 == portlibSignalFlag) || !OMR_IS_ONLY_ONE_BIT_SET(portlibSignalFlag)) {
+		/* If portlibSignalFlag is 0 or if portlibSignalFlag has multiple signal bits set, then fail. */
+		Trc_PRT_signal_omrsig_register_os_handler_invalid_portlibSignalFlag(portlibSignalFlag);
+		rc = OMRPORT_SIG_ERROR;
+	} else {
+		omrthread_monitor_enter(registerHandlerMonitor);
+		rc = registerSignalHandlerWithOS(portLibrary, portlibSignalFlag, (win_signal)newOSHandler, oldOSHandler);
+		omrthread_monitor_exit(registerHandlerMonitor);
+	}
+
+	if (NULL != oldOSHandler) {
+		Trc_PRT_signal_omrsig_register_os_handler_exiting(rc, portlibSignalFlag, newOSHandler, *oldOSHandler);
+	} else {
+		Trc_PRT_signal_omrsig_register_os_handler_exiting(rc, portlibSignalFlag, newOSHandler, NULL);
+	}
+
+	return rc;
 }
 
 BOOLEAN

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -337,6 +337,17 @@ omrsig_shutdown(struct OMRPortLibrary *portLibrary)
 	omrthread_monitor_enter(globalMonitor);
 
 	if (--attachedPortLibraries == 0) {
+#if defined(OMR_PORT_ASYNC_HANDLER)
+		/* Terminate asynchSignalReporterThread. */
+		omrthread_monitor_enter(asyncReporterShutdownMonitor);
+		shutDownASynchReporter = 1;
+		j9sem_post(wakeUpASyncReporter);
+		while (0 != shutDownASynchReporter) {
+			omrthread_monitor_wait(asyncReporterShutdownMonitor);
+		}
+		omrthread_monitor_exit(asyncReporterShutdownMonitor);
+#endif /* defined(OMR_PORT_ASYNC_HANDLER) */
+
 		/* Register the original signal handlers, which were overwritten. */
 		for (index = 1; index < ARRAY_SIZE_SIGNALS; index++) {
 			if (0 != handlerInfo[index].restore) {

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -783,60 +783,39 @@ countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t cat
 	return count;
 }
 
+/**
+ * Translate the control signal into an OS signal, update signalCounts
+ * and notify asynchSignalReporterThread to execute the associated handlers.
+ *
+ * @param[in] dwCtrlType the type of control signal received
+ *
+ * @return TRUE if the control signal is handled. Otherwise, return FALSE.
+ */
 static BOOL WINAPI
 consoleCtrlHandler(DWORD dwCtrlType)
 {
-	uint32_t flags;
 	BOOL result = FALSE;
+	int osSignalNo = OMRPORT_SIG_ERROR;
 
 	switch (dwCtrlType) {
 	case CTRL_BREAK_EVENT:
-		flags = OMRPORT_SIG_FLAG_SIGQUIT;
+		osSignalNo = SIGBREAK;
 		break;
 	case CTRL_C_EVENT:
-		flags = OMRPORT_SIG_FLAG_SIGINT;
+		osSignalNo = SIGINT;
 		break;
 	case CTRL_CLOSE_EVENT:
-		flags = OMRPORT_SIG_FLAG_SIGTERM;
+	case CTRL_LOGOFF_EVENT:
+	case CTRL_SHUTDOWN_EVENT:
+		osSignalNo = SIGTERM;
 		break;
 	default:
-		return result;
+		break;
 	}
 
-	if (0 == omrthread_attach_ex(NULL, J9THREAD_ATTR_DEFAULT)) {
-		J9Win32AsyncHandlerRecord *cursor;
-		uint32_t handlerCount = 0;
-
-		/* incrementing the asyncThreadCount will prevent the list from being modified while we use it */
-		omrthread_monitor_enter(asyncMonitor);
-		asyncThreadCount++;
-		omrthread_monitor_exit(asyncMonitor);
-
-		cursor = asyncHandlerList;
-		while (cursor) {
-
-			if (OMR_ARE_ANY_BITS_SET(cursor->flags, flags)) {
-				cursor->handler(cursor->portLib, flags, NULL, cursor->handler_arg);
-
-				/* Returning TRUE stops control from being passed to the next handler routine. The OS default handler may be the next handler routine.
-				 * The default action of the OS default handler routine is to shut down the process
-				 */
-				if (OMR_ARE_ANY_BITS_SET(flags, OMRPORT_SIG_FLAG_SIGQUIT)) {
-					/* Continue executing */
-					result = TRUE;
-				}
-			}
-			cursor = cursor->next;
-		}
-
-		omrthread_monitor_enter(asyncMonitor);
-		if (--asyncThreadCount == 0) {
-			omrthread_monitor_notify_all(asyncMonitor);
-		}
-		omrthread_monitor_exit(asyncMonitor);
-
-		/* TODO: possible timing hole. The thread library could be unloaded by the time we reach this line. We can't use omrthread_exit(), as that kills the async reporting thread */
-		omrthread_detach(NULL);
+	if (OMRPORT_SIG_ERROR != osSignalNo) {
+		updateSignalCount(osSignalNo);
+		result = TRUE;
 	}
 
 	return result;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -123,6 +123,8 @@ static void runHandlers(uint32_t asyncSignalFlag);
 
 static int32_t registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t allowedSubsetOfFlags, void **oldOSHandler);
 
+static J9Win32AsyncHandlerRecord *createAsyncHandlerRecord(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags);
+
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)
 {
@@ -218,29 +220,15 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 		cursor = cursor->next;
 	}
 
-	if (NULL == cursor) {
-		/* Cursor will only be NULL if we failed to find it in the list. */
-		if (0 != flags) {
-			J9Win32AsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
-
-			if (NULL == record) {
-				rc = OMRPORT_SIG_ERROR;
-			} else {
-				record->portLib = portLibrary;
-				record->handler = handler;
-				record->handler_arg = handler_arg;
-				record->flags = flags;
-				record->next = NULL;
-
-				/* If this is the first handler, register the handler function. */
-				if (NULL == asyncHandlerList) {
-					SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
-				}
-
-				/* Add the new record to the end of the list. */
-				Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_added_2(handler, handler_arg, flags);
-				*previousLink = record;
-			}
+	/* Cursor will only be NULL if we failed to find it in the list. */
+	if ((NULL == cursor) && (0 != flags)) {
+		J9Win32AsyncHandlerRecord *record = createAsyncHandlerRecord(portLibrary, handler, handler_arg, flags);
+		if (NULL != record) {
+			/* Add the new record to the end of the list. */
+			Trc_PRT_signal_omrsig_set_async_signal_handler_user_handler_added_2(handler, handler_arg, flags);
+			*previousLink = record;
+		} else {
+			rc = OMRPORT_SIG_ERROR;
 		}
 	}
 
@@ -315,25 +303,13 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 	}
 
 	if (!foundHandler && (0 != portlibSignalFlag)) {
-		J9Win32AsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
-
-		if (NULL == record) {
-			rc = OMRPORT_SIG_ERROR;
-		} else {
-			record->portLib = portLibrary;
-			record->handler = handler;
-			record->handler_arg = handler_arg;
-			record->flags = portlibSignalFlag;
-			record->next = NULL;
-
-			/* If this is the first handler, register the handler function. */
-			if (NULL == asyncHandlerList) {
-				SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
-			}
-
+		J9Win32AsyncHandlerRecord *record = createAsyncHandlerRecord(portLibrary, handler, handler_arg, portlibSignalFlag);
+		if (NULL != record) {
 			/* Add the new record to the end of the list. */
 			Trc_PRT_signal_omrsig_set_single_async_signal_handler_user_handler_added_2(handler, handler_arg, portlibSignalFlag);
 			*previousLink = record;
+		} else {
+			rc = OMRPORT_SIG_ERROR;
 		}
 	}
 
@@ -1310,4 +1286,36 @@ registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t all
 	}
 
 	return rc;
+}
+
+/**
+ * Create a new async handler record. If this is the first handler in asyncHandlerList,
+ * then register consoleCtrlHandler (HandlerRoutine) using SetConsoleCtrlHandler.
+ *
+ * @param[in] portLibrary The OMR port library
+ * @param[in] handler the function to call if an asynchronous signal arrives
+ * @param[in] handler_arg the argument to handler
+ * @param[in] flags indicates the asynchronous signals handled
+ *
+ * @return pointer to the new async handler record on success and NULL on failure.
+ */
+static J9Win32AsyncHandlerRecord *
+createAsyncHandlerRecord(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
+{
+	J9Win32AsyncHandlerRecord *record = (J9Win32AsyncHandlerRecord *)portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+
+	if (NULL != record) {
+		record->portLib = portLibrary;
+		record->handler = handler;
+		record->handler_arg = handler_arg;
+		record->flags = flags;
+		record->next = NULL;
+
+		/* If this is the first handler, register the handler function. */
+		if (NULL == asyncHandlerList) {
+			SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
+		}
+	}
+
+	return record;
 }

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -62,6 +62,9 @@ static struct {
 	uint32_t restore;
 } handlerInfo[ARRAY_SIZE_SIGNALS];
 
+/* Keep track of signal counts. */
+static volatile uintptr_t signalCounts[ARRAY_SIZE_SIGNALS] = {0};
+
 static J9Win32AsyncHandlerRecord *asyncHandlerList;
 static omrthread_monitor_t asyncMonitor;
 static uint32_t asyncThreadCount;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -88,6 +88,9 @@ static omrthread_monitor_t registerHandlerMonitor;
  */
 static j9sem_t wakeUpASyncReporter;
 
+/* Used to synchronize shutdown of asynchSignalReporterThread. */
+static omrthread_monitor_t asyncReporterShutdownMonitor;
+
 static uint32_t mapWin32ExceptionToPortlibType(uint32_t exceptionCode);
 static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
 static void removeAsyncHandlers(OMRPortLibrary *portLibrary);
@@ -951,8 +954,12 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 		goto cleanup2;
 	}
 
-	if (omrthread_tls_alloc(&tlsKeyCurrentSignal)) {
+	if (0 != omrthread_tls_alloc(&tlsKeyCurrentSignal)) {
 		goto cleanup3;
+	}
+
+	if (0 != omrthread_monitor_init_with_name(&asyncReporterShutdownMonitor, 0, "portLibrary_omrsig_asynch_reporter_shutdown_monitor")) {
+		goto cleanup4;
 	}
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
@@ -965,16 +972,18 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 			NULL,
 			J9THREAD_CATEGORY_SYSTEM_THREAD)
 	) {
-		goto cleanup4;
+		goto cleanup5;
 	}
 #endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
 	return 0;
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
+cleanup5:
+	omrthread_monitor_destroy(asyncReporterShutdownMonitor);
+#endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 cleanup4:
 	omrthread_tls_free(tlsKeyCurrentSignal);
-#endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 cleanup3:
 	j9sem_destroy(wakeUpASyncReporter);
 cleanup2:
@@ -999,6 +1008,7 @@ destroySignalTools(OMRPortLibrary *portLibrary)
 	omrthread_monitor_destroy(registerHandlerMonitor);
 	j9sem_destroy(wakeUpASyncReporter);
 	omrthread_tls_free(tlsKeyCurrentSignal);
+	omrthread_monitor_destroy(asyncReporterShutdownMonitor);
 }
 
 /**

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1656,7 +1656,7 @@ removeAsyncHandlers(OMRPortLibrary *portLibrary)
 
 	previousLink = &asyncHandlerList;
 	cursor = asyncHandlerList;
-	while (cursor) {
+	while (NULL != cursor) {
 		if (cursor->portLib == portLibrary) {
 			*previousLink = cursor->next;
 			portLibrary->mem_free_memory(portLibrary, cursor);
@@ -1665,6 +1665,10 @@ removeAsyncHandlers(OMRPortLibrary *portLibrary)
 			previousLink = &cursor->next;
  			cursor = cursor->next;
  		}
+	}
+
+	if (NULL == asyncHandlerList) {
+		SetConsoleCtrlHandler(consoleCtrlHandler, FALSE);
 	}
 
 	omrthread_monitor_exit(asyncMonitor);

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1355,15 +1355,15 @@ destroySignalTools(OMRPortLibrary *portLibrary)
 static int32_t
 initializeSignalTools(OMRPortLibrary *portLibrary)
 {
-	if (omrthread_monitor_init_with_name(&asyncMonitor, 0, "portLibrary_omrsig_async_monitor")) {
+	if (0 != omrthread_monitor_init_with_name(&asyncMonitor, 0, "portLibrary_omrsig_async_monitor")) {
 		goto error;
 	}
 
-	if (omrthread_monitor_init_with_name(&masterExceptionMonitor, 0, "portLibrary_omrsig_master_exception_monitor")) {
+	if (0 != omrthread_monitor_init_with_name(&masterExceptionMonitor, 0, "portLibrary_omrsig_master_exception_monitor")) {
 		goto cleanup1;
 	}
 
-	if (omrthread_monitor_init_with_name(&registerHandlerMonitor, 0, "portLibrary_omrsig_register_handler_monitor")) {
+	if (0 != omrthread_monitor_init_with_name(&registerHandlerMonitor, 0, "portLibrary_omrsig_register_handler_monitor")) {
 		goto cleanup2;
 	}
 
@@ -1371,8 +1371,8 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 		goto cleanup3;
 	}
 
-	if (omrthread_monitor_init_with_name(&asyncReporterShutdownMonitor, 0, "portLibrary_omrsig_asynch_reporter_shutdown_monitor")) {
-			goto cleanup4;
+	if (0 != omrthread_monitor_init_with_name(&asyncReporterShutdownMonitor, 0, "portLibrary_omrsig_asynch_reporter_shutdown_monitor")) {
+		goto cleanup4;
 	}
 
 #if defined(OMR_PORT_ASYNC_HANDLER)


### PR DESCRIPTION

1) **Add signalMap [win32]**

	signalMap includes the list of signals supported by a platform.

	OMRPORT_SIG_FLAG_SIGALLASYNC is a bit-mask of all the asynchronous
	signals that OMR signal library supports on all platforms.

	OMRPORT_SIG_FLAG_SIGALLSYNC is a bit-mask of all the synchronous signals
	that OMR signal library supports on all the platforms.

	signalMap has been added for win32. It specifies the signals which
	are supported on win32.

2) **Add implementation of omrsig_map_os_signal_to_portlib_signal [win32]**

	Added a static method, mapOSSignalToPortLib, which is called from
	omrsig_map_portlib_signal_to_os_signal. mapOSSignalToPortLib will be
	used from other places in the future.

3) **Add implementation of omrsig_map_portlib_signal_to_os_signal [win32]**

	Added a static method, mapPortLibSignalToOSSignal, which is called from
	omrsig_map_portlib_signal_to_os_signal. mapPortLibSignalToOSSignal will
	be used from other places in the future.

4) **Add a data structure to store signal handler info [win32]**

	We want to restore the signal handlers after the OMR port library
	shutdowns. So, we need to cache the original signal handler.

	handlerInfo is added to store {originalHandler, restore} for every
	signal on win32. restore will be set to 1 after the original signal
	handler is cached.

5) **Add registerSignalHandlerWithOS [win32]**

	registerSignalHandlerWithOS registers the signal handler with the OS on
	win32 platform. Also, it caches the original signal handler.

6) **Function may return without exiting the monitor [win32]**

	In win32, omrsig_startup may return without exiting the globalMonitor if
	omrthread_tls_alloc fails.

	A static function, initializeSignalTools, is added to initialize signal
	tools. It returns 0 on success and non-zero otherwise. It properly free
	allocated tools in case of failure.

	A call to initializeSignalTools in omrsig_startup resolves the issue of
	returning without exiting the globalMonitor. 

7) **Add destroySignalTools [win32]**

	Currently, signals tools are freed in omrsig_shutdown. This change
	isolates freeing of signal tools in a separate static function,
	destroySignalTools.

8) **Add registerHandlerMonitor [win32]**

	Added registerHandlerMonitor to synchronize calls to
	registerSignalHandlerWithOS.

	initializeSignalTools updated to initialize registerHandlerMonitor, and
	destroySignalTools updated to free registerHandlerMonitor.

9) **Add implementation of omrsig_register_os_handler [win32]**

	omrsig_register_os_handler registers a signal handler with the OS.

10) **Add wakeUpASyncReporter semaphore [win32]**

	wakeUpASyncReporter semaphore will coordinate between master async
	signal handler and async signal reporter thread.

	initializeSignalTools updated to initialize wakeUpASyncReporter, and
	destroySignalTools updated to free wakeUpASyncReporter.

11) **Add signalCounts [win32]**

	signalCounts will keep track of unprocessed signals.

12) **Add masterASynchSignalHandler [win32]**

	masterASynchSignalHandler updates signalCounts after a signal is
	received, and re-registers masterASynchSignalHandler.

	updateSignalCount is added to update signal counts. Currently, it is
	only invoked from masterASynchSignalHandler. In the future, it will be
	called from consoleCtrlHandler.

13) **Add implementation of omrsig_is_master_signal_handler [win32]**

14) **Initialize and clean handlerInfo [win32]**

	In omrsig_startup, handlerInfo[osSignalNo].restore is initialized to 0.

	In sig_full_shutdown, handlerInfo[osSignalNo].originalHandler is
	registered with the OS, and handlerInfo[osSignalNo].restore is reset to
	0.

15) **Add thread to execute handlers for asynchronous signals [win32]**

	Added asynchSignalReporterThread to execute handlers
	(J9Win32AsyncHandlerRecord->handler) for asynchronous signals.

	asynchSignalReporterThread is initialized/created within
	initializeSignalTools.

	asynchSignalReporter represents the main body of
	asynchSignalReporterThread. Currently, it is a stub which sets the
	thread's name and executes the thread exit code. The main functionality
	of asynchSignalReporter will be added later once required dependencies
	have been introduced.
	Code related to asynchSignalReporterThread is wrapped with
	OMR_PORT_ASYNC_HANDLER flag (similar to the Unix implementation).

	omrutil.h has the prototype for createThreadWithCategory.

16) **Add registerMasterHandlers [win32]**

	registerMasterHandlers registers a master signal handler for the signals
	specified in flags.

	Currently, win32 only has a master signal handler for asynchronous
	signals: masterASynchSignalHandler. So, registerMasterHandlers only
	supports masterASynchSignalHandler (OMRPORT_SIG_FLAG_SIGALLASYNC).
	OMRPORT_SIG_FLAG_SIGALLSYNC is not supported on win32.

17) **Add asyncReporterShutdownMonitor [win32]**

	asyncReporterShutdownMonitor will be used to synchronize shutdown of
	asynchSignalReporterThread.

	initializeSignalTools updated to initialize
	asyncReporterShutdownMonitor, and destroySignalTools updated to destroy
	asyncReporterShutdownMonitor.

18) **Add runHandlers [win32]**

	runHandlers executes the associated handlers stored within
	asyncHandlerList for a a port library signal flag. It will be used to
	invoke asynchronous handlers from asynchSignalReporter (main body of
	asynchSignalReporterThread).

19) **Implement asynchSignalReporter [win32]**

	Previously, only a stub existed for asynchSignalReporter. An
	implementation for asynchSignalReporter is added. asynchSignalReporter
	executes handlers associated to pending signals (signalCounts[...]). It
	receives notification of a signal via a j9sem_post (from
	masterASynchSignalHandler). For thread shutdown,
	asyncReporterShutdownMonitor is used.

	shutDownASynchReporter is used to indicate start and end of
	asynchSignalReporterThread termination.

20) **Terminate asynchSignalReporterThread in omrsig_shutdown [win32]**

	Added code to terminate asynchSignalReporterThread in omrsig_shutdown.
	omrsig_shutdown waits until asynchSignalReporterThread is terminated.

21) **Fix omrsig_set_async_signal_handler [win32]**

	i) Properly initialize variables during declaration.

	ii) Add trace points.

	iii) For the specified port library signal flags, register master
	asynchronous handler (masterASynchSignalHandler) with the OS.

	iv) Currently, J9Win32AsyncHandlerRecord->flags is assigned a new
	value which removes previous signal/handler relations. This is incorrect
	and inconsistent with the win64amd/unix/ztpf implementations. When
	associating signals with existing handlers,
	J9Win32AsyncHandlerRecord->flags must be updated using a bit-wise OR so
	that previous signal/handler relations are not impacted.

22) **Add implementation of omrsig_set_single_async_signal_handler [win32]**

23) **Add createAsyncHandlerRecord for common code [win32]**

	createAsyncHandlerRecord function creates a new async handler record.
	omrsig_set_async_signal_handler and
	omrsig_set_single_async_signal_handler have this code in common. Adding
	createAsyncHandlerRecord function reduces redundant code.

24) **Update consoleCtrlHandler [win32]**

	consoleCtrlHandler is a HandlerRoutine, and it is responsible for
	handling control events.

	i) consoleCtrlHandler only handled three control events. Now,
	consoleCtrlHandler handles all five control events: CTRL_BREAK_EVENT is
	translated to SIGBREAK, CTRL_C_EVENT is translated to SIGINT,
	CTRL_CLOSE_EVENT/CTRL_LOGOFF_EVENT/CTRL_SHUTDOWN_EVENT are translated to
	SIGTERM.

	ii) Before, consoleCtrlHandler invoked the handlers. Now,
	consoleCtrlHandler only increments counters (signalCounts[...]) for
	unprocessed signals, and notifies the asynchSignalReporterThread.

	iii) consoleCtrlHandler (HandlerRoutine) won't be invoked for a signal
	send using the raise(...) function. In case of raise(...), the signal
	handler registered with the OS using signal(...) will be invoked. So,
	consoleCtrlHandler must not be used to invoke
	J9Win32AsyncHandlerRecord->handler(s). Now, asynchSignalReporterThread
	is responsible for invoking J9Win32AsyncHandlerRecord->handler(s).

25) **Add setReporterPriority [win32]**

	setReporterPriority sets the thread priority for
	asynchSignalReporterThread.

26) **Update omrsig_set_reporter_priority [win32]**

	asynchSignalReporterThread has been added on win32. So,
	omrsig_set_reporter_priority is updated to set the priority of
	asynchSignalReporterThread.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>