### PR TITLE
Improve DDR support to allow use of VS 2017

### DIFF
--- a/configure
+++ b/configure
@@ -789,7 +789,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -964,7 +963,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1217,15 +1215,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1363,7 +1352,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1516,7 +1505,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -7215,16 +7203,15 @@ $as_echo X"$VS_CL_PATH" |
 	    q
 	  }
 	  s/.*/./; q')
-					diasdk_dir="$vc_bin_dir/../../DIA SDK"
-					if test -f "$diasdk_dir/include/dia2.h"
-						DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"; then :
-
-						diasdk_dir="$vc_bin_dir/../../../DIA SDK"
-						if test -f "$diasdk_dir/include/dia2.h"; then :
-  DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"
-
-fi
-
+					diasdk_dir1="$vc_bin_dir/../../DIA SDK"
+					diasdk_dir2="$vc_bin_dir/../../../DIA SDK"
+					diasdk_dir3="$vc_bin_dir/../../../../../../../DIA SDK"
+					if test -f "$diasdk_dir1/include/dia2.h"; then :
+  DIASDK_HOME="$(cygpath -a -w "$diasdk_dir1")"
+elif test -f "$diasdk_dir2/include/dia2.h"; then :
+  DIASDK_HOME="$(cygpath -a -w "$diasdk_dir2")"
+elif test -f "$diasdk_dir3/include/dia2.h"; then :
+  DIASDK_HOME="$(cygpath -a -w "$diasdk_dir3")"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -540,15 +540,12 @@ AS_IF([test "$enable_DDR" = yes -a "$cross_compiling" != "yes"],
 					[
 					# this should yield .../VC/bin/cl.exe or .../VC/bin/amd64/cl.exe
 					vc_bin_dir=$(AS_DIRNAME(["$VS_CL_PATH"]))
-					diasdk_dir="$vc_bin_dir/../../DIA SDK"
-					AS_IF([test -f "$diasdk_dir/include/dia2.h"]
-						[DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"],
-						[
-						diasdk_dir="$vc_bin_dir/../../../DIA SDK"
-						AS_IF([test -f "$diasdk_dir/include/dia2.h"],
-							[DIASDK_HOME="$(cygpath -a -w "$diasdk_dir")"]
-						)
-						]
+					diasdk_dir1="$vc_bin_dir/../../DIA SDK"
+					diasdk_dir2="$vc_bin_dir/../../../DIA SDK"
+					diasdk_dir3="$vc_bin_dir/../../../../../../../DIA SDK"
+					AS_IF([test -f "$diasdk_dir1/include/dia2.h"], [DIASDK_HOME="$(cygpath -a -w "$diasdk_dir1")"],
+						[test -f "$diasdk_dir2/include/dia2.h"], [DIASDK_HOME="$(cygpath -a -w "$diasdk_dir2")"],
+						[test -f "$diasdk_dir3/include/dia2.h"], [DIASDK_HOME="$(cygpath -a -w "$diasdk_dir3")"]
 					)
 					]
 				)

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -198,7 +198,7 @@ PdbScanner::loadDataFromPdb(const wchar_t *filename, IDiaDataSource **dataSource
 	HRESULT hr = CoCreateInstance(__uuidof(DiaSource), NULL, CLSCTX_INPROC_SERVER, __uuidof(IDiaDataSource), (void **)dataSource);
 	if (FAILED(hr)) {
 		ERRMSG("CoCreateInstance failed with HRESULT = %08lX", hr);
-		static const char * const libraries[] = { "MSDIA120", "MSDIA100", "MSDIA80", "MSDIA70", "MSDIA60" };
+		static const char * const libraries[] = { "MSDIA140", "MSDIA120", "MSDIA100", "MSDIA80", "MSDIA70", "MSDIA60" };
 		rc = DDR_RC_ERROR;
 		for (size_t i = 0; i < sizeof(libraries) / sizeof(*libraries); ++i) {
 			HMODULE hmodule = LoadLibrary(libraries[i]);
@@ -603,6 +603,7 @@ PdbScanner::setMemberOffset(IDiaSymbol *symbol, Field *newField)
 			break;
 		}
 		case LocIsStatic:
+		case LocIsConstant:
 		{
 			/* Get offset of static class members. */
 			newField->_isStatic = true;


### PR DESCRIPTION
The change is to improve DDR support in script/code
so as to allow use of VS 2017 on Windows.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>