### PR TITLE
Enable aliasing of auto variables that have their address taken

### DIFF
--- a/compiler/compile/OMRAliasBuilder.cpp
+++ b/compiler/compile/OMRAliasBuilder.cpp
@@ -55,6 +55,7 @@ OMR::AliasBuilder::AliasBuilder(TR::SymbolReferenceTable *symRefTab, size_t size
      _refinedNonIntPrimitiveArrayShadows(1, c->trMemory(), heapAlloc, growable),
      _refinedAddressArrayShadows(1, c->trMemory(), heapAlloc, growable),
      _refinedIntArrayShadows(1, c->trMemory(), heapAlloc, growable),
+     _addressTakenAutos(1, c->trMemory(), heapAlloc, growable),
      _litPoolGenericIntShadowHasBeenCreated(false),
      _userFieldMethodDefAliases(c->trMemory(), _numNonUserFieldClasses),
      _conservativeGenericIntShadowAliasingRequired(false),

--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -108,6 +108,8 @@ public:
    TR_BitVector & refinedAddressArrayShadows() { return _refinedAddressArrayShadows; }
    TR_BitVector & refinedIntArrayShadows() { return _refinedIntArrayShadows; }
 
+   TR_BitVector & addressTakenAutos() { return _addressTakenAutos; }
+
    bool litPoolGenericIntShadowHasBeenCreated(){ return _litPoolGenericIntShadowHasBeenCreated; }
    void setLitPoolGenericIntShadowHasBeenCreated(){ _litPoolGenericIntShadowHasBeenCreated = true; }
 
@@ -184,6 +186,8 @@ protected:
    TR_BitVector _refinedAddressArrayShadows;
    TR_BitVector _refinedIntArrayShadows;
    TR_BitVector _refinedNonIntPrimitiveArrayShadows;
+
+   TR_BitVector _addressTakenAutos;
 
    bool _litPoolGenericIntShadowHasBeenCreated;
 

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -580,11 +580,18 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             return aliases;
             }
 #endif
-         TR_BitVector * aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
-         *aliases |= symRefTab->aliasBuilder.addressTakenAutos();
-         TR_BitVector *methodAliases = symRefTab->aliasBuilder.methodAliases(self());
-         *aliases |= *methodAliases;
-         return aliases;
+         if (!symRefTab->aliasBuilder.addressTakenAutos().isEmpty())
+            {
+               TR_BitVector * aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
+               *aliases |= symRefTab->aliasBuilder.addressTakenAutos();
+               TR_BitVector *methodAliases = symRefTab->aliasBuilder.methodAliases(self());
+               *aliases |= *methodAliases;
+               return aliases;
+            }
+         else 
+            {
+               return symRefTab->aliasBuilder.methodAliases(self());
+            }
          }
       case TR::Symbol::IsShadow:
          {

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -580,8 +580,11 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             return aliases;
             }
 #endif
-
-         return symRefTab->aliasBuilder.methodAliases(self());
+         TR_BitVector * aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
+         *aliases |= symRefTab->aliasBuilder.addressTakenAutos();
+         TR_BitVector *methodAliases = symRefTab->aliasBuilder.methodAliases(self());
+         *aliases |= *methodAliases;
+         return aliases;
          }
       case TR::Symbol::IsShadow:
          {

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -143,7 +143,13 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
       }
 
    bool canBuild = false;
-   _hasCallsAsUses = false;
+   // OMR sets this to false, but we need this to be enabled to ensure call nodes
+   // participate in use/def analysis, and thereby allow any aliased locals
+   // to be handled correctly; this is WIP as for Java like languages this is
+   // not needed, as locals cannot be aliased by function calls. However for C
+   // like languages this is needed; therefore this needs to be controlled via
+   // a parameter
+   _hasCallsAsUses = true;  
    _uniqueIndexForDefsOnEntry = false;
 
    if (comp()->cg()->getGRACompleted() && conversionRegsOnly)

--- a/compiler/optimizer/UseDefInfo.cpp
+++ b/compiler/optimizer/UseDefInfo.cpp
@@ -143,13 +143,6 @@ void TR_UseDefInfo::prepareUseDefInfo(bool requiresGlobals, bool prefersGlobals,
       }
 
    bool canBuild = false;
-   // OMR sets this to false, but we need this to be enabled to ensure call nodes
-   // participate in use/def analysis, and thereby allow any aliased locals
-   // to be handled correctly; this is WIP as for Java like languages this is
-   // not needed, as locals cannot be aliased by function calls. However for C
-   // like languages this is needed; therefore this needs to be controlled via
-   // a parameter
-   _hasCallsAsUses = true;  
    _uniqueIndexForDefsOnEntry = false;
 
    if (comp()->cg()->getGRACompleted() && conversionRegsOnly)

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -48,9 +48,9 @@ add_executable(comptest
 	CompareTest.cpp
 	TypeConversionTest.cpp
 	TernaryTest.cpp
-	# Following test crashes at present because
+	# Following test fails at present because
 	# it requires optimizer callsAsUses flags enabled
-	#LocalPassByRefTest.cpp
+	LocalPassByRefTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -48,6 +48,9 @@ add_executable(comptest
 	CompareTest.cpp
 	TypeConversionTest.cpp
 	TernaryTest.cpp
+	# Following test crashes at present because
+	# it requires optimizer callsAsUses flags enabled
+	#LocalPassByRefTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/LocalPassByRefTest.cpp
+++ b/fvtest/compilertriltest/LocalPassByRefTest.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JitTest.hpp"
+#include "default_compiler.hpp"
+
+class LocalPassByRefTest : public TRTest::JitTest {};
+
+int foo(int*i, long long*l)
+{
+	*i = (int) *l;
+	return 0;
+}
+
+TEST_F(LocalPassByRefTest, passByRefTest) { 
+    char inputTrees[512] = {0};
+	const auto format_string = "(method return=Int32 (block (istore temp=\"a\" (iconst 5)) (lstore temp=\"b\" (lconst 42)) (treetop (icall address=0x%jX args=[Address, Address] (loadaddr temp=\"a\") (loadaddr temp=\"b\") )) (ireturn (iadd (l2i (lload temp=\"b\")) (iload temp=\"a\")))))";
+    std::snprintf(inputTrees, sizeof inputTrees, format_string, reinterpret_cast<uintmax_t>(&foo));
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
+
+    // Execution of this test is disabled on non-X86 platforms, as we 
+    // do not have trampoline support, and so this call may be out of 
+    // range for some architectures. 
+#ifdef TR_TARGET_X86
+    Tril::DefaultCompiler compiler{trees};
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)()>();
+
+    EXPECT_EQ(84, entry_point());
+#endif
+}

--- a/fvtest/compilertriltest/LocalPassByRefTest.cpp
+++ b/fvtest/compilertriltest/LocalPassByRefTest.cpp
@@ -24,6 +24,26 @@
 
 class LocalPassByRefTest : public TRTest::JitTest {};
 
+/*
+ * Purpose of this test is to exercise the
+ * optimizer when local stack variables (autos) are
+ * passed by reference to functions, which may modify the
+ * values. Thus the functin aliases the local stack values
+ * and the optimizer needs to be aware of this aliasing.
+ *
+ * This requires two steps:
+ *
+ * The optimizer flag callsAsUses must be true. This flag
+ * controls whether the optimizer will consider functions as
+ * possibly aliasing local stack values.
+ *
+ * Secondly the language front end needs to set the aliasing
+ * data whenever such aliasing can occur.
+ *
+ * The test below does neither of these things (as of now),
+ * hence will fail.
+ */
+
 int foo(int*i, long long*l)
 {
 	*i = (int) *l;
@@ -31,22 +51,41 @@ int foo(int*i, long long*l)
 }
 
 TEST_F(LocalPassByRefTest, passByRefTest) { 
-    char inputTrees[512] = {0};
-	const auto format_string = "(method return=Int32 (block (istore temp=\"a\" (iconst 5)) (lstore temp=\"b\" (lconst 42)) (treetop (icall address=0x%jX args=[Address, Address] (loadaddr temp=\"a\") (loadaddr temp=\"b\") )) (ireturn (iadd (l2i (lload temp=\"b\")) (iload temp=\"a\")))))";
+    char inputTrees[1024] = {0};
+	const char format_string[] = 
+		"(method return=Int32          "
+		"  (block                      "
+		"    (istore temp=\"a\"        "
+		"      (iconst 5)              "
+		"    )                         "
+		"    (lstore temp=\"b\"        "
+		"      (lconst 42)             "
+		"    )                         "
+		"    (treetop                  "
+		"      (icall address=0x%jX args=[Address, Address] "
+		"        (loadaddr temp=\"a\") "
+		"        (loadaddr temp=\"b\") "
+		"      )                       "
+		"    )                         "
+		"    (ireturn                  "
+		"      (iadd                   "
+		"        (l2i                  "
+		"          (lload temp=\"b\")  "
+		"        )                     "
+		"        (iload temp=\"a\")    "
+		"      )                       "
+		"    )                         "
+		"  )                           "
+		")";
     std::snprintf(inputTrees, sizeof inputTrees, format_string, reinterpret_cast<uintmax_t>(&foo));
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees) << "Trees failed to parse\n" << inputTrees;
 
-    // Execution of this test is disabled on non-X86 platforms, as we 
-    // do not have trampoline support, and so this call may be out of 
-    // range for some architectures. 
-#ifdef TR_TARGET_X86
     Tril::DefaultCompiler compiler{trees};
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<int32_t (*)()>();
 
     EXPECT_EQ(84, entry_point());
-#endif
 }

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -318,7 +318,21 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
      }
      else {
         TraceIL("  unrecognized opcode; using default creation mechanism\n", "");
-        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
+        if (tree->getArgByName("parm") != NULL) {
+             auto arg = tree->getArgByName("parm")->getValue()->get<int32_t>();
+             TraceIL("parameter %d\n", arg);
+             auto symref = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, arg, opcode.getType() );
+             node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
+         }
+         else if (tree->getArgByName("temp") != NULL) {
+             const auto symName = tree->getArgByName("temp")->getValue()->getString();
+             TraceIL("temporary %s\n", symName);
+             auto symref = _symRefMap[symName];
+             node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
+         }
+         else {
+             node = TR::Node::create(opcode.getOpCodeValue(), childCount);
+         }
      }
      node->setFlags(parseFlags(tree));
 


### PR DESCRIPTION
In languages like C it is possible for local (auto) variables to have their address taken
and then passed by reference to another function. Example:

int foo(int*i, long long*l)
{
	*i = (int) *l;
	return 0;
}

int simplelocals(void)
{
	int a = 5;
	long long b = 42;
	foo(&a, &b);	// Just to fool the optimiser
	return a+(int)b;
}

Currently OMR's localCSE ignores the fact that the two locals were passed by reference to foo() and therefore
could have been changed by foo(). This results in incorrect optimization. The solution is to alias the autos
for "a" and "b" with the call "foo".

To enable this a new BitVector _addressTakenAutos is introduced in OMR::AliasBuilder. This is made available
to front-ends via OMR::AliasBuilder::addressTakenAutos(). The front-end is expected to set the symbols for
which addresses have been taken into this set.

The second part of this change is to use the aliasing information. The aliasing api that controls what the
rest of the optimizer sees is getUseDefAliasesBV in
https://github.com/eclipse/omr/blob/master/compiler/il/Aliases.cpp

In this routine the case for:

case TR::Symbol::IsResolvedMethod

Is updated to OR the addressTakenAliases with the method's aliases.

This change relates to the bug logged in #issue 2768.

Signed-off-by: Dibyendu Majumdar <mobile@majumdar.org.uk>