### PR TITLE
AArch64: Add utility functions for generating CMP and TST instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -928,6 +928,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
                              TR::Register *sreg, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, cg), _source1Register(sreg)
       {
+      setDependencyConditions(NULL);
       }
 
    /*
@@ -944,6 +945,41 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _source1Register(sreg)
       {
+      setDependencyConditions(NULL);
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] sreg : source register
+    * @param[in] cond : register dependency conditions
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                             TR::Register *sreg, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : ARM64Trg1Instruction(op, node, treg, cg), _source1Register(sreg)
+      {
+      setDependencyConditions(cond);
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] sreg : source register
+    * @param[in] cond : register dependency conditions
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                             TR::Register *sreg, TR::RegisterDependencyConditions *cond,
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _source1Register(sreg)
+      {
+      setDependencyConditions(cond);
       }
 
    /**
@@ -1023,6 +1059,41 @@ class ARM64Trg1Src1ImmInstruction : public ARM64Trg1Src1Instruction
                                 TR::Register *sreg, uint32_t imm,
                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Src1Instruction(op, node, treg, sreg, precedingInstruction, cg), _source1Immediate(imm)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] sreg : source register
+    * @param[in] imm : immediate value
+    * @param[in] cond : register dependency conditions
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                               TR::Register *sreg, uint32_t imm,
+                               TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : ARM64Trg1Src1Instruction(op, node, treg, sreg, cond, cg), _source1Immediate(imm)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] sreg : source register
+    * @param[in] imm : immediate value
+    * @param[in] cond : register dependency conditions
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src1ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                               TR::Register *sreg, uint32_t imm, TR::RegisterDependencyConditions *cond,
+                               TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src1Instruction(op, node, treg, sreg, cond, precedingInstruction, cg), _source1Immediate(imm)
       {
       }
 

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -485,4 +485,36 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(
                    uint32_t shiftAmount,
                    TR::Instruction *preced = NULL);
 
+/*
+ * @brief Generates CMP (immediate) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] sreg : source register
+ * @param[in] imm : immediate value
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateCompareImmInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *sreg,
+                  int32_t imm,
+                  TR::Instruction *preced);
+
+/*
+ * @brief Generates TST (immediate) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] sreg : source register
+ * @param[in] imm : immediate value
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTestImmInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *sreg,
+                  int32_t imm,
+                  TR::Instruction *preced);
+
 #endif


### PR DESCRIPTION
This commit implements utility functions in GenerateInstructions.*
for generating CMP (immediate) and TST (immediate) instructions
for aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>