### PR TITLE
Define missing instruction formats in the Z codegen

### DIFF
--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -153,7 +153,6 @@ OMR::Z::InstOpCode::copyBinaryToBufferWithoutClear(uint8_t *cursor, TR::InstOpCo
       case RXE_FORMAT:
       case RXY_FORMAT:
       case RXF_FORMAT:
-      case RSE_FORMAT:
       case RSY_FORMAT:
       case RSL_FORMAT:
       case RIE_FORMAT:

--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -146,50 +146,65 @@ void
 OMR::Z::InstOpCode::copyBinaryToBufferWithoutClear(uint8_t *cursor, TR::InstOpCode::Mnemonic i_opCode)
   {
   cursor[0] = metadata[i_opCode].opcode[0];
-  if( metadata[i_opCode].opcode[1] ) //Two byte opcode
-    {
-    switch (getInstructionFormat(i_opCode))
-      {
-      case RXE_FORMAT:
-      case RXY_FORMAT:
-      case RXF_FORMAT:
-      case RSY_FORMAT:
-      case RSL_FORMAT:
-      case RIE_FORMAT:
-      case SIY_FORMAT:
-      case RRS_FORMAT:
-      case RIS_FORMAT:
-      case VRIa_FORMAT:
-      case VRIb_FORMAT:
-      case VRIc_FORMAT:
-      case VRId_FORMAT:
-      case VRIe_FORMAT:
-      case VRIf_FORMAT:
-      case VRIg_FORMAT:
-      case VRIh_FORMAT:
-      case VRIi_FORMAT:
-      case VRRa_FORMAT:
-      case VRRb_FORMAT:
-      case VRRc_FORMAT:
-      case VRRd_FORMAT:
-      case VRRe_FORMAT:
-      case VRRf_FORMAT:
-      case VRRg_FORMAT:
-      case VRRh_FORMAT:
-      case VRRi_FORMAT:
-      case VRSa_FORMAT:
-      case VRSb_FORMAT:
-      case VRSc_FORMAT:
-      case VRSd_FORMAT:
-      case VRV_FORMAT:
-      case VRX_FORMAT:
-      case VSI_FORMAT:
-         cursor[5] = metadata[i_opCode].opcode[1];
-         //second byte of opcode begins at bit 47 (sixth byte)
-         break;
-       default:
-         cursor[1] = metadata[i_opCode].opcode[1];
-         break;
+
+  // Second opcode being non-zero indicates a two-byte opcode the second of which is always the last byte of the instruction
+  if (metadata[i_opCode].opcode[1] != 0)
+     {
+     switch (getInstructionFormat(i_opCode))
+        {
+        case RIE_FORMAT:
+        case RIEa_FORMAT:
+        case RIEb_FORMAT:
+        case RIEc_FORMAT:
+        case RIEd_FORMAT:
+        case RIEe_FORMAT:
+        case RIEf_FORMAT:
+        case RIEg_FORMAT:
+        case RIS_FORMAT:
+        case RRS_FORMAT:
+        case RSL_FORMAT:
+        case RSLa_FORMAT:
+        case RSLb_FORMAT:
+        case RSY_FORMAT:
+        case RSYa_FORMAT:
+        case RSYb_FORMAT:
+        case RXE_FORMAT:
+        case RXF_FORMAT:
+        case RXY_FORMAT:
+        case RXYa_FORMAT:
+        case RXYb_FORMAT:
+        case SIY_FORMAT:
+        case VRIa_FORMAT:
+        case VRIb_FORMAT:
+        case VRIc_FORMAT:
+        case VRId_FORMAT:
+        case VRIe_FORMAT:
+        case VRIf_FORMAT:
+        case VRIg_FORMAT:
+        case VRIh_FORMAT:
+        case VRIi_FORMAT:
+        case VRRa_FORMAT:
+        case VRRb_FORMAT:
+        case VRRc_FORMAT:
+        case VRRd_FORMAT:
+        case VRRe_FORMAT:
+        case VRRf_FORMAT:
+        case VRRg_FORMAT:
+        case VRRh_FORMAT:
+        case VRRi_FORMAT:
+        case VRSa_FORMAT:
+        case VRSb_FORMAT:
+        case VRSc_FORMAT:
+        case VRSd_FORMAT:
+        case VRV_FORMAT:
+        case VRX_FORMAT:
+        case VSI_FORMAT:
+           cursor[5] = metadata[i_opCode].opcode[1];
+           break;
+
+        default:
+           cursor[1] = metadata[i_opCode].opcode[1];
+           break;
        }
     }
   }

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -428,8 +428,6 @@ namespace Z
 #define   VRX_FORMAT    91
 #define   VSI_FORMAT    92
 
-#define   RRR_FORMAT    94 // TODO: This format does not even exist and should be change to the ones above
-
 /* Instruction Properties (One hot encoding) */
 #define S390OpProp_None                   static_cast<uint64_t>(0x0000000000000000ull)
 #define S390OpProp_UsesTarget             static_cast<uint64_t>(0x0000000000000001ull)

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -336,68 +336,100 @@ namespace Z
 */
 #define   PSEUDO        0
 #define   DC_FORMAT     1
-#define   E_FORMAT      2   //83180:  This define is busting a pragma report(level,E) in Node.hpp
-#define   RR_FORMAT     3
-#define   RRE_FORMAT    4
-#define   RRF_FORMAT    5
-#define   RRF2_FORMAT   6
-#define   RRF3_FORMAT   7
-#define   RX_FORMAT     8
-#define   RS_FORMAT     9
-#define   RSI_FORMAT    10
-#define   RI_FORMAT     11
-#define   SI_FORMAT     12
-#define   S_FORMAT      13
-#define   RXE_FORMAT    14
-#define   RXF_FORMAT    15
-#define   SS_FORMAT     16
-#define   SSE_FORMAT    17
-#define   SS1_FORMAT    18
-#define   RIL_FORMAT    19
-#define   RSE_FORMAT    20
-#define   RSL_FORMAT    21
-#define   RIE_FORMAT    22
-#define   RXY_FORMAT    23
-#define   RSY_FORMAT    24
-#define   SIY_FORMAT    25
-#define   RRR_FORMAT    26
-#define   RRS_FORMAT    27
-#define   RIS_FORMAT    28
-#define   SIL_FORMAT    29
-#define   I_FORMAT      30
-#define   SSF_FORMAT    31
-#define   SMI_FORMAT    32
-#define   MII_FORMAT    33
-#define   IE_FORMAT     34
+#define   E_FORMAT      2
+#define   I_FORMAT      3
+#define   IE_FORMAT     4
+#define   MII_FORMAT    5
+#define   RI_FORMAT     6  // TODO: This needs to be folded and reblaced by the 3 formats following it
+#define   RIa_FORMAT    7
+#define   RIb_FORMAT    8
+#define   RIc_FORMAT    9
+#define   RIE_FORMAT    10 // TODO: This needs to be folded and reblaced by the 7 formats following it
+#define   RIEa_FORMAT   11
+#define   RIEb_FORMAT   12
+#define   RIEc_FORMAT   13
+#define   RIEd_FORMAT   14
+#define   RIEe_FORMAT   15
+#define   RIEf_FORMAT   16
+#define   RIEg_FORMAT   17
+#define   RIL_FORMAT    18 // TODO: This needs to be folded and reblaced by the 3 formats following it
+#define   RILa_FORMAT   19
+#define   RILb_FORMAT   20
+#define   RILc_FORMAT   21
+#define   RIS_FORMAT    22
+#define   RR_FORMAT     23
+#define   RRD_FORMAT    24
+#define   RRE_FORMAT    25
+#define   RRF_FORMAT    26 // TODO: This needs to be folded and reblaced by the 5 formats following it
+#define   RRF2_FORMAT   27 // TODO: This needs to be folded and reblaced by the 5 formats following it
+#define   RRF3_FORMAT   28 // TODO: This needs to be folded and reblaced by the 5 formats following it
+#define   RRFa_FORMAT   29
+#define   RRFb_FORMAT   30
+#define   RRFc_FORMAT   31
+#define   RRFd_FORMAT   32
+#define   RRFe_FORMAT   33
+#define   RRS_FORMAT    34
+#define   RS_FORMAT     35 // TODO: This needs to be folded and reblaced by the 2 formats following it
+#define   RSa_FORMAT    36
+#define   RSb_FORMAT    37
+#define   RSI_FORMAT    38
+#define   RSL_FORMAT    39 // TODO: This needs to be folded and reblaced by the 2 formats following it
+#define   RSLa_FORMAT   40 
+#define   RSLb_FORMAT   41
+#define   RSY_FORMAT    42 // TODO: This needs to be folded and reblaced by the 2 formats following it
+#define   RSYa_FORMAT   43
+#define   RSYb_FORMAT   44
+#define   RX_FORMAT     45 // TODO: This needs to be folded and reblaced by the 2 formats following it
+#define   RXa_FORMAT    46
+#define   RXb_FORMAT    47
+#define   RXE_FORMAT    48
+#define   RXF_FORMAT    49
+#define   RXY_FORMAT    50 // TODO: This needs to be folded and reblaced by the 2 formats following it
+#define   RXYa_FORMAT   51
+#define   RXYb_FORMAT   52
+#define   S_FORMAT      53
+#define   SI_FORMAT     54
+#define   SIL_FORMAT    55
+#define   SIY_FORMAT    56
+#define   SMI_FORMAT    57
+#define   SS_FORMAT     58 // TODO: This needs to be folded and reblaced by the 6 formats following it
+#define   SS1_FORMAT    59 // TODO: This needs to be folded and reblaced by the 6 formats following it
+#define   SSa_FORMAT    60
+#define   SSb_FORMAT    61
+#define   SSc_FORMAT    62
+#define   SSd_FORMAT    63
+#define   SSe_FORMAT    64
+#define   SSf_FORMAT    65
+#define   SSE_FORMAT    66
+#define   SSF_FORMAT    67
+#define   VRIa_FORMAT   68
+#define   VRIb_FORMAT   69
+#define   VRIc_FORMAT   70
+#define   VRId_FORMAT   71
+#define   VRIe_FORMAT   72
+#define   VRIf_FORMAT   73
+#define   VRIg_FORMAT   74
+#define   VRIh_FORMAT   75
+#define   VRIi_FORMAT   76
+#define   VRRa_FORMAT   77
+#define   VRRb_FORMAT   78
+#define   VRRc_FORMAT   79
+#define   VRRd_FORMAT   80
+#define   VRRe_FORMAT   81
+#define   VRRf_FORMAT   82
+#define   VRRg_FORMAT   83
+#define   VRRh_FORMAT   84
+#define   VRRi_FORMAT   85
+#define   VRSa_FORMAT   86
+#define   VRSb_FORMAT   87
+#define   VRSc_FORMAT   88
+#define   VRSd_FORMAT   89
+#define   VRV_FORMAT    90
+#define   VRX_FORMAT    91
+#define   VSI_FORMAT    92
 
-#define   VRIa_FORMAT   35 // VRI denotes a vector register-and-immediate operation and an extended op-code field.
-#define   VRIb_FORMAT   36
-#define   VRIc_FORMAT   37
-#define   VRId_FORMAT   38
-#define   VRIe_FORMAT   39
-#define   VRIf_FORMAT   40
-#define   VRIg_FORMAT   41
-#define   VRIh_FORMAT   42
-#define   VRIi_FORMAT   43
-
-#define   VRRa_FORMAT   44 // VRR denotes a vector register-and-register operation and an extended op-code field.
-#define   VRRb_FORMAT   45
-#define   VRRc_FORMAT   46
-#define   VRRd_FORMAT   47
-#define   VRRe_FORMAT   48
-#define   VRRf_FORMAT   49
-#define   VRRg_FORMAT   50
-#define   VRRh_FORMAT   51
-#define   VRRi_FORMAT   52
-
-#define   VRSa_FORMAT   53 // VRS denotes a vector register-and-storage operation and an extended op-code field.
-#define   VRSb_FORMAT   54
-#define   VRSc_FORMAT   55
-#define   VRSd_FORMAT   56
-
-#define   VRV_FORMAT    57 // VRV denotes a vector register-and-vector-index-storage operation and an extended op-code field.
-#define   VRX_FORMAT    58 // VRX denotes a vector register-and-index-storage operation and an extended op-code field
-#define   VSI_FORMAT    59
+#define   RSE_FORMAT    93 // TODO: This format does not even exist and should be change to the ones above
+#define   RRR_FORMAT    94 // TODO: This format does not even exist and should be change to the ones above
 
 /* Instruction Properties (One hot encoding) */
 #define S390OpProp_None                   static_cast<uint64_t>(0x0000000000000000ull)

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -428,7 +428,6 @@ namespace Z
 #define   VRX_FORMAT    91
 #define   VSI_FORMAT    92
 
-#define   RSE_FORMAT    93 // TODO: This format does not even exist and should be change to the ones above
 #define   RRR_FORMAT    94 // TODO: This format does not even exist and should be change to the ones above
 
 /* Instruction Properties (One hot encoding) */

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -8987,7 +8987,7 @@
    /* .description = */ "Add (DFP128)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDA,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9413,7 +9413,7 @@
    /* .description = */ "Divide (DFP128)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD9,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10048,7 +10048,7 @@
    /* .description = */ "Multiply (DFP128)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD8,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10438,7 +10438,7 @@
    /* .description = */ "Subtract (DFP128)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDB,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -11632,7 +11632,7 @@
    /* .description = */ "Add (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE8,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsSignFlag |
@@ -11646,7 +11646,7 @@
    /* .description = */ "Add High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xC8,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -11663,7 +11663,7 @@
    /* .description = */ "Add High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xD8,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -11725,7 +11725,7 @@
    /* .description = */ "Add Logical (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xEA,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsZeroFlag |
@@ -11738,7 +11738,7 @@
    /* .description = */ "Add Logical High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xCA,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
@@ -11754,7 +11754,7 @@
    /* .description = */ "Add Logical High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xDA,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
@@ -11784,7 +11784,7 @@
    /* .description = */ "Add Logical (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xFA,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsZeroFlag |
@@ -11826,7 +11826,7 @@
    /* .description = */ "Add (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF8,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsSignFlag |
@@ -12525,7 +12525,7 @@
    /* .description = */ "And (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE4,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12538,7 +12538,7 @@
    /* .description = */ "And (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF4,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12551,7 +12551,7 @@
    /* .description = */ "Or (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE6,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12564,7 +12564,7 @@
    /* .description = */ "Or (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF6,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12621,7 +12621,7 @@
    /* .description = */ "Subtract (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE9,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsSignFlag |
@@ -12635,7 +12635,7 @@
    /* .description = */ "Subtract High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xC9,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -12651,7 +12651,7 @@
    /* .description = */ "Subtract High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xD9,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -12682,7 +12682,7 @@
    /* .description = */ "Subtract (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xEB,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12695,7 +12695,7 @@
    /* .description = */ "Subtract High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xCB,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -12710,7 +12710,7 @@
    /* .description = */ "Subtract High (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xDB,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -12738,7 +12738,7 @@
    /* .description = */ "Subtract (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xFB,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12765,7 +12765,7 @@
    /* .description = */ "Subtract (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF9,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsSignFlag |
@@ -12859,7 +12859,7 @@
    /* .description = */ "Exclusive Or (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE7,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsZeroFlag |
@@ -12872,7 +12872,7 @@
    /* .description = */ "Exclusive Or (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF7,
-   /* .format      = */ RRR_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsZeroFlag |


### PR DESCRIPTION
Define missing instruction formats as outlined in in PoPs Chapter 5: Program Execution - Instructions - Instruction Formats. The formats are defined in the same order as listed in the PoPs document.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>