### PR TITLE
Remove unused reconnectCache() function

### DIFF
--- a/gc/base/AllocationInterfaceGeneric.cpp
+++ b/gc/base/AllocationInterfaceGeneric.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,14 +117,6 @@ MM_AllocationInterfaceGeneric::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_
  */
 void
 MM_AllocationInterfaceGeneric::flushCache(MM_EnvironmentBase *env)
-{
-}
-
-/**
- * Reconnect the allocation cache.
- */
-void
-MM_AllocationInterfaceGeneric::reconnectCache(MM_EnvironmentBase *env)
 {
 }
 

--- a/gc/base/AllocationInterfaceGeneric.hpp
+++ b/gc/base/AllocationInterfaceGeneric.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,6 @@ public:
 #endif /* OMR_GC_ARRAYLETS */
 
 	virtual void flushCache(MM_EnvironmentBase *env);
-	virtual void reconnectCache(MM_EnvironmentBase *env);
 
 	virtual void enableCachedAllocations(MM_EnvironmentBase* env);
 	virtual void disableCachedAllocations(MM_EnvironmentBase* env);

--- a/gc/base/ObjectAllocationInterface.cpp
+++ b/gc/base/ObjectAllocationInterface.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,20 +58,6 @@ MM_ObjectAllocationInterface::allocateTLH(MM_EnvironmentBase *env, MM_AllocateDe
  */
 void
 MM_ObjectAllocationInterface::flushCache(MM_EnvironmentBase *env)
-{
-	/* Do nothing */
-}
-
-/**
- * Reconnect any cached heap allocation system against the owning Environment.
- * When an Environment has its memory space switched or some configuration in the system changes such that
- * the caching system must re-evaluate how it performs its allocations, this method must be called.  This call
- * implies a flushCache() call as well.
- * 
- * @note The calling environment may not be the owning environment of the receiver.
- */ 
-void
-MM_ObjectAllocationInterface::reconnectCache(MM_EnvironmentBase *env)
 {
 	/* Do nothing */
 }

--- a/gc/base/ObjectAllocationInterface.hpp
+++ b/gc/base/ObjectAllocationInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -128,7 +128,6 @@ public:
 #endif /* OMR_GC_THREAD_LOCAL_HEAP */
 
 	virtual void flushCache(MM_EnvironmentBase *env);
-	virtual void reconnectCache(MM_EnvironmentBase *env);
 	virtual void restartCache(MM_EnvironmentBase *env);
 	
 	virtual void enableCachedAllocations(MM_EnvironmentBase* env) {};

--- a/gc/base/TLHAllocationInterface.cpp
+++ b/gc/base/TLHAllocationInterface.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -299,25 +299,6 @@ MM_TLHAllocationInterface::flushCache(MM_EnvironmentBase *env)
 #if defined(OMR_GC_NON_ZERO_TLH)
 	_tlhAllocationSupportNonZero.flushCache(env);
 #endif /* defined(OMR_GC_NON_ZERO_TLH) */
-}
-
-void
-MM_TLHAllocationInterface::reconnectCache(MM_EnvironmentBase *env)
-{
-	uintptr_t vmState;
-	
-#if defined(OMR_GC_THREAD_LOCAL_HEAP)
-	if (!_owningEnv->isInlineTLHAllocateEnabled()) {
-		/* Only need to reset heapAlloc and realHeapAlloc if there is an existing TLH to reset */
-		_owningEnv->enableInlineTLHAllocate();
-	}	
-#endif /* OMR_GC_THREAD_LOCAL_HEAP */
-	
-	vmState = env->pushVMstate(J9VMSTATE_GC_TLH_RESET);
-
-	reconnect(env, true);
-
-	env->popVMstate(vmState);
 }
 
 void

--- a/gc/base/TLHAllocationInterface.hpp
+++ b/gc/base/TLHAllocationInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,7 +78,6 @@ public:
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *memorySubSpace, MM_MemoryPool *memoryPool);
 
 	virtual void flushCache(MM_EnvironmentBase *env);
-	virtual void reconnectCache(MM_EnvironmentBase *env);
 	virtual void restartCache(MM_EnvironmentBase *env);
 	
 	/* BEN TODO: Collapse the env->enable/disableInlineTLHAllocate with these enable/disableCachedAllocations */

--- a/gc/base/segregated/SegregatedAllocationInterface.cpp
+++ b/gc/base/segregated/SegregatedAllocationInterface.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -269,15 +269,6 @@ MM_SegregatedAllocationInterface::flushCache(MM_EnvironmentBase *env)
 	memset(_allocationCache, 0, sizeof(LanguageSegregatedAllocationCache));
 	env->getExtensions()->allocationStats.merge(&_stats);
 	_stats.clear();
-}
-
-/**
- * Reconnect the allocation cache.
- */
-void
-MM_SegregatedAllocationInterface::reconnectCache(MM_EnvironmentBase *env)
-{
-	
 }
 
 /**

--- a/gc/base/segregated/SegregatedAllocationInterface.hpp
+++ b/gc/base/segregated/SegregatedAllocationInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,6 @@ public:
 #endif /* OMR_GC_ARRAYLETS */
 	
 	virtual void flushCache(MM_EnvironmentBase *env);
-	virtual void reconnectCache(MM_EnvironmentBase *env);
 
 	void restartCache(MM_EnvironmentBase *env);
 	uintptr_t getAllocatableSize(uintptr_t sizeClass) { return (uintptr_t)_allocationCache[sizeClass].top - (uintptr_t)_allocationCache[sizeClass].current; }

--- a/gc/include/omrmodroncore.h
+++ b/gc/include/omrmodroncore.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corp. and others
+ * Copyright (c) 2014, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -100,7 +100,7 @@ typedef U_8 Card;
 #define J9VMSTATE_GC_COLLECTOR_GLOBALGC (J9VMSTATE_GC | 0x0014)
 #define J9VMSTATE_GC_COLLECTOR_SCAVENGER (J9VMSTATE_GC | 0x0015)
 #define J9VMSTATE_GC_ALLOCATE_OBJECT (J9VMSTATE_GC | 0x0019)
-#define J9VMSTATE_GC_TLH_RESET (J9VMSTATE_GC | 0x001D)
+#define J9VMSTATE_GC_THIS_STATE_CAN_BE_REUSED (J9VMSTATE_GC | 0x001D)
 #define J9VMSTATE_GC_CONCURRENT_MARK_COMPLETE_TRACING (J9VMSTATE_GC | 0x001E)
 #define J9VMSTATE_GC_CHECK_RESIZE (J9VMSTATE_GC | 0x0020)
 #define J9VMSTATE_GC_PERFORM_RESIZE (J9VMSTATE_GC | 0x0021)


### PR DESCRIPTION
reconnectCache() is not called and can be removed from Allocation
Interface family

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>