### PR TITLE
Code cleanup related to VMifInstanceOf on X86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4038,12 +4038,6 @@ OMR::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node*, bool, TR::CodeGenerato
    }
 
 TR::Register *
-OMR::X86::TreeEvaluator::VMifInstanceOfEvaluator(TR::Node*, TR::CodeGenerator*)
-   {
-   return 0;
-   }
-
-TR::Register *
 OMR::X86::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_ASSERT(node->getNumChildren() == 1, "Wrong number of children in byteswapEvaluator");

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -300,7 +300,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *bztestnsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    // VM dependent routines
-   static TR::Register *VMifInstanceOfEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *VMmergenewEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *VMarrayStoreCheckArrayCopyEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static bool VMinlineCallEvaluator(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg);


### PR DESCRIPTION
Code related to VMifInstanceOf has been deprecated, removing them.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>