### PR TITLE
Add registers in maxMinHelper to register dependency

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -939,6 +939,14 @@ static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool i
          TR::LabelSymbol * done = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::Instruction* cursor = NULL;
 
+         TR::RegisterDependencyConditions * regDeps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 6, cg);
+         regDeps->addPostCondition(registerA, TR::RealRegister::EvenOddPair);
+         regDeps->addPostCondition(registerA->getHighOrder(), TR::RealRegister::LegalEvenOfPair);
+         regDeps->addPostCondition(registerA->getLowOrder(), TR::RealRegister::LegalOddOfPair);
+         regDeps->addPostCondition(registerB, TR::RealRegister::EvenOddPair);
+         regDeps->addPostCondition(registerB->getHighOrder(), TR::RealRegister::LegalEvenOfPair);
+         regDeps->addPostCondition(registerB->getLowOrder(), TR::RealRegister::LegalOddOfPair);
+
          generateRRInstruction(cg, TR::InstOpCode::CR, node, registerA->getHighOrder(), registerB->getHighOrder());
          generateRRFInstruction(cg, TR::InstOpCode::LOCR, node, registerA->getHighOrder(), registerB->getHighOrder(), mask, true);
          generateRRFInstruction(cg, TR::InstOpCode::LOCR, node, registerA->getLowOrder(), registerB->getLowOrder(), mask, true);
@@ -949,7 +957,7 @@ static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool i
          generateRRFInstruction(cg, TR::InstOpCode::LOCR, node, registerA->getHighOrder(), registerB->getHighOrder(), mask, true);
          generateRRFInstruction(cg, TR::InstOpCode::LOCR, node, registerA->getLowOrder(), registerB->getLowOrder(), mask, true);
 
-         cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, done);
+         cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, done, regDeps);
          cursor->setEndInternalControlFlow();
          }
       }

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1263,7 +1263,7 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
       {
       if (self()->cg()->insideInternalControlFlow())
          {
-         TR_ASSERT(0, "ASSERTION assignBestRegisterSingle inside Internal Control Flow on currInst=%p.\n"
+         TR_ASSERT_FATAL(0, "ASSERTION assignBestRegisterSingle inside Internal Control Flow on currInst=%p.\n"
                       "Ensure all registers within ICF have a dependency anchored at the end-ICF label\n",currInst);
          }
       }

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -103,7 +103,7 @@ class TR_S390RegisterDependencyGroup
 
    void setDependencyInfo(uint32_t                                  index,
                           TR::Register                              *vr,
-                          TR::RealRegister::RegDep rr,
+                          TR::RealRegister::RegDep                  rr,
                           uint8_t                                   flag)
      {
      setDependencyInfo(index, vr, static_cast<TR::RealRegister::RegNum>(rr), flag);
@@ -111,7 +111,7 @@ class TR_S390RegisterDependencyGroup
 
    void setDependencyInfo(uint32_t                                  index,
                           TR::Register                              *vr,
-                          TR::RealRegister::RegNum rr,
+                          TR::RealRegister::RegNum                  rr,
                           uint8_t                                   flag)
       {
       _dependencies[index].setRegister(vr);


### PR DESCRIPTION
Add registers used in ICF in maxMinHelper to register
dependency. This change also changes the assertion that
registers used inside an ICF have been added to the
dependency since this is a fatal error.

Signed-off-by: Daniel Hong <daniel.hong@live.com>