### PR TITLE
AArch64: Remove CodeGenerator parm from MemoryReference::estimateBinaryLength()

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -246,7 +246,7 @@ uint8_t *TR::ARM64Trg1MemInstruction::generateBinaryEncoding()
 
 int32_t TR::ARM64Trg1MemInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(*cg()));
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength());
    return currentEstimate + getEstimatedBinaryLength();
    }
 
@@ -264,7 +264,7 @@ uint8_t *TR::ARM64MemInstruction::generateBinaryEncoding()
 
 int32_t TR::ARM64MemInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(*cg()));
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength());
    return(currentEstimate + getEstimatedBinaryLength());
    }
 
@@ -283,6 +283,6 @@ uint8_t *TR::ARM64MemSrc1Instruction::generateBinaryEncoding()
 
 int32_t TR::ARM64MemSrc1Instruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(*cg()));
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength());
    return(currentEstimate + getEstimatedBinaryLength());
    }


### PR DESCRIPTION
This commit adds CodeGenerator to the parameter list of
OMR::ARM64::MemoryReference::estimateBinaryLength().

Issue: #2863

Signed-off-by: knn-k <konno@jp.ibm.com>