### PR TITLE
Deprecate unused Z codegen APIs

### DIFF
--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -3039,29 +3039,6 @@ OMR::Z::Linkage::unlockRegister(TR::RealRegister * lpReal)
    }
 
 void
-OMR::Z::Linkage::lockGPR(int32_t registerNo)
-   {
-      // +1 beacuse TR::RealRegister::GPR0 is 1
-   TR::RealRegister * tempRegister=self()->cg()->machine()->getS390RealRegister(REGNUM(registerNo+1));
-
-   tempRegister->setAssignedRegister(tempRegister);
-   tempRegister->setState(TR::RealRegister::Locked);
-   tempRegister->setHasBeenAssignedInMethod(true);
-
-   }
-
-void
-OMR::Z::Linkage::unlockGPR(int32_t registerNo)
-   {
-     // +1 beacuse TR::RealRegister::GPR0 is 1
-   TR::RealRegister * tempRegister=self()->cg()->machine()->getS390RealRegister(REGNUM(registerNo+1));
-
-   tempRegister->resetState(TR::RealRegister::Free);
-   tempRegister->setHasBeenAssignedInMethod(false);
-   tempRegister->setAssignedRegister(NULL);
-   }
-
-void
 OMR::Z::Linkage::lockAR(int32_t registerNo)
    {
    // registerNo is 1 less than the ARxx number.  i.e. AR05, registerNo = 4

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -370,9 +370,6 @@ enum TR_DispatchType
    virtual void lockAccessRegisters();
    virtual void lockRegister(TR::RealRegister * lpReal);
    virtual void unlockRegister(TR::RealRegister * lpReal);
-
-   void lockGPR(int32_t registerNo);
-   void unlockGPR(int32_t registerNo);
    void lockAR(int32_t registerNo);
    void unlockAR(int32_t registerNo);
 

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6700,22 +6700,6 @@ OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 #undef addToGRAMap
    }
 
-int
-OMR::Z::Machine::findGlobalRegisterIndex(TR::RealRegister::RegNum gReg)
-   {
-   int32_t index = -1;
-   int32_t last = self()->getLastGlobalCCRRegisterNumber();
-   for (int32_t i = 0; i < last; i++)
-      {
-      if (_globalRegisterNumberToRealRegisterMap[i] == gReg)
-         {
-         index = i;
-         break;
-         }
-      }
-   return index;
-   }
-
 // call this if optimizer run TR_DynamicLiteralPool pass
 void
 OMR::Z::Machine::releaseLiteralPoolRegister()

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6700,22 +6700,6 @@ OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 #undef addToGRAMap
    }
 
-
-void
-OMR::Z::Machine::lockGlobalRegister(int32_t globalRegisterTableIndex)
-   {
-   TR::Compilation *comp = self()->cg()->comp();
-   if (comp->getOption(TR_DisableRegisterPressureSimulation))
-      {
-      _globalRegisterNumberToRealRegisterMap[globalRegisterTableIndex] = (uint32_t) (-1);
-      }
-   else
-      {
-      // TODO: make sure this method is not called without TR_DisableRegisterPressureSimulation
-      // TR_ASSERTC( false,comp, "lockGlobalRegister() does not work with new pickRegister\n");
-      }
-   }
-
 void
 OMR::Z::Machine::releaseGlobalRegister(int32_t globalRegisterTableIndex, TR::RealRegister::RegNum gReg)
    {

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -6700,12 +6700,6 @@ OMR::Z::Machine::initGlobalVectorRegisterMap(uint32_t vectorOffset)
 #undef addToGRAMap
    }
 
-void
-OMR::Z::Machine::releaseGlobalRegister(int32_t globalRegisterTableIndex, TR::RealRegister::RegNum gReg)
-   {
-   _globalRegisterNumberToRealRegisterMap[globalRegisterTableIndex] = gReg;
-   }
-
 int
 OMR::Z::Machine::findGlobalRegisterIndex(TR::RealRegister::RegNum gReg)
    {

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1544,9 +1544,7 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
      }
 
    // Bookkeeping to update the future use count
-      if (doBookKeeping &&
-         (assignedRegister->getState() != TR::RealRegister::Locked ||
-         self()->supportLockedRegisterAssignment()))
+      if (doBookKeeping && (assignedRegister->getState() != TR::RealRegister::Locked))
       {
       targetRegister->decFutureUseCount();
       targetRegister->setIsLive();
@@ -2032,7 +2030,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
       if (((firstReg->decFutureUseCount() == 0) ||
            ((comp->getOption(TR_EnableTrueRegisterModel)) && currInst->startOfLiveRange(firstReg)) ||
            (self()->cg()->isOutOfLineHotPath() && firstReg->getStartOfRange() == currInst)) &&
-           (freeRegisterHigh->getState() != TR::RealRegister::Locked || self()->supportLockedRegisterAssignment()))
+           (freeRegisterHigh->getState() != TR::RealRegister::Locked))
          {
          firstReg->resetIsLive();
          firstReg->setAssignedRegister(NULL);
@@ -2049,7 +2047,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
       if (((lastReg->decFutureUseCount() == 0) ||
            ((comp->getOption(TR_EnableTrueRegisterModel)) && currInst->startOfLiveRange(lastReg)) ||
            (self()->cg()->isOutOfLineHotPath() && lastReg->getStartOfRange() == currInst)) &&
-          (freeRegisterLow->getState() != TR::RealRegister::Locked || self()->supportLockedRegisterAssignment()))
+          (freeRegisterLow->getState() != TR::RealRegister::Locked))
          {
          lastReg->resetIsLive();
          lastReg->setAssignedRegister(NULL);
@@ -5880,38 +5878,6 @@ OMR::Z::Machine::coerceRegisterAssignment(TR::Instruction                       
          currentAssignedRegister->setState(TR::RealRegister::Free);
          currentAssignedRegister->setAssignedRegister(NULL);
          }
-
-      if (self()->supportLockedRegisterAssignment())
-      	 {
-      	 // the AR check is to avoid false errors for biit call
-      	 // like "LAM(R1,R1,...)" and needs to be re-visited
-
-      	 if (!self()->cg()->getRAPassAR() &&
-      	 	   targetRegister->getAssignedRegister() != NULL &&
-      	 	   targetRegister->getAssignedRegister() != targetRegister)
-      	 	   {
-      	     TR::Register * toFreeRegister = targetRegister->getAssignedRegister();
-             // register is locked but assigned to a VR, need to re-assign VR to another reg via reg copy or spill it
-             self()->cg()->traceRegisterAssignment(" Freeing locked register %R ", targetRegister);
-             uint64_t availRegMask = 0xffffffff;
-             if (toFreeRegister->isUsedInMemRef())
-                {
-                availRegMask &= ~TR::RealRegister::GPR0Mask;
-                }
-
-             TR::RealRegister * bestRegister = NULL;
-             if ((bestRegister = self()->findBestFreeRegister(currentInstruction, toFreeRegister->getKind(), toFreeRegister, availRegMask)) == NULL)
-                {
-                bestRegister = self()->freeBestRegister(currentInstruction, toFreeRegister, toFreeRegister->getKind(), availRegMask);
-                }
-             self()->registerCopy(currentInstruction, toFreeRegister->getKind(), toRealRegister(targetRegister), bestRegister, self()->cg(), 0);
-             toFreeRegister->setAssignedRegister(bestRegister);
-             bestRegister->setAssignedRegister(toFreeRegister);
-             bestRegister->setState(TR::RealRegister::Assigned);
-
-             }
-      	 targetRegister->setAssignedRegister(virtualRegister);
-         }
       }
 
    virtualRegister->setAssignedRegister(targetRegister);
@@ -6946,12 +6912,6 @@ OMR::Z::Machine::setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, T
       }
 
    return _registerAssociations[regNum] = virtReg;
-   }
-
-bool
-OMR::Z::Machine::supportLockedRegisterAssignment()
-   {
-   return false; // TODO : Identity needs folding
    }
 
 TR::RealRegister *

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -375,7 +375,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    uint32_t *initializeGlobalRegisterTable();
    uint32_t initGlobalVectorRegisterMap(uint32_t vectorOffset);
-   void releaseGlobalRegister(int32_t globalRegisterTableIndex, TR::RealRegister::RegNum gReg);
    int32_t findGlobalRegisterIndex(TR::RealRegister::RegNum gReg);
 
    void releaseLiteralPoolRegister();    // free up GPR6

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -375,7 +375,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    uint32_t *initializeGlobalRegisterTable();
    uint32_t initGlobalVectorRegisterMap(uint32_t vectorOffset);
-   int32_t findGlobalRegisterIndex(TR::RealRegister::RegNum gReg);
 
    void releaseLiteralPoolRegister();    // free up GPR6
 

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -635,7 +635,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
       {
       memset(_registerAssociations, 0, sizeof(TR::Register *) * (TR::RealRegister::NumRegisters));
       }
-   bool supportLockedRegisterAssignment();
 
    TR::RealRegister *getRegisterFile(int32_t i);
 

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -375,7 +375,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    uint32_t *initializeGlobalRegisterTable();
    uint32_t initGlobalVectorRegisterMap(uint32_t vectorOffset);
-   void lockGlobalRegister(int32_t globalRegisterTableIndex);
    void releaseGlobalRegister(int32_t globalRegisterTableIndex, TR::RealRegister::RegNum gReg);
    int32_t findGlobalRegisterIndex(TR::RealRegister::RegNum gReg);
 

--- a/compiler/z/codegen/S390SystemLinkage.hpp
+++ b/compiler/z/codegen/S390SystemLinkage.hpp
@@ -245,8 +245,6 @@ public:
    virtual void mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & stackIndex);
    virtual bool hasToBeOnStack(TR::ParameterSymbol * parm);
 
-   virtual void notifyHasalloca();
-
    virtual void createPrologue(TR::Instruction * cursor);
    virtual void createEpilogue(TR::Instruction * cursor);
 

--- a/compiler/z/codegen/S390SystemLinkage.hpp
+++ b/compiler/z/codegen/S390SystemLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,19 +64,6 @@ namespace TR {
 ////////////////////////////////////////////////////////////////////////////////
 //  TR::S390SystemLinkage Definition
 ////////////////////////////////////////////////////////////////////////////////
-class AllocaPatchGroup
-   {
-public:
-   TR::Instruction *ahi;
-   TR::Instruction *mvc;
-   TR::Instruction *auxMvc;
-
-   AllocaPatchGroup() : ahi(NULL), mvc(NULL), auxMvc(NULL)
-      {
-      }
-   };
-
-
 class S390SystemLinkage : public TR::Linkage
    {
    TR::RealRegister::RegNum _normalStackPointerRegister;

--- a/compiler/z/codegen/S390SystemLinkage.hpp
+++ b/compiler/z/codegen/S390SystemLinkage.hpp
@@ -76,17 +76,6 @@ public:
       }
    };
 
-class VaStartPatchGroup
-   {
-public:
-   TR::Instruction * instrToBePatched[4];
-   VaStartPatchGroup()
-      {
-      for (int i = 0; i < 4; ++i)
-         instrToBePatched[i] = NULL;
-      }
-   };
-
 
 class S390SystemLinkage : public TR::Linkage
    {

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -2320,30 +2320,6 @@ void TR::S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
    ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
    }
 
-void TR::S390SystemLinkage::notifyHasalloca()
-   {
-   TR::RealRegister::RegNum alternateSP = getAlternateStackPointerRegister();
-   TR::RealRegister * alternateStackReg = getS390RealRegister(getAlternateStackPointerRegister());
-   alternateStackReg->setState(TR::RealRegister::Locked);
-   alternateStackReg->setAssignedRegister(alternateStackReg);
-   alternateStackReg->setHasBeenAssignedInMethod(true);
-   if (cg()->supportsHighWordFacility() && !comp()->getOption(TR_DisableHighWordRA) && TR::Compiler->target.is64Bit())
-      {
-      TR::RealRegister * tempHigh = toRealRegister(alternateStackReg)->getHighWordRegister();
-      tempHigh->setState(TR::RealRegister::Locked);
-      tempHigh->setAssignedRegister(tempHigh);
-      tempHigh->setHasBeenAssignedInMethod(true);
-      }
-   _notifiedOfalloca = true;
-   setStackPointerRegister(getAlternateStackPointerRegister());
-
-    int32_t globalAltStackReg = cg()->machine()->findGlobalRegisterIndex(alternateSP);
-    if (globalAltStackReg != -1)
-       {
-       cg()->machine()->lockGlobalRegister(globalAltStackReg);
-       }
-   }
-
 int32_t
 TR::S390zLinuxSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
    {


### PR DESCRIPTION
- Deprecate unused `notifyHasalloca` function
- Deprecate unused `lockGlobalRegister` function
- Deprecate unused `releaseGlobalRegister` function
- Deprecate unused `findGlobalRegisterIndex` function
- Fold `supportLockedRegisterAssignment` as false
- Deprecate unused `[un]lockGPR` function
- Deprecate unused `VaStartPatchGroup` class
- Deprecate unused `AllocaPatchGroup` class 