### PR TITLE
Add new API for RRF-C Instructions

### DIFF
--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -621,6 +621,13 @@ generateRRDInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    }
 
 TR::Instruction *
+generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, uint8_t mask, bool isMask3,
+                       TR::Instruction * preced)
+   {
+   return new (INSN_HEAP) TR::S390RRFInstruction(op, n, mask, isMask3, cg);
+   }
+
+TR::Instruction *
 generateRRFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * n, TR::Register * treg, TR::Register * sreg,
                        TR::Register * sreg2, TR::Instruction * preced)
    {

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -259,6 +259,14 @@ TR::Instruction * generateRRDInstruction(
                    TR::Instruction        *preced = 0);
 
 TR::Instruction * generateRRFInstruction(
+                   TR::CodeGenerator * cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node * n,
+                   uint8_t mask,
+                   bool isMask3,
+                   TR::Instruction * preced = 0);
+
+TR::Instruction * generateRRFInstruction(
                    TR::CodeGenerator *cg,
                    TR::InstOpCode::Mnemonic         op,
                    TR::Node               *n,

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -1680,7 +1680,7 @@ TR::S390RRFInstruction::generateBinaryEncoding()
 
    TR::Register *srcReg = getRegisterOperand(2);
    bool isSrcPair = false, isSrc2Pair = false, isTgtPair = false;
-   TR::RegisterPair* srcRegPair = srcReg->getRegisterPair();
+   TR::RegisterPair* srcRegPair = srcReg != NULL ? srcReg->getRegisterPair() : NULL;
    if (srcRegPair != NULL)
      isSrcPair = true;
 
@@ -1695,7 +1695,7 @@ TR::S390RRFInstruction::generateBinaryEncoding()
      isSrc2Pair = true;
 
    TR::Register *tgtReg = getRegisterOperand(1);
-   TR::RegisterPair* tgtRegPair = tgtReg->getRegisterPair();
+   TR::RegisterPair* tgtRegPair = tgtReg != NULL ? tgtReg->getRegisterPair() : NULL;
    if (tgtRegPair != NULL)
      isTgtPair = true;
 
@@ -1737,15 +1737,21 @@ TR::S390RRFInstruction::generateBinaryEncoding()
 
          break;
       case TR::Instruction::IsRRF2:			// M3,  ., R1, R2
-         if ( !isTgtPair )
-            toRealRegister(getRegForBinaryEncoding(tgtReg))->setRegisterField((uint32_t *) cursor, 1);
-         else
-            toRealRegister(tgtRegPair->getHighOrder())->setRegisterField((uint32_t *) cursor, 1);
+         if (tgtReg != NULL)
+            {
+            if ( !isTgtPair )
+               toRealRegister(getRegForBinaryEncoding(tgtReg))->setRegisterField((uint32_t *) cursor, 1);
+            else
+               toRealRegister(tgtRegPair->getHighOrder())->setRegisterField((uint32_t *) cursor, 1);
+            }
 
-         if ( !isSrcPair )
-            toRealRegister(getRegForBinaryEncoding(srcReg))->setRegisterField((uint32_t *) cursor, 0);
-         else
-            toRealRegister(srcRegPair->getHighOrder())->setRegisterField((uint32_t *) cursor, 0);
+         if (srcReg != NULL)
+            {
+            if ( !isSrcPair )
+               toRealRegister(getRegForBinaryEncoding(srcReg))->setRegisterField((uint32_t *) cursor, 0);
+            else
+               toRealRegister(srcRegPair->getHighOrder())->setRegisterField((uint32_t *) cursor, 0);
+            }
 
          setMaskField((uint32_t *) cursor, getMask3(), 3);
          break;

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -1459,6 +1459,14 @@ class S390RRInstruction : public TR::S390RegInstruction
       }
 
    S390RRInstruction(TR::InstOpCode::Mnemonic         op,
+                        TR::Node                      *n,
+                        TR::CodeGenerator             *cg)
+      : S390RegInstruction(op, n, cg), _flagsRR(0), _secondConstant(-1)
+      {
+      }
+
+
+   S390RRInstruction(TR::InstOpCode::Mnemonic         op,
                         TR::Node               *n,
                         TR::Register           *treg,
                         TR::Register           *sreg,
@@ -1810,6 +1818,20 @@ class S390RRFInstruction : public TR::S390RRInstruction
                         TR::CodeGenerator      *cg)
       : S390RRInstruction(op, n, treg, sreg, cg), _encodeAsRRD(false),
         _isSourceReg2Present(false), _isMask3Present(isMask3),_isMask4Present(!isMask3)
+      {
+      if (isMask3)
+         _mask3 = mask;
+      else
+         _mask4 = mask;
+      }
+
+   S390RRFInstruction(TR::InstOpCode::Mnemonic        op,
+                        TR::Node               *n,
+                        uint8_t                mask,
+                        bool                   isMask3,
+                        TR::CodeGenerator      *cg)
+      : S390RRInstruction(op, n, cg), _encodeAsRRD(false),
+        _isMask3Present(isMask3), _isMask4Present(!isMask3), _isSourceReg2Present(false)
       {
       if (isMask3)
          _mask3 = mask;


### PR DESCRIPTION
RRF instructions such as PPA15 ignore the register fields in their encoding. In order to simplify the generation of these RRF instructions, this commit introduces a new API that allows the creation of new RRF-C instructions without the need to provide registers. The code generator will encode zeros in the instruction's register fields automatically.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>