### PR TITLE
Fix 'error=class-memaccess' warnings with gcc 8

### DIFF
--- a/ddr/tools/blob_reader/blob_reader.cpp
+++ b/ddr/tools/blob_reader/blob_reader.cpp
@@ -148,6 +148,17 @@ struct Structure {
 	uint32_t size;
 	vector<Field *> fields;
 	vector<Constant *> constants;
+
+	Structure()
+		: name(NULL)
+		, nameLength(0)
+		, superName(NULL)
+		, superNameLength(0)
+		, size(0)
+		, fields()
+		, constants()
+	{
+	}
 };
 
 bool
@@ -293,8 +304,7 @@ main(int argc, char *argv[])
 
 			currentStruct += sizeof(BlobStruct);
 
-			Structure *builtStruct = (Structure *)malloc(sizeof(Structure));
-			memset(builtStruct, 0, sizeof(Structure));
+			Structure *builtStruct = new Structure;
 
 			builtStruct->name = BLOBSTRING_AT(blobStruct->nameOffset)->data;
 			builtStruct->nameLength = BLOBSTRING_AT(blobStruct->nameOffset)->length;
@@ -393,10 +403,10 @@ main(int argc, char *argv[])
 				printf(" Constant name: %.*s\n",
 					   constant->nameLength,
 					   constant->name);
-				printf("  value: %lld\n", (long long unsigned int)constant->value);
+				printf("  value: %llu\n", (long long unsigned int)constant->value);
 				free(constant);
 			}
-			free(builtStruct);
+			delete builtStruct;
 		}
 #undef BLOBSTRING_AT
 	}

--- a/gc/base/standard/ConcurrentSweepScheme.cpp
+++ b/gc/base/standard/ConcurrentSweepScheme.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -722,29 +722,20 @@ MM_ConcurrentSweepScheme::setupForSweep(MM_EnvironmentBase *env)
 void
 MM_ConcurrentSweepScheme::verifyFreeList(MM_EnvironmentStandard *env, MM_HeapLinkedFreeHeader *freeListHead)
 {
-	MM_HeapLinkedFreeHeader *current;
-
-	current = freeListHead;
-	while(NULL != current) {
+	for (MM_HeapLinkedFreeHeader *current = freeListHead; NULL != current; current = current->getNext()) {
 		assume(current < current->afterEnd(), "Free list size overflows");
 		assume( (current->getNext() == NULL) || (current < current->getNext()), "Free list next pointer is lower in memory");
 		assume( (current->getNext() == NULL) || (current->getNext() > current->afterEnd()), "Size is too large (flows into next free entry)");
 
 #if 1
-		{
-			MM_HeapLinkedFreeHeader *tempNext;
-			UDATA tempSize;
-			tempNext = current->getNext();
-			tempSize = current->getSize();
-			
-			memset(current, 0xFA, tempSize);
-			
-			current->setNext(tempNext);
-			current->setSize(tempSize);
-		}
-#endif /* 0 */
-		
-		current = current->getNext();
+		MM_HeapLinkedFreeHeader *tempNext = current->getNext();
+		UDATA tempSize = current->getSize();
+
+		memset((void *)current, 0xFA, tempSize);
+
+		current->setNext(tempNext);
+		current->setSize(tempSize);
+#endif /* 1 */
 	}
 }
 


### PR DESCRIPTION
Address diagnostics of the form:
```
error: 'void* memset(void*, int, size_t)' clearing an object with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
```