### PR TITLE
Guard against negative callerIndexes in debugCounters

### DIFF
--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -378,7 +378,7 @@ void TR::DebugCounterAggregation::aggregateStandardCounters(TR::Compilation *com
    int32_t bytecodeIndex = bci.getByteCodeIndex();
    TR_OpaqueMethodBlock *method = NULL;
 
-   if (callerIndex != -1)
+   if (callerIndex > -1)
       {
       TR_InlinedCallSite &ics = comp->getInlinedCallSite(callerIndex);
       method = ics._methodInfo;


### PR DESCRIPTION
Change debug counters to guard against negative caller
indexes which are less than negative 1. Nodes created in
TR_J9EstimateCodeSize have callerIndexes set to -10 and
would cause a crash when attempting to access the method
using the caller index.

Signed-off-by: Daniel Hong <daniel.hong@live.com>