### PR TITLE
Change implementation of JitBuilder's IfAnd and IfOr services

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1640,6 +1640,14 @@ OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBui
    setComesBack();
    }
 
+TR::IlBuilder::JBCondition *
+OMR::IlBuilder::MakeCondition(TR::IlBuilder *conditionBuilder, TR::IlValue *conditionValue)
+   {
+   TR_ASSERT(conditionBuilder != NULL, "MakeCondition needs to have non-null conditionBuilder");
+   TR_ASSERT(conditionValue != NULL, "MakeCondition needs to have non-null conditionValue");
+   return new (_comp->trHeapMemory()) JBCondition(conditionBuilder, conditionValue);
+   }
+
 TR::IlValue *
 OMR::IlBuilder::EqualTo(TR::IlValue *left, TR::IlValue *right)
    {

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1532,10 +1532,12 @@ OMR::IlBuilder::UnsignedShiftR(TR::IlValue *v, TR::IlValue *amount)
 
 /*
  * @brief IfAnd service for constructing short circuit AND conditional nests (like the && operator)
- * @param allTrueBuilder builder containing operations to execute if all conditional tests evaluate to true
+ * @param allTrueBuilder builder containing operations to execute if all conditional tests evaluate 
+ *        to true (automatically allocated if pointed-to pointer is null)
  * @param anyFalseBuilder builder containing operations to execute if any conditional test is false
+ *        (automatically allocated if pointed-to pointer is null)
  * @param numTerms the number of conditional terms
- * @param ... for each term, provide a TR::IlBuilder object and a TR::IlValue object that evaluates a condition (builder is where all the operations to evaluate the condition go, the value is the final result of the condition)
+ * @param terms array of JBCondition instances that evaluate a condition
  *
  * Example:
  * TR::IlBuilder *cond1Builder = OrphanBuilder();
@@ -1547,26 +1549,24 @@ OMR::IlBuilder::UnsignedShiftR(TR::IlValue *v, TR::IlValue *amount)
  *                      cond2Builder->   Load("x"),
  *                      cond2Builder->   Load("upper"));
  * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
- * IfAnd(&inRange, &outOfRange, 2, cond1Builder, cond1, cond2Builder, cond2);
+ * TR::IlBuilder *conditions[] = {MakeCondition(cond1Builder, cond1), MakeCondition(cond2Builder, cond2)};
+ * IfAnd(&inRange, &outOfRange, 2, conditions);
  */
 void
-OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ...)
+OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, JBCondition **terms)
    {
    TR::IlBuilder *mergePoint = OrphanBuilder();
    *allTrueBuilder = createBuilderIfNeeded(*allTrueBuilder);
    *anyFalseBuilder = createBuilderIfNeeded(*anyFalseBuilder);
 
-   va_list terms;
-   va_start(terms, numTerms);
    for (int32_t t=0;t < numTerms;t++)
       {
-      TR::IlBuilder *condBuilder = va_arg(terms, TR::IlBuilder*);
-      TR::IlValue *condValue = va_arg(terms, TR::IlValue*);
+      TR::IlBuilder *condBuilder = terms[t]->_builder;
+      TR::IlValue *condValue = terms[t]->_condition;
       AppendBuilder(condBuilder);
       condBuilder->IfCmpEqualZero(anyFalseBuilder, condValue);
       // otherwise fall through to test next term
       }
-   va_end(terms);
 
    // if control gets here, all the provided terms were true
    AppendBuilder(*allTrueBuilder);
@@ -1582,12 +1582,53 @@ OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBu
    setComesBack();
    }
 
+/**
+ * @brief Overload taking a varargs instead of an array of JBCondition pointers
+ *
+ * @param allTrueBuilder builder containing operations to execute if all conditional tests 
+ *        evaluate to true (automatically allocated if pointed-to pointer is null)
+ * @param anyFalseBuilder builder containing operations to execute if any conditional test
+ *        is false (automatically allocated if pointed-to pointer is null)
+ * @param numTerms the number of conditional terms
+ * @param ... for each term, provide a TR::IlBuilder::JBCondition object for the condition
+ *
+ * Example:
+ * TR::IlBuilder *cond1Builder = OrphanBuilder();
+ * TR::IlValue *cond1 = cond1Builder->GreaterOrEqual(
+ *                      cond1Builder->   Load("x"),
+ *                      cond1Builder->   Load("lower"));
+ * TR::IlBuilder *cond2Builder = OrphanBuilder();
+ * TR::IlValue *cond2 = cond2Builder->LessThan(
+ *                      cond2Builder->   Load("x"),
+ *                      cond2Builder->   Load("upper"));
+ * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
+ * IfAnd(&inRange, &outOfRange, 2, MakeCondition(cond1Builder, cond1), MakeCondition(cond2Builder, cond2));
+ */
+void
+OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ...)
+   {
+   JBCondition **terms = (JBCondition **) _comp->trMemory()->allocateHeapMemory(numTerms * sizeof(JBCondition *));
+   TR_ASSERT(NULL != terms, "out of memory");
+
+   va_list args;
+   va_start(args, numTerms);
+   for (int32_t c = 0; c < numTerms; ++c)
+      {
+      terms[c] = va_arg(args, JBCondition *);
+      }
+   va_end(args);
+
+   IfAnd(allTrueBuilder, anyFalseBuilder, numTerms, terms);
+   }
+
 /*
  * @brief IfOr service for constructing short circuit OR conditional nests (like the || operator)
- * @param anyTrueBuilder builder containing operations to execute if any conditional test evaluates to true
- * @param allFalseBuilder builder containing operations to execute if all conditional tests are false
+ * @param anyTrueBuilder builder containing operations to execute if any conditional test evaluates
+ *        to true (automatically allocated if pointed-to pointer is null)
+ * @param allFalseBuilder builder containing operations to execute if all conditional tests are
+ *        false (automatically allocated if pointed-to pointer is null)
  * @param numTerms the number of conditional terms
- * @param ... for each term, provide a TR::IlBuilder object and a TR::IlValue object that evaluates a condition (builder is where all the operations to evaluate the condition go, the value is the final result of the condition)
+ * @param terms array of JBCondition instances that evaluate a condition
  *
  * Example:
  * TR::IlBuilder *cond1Builder = OrphanBuilder();
@@ -1599,32 +1640,30 @@ OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBu
  *                      cond2Builder->   Load("x"),
  *                      cond2Builder->   Load("upper"));
  * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
- * IfOr(&outOfRange, &inRange, 2, cond1Builder, cond1, cond2Builder, cond2);
+ * TR::IlBuilder *conditions[] = {MakeCondition(cond1Builder, cond1), MakeCondition(cond2Builder, cond2)};
+ * IfOr(&outOfRange, &inRange, 2, conditions);
  */
 void
-OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ...)
+OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, JBCondition **terms)
    {
    TR::IlBuilder *mergePoint = OrphanBuilder();
    *anyTrueBuilder = createBuilderIfNeeded(*anyTrueBuilder);
    *allFalseBuilder = createBuilderIfNeeded(*allFalseBuilder);
 
-   va_list terms;
-   va_start(terms, numTerms);
    for (int32_t t=0;t < numTerms-1;t++)
       {
-      TR::IlBuilder *condBuilder = va_arg(terms, TR::IlBuilder*);
-      TR::IlValue *condValue = va_arg(terms, TR::IlValue*);
+      TR::IlBuilder *condBuilder = terms[t]->_builder;
+      TR::IlValue *condValue = terms[t]->_condition;
       AppendBuilder(condBuilder);
       condBuilder->IfCmpNotEqualZero(anyTrueBuilder, condValue);
       // otherwise fall through to test next term
       }
 
    // reverse condition on last term so that it can fall through to anyTrueBuilder
-   TR::IlBuilder *condBuilder = va_arg(terms, TR::IlBuilder*);
-   TR::IlValue *condValue = va_arg(terms, TR::IlValue*);
+   TR::IlBuilder *condBuilder = terms[numTerms - 1]->_builder;
+   TR::IlValue *condValue = terms[numTerms - 1]->_condition;
    AppendBuilder(condBuilder);
    condBuilder->IfCmpEqualZero(allFalseBuilder, condValue);
-   va_end(terms);
 
    // any true term will end up here
    AppendBuilder(*anyTrueBuilder);
@@ -1638,6 +1677,45 @@ OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBui
 
    // return state for "this" can get confused by the Goto's in this service
    setComesBack();
+   }
+
+/**
+ * @brief Overload taking a varargs instead of an array of JBCondition pointers
+ *
+ * @param anyTrueBuilder builder containing operations to execute if any conditional test 
+ *        evaluates to true (automatically allocated if pointed-to pointer is null)
+ * @param allFalseBuilder builder containing operations to execute if all conditional
+ *        tests are false (automatically allocated if pointed-to pointer is null)
+ * @param numTerms the number of conditional terms
+ * @param ... for each term, provide a TR::IlBuilder::JBCondition object for the condition
+ *
+ * Example:
+ * TR::IlBuilder *cond1Builder = OrphanBuilder();
+ * TR::IlValue *cond1 = cond1Builder->LessThan(
+ *                      cond1Builder->   Load("x"),
+ *                      cond1Builder->   Load("lower"));
+ * TR::IlBuilder *cond2Builder = OrphanBuilder();
+ * TR::IlValue *cond2 = cond2Builder->GreaterOrEqual(
+ *                      cond2Builder->   Load("x"),
+ *                      cond2Builder->   Load("upper"));
+ * TR::IlBuilder *inRange = NULL, *outOfRange = NULL;
+ * IfOr(&outOfRange, &inRange, 2, MakeCondition(cond1Builder, cond1), MakeCondition(cond2Builder, cond2));
+ */
+void
+OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ...)
+   {
+   JBCondition **terms = (JBCondition **) _comp->trMemory()->allocateHeapMemory(numTerms * sizeof(JBCondition *));
+   TR_ASSERT(NULL != terms, "out of memory");
+
+   va_list args;
+   va_start(args, numTerms);
+   for (int32_t c = 0; c < numTerms; ++c)
+      {
+      terms[c] = va_arg(args, JBCondition *);
+      }
+   va_end(args);
+
+   IfOr(anyTrueBuilder, allFalseBuilder, numTerms, terms);
    }
 
 TR::IlBuilder::JBCondition *

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -115,6 +115,33 @@ public:
          friend class OMR::IlBuilder;
       };
 
+   /**
+    * @brief A class encapsulating the information needed for IfAnd and IfOr.
+    *
+    * This class encapsulates a condition value and the builder object used
+    * to construct the value.
+    */
+   class JBCondition
+      {
+      private:
+         /**
+          * @brief Construct a new JBCondition object.
+          *
+          * This constructor should not be called directly outside of the JitBuilder
+          * implementation. A call to `MakeCondition()` should be used instead.
+          *
+          * @param conditionBuilder pointer to the builder used to generate the condition value
+          * @param conditionValue the value of the condition
+          */
+         JBCondition(TR::IlBuilder *conditionBuilder, TR::IlValue *conditionValue)
+            : _builder(conditionBuilder), _condition(conditionValue) {}
+
+         TR::IlBuilder *_builder; // builder used to generate the condition value
+         TR::IlValue *_condition; // value of the condition
+
+         friend class OMR::IlBuilder;
+      };
+
    friend class OMR::MethodBuilder;
 
    IlBuilder(TR::MethodBuilder *methodBuilder, TR::TypeDictionary *types)
@@ -396,6 +423,15 @@ public:
    void IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ... );
    /* @brief creates an OR nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
    void IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ... );
+
+   /**
+    * @brief Construct an Instance of JBCondition.
+    *
+    * @param conditionBuilder the Builder used to generate the condition value
+    * @param conditionValue the IlValue instance representing the condition value
+    * @return JBCondition* pointer to the constructed JBCondition instance
+    */
+   JBCondition * MakeCondition(TR::IlBuilder *conditionBuilder, TR::IlValue *conditionValue);
 
    void IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition);
    void IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition);

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -118,8 +118,8 @@ public:
    /**
     * @brief A class encapsulating the information needed for IfAnd and IfOr.
     *
-    * This class encapsulates a condition value and the builder object used
-    * to construct the value.
+    * This class encapsulates the value of the condition and the builder
+    * object used generate the value (used to evaluate the condition).
     */
    class JBCondition
       {
@@ -131,13 +131,13 @@ public:
           * implementation. A call to `MakeCondition()` should be used instead.
           *
           * @param conditionBuilder pointer to the builder used to generate the condition value
-          * @param conditionValue the value of the condition
+          * @param conditionValue the IlValue representing value for the condition
           */
          JBCondition(TR::IlBuilder *conditionBuilder, TR::IlValue *conditionValue)
             : _builder(conditionBuilder), _condition(conditionValue) {}
 
          TR::IlBuilder *_builder; // builder used to generate the condition value
-         TR::IlValue *_condition; // value of the condition
+         TR::IlValue *_condition; // value for the condition
 
          friend class OMR::IlBuilder;
       };
@@ -419,9 +419,11 @@ public:
       DoWhileLoop(exitCondition, body, NULL, continueBuilder);
       }
 
-   /* @brief creates an AND nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
+   /* @brief creates an AND nest of short-circuited conditions, for each term pass a JBCondition instance */
+   void IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, JBCondition **terms);
    void IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ... );
-   /* @brief creates an OR nest of short-circuited conditions, for each term pass an IlBuilder containing the condition and the IlValue that computes the condition */
+   /* @brief creates an OR nest of short-circuited conditions, for each term pass a JBCondition instance */
+   void IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, JBCondition **terms);
    void IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ... );
 
    /**

--- a/jitbuilder/release/src/Conditionals.cpp
+++ b/jitbuilder/release/src/Conditionals.cpp
@@ -79,7 +79,9 @@ ConditionalMethod::buildIL()
                          x_lt_U_builder->   Load("U"));
 
    TR::IlBuilder *rc1True = NULL, *rc1False = NULL;
-   IfAnd(&rc1True, &rc1False, 2, x_ge_L_builder, x_ge_L, x_lt_U_builder, x_lt_U);
+   IfAnd(&rc1True, &rc1False, 2,
+      MakeCondition(x_ge_L_builder, x_ge_L),
+      MakeCondition(x_lt_U_builder, x_lt_U));
    rc1True->Store("rc1",
    rc1True->   ConstInt32(1));
    rc1False->Store("rc1",
@@ -100,7 +102,9 @@ ConditionalMethod::buildIL()
                          x_ge_U_builder->   Load("U"));
 
    TR::IlBuilder *rc2True = NULL, *rc2False = NULL;
-   IfOr(&rc2False, &rc2True, 2, x_lt_L_builder, x_lt_L, x_ge_U_builder, x_ge_U);
+   IfOr(&rc2False, &rc2True, 2,
+      MakeCondition(x_lt_L_builder, x_lt_L),
+      MakeCondition(x_ge_U_builder, x_ge_U));
    rc2True->Store("rc2",
    rc2True->   ConstInt32(1));
    rc2False->Store("rc2",
@@ -158,9 +162,10 @@ ConditionalMethod::buildIL()
                             equiv1->   Load("rc4"));
 
    TR::IlBuilder *returnTrue = NULL, *returnFalse = NULL;
-   IfAnd(&returnTrue, &returnFalse, 3, equiv1, rc12Equal,
-                                       equiv2, rc23Equal,
-                                       equiv3, rc34Equal);
+   IfAnd(&returnTrue, &returnFalse, 3,
+      MakeCondition(equiv1, rc12Equal),
+      MakeCondition(equiv2, rc23Equal),
+      MakeCondition(equiv3, rc34Equal));
 
    returnTrue->Return(
    returnTrue->   ConstInt32(1));


### PR DESCRIPTION
As was done in #2821 for JitBuilder's `Switch()` service, the new class `JBCondition` is added to encapsulate the different pieces needed to use the `IfAnd()` and `IfOr()` services. This avoids having to keep track of the different pieces independently in the implementation and also simplifies generating language bindings for the services.

This is a breaking change as the API is not backwards compatible. Code of the form:

```c++
IfAnd(&returnTrue, &returnFalse, 3,
    equiv1, rc12Equal,
    equiv2, rc23Equal,
    equiv3, rc34Equal);
```
must be changed to
```c++
IfAnd(&returnTrue, &returnFalse, 3,
   MakeCondition(equiv1, rc12Equal),
   MakeCondition(equiv2, rc23Equal),
   MakeCondition(equiv3, rc34Equal));
```

FYI @mstoodle @jduimovich @charliegracie @rwy0717