### PR TITLE
Signal changes [win32/win64amd]

### DIFF
--- a/omrsigcompat/omrsig.cpp
+++ b/omrsigcompat/omrsig.cpp
@@ -95,7 +95,7 @@ validSignalNum(int signum, bool nullAction)
 {
 #if defined(OMR_OS_WINDOWS)
 	return (SIGABRT == signum) || (SIGFPE == signum) || (SIGILL == signum) || (SIGINT == signum)
-		|| (SIGSEGV == signum) || (SIGTERM == signum);
+		|| (SIGSEGV == signum) || (SIGTERM == signum) || (SIGBREAK == signum);
 #elif defined(J9ZOS390)
 	return (signum >= 0) && (signum < NSIG) && (((signum != SIGKILL) && (signum != SIGSTOP)
 		&& (signum != SIGTHCONT) && (signum != SIGTHSTOP)) || nullAction);

--- a/omrsigcompat/omrsig_internal.hpp
+++ b/omrsigcompat/omrsig_internal.hpp
@@ -85,7 +85,30 @@ struct OMR_SigData {
 	sigMutex.unlock();
 
 #if !defined(MSVC_RUNTIME_DLL)
+#if (_MSC_VER == 1200) /* Visual Studio (VS) 6 */
+#define MSVC_RUNTIME_DLL "MSVCR60.dll"
+#elif (_MSC_VER == 1300) /* VS 7 */
+#define MSVC_RUNTIME_DLL "MSVCR70.dll"
+#elif (_MSC_VER == 1310) /* VS 7.1 */
+#define MSVC_RUNTIME_DLL "MSVCR71.dll"
+#elif (_MSC_VER == 1400) /* VS 8 */
+#define MSVC_RUNTIME_DLL "MSVCR80.dll"
+#elif (_MSC_VER == 1500) /* VS 9 */
+#define MSVC_RUNTIME_DLL "MSVCR90.dll"
+#elif (_MSC_VER == 1600) /* VS 10 */
 #define MSVC_RUNTIME_DLL "MSVCR100.dll"
+#elif (_MSC_VER == 1700) /* VS 11 */
+#define MSVC_RUNTIME_DLL "MSVCR110.dll"
+#elif (_MSC_VER == 1800) /* VS 12 */
+#define MSVC_RUNTIME_DLL "MSVCR120.dll"
+#elif (_MSC_VER > 1800) /* VS 14+ */
+#define MSVC_RUNTIME_DLL "UCRTBASE.dll"
+#else /* VS unknown */
+/* This will assure that a user will update MSVC_RUNTIME_DLL
+ * if it is undefined.
+ */
+#error "Unrecognized MSVC_RUNTIME_DLL."
+#endif /* (_MSC_VER >= 1200) */
 #endif /* !defined(MSVC_RUINTIME_DLL) */
 #else /* defined(OMR_OS_WINDOWS) */
 

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -22,7 +22,6 @@
 
 #include <windows.h>
 #include <stdlib.h>
-#include <signal.h>
 
 #include "omrport.h"
 #include "omrthread.h"
@@ -30,6 +29,10 @@
 #include "omrutil.h"
 #include "omrutilbase.h"
 #include "ut_omrport.h"
+
+#if defined(OMRPORT_OMRSIG_SUPPORT)
+#include "omrsig.h"
+#endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
 
 typedef struct J9Win32AsyncHandlerRecord {
 	OMRPortLibrary *portLib;
@@ -118,7 +121,7 @@ static void masterASynchSignalHandler(int osSignalNo);
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
 static int J9THREAD_PROC asynchSignalReporter(void *userData);
-static void runHandlers(uint32_t asyncSignalFlag);
+static void runHandlers(uint32_t asyncSignalFlag, int osSignal);
 #endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
 static int32_t registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t allowedSubsetOfFlags, void **oldOSHandler);
@@ -440,7 +443,7 @@ omrsig_shutdown(struct OMRPortLibrary *portLibrary)
 		/* Register the original signal handlers, which were overwritten. */
 		for (index = 1; index < ARRAY_SIZE_SIGNALS; index++) {
 			if (0 != handlerInfo[index].restore) {
-				signal(index, handlerInfo[index].originalHandler);
+				OMRSIG_SIGNAL(index, handlerInfo[index].originalHandler);
 				/* record that we no longer have a handler installed with the OS for this signal */
 				Trc_PRT_signal_sig_full_shutdown_deregistered_handler_with_OS(portLibrary, index);
 				handlerInfo[index].restore = 0;
@@ -1008,7 +1011,7 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
         return OMRPORT_SIG_ERROR;
     }
 
-    localOldOSHandler = signal(osSignalNo, handler);
+    localOldOSHandler = OMRSIG_SIGNAL(osSignalNo, handler);
     if (SIG_ERR == localOldOSHandler) {
         Trc_PRT_signal_registerSignalHandlerWithOS_failed_to_registerHandler(portLibrarySignalNo, osSignalNo, handler);
         return OMRPORT_SIG_ERROR;
@@ -1137,7 +1140,7 @@ masterASynchSignalHandler(int osSignalNo)
 	/* Signal handler is reset after invocation. So, the signal handler needs to
 	 * be registered again after it is invoked.
 	 */
-	signal(osSignalNo, masterASynchSignalHandler);
+	OMRSIG_SIGNAL(osSignalNo, masterASynchSignalHandler);
 }
 
 #if defined(OMR_PORT_ASYNC_HANDLER)
@@ -1150,7 +1153,7 @@ masterASynchSignalHandler(int osSignalNo)
  * @return void
  */
 static void
-runHandlers(uint32_t asyncSignalFlag)
+runHandlers(uint32_t asyncSignalFlag, int osSignal)
 {
 	J9Win32AsyncHandlerRecord *cursor = NULL;
 
@@ -1173,6 +1176,14 @@ runHandlers(uint32_t asyncSignalFlag)
 		omrthread_monitor_notify_all(asyncMonitor);
 	}
 	omrthread_monitor_exit(asyncMonitor);
+
+#if defined(OMRPORT_OMRSIG_SUPPORT)
+	if (OMR_ARE_NO_BITS_SET(signalOptions, OMRPORT_SIG_OPTIONS_OMRSIG_NO_CHAIN)) {
+		if (OMRPORT_SIG_ERROR != osSignal) {
+			omrsig_handler(osSignal, NULL, NULL);
+		}
+	}
+#endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
 }
 
 /**
@@ -1200,7 +1211,7 @@ asynchSignalReporter(void *userData)
 
 			if (signalCount > 0) {
 				asyncSignalFlag = mapOSSignalToPortLib(osSignal);
-				runHandlers(asyncSignalFlag);
+				runHandlers(asyncSignalFlag, osSignal);
 				subtractAtomic(&signalCounts[osSignal], 1);
 				/* j9sem_wait will fall-through for each j9sem_post. We can handle
 				 * one signal at a time. Ultimately, all signals will be handled


### PR DESCRIPTION
1) **Properly define MSVC_RUNTIME_DLL in omrsig_internal.hpp**

    Added a fail-safe to properly define MSVC_RUNTIME_DLL if build files
    fail to define MSVC_RUNTIME_DLL. The new CMake build files set
    MSVC_RUNTIME_DLL during compilation. But, the old OMR build files don't
    set MSVC_RUNTIME_DLL during compilation. This fail-safe is to support
    the old build files.

    This is identical to the changes in cmake/modules/OmrMsvcRuntime.cmake.

    Closes: #2904

2) **omrsig should support SIGBREAK on Windows**

    SIGBREAK is a valid signal on Windows. So, omrsig.cpp::validSignalNum
    should accept SIGBREAK as a valid signal on Windows.

3) **Enable signal chaining and use omrsig in omrsignal.c [win32/win64amd]**

    a) Calls to signal are replaced with OMRSIG_SIGNAL. OMRSIG_SIGNAL deals
    with caching application signal handler while registering another OS
    signal handler.

    b) omrsig_handler is called from runHandlers to invoke the application
    signal handler after J9Win*AsyncHandlerRecord->handler is invoked.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>