### PR TITLE
Use port library for printing types

### DIFF
--- a/ddr/include/ddr/ir/Symbol_IR.hpp
+++ b/ddr/include/ddr/ir/Symbol_IR.hpp
@@ -48,6 +48,8 @@ class TypeReplaceVisitor;
 
 class Symbol_IR {
 private:
+	OMRPortLibrary * const _portLibrary;
+
 	struct OverrideInfo {
 		set<string> opaqueTypeNames;
 		vector<FieldOverride> fieldOverrides;
@@ -55,7 +57,7 @@ private:
 		OverrideInfo();
 	};
 
-	DDR_RC readOverridesFile(OMRPortLibrary *portLibrary, const char *overridesFile, OverrideInfo *overrideInfo);
+	DDR_RC readOverridesFile(const char *overridesFile, OverrideInfo *overrideInfo);
 
 public:
 	vector<Type *> _types;
@@ -69,10 +71,27 @@ public:
 	set<Type *> _typeSet;
 	unordered_map<string, set<Type *> > _typeMap;
 
-	Symbol_IR() : _types(), _fullTypeNames(), _typeSet(), _typeMap() {}
+	explicit Symbol_IR(OMRPortLibrary *portLibrary)
+		: _portLibrary(portLibrary)
+		, _types()
+		, _fullTypeNames()
+		, _typeSet()
+		, _typeMap()
+	{
+	}
+
+	explicit Symbol_IR(Symbol_IR *other)
+		: _portLibrary(other->_portLibrary)
+		, _types()
+		, _fullTypeNames()
+		, _typeSet()
+		, _typeMap()
+	{
+	}
+
 	~Symbol_IR();
 
-	DDR_RC applyOverridesList(OMRPortLibrary *portLibrary, const char *overridesListFile);
+	DDR_RC applyOverridesList(const char *overridesListFile);
 	void removeDuplicates();
 	DDR_RC mergeIR(Symbol_IR *other);
 

--- a/ddr/include/ddr/ir/TypePrinter.hpp
+++ b/ddr/include/ddr/ir/TypePrinter.hpp
@@ -22,6 +22,7 @@
 #include "ddr/ir/TypeVisitor.hpp"
 
 #include "ddr/ir/Macro.hpp"
+#include "omrport.h"
 
 class EnumMember;
 class Field;
@@ -31,6 +32,7 @@ class Field;
 class TypePrinter : public TypeVisitor
 {
 private:
+	OMRPortLibrary * const _portLibrary;
 	const int32_t _flags;
 	const int32_t _indent;
 
@@ -41,6 +43,7 @@ private:
 
 	explicit TypePrinter(const TypePrinter *outer)
 		: TypeVisitor()
+		, _portLibrary(outer->_portLibrary)
 		, _flags(outer->_flags)
 		, _indent(outer->_indent + 1)
 	{
@@ -49,8 +52,9 @@ private:
 public:
 	enum { FIELDS = 1, LITERALS = 2, MACROS = 4 };
 
-	explicit TypePrinter(int32_t flags)
+	TypePrinter(OMRPortLibrary * portLibrary, int32_t flags)
 		: TypeVisitor()
+		, _portLibrary(portLibrary)
 		, _flags(flags)
 		, _indent(0)
 	{

--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -73,10 +73,10 @@ Symbol_IR::~Symbol_IR()
 }
 
 DDR_RC
-Symbol_IR::applyOverridesList(OMRPortLibrary *portLibrary, const char *overridesListFile)
+Symbol_IR::applyOverridesList(const char *overridesListFile)
 {
 	DDR_RC rc = DDR_RC_OK;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+	OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
 	vector<string> filenames;
 	OverrideInfo overrideInfo;
 
@@ -117,7 +117,7 @@ closeFile:
 	}
 
 	for (vector<string>::const_iterator it = filenames.begin(); filenames.end() != it; ++it) {
-		rc = readOverridesFile(portLibrary, it->c_str(), &overrideInfo);
+		rc = readOverridesFile(it->c_str(), &overrideInfo);
 		if (DDR_RC_OK != rc) {
 			break;
 		}
@@ -179,10 +179,10 @@ startsWith(const string &str, const string &prefix)
 }
 
 DDR_RC
-Symbol_IR::readOverridesFile(OMRPortLibrary *portLibrary, const char *overridesFile, OverrideInfo *overrideInfo)
+Symbol_IR::readOverridesFile(const char *overridesFile, OverrideInfo *overrideInfo)
 {
 	DDR_RC rc = DDR_RC_OK;
-	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+	OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
 
 	/* Read list of type overrides from specified file. */
 	intptr_t fd = omrfile_open(overridesFile, EsOpenRead, 0);
@@ -673,7 +673,7 @@ DDR_RC
 Symbol_IR::mergeIR(Symbol_IR *other)
 {
 #if defined(DEBUG_PRINT_TYPES)
-	TypePrinter printer(TypePrinter::LITERALS);
+	TypePrinter printer(_portLibrary, TypePrinter::LITERALS);
 
 	if (this != previousIR) {
 		printf("\n");

--- a/ddr/lib/ddr-ir/TypePrinter.cpp
+++ b/ddr/lib/ddr-ir/TypePrinter.cpp
@@ -31,7 +31,7 @@ void
 TypePrinter::printIndent() const
 {
 	for (int32_t i = _indent; i > 0; --i) {
-		printf("  ");
+		_portLibrary->tty_printf(_portLibrary, "  ");
 	}
 }
 
@@ -41,7 +41,7 @@ TypePrinter::printFields(const std::vector<Field *> &fields) const
 	if (0 != (_flags & FIELDS)) {
 		for (vector<Field *>::const_iterator it = fields.begin(); it != fields.end(); ++it) {
 			printIndent();
-			printf("field '%s'\n", (*it)->_name.c_str());
+			_portLibrary->tty_printf(_portLibrary, "field '%s'\n", (*it)->_name.c_str());
 		}
 	}
 }
@@ -52,7 +52,7 @@ TypePrinter::printLiterals(const std::vector<EnumMember *> &literals) const
 	if (0 != (_flags & LITERALS)) {
 		for (vector<EnumMember *>::const_iterator it = literals.begin(); it != literals.end(); ++it) {
 			printIndent();
-			printf("literal '%s' = %d\n", (*it)->_name.c_str(), (*it)->_value);
+			_portLibrary->tty_printf(_portLibrary, "literal '%s' = %d\n", (*it)->_name.c_str(), (*it)->_value);
 		}
 	}
 }
@@ -63,7 +63,7 @@ TypePrinter::printMacros(const std::vector<Macro> &macros) const
 	if (0 != (_flags & MACROS)) {
 		for (vector<Macro>::const_iterator it = macros.begin(); it != macros.end(); ++it) {
 			printIndent();
-			printf("macro '%s' = %s\n", it->_name.c_str(), it->getValue().c_str());
+			_portLibrary->tty_printf(_portLibrary, "macro '%s' = %s\n", it->_name.c_str(), it->getValue().c_str());
 		}
 	}
 }
@@ -72,7 +72,7 @@ DDR_RC
 TypePrinter::visitType(Type *type) const
 {
 	printIndent();
-	printf("type '%s' size(%lu)\n", type->_name.c_str(), (unsigned long)type->_sizeOf);
+	_portLibrary->tty_printf(_portLibrary, "type '%s' size(%zu)\n", type->_name.c_str(), type->_sizeOf);
 	return DDR_RC_OK;
 }
 
@@ -80,14 +80,14 @@ DDR_RC
 TypePrinter::visitClass(ClassUDT *type) const
 {
 	printIndent();
-	printf("%s '%s' size(%lu)",
+	_portLibrary->tty_printf(_portLibrary, "%s '%s' size(%zu)",
 			type->_isClass ? "class" : "struct",
 			type->_name.c_str(),
-			(unsigned long)type->_sizeOf);
+			type->_sizeOf);
 	if (NULL != type->_superClass) {
-		printf(":  %s", type->_superClass->_name.c_str());
+		_portLibrary->tty_printf(_portLibrary, ":  %s", type->_superClass->_name.c_str());
 	}
-	printf(" {\n");
+	_portLibrary->tty_printf(_portLibrary, " {\n");
 
 	{
 		const TypePrinter indented(this);
@@ -99,7 +99,7 @@ TypePrinter::visitClass(ClassUDT *type) const
 	}
 
 	printIndent();
-	printf("}\n");
+	_portLibrary->tty_printf(_portLibrary, "}\n");
 
 	return DDR_RC_OK;
 }
@@ -108,7 +108,7 @@ DDR_RC
 TypePrinter::visitEnum(EnumUDT *type) const
 {
 	printIndent();
-	printf("enum '%s' size(%lu) {\n", type->_name.c_str(), (unsigned long)type->_sizeOf);
+	_portLibrary->tty_printf(_portLibrary, "enum '%s' size(%zu) {\n", type->_name.c_str(), type->_sizeOf);
 
 	{
 		const TypePrinter indented(this);
@@ -117,7 +117,7 @@ TypePrinter::visitEnum(EnumUDT *type) const
 	}
 
 	printIndent();
-	printf("}\n");
+	_portLibrary->tty_printf(_portLibrary, "}\n");
 
 	return DDR_RC_OK;
 }
@@ -126,7 +126,7 @@ DDR_RC
 TypePrinter::visitNamespace(NamespaceUDT *type) const
 {
 	printIndent();
-	printf("namespace '%s' {\n", type->_name.c_str());
+	_portLibrary->tty_printf(_portLibrary, "namespace '%s' {\n", type->_name.c_str());
 
 	{
 		const TypePrinter indented(this);
@@ -137,7 +137,7 @@ TypePrinter::visitNamespace(NamespaceUDT *type) const
 	}
 
 	printIndent();
-	printf("}\n");
+	_portLibrary->tty_printf(_portLibrary, "}\n");
 
 	return DDR_RC_OK;
 }
@@ -146,7 +146,7 @@ DDR_RC
 TypePrinter::visitTypedef(TypedefUDT *type) const
 {
 	printIndent();
-	printf("typedef '%s'\n", type->_name.c_str());
+	_portLibrary->tty_printf(_portLibrary, "typedef '%s'\n", type->_name.c_str());
 
 	return DDR_RC_OK;
 }
@@ -155,7 +155,7 @@ DDR_RC
 TypePrinter::visitUnion(UnionUDT *type) const
 {
 	printIndent();
-	printf("union '%s' size(%lu) {\n", type->_name.c_str(), type->_sizeOf);
+	_portLibrary->tty_printf(_portLibrary, "union '%s' size(%zu) {\n", type->_name.c_str(), type->_sizeOf);
 
 	{
 		const TypePrinter indented(this);
@@ -167,7 +167,7 @@ TypePrinter::visitUnion(UnionUDT *type) const
 	}
 
 	printIndent();
-	printf("}\n");
+	_portLibrary->tty_printf(_portLibrary, "}\n");
 
 	return DDR_RC_OK;
 }

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -1261,7 +1261,7 @@ DwarfScanner::traverse_cu_in_debug_section(Symbol_IR *ir)
 
 	/* Go over each cu header. */
 	while (DDR_RC_OK == rc) {
-		Symbol_IR newIR;
+		Symbol_IR newIR(ir);
 		_typeOffsetMap.clear();
 		_ir = &newIR;
 
@@ -1355,7 +1355,7 @@ DwarfScanner::startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir, vector<strin
 	/* Read list of debug files to scan from the input file. */
 	for (vector<string>::iterator it = debugFiles->begin(); it != debugFiles->end(); ++it) {
 		const string & debugFile = *it;
-		Symbol_IR newIR;
+		Symbol_IR newIR(ir);
 		rc = scanFile(portLibrary, &newIR, debugFile.c_str());
 		if (DDR_RC_OK != rc) {
 			break;

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -77,8 +77,6 @@ private:
 
 #if defined(DEBUG_PRINT_TYPES)
 #include "ddr/ir/TypePrinter.hpp"
-
-static const TypePrinter printer(TypePrinter::FIELDS | TypePrinter::LITERALS | TypePrinter::MACROS);
 #endif /* DEBUG_PRINT_TYPES */
 
 int
@@ -126,7 +124,11 @@ main(int argc, char *argv[])
 #else /* defined(_MSC_VER) */
 	DwarfScanner scanner;
 #endif /* defined(_MSC_VER) */
-	Symbol_IR ir;
+	Symbol_IR ir(&portLibrary);
+#if defined(DEBUG_PRINT_TYPES)
+	const TypePrinter printer(&portLibrary, TypePrinter::FIELDS | TypePrinter::LITERALS | TypePrinter::MACROS);
+#endif /* DEBUG_PRINT_TYPES */
+
 	if ((DDR_RC_OK == rc) && !options.debugFiles.empty()) {
 		rc = scanner.startScan(&portLibrary, &ir, &options.debugFiles, options.blacklistFile);
 
@@ -163,7 +165,7 @@ main(int argc, char *argv[])
 
 	/* Apply Type Overrides; must be after scanning and loading macros. */
 	if ((DDR_RC_OK == rc) && (NULL != options.overrideListFile)) {
-		rc = ir.applyOverridesList(&portLibrary, options.overrideListFile);
+		rc = ir.applyOverridesList(options.overrideListFile);
 	}
 
 	if ((DDR_RC_OK == rc) && options.showBlacklisted) {


### PR DESCRIPTION
Previously, `printf` was used directly which triggers a warning from VS2017 about providing a value of type `size_t` for a format `%ul` which expects `unsigned long`.

> printf("union '%s' size(%lu) {\n", type->_name.c_str(), type->_sizeOf);

Using the port library allows us to use the format `%zu` for values of type `size_t`.