### PR TITLE
Use immediately available self() in CodeGenerator

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -75,7 +75,6 @@
 #include "optimizer/Structure.hpp"
 #include "ras/Debug.hpp"                       // for TR_DebugBase
 
-
 #define OPT_DETAILS "O^O CODE GENERATION: "
 
 #define NUM_REGS_USED_BY_COMPLEX_OPCODES 3
@@ -91,9 +90,6 @@ int OMR::CodeGenerator::_totalNumRematerializedIndirects = 0;
 int OMR::CodeGenerator::_totalNumRematerializedAddresses = 0;
 int OMR::CodeGenerator::_totalNumRematerializedXMMRs = 0;
 #endif
-
-
-
 
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 void
@@ -346,10 +342,10 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Block *block, vcount_t visitCou
    while (treeTop)
       {
       TR::Node *node = treeTop->getNode();
-      self()->estimateRegisterPressure(node, currRegisterPressure, maxRegisterPressure, self()->comp()->cg()->getMaximumNumbersOfAssignableGPRs(), valuesInGlobalRegs, isCold, visitCount, symRef, symRefIsLive, checkForIMuls, vmThreadUsed);
+      self()->estimateRegisterPressure(node, currRegisterPressure, maxRegisterPressure, self()->getMaximumNumbersOfAssignableGPRs(), valuesInGlobalRegs, isCold, visitCount, symRef, symRefIsLive, checkForIMuls, vmThreadUsed);
 
       if (vmThreadUsed &&
-          (maxRegisterPressure >= self()->comp()->cg()->getMaximumNumbersOfAssignableGPRs()))
+          (maxRegisterPressure >= self()->getMaximumNumbersOfAssignableGPRs()))
          {
          //dumpOptDetails("For global register candidate %d reg pressure reached limit %d at block_%d isCold %d maxFreq %d\n", rc->getSymbolReference()->getReferenceNumber(), maxRegisterPressure, liveBlockNum, isCold, maxFrequency);
          break;
@@ -1167,7 +1163,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
                                TR_GlobalRegisterNumber & highRegisterNumber,
                                TR_LinkHead<TR_RegisterCandidate> *candidatesAlreadyAssigned)
    {
-   bool enableHighWordGRA =  self()->comp()->cg()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA);
+   bool enableHighWordGRA =  self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA);
    static volatile bool isInitialized=false;
    static volatile uint8_t gprsWithheldFromPickRegister=0, fprsWithheldFromPickRegister=0, vrfWithheldFromPickRegister=0, gprsWithheldFromPickRegisterWhenWarm=0;
    int32_t currentCandidateWeight =-1;
@@ -2591,7 +2587,7 @@ nodeGotFoldedIntoMemref(
 void
 OMR::CodeGenerator::simulateTreeEvaluation(TR::Node *node, TR_RegisterPressureState *state, TR_RegisterPressureSummary *summary)
    {
-   bool enableHighWordGRA = self()->comp()->cg()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA);
+   bool enableHighWordGRA = self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA);
    // Analogous to cg->evaluate(node).
    //
    // This can be called on nodes that have already been evaluated, and it does
@@ -2733,7 +2729,7 @@ OMR::CodeGenerator::simulateTreeEvaluation(TR::Node *node, TR_RegisterPressureSt
 
       if (isCall)
          {
-         isCall = self()->comp()->cg()->willBeEvaluatedAsCallByCodeGen(node, self()->comp());
+         isCall = self()->willBeEvaluatedAsCallByCodeGen(node, self()->comp());
          }
 
       if (isCall && node->isTheVirtualCallNodeForAGuardedInlinedCall())
@@ -2906,7 +2902,7 @@ OMR::CodeGenerator::simulateTreeEvaluation(TR::Node *node, TR_RegisterPressureSt
             summary->spill(TR_volatileSpill, self());
 
             TR::Symbol * rcSymbol = state->_candidate->getSymbolReference()->getSymbol();
-            TR::Linkage *linkage = self()->comp()->cg()->getLinkage();
+            TR::Linkage *linkage = self()->getLinkage();
 
 #if defined(TR_TARGET_S390)
             TR_BitVector* killedRegisters = linkage->getKilledRegisters(node);

--- a/compiler/codegen/CodeGenerator.hpp
+++ b/compiler/codegen/CodeGenerator.hpp
@@ -35,7 +35,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGeneratorConnector
 public:
 
    /**
-    * @param[in] comp : the TR::Compilaation object
+    * @param[in] comp : the TR::Compilation object
     */
    CodeGenerator(TR::Compilation *comp) :
       OMR::CodeGeneratorConnector() {}

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1152,7 +1152,7 @@ OMR::CodeGenerator::getNumberOfGlobalRegisters()
 #ifdef TR_HOST_S390
 uint16_t OMR::CodeGenerator::getNumberOfGlobalGPRs()
    {
-   if (self()->comp()->cg()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA))
+   if (self()->supportsHighWordFacility() && !self()->comp()->getOption(TR_DisableHighWordRA))
       {
       return _firstGlobalHPR;
       }
@@ -2311,7 +2311,7 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
    if (boundary && (boundary & boundary - 1) == 0)
       {
       uintptr_t round = boundary - 1;
-      uintptr_t offset = self()->comp()->cg()->getPreJitMethodEntrySize();
+      uintptr_t offset = self()->getPreJitMethodEntrySize();
 
       _binaryBufferCursor += offset;
       _binaryBufferCursor = (uint8_t *)(((uintptr_t)_binaryBufferCursor + round) & ~round);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -730,7 +730,7 @@ void OMR::X86::CodeGenerator::removeLiveDiscardableRegister(TR::Register * reg)
 
 bool OMR::X86::CodeGenerator::canNullChkBeImplicit(TR::Node * node)
    {
-   return self()->comp()->cg()->canNullChkBeImplicit(node, true);
+   return self()->canNullChkBeImplicit(node, true);
    }
 
 void OMR::X86::CodeGenerator::clobberLiveDiscardableRegisters(
@@ -2712,7 +2712,7 @@ int32_t OMR::X86::CodeGenerator::computeRegisterSaveDescription(TR_BitVector *re
    // metadata for the method
    //
    if (populateInfo)
-      self()->comp()->cg()->setLowestSavedRegister(rsd & 0xFFFF);
+      self()->setLowestSavedRegister(rsd & 0xFFFF);
 
    return rsd;
    }

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -301,15 +301,15 @@ OMR::X86::I386::CodeGenerator::pickRegister(
 
          maxRegisterPressure = self()->estimateRegisterPressure(block, visitCount, maxStaticFrequency, maxFrequency, vmThreadUsed, numAssignedGlobalRegs, _assignedGlobalRegisters, rc->getSymbolReference(), assigningEDX);
 
-         if (maxRegisterPressure >= self()->comp()->cg()->getMaximumNumbersOfAssignableGPRs())
+         if (maxRegisterPressure >= self()->getMaximumNumbersOfAssignableGPRs())
             break;
          }
 
       // Determine if we can spare any extra registers for this candidate without spilling
       // in any hot (critical) blocks
       //
-      if (maxRegisterPressure < self()->comp()->cg()->getMaximumNumbersOfAssignableGPRs())
-         numExtraRegs = self()->comp()->cg()->getMaximumNumbersOfAssignableGPRs() - maxRegisterPressure;
+      if (maxRegisterPressure < self()->getMaximumNumbersOfAssignableGPRs())
+         numExtraRegs = self()->getMaximumNumbersOfAssignableGPRs() - maxRegisterPressure;
 
       //dumpOptDetails("For global register candidate %d reg pressure is %d maxRegs %d numExtraRegs %d\n", rc->getSymbolReference()->getReferenceNumber(), maxRegisterPressure, comp()->cg()->getMaximumNumbersOfAssignableGPRs(), numExtraRegs);
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6331,7 +6331,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
          self()->addBreakPointAddress(instructionStart);
          }
 
-      if (self()->comp()->cg()->isBranchInstruction(data.cursorInstruction))
+      if (self()->isBranchInstruction(data.cursorInstruction))
          {
          TR::LabelSymbol * branchLabelSymbol = ((TR::S390BranchInstruction *)data.cursorInstruction)->getLabelSymbol();
          if (data.cursorInstruction->getKind() == TR::Instruction::IsRIE &&
@@ -6355,7 +6355,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
             branchHashTable->add((void *)targetLabel, hashIndex, (void *)targetLabel);
             }
          }
-      else if (self()->comp()->cg()->isLabelInstruction(data.cursorInstruction))
+      else if (self()->isLabelInstruction(data.cursorInstruction))
          {
          TR::LabelSymbol * labelSymbol = ((TR::S390BranchInstruction *)data.cursorInstruction)->getLabelSymbol();
          TR_HashId hashIndex = 0;
@@ -7003,7 +7003,7 @@ OMR::Z::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node * node)
          {
          int64_t value = getIntegralValue(node->getSecondChild());
 
-         if (self()->comp()->cg()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12) && value >= MIN_IMMEDIATE_BYTE_VAL && value <= MAX_IMMEDIATE_BYTE_VAL)
+         if (self()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_zEC12) && value >= MIN_IMMEDIATE_BYTE_VAL && value <= MAX_IMMEDIATE_BYTE_VAL)
             {
             return maxGPRs - 2;   // CLGIJ R,IMM,LAB,MASK, last instruction on block boundary
             }
@@ -7470,7 +7470,7 @@ OMR::Z::CodeGenerator::ssrClobberEvaluate(TR::Node * node, TR::MemoryReference *
       int32_t digitsInSrc = isBCD ? TR::DataType::getBCDPrecisionFromSize(node->getDataType(), byteLength) : 0;
       int32_t digitsToClear = srcRegister->getLeftAlignedZeroDigits() > 0 ? srcRegister->getDigitsToClear(0, digitsInSrc) : digitsInSrc;
       int32_t alreadyClearedDigits = digitsInSrc - digitsToClear;
-      if (self()->comp()->cg()->traceBCDCodeGen())
+      if (self()->traceBCDCodeGen())
          traceMsg(self()->comp(),"\tupdate srcRegister %s with copy ref #%d (%s)\n",
             self()->getDebug()->getName(srcRegister),copyStorageReference->getReferenceNumber(),self()->getDebug()->getName(copyStorageReference->getSymbol()));
       srcRegister->setStorageReference(copyStorageReference, node); // clears leftAlignedZeroDigits so query getDigitsToClear above
@@ -7541,7 +7541,7 @@ OMR::Z::CodeGenerator::ssrClobberEvaluate(TR::Node * node, TR::MemoryReference *
                   // prevent the symA -> VTS_3 update as symA != the orig VTS_2
                   // if the update is done then the last pdModPrecA ref is now using VTS_3 and the final decReferenceCount of the symA aload is never done (live reg alive bug)
                   //
-                  if (self()->comp()->cg()->traceBCDCodeGen())
+                  if (self()->traceBCDCodeGen())
                      traceMsg(self()->comp(),"\ty^y : skip update on reg %s node %s (%p), storageRef has already changed -- was #%d (%s), now #%d (%s)\n",
                         self()->getDebug()->getName(listReg),
                         listNode->getOpCode().getName(),listNode,
@@ -7550,7 +7550,7 @@ OMR::Z::CodeGenerator::ssrClobberEvaluate(TR::Node * node, TR::MemoryReference *
                   }
                else
                   {
-                  if (self()->comp()->cg()->traceBCDCodeGen())
+                  if (self()->traceBCDCodeGen())
                      traceMsg(self()->comp(),"\ty^y : update reg %s with ref #%d (%s) on node %s (%p) refCount %d from _nodesToUpdateOnClobber with copy ref #%d (%s) (skip if refCount == 0)\n",
                         self()->getDebug()->getName(listReg),
                         listReg->getStorageReference()->getReferenceNumber(),self()->getDebug()->getName(listReg->getStorageReference()->getSymbol()),
@@ -10207,7 +10207,7 @@ OMR::Z::CodeGenerator::removeUnavailableRegisters(TR_RegisterCandidate * rc, TR:
          {
          TR_LinkageConventions callLinkage= lastTreeTopNode->getFirstChild()->getSymbol()->castToMethodSymbol()->getLinkageConvention();
 
-         TR_BitVector *volatileRegs = self()->comp()->cg()->getGlobalRegisters(TR_volatileSpill, callLinkage);
+         TR_BitVector *volatileRegs = self()->getGlobalRegisters(TR_volatileSpill, callLinkage);
 
 //         traceMsg(comp(), "volatileRegs = \n");
 //         volatileRegs->print(comp());


### PR DESCRIPTION
There are several places in the CodeGenerator (common codegen and
individual architectures) where the CodeGenerator object is retrieved
indirectly within CodeGenerator member functions rather than simply from
the immediately available `self()` function. In this case, `self()` is
sufficient rather than `self()->comp()->cg()` as they should return the
same pointer.

Closes: #2755
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>