### PR TITLE
Fix unused variable 'shutDownASynchReporter' error

### DIFF
--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -138,8 +138,10 @@ static j9sem_t wakeUpASyncReporter;
 /* Used to synchronize shutdown of asynchSignalReporterThread. */
 static omrthread_monitor_t asyncReporterShutdownMonitor;
 
+#if defined(OMR_PORT_ASYNC_HANDLER)
 /* Used to indicate start and end of asynchSignalReporterThread termination. */
 static uint32_t shutDownASynchReporter;
+#endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
 static uint32_t mapWin32ExceptionToPortlibType(uint32_t exceptionCode);
 static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);


### PR DESCRIPTION
The following error occurs when OMR is being built by Clang:

port\CMakeFiles\omrport_obj.dir\win64amd\omrsignal.c.obj
port\CMakeFiles\omrport_obj.dir\ -c ..\..\port\win64amd\omrsignal.c
..\..\port\win64amd\omrsignal.c(142,17):  error: unused variable
'shutDownASynchReporter' [-Werror,-Wunused-variable]
static uint32_t shutDownASynchReporter;
                ^
1 error generated.

The 'shutDownASynchReporter' variable is used only inside the wrapped by
'#if defined(OMR_PORT_ASYNC_HANDLER)' blocks and must be defined within
the same preprocessor directives.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>