### PR TITLE
Update PPA format to RRF2

### DIFF
--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -13105,7 +13105,7 @@
    /* .description = */ "Perform Processor Assist",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xE8,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_UsesTarget
    },


### PR DESCRIPTION
According to PoPs the PPA instruction is an RRF-c format instruction
with no third register and a mask, hence it should be labeled as an
RRF2 instruction.

Note that the .format field in the table modified is only used as a
reference and has no bearing on any execution path.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>