### PR TITLE
Hoist registerFile to base Machine class

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -31,7 +31,6 @@
 OMR::ARM64::Machine::Machine(TR::CodeGenerator *cg) :
       OMR::Machine(cg)
    {
-   _registerFile = (TR::RealRegister **)cg->trMemory()->allocateMemory(sizeof(TR::RealRegister *)*TR::RealRegister::NumRegisters, heapAlloc);
    self()->initializeRegisterFile();
    }
 

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -153,8 +153,6 @@ public:
 
 private:
 
-   TR::RealRegister  **_registerFile;
-
    // For register snap shot
    uint16_t                   _registerFlagsSnapShot[TR::RealRegister::NumRegisters];
    TR::RealRegister::RegState _registerStatesSnapShot[TR::RealRegister::NumRegisters];

--- a/compiler/arm/codegen/OMRMachine.hpp
+++ b/compiler/arm/codegen/OMRMachine.hpp
@@ -63,7 +63,6 @@ namespace ARM
 
 class OMR_EXTENSIBLE Machine : public OMR::Machine
    {
-   TR::RealRegister   *_registerFile[TR::RealRegister::NumRegisters];
 
    static uint32_t       _globalRegisterNumberToRealRegisterMap[MAX_ARM_GLOBAL_GPRS + MAX_ARM_GLOBAL_FPRS];
 

--- a/compiler/codegen/OMRMachine.hpp
+++ b/compiler/codegen/OMRMachine.hpp
@@ -34,6 +34,7 @@ namespace OMR { typedef OMR::Machine MachineConnector; }
 #include <stddef.h>                            // for NULL
 #include <stdint.h>                            // for uint8_t, uint32_t
 #include "codegen/RegisterConstants.hpp"
+#include "codegen/RealRegister.hpp"
 #include "env/TRMemory.hpp"                    // for TR_Memory, etc
 #include "infra/Annotations.hpp"               // for OMR_EXTENSIBLE
 
@@ -45,7 +46,6 @@ namespace OMR
 
 class OMR_EXTENSIBLE Machine
    {
-   TR::CodeGenerator *_cg;
 
    int16_t numLockedGPRs;
    int16_t numLockedHPRs;
@@ -68,6 +68,9 @@ class OMR_EXTENSIBLE Machine
 
    inline TR::Machine * self();
 
+   /**
+    * \return : the cached TR::CodeGenerator object
+    */
    TR::CodeGenerator *cg() {return _cg;}
 
    /** \brief
@@ -119,6 +122,29 @@ class OMR_EXTENSIBLE Machine
             return -1;
          }
       }
+
+   /**
+    * \brief Retrieve a pointer to the register file
+    */
+   TR::RealRegister **registerFile() { return _registerFile; }
+
+   /**
+    * \brief Retrieves the TR::RealRegister object for the given real register
+    *
+    * \param[in] rn : the desired real register
+    *
+    * \return : the desired TR::RealRegister object
+    */
+   TR::RealRegister *realRegister(TR::RealRegister::RegNum rn) { return _registerFile[rn]; }
+
+private:
+
+   TR::CodeGenerator *_cg;
+
+protected:
+
+   TR::RealRegister *_registerFile[TR::RealRegister::NumRegisters];
+
    };
 }
 

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -140,7 +140,6 @@ static bool boundNext(TR::Instruction *currentInstruction, int32_t realNum, TR::
 OMR::Power::Machine::Machine(TR::CodeGenerator *cg) :
       OMR::Machine(cg)
    {
-   _registerFile = (TR::RealRegister **)cg->trMemory()->allocateMemory(sizeof(TR::RealRegister *)*TR::RealRegister::NumRegisters, heapAlloc);
    self()->initializeRegisterFile();
    memset( _registerAssociations, 0, sizeof(TR::Register*)*TR::RealRegister::NumRegisters );
    }

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -62,7 +62,6 @@ namespace Power
 
 class OMR_EXTENSIBLE Machine : public OMR::Machine
    {
-   TR::RealRegister   **_registerFile;
    TR::Register          *_registerAssociations[TR::RealRegister::NumRegisters];
 
    void initializeRegisterFile();
@@ -137,8 +136,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::RealRegister **cloneRegisterFile(TR::RealRegister **registerFile, TR_AllocationKind allocKind = heapAlloc);
    TR::RealRegister **cloneRegisterFileByType(TR::RealRegister **registerFileClone, TR::RealRegister **registerFile,
                                                 int32_t start, int32_t end, TR_RegisterKinds kind, TR_AllocationKind allocKind);
-   TR::RealRegister **getRegisterFile() { return _registerFile; }
-   TR::RealRegister **setRegisterFile(TR::RealRegister **r) { return _registerFile = r; }
    TR::RegisterDependencyConditions  *createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::list<TR::Register*> *spilledRegisterList = NULL);
 
    void decFutureUseCountAndUnlatch(TR::Register *virtualRegister);

--- a/compiler/x/amd64/codegen/OMRMachine.cpp
+++ b/compiler/x/amd64/codegen/OMRMachine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,6 @@ OMR::X86::AMD64::Machine::Machine(TR::CodeGenerator *cg)
       AMD64_NUM_GPR, // TODO:AMD64: What do these actually do? Possibly
       AMD64_NUM_FPR, // clean up TR_Machine to remove them.
       cg,
-      _registerFileStorage,
       _registerAssociationsStorage,
       TR::Machine::enableNewPickRegister()? (AMD64_MAX_GLOBAL_GPRS      - TR::Machine::numGPRRegsWithheld(cg)) : 8,
       TR::Machine::enableNewPickRegister()? (AMD64_MAX_8BIT_GLOBAL_GPRS - TR::Machine::numRegsWithheld(cg)) : 8,

--- a/compiler/x/amd64/codegen/OMRMachine.hpp
+++ b/compiler/x/amd64/codegen/OMRMachine.hpp
@@ -63,8 +63,7 @@ class OMR_EXTENSIBLE Machine : public OMR::X86::Machine
       AMD64_MAX_GLOBAL_FPRS      = 16,
       };
 
-   TR::RealRegister  *_registerFileStorage[TR_X86_REGISTER_FILE_SIZE];
-   TR::Register         *_registerAssociationsStorage[TR_X86_REGISTER_FILE_SIZE];
+   TR::Register         *_registerAssociationsStorage[TR::RealRegister::NumRegisters];
    TR::Register         *_xmmGlobalRegisterStorage[AMD64_NUM_XMMR];
    uint32_t _globalRegisterNumberToRealRegisterMapStorage[AMD64_MAX_GLOBAL_GPRS + AMD64_MAX_GLOBAL_FPRS];
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -3535,7 +3535,7 @@ void OMR::X86::CodeGenerator::dumpPreGPRegisterAssignment(TR::Instruction * inst
 
       if (debug("dumpGPRegStatus"))
          {
-         self()->machine()->printGPRegisterStatus(self()->fe(), self()->machine()->getRegisterFile(), self()->comp()->getOutFile());
+         self()->machine()->printGPRegisterStatus(self()->fe(), self()->machine()->registerFile(), self()->comp()->getOutFile());
          }
       }
    }
@@ -3565,7 +3565,7 @@ void OMR::X86::CodeGenerator::dumpPostGPRegisterAssignment(TR::Instruction * ins
 
       if (debug("dumpGPRegStatus"))
          {
-         self()->machine()->printGPRegisterStatus(self()->fe(), self()->machine()->getRegisterFile(), self()->comp()->getOutFile());
+         self()->machine()->printGPRegisterStatus(self()->fe(), self()->machine()->registerFile(), self()->comp()->getOutFile());
          }
       }
    }

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -174,7 +174,6 @@ OMR::X86::Machine::Machine
    uint8_t numIntRegs,
    uint8_t numFPRegs,
    TR::CodeGenerator *cg,
-   TR::RealRegister **registerFile,
    TR::Register **registerAssociations,
    uint8_t numGlobalGPRs,
    uint8_t numGlobal8BitGPRs,
@@ -183,7 +182,6 @@ OMR::X86::Machine::Machine
    uint32_t *globalRegisterNumberToRealRegisterMap
    )
    : OMR::Machine(cg),
-   _registerFile(registerFile),
    _registerAssociations(registerAssociations),
    _numGlobalGPRs(numGlobalGPRs),
    _numGlobal8BitGPRs(numGlobal8BitGPRs),
@@ -1722,7 +1720,7 @@ OMR::X86::Machine::getGlobalRegisterTable(const struct TR::X86LinkageProperties&
 TR::RealRegister **
 OMR::X86::Machine::cloneRegisterFile(TR::RealRegister **registerFile, TR_AllocationKind allocKind)
    {
-   int32_t arraySize = sizeof(TR::RealRegister *)*TR_X86_REGISTER_FILE_SIZE;
+   int32_t arraySize = sizeof(TR::RealRegister *) * TR::RealRegister::NumRegisters;
    TR::RealRegister  **registerFileClone = (TR::RealRegister **)self()->cg()->trMemory()->allocateMemory(arraySize, allocKind);
    int32_t i = 0;
    int32_t endReg = TR::RealRegister::LastAssignableGPR;
@@ -1875,7 +1873,7 @@ TR::RegisterDependencyConditions * OMR::X86::Machine::createCondForLiveAndSpille
 //
 TR::RealRegister **OMR::X86::Machine::captureRegisterFile()
    {
-   int32_t arraySize = sizeof(TR::RealRegister *) * TR_X86_REGISTER_FILE_SIZE;
+   int32_t arraySize = sizeof(TR::RealRegister *) * TR::RealRegister::NumRegisters;
 
    TR::RealRegister **registerFileClone =
       (TR::RealRegister **)self()->cg()->trMemory()->allocateMemory(arraySize, heapAlloc);
@@ -1950,7 +1948,7 @@ void OMR::X86::Machine::installRegisterFile(TR::RealRegister **registerFileCopy)
 
 TR::Register **OMR::X86::Machine::captureRegisterAssociations()
    {
-   int32_t arraySize = sizeof(TR::Register *) * TR_X86_REGISTER_FILE_SIZE;
+   int32_t arraySize = sizeof(TR::Register *) * TR::RealRegister::NumRegisters;
 
    TR::Register **registerAssociationsClone =
       (TR::Register **)self()->cg()->trMemory()->allocateMemory(arraySize, heapAlloc);

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -57,9 +57,6 @@ namespace TR { class SymbolReference; }
 namespace TR { struct X86LinkageProperties; }
 template <typename ListKind> class List;
 
-#define TR_X86_REGISTER_FILE_SIZE (TR::RealRegister::NumRegisters)
-
-
 // Encapsulates the state of the register assigner at a particular point
 // during assignment.  Includes the state of the register file and all
 // live registers.
@@ -101,7 +98,6 @@ namespace X86
 
 class OMR_EXTENSIBLE Machine : public OMR::Machine
    {
-   TR::RealRegister  **_registerFile;
    TR::Register         **_registerAssociations;
 
    /**
@@ -148,8 +144,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
       }
 
    TR::RealRegister **cloneRegisterFile(TR::RealRegister **registerFile, TR_AllocationKind allocKind = heapAlloc);
-   TR::RealRegister **getRegisterFile() { return _registerFile; }
-   TR::RealRegister **setRegisterFile(TR::RealRegister **r) { return _registerFile = r; }
 
    TR::RealRegister **captureRegisterFile();
    void installRegisterFile(TR::RealRegister **registerFileCopy);
@@ -328,7 +322,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
       uint8_t numIntRegs,
       uint8_t numFPRegs,
       TR::CodeGenerator *cg,
-      TR::RealRegister **registerFile,
       TR::Register **registerAssociations,
       uint8_t numGlobalGPRs,
       uint8_t numGlobal8BitGPRs,

--- a/compiler/x/i386/codegen/OMRMachine.hpp
+++ b/compiler/x/i386/codegen/OMRMachine.hpp
@@ -64,8 +64,7 @@ class OMR_EXTENSIBLE Machine : public OMR::X86::Machine
       IA32_MAX_GLOBAL_FPRS      = 8,
       };
 
-   TR::RealRegister  *_registerFileStorage[TR_X86_REGISTER_FILE_SIZE];
-   TR::Register         *_registerAssociationsStorage[TR_X86_REGISTER_FILE_SIZE];
+   TR::Register         *_registerAssociationsStorage[TR::RealRegister::NumRegisters];
    TR::Register         *_xmmGlobalRegisterStorage[IA32_NUM_XMMR];
    uint32_t _globalRegisterNumberToRealRegisterMapStorage[IA32_MAX_GLOBAL_GPRS + IA32_MAX_GLOBAL_FPRS];
 
@@ -77,7 +76,6 @@ class OMR_EXTENSIBLE Machine : public OMR::X86::Machine
          IA32_NUM_GPR,
          IA32_NUM_FPR,
          cg,
-         _registerFileStorage,
          _registerAssociationsStorage,
          IA32_MAX_GLOBAL_GPRS,
          IA32_MAX_8BIT_GLOBAL_GPRS,

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2617,7 +2617,7 @@ OMR::Z::CodeGenerator::prepareRegistersForAssignment()
        {
        for (int32_t i = TR::RealRegister::LastAssignableVRF; i > (TR::RealRegister::LastAssignableVRF - TR::Options::_numVecRegsToLock); --i)
           {
-          machine->getRegisterFile(i)->setState(TR::RealRegister::Locked);
+          machine->realRegister(static_cast<TR::RealRegister::RegNum>(i))->setState(TR::RealRegister::Locked);
           }
        }
 
@@ -2754,7 +2754,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
          uint8_t regMask = 0;
          for(int8_t i = TR::RealRegister::GPR0; i != TR::RealRegister::GPR15 + 1; i++)
             {
-            if (self()->machine()->getRegisterFile(i)->getState() == TR::RealRegister::Assigned)
+            if (self()->machine()->realRegister(static_cast<TR::RealRegister::RegNum>(i))->getState() == TR::RealRegister::Assigned)
                regMask |= (1 << (7 - ((i - 1) >> 1))); // bit 0 = GPR0/1, GPR0=1, GPR15=16. 'Or' with bit [(i-1)>>1]
             }
          immValue = immValue | (regMask<<8);
@@ -2775,7 +2775,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
          for (int32_t i=first; i<=last; i++)
             {
-            realReg = self()->machine()->getRegisterFile(i);
+            realReg = self()->machine()->realRegister(static_cast<TR::RealRegister::RegNum>(i));
 
             if ( realReg->getState() == TR::RealRegister::Free && realReg->getHighWordRegister()->getState() == TR::RealRegister::Free)
                {

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6914,12 +6914,6 @@ OMR::Z::Machine::setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, T
    return _registerAssociations[regNum] = virtReg;
    }
 
-TR::RealRegister *
-OMR::Z::Machine::getRegisterFile(int32_t i)
-   {
-   return  _registerFile[i];
-   }
-
 void
 OMR::Z::Machine::takeRegisterStateSnapShot()
    {

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -182,7 +182,6 @@ namespace Z
 
 class OMR_EXTENSIBLE Machine : public OMR::Machine
    {
-   TR::RealRegister            *_registerFile[TR::RealRegister::NumRegisters];
    TR::Register                *_registerAssociations[TR::RealRegister::NumRegisters];
    uint32_t                     _globalRegisterNumberToRealRegisterMap[NUM_S390_GPR+NUM_S390_FPR+NUM_S390_VRF+NUM_S390_HPR];
    TR::RealRegister::RegNum     _S390FirstOfFPRegisterPairs[NUM_S390_FPR_PAIRS];
@@ -635,8 +634,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
       {
       memset(_registerAssociations, 0, sizeof(TR::Register *) * (TR::RealRegister::NumRegisters));
       }
-
-   TR::RealRegister *getRegisterFile(int32_t i);
 
    void takeRegisterStateSnapShot();
    void restoreRegisterStateFromSnapShot();

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -2938,15 +2938,17 @@ TR_Debug::printGPRegisterStatus(TR::FILE *pOutFile, TR::Machine *machine)
    trfprintf(pOutFile, "\n                         GP Reg Status:          Register         State        Assigned\n");
    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++)
       {
-      trfprintf(pOutFile, "%p                      ", machine->getRegisterFile(i));
-      printFullRegInfo(pOutFile, machine->getRegisterFile(i));
+      TR::RealRegister *realReg = machine->realRegister(static_cast<TR::RealRegister::RegNum>(i));
+      trfprintf(pOutFile, "%p                      ", realReg);
+      printFullRegInfo(pOutFile, realReg);
       }
    if ( _comp->getOption(TR_Enable390AccessRegs) )
       {
       for (int i = TR::RealRegister::FirstAR; i <= TR::RealRegister::LastAR; i++)
          {
-         trfprintf(pOutFile, "%p                      ", machine->getRegisterFile(i));
-         printFullRegInfo(pOutFile, machine->getRegisterFile(i));
+         TR::RealRegister *realReg = machine->realRegister(static_cast<TR::RealRegister::RegNum>(i));
+         trfprintf(pOutFile, "%p                      ", realReg);
+         printFullRegInfo(pOutFile, realReg);
          }
       }
    trfflush(pOutFile);
@@ -2961,8 +2963,9 @@ TR_Debug::printFPRegisterStatus(TR::FILE *pOutFile, TR::Machine *machine)
    trfprintf(pOutFile, "\n                         FP Reg Status:          Register         State        Assigned\n");
    for (int i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; i++)
       {
-      trfprintf(pOutFile, "%p                      ", machine->getRegisterFile(i));
-      printFullRegInfo(pOutFile, machine->getRegisterFile(i));
+      TR::RealRegister *realReg = machine->realRegister(static_cast<TR::RealRegister::RegNum>(i));
+      trfprintf(pOutFile, "%p                      ", realReg);
+      printFullRegInfo(pOutFile, realReg);
       }
    trfflush(pOutFile);
    }


### PR DESCRIPTION
Hoist the registerFile array to the common base class to
share the implementation.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>