### PR TITLE
Create an implementation of findOrCreateLiteral in Z CodeGenerator

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -11380,3 +11380,12 @@ OMR::Z::CodeGenerator::isCompressedClassPointerOfObjectHeader(TR::Node * node)
            (node->getSymbol()->isClassObject() ||
             node->getSymbolReference() == self()->getSymRefTab()->findVftSymbolRef()));
    }
+
+
+size_t
+OMR::Z::CodeGenerator::findOrCreateLiteral(void *value, size_t len)
+   {
+   TR_ASSERT(0, "findOrCreateLiteral unimplemented\n");
+   return 0;
+   }
+

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -393,7 +393,14 @@ public:
 
    bool isCompressedClassPointerOfObjectHeader(TR::Node * node);
 
-
+   /**
+    * @brief Create a literal pool entry for the given value.
+    *
+    * @details
+    *    This function must be implemented and will assert if called.
+    *    See issue eclipse/omr#2180 for details.
+    */
+   size_t findOrCreateLiteral(void *value, size_t len);
 
    bool usesImplicit64BitGPRs(TR::Node *node);
    bool nodeMayCauseException(TR::Node *node);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -15784,7 +15784,7 @@ void arraycmpWithPadHelper::generateCLCLitPoolPadding()
 
       constSpacePadding = true;
 
-      paddingLitPoolOffset = cg->fe()->findOrCreateLiteral(comp, paddingValue, paddingByteLength);
+      paddingLitPoolOffset = cg->findOrCreateLiteral(paddingValue, paddingByteLength);
       newLitPoolReg = cg->isLiteralPoolOnDemandOn();
       if (newLitPoolReg)
          litPoolBaseReg = cg->allocateRegister();
@@ -19157,24 +19157,24 @@ OMR::Z::TreeEvaluator::vsetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
             if (size == 1)
                {
                uint8_t value = valueNode->getIntegerNodeValue<uint8_t>();
-               offset = cg->fe()->findOrCreateLiteral(cg->comp(), &value, size);
+               offset = cg->findOrCreateLiteral(&value, size);
                }
             else if (size == 2)
                {
                uint16_t value = valueNode->getIntegerNodeValue<uint16_t>();
-               offset = cg->fe()->findOrCreateLiteral(cg->comp(), &value, size);
+               offset = cg->findOrCreateLiteral(&value, size);
                }
             else if (size == 4)
                {
                if (valueNode->getOpCode().isFloat())
                   {
                   float value = valueNode->getFloat();
-                  offset = cg->fe()->findOrCreateLiteral(cg->comp(), &value, size);
+                  offset = cg->findOrCreateLiteral(&value, size);
                   }
                else
                   {
                   uint32_t value = valueNode->getIntegerNodeValue<uint32_t>();
-                  offset = cg->fe()->findOrCreateLiteral(cg->comp(), &value, size);
+                  offset = cg->findOrCreateLiteral(&value, size);
                   }
                }
             else if (size == 8)
@@ -19182,12 +19182,12 @@ OMR::Z::TreeEvaluator::vsetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
                if (valueNode->getOpCode().isDouble())
                   {
                   double value = valueNode->getDouble();
-                  offset = cg->fe()->findOrCreateLiteral(cg->comp(), &value, size);
+                  offset = cg->findOrCreateLiteral(&value, size);
                   }
                else
                   {
                   uint64_t value = valueNode->getIntegerNodeValue<uint64_t>();
-                  offset = cg->fe()->findOrCreateLiteral(cg->comp(), &value, size);
+                  offset = cg->findOrCreateLiteral(&value, size);
                   }
                }
 


### PR DESCRIPTION
This commit does not provide an implementation for findOrCreateLiteral
but simply produces an equivalent stub in the Z CodeGenerator class.
This is the first step in a series of staged commits to safely remove
it from the FrontEnd class.

Issue #2180

Signed-off-by: Daryl Maier <maier@ca.ibm.com>