### PR TITLE
Update OMR README with Travis Matrix Builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,19 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 
 | Build | Status |
 | ---------------------- | -------------------- |
-| **Travis CI** | [![Travis Status](https://api.travis-ci.org/eclipse/omr.svg?branch=master)](https://travis-ci.org/eclipse/omr) |
-| **Windows x86** | [![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/eclipse/omr?svg=true&branch=master)](https://ci.appveyor.com/project/eclipsewebmaster/omr) |
-| **Windows x86-64** | [![Windows x86-64 Status](https://ci.eclipse.org/omr/job/Build-win_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-win_x86-64/) |
-| **Linux x86-64** | [![Linux x86-64 Status](https://ci.eclipse.org/omr/job/Build-linux_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_x86-64/) |
-| **Power 64-bit Linux** | [![Build-linux_ppc-64_le_gcc Status](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/) |
-| **Power 64-bit AIX** | [![Build-aix_ppc-64 Status](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/) |
-| **Linux on Z 64-bit** | [![Build-linux_390-64 Status](https://ci.eclipse.org/omr/job/Build-linux_390-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_390-64/) |
+| **Travis CI (Overall)** | [![Travis Overall Status](https://api.travis-ci.org/eclipse/omr.svg?branch=master)](https://travis-ci.org/eclipse/omr) |
+| **Windows x86(Appveyor)** | [![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/eclipse/omr?svg=true&branch=master)](https://ci.appveyor.com/project/eclipsewebmaster/omr) |
+| **Windows x86-64 (Jenkins)** | [![Windows x86-64 Status](https://ci.eclipse.org/omr/job/Build-win_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-win_x86-64/) |
+| **Linux x86-64 (Jenkins)** | [![Linux x86-64 Status](https://ci.eclipse.org/omr/job/Build-linux_x86-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_x86-64/) |
+| **Linux x86-64 CMAKE Makefile (Travis)** | [![Travis Linux x86-64 CMAKE Makefile Status](https://travis-matrix-badges.herokuapp.com/repos/eclipse/omr/branches/master/1)](https://travis-ci.org/eclipse/omr) |
+| **Linux x86-64 (Travis)** | [![Travis Linux x86-64 Status](https://travis-matrix-badges.herokuapp.com/repos/eclipse/omr/branches/master/2)](https://travis-ci.org/eclipse/omr) |
+| **Linux x86-64 LINT (Travis)** | [![Travis Linux x86-64 LINT Status](https://travis-matrix-badges.herokuapp.com/repos/eclipse/omr/branches/master/5)](https://travis-ci.org/eclipse/omr) |
+| **Linux x86-64 CMAKE Ninja (Travis)** | [![Travis Linux x86-64 CMAKE Ninja Status](https://travis-matrix-badges.herokuapp.com/repos/eclipse/omr/branches/master/6)](https://travis-ci.org/eclipse/omr) |
+| **Linux AArch64 (Travis)** | [![Travis Linux AArch64 Status](https://travis-matrix-badges.herokuapp.com/repos/eclipse/omr/branches/master/3)](https://travis-ci.org/eclipse/omr) |
+| **Linux ARM (Travis)** | [![Travis Linux ARM Status](https://travis-matrix-badges.herokuapp.com/repos/eclipse/omr/branches/master/4)](https://travis-ci.org/eclipse/omr) |
+| **Power 64-bit Linux (Jenkins)** | [![Build-linux_ppc-64_le_gcc Status](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_ppc-64_le_gcc/) |
+| **Power 64-bit AIX (Jenkins)** | [![Build-aix_ppc-64 Status](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-aix_ppc-64/) |
+| **Linux on Z 64-bit (Jenkins)** | [![Build-linux_390-64 Status](https://ci.eclipse.org/omr/job/Build-linux_390-64/badge/icon)](https://ci.eclipse.org/omr/job/Build-linux_390-64/) |
 
 What Is Eclipse OMR?
 ====================


### PR DESCRIPTION
Travis: Update OMR README
-Add breakdown of Travis CI matrix builds to main OMR README
-Arrange Builds by Platform in OMR README

[skip ci]

Signed-off-by: Aaron Graham <aaron.graham@unb.ca>