### PR TITLE
Enable SSE/SSE2 on OMR X86-32

### DIFF
--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -513,8 +513,11 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
    TR_ASSERT(returnRegister, "Return node's child should evaluate to a register");
    TR::Compilation *comp = cg->comp();
 
+   const TR::X86LinkageProperties &linkageProperties = cg->getProperties();
+   auto machineReturnRegister = (returnRegister->isSinglePrecision())? linkageProperties.getFloatReturnRegister() : linkageProperties.getDoubleReturnRegister();
+
    if (TR::Compiler->target.is32Bit() &&
-       !cg->useSSEForDoublePrecision() &&
+       machineReturnRegister < TR::RealRegister::FirstXMMR &&
        returnRegister->getKind() == TR_FPR)
       {
       // TODO: Modify linkage to allow the returned value to remain in an XMMR.
@@ -531,10 +534,6 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
       {
       generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST), cg), cg);
       }
-
-   const TR::X86LinkageProperties &linkageProperties = cg->getProperties();
-   TR::RealRegister::RegNum machineReturnRegister =
-      (returnRegister->isSinglePrecision())? linkageProperties.getFloatReturnRegister() : linkageProperties.getDoubleReturnRegister();
 
    TR::RegisterDependencyConditions *dependencies = NULL;
    if (machineReturnRegister != TR::RealRegister::NoReg)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -204,8 +204,6 @@ void TR_X86ProcessorInfo::initialize()
 void
 OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    {
-
-   bool supportsSSE2 = false;
    _targetProcessorInfo.initialize();
 
    // Pick a padding table
@@ -222,14 +220,6 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       _paddingTable = &_old32BitPaddingTable; // Unknown 32-bit target
    else
       _paddingTable = &_K8PaddingTable; // Unknown 64-bit target
-
-   // Determine whether or not x87 or SSE should be used for floating point.
-   //
-
-#if defined(TR_TARGET_X86) && !defined(J9HAMMER)
-   if (_targetProcessorInfo.supportsSSE2() && TR::Compiler->target.cpu.testOSForSSESupport())
-      supportsSSE2 = true;
-#endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
 
    if (_targetProcessorInfo.supportsTM() && !comp->getOption(TR_DisableTM))
       {
@@ -248,17 +238,10 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
          }
       }
 
-   if (TR::Compiler->target.is64Bit()
-#if defined(TR_TARGET_X86) && !defined(J9HAMMER)
-       || supportsSSE2
-#endif
-      )
-      {
-      self()->setUseSSEForSinglePrecision();
-      self()->setUseSSEForDoublePrecision();
-      self()->setSupportsAutoSIMD();
-      self()->setSupportsJavaFloatSemantics();
-      }
+   self()->setUseSSEForSinglePrecision();
+   self()->setUseSSEForDoublePrecision();
+   self()->setSupportsAutoSIMD();
+   self()->setSupportsJavaFloatSemantics();
 
    // Choose the best XMM double precision load instruction for the target architecture.
    //
@@ -275,17 +258,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
          }
       }
 
-#if defined(TR_TARGET_X86) && !defined(J9HAMMER)
-   // Determine if software prefetches are supported.
-   //
-   // 32-bit platforms must check the processor and OS.
-   // 64-bit platforms unconditionally support prefetching.
-   //
-   if (_targetProcessorInfo.supportsSSE() && TR::Compiler->target.cpu.testOSForSSESupport())
-#endif // defined(TR_TARGET_X86) && !defined(J9HAMMER)
-      {
-      self()->setTargetSupportsSoftwarePrefetches();
-      }
+   self()->setTargetSupportsSoftwarePrefetches();
 
    // Enable software prefetch of the TLH and configure the TLH prefetching
    // geometry.

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -106,9 +106,3 @@ OMR::X86::CPU::getX86ProcessorFeatureFlags8()
    {
    return self()->queryX86TargetCPUID()->_featureFlags8;
    }
-
-bool
-OMR::X86::CPU::testOSForSSESupport()
-   {
-   return false;
-   }

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -62,8 +62,6 @@ public:
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
 
-   bool testOSForSSESupport();
-
    /**
     * @brief Answers whether the distance between a target and source address
     *        is within the reachable RIP displacement range.
@@ -79,7 +77,6 @@ public:
       {
       return targetAddress == sourceAddress + (int32_t)(targetAddress - sourceAddress);
       }
-
    };
 
 }


### PR DESCRIPTION
All known downstream projects uses SSE/SSE2 for floating point operations;
however OMR itself still kept X87 as default on X86-32.
This commit turns SSE/SSE2 on as default, allowing OMR's tests exercising SSE/SSE2 route.
X87 support is deprecated, and will be removed.

Closes #2429

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>