### PR TITLE
Consolidate data size check helpers on X86

### DIFF
--- a/compiler/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -91,12 +91,5 @@ class OMR_EXTENSIBLE TreeEvaluator
    };
 
 }
-
-#define IS_8BIT_SIGNED(x)    ((x) == (  int8_t)(x))
-#define IS_8BIT_UNSIGNED(x)  ((x) == ( uint8_t)(x))
-#define IS_16BIT_SIGNED(x)   ((x) == ( int16_t)(x))
-#define IS_16BIT_UNSIGNED(x) ((x) == (uint16_t)(x))
-#define IS_32BIT_SIGNED(x)   ((x) == ( int32_t)(x))
-#define IS_32BIT_UNSIGNED(x) ((x) == (uint32_t)(x))
 
 #endif

--- a/compiler/env/jittypes.h
+++ b/compiler/env/jittypes.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,13 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#define IS_8BIT_SIGNED(x)    ((x) == (  int8_t)(x))
+#define IS_8BIT_UNSIGNED(x)  ((x) == ( uint8_t)(x))
+#define IS_16BIT_SIGNED(x)   ((x) == ( int16_t)(x))
+#define IS_16BIT_UNSIGNED(x) ((x) == (uint16_t)(x))
+#define IS_32BIT_SIGNED(x)   ((x) == ( int32_t)(x))
+#define IS_32BIT_UNSIGNED(x) ((x) == (uint32_t)(x))
 
 /*
  * -----------------------------------------------------------------------------

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -30,7 +30,6 @@
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/Relocation.hpp"
 #include "codegen/ScratchRegisterManager.hpp"
-#include "codegen/TreeEvaluator.hpp"               // for IS_32BIT_SIGNED
 #include "codegen/UnresolvedDataSnippet.hpp"
 #include "compile/Compilation.hpp"                 // for Compilation, isSMP
 #include "control/Options.hpp"

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -30,7 +30,6 @@
 #include "codegen/Register.hpp"                    // for Register
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/Relocation.hpp"
-#include "codegen/TreeEvaluator.hpp"               // for IS_32BIT_SIGNED, etc
 #include "codegen/UnresolvedDataSnippet.hpp"
 #include "compile/Compilation.hpp"                 // for Compilation
 #include "compile/ResolvedMethod.hpp"              // for TR_ResolvedMethod


### PR DESCRIPTION
Move data size check helpers into shared header file: env/jittypes.h

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>