### PR TITLE
Add support for CUDA 9.1 and 9.2

### DIFF
--- a/port/common/omrcuda.cpp
+++ b/port/common/omrcuda.cpp
@@ -999,6 +999,14 @@ const J9CudaLibraryDescriptor runtimeLibraries[] = {
 /*
  * Include forward-compatible support for runtime libraries.
  */
+#if CUDA_VERSION <= 9020
+	OMRCUDA_LIBRARY_ENTRY(9, 2),
+#endif /* CUDA_VERSION <= 9020 */
+
+#if CUDA_VERSION <= 9010
+	OMRCUDA_LIBRARY_ENTRY(9, 1),
+#endif /* CUDA_VERSION <= 9010 */
+
 #if CUDA_VERSION <= 9000
 	OMRCUDA_LIBRARY_ENTRY(9, 0),
 #endif /* CUDA_VERSION <= 9000 */


### PR DESCRIPTION
According to [1], CUDA Toolkit version 9.1 was released in December 2017 and version 9.2 was released in March 2018.

[1] https://developer.nvidia.com/cuda-toolkit-archive