### PR TITLE
Change checking opcode to queries on properties

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1541,16 +1541,18 @@ OMR::CodeGenerator::nodeMatches(TR::Node *addr1, TR::Node *addr2, bool addresses
       }
    else if (self()->uniqueAddressOccurrence(addr1, addr2, addressesUnderSameTreeTop))
       {
-      if (addr1->getOpCodeValue() == TR::aload && addr2->getOpCodeValue() == TR::aload &&
+      TR::ILOpCode op1 = addr1->getOpCode();
+      TR::ILOpCode op2 = addr2->getOpCode();
+      if (op1.getOpCodeValue() == op2.getOpCodeValue() &&
+            op1.isLoadVar() && op1.getDataType() == TR::Address &&
                addr1->getSymbolReference() == addr2->getSymbolReference())
          {
-         foundMatch = true;
-         }
-      else if (addr1->getOpCodeValue() == TR::aloadi && addr2->getOpCodeValue() == TR::aloadi &&
-               addr1->getSymbolReference() == addr2->getSymbolReference() &&
-               self()->nodeMatches(addr1->getFirstChild(), addr2->getFirstChild(),addressesUnderSameTreeTop))
-         {
-         foundMatch = true;
+         // aload, ardbar etc
+         if (op1.isLoadDirect())
+            foundMatch = true;
+         // aloadi, ardbari etc
+         else if (op1.isLoadIndirect() && self()->nodeMatches(addr1->getFirstChild(), addr2->getFirstChild(),addressesUnderSameTreeTop))
+            foundMatch = true;
          }
       }
 


### PR DESCRIPTION
It's good practice to query on opcode properties rather than checking
individual opcode value one by one when working on a group of opcodes.
With this change, newly added read barrier opcode is included without
explicitly adding the new opcode value to the checking condition.

This is part of #2812 

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>