### PR TITLE
Remove unused queries in CodeGen

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -568,11 +568,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm){ return cursor; } // no virt, default, cast
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm){ return cursor; } // no virt, default, cast
 
-   // NOT USED?
-   bool supportsDebugCounters(TR::DebugCounterInjectionPoint injectionPoint){ return injectionPoint == TR::TR_BeforeCodegen; } // no virt, default
-
-   void incrementEventCounter(TR::Node *node, TR::SymbolReference *symRef, TR::CodeGenerator *cg) { TR_ASSERT(0,"not implemented\n");} // no virt, default
-
    // --------------------------------------------------------------------------
    // Linkage
    //

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -450,8 +450,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm);
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm);
 
-   bool supportsDebugCounters(TR::DebugCounterInjectionPoint injectionPoint){ return injectionPoint != TR::TR_AfterRegAlloc; }
-
    int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget) { return 8; } //FIXME
    int32_t arrayTranslateAndTestMinimumNumberOfIterations() { return 8; } //FIXME
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -551,8 +551,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, int32_t delta, TR_ScratchRegisterManager &srm);
    TR::Instruction *generateDebugCounterBump(TR::Instruction *cursor, TR::DebugCounterBase *counter, TR::Register *deltaReg, TR_ScratchRegisterManager &srm);
 
-   bool supportsDebugCounters(TR::DebugCounterInjectionPoint injectionPoint){ return true; }
-
    virtual uint8_t nodeResultGPRCount  (TR::Node *node, TR_RegisterPressureState *state);
 
    virtual TR_BitVector *getGlobalRegisters(TR_SpillKinds kind, TR_LinkageConventions lc){ return &_globalRegisterBitVectors[kind]; }


### PR DESCRIPTION
Following two queries are not used in anywhere, removing them:
    supportsDebugCounters
    incrementEventCounter

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>