### PR TITLE
Read barrier stats

### DIFF
--- a/gc/stats/ScavengerCopyScanRatio.hpp
+++ b/gc/stats/ScavengerCopyScanRatio.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -101,6 +101,10 @@ public:
 		uint64_t threads;	/* number of active or stalled threads */
 		uint64_t lists;		/* number of nonempty scan lists */
 		uint64_t caches;	/* number of caches in scan queues */
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		uint64_t readObjectBarrierCopy; /* number of object copied by read barrier */
+		uint64_t readObjectBarrierUpdate; /* number of reference slots updates by read barrier */
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 		uint64_t time;		/* timestamp of most recent sample included in this record */
 	} UpdateHistory;
 

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,10 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_copy_cachesize_sum(0)
 	,_slotsCopied(0)
 	,_slotsScanned(0)
-
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	,_readObjectBarrierCopy(0)
+	,_readObjectBarrierUpdate(0)
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	,_flipHistoryNewIndex(0)
 {
 	memset(_flipHistory, 0, sizeof(_flipHistory));
@@ -181,6 +184,12 @@ MM_ScavengerStats::clear(bool firstIncrement)
 
 	_slotsCopied = 0;
 	_slotsScanned = 0;
+
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	_readObjectBarrierCopy = 0;
+	_readObjectBarrierUpdate = 0;
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 	_leafObjectCount = 0;
 	_copy_cachesize_sum = 0;
 	memset(_copy_distance_counts, 0, sizeof(_copy_distance_counts));

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,11 @@ public:
 
 	uint64_t _slotsCopied; /**< The number of slots copied by the thread since _slotsScanned was last sampled and reset */
 	uint64_t _slotsScanned; /**< The number of slots scanned by the thread since _slotsCopied was last sampled and reset */
-
+	
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	uint64_t _readObjectBarrierCopy; /**< Number of objects copied by read barrier */
+	uint64_t _readObjectBarrierUpdate; /**< Number of reference slots updates, which may be (often is) preceded by object copy */ 
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 protected:
 


### PR DESCRIPTION
Introduce two Concurrent Scavenger specific read barrier stats counts:
- number of objects being copied 
- number of reference slots being updated

Maintain them in ScavengerCopyScanRatio structure, so that we can report
progress of the counts throughout a GC cycle (reporting itself is done
by downstream project, like OpenJ9).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>