### PR TITLE
Avoid reusing mem ref in fbits2i evaluator in Z codegen

### DIFF
--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1238,7 +1238,8 @@ OMR::Z::TreeEvaluator::fbits2iEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          TR::MemoryReference * tempMR1 = generateS390MemoryReference(node, f2iSR, cg);
          generateRXInstruction(cg, TR::InstOpCode::STE, node, sourceReg, tempMR1);
 
-         targetReg = genericLoadHelper<32, 32, MemReg>(node, cg, tempMR1, NULL, false, true);
+         TR::MemoryReference * tempMR2 = generateS390MemoryReference(node, f2iSR, cg);
+         targetReg = genericLoadHelper<32, 32, MemReg>(node, cg, tempMR2, NULL, false, true);
          }
       }
     

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1238,7 +1238,7 @@ OMR::Z::TreeEvaluator::fbits2iEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          TR::MemoryReference * tempMR1 = generateS390MemoryReference(node, f2iSR, cg);
          generateRXInstruction(cg, TR::InstOpCode::STE, node, sourceReg, tempMR1);
 
-         TR::MemoryReference * tempMR2 = generateS390MemoryReference(node, f2iSR, cg);
+         TR::MemoryReference * tempMR2 = generateS390MemoryReference(*tempMR1, 0, cg);
          targetReg = genericLoadHelper<32, 32, MemReg>(node, cg, tempMR2, NULL, false, true);
          }
       }


### PR DESCRIPTION
Z codegen does not allow memory references to be used in
more than instruction. This change removes the duplicated
usage in fbits2i and instead creates 2 memory references.

Signed-off-by: Daniel Hong <daniel.hong@live.com>