### PR TITLE
Rename IA32DataSnippet and IA32ConstantDataSnippet

### DIFF
--- a/compiler/x/amd64/codegen/MemoryReference.hpp
+++ b/compiler/x/amd64/codegen/MemoryReference.hpp
@@ -28,7 +28,7 @@
 #include <stdint.h>        // for uint8_t
 #include "env/jittypes.h"  // for intptrj_t
 
-namespace TR { class IA32DataSnippet; }
+namespace TR { class X86DataSnippet; }
 class TR_ScratchRegisterManager;
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
@@ -76,7 +76,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, s, disp, cg) {}
 
-   MemoryReference(TR::IA32DataSnippet *cds,
+   MemoryReference(TR::X86DataSnippet *cds,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(cds, cg) {}
 

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -94,7 +94,7 @@ OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Register *br, TR::Register
    self()->finishInitialization(cg, NULL);
    }
 
-OMR::X86::AMD64::MemoryReference::MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator *cg):
+OMR::X86::AMD64::MemoryReference::MemoryReference(TR::X86DataSnippet *cds, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(cds, cg)
    {
    self()->finishInitialization(cg, NULL);

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -84,7 +84,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::X86::MemoryReference
 
    MemoryReference(TR::Register *br, TR::Register *ir, uint8_t s, intptrj_t disp, TR::CodeGenerator *cg);
 
-   MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator *cg);
+   MemoryReference(TR::X86DataSnippet *cds, TR::CodeGenerator *cg);
 
    MemoryReference(TR::LabelSymbol    *label, TR::CodeGenerator *cg);
 

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -374,10 +374,8 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
          TR::RegisterDependencyConditions  *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)1, cg);
          deps->addPostCondition(treg, TR::RealRegister::NoReg, cg);
 
-         TR::IA32ConstantDataSnippet *nan1Snippet = cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_1_LOW);
-         TR::IA32ConstantDataSnippet *nan2Snippet = cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_2_LOW);
-         TR::MemoryReference      *nan1MR      = generateX86MemoryReference(nan1Snippet, cg);
-         TR::MemoryReference      *nan2MR      = generateX86MemoryReference(nan2Snippet, cg);
+         TR::MemoryReference* nan1MR     = generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_1_LOW), cg);
+         TR::MemoryReference* nan2MR     = generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, DOUBLE_NAN_2_LOW), cg);
 
          TR::LabelSymbol *startLabel     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::LabelSymbol *normalizeLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
@@ -407,8 +405,7 @@ TR::Register *OMR::X86::AMD64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, T
          helperDeps->addPreCondition( treg, TR::RealRegister::eax, cg);
          helperDeps->addPostCondition(treg, TR::RealRegister::eax, cg);
 
-         TR::IA32ConstantDataSnippet *nanDetectorSnippet  = cg->findOrCreate8ByteConstant(node, nanDetector);
-         TR::MemoryReference      *nanDetectorMR       = generateX86MemoryReference(nanDetectorSnippet,  cg);
+         TR::MemoryReference* nanDetectorMR = generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, nanDetector),  cg);
 
          TR::LabelSymbol *startLabel     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::LabelSymbol *slowPathLabel  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);

--- a/compiler/x/codegen/ConstantDataSnippet.hpp
+++ b/compiler/x/codegen/ConstantDataSnippet.hpp
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef IA32CONSTANTDATASNIPPET_INCL
-#define IA32CONSTANTDATASNIPPET_INCL
+#ifndef X86CONSTANTDATASNIPPET_INCL
+#define X86CONSTANTDATASNIPPET_INCL
 
 #include "x/codegen/DataSnippet.hpp"
 
@@ -32,11 +32,11 @@ namespace TR { class Node; }
 
 namespace TR {
 
-class IA32ConstantDataSnippet : public TR::IA32DataSnippet
+class X86ConstantDataSnippet : public TR::X86DataSnippet
    {
    public:
 
-   inline IA32ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *n, void *c, uint8_t size) : TR::IA32DataSnippet(cg, n, c, size) { }
+   inline X86ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *n, void *c, uint8_t size) : TR::X86DataSnippet(cg, n, c, size) { }
    virtual Kind getKind() { return IsConstantData; }
    };
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1177,8 +1177,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerReturnEvaluator(TR::Node *node, TR
    if (cg->enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST), cg), cg);
       }
 
    TR::Node     *firstChild     = node->getFirstChild();
@@ -1245,8 +1244,7 @@ TR::Register *OMR::X86::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeG
    if (cg->enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST), cg), cg);
       }
 
    if (cg->getProperties().getCallerCleanup())

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -34,7 +34,7 @@
 
 namespace TR { class Node; }
 
-TR::IA32DataSnippet::IA32DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
+TR::X86DataSnippet::X86DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, uint8_t size)
    : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false),
      _data(size, 0, getTypedAllocator<uint8_t>(TR::comp()->allocator()))
    {
@@ -45,7 +45,7 @@ TR::IA32DataSnippet::IA32DataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *
 
 
 void
-TR::IA32DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
+TR::X86DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
    {
    // add dummy class unload/redefinition assumption.
    if (_isClassAddress)
@@ -70,7 +70,7 @@ TR::IA32DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
    }
 
 
-uint8_t *TR::IA32DataSnippet::emitSnippetBody()
+uint8_t *TR::X86DataSnippet::emitSnippetBody()
    {
    uint8_t *cursor = cg()->getBinaryBufferCursor();
 
@@ -92,7 +92,7 @@ uint8_t *TR::IA32DataSnippet::emitSnippetBody()
    return cursor;
    }
 
-void TR::IA32DataSnippet::printValue(TR::FILE* pOutFile, TR_Debug* debug)
+void TR::X86DataSnippet::printValue(TR::FILE* pOutFile, TR_Debug* debug)
    {
    if (pOutFile == NULL)
       return;
@@ -122,7 +122,7 @@ void TR::IA32DataSnippet::printValue(TR::FILE* pOutFile, TR_Debug* debug)
       }
    }
 
-void TR::IA32DataSnippet::print(TR::FILE* pOutFile, TR_Debug* debug)
+void TR::X86DataSnippet::print(TR::FILE* pOutFile, TR_Debug* debug)
    {
    if (pOutFile == NULL)
       return;

--- a/compiler/x/codegen/DataSnippet.hpp
+++ b/compiler/x/codegen/DataSnippet.hpp
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef IA32DATASNIPPET_INCL
-#define IA32DATASNIPPET_INCL
+#ifndef X86DATASNIPPET_INCL
+#define X86DATASNIPPET_INCL
 
 #include "codegen/Snippet.hpp"
 #include "infra/vector.hpp"    // for TR::vector
@@ -31,11 +31,11 @@ namespace TR { class Node; }
 
 namespace TR {
 
-class IA32DataSnippet : public TR::Snippet
+class X86DataSnippet : public TR::Snippet
    {
    public:
 
-   IA32DataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
+   X86DataSnippet(TR::CodeGenerator *cg, TR::Node *, void *c, uint8_t size);
 
    virtual Kind getKind() { return IsData; }
    uint8_t* getRawData()  { return _data.data(); }

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.cpp
@@ -227,8 +227,7 @@ void TR_X86FPBinaryArithmeticAnalyser::genericFPAnalyser(TR::Node *root)
          {
          scalingRegister = _cg->allocateRegister(TR_X87);
 
-         TR::IA32ConstantDataSnippet *cds = _cg->findOrCreate8ByteConstant(root, DOUBLE_EXPONENT_SCALE);
-         constMR = generateX86MemoryReference(cds, _cg);
+         constMR = generateX86MemoryReference(_cg->findOrCreate8ByteConstant(root, DOUBLE_EXPONENT_SCALE), _cg);
 
          generateFPRegMemInstruction(DLDRegMem, root, scalingRegister, constMR, _cg);
          operandNeedsScaling = true;

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -212,8 +212,7 @@ TR::Register *OMR::X86::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, node->getFloatBits());
-         TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
+         TR::MemoryReference  *tempMR = generateX86MemoryReference(cg->findOrCreate4ByteConstant(node, node->getFloatBits()), cg);
          TR::Instruction *instr = generateRegMemInstruction(MOVSSRegMem, node, targetRegister, tempMR, cg);
          setDiscardableIfPossible(TR_RematerializableFloat, targetRegister, node, instr, (intptrj_t)node->getFloatBits(), cg);
          }
@@ -232,8 +231,7 @@ TR::Register *OMR::X86::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate4ByteConstant(node, node->getFloatBits());
-         TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
+         TR::MemoryReference  *tempMR = generateX86MemoryReference(cg->findOrCreate4ByteConstant(node, node->getFloatBits()), cg);
          generateFPRegMemInstruction(FLDRegMem, node, targetRegister, tempMR, cg);
          }
       }
@@ -255,8 +253,7 @@ TR::Register *OMR::X86::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, node->getLongInt());
-         TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
+         TR::MemoryReference  *tempMR = generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, node->getLongInt()), cg);
          generateRegMemInstruction(cg->getXMMDoubleLoadOpCode(), node, targetRegister, tempMR, cg);
          }
       }
@@ -274,8 +271,7 @@ TR::Register *OMR::X86::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
          }
       else
          {
-         TR::IA32ConstantDataSnippet *cds = cg->findOrCreate8ByteConstant(node, node->getLongInt());
-         TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, cg);
+         TR::MemoryReference  *tempMR = generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, node->getLongInt()), cg);
          generateFPRegMemInstruction(DLDRegMem, node, targetRegister, tempMR, cg);
          }
       }
@@ -526,8 +522,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
    //
    if (comp->getJittedMethodSymbol()->usesSinglePrecisionMode() && !cg->useSSEForDoublePrecision())
       {
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST), cg), cg);
       }
 
    const TR::X86LinkageProperties &linkageProperties = cg->getProperties();
@@ -1022,18 +1017,14 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::Symbol
       fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                 SINGLE_PRECISION_ROUND_TO_ZERO : DOUBLE_PRECISION_ROUND_TO_ZERO;
 
-      TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate2ByteConstant(node, fpcw);
-
       fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                 SINGLE_PRECISION_ROUND_TO_NEAREST : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
-      TR::IA32ConstantDataSnippet *cds2 = cg->findOrCreate2ByteConstant(node, fpcw);
-
       tempMR = (cg->machine())->getDummyLocalMR(TR::Int32);
 
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds1, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
       generateFPMemRegInstruction(FISTMemReg, node, tempMR, floatReg, cg);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds2, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
       resultReg = cg->allocateRegister();
       loadInstr = generateRegMemInstruction(L4RegMem, node, resultReg, generateX86MemoryReference(*tempMR, 0, cg), cg);
       generateRegImmInstruction(CMP4RegImm4, node, resultReg, INT_MIN, cg);
@@ -1248,8 +1239,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
       int16_t fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                         SINGLE_PRECISION_ROUND_TO_ZERO : DOUBLE_PRECISION_ROUND_TO_ZERO;
 
-      TR::IA32ConstantDataSnippet *cds1 = cg->findOrCreate2ByteConstant(node, fpcw);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds1, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
 
       TR::MemoryReference  *convertedLongMR = (cg->machine())->getDummyLocalMR(TR::Int64);
       generateFPMemRegInstruction(FLSTPMem, node, convertedLongMR, tempFPR1, cg);
@@ -1258,8 +1248,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
       fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ?
                 SINGLE_PRECISION_ROUND_TO_NEAREST : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
-      TR::IA32ConstantDataSnippet *cds2 = cg->findOrCreate2ByteConstant(node, fpcw);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds2, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
 
       // WARNING:
       //

--- a/compiler/x/codegen/MemoryReference.hpp
+++ b/compiler/x/codegen/MemoryReference.hpp
@@ -28,7 +28,7 @@
 #include <stdint.h>        // for uint8_t
 #include "env/jittypes.h"  // for intptrj_t
 
-namespace TR { class IA32DataSnippet; }
+namespace TR { class X86DataSnippet; }
 class TR_ScratchRegisterManager;
 namespace TR { class CodeGenerator; }
 namespace TR { class LabelSymbol; }
@@ -75,7 +75,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(br, ir, s, disp, cg) {}
 
-   MemoryReference(TR::IA32DataSnippet *cds,
+   MemoryReference(TR::X86DataSnippet *cds,
       TR::CodeGenerator *cg) :
          OMR::MemoryReferenceConnector(cds, cg) {}
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -61,8 +61,8 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include "codegen/GCStackAtlas.hpp"
 
 class TR_GCStackMap;
-namespace TR { class IA32ConstantDataSnippet; }
-namespace TR { class IA32DataSnippet; }
+namespace TR { class X86ConstantDataSnippet; }
+namespace TR { class X86DataSnippet; }
 class TR_OutlinedInstructions;
 namespace OMR { namespace X86 { class CodeGenerator; } }
 namespace TR { class CodeGenerator; }
@@ -518,14 +518,14 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    void dumpDataSnippets(TR::FILE *pOutFile);
 
-   TR::IA32ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c);
-   TR::IA32ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c);
-   TR::IA32ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c);
-   TR::IA32ConstantDataSnippet *findOrCreate16ByteConstant(TR::Node *, void *c);
-   TR::IA32DataSnippet *create2ByteData(TR::Node *, int16_t c);
-   TR::IA32DataSnippet *create4ByteData(TR::Node *, int32_t c);
-   TR::IA32DataSnippet *create8ByteData(TR::Node *, int64_t c);
-   TR::IA32DataSnippet *create16ByteData(TR::Node *, void *c);
+   TR::X86ConstantDataSnippet *findOrCreate2ByteConstant(TR::Node *, int16_t c);
+   TR::X86ConstantDataSnippet *findOrCreate4ByteConstant(TR::Node *, int32_t c);
+   TR::X86ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *, int64_t c);
+   TR::X86ConstantDataSnippet *findOrCreate16ByteConstant(TR::Node *, void *c);
+   TR::X86DataSnippet *create2ByteData(TR::Node *, int16_t c);
+   TR::X86DataSnippet *create4ByteData(TR::Node *, int32_t c);
+   TR::X86DataSnippet *create8ByteData(TR::Node *, int64_t c);
+   TR::X86DataSnippet *create16ByteData(TR::Node *, void *c);
 
    static TR_X86ProcessorInfo _targetProcessorInfo;
 
@@ -597,7 +597,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     *
     * \return : a data snippet with size s
     */
-   TR::IA32DataSnippet         *createDataSnippet(TR::Node *n, void *c, uint8_t s);
+   TR::X86DataSnippet*         createDataSnippet(TR::Node *n, void *c, uint8_t s);
    /*
     * \brief find or create a constant data snippet.
     *
@@ -607,7 +607,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     *
     * \return : a constant data snippet with size s
     */
-   TR::IA32ConstantDataSnippet *findOrCreateConstantDataSnippet(TR::Node *n, void *c, uint8_t s);
+   TR::X86ConstantDataSnippet* findOrCreateConstantDataSnippet(TR::Node *n, void *c, uint8_t s);
 
    TR::RealRegister             *_frameRegister;
 
@@ -619,13 +619,13 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Instruction                 *_lastCatchAppendInstruction;
    TR_BetterSpillPlacement        *_betterSpillPlacements;
 
-   TR::vector<TR::IA32DataSnippet*>      _dataSnippetList;
+   TR::vector<TR::X86DataSnippet*>       _dataSnippetList;
    TR::list<TR::Register*>               _spilledIntRegisters;
    TR::list<TR::Register*>               _liveDiscardableRegisters;
    TR::list<TR::Register*>               _dependentDiscardableRegisters;
    TR::list<TR::ClobberingInstruction*>  _clobberingInstructions;
    std::list<TR::ClobberingInstruction*, TR::typed_allocator<TR::ClobberingInstruction*, TR::Allocator> >::iterator _clobIterator;
-   TR::list<TR_OutlinedInstructions*>   _outlinedInstructionsList;
+   TR::list<TR_OutlinedInstructions*>    _outlinedInstructionsList;
 
    RegisterAssignmentDirection     _assignmentDirection;
    TR::RegisterIterator            *_x87RegisterIterator;

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -810,8 +810,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
          {
          if (info->getDataType() == TR_RematerializableFloat)
             {
-            TR::IA32ConstantDataSnippet *cds = self()->cg()->findOrCreate4ByteConstant(currentInstruction->getNode(), info->getConstant());
-            TR::MemoryReference  *tempMR = generateX86MemoryReference(cds, self()->cg());
+            TR::MemoryReference* tempMR = generateX86MemoryReference(self()->cg()->findOrCreate4ByteConstant(currentInstruction->getNode(), info->getConstant()), self()->cg());
             instr = generateRegMemInstruction(currentInstruction, MOVSSRegMem, best, tempMR, self()->cg());
 #ifdef DEBUG
             self()->cg()->incNumRematerializedXMMRs();

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -86,7 +86,7 @@ OMR::X86::MemoryReference::getDisplacement()
    }
 
 
-OMR::X86::MemoryReference::MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator   *cg):
+OMR::X86::MemoryReference::MemoryReference(TR::X86DataSnippet *cds, TR::CodeGenerator   *cg):
    _baseRegister(NULL),
    _baseNode(NULL),
    _indexRegister(NULL),
@@ -289,10 +289,10 @@ OMR::X86::MemoryReference::setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s
    return ( (TR::UnresolvedDataSnippet *) (_dataSnippet = s) );
    }
 
-TR::IA32DataSnippet *
+TR::X86DataSnippet*
 OMR::X86::MemoryReference::getDataSnippet()
    {
-   return (self()->hasUnresolvedDataSnippet() || self()->hasUnresolvedVirtualCallSnippet()) ? NULL : (TR::IA32DataSnippet *)_dataSnippet;
+   return (self()->hasUnresolvedDataSnippet() || self()->hasUnresolvedVirtualCallSnippet()) ? NULL : (TR::X86DataSnippet*)_dataSnippet;
    }
 
 
@@ -1297,7 +1297,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
             }
          else
             {
-            TR::IA32DataSnippet *cds = self()->getDataSnippet();
+            TR::X86DataSnippet* cds = self()->getDataSnippet();
             TR::LabelSymbol *label = NULL;
 
             if (cds)
@@ -1548,7 +1548,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             }
          else
             {
-            TR::IA32DataSnippet *cds = self()->getDataSnippet();
+            TR::X86DataSnippet* cds = self()->getDataSnippet();
             TR_ASSERT(cds == NULL || self()->getLabel() == NULL,
                    "a memRef cannot have both a constant data snippet and a label");
             TR::LabelSymbol *label = NULL;
@@ -1843,7 +1843,7 @@ generateX86MemoryReference(TR::SymbolReference * sr, intptrj_t displacement, TR:
    }
 
 TR::MemoryReference  *
-generateX86MemoryReference(TR::IA32DataSnippet * cds, TR::CodeGenerator *cg)
+generateX86MemoryReference(TR::X86DataSnippet* cds, TR::CodeGenerator *cg)
    {
    return new (cg->trHeapMemory()) TR::MemoryReference(cds, cg);
    }

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -202,7 +202,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       _symbolReference.setOffset(disp);
       }
 
-   MemoryReference(TR::IA32DataSnippet *cds, TR::CodeGenerator   *cg);
+   MemoryReference(TR::X86DataSnippet *cds, TR::CodeGenerator   *cg);
 
    MemoryReference(TR::LabelSymbol *label, TR::CodeGenerator *cg);
 
@@ -235,11 +235,11 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
 
    TR::UnresolvedDataSnippet *setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s);
 
-   TR::IA32DataSnippet *getDataSnippet();
+   TR::X86DataSnippet *getDataSnippet();
 
-   TR::IA32DataSnippet *setConstantDataSnippet(TR::IA32DataSnippet *s)
+   TR::X86DataSnippet *setConstantDataSnippet(TR::X86DataSnippet *s)
       {
-      return ( (TR::IA32DataSnippet *) (_dataSnippet = s) );
+      return ( (TR::X86DataSnippet*) (_dataSnippet = s) );
       }
 
    TR::LabelSymbol *getLabel()                   { return _label; }
@@ -440,7 +440,7 @@ TR::MemoryReference  * generateX86MemoryReference(TR::MemoryReference  &, intptr
 TR::MemoryReference  * generateX86MemoryReference(TR::MemoryReference  &, intptrj_t, TR_ScratchRegisterManager *, TR::CodeGenerator *cg);
 TR::MemoryReference  * generateX86MemoryReference(TR::SymbolReference *, TR::CodeGenerator *cg);
 TR::MemoryReference  * generateX86MemoryReference(TR::SymbolReference *, intptrj_t, TR::CodeGenerator *cg);
-TR::MemoryReference  * generateX86MemoryReference(TR::IA32DataSnippet *, TR::CodeGenerator *cg);
+TR::MemoryReference  * generateX86MemoryReference(TR::X86DataSnippet  *, TR::CodeGenerator *cg);
 TR::MemoryReference  * generateX86MemoryReference(TR::LabelSymbol *, TR::CodeGenerator *cg);
 
 #endif

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -50,7 +50,7 @@
 #include "infra/Assert.hpp"                      // for TR_ASSERT
 #include "infra/List.hpp"                        // for ListIterator, List
 #include "ras/Debug.hpp"                         // for TR_Debug, etc
-#include "x/codegen/DataSnippet.hpp"             // for TR::IA32DataSnippet
+#include "x/codegen/DataSnippet.hpp"             // for TR::X86DataSnippet
 #include "x/codegen/OutlinedInstructions.hpp"
 #include "x/codegen/X86Instruction.hpp"
 #include "x/codegen/X86Ops.hpp"                  // for TR_X86OpCode, etc
@@ -1540,7 +1540,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
       {
       // This must be an absolute memory reference (a constant data snippet or a label)
       //
-      TR::IA32DataSnippet *cds = mr->getDataSnippet();
+      TR::X86DataSnippet *cds = mr->getDataSnippet();
       TR::LabelSymbol *label = NULL;
       if (cds)
          label = cds->getSnippetLabel();

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -583,8 +583,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::integerPairReturnEvaluator(TR::Node
    if (cg->enableSinglePrecisionMethods() &&
        comp->getJittedMethodSymbol()->usesSinglePrecisionMode())
       {
-      TR::IA32ConstantDataSnippet *cds = cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cds, cg), cg);
+      generateMemInstruction(LDCWMem, node, generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, DOUBLE_PRECISION_ROUND_TO_NEAREST), cg), cg);
       }
 
    TR::Node     *firstChild     = node->getFirstChild();


### PR DESCRIPTION
IA32DataSnippet and IA32ConstantDataSnippet are actually shared by both X86-32 and X86-64 CodeGen;
however, the "IA32" in their names is misleading as "IA32" usually means X86-32.
Therefore, they are renamed to X86DataSnippet and X86ConstantDataSnippet respectively.

Closes #2792

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>