### PR TITLE
Remove unused query for CMOV support on X86

### DIFF
--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -531,8 +531,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::IA32DataSnippet *create8ByteData(TR::Node *, int64_t c);
    TR::IA32DataSnippet *create16ByteData(TR::Node *, void *c);
 
-   bool supportsCMOV() {return (_targetProcessorInfo.supportsCMOVInstructions());}
-
    static TR_X86ProcessorInfo _targetProcessorInfo;
 
    // The core "clobberEvaluate" logic for single registers (not register


### PR DESCRIPTION
supportsCMOV() is not in-use and unnecessary, removing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>