### PR TITLE
Do not skip generation of LA in aiadd evaluator

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7101,19 +7101,7 @@ OMR::Z::TreeEvaluator::aiaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    aiaddMR->populateAddTree(node, cg);
    aiaddMR->eliminateNegativeDisplacement(node, cg);
-
-   // this is partial extract from enforceDisplacementLimit in order to remove the need for the final LA in some cases
-   if (aiaddMR->getOffset() >= MAXLONGDISP && aiaddMR->getOffset() <= TR::getMaxSigned<TR::Int32>() && TR::Compiler->target.is32Bit())
-      {
-      TR::MemoryReference *tempMR = generateS390MemoryReference(aiaddMR->getBaseRegister(), aiaddMR->getIndexRegister(), 0, cg);
-      tempMR->setSymbolReference(aiaddMR->getSymbolReference());
-      generateRXInstruction(cg, TR::InstOpCode::LA, node, targetRegister, tempMR);
-      generateS390ImmOp(cg, TR::InstOpCode::getAddOpCode(), node, targetRegister, targetRegister, (int32_t)aiaddMR->getOffset());
-      }
-   else
-      {
-      aiaddMR->enforceDisplacementLimit(node, cg, NULL);
-      }
+   aiaddMR->enforceDisplacementLimit(node, cg, NULL);
 
    if (node->getOpCodeValue() == TR::aiadd && node->isInternalPointer())
       {
@@ -7143,6 +7131,7 @@ OMR::Z::TreeEvaluator::aiaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          }
       }
 
+   generateRXInstruction(cg, TR::InstOpCode::LA, node, targetRegister, aiaddMR);
    node->setRegister(targetRegister);
 
    return targetRegister;


### PR DESCRIPTION
When evaluating the following tree we currently have a bug where we do
not generate the actual add because the displacement is too large to be
handled by long displacement instructions:

```
aiadd
  aconst 0x784b8500
  iconst 28
```

This is specific to 31-bit. The reason is because we do not generate
the LA instruction to add the 28 to the previous memory reference. This
bug was introduced in commit 564fb25 as part of #2882. In fact the code
that was removed here is actually an optimization on 31-bit that does
not exist for 64-bit but it really should.

This will be addressed in a separate Issue which will be opened as part
of the PR containing this commit.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>