### PR TITLE
Deprecate VMifInstanceOf helper on X86

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1310,6 +1310,9 @@ TR::Register *OMR::X86::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::Cod
 
 static bool canBeHandledByIfInstanceOfHelper(TR::Node *node, TR::CodeGenerator *cg)
    {
+   static const auto ForceOldIfInstanceOf = (bool)feGetEnv("TR_ForceOldIfInstanceOf");
+   if (!ForceOldIfInstanceOf)
+      return false;
    TR::Node *firstChild  = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
    if (secondChild->getOpCode().isLoadConst() &&


### PR DESCRIPTION
Requested by OpenJ9, VMifInstanceOf helper is deprecated. Their old
implementation contains potential functional issues.

Note that VMifInstanceOf is a J9 project specific feature although
it is not yet guarded by J9_PROJECT_SPECIFIC. TR::instanceOf itself
is also a OpenJ9 project specific IL Op.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>