### PR TITLE
JIT Debug trace enhancement

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -221,7 +221,23 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
         setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getCodeLength(),"SLIPDLL31", comp);
         }
      }
+   if (comp->getOption(TR_TraceCG) || comp->getOptions()->getTraceCGOption(TR_TraceCGPostBinaryEncoding))
+      {
+      const char * title = "Post Relocation Instructions";
+      comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), title, false, true);
 
+      traceMsg(comp,"<snippets>");
+      comp->getDebug()->print(comp->getOutFile(), cg->getSnippetList());
+      traceMsg(comp,"\n</snippets>\n");
+
+      auto iterator = cg->getSnippetList().begin();
+      int32_t estimatedSnippetStart = cg->getEstimatedSnippetStart();
+      while (iterator != cg->getSnippetList().end())
+         {
+         estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);
+         ++iterator;
+         }
+      }
    }
 
 

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -1557,7 +1557,10 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
          }
       else if (disp)
          {
-         printIntConstant(pOutFile, (int32_t)disp, 16, TR_WordReg, true);
+         printHexConstant(pOutFile,
+                          TR::Compiler->target.is64Bit() ? disp : (uint32_t)disp,
+                          TR::Compiler->target.is64Bit() ? 16 : 8,
+                          true);
          }
       else if (cds)
          {


### PR DESCRIPTION
1. Dump instructions after ProcessRelocationsPhase;
2. Properly print absolute address for DataSnippet on X86.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>