### PR TITLE
Update documents related to C++11 nullptr

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -133,6 +133,7 @@ Variadic templates                              | Some
 static_assert                                   | Yes
 auto                                            | Yes
 decltype                                        | Yes
+nullptr                                         | No
 Delegating constructors                         | No
 Inheriting constructors                         | No
 Extended friend declarations                    | No


### PR DESCRIPTION
nullptr is not supported by g++ 4.4.7, the oldest gcc/g++ that OMR supports.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>