### PR TITLE
Disable OSRLiveRangeAnalysis when mimic interpreter

### DIFF
--- a/compiler/optimizer/OSRDefAnalysis.cpp
+++ b/compiler/optimizer/OSRDefAnalysis.cpp
@@ -729,10 +729,16 @@ bool TR_OSRLiveRangeAnalysis::shouldPerformAnalysis()
    else if (comp()->getOSRMode() == TR::involuntaryOSR)
       {
       static const char* disableOSRPointDeadslotsBookKeeping = feGetEnv("TR_DisableOSRPointDeadslotsBookKeeping");
-      if (comp()->getOSRMode() == TR::involuntaryOSR && disableOSRPointDeadslotsBookKeeping) // save some compile time
+      if (comp()->getOption(TR_MimicInterpreterFrameShape))
          {
          if (comp()->getOption(TR_TraceOSR))
-            traceMsg(comp(), "Should not perform OSRLiveRangeAnlysis under involuntary OSR mode in certain cases\n");
+            traceMsg(comp(), "No need to perform OSRLiveRangeAnlysis under mimic interpreter frame shape\n");
+         return false;
+         }
+      else if (disableOSRPointDeadslotsBookKeeping) // save some compile time
+         {
+         if (comp()->getOption(TR_TraceOSR))
+            traceMsg(comp(), "Dead slots bookkeeping is disabled and therefore OSRLiveRangeAnlysis is not needed\n");
          return false;
          }
       }


### PR DESCRIPTION
Mimic interpreter frame shape doesn't need to zero out dead slots after
OSR out and therefore OSRLiveRangeAnalysis is not needed.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>