### PR TITLE
Change implementation of JitBuilder's Switch service

### DIFF
--- a/jitbuilder/release/src/Switch.cpp
+++ b/jitbuilder/release/src/Switch.cpp
@@ -90,9 +90,9 @@ SwitchMethod::buildIL()
    TR::IlBuilder *defaultBldr=NULL;
    TR::IlBuilder *case1Bldr=NULL, *case2Bldr=NULL, *case3Bldr=NULL;
    Switch("selector", &defaultBldr, 3,
-          1, &case1Bldr, false,
-          2, &case2Bldr, false,
-          3, &case3Bldr, false);
+          MakeCase(1, &case1Bldr, false),
+          MakeCase(2, &case2Bldr, false),
+          MakeCase(3, &case3Bldr, false));
 
    PrintString(case1Bldr, "\tcase 1 reached\n");
 


### PR DESCRIPTION
This change set adds the `IlBuilder::JBCase` class to encapsulate the different pieces needed to construct a "case" for the `IlBuilder::Switch()` service. This avoids having to keep track of the different pieces independently in the implementation and also simplifies generating language bindings for the service.

This is a breaking change as the API is not backwards compatible. Code of the form:

```c++
Switch("foo", &defaultBuilder, 3,
    1, &case1Builder, false,
    2, &case2Builder, false,
    3, &case3Builder,false);
```
must be changed to
```c++
Switch("foo", &defaultBuilder, 3,
    MakeCase(1, &case1Builder, false),
    MakeCase(2, &case2Builder, false),
    MakeCase(3, &case3Builder,false));
```

FYI @mstoodle @jduimovich @charliegracie @rwy0717