### PR TITLE
Fix incorrect hasMandatoryPrefix() on X86

### DIFF
--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -377,7 +377,7 @@ class TR_X86OpCode
       // check if the instruction has mandatory prefix(es)
       inline bool hasMandatoryPrefix() const
          {
-         return prefixes == PREFIX___;
+         return prefixes != PREFIX___;
          }
       // check if the instruction is part of Group 7 OpCode Extension
       inline bool isGroup07() const


### PR DESCRIPTION
hasMandatoryPrefix() should answer true when there is one prefix;
however, its answer was reversed. Fixing it.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>