### PR TITLE
Cleanup never-used VMifArrayCmpEvaluator on X86

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1328,38 +1328,11 @@ static bool canBeHandledByIfInstanceOfHelper(TR::Node *node, TR::CodeGenerator *
       }
    }
 
-
-static bool canBeHandledByIfArrayCmpHelper(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return false;
-   TR::Node *firstChild  = node->getFirstChild();
-   TR::Node *secondChild = node->getSecondChild();
-
-   if (secondChild->getOpCode().isLoadConst() &&
-       (cg->getX86ProcessorInfo().supportsSSE2()))
-      {
-      intptrj_t constValue = integerConstNodeValue(secondChild, cg);
-      return (firstChild->getOpCodeValue() == TR::arraycmp &&
-              !firstChild->isArrayCmpLen() &&
-              firstChild->getRegister() == NULL &&
-              firstChild->getReferenceCount() == 1 &&
-              constValue == 0);
-      }
-   else
-      {
-      return false;
-      }
-   }
-
 TR::Register *OMR::X86::TreeEvaluator::integerIfCmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (canBeHandledByIfInstanceOfHelper(node, cg))
       {
       return TR::TreeEvaluator::VMifInstanceOfEvaluator(node, cg);
-      }
-   else if (canBeHandledByIfArrayCmpHelper(node, cg))
-      {
-      return TR::TreeEvaluator::VMifArrayCmpEvaluator(node, cg);
       }
    else
       {
@@ -1439,10 +1412,6 @@ TR::Register *OMR::X86::TreeEvaluator::integerIfCmpneEvaluator(TR::Node *node, T
    else if (canBeHandledByIfInstanceOfHelper(node, cg))
       {
       return TR::TreeEvaluator::VMifInstanceOfEvaluator(node, cg);
-      }
-   else if (canBeHandledByIfArrayCmpHelper(node, cg))
-      {
-      return TR::TreeEvaluator::VMifArrayCmpEvaluator(node, cg);
       }
    else
       {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4044,12 +4044,6 @@ OMR::X86::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node*, TR::CodeGenerator*)
    }
 
 TR::Register *
-OMR::X86::TreeEvaluator::VMifArrayCmpEvaluator(TR::Node*, TR::CodeGenerator*)
-   {
-   return 0;
-   }
-
-TR::Register *
 OMR::X86::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_ASSERT(node->getNumChildren() == 1, "Wrong number of children in byteswapEvaluator");

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -306,7 +306,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static bool VMinlineCallEvaluator(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg);
    static TR::Instruction *VMtestForReferenceArray(TR::Node *, TR::Register *objectReg, TR::CodeGenerator *cg);
    static bool genNullTestSequence(TR::Node *node, TR::Register *opReg, TR::Register *targetReg, TR::CodeGenerator *cg);
-   static TR::Register *VMifArrayCmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Instruction *insertLoadConstant(TR::Node *node,
                                              TR::Register *target,
                                              intptrj_t value,


### PR DESCRIPTION
VMifArrayCmpEvaluator is never used, removing code related it..

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>