### PR TITLE
Implement JitBuilder bit-wise type conversion services

### DIFF
--- a/compiler/il/OMRDataTypes.cpp
+++ b/compiler/il/OMRDataTypes.cpp
@@ -203,6 +203,23 @@ OMR::DataType::getDataTypeConversion(TR::DataType t1, TR::DataType t2)
    return OMR::conversionMap[t1][t2];
    }
 
+TR::ILOpCodes
+OMR::DataType::getDataTypeBitConversion(TR::DataType t1, TR::DataType t2)
+   {
+   TR_ASSERT(t1 < TR::NumOMRTypes, "conversion opcode from unexpected datatype %s requested", t1.toString());
+   TR_ASSERT(t2 < TR::NumOMRTypes, "conversion opcode to unexpected datatype %s requested", t2.toString());
+   if (t1 == TR::Int32 && t2 == TR::Float)
+      return TR::ibits2f;
+   else if (t1 == TR::Float && t2 == TR::Int32)
+      return TR::fbits2i;
+   else if (t1 == TR::Int64 && t2 == TR::Double)
+      return TR::lbits2d;
+   else if (t1 == TR::Double && t2 == TR::Int64)
+      return TR::dbits2l;
+   else
+      return TR::BadILOp;
+   }
+
 static int32_t OMRDataTypeSizes[] =
    {
    0,                 // TR::NoType

--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -366,6 +366,8 @@ public:
 
    static TR::ILOpCodes getDataTypeConversion(TR::DataType t1, TR::DataType t2);
 
+   static TR::ILOpCodes getDataTypeBitConversion(TR::DataType t1, TR::DataType t2);
+
    static const char    * getName(TR::DataType dt);
    static int32_t         getSize(TR::DataType dt);
    static void            setSize(TR::DataType dt, int32_t newValue);

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1005,6 +1005,30 @@ OMR::IlBuilder::convertTo(TR::DataType typeTo, TR::IlValue *v, bool needUnsigned
    return convertedValue;
    }
 
+TR::IlValue*
+OMR::IlBuilder::ConvertBitsTo(TR::IlType* t, TR::IlValue* v)
+   {
+   TR::DataType typeFrom = v->getDataType();
+   TR::DataType typeTo = t->getPrimitiveType();
+
+   if (typeTo == typeFrom)
+      {
+      TraceIL("IlBuilder[ %p ]::%d is ConvertBitsTo (already has type %s) %d\n", this, v->getID(), t->getName(), v->getID());
+      return v;
+      }
+
+   TR::ILOpCodes convertOpcode = TR::DataType::getDataTypeBitConversion(typeFrom, typeTo);
+   TR_ASSERT(convertOpcode != TR::BadILOp && TR::DataType::getSize(typeTo) == TR::DataType::getSize(typeFrom),
+             "Builder [ %p ] requested bit conversion for value %d from type of size %d (%s) to type of size %d (%s) (consider using ConvertTo() to for narrowing/widening)",
+             this, v->getID(), TR::DataType::getSize(typeFrom), typeFrom.toString(), TR::DataType::getSize(typeTo), typeTo.toString());
+   TR_ASSERT(convertOpcode != TR::BadILOp, "Builder [ %p ] unknown bit conversion requested for value %d (%s) to type %s", this, v->getID(), typeFrom.toString(), t->getName());
+
+   TR::Node *result = TR::Node::create(convertOpcode, 1, loadValue(v));
+   TR::IlValue *convertedValue = newValue(t, result);
+   TraceIL("IlBuilder[ %p ]::%d is CoerceTo(%s) %d\n", this, convertedValue->getID(), t->getName(), v->getID());
+   return convertedValue;
+   }
+
 TR::IlValue *
 OMR::IlBuilder::unaryOp(TR::ILOpCodes op, TR::IlValue *v)
    {

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -255,6 +255,18 @@ public:
    TR::IlValue *ConvertTo(TR::IlType *t, TR::IlValue *v);
    TR::IlValue *UnsignedConvertTo(TR::IlType *t, TR::IlValue *v);
 
+   /**
+    * @brief Convert the bit representation of an IlValue to a given type
+    * @param type is the target type of the conversion
+    * @param value is the value to be converted
+    * @return the IlValue converted to the specified type
+    *
+    * This service allows the bit representation of a floating-point
+    * IlValue to be converted to an integer IlValue and vice versa.
+    * The floating-point and integer types must be of the same bit-width.
+    */
+   TR::IlValue* ConvertBitsTo(TR::IlType* type, TR::IlValue* value);
+
    // memory
    TR::IlValue *CreateLocalArray(int32_t numElements, TR::IlType *elementType);
    TR::IlValue *CreateLocalStruct(TR::IlType *structType);

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(jitbuildertest
 	SystemLinkageTest.cpp
 	WorklistTest.cpp
 	FieldNameTest.cpp
+	ConvertBitsTest.cpp
 )
 
 if(OMR_HOST_ARCH STREQUAL "x86")

--- a/fvtest/jitbuildertest/ConvertBitsTest.cpp
+++ b/fvtest/jitbuildertest/ConvertBitsTest.cpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+class BitConversionTest : public JitBuilderTest {};
+
+typedef float (BitConvertInt2FloatFunction)(uint32_t);
+
+DEFINE_BUILDER( BitConvertInt2Float,
+                Float,
+                PARAM("p", Int32) )
+   {
+   Return(
+      ConvertBitsTo(Float, Load("p")));
+   return true;
+   }
+
+TEST_F(BitConversionTest, Int2Float)
+   {
+   BitConvertInt2FloatFunction* int2float;
+   ASSERT_COMPILE(TR::TypeDictionary, BitConvertInt2Float, int2float);
+
+   ASSERT_EQ(0.0f, int2float(0));
+   ASSERT_EQ(-1.0f, int2float(0xbf800000U));
+   ASSERT_EQ(3.125f, int2float(0x40480000U));
+   ASSERT_NE(127.0f, int2float(127));
+   }
+
+typedef uint32_t (BitConvertFloat2IntFunction)(float);
+
+DEFINE_BUILDER( BitConvertFloat2Int,
+                Int32,
+                PARAM("p", Float) )
+   {
+   Return(
+      ConvertBitsTo(Int32, Load("p")));
+   return true;
+   }
+
+TEST_F(BitConversionTest, Float2Int)
+   {
+   BitConvertFloat2IntFunction* float2int;
+   ASSERT_COMPILE(TR::TypeDictionary, BitConvertFloat2Int, float2int);
+
+   ASSERT_EQ(0, float2int(0.0f));
+   ASSERT_EQ(0xbf800000U, float2int(-1.0f));
+   ASSERT_EQ(0x40480000U, float2int(3.125f));
+   ASSERT_NE(127, float2int(127.0f));
+   }
+
+typedef double (BitConvertLong2DoubleFunction)(uint64_t);
+
+DEFINE_BUILDER( BitConvertLong2Double,
+                Double,
+                PARAM("p", Int64) )
+   {
+   Return(
+      ConvertBitsTo(Double, Load("p")));
+   return true;
+   }
+
+TEST_F(BitConversionTest, Long2Double)
+   {
+   BitConvertLong2DoubleFunction* long2double;
+   ASSERT_COMPILE(TR::TypeDictionary, BitConvertLong2Double, long2double);
+
+   ASSERT_EQ(0.0, long2double(0));
+   ASSERT_EQ(-1.0, long2double(0xbff0000000000000ULL));
+   ASSERT_EQ(3.125, long2double(0x4009000000000000ULL));
+   ASSERT_NE(2047.0, long2double(2047));
+   }
+
+typedef uint64_t (BitConvertDouble2LongFunction)(double);
+
+DEFINE_BUILDER( BitConvertDouble2Long,
+                Int64,
+                PARAM("p", Double) )
+   {
+   Return(
+      ConvertBitsTo(Int64, Load("p")));
+   return true;
+   }
+
+TEST_F(BitConversionTest, Double2Long)
+   {
+   BitConvertDouble2LongFunction* double2long;
+   ASSERT_COMPILE(TR::TypeDictionary, BitConvertDouble2Long, double2long);
+
+   ASSERT_EQ(0, double2long(0.0));
+   ASSERT_EQ(0xbff0000000000000ULL, double2long(-1.0));
+   ASSERT_EQ(0x4009000000000000ULL, double2long(3.125f));
+   ASSERT_NE(2047, double2long(2047.0f));
+   }

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -36,7 +36,8 @@ OBJECTS := \
 	WorklistTest \
 	IfThenElseTest \
 	CallReturnTest \
-	FieldNameTest
+	FieldNameTest \
+	ConvertBitsTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 


### PR DESCRIPTION
This commit adds the `ConvertBitsTo` service to JitBuilder. It allows an
integer value's bit pattern to be reinterpreted as a floating point
value and vice versa. It maps directly to the following OMR compiler
IL opcodes:

- `ibits2f`
- `fbits2i`
- `lbits2d`
- `dbits2l`

Fixes #2921

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>