### PR TITLE
Move allocation of CodeCacheHashEntrySlab to CodeCache initialization

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -1840,8 +1840,8 @@ OMR::CodeCache::reserveNTrampolines(int64_t n)
 //
 TR::CodeCache *
 OMR::CodeCache::allocate(TR::CodeCacheManager *manager,
-                       size_t segmentSize,
-                       int32_t reservingCompThreadID)
+                         size_t segmentSize,
+                         int32_t reservingCompThreadID)
    {
    TR::CodeCacheConfig & config = manager->codeCacheConfig();
    bool verboseCodeCache = config.verboseCodeCache();
@@ -1851,40 +1851,29 @@ OMR::CodeCache::allocate(TR::CodeCacheManager *manager,
 
    if (codeCacheSegment)
       {
-      // allocate hash entry slab now, instead of after codeCache allocation as its less expensive and easier to
-      // fully unroll
-      CodeCacheHashEntrySlab *hashEntrySlab = CodeCacheHashEntrySlab::allocate(manager, config.codeCacheHashEntryAllocatorSlabSize());
-      if (hashEntrySlab)
+      TR::CodeCache *codeCache = manager->allocateCodeCacheObject(codeCacheSegment,
+                                                                  codeCacheSizeAllocated);
+
+      if (codeCache)
          {
-         uint8_t *start = NULL;
-         TR::CodeCache *codeCache = manager->allocateCodeCacheObject(codeCacheSegment,
-                                                                     codeCacheSizeAllocated,
-                                                                     hashEntrySlab);
-
-         if (codeCache)
+         // If we wanted to reserve this code cache, then mark it as reserved now
+         if (reservingCompThreadID >= -1)
             {
-            // If we wanted to reserve this code cache, then mark it as reserved now
-            if (reservingCompThreadID >= -1)
-               {
-               codeCache->reserve(reservingCompThreadID);
-               }
-
-            // Add it to our list of code caches
-            manager->addCodeCache(codeCache);
-
-            if (verboseCodeCache)
-               {
-               TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "CodeCache allocated %p @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT " HelperBase:" POINTER_PRINTF_FORMAT, codeCache, codeCache->getCodeBase(), codeCache->getCodeTop(), codeCache->_helperBase);
-               }
-
-            return codeCache;
+            codeCache->reserve(reservingCompThreadID);
             }
 
-         // failed to allocate code cache so need to free hash entry slab
-         hashEntrySlab->free(manager);
+         // Add it to our list of code caches
+         manager->addCodeCache(codeCache);
+
+         if (verboseCodeCache)
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "CodeCache allocated %p @ " POINTER_PRINTF_FORMAT "-" POINTER_PRINTF_FORMAT " HelperBase:" POINTER_PRINTF_FORMAT, codeCache, codeCache->getCodeBase(), codeCache->getCodeTop(), codeCache->_helperBase);
+            }
+
+         return codeCache;
          }
 
-      // failed to allocate hash entry slab so need to free code cache segment
+      // Free code cache segment
       if (manager->usingRepository())
          {
          // return back the portion we carved

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -100,7 +100,7 @@ OMR::CodeCacheManager::initialize(
 #endif // HOST_OS == OMR_LINUX
 
    TR::CodeCacheConfig &config = self()->codeCacheConfig();
-      
+
    if (allocateMonolithicCodeCache)
       {
       size_t size = config.codeCacheTotalKB() * 1024;
@@ -156,7 +156,7 @@ OMR::CodeCacheManager::initialize(
             config.codeCacheTotalKB() <= REACHEABLE_RANGE_KB)
 #endif
         );
-   
+
    _lowCodeCacheSpaceThresholdReached = false;
 
    _initialized = true;
@@ -220,7 +220,7 @@ OMR::CodeCacheManager::destroy()
       int numCharsWritten = snprintf(elfFilename, maxElfFilenameSize, "/tmp/perf-%d.jit", jvmPid);
       if (numCharsWritten > 0 && numCharsWritten < maxElfFilenameSize)
       {
-         TR_ASSERT(_elfExecutableGenerator->emitELF((const char*) &elfFilename, 
+         TR_ASSERT(_elfExecutableGenerator->emitELF((const char*) &elfFilename,
                                 _symbolContainer->_head,
                                 _symbolContainer->_numSymbols,
                                 _symbolContainer->_totalSymbolNameLength),
@@ -254,14 +254,13 @@ OMR::CodeCacheManager::freeMemory(void *memoryToFree)
 
 TR::CodeCache *
 OMR::CodeCacheManager::allocateCodeCacheObject(TR::CodeCacheMemorySegment *codeCacheSegment,
-                                             size_t codeCacheSizeAllocated,
-                                             CodeCacheHashEntrySlab *hashEntrySlab)
+                                               size_t codeCacheSize)
    {
    TR::CodeCache *codeCache = static_cast<TR::CodeCache *>(self()->getMemory(sizeof(TR::CodeCache)));
    if (codeCache)
       {
       new (codeCache) TR::CodeCache();
-      if (!codeCache->initialize(self(), codeCacheSegment, codeCacheSizeAllocated, hashEntrySlab))
+      if (!codeCache->initialize(self(), codeCacheSegment, codeCacheSize))
          {
          self()->freeMemory(codeCache);
          codeCache = NULL;
@@ -1245,7 +1244,7 @@ void
 OMR::CodeCacheManager::initializeRelocatableELFGenerator(void)
    {
    _objectFileName = TR::Options::getCmdLineOptions()->getObjectFileName();
-   
+
    TR::CodeCacheSymbolContainer * symbolContainer = static_cast<TR::CodeCacheSymbolContainer *>(self()->getMemory(sizeof(TR::CodeCacheSymbolContainer)));
    symbolContainer->_head = NULL;
    symbolContainer->_tail = NULL;
@@ -1253,7 +1252,7 @@ OMR::CodeCacheManager::initializeRelocatableELFGenerator(void)
    symbolContainer->_totalSymbolNameLength = 1; //precount for the UNDEF symbol
    _relocatableSymbolContainer = symbolContainer;
 
-   
+
    TR::CodeCacheRelocationInfoContainer * relInfo = static_cast<TR::CodeCacheRelocationInfoContainer *>(self()->getMemory(sizeof(TR::CodeCacheRelocationInfoContainer)));
    relInfo->_head = NULL;
    relInfo->_tail = NULL;

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,8 +144,7 @@ public:
    void  freeMemory(void *memoryToFree);
 
    TR::CodeCache * allocateCodeCacheObject(TR::CodeCacheMemorySegment *codeCacheSegment,
-                                           size_t codeCacheSizeAllocated,
-                                           CodeCacheHashEntrySlab *hashEntrySlab);
+                                           size_t codeCacheSize);
    void * chooseCacheStartAddress(size_t repositorySize);
 
    TR::CodeCache * getFirstCodeCache()            { return _codeCacheList._head; }


### PR DESCRIPTION
Currently, the initial CodeCacheHashEntrySlab is allocated before the
CodeCache object is allocated and then passed in as a parameter to the
CodeCache object initialization.  This is done mainly for the reasons
discussed in Issue #2470.

This commit moves the allocation of the CodeCacheHashEntrySlab object
and the first slab to the CodeCache::initialize() function.  Handling
of allocation failures has also been adjusted to accommodate the new
location to ensure memory is reclaimed.

This change is necessary to consolidate trampoline artifact creation
to a single location to facilitate further refactoring in this area.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>