### PR TITLE
Transpose platform build status table in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 # Eclipse OMR
 
-| **Travis CI** | **Windows x86** | **Windows x86-64** | **Linux x86-64** | **Power 64-bit Linux** | **Power 64-bit AIX** | **Linux on Z 64-bit** |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|[![Travis Status](https://api.travis-ci.org/eclipse/omr.svg?branch=master)](https://travis-ci.org/eclipse/omr)|[![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/eclipse/omr?svg=true&branch=master)](https://ci.appveyor.com/project/eclipsewebmaster/omr)|[![Windows x86-64 Status](https://ci.eclipse.org/omr/job/Build-win_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-win_x86-64/)|[![Linux x86-64 Status](https://ci.eclipse.org/omr/job/Build-linux_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_x86-64/)|[![Build-linux_ppc-64_le_gcc Status](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/)|[![Build-aix_ppc-64 Status](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/)|[![Build-linux_390-64 Status](https://ci.eclipse.org/omr/job/Build-linux_390-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_390-64/)|
-
+| Build | Status |
+| ---------------------- | -------------------- |
+| **Travis CI** | [![Travis Status](https://api.travis-ci.org/eclipse/omr.svg?branch=master)](https://travis-ci.org/eclipse/omr) |
+| **Windows x86** | [![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/eclipse/omr?svg=true&branch=master)](https://ci.appveyor.com/project/eclipsewebmaster/omr) |
+| **Windows x86-64** | [![Windows x86-64 Status](https://ci.eclipse.org/omr/job/Build-win_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-win_x86-64/) |
+| **Linux x86-64** | [![Linux x86-64 Status](https://ci.eclipse.org/omr/job/Build-linux_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_x86-64/) |
+| **Power 64-bit Linux** | [![Build-linux_ppc-64_le_gcc Status](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/) |
+| **Power 64-bit AIX** | [![Build-aix_ppc-64 Status](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/) |
+| **Linux on Z 64-bit** | [![Build-linux_390-64 Status](https://ci.eclipse.org/omr/job/Build-linux_390-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_390-64/) |
 
 What Is Eclipse OMR?
 ====================


### PR DESCRIPTION
Accidentally discovered this issue. Too many columns resulted in the
platform names being split into multiple lines to fit smaller screens.

### Before this change:
![img_5234](https://user-images.githubusercontent.com/23691212/43462406-02b650a6-94a4-11e8-8b1e-8a1b67cf5291.PNG)


### After this change:
![img_5235](https://user-images.githubusercontent.com/23691212/43462432-16205858-94a4-11e8-859d-a5d914c3804e.PNG)
