### PR TITLE
Properly link omrsig with ddrgen

### DIFF
--- a/ddr/tools/ddrgen/CMakeLists.txt
+++ b/ddr/tools/ddrgen/CMakeLists.txt
@@ -36,3 +36,7 @@ target_link_libraries(omr_ddrgen
 	omr_ddr_scanner
 	${OMR_PORT_LIB}
 )
+
+if(OMRPORT_OMRSIG_SUPPORT)
+	target_link_libraries(omr_ddrgen omrsig)
+endif()

--- a/ddr/tools/ddrgen/Makefile
+++ b/ddr/tools/ddrgen/Makefile
@@ -67,6 +67,10 @@ ifeq (msvc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += /EHsc
 endif
 
+ifeq (1,$(OMRPORT_OMRSIG_SUPPORT))
+  MODULE_SHARED_LIBS += omrsig
+endif
+
 DDRGEN_STATIC_LIBS = \
   ddr-scanner \
   ddr-ir \


### PR DESCRIPTION
If OMRPORT_OMRSIG_SUPPORT is defined globally, then ddrgen needs to link
to omrsig in order to compile properly.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>