### PR TITLE
Reduce output from hookgen and tracegen

### DIFF
--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1077,6 +1077,6 @@ TraceException=Trc_PRT_readCgroupFile_fgets_failed Group=sysinfo Overhead=1 Leve
 TraceException=Trc_PRT_isRunningInContainer_fgets_failed Group=sysinfo Overhead=1 Level=3 NoEnv Template="isRunningInContainer: unexpected format of file %s with errno=%d"
 
 TraceException=Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal Group=signal Overhead=1 Level=3 NoEnv Template="omrsignal: mapPortLibSignalToOSSignal: ERROR, unknown signal, portLibSignal=0x%X" 
- 
+
 TraceException=Trc_PRT_retrieveLinuxCgroupMemoryStats_invalidValue Group=sysinfo Overhead=1 Level=1 NoEnv Template="retrieveLinuxCgroupMemoryStats: Value of field \"%s\" in file %s is invalid"
 TraceEvent=Trc_PRT_retrieveLinuxMemoryStats_CgroupMemoryStatsFailed Group=sysinfo Overhead=1 Level=1 NoEnv Template="retrieveLinuxMemoryStats: Failed to retrieve memory stats of cgroup with error code=%d"

--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -521,19 +521,32 @@ HookGen::processFile()
 void
 HookGen::displayUsage()
 {
-	fprintf(stderr, "hookgen {fileName}\n");
+	fprintf(stderr, "hookgen [-v] fileName\n");
 }
 
 RCType
 HookGen::parseOptions(int argc, char *argv[])
 {
-	if (argc != 2) {
+	for (int i = 1; i < argc; i++) {
+		printf("%d: %s", i, argv[i]);
+		if(0 == strcmp(argv[i], "-v")) {
+			_verbose = true;
+		} else {
+			if (NULL != _fileName) {
+				fprintf(stderr, "Please specify only one filename\n");
+				displayUsage();
+				return RC_FAILED;
+			}
+			_fileName = argv[i];
+		}
+	}
+
+	if (NULL == _fileName) {
 		fprintf(stderr, "Please provide a file to process\n");
 		displayUsage();
 		return RC_FAILED;
 	}
 
-	_fileName = argv[1];
 
 	return RC_OK;
 }
@@ -564,7 +577,9 @@ startHookGen(int argc, char *argv[])
 		goto finish;
 	}
 
-	fprintf(stderr, "Processed %s to create public header %s and private header %s\n", hookGen.getFileName(), hookGen.getPublicFileName(), hookGen.getPrivateFileName());
+	if(hookGen.isVerbose()) {
+		fprintf(stderr, "Processed %s to create public header %s and private header %s\n", hookGen.getFileName(), hookGen.getPublicFileName(), hookGen.getPrivateFileName());
+	}
 
 finish:
 	hookGen.tearDown();

--- a/tools/hookgen/HookGen.hpp
+++ b/tools/hookgen/HookGen.hpp
@@ -51,6 +51,7 @@ private:
 	FILE *_publicFile; /**< FILE handle for public header file.  close in tearDown if non-NULL */
 	const char *_privateFileName; /**< value (or substring) from XML parsing so no need to free */
 	FILE *_privateFile; /**< FILE handle for prviate header file.  close in tearDown if non-NULL */
+	bool _verbose; /**< If we want to print verbose information to stderr */
 protected:
 public:
 
@@ -92,6 +93,7 @@ public:
 		, _publicFile(NULL)
 		, _privateFileName(NULL)
 		, _privateFile(NULL)
+		, _verbose(false)
 	{
 	}
 
@@ -106,6 +108,7 @@ public:
 	const char *getFileName() const {return _fileName;}
 	const char *getPublicFileName() const {return _publicFileName;}
 	const char *getPrivateFileName() const {return _privateFileName;}
+	bool isVerbose() const {return _verbose;}
 };
 
 #endif /* HOOKGEN_HPP_ */

--- a/tools/tracegen/ArgParser.cpp
+++ b/tools/tracegen/ArgParser.cpp
@@ -101,6 +101,8 @@ ArgParser::parseOptions(int argc, char *argv[], J9TDFOptions *options)
 			} else {
 				options->rasMinorVersion = atoi(argv[i]);
 			}
+		} else if (StringUtils::startsWithUpperLower(argv[i], "-verbose")) {
+			options->verboseOutput = true;
 		} else if (StringUtils::startsWithUpperLower(argv[i], "-debug")) {
 			options->debugOutput = true;
 		} else if (StringUtils::startsWithUpperLower(argv[i], "-w2cd"))	{

--- a/tools/tracegen/CFileWriter.cpp
+++ b/tools/tracegen/CFileWriter.cpp
@@ -50,7 +50,9 @@ CFileWriter::writeOutputFiles(J9TDFOptions *options, J9TDFFile *tdf, J9TDFGroup 
 		return RC_OK;
 	}
 
-	printf("Creating c file: %s\n", fileName);
+	if (options->verboseOutput) {
+		printf("Creating c file: %s\n", fileName);
+	}
 
 	fd = Port::fopen(fileName, "wb");
 

--- a/tools/tracegen/DATFileWriter.cpp
+++ b/tools/tracegen/DATFileWriter.cpp
@@ -54,7 +54,9 @@ DATFileWriter::writeOutputFiles(J9TDFOptions *options, J9TDFFile *tdf)
 		return RC_OK;
 	}
 
-	printf("Creating pdat file: %s\n", fileName);
+	if (options->verboseOutput) {
+		printf("Creating pdat file: %s\n", fileName);
+	}
 
 	FILE *datFile = Port::fopen(fileName, "w");
 	if (NULL == datFile) {

--- a/tools/tracegen/TDFTypes.hpp
+++ b/tools/tracegen/TDFTypes.hpp
@@ -142,6 +142,7 @@ typedef struct J9TDFOptions {
 
 	/* debug options */
 	bool debugOutput;
+	bool verboseOutput;
 	bool treatWarningAsError;
 
 	J9TDFOptions()
@@ -154,6 +155,7 @@ typedef struct J9TDFOptions {
 		, rootDirectory(NULL)
 		, files(NULL)
 		, debugOutput(false)
+		, verboseOutput(false)
 		, treatWarningAsError(false)
 	{
 	}

--- a/tools/tracegen/TraceGen.cpp
+++ b/tools/tracegen/TraceGen.cpp
@@ -178,7 +178,10 @@ TraceGen::generate(J9TDFOptions *options, const char *currentTDFFile)
 		goto done;
 	}
 
-	printf("Processing tdf file %s\n", currentTDFFile);
+	if (true == options->verboseOutput) {
+		printf("Processing tdf file %s\n", currentTDFFile);
+	}
+
 
 	rc = reader.init(currentTDFFile);
 	if (RC_OK != rc) {
@@ -200,7 +203,7 @@ TraceGen::generate(J9TDFOptions *options, const char *currentTDFFile)
 		goto done;
 	}
 
-	groups = calculateGroups(tdf, &groupCount);
+	groups = calculateGroups(options, tdf, &groupCount);
 	if (NULL == groups) {
 		FileUtils::printError("Failed to calculate tracepoint groups");
 		rc = RC_FAILED;
@@ -387,7 +390,7 @@ failed:
 }
 
 J9TDFGroup *
-TraceGen::calculateGroups(J9TDFFile *tdf, unsigned int *groupCount)
+TraceGen::calculateGroups(J9TDFOptions *options, J9TDFFile *tdf, unsigned int *groupCount)
 {
 	const char *EVENT_TYPES[] = {
 		"Event",
@@ -415,7 +418,9 @@ TraceGen::calculateGroups(J9TDFFile *tdf, unsigned int *groupCount)
 	}
 
 
-	printf("Calculating groups for %s\n", tdf->header.executable);
+	if (true == options->verboseOutput) {
+		printf("Calculating groups for %s\n", tdf->header.executable);
+	}
 
 	/* Add tracepoint ID to tracegroup */
 	while (NULL != tp) {

--- a/tools/tracegen/TraceGen.hpp
+++ b/tools/tracegen/TraceGen.hpp
@@ -92,7 +92,7 @@ private:
 	 * @param[out] groupCount Number of trace groups in TDF file
 	 * @return On success trace groups. On failure NULL.
 	 */
-	J9TDFGroup *calculateGroups(J9TDFFile *tdf, unsigned int *groupCount);
+	J9TDFGroup *calculateGroups(J9TDFOptions *options, J9TDFFile *tdf, unsigned int *groupCount);
 protected:
 public:
 	TraceGen()

--- a/tools/tracegen/TraceHeaderWriter.cpp
+++ b/tools/tracegen/TraceHeaderWriter.cpp
@@ -158,7 +158,9 @@ TraceHeaderWriter::writeOutputFiles(J9TDFOptions *options, J9TDFFile *tdf)
 		return RC_OK;
 	}
 
-	printf("Creating header file: %s\n", fileName);
+	if (true == options->verboseOutput) {
+		printf("Creating header file: %s\n", fileName);
+	}
 
 	fd = Port::fopen(fileName, "wb");
 

--- a/tools/tracemerge/DATMerge.cpp
+++ b/tools/tracemerge/DATMerge.cpp
@@ -228,13 +228,16 @@ DATMerge::merge(J9TDFOptions *options, const char *fromFileName)
 			perror("fopen error");
 			goto failed;
 		}
-		printf("tracemerge creating dat file: %s\n", toFileName);
+		if (true == options->verboseOutput) {
+			printf("tracemerge creating dat file: %s\n", toFileName);
+		}
 
 		fprintf(toFile, "%u.%u\n", options->rasMajorVersion, options->rasMinorVersion);
 	}
 
-
-	printf("Adding %s to dat file: %s\n", fromFileName, toFileName);
+	if (true == options->verboseOutput) {
+		printf("Adding %s to dat file: %s\n", fromFileName, toFileName);
+	}
 
 	while (fromFilereader.hasNext()) {
 		const char *line = fromFilereader.next();


### PR DESCRIPTION
Reduce the output of both of these tools to none, unless something goes
wrong.  Add a verbose output to give the old output.