### PR TITLE
Introduce CodeCache::initialize() without CodeCacheHashEntrySlab parm

### DIFF
--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -196,6 +196,19 @@ public:
                                          size_t codeCacheSizeAllocated,
                                          CodeCacheHashEntrySlab *hashEntrySlab);
 
+   /**
+    * @brief Initialize an allocated CodeCache object
+    *
+    * @param[in] manager : the TR::CodeCacheManager
+    * @param[in] codeCacheSegment : the code cache memory segment that has been allocated
+    * @param[in] allocatedCodeCacheSizeInBytes : the size (in bytes) of the allocated code cache
+    *
+    * @return true on a successful initialization; false otherwise.
+    */
+   bool                       initialize(TR::CodeCacheManager *manager,
+                                         TR::CodeCacheMemorySegment *codeCacheSegment,
+                                         size_t allocatedCodeCacheSizeInBytes);
+
 private:
    void                       updateMaxSizeOfFreeBlocks(CodeCacheFreeCacheBlock *blockPtr, size_t blockSize);
 


### PR DESCRIPTION
As part of the work to stage the changes for #2832, this PR introduces a
new API for the OMR::CodeCache::initialize() function that does not
accept a CodeCacheHashEntrySlab parameter.  Instead, it will allocate the
slab as part of the initialization process thereby encapsulating the
trampoline requirements within the CodeCache.

This single change is being introduced to allow downstream projects to
adapt to the changes proposed in #2832.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>