### PR TITLE
Do GC on idle every time

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -724,7 +724,6 @@ public:
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
 	uintptr_t idleMinimumFree;   /**< percentage of free heap to be retained as committed, default=0 for gencon, complete tenture free memory will be decommitted */
 	uintptr_t lastGCFreeBytes;  /**< records the free memory size from last Global GC cycle */
-	uintptr_t gcOnIdleRatio; /**< the percentage of allocation since the last GC allocation determines the invocation of global GC, default global GC is invoked if allocation is > 20% */
 	bool gcOnIdle; /**< Enables releasing free heap pages if true while systemGarbageCollect invoked with IDLE GC code, default is false */
 	bool compactOnIdle; /**< Forces compaction if global GC executed while VM Runtime State set to IDLE, default is false */
 #endif
@@ -1599,7 +1598,6 @@ public:
 #if defined(OMR_GC_IDLE_HEAP_MANAGER)
 		, idleMinimumFree(0)
 		, lastGCFreeBytes(0)
-		, gcOnIdleRatio(20)
 		, gcOnIdle(false)
 		, compactOnIdle(false)
 #endif


### PR DESCRIPTION
Currently JVM goes into idle state, it performs GC only if the amount
of memory allocated in the java heap since last GC cycle is above a
threshold specified by 'gcOnIdleRatio'.
This is very conservative approach. Since JVM is going into idle state
it can be aggressive in doing GC.
With this change JVM would do GC unconditionally everytime it goes into
idle state.

Issue https://github.com/eclipse/openj9/issues/2312

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>