### PR TITLE
AArch64: Implement OMRMemoryReference::assignRegisters()

### DIFF
--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -68,6 +68,13 @@ OMR::ARM64::Instruction::remove()
    }
 
 
+void OMR::ARM64::Instruction::ARM64NeedsGCMap(TR::CodeGenerator *cg, uint32_t mask)
+   {
+   if (cg->comp()->useRegisterMaps())
+      self()->setNeedsGCMap(mask);
+   }
+
+
 TR::Register *
 OMR::ARM64::Instruction::getMemoryDataRegister()
    {

--- a/compiler/aarch64/codegen/OMRInstruction.hpp
+++ b/compiler/aarch64/codegen/OMRInstruction.hpp
@@ -171,6 +171,13 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    void setBlockIndex(int32_t i)   { _blockIndex = i; }
 
    /**
+    * @brief Sets GCMap mask
+    * @param[in] cg : CodeGenerator
+    * @param[in] mask : GCMap mask
+    */
+   void ARM64NeedsGCMap(TR::CodeGenerator *cg, uint32_t mask);
+
+   /**
     * @brief Gets the memory data register
     * @return memory data register
     */

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -221,6 +221,47 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       }
 
    /**
+    * @brief Answers if MemoryReference refs specified register
+    * @param[in] reg : register
+    * @return true if MemoryReference refs the register, false otherwise
+    */
+   bool refsRegister(TR::Register *reg)
+      {
+      return (reg == _baseRegister ||
+              reg == _indexRegister);
+      }
+
+   /**
+    * @brief Blocks registers used by MemoryReference
+    */
+   void blockRegisters()
+      {
+      if (_baseRegister != NULL)
+         {
+         _baseRegister->block();
+         }
+      if (_indexRegister != NULL)
+         {
+         _indexRegister->block();
+         }
+      }
+
+   /**
+    * @brief Unblocks registers used by MemoryReference
+    */
+   void unblockRegisters()
+      {
+      if (_baseRegister != NULL)
+         {
+         _baseRegister->unblock();
+         }
+      if (_indexRegister != NULL)
+         {
+         _indexRegister->unblock();
+         }
+      }
+
+   /**
     * @brief Base register is modifiable or not
     * @return true when base register is modifiable
     */
@@ -273,6 +314,13 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
     * @return the symbol reference
     */
    TR::SymbolReference *getSymbolReference() {return _symbolReference;}
+
+   /**
+    * @brief Assigns registers
+    * @param[in] currentInstruction : current instruction
+    * @param[in] cg : CodeGenerator
+    */
+   void assignRegisters(TR::Instruction *currentInstruction, TR::CodeGenerator *cg);
 
    /**
     * @brief Estimates the length of generated binary


### PR DESCRIPTION
This commit implements assignRegisters() in OMRMemoryReference
for aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>