### PR TITLE
Initialize CS background GC thread count

### DIFF
--- a/gc/base/Configuration.hpp
+++ b/gc/base/Configuration.hpp
@@ -148,14 +148,15 @@ protected:
 	 * @return whether NUMAMAnager was initialized or not.  False implies startup failure.
 	 */
 	virtual bool initializeNUMAManager(MM_EnvironmentBase* env);
-
-private:
+	
 	/**
 	 * Sets the number of gc threads
 	 *
 	 * @param env[in] - the current environment
 	 */
-	void initializeGCThreadCount(MM_EnvironmentBase* env);
+	virtual void initializeGCThreadCount(MM_EnvironmentBase* env);
+	
+private:
 
 	/**
 	 * Sets GC parameters that are dependent on the number of gc threads (if not previously initialized):

--- a/gc/base/standard/ConfigurationStandard.cpp
+++ b/gc/base/standard/ConfigurationStandard.cpp
@@ -87,6 +87,26 @@ MM_ConfigurationStandard::initialize(MM_EnvironmentBase* env)
 	return result;
 }
 
+
+void
+MM_ConfigurationStandard::initializeGCThreadCount(MM_EnvironmentBase* env)
+{
+
+	MM_Configuration::initializeGCThreadCount(env);
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	MM_GCExtensionsBase* extensions = env->getExtensions();
+
+	/* If not explicitly set, concurrent phase of CS runs with approx 1/4 the thread count (relative to STW phases thread count */
+	if (!extensions->concurrentScavengerBackgroundThreadsForced) {
+		extensions->concurrentScavengerBackgroundThreads = OMR_MAX(1, (extensions->gcThreadCount + 1) / 4);
+	} else if (extensions->concurrentScavengerBackgroundThreads > extensions->gcThreadCount) {
+		extensions->concurrentScavengerBackgroundThreads = extensions->gcThreadCount;
+	}
+#endif
+}
+
+
 /**
  * Create the global collector for a Standard configuration
  */

--- a/gc/base/standard/ConfigurationStandard.hpp
+++ b/gc/base/standard/ConfigurationStandard.hpp
@@ -74,6 +74,13 @@ public:
 protected:
 	virtual bool initialize(MM_EnvironmentBase* env);
 	virtual MM_EnvironmentBase* allocateNewEnvironment(MM_GCExtensionsBase* extensions, OMR_VMThread* omrVMThread);
+	
+	/**
+	 * Sets the number of gc threads
+	 *
+	 * @param env[in] - the current environment
+	 */
+	virtual void initializeGCThreadCount(MM_EnvironmentBase* env);
 
 private:
 	static MM_GCWriteBarrierType getWriteBarrierType(MM_EnvironmentBase* env)

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -251,7 +251,9 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 	writer->formatAndOutput(env, 0, "<initialized %s>", tagTemplate);
 	writer->formatAndOutput(env, 1, "<attribute name=\"gcPolicy\" value=\"%s\" />", event->gcPolicy);
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />", event->concurrentScavenger ? "true" : "false");
+	if (gc_policy_gencon == _extensions->configurationOptions._gcPolicy) {
+		writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />", event->concurrentScavenger ? "true" : "false");
+	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	writer->formatAndOutput(env, 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", event->maxHeapSize);
 	writer->formatAndOutput(env, 1, "<attribute name=\"initialHeapSize\" value=\"0x%zx\" />", event->initialHeapSize);
@@ -267,6 +269,19 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 	writer->formatAndOutput(env, 1, "<attribute name=\"requestedPageSize\" value=\"0x%zx\" />", event->heapRequestedPageSize);
 	writer->formatAndOutput(env, 1, "<attribute name=\"requestedPageType\" value=\"%s\" />", event->heapRequestedPageType);
 	writer->formatAndOutput(env, 1, "<attribute name=\"gcthreads\" value=\"%zu\" />", event->gcThreads);
+	if (gc_policy_gencon == _extensions->configurationOptions._gcPolicy) {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		if (_extensions->isConcurrentScavengerEnabled()) {
+			writer->formatAndOutput(env, 1, "<attribute name=\"gcthreads Concurrent Scavenger\" value=\"%zu\" />", _extensions->concurrentScavengerBackgroundThreads);
+		}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+		if (_extensions->isConcurrentMarkEnabled()) {
+			writer->formatAndOutput(env, 1, "<attribute name=\"gcthreads Concurrent Mark\" value=\"%zu\" />", _extensions->concurrentBackground);
+		}
+#endif /* OMR_GC_MODRON_CONCURRENT_MARK */
+	}
+
 	writer->formatAndOutput(env, 1, "<attribute name=\"numaNodes\" value=\"%zu\" />", event->numaNodes);
 
 	handleInitializedInnerStanzas(hook, eventNum, eventData);


### PR DESCRIPTION
This is done now in Configuration class, while it used to be initialized
in downstream projects like OpenJ9.

It is done just after initilization of GC thread count for STW
phase. Then Concurrent Scavenger can initialize its own
background count as a function of STW GC thread count.

The background default is set to appox 1/4 of STW GC thread count.

Also, reporting the counts in verbose GC <initialized stanza. It can now
have two more lines (adding for Concurrent Mark, too):

```

  <attribute name="gcthreads" value="24" />
  <attribute name="gcthreads Concurrent Scavenger" value="6" />
  <attribute name="gcthreads Concurrent Mark" value="1" />
  
```  

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>