### PR TITLE
Change insert prefetch to insert BPP after ICF

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1510,7 +1510,7 @@ OMR::Z::CodeGenerator::insertInstructionPrefetches()
             if (!op.isAdmin())
                {
                real = first;
-               if (op.isLabel() || op.isCall())
+               if (op.isLabel() || op.isCall() || first->isEndInternalControlFlow())
                   {
                   break;
                   }


### PR DESCRIPTION
Change insert prefetch to insert BPP after ending internal
control flow, this will prevent BPP from being inserted
within a ICF.

Signed-off-by: Daniel Hong <daniel.hong@live.com>