### PR TITLE
Remove checking REX.W when encoding on X86-32

### DIFF
--- a/compiler/x/codegen/X86Ops_inlines.hpp
+++ b/compiler/x/codegen/X86Ops_inlines.hpp
@@ -36,7 +36,6 @@ template <typename TBuffer> inline typename TBuffer::cursor_t TR_X86OpCode::OpCo
    // Prefixes
    TR::Instruction::REX rex(rexbits);
    rex.W = rex_w;
-   TR_ASSERT(TR::Compiler->target.is64Bit() || !rex.value(), "ERROR: REX.W used on X86-32. OpCode = %d; rex = %02x", opcode, (uint32_t)(uint8_t)rex.value());
    // Use AVX if possible
    if (supportsAVX() && TR::CodeGenerator::getX86ProcessorInfo().supportsAVX())
       {


### PR DESCRIPTION
The assumption which REX.W can only be set on X86-64 is no-longer true.
For example, REX.W of FMA instructions is set even on X86-32.
Therefore, the assertion should be removed.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>