### PR TITLE
Build AArch64 Compiler Files

### DIFF
--- a/jitbuilder/build/files/target/aarch64.mk
+++ b/jitbuilder/build/files/target/aarch64.mk
@@ -20,9 +20,23 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 #codegen files
+
 JIT_PRODUCT_BACKEND_SOURCES+= \
-    $(wildcard $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/*.cpp)
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64BinaryEncoding.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64OutOfLineCodeSection.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64SystemLinkage.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/GenerateInstructions.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRCodeGenerator.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRInstruction.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRLinkage.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRMachine.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRMemoryReference.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRRealRegister.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRRegisterDependency.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRRegisterIterator.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRSnippet.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OpBinary.cpp
 
 #environement files
-JIT_PRODUCT_BACKEND_SOURCES+= \
-    $(wildcard $(JIT_OMR_DIRTY_DIR)/aarch64/env/*.cpp)
+#JIT_PRODUCT_BACKEND_SOURCES+= \
+#    $(JIT_OMR_DIRTY_DIR)/aarch64/env/<file>.cpp


### PR DESCRIPTION
Build AArch64 Compiler Files

- The Makefile in the JITBuilder was trying to use a wildcard operation to get all of the .cpp files in the AArch64 Compiler directory but it was failing to do so.
- Now explicitly lists all of the .ccp files as is convention.

For Issue #2839

Signed-off-by: Aaron Graham <aaron.graham@unb.ca>