### PR TITLE
Allows arbitrary size data snippet on X86

### DIFF
--- a/compiler/x/codegen/ConstantDataSnippet.hpp
+++ b/compiler/x/codegen/ConstantDataSnippet.hpp
@@ -36,7 +36,7 @@ class X86ConstantDataSnippet : public TR::X86DataSnippet
    {
    public:
 
-   inline X86ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *n, void *c, uint8_t size) : TR::X86DataSnippet(cg, n, c, size) { }
+   inline X86ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *n, void *c, size_t size) : TR::X86DataSnippet(cg, n, c, size) { }
    virtual Kind getKind() { return IsConstantData; }
    };
 

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -34,13 +34,15 @@
 
 namespace TR { class Node; }
 
-TR::X86DataSnippet::X86DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
+TR::X86DataSnippet::X86DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, size_t size)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false),
-     _data(size, 0, getTypedAllocator<uint8_t>(TR::comp()->allocator()))
+     _data(size, 0, getTypedAllocator<uint8_t>(TR::comp()->allocator())),
+     _isClassAddress(false)
    {
    if (c)
       memcpy(_data.data(), c, size);
-   _isClassAddress = false;
+   else
+      memset(_data.data(), 0, size);
    }
 
 

--- a/compiler/x/codegen/DataSnippet.hpp
+++ b/compiler/x/codegen/DataSnippet.hpp
@@ -35,23 +35,22 @@ class X86DataSnippet : public TR::Snippet
    {
    public:
 
-   X86DataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
+   X86DataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, size_t size);
 
-   virtual Kind getKind() { return IsData; }
-   uint8_t* getRawData()  { return _data.data(); }
-   virtual uint8_t *emitSnippetBody();
-   virtual uint8_t getDataSize() const { return _data.size(); }
-   virtual void print(TR::FILE* pOutFile, TR_Debug* debug);
-   virtual void printValue(TR::FILE* pOutFile, TR_Debug* debug);
-   virtual uint32_t getLength(int32_t estimatedSnippetStart) { return _data.size(); }
-   virtual bool setClassAddress(bool isClassAddress) { return _isClassAddress = isClassAddress;}
+   virtual Kind                   getKind()                                { return IsData; }
+   uint8_t*                       getRawData()                             { return _data.data(); }
+   virtual size_t                 getDataSize() const                      { return _data.size(); }
+   virtual uint32_t               getLength(int32_t estimatedSnippetStart) { return getDataSize(); }
+   virtual bool                   setClassAddress(bool isClassAddress)     { return _isClassAddress = isClassAddress;}
+   template <typename T> inline T getData()                                { return *((T*)getRawData()); }
 
-   void addMetaDataForCodeAddress(uint8_t *cursor);
-
-   template <typename T> inline T getData() { return *((T*)getRawData()); }
+   virtual uint8_t*               emitSnippetBody();
+   virtual void                   print(TR::FILE* pOutFile, TR_Debug* debug);
+   virtual void                   printValue(TR::FILE* pOutFile, TR_Debug* debug);
+   void                           addMetaDataForCodeAddress(uint8_t *cursor);
 
    private:
-   bool    _isClassAddress;
+   bool                _isClassAddress;
    TR::vector<uint8_t> _data;
    };
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -2136,14 +2136,14 @@ TR_OutlinedInstructions * OMR::X86::CodeGenerator::findOutlinedInstructionsFromM
    return NULL;
    }
 
-TR::X86DataSnippet * OMR::X86::CodeGenerator::createDataSnippet(TR::Node * n, void * c, uint8_t s)
+TR::X86DataSnippet * OMR::X86::CodeGenerator::createDataSnippet(TR::Node * n, void * c, size_t s)
    {
    auto snippet = new (self()->trHeapMemory()) TR::X86DataSnippet(self(), n, c, s);
    _dataSnippetList.push_back(snippet);
    return snippet;
    }
 
-TR::X86ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstantDataSnippet(TR::Node * n, void * c, uint8_t s)
+TR::X86ConstantDataSnippet * OMR::X86::CodeGenerator::findOrCreateConstantDataSnippet(TR::Node * n, void * c, size_t s)
    {
    // A simple linear search should suffice for now since the number of data constants
    // produced is typically very small.  Eventually, this should be implemented as an
@@ -2232,7 +2232,6 @@ static uint32_t registerBitMask(int32_t reg)
    {
    return 1 << (reg-1); // TODO:AMD64: Use the proper mask value
    }
-
 
 void OMR::X86::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map)
    {

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -527,6 +527,46 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::X86DataSnippet *create8ByteData(TR::Node *, int64_t c);
    TR::X86DataSnippet *create16ByteData(TR::Node *, void *c);
 
+   /*
+    * \brief create a data snippet.
+    *
+    * \param[in] node : the node which this data snippet belongs to
+    * \param[in] data : a pointer to initial data or NULL for skipping initialization
+    * \param[in] size : the size of this data snippet
+    *
+    * \return : a data snippet with specified size
+    */
+   TR::X86DataSnippet* createDataSnippet(TR::Node* node, void* data, size_t size);
+   /*
+    * \brief create a data snippet
+    *
+    * \param[in] node : the node which this data snippet belongs to
+    * \param[in] data : the data which this data snippet holds
+    *
+    * \return : a data snippet containing one type T element
+    */
+   template<typename T> inline TR::X86DataSnippet* createDataSnippet(TR::Node* node, T data) { return createDataSnippet(node, &data, sizeof(data)); }
+   /*
+    * \brief find or create a constant data snippet.
+    *
+    * \param[in] node : the node which this constant data snippet belongs to
+    * \param[in] data : a pointer to initial data or NULL for skipping initialization
+    * \param[in] size : the size of this constant data snippet
+    *
+    * \return : a constant data snippet with specified size
+    */
+   TR::X86ConstantDataSnippet* findOrCreateConstantDataSnippet(TR::Node* node, void* data, size_t size);
+   /*
+    * \brief find or create a constant data snippet.
+    *
+    * \param[in] node : the node which this constant data snippet belongs to
+    * \param[in] data : the data which this constant data snippet holds
+    *
+    * \return : a constant data snippet containing one type T element
+    */
+   template<typename T> inline TR::X86ConstantDataSnippet* findOrCreateConstantDataSnippet(TR::Node* node, T data) { return findOrCreateConstantDataSnippet(node, &data, sizeof(data)); }
+
+
    static TR_X86ProcessorInfo _targetProcessorInfo;
 
    // The core "clobberEvaluate" logic for single registers (not register
@@ -587,27 +627,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    private:
 
    bool nodeIsFoldableMemOperand(TR::Node *node, TR::Node *parent, TR_RegisterPressureState *state);
-
-   /*
-    * \brief create a data snippet.
-    *
-    * \param[in] n : the node which this data snippet belongs to
-    * \param[in] c : a pointer to initial data or NULL for skipping initialization
-    * \param[in] s : the size of this data snippet
-    *
-    * \return : a data snippet with size s
-    */
-   TR::X86DataSnippet*         createDataSnippet(TR::Node *n, void *c, uint8_t s);
-   /*
-    * \brief find or create a constant data snippet.
-    *
-    * \param[in] n : the node which this constant data snippet belongs to
-    * \param[in] c : a pointer to initial data or NULL for skipping initialization
-    * \param[in] s : the size of this constant data snippet
-    *
-    * \return : a constant data snippet with size s
-    */
-   TR::X86ConstantDataSnippet* findOrCreateConstantDataSnippet(TR::Node *n, void *c, uint8_t s);
 
    TR::RealRegister             *_frameRegister;
 


### PR DESCRIPTION
The facilities to support arbitrary size data snippet was introduced by #2772;
this changeset exposes APIs to allow users create arbitrary size data snippets.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>