### PR TITLE
AArch64: Add constructors for ARM64AdminInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -711,8 +711,38 @@ class ARM64AdminInstruction : public TR::Instruction
     * @param[in] cg : CodeGenerator
     */
    ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Node *fenceNode,
-                          TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, precedingInstruction, cg), _fenceNode(fenceNode)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] cond : register dependency conditions
+    * @param[in] node : node
+    * @param[in] fenceNode : fence node
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond,
+                         TR::Node *node, TR::Node *fenceNode, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cond, cg), _fenceNode(fenceNode)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] cond : register dependency conditions
+    * @param[in] node : node
+    * @param[in] fenceNode : fence node
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64AdminInstruction(TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond,
+                         TR::Node *node, TR::Node *fenceNode, TR::Instruction *precedingInstruction,
+                         TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cond, precedingInstruction, cg), _fenceNode(fenceNode)
       {
       }
 

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -120,6 +120,14 @@ TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
    return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, node, fenceNode, cg);
    }
 
+TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::RegisterDependencyConditions *cond, TR::Node *fenceNode, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, cond, node, fenceNode, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64AdminInstruction(op, cond, node, fenceNode, cg);
+   }
+
 TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::Register *treg, uint32_t imm, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -232,6 +232,24 @@ TR::Instruction *generateAdminInstruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates admin instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] cond : register dependency condition
+ * @param[in] fenceNode : fence node
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateAdminInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::RegisterDependencyConditions *cond,
+                   TR::Node *fenceNode = NULL,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates imm-to-trg instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/Instruction.hpp
+++ b/compiler/aarch64/codegen/Instruction.hpp
@@ -55,6 +55,31 @@ class OMR_EXTENSIBLE Instruction : public OMR::InstructionConnector
       {
       }
 
+   /**
+    * @brief Constructor
+    * @param[in] op : opcode
+    * @param[in] node : node
+    * @param[in] cond : register dependency conditions
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+               TR::Instruction *precedingInstruction, TR::CodeGenerator *cg) :
+      OMR::InstructionConnector(cg, precedingInstruction, op, cond, node)
+      {}
+
+   /**
+    * @brief Constructor
+    * @param[in] op : opcode
+    * @param[in] node : node
+    * @param[in] cond : register dependency conditions
+    * @param[in] cg : CodeGenerator
+    */
+   Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::RegisterDependencyConditions *cond,
+               TR::CodeGenerator *cg) :
+      OMR::InstructionConnector(cg, op, cond, node)
+      {}
+
    };
 
 } // TR

--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -44,6 +44,22 @@ OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *pre
    }
 
 
+OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node)
+   : OMR::Instruction(cg, op, node),
+     _conditions(cond)
+   {
+   self()->setBlockIndex(cg->getCurrentBlockIndex());
+   }
+
+
+OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node)
+   : OMR::Instruction(cg, precedingInstruction, op, node),
+     _conditions(cond)
+   {
+   self()->setBlockIndex(cg->getCurrentBlockIndex());
+   }
+
+
 void
 OMR::ARM64::Instruction::remove()
    {

--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -71,6 +71,23 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
     * @param[in] node : node
     */
    Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::Node *node = NULL);
+   /**
+    * @brief Constructor
+    * @param[in] cg : CodeGenerator
+    * @param[in] op : opcode
+    * @param[in] cond : register dependency conditions
+    * @param[in] node : node
+    */
+   Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node = NULL);
+   /**
+    * @brief Constructor
+    * @param[in] cg : CodeGenerator
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] op : opcode
+    * @param[in] cond : register dependency conditions
+    * @param[in] node : node
+    */
+   Instruction(TR::CodeGenerator *cg, TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op, TR::RegisterDependencyConditions *cond, TR::Node *node = NULL);
 
    /**
     * @brief Instruction description string


### PR DESCRIPTION
This commit adds constructors with RegisterDependencyConditions for
ARM64AdminInstruction.

Signed-off-by: knn-k <konno@jp.ibm.com>