### PR TITLE
AArch64: Implement OMRMemoryReference::estimateBinaryLength()

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -246,7 +246,7 @@ uint8_t *TR::ARM64Trg1MemInstruction::generateBinaryEncoding()
 
 int32_t TR::ARM64Trg1MemInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength());
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
    return currentEstimate + getEstimatedBinaryLength();
    }
 
@@ -264,7 +264,7 @@ uint8_t *TR::ARM64MemInstruction::generateBinaryEncoding()
 
 int32_t TR::ARM64MemInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength());
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
    return(currentEstimate + getEstimatedBinaryLength());
    }
 
@@ -283,6 +283,6 @@ uint8_t *TR::ARM64MemSrc1Instruction::generateBinaryEncoding()
 
 int32_t TR::ARM64MemSrc1Instruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength());
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
    return(currentEstimate + getEstimatedBinaryLength());
    }

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -41,7 +41,7 @@ namespace TR { class SymbolReference; }
  * @param[in] intValue : signed integer value
  * @return true if the value can be placed in 9-bit field, false otherwise
  */
-inline bool constantIsImmed9(int32_t intValue)
+inline bool constantIsImm9(int32_t intValue)
    {
    return (-256 <= intValue && intValue < 256);
    }
@@ -51,7 +51,7 @@ inline bool constantIsImmed9(int32_t intValue)
  * @param[in] intValue : unsigned integer value
  * @return true if the value can be placed in 12-bit field, false otherwise
  */
-inline bool constantIsUnsignedImmed12(uint32_t intValue)
+inline bool constantIsUnsignedImm12(uint32_t intValue)
    {
    return (intValue < 4096);
    }

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -365,7 +365,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
 
    // allocate stack space
    uint32_t frameSize = (uint32_t)codeGen->getFrameSizeInBytes();
-   if (constantIsUnsignedImmed12(frameSize))
+   if (constantIsUnsignedImm12(frameSize))
       {
       cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::subimmx, firstNode, sp, sp, frameSize, cursor);
       }
@@ -488,7 +488,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    // remove space for preserved registers
    uint32_t frameSize = codeGen->getFrameSizeInBytes();
-   if (constantIsUnsignedImmed12(frameSize))
+   if (constantIsUnsignedImm12(frameSize))
       {
       cursor = generateTrg1Src1ImmInstruction(codeGen, TR::InstOpCode::addimmx, lastNode, sp, sp, frameSize, cursor);
       }

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -37,6 +37,7 @@ namespace OMR { typedef OMR::ARM64::MemoryReference MemoryReferenceConnector; }
 
 #include <stddef.h>
 #include <stdint.h>
+#include "codegen/InstOpCode.hpp"
 #include "codegen/Register.hpp"
 #include "env/TRMemory.hpp"
 #include "il/SymbolReference.hpp"
@@ -324,9 +325,10 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
 
    /**
     * @brief Estimates the length of generated binary
+    * @param[in] op : opcode of the instruction to attach this memory reference to
     * @return estimated binary length
     */
-   uint32_t estimateBinaryLength();
+   uint32_t estimateBinaryLength(TR::InstOpCode op);
 
    /**
     * @brief Generates binary encoding


### PR DESCRIPTION
This commit implements some more cases for estimateBinaryLength()
in OMRMemoryReference for aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>