### PR TITLE
Implement omrsig_is_signal_ignored

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1409,6 +1409,8 @@ typedef struct OMRPortLibrary {
 	int32_t (*sig_register_os_handler)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler) ;
 	/** see @ref omrsignal.c::omrsig_is_master_signal_handler "omrsig_is_master_signal_handler"*/
 	BOOLEAN (*sig_is_master_signal_handler)(struct OMRPortLibrary *portLibrary, void *osHandler) ;
+	/** see @ref omrsignal.c::omrsig_is_signal_ignored "omrsig_is_signal_ignored"*/
+	int32_t (*sig_is_signal_ignored)(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored) ;
 	/** see @ref omrsignal.c::omrsig_info "omrsig_info"*/
 	uint32_t (*sig_info)(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value) ;
 	/** see @ref omrsignal.c::omrsig_info_count "omrsig_info_count"*/
@@ -1914,6 +1916,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsig_map_portlib_signal_to_os_signal(param1) privateOmrPortLibrary->sig_map_portlib_signal_to_os_signal(privateOmrPortLibrary, (param1))
 #define omrsig_register_os_handler(param1,param2,param3) privateOmrPortLibrary->sig_register_os_handler(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsig_is_master_signal_handler(param1) privateOmrPortLibrary->sig_is_master_signal_handler(privateOmrPortLibrary, (param1))
+#define omrsig_is_signal_ignored(param1, param2) privateOmrPortLibrary->sig_is_signal_ignored(privateOmrPortLibrary, (param1), (param2))
 #define omrsig_info(param1,param2,param3,param4,param5) privateOmrPortLibrary->sig_info(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
 #define omrsig_info_count(param1,param2) privateOmrPortLibrary->sig_info_count(privateOmrPortLibrary, (param1), (param2))
 #define omrsig_set_options(param1) privateOmrPortLibrary->sig_set_options(privateOmrPortLibrary, (param1))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -221,6 +221,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsig_map_portlib_signal_to_os_signal, /* sig_map_portlib_signal_to_os_signal */
 	omrsig_register_os_handler, /* sig_register_os_handler */
 	omrsig_is_master_signal_handler, /* sig_is_master_signal_handler */
+	omrsig_is_signal_ignored, /* sig_is_signal_ignored */
 	omrsig_info, /* sig_info */
 	omrsig_info_count, /* sig_info_count */
 	omrsig_set_options, /* sig_set_options */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1080,3 +1080,6 @@ TraceException=Trc_PRT_signal_mapPortLibSignalToOSSignal_ERROR_unknown_signal Gr
 
 TraceException=Trc_PRT_retrieveLinuxCgroupMemoryStats_invalidValue Group=sysinfo Overhead=1 Level=1 NoEnv Template="retrieveLinuxCgroupMemoryStats: Value of field \"%s\" in file %s is invalid"
 TraceEvent=Trc_PRT_retrieveLinuxMemoryStats_CgroupMemoryStatsFailed Group=sysinfo Overhead=1 Level=1 NoEnv Template="retrieveLinuxMemoryStats: Failed to retrieve memory stats of cgroup with error code=%d"
+
+TraceEntry=Trc_PRT_signal_omrsig_is_signal_ignored_entered Group=signal Overhead=1 Level=3 NoEnv Template="omrsig_is_signal_ignored: Entered, portLibrarySignalFlag=0x%X"
+TraceExit=Trc_PRT_signal_omrsig_is_signal_ignored_exiting Group=signal Overhead=1 Level=3 NoEnv Template="omrsig_is_signal_ignored: Exiting, rc=%d, isSignalIgnored=%d"

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -293,6 +293,29 @@ omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHand
 }
 
 /**
+ * Determine if a signal is ignored by the OS.
+ *
+ * @param[in] portLibrary the port library
+ * @param[in] portlibSignalFlag a single port library signal flag
+ * @param[out] *isSignalIgnored will contain either TRUE if the signal
+ *             is ignored or FALSE if the signal is not ignored
+ *
+ * @return 0 on success and OMRPORT_SIG_ERROR (-1) on failure
+ */
+int32_t
+omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored)
+{
+	int32_t rc = 0;
+	Trc_PRT_signal_omrsig_is_signal_ignored_entered(portlibSignalFlag);
+
+	*isSignalIgnored = FALSE;
+
+	Trc_PRT_signal_omrsig_is_signal_ignored_exiting(rc, *isSignalIgnored);
+	return rc;
+}
+
+
+/**
  * Determine if the port library is capable of protecting a function from the indicated signals in the indicated way.
  *
  * @param[in] portLibrary The port library

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -561,6 +561,8 @@ extern J9_CFUNC int32_t
 omrsig_register_os_handler(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, void *newOSHandler, void **oldOSHandler);
 extern J9_CFUNC BOOLEAN
 omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHandler);
+extern J9_CFUNC int32_t
+omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored);
 extern J9_CFUNC uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value);
 extern J9_CFUNC int32_t

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -643,10 +643,41 @@ int32_t
 omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored)
 {
 	int32_t rc = 0;
+	int osSignalNo = OMRPORT_SIG_ERROR;
+	void *oldHandler = NULL;
+	struct sigaction oldSignalAction;
+
 	Trc_PRT_signal_omrsig_is_signal_ignored_entered(portlibSignalFlag);
 
 	*isSignalIgnored = FALSE;
 
+	if (0 != portlibSignalFlag) {
+		/* For non-zero portlibSignalFlag, check if only one signal bit is set. Otherwise, fail. */
+		if (!OMR_IS_ONLY_ONE_BIT_SET(portlibSignalFlag)) {
+			rc = OMRPORT_SIG_ERROR;
+			goto exit;
+		}
+	}
+
+	osSignalNo = mapPortLibSignalToOSSignal(portlibSignalFlag);
+	if (OMRPORT_SIG_ERROR == osSignalNo) {
+		rc = OMRPORT_SIG_ERROR;
+		goto exit;
+	}
+
+	memset(&oldSignalAction, 0, sizeof(struct sigaction));
+	OMRSIG_SIGACTION(osSignalNo, NULL, &oldSignalAction);
+
+	oldHandler = (void *)oldSignalAction.sa_sigaction;
+	if (NULL == oldHandler) {
+		oldHandler = (void *)oldSignalAction.sa_handler;
+	}
+
+	if (oldHandler == (void *)SIG_IGN) {
+		*isSignalIgnored = TRUE;
+	}
+
+exit:
 	Trc_PRT_signal_omrsig_is_signal_ignored_exiting(rc, *isSignalIgnored);
 	return rc;
 }

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -639,6 +639,18 @@ omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHand
 	return rc;
 }
 
+int32_t
+omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored)
+{
+	int32_t rc = 0;
+	Trc_PRT_signal_omrsig_is_signal_ignored_entered(portlibSignalFlag);
+
+	*isSignalIgnored = FALSE;
+
+	Trc_PRT_signal_omrsig_is_signal_ignored_exiting(rc, *isSignalIgnored);
+	return rc;
+}
+
 /*
  * The full shutdown routine "sig_full_shutdown" overwrites this once we've completed startup
  */

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -379,6 +379,18 @@ omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHand
 }
 
 int32_t
+omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored)
+{
+	int32_t rc = 0;
+	Trc_PRT_signal_omrsig_is_signal_ignored_entered(portlibSignalFlag);
+
+	*isSignalIgnored = FALSE;
+
+	Trc_PRT_signal_omrsig_is_signal_ignored_exiting(rc, *isSignalIgnored);
+	return rc;
+}
+
+int32_t
 omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 {
 	uint32_t supportedFlags = OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION;

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -500,6 +500,18 @@ omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHand
 }
 
 int32_t
+omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored)
+{
+	int32_t rc = 0;
+	Trc_PRT_signal_omrsig_is_signal_ignored_entered(portlibSignalFlag);
+
+	*isSignalIgnored = FALSE;
+
+	Trc_PRT_signal_omrsig_is_signal_ignored_exiting(rc, *isSignalIgnored);
+	return rc;
+}
+
+int32_t
 omrsig_can_protect(struct OMRPortLibrary *portLibrary,  uint32_t flags)
 {
 	uint32_t supportedFlags = OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION;

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -581,6 +581,18 @@ omrsig_is_master_signal_handler(struct OMRPortLibrary *portLibrary, void *osHand
 	return FALSE;
 }
 
+int32_t
+omrsig_is_signal_ignored(struct OMRPortLibrary *portLibrary, uint32_t portlibSignalFlag, BOOLEAN *isSignalIgnored)
+{
+	int32_t rc = 0;
+	Trc_PRT_signal_omrsig_is_signal_ignored_entered(portlibSignalFlag);
+
+	*isSignalIgnored = FALSE;
+
+	Trc_PRT_signal_omrsig_is_signal_ignored_exiting(rc, *isSignalIgnored);
+	return rc;
+}
+
 /*
  * The full shutdown routine "sig_full_shutdown" overrides this once we've completed startup 
  */


### PR DESCRIPTION
1) **Add stubs for omrsig_is_signal_ignored**

	omrsig_is_signal_ignored checks if the signal is ignored by the OS. If
	the signal is ignored, isSignalIgnored is set to TRUE. Otherwise,
	isSignalIgnored is set to FALSE.

	If an error is encountered during evaluation, OMRPORT_SIG_ERROR is
	returned. 0 is returned on success. If OMRPORT_SIG_ERROR is returned,
	then the value of isSignalIgnored should be ignored.

2) **Implement omrsig_is_signal_ignored [unix]**

	For unix, implementation for omrsig_is_signal_ignored has been added.

	For win32 and win64amd, sigaction doesn't exist. There is no way to
	check if a signal is ignored on win32/win64amd. omrsig_is_signal_ignored
	should always return FALSE on win32/win64amd. The stub implementation is
	sufficient on win32/win64.

	For ztpf, an implementation of omrsig_is_signal_ignored will be
	required. ztpf implementation should be identical to the unix
	implementation.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>