### PR TITLE
Store a pointer to the original regex string in SimpleRegex

### DIFF
--- a/compiler/infra/SimpleRegex.cpp
+++ b/compiler/infra/SimpleRegex.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,6 +57,7 @@ SimpleRegex *SimpleRegex::create(char *&s)
    {
    if (s == NULL || s[0] != '{')
       return NULL;
+   char *origStr = s;
    ++s;
    bool negate = (s[0] == '^');
    if (negate)
@@ -69,6 +70,8 @@ SimpleRegex *SimpleRegex::create(char *&s)
    SimpleRegex *result = (SimpleRegex *)jitPersistentAlloc(sizeof(SimpleRegex));
    result->_regex = regex;
    result->_negate = negate;
+   result->_regexStr = origStr;
+   result->_regexStrLen = s - origStr;
    return result;
    }
 

--- a/compiler/infra/SimpleRegex.hpp
+++ b/compiler/infra/SimpleRegex.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,6 +63,13 @@ class SimpleRegex
 
    void print(bool negate);
 
+   // Get the original string the regex was parsed from.
+   // This pointer is only valid as long as the original string is not freed.
+   // It is NOT null terminated.
+   //
+   const char *regexStr() const { return _regexStr; }
+   size_t regexStrLen() const { return _regexStrLen; }
+
    enum ComponentType{simple_string, wildcards, char_alternatives};
 
    struct Component
@@ -105,6 +112,10 @@ class SimpleRegex
 
    Regex *_regex;
    bool   _negate;
+
+   // Length and pointer to the original string that the regex was parsed from
+   size_t _regexStrLen;
+   char *_regexStr;
    };
 
 }


### PR DESCRIPTION
This pointer only remains valid for the lifetime of the original string. However, in practice SimpleRegex objects are only created from strings in enviroment variables or command line options, which have a static lifetime.

Needed to pass regex options from client to server for JITaaS.

Signed-off-by: Noah Weninger <noah.weninger@ibm.com>