### PR TITLE
Remove incorrect assertion

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -529,7 +529,6 @@ init_threadParam(char *name, uintptr_t *pDefault)
 
 	ASSERT(name);
 	ASSERT(pDefault);
-	ASSERT(0 != *pDefault);
 
 	p = omrthread_global(name);
 	if (NULL == p) {


### PR DESCRIPTION
init_threadParam was asserting that the default value not be 0, which is
incorrect.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>