### PR TITLE
Make runtime helper table class do lazy address translation

### DIFF
--- a/compiler/runtime/Runtime.cpp
+++ b/compiler/runtime/Runtime.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,6 +45,28 @@ void*
 TR_RuntimeHelperTable::translateAddress(void * a)
    {
    return a;
+   }
+
+void* TR_RuntimeHelperTable::getFunctionEntryPointOrConst(TR_RuntimeHelper h)
+   {
+   if (h < TR_numRuntimeHelpers)
+      {
+      if (_linkage[h] == TR_Helper)
+         return translateAddress(_helpers[h]);
+      else
+         return _helpers[h];
+      }
+   else
+      return reinterpret_cast<void*>(TR_RuntimeHelperTable::INVALID_FUNCTION_POINTER);
+   }
+
+void*
+TR_RuntimeHelperTable::getFunctionPointer(TR_RuntimeHelper h)
+   {
+   if ((h < TR_numRuntimeHelpers) && (_linkage[h] == TR_Helper))
+      return _helpers[h];
+   else
+      return reinterpret_cast<void*>(TR_RuntimeHelperTable::INVALID_FUNCTION_POINTER);
    }
 
 void

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -318,6 +318,10 @@ typedef struct {
 	void *rawFnAddress;
 } J9FunctionDescriptor_T;
 
+// Set the Address Enviroment pointer.  Same for all routines from
+// same library, so doesn't matter which routine, but currently only
+// used when calling jitProfile* in zOS, so use one of them
+#define TOC_UNWRAP_ENV(wrappedPointer) (wrappedPointer ? ((J9FunctionDescriptor_T *) (wrappedPointer))->ada : NULL)
 #define TOC_UNWRAP_ADDRESS(wrappedPointer) (wrappedPointer ? ((J9FunctionDescriptor_T *)(uintptr_t)(wrappedPointer))->rawFnAddress : NULL)
 
 
@@ -335,6 +339,8 @@ typedef struct {
 
 #endif /* __cplusplus */
 
+#else
+#define TOC_UNWRAP_ENV(wrappedPointer) 0xdeafbeef
 #endif /* J9ZOS390 */
 
 #ifndef J9CONST64


### PR DESCRIPTION
Runtime helper table no longer unwrap function pointers at initialization
time. It now keeps an array of function pointers and only unwraps the raw
entry points whenever a user calls the getAddress() API.

Also, add a getEnvironment() API to get the function pointers'
environments. This can be helpful for platforms whose C functions have
environment pointers.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>