### PR TITLE
WIP: Create VectorLoopBuilder and IlBuilder::VectorForLoop

### DIFF
--- a/compiler/ilgen/CMakeLists.txt
+++ b/compiler/ilgen/CMakeLists.txt
@@ -29,6 +29,7 @@ compiler_library(ilgen
 	${CMAKE_CURRENT_LIST_DIR}/OMRMethodBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRThunkBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRTypeDictionary.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRVectorLoopBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineOperandArray.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineOperandStack.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineState.cpp

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -660,7 +660,7 @@ OMR::IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
    TR::SymbolReference *symRef = lookupSymbol(varName);
 
    TraceIL("IlBuilder[ %p ]::VectorStore %s %d gets %d\n", this, varName, symRef->getCPIndex(), value->getID());
-   storeNode(symRef, loadValue(value));
+   storeNode(symRef, valueNode);
    }
 
 void

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -653,6 +653,14 @@ OMR::IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
    storeNode(symRef, loadValue(value));
    }
 
+void
+OMR::IlBuilder::ArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value)
+   {
+   StoreAt(
+      IndexAt(dt, base, index),
+      value);
+   }
+
 /**
  * @brief Store an IlValue through a pointer
  * @param address the pointer address through which the value will be written
@@ -772,6 +780,13 @@ OMR::IlBuilder::LoadIndirect(const char *type, const char *field, TR::IlValue *o
    TR::IlValue *returnValue = newValue(fieldType, TR::Node::createWithSymRef(comp()->il.opCodeForIndirectLoad(fieldType), 1, loadValue(object), 0, symRef));
    TraceIL("IlBuilder[ %p ]::%d is LoadIndirect %s.%s from (%d)\n", this, returnValue->getID(), type, field, object->getID());
    return returnValue;
+   }
+
+TR::IlValue *
+OMR::IlBuilder::ArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
+   {
+   return LoadAt(dt,
+             IndexAt(dt, base, index));
    }
 
 TR::IlValue *

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -35,6 +35,7 @@ namespace OMR { class MethodBuilder; }
 namespace TR { class Block; }
 namespace TR { class IlGeneratorMethodDetails; }
 namespace TR { class IlBuilder; }
+namespace TR { class VectorLoopBuilder; }
 namespace TR { class ResolvedMethodSymbol; } 
 namespace TR { class SymbolReference; }
 namespace TR { class SymbolReferenceTable; }
@@ -286,8 +287,10 @@ public:
    // vector memory
    TR::IlValue *VectorLoad(const char *name);
    TR::IlValue *VectorLoadAt(TR::IlType *dt, TR::IlValue *address);
+   TR::IlValue *VectorArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
    void VectorStore(const char *name, TR::IlValue *value);
    void VectorStoreAt(TR::IlValue *address, TR::IlValue *value);
+   void VectorArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value);
 
    // control
    void AppendBuilder(TR::IlBuilder *builder);
@@ -399,6 +402,8 @@ public:
       {
       ForLoop(countsUp, indVar, body, NULL, continueBody, initial, iterateWhile, increment);
       }
+
+   TR::VectorLoopBuilder *VectorForLoop(TR::IlType *dt, TR::IlValue *initial, TR::IlValue *end);
 
    virtual void WhileDoLoop(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder = NULL, TR::IlBuilder **continueBuilder = NULL);
    void WhileDoLoopWithBreak(const char *exitCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder)
@@ -513,6 +518,7 @@ public:
 
 
 protected:
+   TR::VectorLoopBuilder *orphanVectorLoopBuilder(TR::IlType *vectorElementType);
 
    /**
     * @brief MethodBuilder parent for this IlBuilder object

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -261,6 +261,8 @@ public:
    TR::IlValue *Load(const char *name);
    void Store(const char *name, TR::IlValue *value);
    void StoreOver(TR::IlValue *dest, TR::IlValue *value);
+   TR::IlValue *ArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
+   void ArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value);
    TR::IlValue *LoadAt(TR::IlType *dt, TR::IlValue *address);
    void StoreAt(TR::IlValue *address, TR::IlValue *value);
    TR::IlValue *LoadIndirect(const char *type, const char *field, TR::IlValue *object);

--- a/compiler/ilgen/OMRVectorLoopBuilder.cpp
+++ b/compiler/ilgen/OMRVectorLoopBuilder.cpp
@@ -1,0 +1,554 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ilgen/VectorLoopBuilder.hpp"
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "compile/Method.hpp"
+#include "compile/SymbolReferenceTable.hpp"
+#include "control/Recompilation.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/FrontEnd.hpp"
+#include "il/Block.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/ILOps.hpp"
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"
+#include "il/TreeTop.hpp"
+#include "il/TreeTop_inlines.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "ilgen/IlGeneratorMethodDetails_inlines.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/IlInjector.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "infra/Cfg.hpp"
+#include "infra/List.hpp"
+
+#define OPT_DETAILS "O^O ILBLD: "
+
+#define TraceEnabled    (comp()->getOption(TR_TraceILGen))
+#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
+
+
+OMR::VectorLoopBuilder::VectorLoopBuilder(TR::Compilation *comp,
+                                          TR::MethodBuilder *methodBuilder,
+                                          TR::TypeDictionary *types,
+                                          TR::IlType *vectorElementType)
+   : TR::IlBuilder(methodBuilder, types),
+   _parent(NULL),
+   _vectorElementType(vectorElementType),
+   _vectorValueMap(),
+   _vectorNameMap(),
+   _vectorLoopBody(methodBuilder, types),
+   _vectorIteratorName(0),
+   _residueLoopBody(methodBuilder, types),
+   _residueIteratorName(0)
+   {
+   static uint32_t vectorLoopNumber = 1; // /leave 0 as a sentinel value
+
+   _loopID = vectorLoopNumber++;
+   _vectorIteratorName = (char *) comp->trMemory()->allocateHeapMemory(6+10+0); // 6 (_viter_) + 10 (maxint) + trailing zero
+   sprintf(_vectorIteratorName, "_viter_%u", _loopID);
+
+   _residueIteratorName = (char *) comp->trMemory()->allocateHeapMemory(8+10+0); // 8 (_resiter_) + 10 (maxint) + trailing zero
+   sprintf(_residueIteratorName, "_resiter_%u", _loopID);
+
+   _residueConditionName = (char *) comp->trMemory()->allocateHeapMemory(11+10+0); // 11 (_rescontinue_) + 10 (maxint) + trailing zero
+   sprintf(_residueConditionName, "_rescontinue_%u", _loopID);
+
+   // won't be initialized otherwise
+   _comp = comp;
+
+   _hasVectorLoop = (VectorLength() > 1);
+   }
+
+void
+OMR::VectorLoopBuilder::initialize(TR::IlGeneratorMethodDetails * details,
+                                   TR::ResolvedMethodSymbol     * methodSymbol,
+                                   TR::FrontEnd                 * fe,
+                                   TR::SymbolReferenceTable     * symRefTab)
+   {
+   OMR::IlInjector::initialize(details, methodSymbol, fe, symRefTab);
+   _residueLoopBody.initialize(details, methodSymbol, fe, symRefTab);
+   if (_hasVectorLoop)
+      _vectorLoopBody.initialize(details, methodSymbol, fe, symRefTab);
+   }
+
+void
+OMR::VectorLoopBuilder::setupForBuildIL()
+   {
+   _residueLoopBody.setupForBuildIL();
+   if (_hasVectorLoop)
+      _vectorLoopBody.setupForBuildIL();
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::getVectorValue(TR::IlValue *value)
+   {
+   if (!_hasVectorLoop)
+      return NULL;
+
+   // if this value was created inside this vector loop builder, it will have a mapping here
+   if (_vectorValueMap.find(value) != _vectorValueMap.end())
+      return _vectorValueMap[value];
+
+   // otherwise, if there's a parent vector loop builder check if it's a value from there
+   TR::VectorLoopBuilder *parent = parentVectorLoopBuilder();
+   if (parent)
+      return parent->getVectorValue(value);
+
+   // otherwise, it's a value that comes from outside the vector loop, so we can just use it in both loops
+   return value;
+   }
+
+char *
+OMR::VectorLoopBuilder::getVectorName(const char *name)
+   {
+   if (!_hasVectorLoop)
+      return NULL;
+
+   // if this value was created inside this vector loop builder, it will have a mapping here
+   if (_vectorNameMap.find(name) != _vectorNameMap.end())
+      return _vectorNameMap[name];
+
+   // otherwise, if there's a parent vector loop builder check if it's a value from there
+   TR::VectorLoopBuilder *parent = parentVectorLoopBuilder();
+   if (parent)
+      return parent->getVectorName(name);
+
+   // otherwise, allocate the name here
+
+#define MAX_SUPPORTED_NAME_LEN 128
+
+   size_t nameLength = MAX_SUPPORTED_NAME_LEN;
+   const char *term = (const char *) memchr(name,'\0',MAX_SUPPORTED_NAME_LEN);
+   if (term != NULL)
+      nameLength = term - name;
+
+   size_t maxLength = 8+nameLength+1; // 8 (_vector_) + strlen(name) + trailing zero
+   char *vectorName = (char *) comp()->trMemory()->allocateHeapMemory(maxLength);
+   memcpy(vectorName, "_vector_", 8);
+   memcpy(vectorName+8, name, nameLength);
+   vectorName[8+nameLength] = '\0';
+   _vectorNameMap[name] = vectorName;
+
+   return vectorName;
+   }
+
+uint32_t
+OMR::VectorLoopBuilder::VectorLength()
+   {
+   // currently assumes vectors are 128 bit registers
+   // should really be a query into the OMR compiler's code generator object
+
+   if (_vectorElementType == Double || _vectorElementType == Int64)
+      return 2;
+   if (_vectorElementType == Float || _vectorElementType == Int32)
+      return 4;
+   if (_vectorElementType == Int16)
+      return 8;
+   if (_vectorElementType == Int8)
+      return 16;
+
+   // unknown datatype, so just do it as a scalar loop
+   return 1;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::LoadIterationVar()
+   {
+   TR::IlValue *residueIterValue = _residueLoopBody.Load(residueIteratorVariable());
+   TraceIL("VectorLoopBuilder[ %p ]::LoadIterationVar residueLoop %d", this, residueIterValue->getID());
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorIterValue =  _vectorLoopBody.Load(vectorIteratorVariable());
+      _vectorValueMap[residueIterValue] = vectorIterValue;
+      TraceIL(" vectorLoop %d\n", this, vectorIterValue->getID());
+      }
+   else
+      TraceIL(" (no vectorLoop) \n");
+
+   return residueIterValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstInt8(int8_t value)
+   {
+   TR::IlValue *residueConstValue = _residueLoopBody.ConstInt8(value);
+   TraceIL("VectorLoopBuilder[ %p ]::ConstInt8 %d into residueLoop %d", this, value, residueConstValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorConstValue = _vectorLoopBody.ConstInt8(value);
+      _vectorValueMap[residueConstValue] = vectorConstValue;
+      TraceIL(" vectorLoop %d\n", this, vectorConstValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueConstValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstInt16(int16_t value)
+   {
+   TR::IlValue *residueConstValue = _residueLoopBody.ConstInt16(value);
+   TraceIL("VectorLoopBuilder[ %p ]::ConstInt16 %d into residueLoop %d", this, value, residueConstValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorConstValue = _vectorLoopBody.ConstInt16(value);
+      _vectorValueMap[residueConstValue] = vectorConstValue;
+      TraceIL(" vectorLoop %d\n", this, vectorConstValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueConstValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstInt32(int32_t value)
+   {
+   TR::IlValue *residueConstValue = _residueLoopBody.ConstInt32(value);
+   TraceIL("VectorLoopBuilder[ %p ]::ConstInt32 %d into residueLoop %d", this, value, residueConstValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorConstValue = _vectorLoopBody.ConstInt32(value);
+      _vectorValueMap[residueConstValue] = vectorConstValue;
+      TraceIL(" vectorLoop %d\n", this, vectorConstValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueConstValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstInt64(int64_t value)
+   {
+   TR::IlValue *residueConstValue = _residueLoopBody.ConstInt64(value);
+   TraceIL("VectorLoopBuilder[ %p ]::ConstInt64 %ld into residueLoop %d", this, value, residueConstValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorConstValue = _vectorLoopBody.ConstInt64(value);
+      _vectorValueMap[residueConstValue] = vectorConstValue;
+      TraceIL(" vectorLoop %d\n", this, vectorConstValue->getID());
+      }
+   else
+      TraceIL(" (no residue loop)\n");
+
+   return residueConstValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstFloat(float value)
+   {
+   TR::IlValue *residueConstValue = _residueLoopBody.ConstFloat(value);
+   TraceIL("VectorLoopBuilder[ %p ]::ConstFloat %f into residueLoop %d", this, value, residueConstValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorConstValue = _vectorLoopBody.ConstFloat(value);
+      _vectorValueMap[residueConstValue] = vectorConstValue;
+      TraceIL(" vectorLoop %d\n", this, vectorConstValue->getID());
+      }
+   else
+      TraceIL(" (no residue loop)\n");
+
+   return residueConstValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstDouble(double value)
+   {
+   TR::IlValue *residueConstValue = _residueLoopBody.ConstDouble(value);
+   TraceIL("VectorLoopBuilder[ %p ]::ConstDouble %d into residueLoop %d", this, value, residueConstValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorConstValue = _vectorLoopBody.ConstDouble(value);
+      _vectorValueMap[residueConstValue] = vectorConstValue;
+      TraceIL(" vectorLoop %d\n", this, vectorConstValue->getID());
+      }
+   else
+      TraceIL(" (no residue loop)\n");
+
+   return residueConstValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ConstInteger(TR::IlType *intType, int64_t value)
+   {
+   if      (intType == Int8)  return ConstInt8 ((int8_t)  value);
+   else if (intType == Int16) return ConstInt16((int16_t) value);
+   else if (intType == Int32) return ConstInt32((int32_t) value);
+   else if (intType == Int64) return ConstInt64(          value);
+
+   TR_ASSERT(0, "unknown integer type");
+   return NULL;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::Add(TR::IlValue *left, TR::IlValue *right)
+   {
+   TR::IlValue *residueReturnValue = _residueLoopBody.Add(left, right);
+   TraceIL("VectorLoopBuilder[ %p ]::Add residueLoop %d = %d + %d ", this, residueReturnValue->getID(), left->getID(), right->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorLeft  = getVectorValue(left);
+      TR::IlValue *vectorRight = getVectorValue(right);
+      TR::IlValue *vectorReturnValue = _vectorLoopBody.Add(vectorLeft, vectorRight);
+      _vectorValueMap[residueReturnValue] = vectorReturnValue;
+
+      TraceIL(" vectorLoop %d = %d + %d\n", this, vectorReturnValue->getID(), vectorLeft->getID(), vectorRight->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueReturnValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::Sub(TR::IlValue *left, TR::IlValue *right)
+   {
+   TR::IlValue *residueReturnValue = _residueLoopBody.Sub(left, right);
+   TraceIL("VectorLoopBuilder[ %p ]::Sub residueLoop %d = %d - %d ", this, residueReturnValue->getID(), left->getID(), right->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorLeft  = getVectorValue(left);
+      TR::IlValue *vectorRight = getVectorValue(right);
+      TR::IlValue *vectorReturnValue = _vectorLoopBody.Sub(vectorLeft, vectorRight);
+      _vectorValueMap[residueReturnValue] = vectorReturnValue;
+
+      TraceIL(" vectorLoop %d = %d - %d\n", this, vectorReturnValue->getID(), vectorLeft->getID(), vectorRight->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueReturnValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::Mul(TR::IlValue *left, TR::IlValue *right)
+   {
+   TR::IlValue *residueReturnValue = _residueLoopBody.Mul(left, right);
+   TraceIL("VectorLoopBuilder[ %p ]::Mul residueLoop %d = %d * %d ", this, residueReturnValue->getID(), left->getID(), right->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorLeft  = getVectorValue(left);
+      TR::IlValue *vectorRight = getVectorValue(right);
+      TR::IlValue *vectorReturnValue = _vectorLoopBody.Mul(vectorLeft, vectorRight);
+      _vectorValueMap[residueReturnValue] = vectorReturnValue;
+
+      TraceIL(" vectorLoop %d = %d * %d\n", this, vectorReturnValue->getID(), vectorLeft->getID(), vectorRight->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueReturnValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::Load(const char *name)
+   {
+   TR::IlValue *residueValue = _residueLoopBody.Load(name);
+   TraceIL("VectorLoopBuilder[ %p ]::Load %s residueLoop into %d", this, name, residueValue->getID());
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorValue = _vectorLoopBody.Load(name);
+      _vectorValueMap[residueValue] = vectorValue;
+
+      TraceIL(" vectorLoop into %d\n", this, vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::VectorLoad(const char *name)
+   {
+   TR::IlValue *residueValue = _residueLoopBody.Load(name);
+   TraceIL("VectorLoopBuilder[ %p ]::VectorLoad residueLoop %s into %d", this, name, residueValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      char *vectorName = getVectorName(name);
+      TR::IlValue *vectorValue = _vectorLoopBody.VectorLoad(vectorName);
+      _vectorValueMap[residueValue] = vectorValue;
+
+      TraceIL(" vectorLoop %s into %d\n", this, vectorName, vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueValue;
+   }
+
+void
+OMR::VectorLoopBuilder::Store(const char *name, TR::IlValue *value)
+   {
+   _residueLoopBody.Store(name, value);
+   TraceIL("VectorLoopBuilder[ %p ]::Store %s gets residueLoop %d", this, name, value->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorValue = getVectorValue(value);
+      _vectorLoopBody.Store(name, vectorValue);
+      TraceIL(" vectorLoop %d\n", vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+   }
+
+void
+OMR::VectorLoopBuilder::VectorStore(const char *name, TR::IlValue *value)
+   {
+   _residueLoopBody.Store(name, value);
+   TraceIL("VectorLoopBuilder[ %p ]: residueLoop VectorStore %s gets %d", this, name, value->getID());
+
+   if (_hasVectorLoop)
+      {
+      char *vectorName = getVectorName(name);
+      TR::IlValue *vectorValue = getVectorValue(value);
+      _vectorLoopBody.VectorStore(vectorName, vectorValue);
+      TraceIL(" vectorLoop Store %s gets %d\n", vectorName, vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::ArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
+   {
+   TR::IlValue *residueValue = _residueLoopBody.ArrayLoad(dt, base, index);
+   TraceIL("VectorLoopBuilder[ %p ]::ArrayLoad type %s residueLoop base %d [ index %d ] into %d", this, dt->getName(), base->getID(), index->getID(), residueValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorBase = getVectorValue(base);
+      TR::IlValue *vectorIndex = getVectorValue(index);
+      TR::IlValue *vectorValue = _vectorLoopBody.ArrayLoad(dt, vectorBase, vectorIndex);
+      _vectorValueMap[residueValue] = vectorValue;
+
+      TraceIL(" vectorLoop base %d [ index %d ] into %d\n", vectorBase->getID(), vectorIndex->getID(), vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueValue;
+   }
+
+TR::IlValue *
+OMR::VectorLoopBuilder::VectorArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
+   {
+   TR::IlValue *residueValue = _residueLoopBody.ArrayLoad(dt, base, index);
+   TraceIL("VectorLoopBuilder[ %p ]::VectorArrayLoad type %s residueLoop base %d [ index %d ] into %d", this, dt->getName(), base->getID(), index->getID(), residueValue->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorBase = getVectorValue(base);
+      TR::IlValue *vectorIndex = getVectorValue(index);
+      TR::IlValue *vectorValue = _vectorLoopBody.VectorArrayLoad(dt, vectorBase, vectorIndex);
+      _vectorValueMap[residueValue] = vectorValue;
+      TraceIL(" vectorLoop base %d [ index %d ] into %d\n", vectorBase->getID(), vectorIndex->getID(), vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return residueValue;
+   }
+
+void
+OMR::VectorLoopBuilder::ArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value)
+   {
+   _residueLoopBody.ArrayStore(dt, base, index, value);
+   TraceIL("VectorLoopBuilder[ %p ]::ArrayStore type %s residueLoop base %d [ index %d ] gets %d", this, dt->getName(), base->getID(), index->getID(), value->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorBase = getVectorValue(base);
+      TR::IlValue *vectorIndex = getVectorValue(index);
+      TR::IlValue *vectorValue = getVectorValue(value);
+      _vectorLoopBody.ArrayStore(dt, vectorBase, vectorIndex, vectorValue);
+
+      TraceIL(" vectorLoop base %d [ index %d ] gets %d\n", this, dt->getName(), vectorBase->getID(), vectorIndex->getID(), vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+   }
+
+void
+OMR::VectorLoopBuilder::VectorArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value)
+   {
+   _residueLoopBody.ArrayStore(dt, base, index, value);
+   TraceIL("VectorLoopBuilder[ %p ]::VectorArrayStore type %s residueLoop base %d [ index %d ] gets %d", this, dt->getName(), base->getID(), index->getID(), value->getID());
+
+   if (_hasVectorLoop)
+      {
+      TR::IlValue *vectorBase = getVectorValue(base);
+      TR::IlValue *vectorIndex = getVectorValue(index);
+      TR::IlValue *vectorValue = getVectorValue(value);
+      _vectorLoopBody.VectorArrayStore(dt, vectorBase, vectorIndex, vectorValue);
+      TraceIL(" vectorLoop base %d [ index %d ] gets %d\n", this, dt->getName(), vectorBase->getID(), vectorIndex->getID(), vectorValue->getID());
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+}
+
+TR::VectorLoopBuilder *
+OMR::VectorLoopBuilder::ForLoop(TR::IlValue *initial,
+                                TR::IlValue *end,
+                                TR::IlValue *increment)
+   {
+   TR::VectorLoopBuilder *loopBuilder = orphanVectorLoopBuilder(_vectorElementType);
+   loopBuilder->setParentVectorLoopBuilder(static_cast<TR::VectorLoopBuilder *>(this));
+
+   TR::IlBuilder *residueLoopBody = loopBuilder->residueBody();
+   char *residueIter = loopBuilder->residueIteratorVariable();
+   _residueLoopBody.ForLoop(true, residueIter, &residueLoopBody, NULL, NULL, initial, end, increment);
+   TraceIL("VectorLoopBuilder[ %p ]::ForLoop from %d to %d by %d residueLoop [ %p ] using %s", this, initial->getID(), end->getID(), increment->getID(), residueLoopBody, residueIter);
+
+   if (_hasVectorLoop)
+      {
+      TR::IlBuilder *vectorLoopBody = loopBuilder->vectorBody();
+      char *vectorIter = loopBuilder->vectorIteratorVariable();
+      _vectorLoopBody.ForLoop(true, vectorIter, &vectorLoopBody, NULL, NULL, initial, end, increment);
+
+      TraceIL(" vectorLoop [ %p ] using %s", vectorLoopBody, vectorIter);
+      }
+   else
+      TraceIL(" (no vector loop)\n");
+
+   return loopBuilder;
+   }

--- a/compiler/ilgen/OMRVectorLoopBuilder.hpp
+++ b/compiler/ilgen/OMRVectorLoopBuilder.hpp
@@ -1,0 +1,304 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_VECTORLOOPBUILDER_INCL
+#define OMR_VECTORLOOPBUILDER_INCL
+
+#include <map>
+
+#include "ilgen/IlBuilder.hpp"
+
+namespace OMR
+{
+
+/**
+ * The VectorLoopBuilder class is designed to simplify the construction of vectorized
+ * loops, by automatically handling one of the trickier and error prone aspects of
+ * vector loops: ensuring that both vector and scalar loops perform the same operations.
+ *
+ * A VectorLoopBuilder object is typically constructed via IlBuilder::VectorForLoop()
+ * which returns the VectorLoopBuilder object to be used for the loop.  VectorLoopBuilder
+ * duplicates vectorizable services from IlBuilder, including ForLoop to facilitate
+ * outer loop vectorization. Each of these services automatically injects operations
+ * into the scalar and (if it is needed) the vector loop body. IlBuilder::VectorForLoop
+ * creates the control flow for the vectorized loop but uses the VectorLoopBuilder's
+ * vectorBody() and residueBody() IlBuilder objects as the core builder objects
+ * representing the loop operations. The VectorLoopBuilder object becomes a proxy to
+ * clients for populating those loops consistently with the same basic operations
+ * (vector operations in the vector loop, and scalar operations in the residue loop).
+ *
+ * To make all that work smoothly, VectorLoopBuilder considers the residue loop to be
+ * the "master" * loop. VectorLoopBuilder also maintains a mapping between TR::IlValues
+ * computed in the residue loop and the corresponding TR::IlValues created for the
+ * same operation in the vector loop. In this way, the client works with the residue
+ * loop TR::IlValues, but the VectorLoopBuilder can always associate those values to
+ * the corresponding values int he vector loop so as to build the same operations there.
+ * Another source of confusion is referencing the loop iteration variable, so the
+ * VectorLoopBuilder object provides LoadIterationVar() to hide the actual names from
+ * the client by returning a TR::IlValue corresponding to the iteration variable's value
+ * in the residue loop (which is transparently mapped to the corresponding TR::IlValue
+ * in the vector
+ * loop).
+ */
+
+class VectorLoopBuilder : public TR::IlBuilder
+   {
+public:
+   TR_ALLOC(TR_Memory::IlGenerator)
+
+   VectorLoopBuilder(TR::Compilation *comp, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, TR::IlType *vectorElementType);
+   virtual ~VectorLoopBuilder() { }
+
+   TR::IlBuilder *vectorBody() { return &_vectorLoopBody; }
+   char *vectorIteratorVariable() { return _vectorIteratorName; }
+   TR::IlBuilder *residueBody() { return &_residueLoopBody; }
+   char *residueIteratorVariable() { return _residueIteratorName; }
+   char *residueConditionVariable() { return _residueConditionName; }
+
+   /**
+    * @brief returns the vector length being used for this loop, which can be 1 if there is only
+    *        a scalar loop
+    */
+   uint32_t VectorLength();
+
+   /**
+    * @brief returns the value of the loop iteration variable
+    */
+   TR::IlValue *LoadIterationVar();
+
+   // constants
+
+   /**
+    * @brief creates a TR::IlValue for the given 8-bit constant in both residue and vector loops
+    */
+   TR::IlValue *ConstInt8(int8_t value);
+
+   /**
+    * @brief creates a TR::IlValue for the given 16-bit constant in both residue and vector loops
+    */
+   TR::IlValue *ConstInt16(int16_t value);
+
+   /**
+    * @brief creates a TR::IlValue for the given 32-bit constant in both residue and vector loops
+    */
+   TR::IlValue *ConstInt32(int32_t value);
+
+   /**
+    * @brief creates a TR::IlValue for the given 64-bit constant in both residue and vector loops
+    */
+   TR::IlValue *ConstInt64(int64_t value);
+
+   /**
+    * @brief creates a TR::IlValue for the given 32-bit floating point constant in both residue
+    *        and vector loops
+    */
+   TR::IlValue *ConstFloat(float value);
+
+   /**
+    * @brief creates a TR::IlValue for the given 64-bit floating point constant in both residue
+    *        and vector loops
+    */
+   TR::IlValue *ConstDouble(double value);
+
+   /**
+    * @brief creates a TR::IlValue for the given 8-bit constant in both residue and vector loops
+    */
+   TR::IlValue *Const(int8_t value)             { return ConstInt8(value); }
+
+   /**
+    * @brief creates a TR::IlValue for the given 16-bit constant in both residue and vector loops
+    */
+   TR::IlValue *Const(int16_t value)            { return ConstInt16(value); }
+
+   /**
+    * @brief creates a TR::IlValue for the given 32-bit constant in both residue and vector loops
+    */
+   TR::IlValue *Const(int32_t value)            { return ConstInt32(value); }
+
+   /**
+    * @brief creates a TR::IlValue for the given 64-bit constant in both residue and vector loops
+    */
+   TR::IlValue *Const(int64_t value)            { return ConstInt64(value); }
+
+   /**
+    * @brief creates a TR::IlValue for the given 32-bit floating point constant in both residue
+    *        and vector loops
+    */
+   TR::IlValue *Const(float value)              { return ConstFloat(value); }
+
+   /**
+    * @brief creates a TR::IlValue for the given 64-bit floating point constant in both residue
+    *        and vector loops
+    */
+   TR::IlValue *Const(double value)             { return ConstDouble(value); }
+
+   /**
+    * @brief creates a TR::IlValue according to the provided type for the given integer constant
+    *        in both residue and vector loops
+    * @param intType the type of constant desired
+    * @param value the integer value which will be coerced to the appropriate type
+    */
+   TR::IlValue *ConstInteger(TR::IlType *intType, int64_t value);
+
+   /**
+    * @brief returns a value for the sum of left and right, performed in both residue and vector
+    *        loops
+    */
+   TR::IlValue *Add(TR::IlValue *left, TR::IlValue *right);
+
+   /**
+    * @brief returns a value for the difference left minus right, performed as scalar in residue
+    *        loop and as vector in vector loop
+    */
+   TR::IlValue *Sub(TR::IlValue *left, TR::IlValue *right);
+
+   /**
+    * @brief returns a value for the product of left and right, performed as scalar in residue
+    *        loop and as vector in vector loop
+    */
+   TR::IlValue *Mul(TR::IlValue *left, TR::IlValue *right);
+
+   /**
+    * @brief Loads the named local variable, performed in both residue and vector loops
+    */
+   TR::IlValue *Load(const char *name);
+
+   /**
+    * @brief Stores value to the named local variable, performed in both residue and vector loops
+    */
+   void Store(const char *name, TR::IlValue *value);
+
+   /**
+    * @brief Loads the named local variable, performed as scalar load in residue loop and as
+    *        vector load in vector loop
+    */
+   TR::IlValue *VectorLoad(const char *name);
+
+   /**
+    * @brief Stores the value to the named local variable, performed as scalar store in residue
+    *        loop and as vector store in vector loop
+    */
+   void VectorStore(const char *name, TR::IlValue *value);
+
+   /**
+    * @brief Loads scalar value from base[index], performed in both residue and vector loops
+    */
+   TR::IlValue *ArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
+
+   /**
+    * @brief Stores scalar value to base[index] as type dt, performed in both residue and
+    *        vector loops
+    */
+   void ArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value);
+
+   /**
+    * @brief Loads value from base[index], performed as scalar load in residue loop and as
+    *        vector load in vector loop
+    */
+   TR::IlValue *VectorArrayLoad(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index);
+
+   /**
+    * @brief Stores value to base[index] as type pdt, performed as scalar store in residue loop
+    *        and as vector store in vector loop
+    */
+   void VectorArrayStore(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index, TR::IlValue *value);
+
+   /**
+    * @brief Creates a simple ForLoop iterating up from initial to end by increment. The loop is
+    *        created in both scalar and vector loops.
+    * @returns VectorLoopBuilder object representing the body of the inner ForLoop
+    */
+   TR::VectorLoopBuilder *ForLoop(TR::IlValue *initial, TR::IlValue *end, TR::IlValue *increment);
+
+   void initialize(TR::IlGeneratorMethodDetails * details,
+                   TR::ResolvedMethodSymbol     * methodSymbol,
+                   TR::FrontEnd                 * fe,
+                   TR::SymbolReferenceTable     * symRefTab);
+
+   void setupForBuildIL();
+
+protected:
+   void setParentVectorLoopBuilder(TR::VectorLoopBuilder *parent) { _parent = parent; }
+   TR::VectorLoopBuilder *parentVectorLoopBuilder() { return _parent; }
+
+   TR::IlValue *getVectorValue(TR::IlValue *value);
+   char * getVectorName(const char *name);
+
+   /**
+    * @brief if this VectorLoopBuilder was created inside another VectorLoopBuilder, record it here
+    *        so that residue-to-vector mappings can be looked up in parent loops
+    */
+   TR::VectorLoopBuilder                  * _parent;
+
+   /**
+    * @brief records where this loop has a vector loop (if vector length > 1)
+    */
+   bool                                     _hasVectorLoop;
+
+   /**
+    * @brief the IlType for each vector element (determines vector length)
+    */
+   TR::IlType                             * _vectorElementType;
+
+   /**
+    * @brief map used to map IlValue's in the vector loop to those in the residue loop
+    */
+   std::map<TR::IlValue *, TR::IlValue *>   _vectorValueMap;
+
+   /**
+    * @brief map used to map local names in the vector loop to those in the residue loop
+    */
+   std::map<const char *, char *>           _vectorNameMap;
+
+   /**
+    * @brief the IlBuilder used for the vectorized loop body
+    */
+   TR::IlBuilder                            _vectorLoopBody;
+
+   /**
+    * @brief the name of the iteration variable used by the vector loop
+    */
+   char *                                   _vectorIteratorName;
+
+   /**
+    * @brief the IlBuilder used for the residue loop body
+    */
+   TR::IlBuilder                            _residueLoopBody;
+
+   /**
+    * @brief the name of the iteration variable used by the residue loop
+    */
+   char *                                   _residueIteratorName;
+
+   /**
+    * @brief the name of the condition variable used to exit the residue loop
+    */
+   char *                                   _residueConditionName;
+
+   /**
+    * @brief a unique identifier for this VectorLoopBuilder
+    */
+   uint32_t                                 _loopID;
+   };
+
+} // namespace OMR
+
+#endif // !defined(OMR_VECTORLOOPBUILDER_INCL)

--- a/compiler/ilgen/VectorLoopBuilder.hpp
+++ b/compiler/ilgen/VectorLoopBuilder.hpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_VECTORLOOPBUILDER_INCL
+#define TR_VECTORLOOPBUILDER_INCL
+
+#include "ilgen/OMRVectorLoopBuilder.hpp"
+
+namespace TR
+{
+   class VectorLoopBuilder : public OMR::VectorLoopBuilder
+      {
+      public:
+         VectorLoopBuilder(TR::Compilation *comp, TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types, TR::IlType *vectorElementType)
+            : OMR::VectorLoopBuilder(comp, methodBuilder, types, vectorElementType)
+            { }
+      };
+
+} // namespace TR
+
+#endif // !defined(TR_VECTORLOOPBUILDER_INCL)

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -259,6 +259,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRBytecodeBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlType.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVectorLoopBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/Alignment.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/CodeCacheTypes.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/OMRCodeCache.cpp \

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -229,6 +229,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRMethodBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRThunkBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVectorLoopBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineState.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -138,6 +138,12 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.hpp: $(FIXED_SRC
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVectorLoopBuilder.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVectorLoopBuilder.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VectorLoopBuilder.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VectorLoopBuilder.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineState.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineState.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
@@ -202,6 +208,8 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/BytecodeBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/TypeDictionary.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVectorLoopBuilder.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VectorLoopBuilder.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineState.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineState.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegister.hpp \

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -41,6 +41,7 @@ ALL_TESTS = \
             iterfib \
             linkedlist \
             localarray \
+            loop \
             nestedloop \
             operandarraytests \
             operandstacktests \
@@ -81,6 +82,7 @@ all_goal: common_goal
 	./inliningrecfib
 	./linkedlist
 	./localarray
+	./loop
 	./operandarraytests
 	./operandstacktests
 	./pointer
@@ -207,6 +209,13 @@ localarray : libjitbuilder.a LocalArray.o
 	$(CXX) -g -fno-rtti -o $@ LocalArray.o $(JITBUILDER_LINK_FLAGS)
 
 LocalArray.o: src/LocalArray.cpp src/LocalArray.hpp
+	$(CXX) -o $@ $(CXXFLAGS) $<
+
+
+loop : libjitbuilder.a Loop.o
+	$(CXX) -g -fno-rtti -o $@ Loop.o $(JITBUILDER_LINK_FLAGS)
+
+Loop.o: src/Loop.cpp src/Loop.hpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
 
 

--- a/jitbuilder/release/Makefile
+++ b/jitbuilder/release/Makefile
@@ -314,6 +314,13 @@ union : libjitbuilder.a Union.o
 Union.o: src/Union.cpp src/Union.hpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
 
+vecmatmult : libjitbuilder.a VectorMatMult.o
+	$(CXX) -g -fno-rtti -o $@ VectorMatMult.o $(JITBUILDER_LINK_FLAGS)
+
+VectorMatMult.o: src/VectorMatMult.cpp src/VectorMatMult.hpp
+	$(CXX) -o $@ $(CXXFLAGS) $<
+
+
 worklist : libjitbuilder.a Worklist.o
 	$(CXX) -g -fno-rtti -o $@ Worklist.o $(JITBUILDER_LINK_FLAGS)
 

--- a/jitbuilder/release/src/Loop.cpp
+++ b/jitbuilder/release/src/Loop.cpp
@@ -1,0 +1,199 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "Loop.hpp"
+
+static void printString(int64_t ptr)
+   {
+   #define PRINTSTRING_LINE LINETOSTR(__LINE__)
+   char *str = (char *) ptr;
+   printf("%s", str);
+   }
+
+static void printInt32(int32_t val)
+   {
+   #define PRINTINT32_LINE LINETOSTR(__LINE__)
+   printf("%d", val);
+   }
+
+static void printDouble(double val)
+   {
+   #define PRINTDOUBLE_LINE LINETOSTR(__LINE__)
+   printf("%lf", val);
+   }
+
+static void printPointer(int64_t val)
+   {
+   #define PRINTPOINTER_LINE LINETOSTR(__LINE__)
+   printf("%llx", val);
+   }
+
+Loop::Loop(TR::TypeDictionary *types)
+   : MethodBuilder(types)
+
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("dotproduct");
+
+   pDouble = types->PointerTo(Double);
+
+   DefineParameter("result", pDouble);
+   DefineParameter("vector1", pDouble);
+   DefineParameter("vector2", pDouble);
+   DefineParameter("length", Int32);
+
+   DefineReturnType(NoType);
+
+   DefineFunction((char *)"printString", 
+                  (char *)__FILE__,
+                  (char *)PRINTSTRING_LINE,
+                  (void *)&printString,
+                  NoType,
+                  1,
+                  Int64);
+   DefineFunction((char *)"printInt32", 
+                  (char *)__FILE__,
+                  (char *)PRINTINT32_LINE,
+                  (void *)&printInt32,
+                  NoType,
+                  1,
+                  Int32);
+   DefineFunction((char *)"printDouble", 
+                  (char *)__FILE__,
+                  (char *)PRINTDOUBLE_LINE,
+                  (void *)&printDouble,
+                  NoType,
+                  1,
+                  Double);
+   DefineFunction((char *)"printPointer", 
+                  (char *)__FILE__,
+                  (char *)PRINTPOINTER_LINE,
+                  (void *)&printPointer,
+                  NoType,
+                  1,
+                  Int64);
+   }
+
+void
+Loop::PrintString(TR::IlBuilder *bldr, const char *s)
+   {
+   bldr->Call("printString", 1,
+   bldr->   ConstInt64((int64_t)(char *)s));
+   }
+
+bool
+Loop::buildIL()
+   {
+   PrintString(this, "multiply parameters:\n");
+
+   PrintString(this, "   result is ");
+   Call("printPointer", 1,
+      Load("result"));
+   PrintString(this, "\n");
+
+   PrintString(this, "   vector1 is ");
+   Call("printPointer", 1,
+      Load("vector1"));
+   PrintString(this, "\n");
+
+   PrintString(this, "   vector2 is ");
+   Call("printPointer", 1,
+      Load("vector2"));
+   PrintString(this, "\n");
+
+   TR::IlBuilder *loop = NULL;
+   ForLoopUp("i", &loop,
+      ConstInt32(0),
+      Load("length"),
+      ConstInt32(1));
+
+   loop->ArrayStore(pDouble,
+   loop->   Load("result"),
+   loop->   Load("i"),
+   loop->   Mul(
+   loop->      ArrayLoad(pDouble,
+   loop->         Load("vector1"),
+   loop->         Load("i")),
+   loop->      ArrayLoad(pDouble,
+   loop->         Load("vector2"),
+   loop->         Load("i"))));
+
+   Return();
+
+   return true;
+   }
+
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define type dictionary\n");
+   TR::TypeDictionary types;
+
+   printf("Step 3: compile method builder\n");
+   Loop method(&types);
+   uint8_t *entry=0;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 4: define values\n");
+   double result[10] = { 0 };
+   double values1[10] = { 1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5,10.5 };
+   double values2[10] = { 10.5,9.5,8.5,7.5,6.5,5.5,4.5,3.5,2.5,1.5 };
+
+   printf("Step 5: invoke compiled code and verify results\n");
+   LoopFunctionType *test = (LoopFunctionType *)entry;
+   test(result, values1, values2, 10);
+
+   printf("result = [\n");
+   for (int32_t i=0;i < 10;i++)
+      printf("           %lf\n", result[i]);
+   printf("         ]\n\n");
+
+   printf ("Step 6: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/release/src/Loop.hpp
+++ b/jitbuilder/release/src/Loop.hpp
@@ -26,14 +26,14 @@
 
 #include "ilgen/MethodBuilder.hpp"
 
-typedef void (LoopFunctionType)(double *, double *, double *, int32_t);
+typedef void (LoopFunctionType)(int32_t *, int32_t *, int32_t *, int32_t);
 
 class Loop : public TR::MethodBuilder
    {
    private:
 
    void PrintString (TR::IlBuilder *bldr, const char *s);
-   TR::IlType *pDouble;
+   TR::IlType *pInt32;
 
    public:
    Loop(TR::TypeDictionary *);

--- a/jitbuilder/release/src/Loop.hpp
+++ b/jitbuilder/release/src/Loop.hpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef LOOP_INCL
+#define LOOP_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+typedef void (LoopFunctionType)(double *, double *, double *, int32_t);
+
+class Loop : public TR::MethodBuilder
+   {
+   private:
+
+   void PrintString (TR::IlBuilder *bldr, const char *s);
+   TR::IlType *pDouble;
+
+   public:
+   Loop(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(LOOP_INCL)

--- a/jitbuilder/release/src/VectorMatMult.cpp
+++ b/jitbuilder/release/src/VectorMatMult.cpp
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "Jit.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/VectorLoopBuilder.hpp"
+#include "VectorMatMult.hpp"
+
+
+VectorMatMult::VectorMatMult(TR::TypeDictionary *types)
+   : MethodBuilder(types)
+   {
+   DefineLine(LINETOSTR(__LINE__));
+   DefineFile(__FILE__);
+
+   DefineName("vecmatmult");
+
+   pDouble = types->PointerTo(Double);
+
+   // C = A * B, all NxN matrices
+   DefineParameter("C", pDouble);
+   DefineParameter("A", pDouble);
+   DefineParameter("B", pDouble);
+   DefineParameter("N", Int32);
+
+   DefineReturnType(NoType);
+
+   DefineLocal("sum", VectorDouble);
+   }
+
+void
+VectorMatMult::VectorStore2D(TR::VectorLoopBuilder *bldr,
+                             TR::IlValue *base,
+                             TR::IlValue *first,
+                             TR::IlValue *second,
+                             TR::IlValue *N,
+                             TR::IlValue *value)
+   {
+   bldr->VectorArrayStore(pDouble,
+            base,
+   bldr->   Add(
+   bldr->      Mul(
+                  first,
+                  N),
+               second),
+            value);
+   }
+
+TR::IlValue *
+VectorMatMult::VectorLoad2D(TR::VectorLoopBuilder *bldr,
+                            TR::IlValue *base,
+                            TR::IlValue *first,
+                            TR::IlValue *second,
+                            TR::IlValue *N)
+   {
+   return
+      bldr->VectorArrayLoad(pDouble,
+               base,
+      bldr->   Add(
+      bldr->      Mul(
+                     first,
+                     N),
+                  second));
+   }
+
+TR::IlValue *
+VectorMatMult::Load2D(TR::VectorLoopBuilder *bldr,
+                      TR::IlValue *base,
+                      TR::IlValue *first,
+                      TR::IlValue *second,
+                      TR::IlValue *N)
+   {
+   return
+      bldr->ArrayLoad(pDouble,
+               base,
+      bldr->   Add(
+      bldr->      Mul(
+                     first,
+                     N),
+                  second));
+   }
+
+bool
+VectorMatMult::buildIL()
+   {
+   // marking all locals as defined allows remaining locals to be temps
+   // which enables further optimization opportunities particularly for
+   //    floating point types
+   AllLocalsHaveBeenDefined();
+
+   TR::IlValue *i, *j, *k;
+   TR::IlValue *A_ik, *B_kj;
+
+   TR::IlValue *A = Load("A");
+   TR::IlValue *B = Load("B");
+   TR::IlValue *C = Load("C");
+   TR::IlValue *N = Load("N");
+   TR::IlValue *zero = ConstInt32(0);
+   TR::IlValue *one = ConstInt32(1);
+   TR::IlValue *two = ConstInt32(2);
+
+   TR::IlBuilder *iloop=NULL;
+   TR::VectorLoopBuilder *jloop=NULL, *kloop=NULL;
+   // outer i loop is not vectorized
+   ForLoopUp("i", &iloop, zero, N, one);
+      {
+      i = iloop->Load("i");
+
+      // vectorizing loop j
+      jloop = iloop->VectorForLoop(Double, zero, N);
+         {
+         j = jloop->LoadIterationVar();
+
+         jloop->VectorStore("sum",                             // sum is a vector
+         jloop->   ConstDouble(0.0));
+
+         // inner k loop is not vectorized
+         kloop = jloop->ForLoop(zero, N, one);
+            {
+            k = kloop->LoadIterationVar();
+
+            A_ik = Load2D(kloop, A, i, k, N);                  // A[i,k] is scalar over j
+            B_kj = VectorLoad2D(kloop, B, k, j, N);            // B[k,j] is vector over j
+            kloop->VectorStore("sum",
+            kloop->   Add(
+            kloop->      VectorLoad("sum"),                    // sum is a vector
+            kloop->      Mul(A_ik, B_kj)));
+            }
+
+         VectorStore2D(jloop, C, i, j, N, jloop->VectorLoad("sum"));
+         }
+      }
+
+   Return();
+
+   return true;
+   }
+
+
+void
+printMatrix(double *M, int32_t N, const char *name)
+   {
+   printf("%s = [\n", name);
+   for (int32_t i=0;i < N;i++)
+      {
+      printf("      [ %lf", M[i*N]);
+      for (int32_t j=1;j < N;j++)
+          printf(", %lf", M[i * N + j]);
+      printf(" ],\n");
+      }
+   printf("    ]\n\n");
+   }
+
+int
+main(int argc, char *argv[])
+   {
+   printf("Step 1: initialize JIT\n");
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
+
+   printf("Step 2: define matrices\n");
+   const int32_t N=5;
+   double A[N*N];
+   double B[N*N];
+   double C[N*N];
+   for (int32_t i=0;i < N;i++)
+      {
+      for (int32_t j=0;j < N;j++)
+         {
+         A[i*N+j] = 1.0;
+         B[i*N+j] = (double)i+(double)j;
+         C[i*N+j] = 0.0;
+         }
+      }
+   printMatrix(A, N, "A");
+   printMatrix(B, N, "B");
+
+   printf("Step 3: define type dictionaries\n");
+   TR::TypeDictionary types;
+
+   printf("Step 4: compile VectorMatMult method builder\n");
+   VectorMatMult method(&types);
+   uint8_t *entry=0;
+   int32_t rc = compileMethodBuilder(&method, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+      }
+
+   printf("Step 5: invoke VectorMatMult compiled code\n");
+   MatMultFunctionType *test = (MatMultFunctionType *)entry;
+   test(C, A, B, N);
+   printMatrix(C, N, "C");
+
+   printf ("Step 6: shutdown JIT\n");
+   shutdownJit();
+
+   printf("PASS\n");
+   }

--- a/jitbuilder/release/src/VectorMatMult.hpp
+++ b/jitbuilder/release/src/VectorMatMult.hpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+
+#ifndef VECTORMATMULT_INCL
+#define VECTORMATMULT_INCL
+
+#include "ilgen/MethodBuilder.hpp"
+
+typedef void (MatMultFunctionType)(double *, double *, double *, int32_t);
+
+class VectorMatMult : public TR::MethodBuilder
+   {
+   private:
+   TR::IlType *pDouble;
+   TR::IlType *ppDouble;
+
+   void VectorStore2D(TR::VectorLoopBuilder *bldr,
+                      TR::IlValue *base,
+                      TR::IlValue *first,
+                      TR::IlValue *second,
+                      TR::IlValue *N,
+                      TR::IlValue *value);
+   TR::IlValue *VectorLoad2D(TR::VectorLoopBuilder *bldr,
+                             TR::IlValue *base,
+                             TR::IlValue *first,
+                             TR::IlValue *second,
+                             TR::IlValue *N);
+   TR::IlValue *Load2D(TR::VectorLoopBuilder *bldr,
+                       TR::IlValue *base,
+                       TR::IlValue *first,
+                       TR::IlValue *second,
+                       TR::IlValue *N);
+
+   public:
+   VectorMatMult(TR::TypeDictionary *);
+   virtual bool buildIL();
+   };
+
+#endif // !defined(VECTORMATMULT_INCL)


### PR DESCRIPTION
To make it easier to build vectorized loops, this pull request creates a new class called a VectorLoopBuilder which takes care of the mundane aspects of managing a vectorized loop along with a residue loop. Basically VectorLoopBuilder manages two internal builder objects, one each corresponding to the vector loop body and the residue loop body. Services called on the VectorLoopBuilder are passed along to *both* the vector and residue loop copy, enabling users to create fully correct vectorized loops while only writing one version of the loop code.

Also provided is a new service on IlBuilder called VectorForLoop() which constructs a VectorLoopBuilder object and connects its internal builder objects into the control flow structure for a vectorized loop. It takes a type which will determine the vector length used in the loop as well as the `initial` and `end` values that describe the loop iterations. It returns a `TR::VectorLoopBuilder` object which can then be used to fill in the loop. If the provided type cannot be vectorized, then only the residue loop will be generated.

Along with this new service, there are two new code samples: Loop which multiplies two 1D vectors together, and VectorMatMult which vectorizes the middle loop of a straightforward ijk matrix multiplication loop nest.

This service is just a start; it's not complete in that only Add, Sub, and Mul, various flavours of Loads/Stores, and ForLoop are implemented on VectorLoopBuilder at the moment, and the vectorization support depends on what the OMR compiler component can do. It will not work on all platforms but it runs just fine on my MacBook and should be good on the x86 platform, at least.