### PR TITLE
Provide extension points for code cache access/egress actions

### DIFF
--- a/compiler/runtime/CodeCacheTypes.hpp
+++ b/compiler/runtime/CodeCacheTypes.hpp
@@ -171,6 +171,19 @@ struct FaintCacheBlock
 
 #define addFreeBlock2(start, end) addFreeBlock2WithCallSite((start), (end), __FILE__, __LINE__)
 
+
+/**
+ * @struct
+ * @brief Projects should optionally subclass this struct with any data they
+ *        need to maintain between acquiring access to a code cache and
+ *        releasing access to a code cache.  For example, the state of a monitor
+ *        prior to entering the code code cache that must be restored upon
+ *        completing access.
+ */
+struct CodeCacheAccessMetaData
+   {
+   };
+
 }
 
-#endif // CODECAHCETYPES_INCL
+#endif // CODECACHETYPES_INCL


### PR DESCRIPTION
Accessing the internals of a code cache during compilation may require
special setup surrounding the manipulation of the code cache.  Two
symmetric functions (`prepareToAccessCodeCache` and
`prepareToEgressCodeCache`) are provided to handle any actions that must
be completed prior to accessing the internals of a code cache and once
access to those internals are complete.
    
Consuming OMR projects can override these functions and metadata parameter
for their own project needs.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>