### PR TITLE
AArch64: Initial version of OMRMemoryReference.generateBinaryEncoding()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -36,6 +36,26 @@ namespace TR { class SymbolReference; }
 
 #define ARM64_INSTRUCTION_LENGTH 4
 
+/*
+ * @brief Answers if the signed integer value can be placed in 9-bit field
+ * @param[in] intValue : signed integer value
+ * @return true if the value can be placed in 9-bit field, false otherwise
+ */
+inline bool constantIsImmed9(int32_t intValue)
+   {
+   return (-256 <= intValue && intValue < 256);
+   }
+
+/*
+ * @brief Answers if the unsigned integer value can be placed in 12-bit field
+ * @param[in] intValue : unsigned integer value
+ * @return true if the value can be placed in 12-bit field, false otherwise
+ */
+inline bool constantIsUnsignedImmed12(uint32_t intValue)
+   {
+   return (intValue < 4096);
+   }
+
 namespace TR
 {
 

--- a/compiler/aarch64/codegen/OMRInstOpCode.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCode.hpp
@@ -61,6 +61,25 @@ class InstOpCode: public OMR::InstOpCode
    static const OpCodeBinaryEntry binaryEncodings[ARM64NumOpCodes];
 
    /*
+    * @brief Answers binary encoding of Mnemonic
+    * @param[in] m : mnemonic
+    * @return binary encoding
+    */
+   static const OpCodeBinaryEntry getOpCodeBinaryEncoding(Mnemonic m)
+      {
+      return binaryEncodings[m];
+      }
+
+   /*
+    * @brief Answers binary encoding of InstOpCode
+    * @return binary encoding
+    */
+   const OpCodeBinaryEntry getOpCodeBinaryEncoding()
+      {
+      return getOpCodeBinaryEncoding(_mnemonic);
+      }
+
+   /*
     * @brief Copies binary encoding of the opcode to buffer
     * @param[in] cursor : instruction cursor
     * @return instruction cursor

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -276,10 +276,9 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
 
    /**
     * @brief Estimates the length of generated binary
-    * @param[in] cg : CodeGenerator
     * @return estimated binary length
     */
-   uint32_t estimateBinaryLength(TR::CodeGenerator&);
+   uint32_t estimateBinaryLength();
 
    /**
     * @brief Generates binary encoding


### PR DESCRIPTION
This commit implements the initial version of generateBinaryEncoding()
in OMRMemoryReference for aarch64 and related functions.

Signed-off-by: knn-k <konno@jp.ibm.com>