### PR TITLE
Fix JitBuilder Call to return the right type for Int8 and Int16

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -972,7 +972,7 @@ OMR::IlBuilder::ConvertTo(TR::IlType *t, TR::IlValue *v)
       TraceIL("IlBuilder[ %p ]::%d is ConvertTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
       return v;
       }
-   TR::IlValue *convertedValue = convertTo(t, v, false);
+   TR::IlValue *convertedValue = convertTo(typeTo, v, false);
    TraceIL("IlBuilder[ %p ]::%d is ConvertTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
    return convertedValue;
    }
@@ -987,22 +987,21 @@ OMR::IlBuilder::UnsignedConvertTo(TR::IlType *t, TR::IlValue *v)
       TraceIL("IlBuilder[ %p ]::%d is UnsignedConvertTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
       return v;
       }
-   TR::IlValue *convertedValue = convertTo(t, v, true);
+   TR::IlValue *convertedValue = convertTo(typeTo, v, true);
    TraceIL("IlBuilder[ %p ]::%d is UnsignedConvertTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
    return convertedValue;
    }
 
 TR::IlValue *
-OMR::IlBuilder::convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned)
+OMR::IlBuilder::convertTo(TR::DataType typeTo, TR::IlValue *v, bool needUnsigned)
    {
    TR::DataType typeFrom = v->getDataType();
-   TR::DataType typeTo = t->getPrimitiveType();
 
    TR::ILOpCodes convertOp = ILOpCode::getProperConversion(typeFrom, typeTo, needUnsigned);
-   TR_ASSERT(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d (TR::DataType %d) to type %s", this, v->getID(), (int)typeFrom, t->getName());
+   TR_ASSERT(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d %s to %s", this, v->getID(), typeFrom.toString(), typeTo.toString());
 
    TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
-   TR::IlValue *convertedValue = newValue(t, result);
+   TR::IlValue *convertedValue = newValue(typeTo, result);
    return convertedValue;
    }
 
@@ -2006,6 +2005,9 @@ OMR::IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::
    if (returnType != TR::NoType)
       {
       TR::IlValue *returnValue = newValue(callNode->getDataType(), callNode);
+      if (returnType != callNode->getDataType())
+         returnValue = convertTo(returnType, returnValue, false);
+
       return returnValue;
       }
 

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -591,7 +591,7 @@ protected:
    TR::IlValue *shiftOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
    TR::IlValue *shiftOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *compareOp(TR_ComparisonTypes ct, bool needUnsigned, TR::IlValue *left, TR::IlValue *right);
-   TR::IlValue *convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned);
+   TR::IlValue *convertTo(TR::DataType typeTo, TR::IlValue *v, bool needUnsigned);
 
    void ifCmpCondition(TR_ComparisonTypes ct, bool isUnsignedCmp, TR::IlValue *left, TR::IlValue *right, TR::Block *target);
    void ifCmpNotEqualZero(TR::IlValue *condition, TR::Block *target);

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,6 +33,12 @@ add_executable(jitbuildertest
 	SystemLinkageTest.cpp
 	WorklistTest.cpp
 )
+
+if(OMR_HOST_ARCH STREQUAL "x86")
+	if(OMR_HOST_OS STREQUAL "linux" OR OMR_HOST_OS STREQUAL "osx")
+		target_sources(jitbuildertest PUBLIC CallReturnTest.cpp)
+	endif()
+endif()
 
 target_link_libraries(jitbuildertest
 	jitbuilder

--- a/fvtest/jitbuildertest/CallReturnTest.cpp
+++ b/fvtest/jitbuildertest/CallReturnTest.cpp
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+static int64_t
+testInt64(int64_t val)
+   {
+   #define TEST_INT64_LINE LINETOSTR(__LINE__)
+   return val;
+   }
+
+static int32_t
+testInt32(int32_t val)
+   {
+   #define TEST_INT32_LINE LINETOSTR(__LINE__)
+   return val;
+   }
+
+static int16_t
+testInt16(int16_t val)
+   {
+   #define TEST_INT16_LINE LINETOSTR(__LINE__)
+   return val;
+   }
+
+static int8_t
+testInt8(int8_t val)
+   {
+   #define TEST_INT8_LINE LINETOSTR(__LINE__)
+   return val;
+   }
+
+DEFINE_BUILDER(TestInt64ReturnType,
+               Int64,
+               PARAM("param", Int64))
+   {
+   DefineFunction((char *)"testInt64",
+                  (char *)__FILE__,
+                  (char *)TEST_INT64_LINE,
+                  (void *)&testInt64,
+                  Int64,
+                  1,
+                  Int64);
+
+   TR::IlValue *param = Load("param");
+   TR::IlValue *int64Result = Call("testInt64", 1, param);
+   TR::IlValue *int64Val = ConstInt64(1);
+   TR::IlValue *result = Add(int64Result, int64Val);
+
+   Return(result);
+
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt32ReturnType,
+               Int32,
+               PARAM("param", Int32))
+   {
+   DefineFunction((char *)"testInt32",
+                  (char *)__FILE__,
+                  (char *)TEST_INT32_LINE,
+                  (void *)&testInt32,
+                  Int32,
+                  1,
+                  Int32);
+
+   TR::IlValue *param = Load("param");
+   TR::IlValue *int32Result = Call("testInt32", 1, param);
+   TR::IlValue *int32Val = ConstInt32(1);
+   TR::IlValue *result = Add(int32Result, int32Val);
+
+   Return(result);
+
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt16ReturnType,
+               Int16,
+               PARAM("param", Int16))
+   {
+   DefineFunction((char *)"testInt16",
+                  (char *)__FILE__,
+                  (char *)TEST_INT16_LINE,
+                  (void *)&testInt16,
+                  Int16,
+                  1,
+                  Int16);
+
+   TR::IlValue *param = Load("param");
+   TR::IlValue *int16Result = Call("testInt16", 1, param);
+   TR::IlValue *int16Val = ConstInt16(1);
+   TR::IlValue *result = Add(int16Result, int16Val);
+
+   Return(result);
+
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt8ReturnType,
+               Int8,
+               PARAM("param", Int8))
+   {
+   DefineFunction((char *)"testInt8",
+                  (char *)__FILE__,
+                  (char *)TEST_INT8_LINE,
+                  (void *)&testInt8,
+                  Int8,
+                  1,
+                  Int8);
+
+   TR::IlValue *param = Load("param");
+   TR::IlValue *int8Result = Call("testInt8", 1, param);
+   TR::IlValue *int8Val = ConstInt8(1);
+   TR::IlValue *result = Add(int8Result, int8Val);
+
+   Return(result);
+
+   return true;
+   }
+
+class ReturnTypeTest : public JitBuilderTest {};
+
+typedef int64_t (*Int64ReturnType)(int64_t);
+TEST_F(ReturnTypeTest, Int64_Test)
+   {
+   Int64ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt64ReturnType, testFunction);
+   ASSERT_EQ(testFunction(0), 1);
+   ASSERT_EQ(testFunction(INT64_MAX - 1), INT64_MAX);
+   ASSERT_EQ(testFunction(-1), 0);
+   ASSERT_EQ(testFunction(INT64_MIN), INT64_MIN + 1);
+   }
+
+typedef int32_t (*Int32ReturnType)(int32_t);
+TEST_F(ReturnTypeTest, Int32_Test)
+   {
+   Int32ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt32ReturnType, testFunction);
+   ASSERT_EQ(testFunction(0), 1);
+   ASSERT_EQ(testFunction(INT32_MAX - 1), INT32_MAX);
+   ASSERT_EQ(testFunction(-1), 0);
+   ASSERT_EQ(testFunction(INT32_MIN), INT32_MIN + 1);
+   }
+
+typedef int16_t (*Int16ReturnType)(int16_t);
+TEST_F(ReturnTypeTest, Int16_Test)
+   {
+   Int16ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt16ReturnType, testFunction);
+   ASSERT_EQ(testFunction(0), 1);
+   ASSERT_EQ(testFunction(INT16_MAX - 1), INT16_MAX);
+   ASSERT_EQ(testFunction(-1), 0);
+   ASSERT_EQ(testFunction(INT16_MIN), INT16_MIN + 1);
+   }
+
+typedef int8_t (*Int8ReturnType)(int8_t);
+TEST_F(ReturnTypeTest, Int8_Test)
+   {
+   Int8ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt8ReturnType, testFunction);
+   ASSERT_EQ(testFunction(0), 1);
+   ASSERT_EQ(testFunction(INT8_MAX - 1), INT8_MAX);
+   ASSERT_EQ(testFunction(-1), 0);
+   ASSERT_EQ(testFunction(INT8_MIN), INT8_MIN + 1);
+   }

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -34,7 +34,8 @@ OBJECTS := \
 	ControlFlowTest \
 	SystemLinkageTest \
 	WorklistTest \
-	IfThenElseTest
+	IfThenElseTest \
+	CallReturnTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 


### PR DESCRIPTION
Currently if a function returns a type smaller than Int32 the
returned value will be of type Int32 and not Int16 or Int8. I
added some tests that will assert in JitBuilder if the type of
the return value does not match the declaration. This is achieved
by adding the result to a Const<type> of the appropriate type.

The solution is to convert the result if callNode->getDataType()
does not match the defined return type. To make the change simpler
I modified the parameters of convertTo to take a TR::DataType
instead of a TR::IlType.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>