### PR TITLE
Avoid amount in heap-resize tag due to idle tuning

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -926,7 +926,12 @@ MM_VerboseHandlerOutput::outputHeapResizeInfo(MM_EnvironmentBase *env, uintptr_t
 
 	getTagTemplate(tagTemplate, sizeof(tagTemplate), omrtime_current_time_millis());
 
-	writer->formatAndOutput(env, indent, "<heap-resize id=\"%zu\" type=\"%s\" space=\"%s\" amount=\"%zu\" count=\"%zu\" timems=\"%llu.%03llu\" reason=\"%s\" %s />", id, resizeTypeName, getSubSpaceType(subSpaceType), resizeAmount, resizeCount, timeInMicroSeconds / 1000, timeInMicroSeconds % 1000, reasonString, tagTemplate);
+	if (HEAP_RELEASE_FREE_PAGES == resizeType) {
+		/* Do not display 'resizeAmount' as it is not accurate for HEAP_RELEASE_FREE_PAGES type */
+		writer->formatAndOutput(env, indent, "<heap-resize id=\"%zu\" type=\"%s\" space=\"%s\" count=\"%zu\" timems=\"%llu.%03llu\" reason=\"%s\" %s />", id, resizeTypeName, getSubSpaceType(subSpaceType), resizeCount, timeInMicroSeconds / 1000, timeInMicroSeconds % 1000, reasonString, tagTemplate);
+	} else {
+		writer->formatAndOutput(env, indent, "<heap-resize id=\"%zu\" type=\"%s\" space=\"%s\" amount=\"%zu\" count=\"%zu\" timems=\"%llu.%03llu\" reason=\"%s\" %s />", id, resizeTypeName, getSubSpaceType(subSpaceType), resizeAmount, resizeCount, timeInMicroSeconds / 1000, timeInMicroSeconds % 1000, reasonString, tagTemplate);
+	}
 	writer->flush(env);
 }
 

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -602,7 +602,7 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 		<attribute name="id" type="integer" use="optional" />
 		<attribute name="type" type="string" use="required" />
 		<attribute name="space" type="string" use="required" />
-		<attribute name="amount" type="integer" use="required" />
+		<attribute name="amount" type="integer" use="optional" />
 		<attribute name="count" type="integer" use="required" />
 		<attribute name="timems" type="float" use="required" />
 		<attribute name="reason" type="string" use="required" />


### PR DESCRIPTION
During idle phase when GC de-commits free heap page, the amount of
memory de-committed is not correctly calculated. As it gets displayed
in gc logs as part of heap-resize tag, it can cause confusion.
So its better to not display this value in the heap-resize tag.

Issue https://github.com/eclipse/openj9/issues/2312

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>