### PR TITLE
CacheList Splitting Configuration Modification

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -282,6 +282,9 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 #endif /* OMR_GC_MODRON_CONCURRENT_MARK */
 	}
 
+	writer->formatAndOutput(env, 1, "<attribute name=\"packetListSplit\" value=\"%zu\" />", _extensions->packetListSplit);
+	writer->formatAndOutput(env, 1, "<attribute name=\"cacheListSplit\" value=\"%zu\" />", _extensions->cacheListSplit);
+	writer->formatAndOutput(env, 1, "<attribute name=\"splitFreeListSplitAmount\" value=\"%zu\" />", _extensions->splitFreeListSplitAmount);
 	writer->formatAndOutput(env, 1, "<attribute name=\"numaNodes\" value=\"%zu\" />", event->numaNodes);
 
 	handleInitializedInnerStanzas(hook, eventNum, eventData);


### PR DESCRIPTION
CacheList Splitting Configuration Modification. Adding arguments
to verbose logging and remove code duplication.

Signed-off-by: Jonathan Oommen <jon.oommen@gmail.com>