### PR TITLE
Add feature to ignore spin thread bound

### DIFF
--- a/include_core/omrthread.h
+++ b/include_core/omrthread.h
@@ -109,6 +109,7 @@ or omrthread priority value.
 
 #define OMRTHREAD_MINIMUM_SPIN_THREADS 1
 #define OMRTHREAD_MINIMUM_WAKE_THREADS 1
+#define OMRTHREAD_IGNORE_SPIN_THREAD_BOUND 0
 
 #include "thread_api.h"
 

--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -72,14 +72,16 @@ omrthread_spinlock_acquire(omrthread_t self, omrthread_monitor_t monitor)
 
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
 	BOOLEAN spinning = TRUE;
- 	if (monitor->spinThreads < lib->maxSpinThreads) {
- 		VM_AtomicSupport::add(&monitor->spinThreads, 1);
- 	} else {
- 		spinCount1Init = 1;
- 		spinCount2Init = 1;
- 		spinCount3Init = 1;
- 		spinning = FALSE;
- 	}
+	if (OMRTHREAD_IGNORE_SPIN_THREAD_BOUND != lib->maxSpinThreads) {
+		if (monitor->spinThreads < lib->maxSpinThreads) {
+			VM_AtomicSupport::add(&monitor->spinThreads, 1);
+		} else {
+			spinCount1Init = 1;
+			spinCount2Init = 1;
+			spinCount3Init = 1;
+			spinning = FALSE;
+		}
+	}
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
 
 	uintptr_t spinCount3 = spinCount3Init;
@@ -134,7 +136,7 @@ update_jlm:
 #endif /* OMR_THR_JLM */
 
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
-	if (spinning) {
+	if (spinning && (OMRTHREAD_IGNORE_SPIN_THREAD_BOUND != lib->maxSpinThreads)) {
 		VM_AtomicSupport::subtract(&monitor->spinThreads, 1);
 	}
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */


### PR DESCRIPTION
In OMR, a user can set `lib->maxSpinThreads` to 0. In the current
implementation, no threads will spin if `lib->maxSpinThreads` is set to 0.
This is a redundant feature since spinning can also be disabled by
setting `lib->defaultMonitorSpinCount1/2/3` to 1.

So, the behavior for `lib->maxSpinThread = 0` is re-purposed. If
`lib->maxSpinThreads` is set to 0, then an upper bound won't be enforced
on spin threads, and unlimited spin threads will be allowed.

This is an experimental feature. A consumer of OMR can enable this
feature by setting `lib->maxSpinThread` to 0 via
`omrthread_global("maxSpinThreads")`. It will be used to create heuristics
for locking workloads which benefit from no bound on the number of spin
threads.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>