### PR TITLE
Fix return code of retrieveLinuxCgroupMemoryStats

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1518,6 +1518,9 @@ retrieveLinuxCgroupMemoryStats(struct OMRPortLibrary *portLibrary, struct OMRCgr
 			if (1 != rc) {
 				Trc_PRT_retrieveLinuxCgroupMemoryStats_invalidValue(CGROUP_MEMORY_STAT_CACHE, CGROUP_MEMORY_STAT_FILE);
 				rc = portLibrary->error_set_last_error_with_message_format(portLibrary, OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_FILE_INVALID_VALUE, "invalid value for field %s in file %s", CGROUP_MEMORY_STAT_CACHE, CGROUP_MEMORY_STAT_FILE);
+			} else {
+				/* reset 'rc' to success code */
+				rc = 0;
 			}
 			break;
 		}


### PR DESCRIPTION
retrieveLinuxCgroupMemoryStats returns non-zero value on success
which is interpreted as failure

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>