### PR TITLE
Minor OpenJ9 project specific changes to relocations

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -974,6 +974,12 @@ public:
     */
    DebugCounterMap &getDebugCounterMap() { return _debugCounterMap; }
 
+   /**
+    *  @brief needRelocationsForStatics
+    *  @return whether static data addresses need to be relocated
+    */
+   bool needRelocationsForStatics() { return true; }
+
 
 public:
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -2520,7 +2520,8 @@ TR::AMD64RegImm64Instruction::addMetaDataForCodeAddress(uint8_t *cursor)
       {
       if (getNode()->getOpCode().hasSymbolReference() &&
           methodSymRef &&
-          methodSymRef->getReferenceNumber()==TR_referenceArrayCopy)
+          (methodSymRef->getReferenceNumber() == TR_referenceArrayCopy ||
+          methodSymRef->getReferenceNumber() == TR_prepareForOSR))
          {// the reference number is set in j9x86evaluator.cpp/VMarrayStoreCheckArrayCopyEvaluator
          cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                          (uint8_t *)methodSymRef,
@@ -2702,15 +2703,17 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
          case TR_DataAddress:
             {
-            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *) getSymbolReference(),
-                                                                                      (uint8_t *)getNode() ? (uint8_t *)(uintptr_t) getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
-                                                                                      (TR_ExternalRelocationTargetKind) getReloKind(),
-                                                                                      cg()),
-                                                                                      __FILE__,
-                                                                                      __LINE__,
-                                                                                      getNode());
-
+            if (comp->needRelocationsForStatics())
+               {
+               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                                         (uint8_t *) getSymbolReference(),
+                                                                                         (uint8_t *)getNode() ? (uint8_t *)(uintptr_t) getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                                                                                         (TR_ExternalRelocationTargetKind) getReloKind(),
+                                                                                         cg()),
+                                                                                         __FILE__,
+                                                                                         __LINE__,
+                                                                                         getNode());
+               }
             break;
             }
          case TR_NativeMethodAbsolute:


### PR DESCRIPTION
- Relocate `prepareForOSR` helper address. This is needed to support
OSR (On Stack Replacement) in JITaaS.
- Guard `TR_DataAddress` relocation for `AMD64RegImm64SymInstruction`,
perform only if statics need to be relocated. This is needed because
the relocation relies on the static field being resolved, which is
not true in JITaaS mode.

Signed-off-by: Dmitry Ten <Dmitry.Ten@ibm.com>