### PR TITLE
Update instruction formats and descriptions as defined in PoPs

### DIFF
--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -59,17 +59,13 @@ OMR::Z::InstOpCode::hasBypass()
 uint32_t
 OMR::Z::InstOpCode::isAdmin()
    {
-   return (_mnemonic == DIRECTIVE ||
-           _mnemonic == RET ||
+   return (_mnemonic == RET ||
            _mnemonic == ASSOCREGS ||
            _mnemonic == DEPEND ||
            _mnemonic == FENCE ||
-           _mnemonic == SCHEDFENCE ||
            _mnemonic == PROC ||
            _mnemonic == DC ||
            _mnemonic == DC2 ||
-           _mnemonic == ASM ||
-           _mnemonic == DS ||
            _mnemonic == DCB);
    }
 

--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -143,7 +143,6 @@ OMR::Z::InstOpCode::copyBinaryToBufferWithoutClear(uint8_t *cursor, TR::InstOpCo
      {
      switch (getInstructionFormat(i_opCode))
         {
-        case RIE_FORMAT:
         case RIEa_FORMAT:
         case RIEb_FORMAT:
         case RIEc_FORMAT:
@@ -153,15 +152,12 @@ OMR::Z::InstOpCode::copyBinaryToBufferWithoutClear(uint8_t *cursor, TR::InstOpCo
         case RIEg_FORMAT:
         case RIS_FORMAT:
         case RRS_FORMAT:
-        case RSL_FORMAT:
         case RSLa_FORMAT:
         case RSLb_FORMAT:
-        case RSY_FORMAT:
         case RSYa_FORMAT:
         case RSYb_FORMAT:
         case RXE_FORMAT:
         case RXF_FORMAT:
-        case RXY_FORMAT:
         case RXYa_FORMAT:
         case RXYb_FORMAT:
         case SIY_FORMAT:
@@ -378,9 +374,6 @@ TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getCmpTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGRT : TR::InstOpCode::CRT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpWidenTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGFRT : TR::InstOpCode::CRT; }
-
-TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getCmpImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGFI : TR::InstOpCode::CFI; }
 
 TR::InstOpCode::Mnemonic
@@ -391,9 +384,6 @@ OMR::Z::InstOpCode::getCmpImmBranchRelOpCode() { return TR::Compiler->target.is6
 
 TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getCmpLogicalTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGRT : TR::InstOpCode::CLRT; }
-
-TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalWidenTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGFRT : TR::InstOpCode::CLRT; }
 
 TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getCmpLogicalImmTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGIT : TR::InstOpCode::CLFIT; }

--- a/compiler/z/codegen/OMRInstOpCode.hpp
+++ b/compiler/z/codegen/OMRInstOpCode.hpp
@@ -340,11 +340,9 @@ namespace Z
 #define   I_FORMAT      3
 #define   IE_FORMAT     4
 #define   MII_FORMAT    5
-#define   RI_FORMAT     6  // TODO: This needs to be folded and reblaced by the 3 formats following it
 #define   RIa_FORMAT    7
 #define   RIb_FORMAT    8
 #define   RIc_FORMAT    9
-#define   RIE_FORMAT    10 // TODO: This needs to be folded and reblaced by the 7 formats following it
 #define   RIEa_FORMAT   11
 #define   RIEb_FORMAT   12
 #define   RIEc_FORMAT   13
@@ -352,7 +350,6 @@ namespace Z
 #define   RIEe_FORMAT   15
 #define   RIEf_FORMAT   16
 #define   RIEg_FORMAT   17
-#define   RIL_FORMAT    18 // TODO: This needs to be folded and reblaced by the 3 formats following it
 #define   RILa_FORMAT   19
 #define   RILb_FORMAT   20
 #define   RILc_FORMAT   21
@@ -360,31 +357,23 @@ namespace Z
 #define   RR_FORMAT     23
 #define   RRD_FORMAT    24
 #define   RRE_FORMAT    25
-#define   RRF_FORMAT    26 // TODO: This needs to be folded and reblaced by the 5 formats following it
-#define   RRF2_FORMAT   27 // TODO: This needs to be folded and reblaced by the 5 formats following it
-#define   RRF3_FORMAT   28 // TODO: This needs to be folded and reblaced by the 5 formats following it
 #define   RRFa_FORMAT   29
 #define   RRFb_FORMAT   30
 #define   RRFc_FORMAT   31
 #define   RRFd_FORMAT   32
 #define   RRFe_FORMAT   33
 #define   RRS_FORMAT    34
-#define   RS_FORMAT     35 // TODO: This needs to be folded and reblaced by the 2 formats following it
 #define   RSa_FORMAT    36
 #define   RSb_FORMAT    37
 #define   RSI_FORMAT    38
-#define   RSL_FORMAT    39 // TODO: This needs to be folded and reblaced by the 2 formats following it
 #define   RSLa_FORMAT   40 
 #define   RSLb_FORMAT   41
-#define   RSY_FORMAT    42 // TODO: This needs to be folded and reblaced by the 2 formats following it
 #define   RSYa_FORMAT   43
 #define   RSYb_FORMAT   44
-#define   RX_FORMAT     45 // TODO: This needs to be folded and reblaced by the 2 formats following it
 #define   RXa_FORMAT    46
 #define   RXb_FORMAT    47
 #define   RXE_FORMAT    48
 #define   RXF_FORMAT    49
-#define   RXY_FORMAT    50 // TODO: This needs to be folded and reblaced by the 2 formats following it
 #define   RXYa_FORMAT   51
 #define   RXYb_FORMAT   52
 #define   S_FORMAT      53
@@ -392,8 +381,6 @@ namespace Z
 #define   SIL_FORMAT    55
 #define   SIY_FORMAT    56
 #define   SMI_FORMAT    57
-#define   SS_FORMAT     58 // TODO: This needs to be folded and reblaced by the 6 formats following it
-#define   SS1_FORMAT    59 // TODO: This needs to be folded and reblaced by the 6 formats following it
 #define   SSa_FORMAT    60
 #define   SSb_FORMAT    61
 #define   SSc_FORMAT    62
@@ -782,12 +769,10 @@ class InstOpCode: public OMR::InstOpCode
    static Mnemonic getXORRegOpCode();
    static Mnemonic getXORThreeRegOpCode();
    static Mnemonic getCmpTrapOpCode();
-   static Mnemonic getCmpWidenTrapOpCode();
    static Mnemonic getCmpImmOpCode();
    static Mnemonic getCmpImmTrapOpCode();
    static Mnemonic getCmpImmBranchRelOpCode();
    static Mnemonic getCmpLogicalTrapOpCode();
-   static Mnemonic getCmpLogicalWidenTrapOpCode();
    static Mnemonic getCmpLogicalImmTrapOpCode();
    static Mnemonic getCmpOpCode();
    static Mnemonic getCmpRegOpCode();

--- a/compiler/z/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeEnum.hpp
@@ -26,18 +26,13 @@
 
    /* Pseudo Instructions */
 
-   ASM,                 // ASM WCode Support
    ASSOCREGS,           // Register Association
    BAD,                 // Bad Opcode
    BREAK,               // Breakpoint (debugger)
-   CGFRB,               // Compare and Branch (64-32)
-   CLGFRB,              // Compare Logical And Branch (64-32)
    DC,                  // DC
    DC2,                 // DC2
    DCB,                 // Debug Counter Bump
    DEPEND,              // Someplace to hang dependencies
-   DIRECTIVE,           // WCode DIR related
-   DS,                  // DS
    FENCE,               // Fence
    LABEL,               // Destination of a jump
    LHHR,                // Load (High <- High)
@@ -61,16 +56,11 @@
    RINEXT,              // Runtime Instrumentation Next
    RIOFF,               // Runtime Instrumentation Off
    RION,                // Runtime Instrumentation On
-   SCHEDFENCE,          // Scheduling Fence
    SLLHH,               // Shift Left Logical (High <- High)
    SLLLH,               // Shift Left Logical (Low <- High)
    SRLHH,               // Shift Right Logical (High <- High)
    SRLLH,               // Shift Right Logical (Low <- High)
-   TAILCALL,            // Tail Call
-   TCDT,                // Test Data Class (DFP64)
-   TRIC,                // Test Runtime Instrumentation Controls
    VGNOP,               // ValueGuardNOP
-   WRTBAR,              // Write Barrier
    XHHR,                // Exclusive OR High (High <- High)
    XHLR,                // Exclusive OR High (High <- Low)
    XLHR,                // Exclusive OR High (Low <- High)

--- a/compiler/z/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeEnum.hpp
@@ -52,10 +52,6 @@
    OLHR,                // OR High (Low <- High)
    PROC,                // Entry to the method
    RET,                 // Return
-   RIEMIT,              // Runtime Instrumentation Emit
-   RINEXT,              // Runtime Instrumentation Next
-   RIOFF,               // Runtime Instrumentation Off
-   RION,                // Runtime Instrumentation On
    SLLHH,               // Shift Left Logical (High <- High)
    SLLLH,               // Shift Left Logical (Low <- High)
    SRLHH,               // Shift Right Logical (High <- High)
@@ -958,6 +954,10 @@
    NIAI,                // Next Instruction Access Intent
    NTSTG,               // Nontransactional Store
    PPA,                 // Perform Processor Assist
+   RIEMIT,              // Runtime Instrumentation Emit
+   RINEXT,              // Runtime Instrumentation Next
+   RIOFF,               // Runtime Instrumentation Off
+   RION,                // Runtime Instrumentation On
    RISBGN,              // Rotate Then Insert Selected Bits
    TABORT,              // Transaction Abort
    TBEGIN,              // Transaction Begin

--- a/compiler/z/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeEnum.hpp
@@ -31,18 +31,11 @@
    BAD,                 // Bad Opcode
    BREAK,               // Breakpoint (debugger)
    CGFRB,               // Compare and Branch (64-32)
-   CGFRJ,               // Compare and Branch Relative (64-32)
-   CGFRT,               // Compare and Trap (64-32)
-   CHHRL,               // Compare Halfword Relative Long (16)
    CLGFRB,              // Compare Logical And Branch (64-32)
-   CLGFRJ,              // Compare Logical And Branch Relative (64-32)
-   CLGFRT,              // Compare Logical And Trap (64-32)
-   CLHHRL,              // Compare Logical Relative Long Halfword (16)
    DC,                  // DC
    DC2,                 // DC2
    DCB,                 // Debug Counter Bump
    DEPEND,              // Someplace to hang dependencies
-   DIDTR,               // Divide to Integer (DFP64)
    DIRECTIVE,           // WCode DIR related
    DS,                  // DS
    FENCE,               // Fence
@@ -56,8 +49,6 @@
    LLHHHR,              // Load Logical Halfword (High <- High)
    LLHHLR,              // Load Logical Halfword (High <- low)
    LLHLHR,              // Load Logical Halfword (Low <- High)
-   LRIC,                // Load Runtime Instrumentation Controls
-   MRIC,                // Modify Runtime Instrumentation Controls
    NHHR,                // AND High (High <- High)
    NHLR,                // AND High (High <- Low)
    NLHR,                // AND High (Low <- High)
@@ -75,7 +66,6 @@
    SLLLH,               // Shift Left Logical (Low <- High)
    SRLHH,               // Shift Right Logical (High <- High)
    SRLLH,               // Shift Right Logical (Low <- High)
-   STRIC,               // Store Runtime Instrumentation Controls
    TAILCALL,            // Tail Call
    TCDT,                // Test Data Class (DFP64)
    TRIC,                // Test Runtime Instrumentation Controls
@@ -210,7 +200,6 @@
    DEB,                 // Divide (SB)
    DEBR,                // Divide (SB)
    DER,                 // Divide, Short HFP
-   DIAG,                // Diagnose Macro
    DIDBR,               // Divide to Integer (LB)
    DIEBR,               // Divide to Integer (SB)
    DLGR,                // Divide Logical

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -6228,7 +6228,7 @@
    /* .name        = */ "STCKE",
    /* .description = */ "Store Clock Extended",
    /* .opcode[0]   = */ 0xB2,
-   /* .opcode[1]   = */ 0x05,
+   /* .opcode[1]   = */ 0x78,
    /* .format      = */ S_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
@@ -10624,7 +10624,7 @@
    /* .name        = */ "AGSI",
    /* .description = */ "Add Direct to Memory (64)",
    /* .opcode[0]   = */ 0xEB,
-   /* .opcode[1]   = */ 0x7a,
+   /* .opcode[1]   = */ 0x7A,
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
@@ -10672,7 +10672,7 @@
    /* .name        = */ "ASI",
    /* .description = */ "Add Direct to Memory",
    /* .opcode[0]   = */ 0xEB,
-   /* .opcode[1]   = */ 0x6a,
+   /* .opcode[1]   = */ 0x6A,
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
@@ -11462,7 +11462,7 @@
    /* .name        = */ "PFDRL",
    /* .description = */ "Prefetch Data Relative Long",
    /* .opcode[0]   = */ 0xC6,
-   /* .opcode[1]   = */ 0x00,
+   /* .opcode[1]   = */ 0x02,
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_None
@@ -15307,7 +15307,7 @@
    /* .mnemonic    = */ OMR::InstOpCode::MGRK,
    /* .name        = */ "MGRK",
    /* .description = */ "multiply (128 <- 64)",
-   /* .opcode[0]   = */ 0xE9,
+   /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xEC,
    /* .format      = */ RRF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -5396,7 +5396,8 @@
    /* .opcode[1]   = */ 0x18,
    /* .format      = */ S_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_ImplicitlySetsGPR3 |
+   /* .properties  = */ S390OpProp_BranchOp |
+                        S390OpProp_ImplicitlySetsGPR3 |
                         S390OpProp_ImplicitlySetsGPR4
    },
 
@@ -5456,7 +5457,7 @@
    /* .opcode[1]   = */ 0x01,
    /* .format      = */ E_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_None
+   /* .properties  = */ S390OpProp_BranchOp
    },
 
    {
@@ -5467,7 +5468,7 @@
    /* .opcode[1]   = */ 0x28,
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_None
+   /* .properties  = */ S390OpProp_BranchOp
    },
 
    {
@@ -15556,6 +15557,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
+                        S390OpProp_BranchOp |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_SetsCC
@@ -15583,6 +15585,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
+                        S390OpProp_BranchOp |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_SetsCC

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -10685,6 +10685,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -10724,6 +10728,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -10826,6 +10834,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -10942,6 +10954,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -10981,6 +10997,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -11069,6 +11089,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -11095,6 +11119,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 
@@ -11151,6 +11179,10 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+
+                        // At binary encoding we may determine the branch distance is too large at which point we have
+                        // no choice but to generate a compare and branch instruction pair
+                        S390OpProp_SetsCC |
                         S390OpProp_BranchOp
    },
 

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -83,48 +83,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::CGFRJ,
-   /* .name        = */ "CGFRJ",
-   /* .description = */ "Compare and Branch Relative (64-32)",
-   /* .opcode[0]   = */ 0xEC,
-   /* .opcode[1]   = */ 0x74,
-   /* .format      = */ RIE_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32To64Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_BranchOp
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CGFRT,
-   /* .name        = */ "CGFRT",
-   /* .description = */ "Compare and Trap (64-32)",
-   /* .opcode[0]   = */ 0xB9,
-   /* .opcode[1]   = */ 0x70,
-   /* .format      = */ RRF2_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32To64Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_Trap
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CHHRL,
-   /* .name        = */ "CHHRL",
-   /* .description = */ "Compare Halfword Relative Long (16)",
-   /* .opcode[0]   = */ 0xC6,
-   /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RIL_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_SetsCC |
-                        S390OpProp_SetsCompareFlag |
-                        S390OpProp_IsLoad |
-                        S390OpProp_IsExtendedImmediate
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::CLGFRB,
    /* .name        = */ "CLGFRB",
    /* .description = */ "Compare Logical And Branch (64-32)",
@@ -135,49 +93,6 @@
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
                         S390OpProp_BranchOp
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CLGFRJ,
-   /* .name        = */ "CLGFRJ",
-   /* .description = */ "Compare Logical And Branch Relative (64-32)",
-   /* .opcode[0]   = */ 0xEC,
-   /* .opcode[1]   = */ 0x75,
-   /* .format      = */ RIE_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32To64Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_BranchOp
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CLGFRT,
-   /* .name        = */ "CLGFRT",
-   /* .description = */ "Compare Logical And Trap (64-32)",
-   /* .opcode[0]   = */ 0xB9,
-   /* .opcode[1]   = */ 0x71,
-   /* .format      = */ RRF2_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32To64Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_Trap
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CLHHRL,
-   /* .name        = */ "CLHHRL",
-   /* .description = */ "Compare Logical Relative Long Halfword (16)",
-   /* .opcode[0]   = */ 0xC6,
-   /* .opcode[1]   = */ 0x03,
-   /* .format      = */ RIL_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_SetsCC |
-                        S390OpProp_SetsCompareFlag |
-                        S390OpProp_IsLoad |
-                        S390OpProp_IsExtendedImmediate |
-                        S390OpProp_UsesTarget
    },
 
    {
@@ -226,21 +141,6 @@
    /* .format      = */ PSEUDO,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::DIDTR,
-   /* .name        = */ "DIDTR",
-   /* .description = */ "Divide to Integer (DFP64)",
-   /* .opcode[0]   = */ 0xB4,
-   /* .opcode[1]   = */ 0xC6,
-   /* .format      = */ RRF3_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_DoubleFP |
-                        S390OpProp_Is64Bit |
-                        S390OpProp_SetsCC |
-                        S390OpProp_SetsOverflowFlag |
-                        S390OpProp_SetsOperand3
    },
 
    {
@@ -414,29 +314,6 @@
                         S390OpProp_SrcHW |
                         S390OpProp_IsRegCopy |
                         S390OpProp_SetsOperand1
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::LRIC,
-   /* .name        = */ "LRIC",
-   /* .description = */ "Load Runtime Instrumentation Controls",
-   /* .opcode[0]   = */ 0xEB,
-   /* .opcode[1]   = */ 0x60,
-   /* .format      = */ RSY_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_IsLoad |
-                        S390OpProp_SetsOperand1
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::MRIC,
-   /* .name        = */ "MRIC",
-   /* .description = */ "Modify Runtime Instrumentation Controls",
-   /* .opcode[0]   = */ 0xEB,
-   /* .opcode[1]   = */ 0x62,
-   /* .format      = */ RSY_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_SetsCC
    },
 
    {
@@ -670,18 +547,6 @@
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
                         S390OpProp_SetsOperand1
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::STRIC,
-   /* .name        = */ "STRIC",
-   /* .description = */ "Store Runtime Instrumentation Controls",
-   /* .opcode[0]   = */ 0xEB,
-   /* .opcode[1]   = */ 0x61,
-   /* .format      = */ RSY_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_IsStore |
-                        S390OpProp_SetsCC
    },
 
    {
@@ -2617,19 +2482,6 @@
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
                         S390OpProp_SetsOperand1
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::DIAG,
-   /* .name        = */ "DIAG",
-   /* .description = */ "Diagnose Macro",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_UsesTarget |
-                        S390OpProp_SetsOperand1 |
-                        S390OpProp_SetsOperand2
    },
 
    {

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -6411,8 +6411,7 @@
    /* .opcode[1]   = */ 0x3A,
    /* .format      = */ S_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_SetsCC |
-                        S390OpProp_IsStore |
+   /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_SetsOperand1
    },
 
@@ -10993,8 +10992,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
-                        S390OpProp_BranchOp |
-                        S390OpProp_SetsCC
+                        S390OpProp_BranchOp
    },
 
    {
@@ -11033,8 +11031,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
-                        S390OpProp_BranchOp |
-                        S390OpProp_SetsCC
+                        S390OpProp_BranchOp
    },
 
    {
@@ -11136,8 +11133,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
-                        S390OpProp_BranchOp |
-                        S390OpProp_SetsCC
+                        S390OpProp_BranchOp
    },
 
    {
@@ -11462,8 +11458,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
-                        S390OpProp_BranchOp |
-                        S390OpProp_SetsCC
+                        S390OpProp_BranchOp
    },
 
    {

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -26,17 +26,6 @@
 
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::ASM,
-   /* .name        = */ "ASM",
-   /* .description = */ "ASM WCode Support",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ PSEUDO,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_None
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::ASSOCREGS,
    /* .name        = */ "ASSOCREGS",
    /* .description = */ "Register Association",
@@ -67,32 +56,6 @@
    /* .format      = */ E_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CGFRB,
-   /* .name        = */ "CGFRB",
-   /* .description = */ "Compare and Branch (64-32)",
-   /* .opcode[0]   = */ 0xEC,
-   /* .opcode[1]   = */ 0xF4,
-   /* .format      = */ RRS_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32To64Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_BranchOp
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::CLGFRB,
-   /* .name        = */ "CLGFRB",
-   /* .description = */ "Compare Logical And Branch (64-32)",
-   /* .opcode[0]   = */ 0xEC,
-   /* .opcode[1]   = */ 0xF5,
-   /* .format      = */ RRS_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_Is32To64Bit |
-                        S390OpProp_IsCompare |
-                        S390OpProp_BranchOp
    },
 
    {
@@ -136,28 +99,6 @@
    /* .mnemonic    = */ OMR::InstOpCode::DEPEND,
    /* .name        = */ "DEPEND",
    /* .description = */ "Someplace to hang dependencies",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ PSEUDO,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_None
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::DIRECTIVE,
-   /* .name        = */ "DIRECTIVE",
-   /* .description = */ "WCode DIR related",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ PSEUDO,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_None
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::DS,
-   /* .name        = */ "DS",
-   /* .description = */ "DS",
    /* .opcode[0]   = */ 0x00,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ PSEUDO,
@@ -481,17 +422,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::SCHEDFENCE,
-   /* .name        = */ "SCHEDFENCE",
-   /* .description = */ "Scheduling Fence",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ PSEUDO,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_None
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::SLLHH,
    /* .name        = */ "SLLHH",
    /* .description = */ "Shift Left Logical (High <- High)",
@@ -550,57 +480,11 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::TAILCALL,
-   /* .name        = */ "TAILCALL",
-   /* .description = */ "Tail Call",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ PSEUDO,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_IsCall
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::TCDT,
-   /* .name        = */ "TCDT",
-   /* .description = */ "Test Data Class (DFP64)",
-   /* .opcode[0]   = */ 0xED,
-   /* .opcode[1]   = */ 0x54,
-   /* .format      = */ RXE_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_DoubleFP |
-                        S390OpProp_Is64Bit |
-                        S390OpProp_SetsCC
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::TRIC,
-   /* .name        = */ "TRIC",
-   /* .description = */ "TEST RUNTIME INSTRUMENTATION CONTROLS",
-   /* .opcode[0]   = */ 0xAA,
-   /* .opcode[1]   = */ 0x02,
-   /* .format      = */ RIa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_SetsCC
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::VGNOP,
    /* .name        = */ "VGNOP",
    /* .description = */ "ValueGuardNOP",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ PSEUDO,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_None
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::WRTBAR,
-   /* .name        = */ "WRTBAR",
-   /* .description = */ "Write Barrier",
-   /* .opcode[0]   = */ 0x00,
-   /* .opcode[1]   = */ 0x00,
    /* .format      = */ PSEUDO,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -118,6 +118,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate
@@ -172,6 +173,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -208,7 +210,8 @@
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ PSEUDO,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_SetsSignFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore
@@ -235,6 +238,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand3
    },
@@ -447,6 +451,7 @@
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -462,6 +467,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -477,6 +483,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -493,6 +500,7 @@
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -508,6 +516,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -523,6 +532,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -743,6 +753,7 @@
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -758,6 +769,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -773,6 +785,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SrcHW |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -797,6 +810,7 @@
    /* .format      = */ RX_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -815,6 +829,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -830,6 +845,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -845,6 +861,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -859,6 +876,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -873,6 +891,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -888,6 +907,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -903,6 +923,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -917,6 +938,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -930,6 +952,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -945,6 +968,7 @@
    /* .format      = */ RI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -961,6 +985,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -976,6 +1001,7 @@
    /* .format      = */ RX_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -994,6 +1020,7 @@
    /* .format      = */ RI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -1010,6 +1037,7 @@
    /* .format      = */ RX_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -1026,6 +1054,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_ReadsCC |
@@ -1041,6 +1070,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_ReadsCC |
@@ -1056,6 +1086,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_SetsOperand1
@@ -1070,6 +1101,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_SetsOperand1
@@ -1084,6 +1116,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_SetsOperand1
@@ -1097,7 +1130,8 @@
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_SetsOverflowFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -1115,6 +1149,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -1131,6 +1166,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -1146,6 +1182,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -1160,6 +1197,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -1175,6 +1213,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -1190,6 +1229,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1208,6 +1248,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -1547,6 +1588,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -1562,6 +1604,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -1576,6 +1619,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -1590,6 +1634,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -1653,6 +1698,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -1666,6 +1712,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -1688,6 +1735,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -1702,6 +1750,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -1716,6 +1765,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -1778,6 +1828,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -1790,6 +1841,7 @@
    /* .format      = */ S_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_ImplicitlyUsesGPR1 |
@@ -1805,6 +1857,7 @@
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1821,6 +1874,7 @@
    /* .format      = */ RRF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1836,6 +1890,7 @@
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1852,6 +1907,7 @@
    /* .format      = */ RRF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1868,6 +1924,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesRegPairForSource |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1884,6 +1941,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesRegPairForSource |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1898,7 +1956,8 @@
    /* .opcode[1]   = */ 0xA9,
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_SetsZeroFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_Is64Bit |
@@ -1914,6 +1973,7 @@
    /* .format      = */ RRF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1928,7 +1988,8 @@
    /* .opcode[1]   = */ 0xA8,
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_SetsZeroFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_Is64Bit |
@@ -1944,6 +2005,7 @@
    /* .format      = */ RRF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -1960,6 +2022,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesTarget
    },
@@ -1974,6 +2037,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -1987,6 +2051,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesTarget
    },
@@ -2001,6 +2066,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesRegPairForSource |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -2017,6 +2083,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesRegPairForSource |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -2033,6 +2100,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -2048,6 +2116,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -2075,6 +2144,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -2090,6 +2160,7 @@
    /* .format      = */ SS1_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_HasTwoMemoryReferences
@@ -2104,6 +2175,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_UsesRegPairForTarget |
@@ -2122,6 +2194,7 @@
    /* .format      = */ RS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_UsesRegPairForTarget |
@@ -2141,6 +2214,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesTarget
    },
@@ -2155,6 +2229,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesTarget
    },
@@ -2168,6 +2243,7 @@
    /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -2183,6 +2259,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -2198,6 +2275,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesTarget
    },
@@ -2227,6 +2305,7 @@
    /* .format      = */ SS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_HasTwoMemoryReferences
@@ -2253,6 +2332,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesTarget
    },
@@ -2267,6 +2347,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -2343,6 +2424,7 @@
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -2410,6 +2492,7 @@
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -3169,6 +3252,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3182,6 +3266,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3195,6 +3280,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3208,6 +3294,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3221,6 +3308,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -3235,6 +3323,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -3249,6 +3338,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -3275,6 +3365,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
@@ -3292,6 +3383,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3650,6 +3742,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3663,6 +3756,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3676,6 +3770,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3689,6 +3784,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3717,6 +3813,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3730,6 +3827,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3743,6 +3841,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
@@ -3760,6 +3859,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3773,6 +3873,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3786,6 +3887,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3799,6 +3901,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3812,6 +3915,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3825,6 +3929,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -3839,6 +3944,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -3853,6 +3959,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -3892,6 +3999,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
@@ -3909,6 +4017,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3973,6 +4082,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -3987,6 +4097,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_SetsOperand1
    },
@@ -4000,6 +4111,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -4014,6 +4126,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_SetsOperand1
    },
@@ -4027,6 +4140,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsRegCopy |
                         S390OpProp_SetsOperand1
@@ -4041,6 +4155,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsRegCopy |
                         S390OpProp_SetsOperand1
@@ -4055,6 +4170,7 @@
    /* .format      = */ RR_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsRegCopy |
                         S390OpProp_SetsOperand1
@@ -4071,6 +4187,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsRegCopy |
+                        S390OpProp_SetsCC |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_SetsOperand1
@@ -4088,6 +4205,7 @@
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_SetsOperand1
    },
@@ -4974,6 +5092,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -4989,6 +5108,7 @@
    /* .format      = */ SS1_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -5006,6 +5126,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5019,6 +5140,7 @@
    /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsStore |
                         S390OpProp_IsLoad |
@@ -5101,6 +5223,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5115,6 +5238,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -5130,6 +5254,7 @@
    /* .format      = */ SS1_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -5147,6 +5272,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5160,6 +5286,7 @@
    /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsStore |
                         S390OpProp_IsLoad |
@@ -5231,6 +5358,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5376,6 +5504,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -5495,6 +5624,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -5510,6 +5640,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -5525,6 +5656,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5539,6 +5671,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5553,6 +5686,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -5568,6 +5702,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_SetsOperand1
@@ -5583,6 +5718,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5597,6 +5733,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5623,6 +5760,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -5638,6 +5776,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -5653,6 +5792,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -5669,6 +5809,7 @@
    /* .format      = */ RS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsOperand1
    },
 
@@ -5682,6 +5823,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -5698,6 +5840,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -5713,6 +5856,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_ReadsCC |
                         S390OpProp_SetsOperand1
@@ -5728,6 +5872,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_ReadsCC |
                         S390OpProp_SetsOperand1
@@ -5742,6 +5887,7 @@
    /* .format      = */ RS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesRegPairForTarget |
@@ -5771,6 +5917,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5785,6 +5932,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5812,6 +5960,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -5824,7 +5973,8 @@
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_SetsOverflowFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -6010,6 +6160,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -6025,6 +6176,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6038,6 +6190,7 @@
    /* .format      = */ RS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_SetsOperand1
@@ -6477,6 +6630,7 @@
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6491,6 +6645,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6517,6 +6672,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6531,6 +6687,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6546,6 +6703,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -6562,6 +6720,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6574,7 +6733,7 @@
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ E_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_None
+   /* .properties  = */ S390OpProp_SetsCC
    },
 
    {
@@ -6950,6 +7109,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -6965,6 +7125,7 @@
    /* .format      = */ SS1_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -6982,6 +7143,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -6995,6 +7157,7 @@
    /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7012,6 +7175,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -7024,7 +7188,8 @@
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SS_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
-   /* .properties  = */ S390OpProp_SetsOverflowFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7041,6 +7206,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -7058,6 +7224,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -7075,6 +7242,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -7093,6 +7261,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -7110,6 +7279,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -7127,6 +7297,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -7143,6 +7314,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -7159,6 +7331,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -7175,6 +7348,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -7240,6 +7414,7 @@
    /* .format      = */ RSY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7262,6 +7437,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7284,6 +7460,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7299,6 +7476,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7314,6 +7492,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7328,6 +7507,7 @@
    /* .format      = */ RSY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_UsesRegPairForTarget |
@@ -7347,6 +7527,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7362,6 +7543,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7376,6 +7558,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7391,6 +7574,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7407,6 +7591,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -7422,6 +7607,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7438,6 +7624,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7458,6 +7645,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7530,6 +7718,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -8270,6 +8459,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8285,6 +8475,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsStore |
                         S390OpProp_IsLoad |
@@ -8302,6 +8493,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8318,6 +8510,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8333,6 +8526,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsStore |
                         S390OpProp_IsLoad |
@@ -8350,6 +8544,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8392,6 +8587,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -8409,6 +8605,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -8426,6 +8623,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -8442,6 +8640,7 @@
    /* .format      = */ RSY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_LongDispSupported |
@@ -8458,6 +8657,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8475,6 +8675,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8492,6 +8693,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8508,6 +8710,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8537,6 +8740,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8552,6 +8756,7 @@
    /* .format      = */ RSY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -8811,6 +9016,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -8841,6 +9047,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8856,6 +9063,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -8873,6 +9081,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -8889,6 +9098,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -8902,6 +9112,7 @@
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -8918,6 +9129,7 @@
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -8934,6 +9146,7 @@
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsExtendedImmediate |
@@ -8949,6 +9162,7 @@
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsExtendedImmediate |
@@ -8965,6 +9179,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
@@ -9008,6 +9223,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_SetsOperand1
    },
@@ -9036,6 +9252,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -9050,6 +9267,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_UsesRegPairForSource
@@ -9065,6 +9283,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsExtendedImmediate
    },
@@ -9079,6 +9298,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -9095,6 +9315,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsExtendedImmediate
    },
@@ -9109,6 +9330,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -9126,6 +9348,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_UsesTarget
@@ -9141,6 +9364,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_UsesTarget
@@ -9348,6 +9572,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget
@@ -9557,6 +9782,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag
    },
 
@@ -9571,6 +9797,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget
@@ -9858,6 +10085,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -9873,6 +10101,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_IsRegCopy |
                         S390OpProp_SetsOperand1
    },
@@ -9887,6 +10116,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -9903,6 +10133,7 @@
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
                         S390OpProp_IsRegCopy |
+                        S390OpProp_SetsCC |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
                         S390OpProp_SetsOperand1
@@ -10249,6 +10480,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOperand1
    },
@@ -10288,6 +10520,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_SetsOperand1
@@ -10303,6 +10536,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_SetsOperand1
@@ -10413,6 +10647,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
@@ -10628,6 +10863,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -10644,6 +10880,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -10660,6 +10897,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -10676,6 +10914,7 @@
    /* .format      = */ SIY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsLoad |
@@ -10693,6 +10932,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -10709,6 +10949,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate
@@ -10724,6 +10965,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -10805,6 +11047,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -10834,6 +11077,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -10848,6 +11092,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate
@@ -10863,6 +11108,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -10917,6 +11163,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -10944,6 +11191,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -10960,6 +11208,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -10976,6 +11225,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -11055,6 +11305,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -11084,6 +11335,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad
    },
@@ -11098,6 +11350,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -11166,6 +11419,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -11222,6 +11476,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_IsExtendedImmediate |
@@ -11338,6 +11593,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32To64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -11492,6 +11748,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -11506,6 +11763,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -11520,6 +11778,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -11590,6 +11849,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsExtendedImmediate |
@@ -11605,6 +11865,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -11618,7 +11879,8 @@
    /* .opcode[1]   = */ 0xC8,
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
-   /* .properties  = */ S390OpProp_SetsSignFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -11635,7 +11897,8 @@
    /* .opcode[1]   = */ 0xD8,
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
-   /* .properties  = */ S390OpProp_SetsSignFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -11652,6 +11915,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_IsExtendedImmediate |
@@ -11666,7 +11930,8 @@
    /* .opcode[1]   = */ 0x08,
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
-   /* .properties  = */ S390OpProp_SetsSignFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
@@ -11683,6 +11948,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_SetsOperand1
@@ -11697,6 +11963,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -11709,7 +11976,8 @@
    /* .opcode[1]   = */ 0xCA,
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
-   /* .properties  = */ S390OpProp_SetsZeroFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
@@ -11725,7 +11993,8 @@
    /* .opcode[1]   = */ 0xDA,
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
-   /* .properties  = */ S390OpProp_SetsZeroFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
@@ -11741,6 +12010,7 @@
    /* .format      = */ RIE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_SetsOperand1
@@ -11755,6 +12025,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -11767,7 +12038,8 @@
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
-   /* .properties  = */ S390OpProp_SetsZeroFlag |
+   /* .properties  = */ S390OpProp_SetsCC |
+                        S390OpProp_SetsZeroFlag |
                         S390OpProp_UsesTarget |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_TargetHW |
@@ -11797,6 +12069,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -11877,6 +12150,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -11892,6 +12166,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW
@@ -11906,6 +12181,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_TargetHW
    },
@@ -11919,6 +12195,7 @@
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_TargetHW
@@ -11933,6 +12210,7 @@
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -11949,6 +12227,7 @@
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -11966,6 +12245,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesRegPairForSource |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -11981,6 +12261,7 @@
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -11997,6 +12278,7 @@
    /* .format      = */ RRF2_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SingleFP |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -12014,6 +12296,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesRegPairForSource |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
@@ -12029,6 +12312,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -12044,6 +12328,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW
@@ -12058,6 +12343,7 @@
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_TargetHW
    },
@@ -12071,6 +12357,7 @@
    /* .format      = */ RIL_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsCompareFlag |
                         S390OpProp_IsExtendedImmediate |
                         S390OpProp_TargetHW
@@ -12165,6 +12452,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_LongDispSupported |
@@ -12183,6 +12471,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_LongDispSupported |
@@ -12200,6 +12489,7 @@
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12216,6 +12506,7 @@
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12233,6 +12524,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12250,6 +12542,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12267,6 +12560,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12284,6 +12578,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12301,6 +12596,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12318,6 +12614,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_IsStore |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12494,6 +12791,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12507,6 +12805,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12520,6 +12819,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12533,6 +12833,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12547,6 +12848,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12589,6 +12891,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -12605,6 +12908,7 @@
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -12621,6 +12925,7 @@
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -12635,6 +12940,7 @@
    /* .format      = */ RSY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_LongDispSupported |
@@ -12650,6 +12956,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12665,6 +12972,7 @@
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
                         S390OpProp_SrcHW |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12679,6 +12987,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_TargetHW |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12705,6 +13014,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12718,6 +13028,7 @@
    /* .format      = */ RSY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -12732,6 +13043,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsOperand1
@@ -12826,6 +13138,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12839,6 +13152,7 @@
    /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
@@ -12934,6 +13248,7 @@
                         S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
                         S390OpProp_SetsOperand2 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag
    },
 
@@ -12949,6 +13264,7 @@
                         S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
                         S390OpProp_SetsOperand2 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForTarget
    },
@@ -13160,6 +13476,7 @@
                         S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
                         S390OpProp_SetsOperand2 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag
    },
 
@@ -13175,6 +13492,7 @@
                         S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
                         S390OpProp_SetsOperand2 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_UsesRegPairForTarget
    },
@@ -13333,7 +13651,7 @@
    /* .opcode[1]   = */ 0x3C,
    /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
-   /* .properties  = */ S390OpProp_None
+   /* .properties  = */ S390OpProp_SetsCC
    },
 
    {
@@ -15198,6 +15516,7 @@
    /* .format      = */ RXY_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is64Bit |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_UsesTarget |
@@ -15328,6 +15647,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsCC
    },
@@ -15345,6 +15665,7 @@
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsCC
    },
@@ -15373,6 +15694,7 @@
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsOperand3 |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsCC
    },
@@ -15389,6 +15711,7 @@
                         S390OpProp_SetsOperand1 |
                         S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
+                        S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
                         S390OpProp_SetsCC
    },

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -562,10 +562,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RIEMIT,
    /* .name        = */ "RIEMIT",
-   /* .description = */ "Runtime Instrumentation Emit",
+   /* .description = */ "RUNTIME INSTRUMENTATION EMIT",
    /* .opcode[0]   = */ 0xAA,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_UsesTarget
    },
@@ -573,10 +573,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RINEXT,
    /* .name        = */ "RINEXT",
-   /* .description = */ "Runtime Instrumentation Next",
+   /* .description = */ "RUNTIME INSTRUMENTATION NEXT",
    /* .opcode[0]   = */ 0xAA,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None
    },
@@ -584,10 +584,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RIOFF,
    /* .name        = */ "RIOFF",
-   /* .description = */ "Runtime Instrumentation Off",
+   /* .description = */ "RUNTIME INSTRUMENTATION OFF",
    /* .opcode[0]   = */ 0xAA,
    /* .opcode[1]   = */ 0x03,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -595,10 +595,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RION,
    /* .name        = */ "RION",
-   /* .description = */ "Runtime Instrumentation On",
+   /* .description = */ "RUNTIME INSTRUMENTATION ON",
    /* .opcode[0]   = */ 0xAA,
    /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -711,10 +711,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRIC,
    /* .name        = */ "TRIC",
-   /* .description = */ "Test Runtime Instrumentation Controls",
+   /* .description = */ "TEST RUNTIME INSTRUMENTATION CONTROLS",
    /* .opcode[0]   = */ 0xAA,
    /* .opcode[1]   = */ 0x02,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -804,10 +804,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::A,
    /* .name        = */ "A",
-   /* .description = */ "Add",
+   /* .description = */ "ADD (32)",
    /* .opcode[0]   = */ 0x5A,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -822,10 +822,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AD,
    /* .name        = */ "AD",
-   /* .description = */ "Add Normalized, Long",
+   /* .description = */ "ADD NORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x6A,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -838,7 +838,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ADB,
    /* .name        = */ "ADB",
-   /* .description = */ "Add (LB)",
+   /* .description = */ "ADD (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x1A,
    /* .format      = */ RXE_FORMAT,
@@ -854,7 +854,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ADBR,
    /* .name        = */ "ADBR",
-   /* .description = */ "Add (LB)",
+   /* .description = */ "ADD (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x1A,
    /* .format      = */ RRE_FORMAT,
@@ -869,7 +869,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ADR,
    /* .name        = */ "ADR",
-   /* .description = */ "Add Normalized, Long",
+   /* .description = */ "ADD NORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x2A,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -884,10 +884,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AE,
    /* .name        = */ "AE",
-   /* .description = */ "Add Normalized, Short",
+   /* .description = */ "ADD NORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x7A,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -900,7 +900,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AEB,
    /* .name        = */ "AEB",
-   /* .description = */ "Add (SB)",
+   /* .description = */ "ADD (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ RXE_FORMAT,
@@ -916,7 +916,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AEBR,
    /* .name        = */ "AEBR",
-   /* .description = */ "Add (SB)",
+   /* .description = */ "ADD (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ RRE_FORMAT,
@@ -931,7 +931,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AER,
    /* .name        = */ "AER",
-   /* .description = */ "Add Normalized, Short",
+   /* .description = */ "ADD NORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x3A,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -946,7 +946,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGFR,
    /* .name        = */ "AGFR",
-   /* .description = */ "Add (64 < 32)",
+   /* .description = */ "ADD (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x18,
    /* .format      = */ RRE_FORMAT,
@@ -962,10 +962,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGHI,
    /* .name        = */ "AGHI",
-   /* .description = */ "Add Halfword Immediate",
+   /* .description = */ "ADD HALFWORD IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -979,7 +979,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGR,
    /* .name        = */ "AGR",
-   /* .description = */ "Add (64)",
+   /* .description = */ "ADD (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x08,
    /* .format      = */ RRE_FORMAT,
@@ -995,10 +995,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AH,
    /* .name        = */ "AH",
-   /* .description = */ "Add Halfword",
+   /* .description = */ "ADD HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0x4A,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -1014,10 +1014,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AHI,
    /* .name        = */ "AHI",
-   /* .description = */ "Add Halfword Immediate",
+   /* .description = */ "ADD HALFWORD IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -1031,10 +1031,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AL,
    /* .name        = */ "AL",
-   /* .description = */ "Add Logical",
+   /* .description = */ "ADD LOGICAL (32)",
    /* .opcode[0]   = */ 0x5E,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -1048,7 +1048,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALCGR,
    /* .name        = */ "ALCGR",
-   /* .description = */ "Add Logical with Carry (64)",
+   /* .description = */ "ADD LOGICAL WITH CARRY (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x88,
    /* .format      = */ RRE_FORMAT,
@@ -1064,7 +1064,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALCR,
    /* .name        = */ "ALCR",
-   /* .description = */ "Add Logical with Carry (32)",
+   /* .description = */ "ADD LOGICAL WITH CARRY (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x98,
    /* .format      = */ RRE_FORMAT,
@@ -1080,7 +1080,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGFR,
    /* .name        = */ "ALGFR",
-   /* .description = */ "Add Logical (64 < 32)",
+   /* .description = */ "ADD LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x1A,
    /* .format      = */ RRE_FORMAT,
@@ -1095,7 +1095,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGR,
    /* .name        = */ "ALGR",
-   /* .description = */ "Add Logical (64)",
+   /* .description = */ "ADD LOGICAL (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ RRE_FORMAT,
@@ -1110,7 +1110,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALR,
    /* .name        = */ "ALR",
-   /* .description = */ "Add Logical (32)",
+   /* .description = */ "ADD LOGICAL (32)",
    /* .opcode[0]   = */ 0x1E,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1125,10 +1125,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AP,
    /* .name        = */ "AP",
-   /* .description = */ "Add Decimal",
+   /* .description = */ "ADD DECIMAL",
    /* .opcode[0]   = */ 0xFA,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
@@ -1143,7 +1143,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AR,
    /* .name        = */ "AR",
-   /* .description = */ "Add (32)",
+   /* .description = */ "ADD (32)",
    /* .opcode[0]   = */ 0x1A,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1159,10 +1159,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AU,
    /* .name        = */ "AU",
-   /* .description = */ "Add Unnormalized, Short",
+   /* .description = */ "ADD UNNORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x7E,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -1175,7 +1175,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AUR,
    /* .name        = */ "AUR",
-   /* .description = */ "Add Unnormalized, Short",
+   /* .description = */ "ADD UNNORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x3E,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1190,10 +1190,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AW,
    /* .name        = */ "AW",
-   /* .description = */ "Add Unnormalized, Long",
+   /* .description = */ "ADD UNNORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x6E,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -1206,7 +1206,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AWR,
    /* .name        = */ "AWR",
-   /* .description = */ "Add Unnormalized, Long",
+   /* .description = */ "ADD UNNORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x2E,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1221,7 +1221,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AXBR,
    /* .name        = */ "AXBR",
-   /* .description = */ "Add (EB)",
+   /* .description = */ "ADD (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x4A,
    /* .format      = */ RRE_FORMAT,
@@ -1240,7 +1240,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AXR,
    /* .name        = */ "AXR",
-   /* .description = */ "Add Normalized, Extended",
+   /* .description = */ "ADD NORMALIZED (extended HFP)",
    /* .opcode[0]   = */ 0x36,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1257,7 +1257,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BAKR,
    /* .name        = */ "BAKR",
-   /* .description = */ "Branch and Stack",
+   /* .description = */ "BRANCH AND STACK",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x40,
    /* .format      = */ RRE_FORMAT,
@@ -1269,10 +1269,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BAL,
    /* .name        = */ "BAL",
-   /* .description = */ "Branch and Link",
+   /* .description = */ "BRANCH AND LINK",
    /* .opcode[0]   = */ 0x45,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_IsCall |
@@ -1283,7 +1283,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BALR,
    /* .name        = */ "BALR",
-   /* .description = */ "Branch and Link",
+   /* .description = */ "BRANCH AND LINK",
    /* .opcode[0]   = */ 0x05,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1296,10 +1296,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BAS,
    /* .name        = */ "BAS",
-   /* .description = */ "Branch and Save",
+   /* .description = */ "BRANCH AND SAVE",
    /* .opcode[0]   = */ 0x4D,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_IsCall |
@@ -1310,7 +1310,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BASR,
    /* .name        = */ "BASR",
-   /* .description = */ "Branch and Save",
+   /* .description = */ "BRANCH AND SAVE",
    /* .opcode[0]   = */ 0x0D,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1323,7 +1323,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BASSM,
    /* .name        = */ "BASSM",
-   /* .description = */ "Branch and Save and Set Mode",
+   /* .description = */ "BRANCH AND SAVE AND SET MODE",
    /* .opcode[0]   = */ 0x0C,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1336,10 +1336,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BC,
    /* .name        = */ "BC",
-   /* .description = */ "Branch on Cond.",
+   /* .description = */ "BRANCH ON CONDITION",
    /* .opcode[0]   = */ 0x47,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_ReadsCC |
@@ -1349,7 +1349,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BCR,
    /* .name        = */ "BCR",
-   /* .description = */ "Branch on Cond.",
+   /* .description = */ "BRANCH ON CONDITION",
    /* .opcode[0]   = */ 0x07,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1361,10 +1361,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BCT,
    /* .name        = */ "BCT",
-   /* .description = */ "Branch on Count (32)",
+   /* .description = */ "BRANCH ON COUNT (32)",
    /* .opcode[0]   = */ 0x46,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is32Bit |
@@ -1376,7 +1376,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BCTGR,
    /* .name        = */ "BCTGR",
-   /* .description = */ "Branch on Count (64)",
+   /* .description = */ "BRANCH ON COUNT (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x46,
    /* .format      = */ RRE_FORMAT,
@@ -1390,7 +1390,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BCTR,
    /* .name        = */ "BCTR",
-   /* .description = */ "Branch on Count (32)",
+   /* .description = */ "BRANCH ON COUNT (32)",
    /* .opcode[0]   = */ 0x06,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1404,10 +1404,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRAS,
    /* .name        = */ "BRAS",
-   /* .description = */ "Branch and Save",
+   /* .description = */ "BRANCH RELATIVE AND SAVE",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x05,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_IsCall |
@@ -1417,10 +1417,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRASL,
    /* .name        = */ "BRASL",
-   /* .description = */ "Branch Rel.and Save Long",
+   /* .description = */ "BRANCH RELATIVE AND SAVE LONG",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x05,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_IsCall |
@@ -1430,10 +1430,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRC,
    /* .name        = */ "BRC",
-   /* .description = */ "Branch Rel. on Cond.",
+   /* .description = */ "BRANCH RELATIVE ON CONDITION",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_ReadsCC
@@ -1442,10 +1442,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRCL,
    /* .name        = */ "BRCL",
-   /* .description = */ "Branch Rel. on Cond. Long",
+   /* .description = */ "BRANCH RELATIVE ON CONDITION LONG",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_ReadsCC
@@ -1454,10 +1454,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRCT,
    /* .name        = */ "BRCT",
-   /* .description = */ "Branch Rel. on Count (32)",
+   /* .description = */ "BRANCH RELATIVE ON COUNT (32)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x06,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is32Bit |
@@ -1468,10 +1468,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRCTG,
    /* .name        = */ "BRCTG",
-   /* .description = */ "Branch Relative on Count (64)",
+   /* .description = */ "BRANCH RELATIVE ON COUNT (64)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x07,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is64Bit |
@@ -1482,7 +1482,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRXH,
    /* .name        = */ "BRXH",
-   /* .description = */ "Branch Rel. on Idx High",
+   /* .description = */ "BRANCH RELATIVE ON INDEX HIGH (32)",
    /* .opcode[0]   = */ 0x84,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RSI_FORMAT,
@@ -1496,10 +1496,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRXHG,
    /* .name        = */ "BRXHG",
-   /* .description = */ "Branch Relative on Index High",
+   /* .description = */ "BRANCH RELATIVE ON INDEX HIGH (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x44,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_UsesTarget |
@@ -1510,7 +1510,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRXLE,
    /* .name        = */ "BRXLE",
-   /* .description = */ "Branch Rel. on Idx Low or Equal (32)",
+   /* .description = */ "BRANCH RELATIVE ON INDEX LOW OR EQ. (32)",
    /* .opcode[0]   = */ 0x85,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RSI_FORMAT,
@@ -1524,10 +1524,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRXLG,
    /* .name        = */ "BRXLG",
-   /* .description = */ "Branch Relative on Index Equal or Low",
+   /* .description = */ "BRANCH RELATIVE ON INDEX LOW OR EQ. (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x45,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is64Bit |
@@ -1538,7 +1538,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BSM,
    /* .name        = */ "BSM",
-   /* .description = */ "Branch and Set Mode",
+   /* .description = */ "BRANCH AND SET MODE",
    /* .opcode[0]   = */ 0x0B,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1551,10 +1551,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BXH,
    /* .name        = */ "BXH",
-   /* .description = */ "Branch on Idx High",
+   /* .description = */ "BRANCH ON INDEX HIGH (32)",
    /* .opcode[0]   = */ 0x86,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is32Bit |
@@ -1566,10 +1566,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BXLE,
    /* .name        = */ "BXLE",
-   /* .description = */ "Branch on Idx Low or Equal (32)",
+   /* .description = */ "BRANCH ON INDEX LOW OR EQUAL (32)",
    /* .opcode[0]   = */ 0x87,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is32Bit |
@@ -1581,10 +1581,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::C,
    /* .name        = */ "C",
-   /* .description = */ "Compare (32)",
+   /* .description = */ "COMPARE (32)",
    /* .opcode[0]   = */ 0x59,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -1597,10 +1597,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CD,
    /* .name        = */ "CD",
-   /* .description = */ "Compare, Long",
+   /* .description = */ "COMPARE (long HFP)",
    /* .opcode[0]   = */ 0x69,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_IsCompare |
@@ -1612,7 +1612,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDB,
    /* .name        = */ "CDB",
-   /* .description = */ "Compare (LB)",
+   /* .description = */ "COMPARE (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x19,
    /* .format      = */ RXE_FORMAT,
@@ -1627,7 +1627,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDBR,
    /* .name        = */ "CDBR",
-   /* .description = */ "Compare (LB)",
+   /* .description = */ "COMPARE (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x19,
    /* .format      = */ RRE_FORMAT,
@@ -1641,7 +1641,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDFBR,
    /* .name        = */ "CDFBR",
-   /* .description = */ "Convert from Fixed (LB < 32)",
+   /* .description = */ "CONVERT FROM FIXED (32 to long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x95,
    /* .format      = */ RRE_FORMAT,
@@ -1654,7 +1654,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDFR,
    /* .name        = */ "CDFR",
-   /* .description = */ "Convert from int32 to long HFP",
+   /* .description = */ "CONVERT FROM FIXED (32 to long HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xB5,
    /* .format      = */ RRE_FORMAT,
@@ -1666,7 +1666,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDGBR,
    /* .name        = */ "CDGBR",
-   /* .description = */ "Convert from Fixed (LB < 64)",
+   /* .description = */ "CONVERT FROM FIXED (64 to long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA5,
    /* .format      = */ RRE_FORMAT,
@@ -1679,7 +1679,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDGR,
    /* .name        = */ "CDGR",
-   /* .description = */ "Convert from int64 to long HFP",
+   /* .description = */ "CONVERT FROM FIXED (64 to long HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xC5,
    /* .format      = */ RRE_FORMAT,
@@ -1691,7 +1691,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDR,
    /* .name        = */ "CDR",
-   /* .description = */ "Compare, Long",
+   /* .description = */ "COMPARE (long HFP)",
    /* .opcode[0]   = */ 0x29,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1705,10 +1705,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDS,
    /* .name        = */ "CDS",
-   /* .description = */ "Compare Double and Swap",
+   /* .description = */ "COMPARE DOUBLE AND SWAP (32)",
    /* .opcode[0]   = */ 0xBB,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -1728,10 +1728,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CE,
    /* .name        = */ "CE",
-   /* .description = */ "Compare, Short",
+   /* .description = */ "COMPARE (short HFP)",
    /* .opcode[0]   = */ 0x79,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_IsCompare |
@@ -1743,7 +1743,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEB,
    /* .name        = */ "CEB",
-   /* .description = */ "Compare (SB)",
+   /* .description = */ "COMPARE (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x09,
    /* .format      = */ RXE_FORMAT,
@@ -1758,7 +1758,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEBR,
    /* .name        = */ "CEBR",
-   /* .description = */ "Compare (SB)",
+   /* .description = */ "COMPARE (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x09,
    /* .format      = */ RRE_FORMAT,
@@ -1772,7 +1772,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEFBR,
    /* .name        = */ "CEFBR",
-   /* .description = */ "Convert from Fixed (SB < 32)",
+   /* .description = */ "CONVERT FROM FIXED (32 to short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x94,
    /* .format      = */ RRE_FORMAT,
@@ -1785,7 +1785,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEFR,
    /* .name        = */ "CEFR",
-   /* .description = */ "Convert from int32 to short HFP",
+   /* .description = */ "CONVERT FROM FIXED (32 to short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xB4,
    /* .format      = */ RRE_FORMAT,
@@ -1797,7 +1797,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEGBR,
    /* .name        = */ "CEGBR",
-   /* .description = */ "Convert from Fixed (SB < 64)",
+   /* .description = */ "CONVERT FROM FIXED (64 to short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA4,
    /* .format      = */ RRE_FORMAT,
@@ -1809,7 +1809,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEGR,
    /* .name        = */ "CEGR",
-   /* .description = */ "Convert from int64 to short HFP",
+   /* .description = */ "CONVERT FROM FIXED (64 to short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xC4,
    /* .format      = */ RRE_FORMAT,
@@ -1821,7 +1821,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CER,
    /* .name        = */ "CER",
-   /* .description = */ "Compare, Short",
+   /* .description = */ "COMPARE (short HFP)",
    /* .opcode[0]   = */ 0x39,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -1835,7 +1835,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFC,
    /* .name        = */ "CFC",
-   /* .description = */ "Compare and Form CodeWord",
+   /* .description = */ "COMPARE AND FORM CODEWORD",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x1A,
    /* .format      = */ S_FORMAT,
@@ -1851,10 +1851,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFDBR,
    /* .name        = */ "CFDBR",
-   /* .description = */ "Convert to Fixed (LB < 32)",
+   /* .description = */ "CONVERT TO FIXED (long BFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x99,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_SetsCC |
@@ -1868,10 +1868,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFDR,
    /* .name        = */ "CFDR",
-   /* .description = */ "Convert long HFP to int32",
+   /* .description = */ "CONVERT TO FIXED (long HFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xB9,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -1884,10 +1884,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFEBR,
    /* .name        = */ "CFEBR",
-   /* .description = */ "Convert to Fixed (SB < 32)",
+   /* .description = */ "CONVERT TO FIXED (short BFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x98,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_SetsCC |
@@ -1901,10 +1901,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFER,
    /* .name        = */ "CFER",
-   /* .description = */ "Convert short HFP to int32",
+   /* .description = */ "CONVERT TO FIXED (short HFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xB8,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -1917,10 +1917,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFXBR,
    /* .name        = */ "CFXBR",
-   /* .description = */ "Convert to Fixed (EB < 32), note here",
+   /* .description = */ "CONVERT TO FIXED (extended BFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x9A,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesRegPairForSource |
@@ -1934,10 +1934,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFXR,
    /* .name        = */ "CFXR",
-   /* .description = */ "Convert long HFP to int32",
+   /* .description = */ "CONVERT TO FIXED (extended HFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xBA,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesRegPairForSource |
@@ -1951,10 +1951,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGDBR,
    /* .name        = */ "CGDBR",
-   /* .description = */ "Convert to Fixed (64 < LB)",
+   /* .description = */ "CONVERT TO FIXED (long BFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA9,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
@@ -1967,10 +1967,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGDR,
    /* .name        = */ "CGDR",
-   /* .description = */ "Convert long HFP to int64",
+   /* .description = */ "CONVERT TO FIXED (long HFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xC9,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -1983,10 +1983,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGEBR,
    /* .name        = */ "CGEBR",
-   /* .description = */ "Convert to Fixed (64 < SB)",
+   /* .description = */ "CONVERT TO FIXED (short BFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA8,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
@@ -1999,10 +1999,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGER,
    /* .name        = */ "CGER",
-   /* .description = */ "Convert short HFP to int64",
+   /* .description = */ "CONVERT TO FIXED (short HFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xC8,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -2015,7 +2015,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGFR,
    /* .name        = */ "CGFR",
-   /* .description = */ "Compare (64 < 32)",
+   /* .description = */ "COMPARE (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x30,
    /* .format      = */ RRE_FORMAT,
@@ -2030,10 +2030,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGHI,
    /* .name        = */ "CGHI",
-   /* .description = */ "Compare Halfword Immediate (64)",
+   /* .description = */ "COMPARE HALFWORD IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -2044,7 +2044,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGR,
    /* .name        = */ "CGR",
-   /* .description = */ "Compare (64)",
+   /* .description = */ "COMPARE (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x20,
    /* .format      = */ RRE_FORMAT,
@@ -2059,10 +2059,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGXBR,
    /* .name        = */ "CGXBR",
-   /* .description = */ "Convert to Fixed (EB < 64), note here",
+   /* .description = */ "CONVERT TO FIXED (extended BFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xAA,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesRegPairForSource |
@@ -2076,10 +2076,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGXR,
    /* .name        = */ "CGXR",
-   /* .description = */ "Convert long HFP to int64",
+   /* .description = */ "CONVERT TO FIXED (extended HFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xCA,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesRegPairForSource |
@@ -2093,10 +2093,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CH,
    /* .name        = */ "CH",
-   /* .description = */ "Compare Halfword",
+   /* .description = */ "COMPARE HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0x49,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -2109,10 +2109,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHI,
    /* .name        = */ "CHI",
-   /* .description = */ "Compare Halfword Immediate (32)",
+   /* .description = */ "COMPARE HALFWORD IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -2123,7 +2123,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CKSM,
    /* .name        = */ "CKSM",
-   /* .description = */ "Checksum",
+   /* .description = */ "CHECKSUM",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x41,
    /* .format      = */ RRE_FORMAT,
@@ -2137,10 +2137,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CL,
    /* .name        = */ "CL",
-   /* .description = */ "Compare Logical (32)",
+   /* .description = */ "COMPARE LOGICAL (32)",
    /* .opcode[0]   = */ 0x55,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -2154,10 +2154,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLC,
    /* .name        = */ "CLC",
-   /* .description = */ "Compare Logical (character)",
+   /* .description = */ "COMPARE LOGICAL (character)",
    /* .opcode[0]   = */ 0xD5,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -2169,7 +2169,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLCL,
    /* .name        = */ "CLCL",
-   /* .description = */ "Compare Logical Long",
+   /* .description = */ "COMPARE LOGICAL LONG",
    /* .opcode[0]   = */ 0x0F,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -2188,10 +2188,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLCLE,
    /* .name        = */ "CLCLE",
-   /* .description = */ "Compare Logical Long Extended",
+   /* .description = */ "COMPARE LOGICAL LONG EXTENDED",
    /* .opcode[0]   = */ 0xA9,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -2207,7 +2207,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGFR,
    /* .name        = */ "CLGFR",
-   /* .description = */ "Compare Logical (64 < 32)",
+   /* .description = */ "COMPARE LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x31,
    /* .format      = */ RRE_FORMAT,
@@ -2222,7 +2222,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGR,
    /* .name        = */ "CLGR",
-   /* .description = */ "Compare Logical (64)",
+   /* .description = */ "COMPARE LOGICAL (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x21,
    /* .format      = */ RRE_FORMAT,
@@ -2237,7 +2237,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLI,
    /* .name        = */ "CLI",
-   /* .description = */ "Compare Logical Immediate",
+   /* .description = */ "COMPARE LOGICAL (immediate)",
    /* .opcode[0]   = */ 0x95,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -2252,10 +2252,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLM,
    /* .name        = */ "CLM",
-   /* .description = */ "Compare Logical Characters under Mask",
+   /* .description = */ "COMPARE LOGICAL CHAR. UNDER MASK (low)",
    /* .opcode[0]   = */ 0xBD,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -2268,7 +2268,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLR,
    /* .name        = */ "CLR",
-   /* .description = */ "Compare Logical (32)",
+   /* .description = */ "COMPARE LOGICAL (32)",
    /* .opcode[0]   = */ 0x15,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -2283,7 +2283,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLST,
    /* .name        = */ "CLST",
-   /* .description = */ "Compare Logical String",
+   /* .description = */ "COMPARE LOGICAL STRING",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x5D,
    /* .format      = */ RRE_FORMAT,
@@ -2299,10 +2299,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CP,
    /* .name        = */ "CP",
-   /* .description = */ "Compare Decimal",
+   /* .description = */ "COMPARE DECIMAL",
    /* .opcode[0]   = */ 0xF9,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -2314,7 +2314,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CPYA,
    /* .name        = */ "CPYA",
-   /* .description = */ "Copy Access Register",
+   /* .description = */ "COPY ACCESS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x4D,
    /* .format      = */ RRE_FORMAT,
@@ -2325,7 +2325,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CR,
    /* .name        = */ "CR",
-   /* .description = */ "Compare (32)",
+   /* .description = */ "COMPARE (32)",
    /* .opcode[0]   = */ 0x19,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -2340,10 +2340,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CS,
    /* .name        = */ "CS",
-   /* .description = */ "Compare and Swap (32)",
+   /* .description = */ "COMPARE AND SWAP (32)",
    /* .opcode[0]   = */ 0xBA,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -2361,7 +2361,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CSCH,
    /* .name        = */ "CSCH",
-   /* .description = */ "Clear Subchannel",
+   /* .description = */ "CLEAR SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x30,
    /* .format      = */ S_FORMAT,
@@ -2373,7 +2373,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CUSE,
    /* .name        = */ "CUSE",
-   /* .description = */ "Compare Until Substring Equal",
+   /* .description = */ "COMPARE UNTIL SUBSTRING EQUAL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x57,
    /* .format      = */ RRE_FORMAT,
@@ -2389,10 +2389,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CVB,
    /* .name        = */ "CVB",
-   /* .description = */ "Convert to Binary",
+   /* .description = */ "CONVERT TO BINARY (32)",
    /* .opcode[0]   = */ 0x4F,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -2402,10 +2402,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CVD,
    /* .name        = */ "CVD",
-   /* .description = */ "Convert to Decimal (32)",
+   /* .description = */ "CONVERT TO DECIMAL (32)",
    /* .opcode[0]   = */ 0x4E,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -2415,7 +2415,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXBR,
    /* .name        = */ "CXBR",
-   /* .description = */ "Compare (EB)",
+   /* .description = */ "COMPARE (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x49,
    /* .format      = */ RRE_FORMAT,
@@ -2431,7 +2431,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXFBR,
    /* .name        = */ "CXFBR",
-   /* .description = */ "Convert from Fixed (EB < 32)",
+   /* .description = */ "CONVERT FROM FIXED (32 to extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x96,
    /* .format      = */ RRE_FORMAT,
@@ -2444,7 +2444,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXFR,
    /* .name        = */ "CXFR",
-   /* .description = */ "Convert from int32 to extended HFP",
+   /* .description = */ "CONVERT FROM FIXED (32 to extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xB6,
    /* .format      = */ RRE_FORMAT,
@@ -2457,7 +2457,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXGBR,
    /* .name        = */ "CXGBR",
-   /* .description = */ "Convert from Fixed (EB < 64)",
+   /* .description = */ "CONVERT FROM FIXED (64 to extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA6,
    /* .format      = */ RRE_FORMAT,
@@ -2470,7 +2470,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXGR,
    /* .name        = */ "CXGR",
-   /* .description = */ "Convert from int64 to extended HFP",
+   /* .description = */ "CONVERT FROM FIXED (64 to extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xC6,
    /* .format      = */ RRE_FORMAT,
@@ -2483,7 +2483,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXR,
    /* .name        = */ "CXR",
-   /* .description = */ "Compare, Extended",
+   /* .description = */ "COMPARE (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x69,
    /* .format      = */ RRE_FORMAT,
@@ -2499,10 +2499,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::D,
    /* .name        = */ "D",
-   /* .description = */ "Divide (32 < 64)",
+   /* .description = */ "DIVIDE (32 <- 64)",
    /* .opcode[0]   = */ 0x5D,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -2514,10 +2514,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DD,
    /* .name        = */ "DD",
-   /* .description = */ "Divide, Long HFP",
+   /* .description = */ "DIVIDE (long HFP)",
    /* .opcode[0]   = */ 0x6D,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -2528,7 +2528,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DDB,
    /* .name        = */ "DDB",
-   /* .description = */ "Divide (LB)",
+   /* .description = */ "DIVIDE (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x1D,
    /* .format      = */ RXE_FORMAT,
@@ -2542,7 +2542,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DDBR,
    /* .name        = */ "DDBR",
-   /* .description = */ "Divide (LB)",
+   /* .description = */ "DIVIDE (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x1D,
    /* .format      = */ RRE_FORMAT,
@@ -2555,7 +2555,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DDR,
    /* .name        = */ "DDR",
-   /* .description = */ "Divide, Long HFP",
+   /* .description = */ "DIVIDE (long HFP)",
    /* .opcode[0]   = */ 0x2D,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -2568,10 +2568,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DE,
    /* .name        = */ "DE",
-   /* .description = */ "Divide, short HFP",
+   /* .description = */ "DIVIDE (short HFP)",
    /* .opcode[0]   = */ 0x7D,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -2582,7 +2582,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DEB,
    /* .name        = */ "DEB",
-   /* .description = */ "Divide (SB)",
+   /* .description = */ "DIVIDE (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x0D,
    /* .format      = */ RXE_FORMAT,
@@ -2596,7 +2596,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DEBR,
    /* .name        = */ "DEBR",
-   /* .description = */ "Divide (SB)",
+   /* .description = */ "DIVIDE (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x0D,
    /* .format      = */ RRE_FORMAT,
@@ -2609,7 +2609,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DER,
    /* .name        = */ "DER",
-   /* .description = */ "Divide, Short HFP",
+   /* .description = */ "DIVIDE (short HFP)",
    /* .opcode[0]   = */ 0x3D,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -2635,10 +2635,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DIDBR,
    /* .name        = */ "DIDBR",
-   /* .description = */ "Divide to Integer (LB)",
+   /* .description = */ "DIVIDE TO INTEGER (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x5B,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_SetsCC |
@@ -2649,10 +2649,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DIEBR,
    /* .name        = */ "DIEBR",
-   /* .description = */ "Divide to Integer (SB)",
+   /* .description = */ "DIVIDE TO INTEGER (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x53,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_SetsCC |
@@ -2663,7 +2663,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DLGR,
    /* .name        = */ "DLGR",
-   /* .description = */ "Divide Logical",
+   /* .description = */ "DIVIDE LOGICAL (64 <- 128)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x87,
    /* .format      = */ RRE_FORMAT,
@@ -2677,7 +2677,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DLR,
    /* .name        = */ "DLR",
-   /* .description = */ "Divide",
+   /* .description = */ "DIVIDE LOGICAL (32 <- 64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x97,
    /* .format      = */ RRE_FORMAT,
@@ -2691,10 +2691,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DP,
    /* .name        = */ "DP",
-   /* .description = */ "Divide Decimal",
+   /* .description = */ "DIVIDE DECIMAL",
    /* .opcode[0]   = */ 0xFD,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -2706,7 +2706,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DR,
    /* .name        = */ "DR",
-   /* .description = */ "Divide",
+   /* .description = */ "DIVIDE (32 <- 64)",
    /* .opcode[0]   = */ 0x1D,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -2720,7 +2720,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DSGFR,
    /* .name        = */ "DSGFR",
-   /* .description = */ "Divide Single (64 < 32)",
+   /* .description = */ "DIVIDE SINGLE (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x1D,
    /* .format      = */ RRE_FORMAT,
@@ -2734,7 +2734,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DSGR,
    /* .name        = */ "DSGR",
-   /* .description = */ "Divide Single (64)",
+   /* .description = */ "DIVIDE SINGLE (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x0D,
    /* .format      = */ RRE_FORMAT,
@@ -2748,7 +2748,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DXBR,
    /* .name        = */ "DXBR",
-   /* .description = */ "Divide (EB)",
+   /* .description = */ "DIVIDE (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x4D,
    /* .format      = */ RRE_FORMAT,
@@ -2763,7 +2763,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DXR,
    /* .name        = */ "DXR",
-   /* .description = */ "Divide, extended HFP",
+   /* .description = */ "DIVIDE (extended HFP)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x2D,
    /* .format      = */ RRE_FORMAT,
@@ -2777,7 +2777,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EAR,
    /* .name        = */ "EAR",
-   /* .description = */ "Extract Access Register",
+   /* .description = */ "EXTRACT ACCESS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x4F,
    /* .format      = */ RRE_FORMAT,
@@ -2788,10 +2788,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ED,
    /* .name        = */ "ED",
-   /* .description = */ "Edit",
+   /* .description = */ "EDIT",
    /* .opcode[0]   = */ 0xDE,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -2804,10 +2804,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EDMK,
    /* .name        = */ "EDMK",
-   /* .description = */ "Edit and Mark",
+   /* .description = */ "EDIT AND MARK",
    /* .opcode[0]   = */ 0xDF,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_ImplicitlySetsGPR1 |
                         S390OpProp_IsLoad |
@@ -2821,7 +2821,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EFPC,
    /* .name        = */ "EFPC",
-   /* .description = */ "Extract FPC",
+   /* .description = */ "EXTRACT FPC",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x8C,
    /* .format      = */ RRE_FORMAT,
@@ -2834,7 +2834,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EPAR,
    /* .name        = */ "EPAR",
-   /* .description = */ "Extract Primary ASN",
+   /* .description = */ "EXTRACT PRIMARY ASN",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x26,
    /* .format      = */ RRE_FORMAT,
@@ -2845,7 +2845,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EPSW,
    /* .name        = */ "EPSW",
-   /* .description = */ "Extract PSW",
+   /* .description = */ "EXTRACT PSW",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x8D,
    /* .format      = */ RRE_FORMAT,
@@ -2857,7 +2857,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EREG,
    /* .name        = */ "EREG",
-   /* .description = */ "Extract Stacked Registers",
+   /* .description = */ "EXTRACT STACKED REGISTERS (32)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x49,
    /* .format      = */ RRE_FORMAT,
@@ -2871,7 +2871,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EREGG,
    /* .name        = */ "EREGG",
-   /* .description = */ "Extract Stacked Registers",
+   /* .description = */ "EXTRACT STACKED REGISTERS (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x0E,
    /* .format      = */ RRE_FORMAT,
@@ -2885,7 +2885,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ESAR,
    /* .name        = */ "ESAR",
-   /* .description = */ "Extract Secondary ASN",
+   /* .description = */ "EXTRACT SECONDARY ASN",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x27,
    /* .format      = */ RRE_FORMAT,
@@ -2896,7 +2896,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ESEA,
    /* .name        = */ "ESEA",
-   /* .description = */ "Extract and Set Extended Authority",
+   /* .description = */ "EXTRACT AND SET EXTENDED AUTHORITY",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x9D,
    /* .format      = */ RRE_FORMAT,
@@ -2907,7 +2907,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ESTA,
    /* .name        = */ "ESTA",
-   /* .description = */ "Extract Stacked State",
+   /* .description = */ "EXTRACT STACKED STATE",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x4A,
    /* .format      = */ RRE_FORMAT,
@@ -2920,10 +2920,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EX,
    /* .name        = */ "EX",
-   /* .description = */ "Execute",
+   /* .description = */ "EXECUTE",
    /* .opcode[0]   = */ 0x44,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_SetsCC
@@ -2932,10 +2932,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIDBR,
    /* .name        = */ "FIDBR",
-   /* .description = */ "Load FP Integer (LB)",
+   /* .description = */ "LOAD FP INTEGER (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x5F,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_SetsOperand1
@@ -2944,7 +2944,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIDR,
    /* .name        = */ "FIDR",
-   /* .description = */ "Load long HFP Integer (round toward 0)",
+   /* .description = */ "LOAD FP INTEGER (long HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x7F,
    /* .format      = */ RRE_FORMAT,
@@ -2956,10 +2956,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIEBR,
    /* .name        = */ "FIEBR",
-   /* .description = */ "Load FP Integer (SB)",
+   /* .description = */ "LOAD FP INTEGER (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x57,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_SetsOperand1
@@ -2968,7 +2968,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIER,
    /* .name        = */ "FIER",
-   /* .description = */ "Load short HFP Integer (round toward 0)",
+   /* .description = */ "LOAD FP INTEGER (short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x77,
    /* .format      = */ RRE_FORMAT,
@@ -2980,10 +2980,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIXBR,
    /* .name        = */ "FIXBR",
-   /* .description = */ "Load FP Integer (EB)",
+   /* .description = */ "LOAD FP INTEGER (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x47,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesRegPairForSource |
                         S390OpProp_UsesRegPairForTarget |
@@ -2993,7 +2993,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIXR,
    /* .name        = */ "FIXR",
-   /* .description = */ "Load extended HFP Integer (round toward 0)",
+   /* .description = */ "LOAD FP INTEGER (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x67,
    /* .format      = */ RRE_FORMAT,
@@ -3007,7 +3007,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::HDR,
    /* .name        = */ "HDR",
-   /* .description = */ "Halve, Long HFP",
+   /* .description = */ "HALVE (long HFP)",
    /* .opcode[0]   = */ 0x24,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3020,7 +3020,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::HER,
    /* .name        = */ "HER",
-   /* .description = */ "Halve, short HFP",
+   /* .description = */ "HALVE (short HFP)",
    /* .opcode[0]   = */ 0x34,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3033,7 +3033,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::HSCH,
    /* .name        = */ "HSCH",
-   /* .description = */ "Halt Subchannel",
+   /* .description = */ "HALT SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x31,
    /* .format      = */ S_FORMAT,
@@ -3045,7 +3045,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IAC,
    /* .name        = */ "IAC",
-   /* .description = */ "Insert Address Space Control",
+   /* .description = */ "INSERT ADDRESS SPACE CONTROL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x24,
    /* .format      = */ RRE_FORMAT,
@@ -3057,10 +3057,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IC,
    /* .name        = */ "IC",
-   /* .description = */ "Insert Character",
+   /* .description = */ "INSERT CHARACTER",
    /* .opcode[0]   = */ 0x43,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -3071,10 +3071,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ICM,
    /* .name        = */ "ICM",
-   /* .description = */ "Insert Character under Mask",
+   /* .description = */ "INSERT CHARACTERS UNDER MASK (low)",
    /* .opcode[0]   = */ 0xBF,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -3086,10 +3086,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IIHH,
    /* .name        = */ "IIHH",
-   /* .description = */ "Insert Immediate",
+   /* .description = */ "INSERT IMMEDIATE (high high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_SetsOperand1 |
@@ -3099,10 +3099,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IIHL,
    /* .name        = */ "IIHL",
-   /* .description = */ "Insert Immediate",
+   /* .description = */ "INSERT IMMEDIATE (high low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_SetsOperand1 |
@@ -3112,10 +3112,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IILH,
    /* .name        = */ "IILH",
-   /* .description = */ "Insert Immediate",
+   /* .description = */ "INSERT IMMEDIATE (low high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x02,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -3124,10 +3124,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IILL,
    /* .name        = */ "IILL",
-   /* .description = */ "Insert Immediate",
+   /* .description = */ "INSERT IMMEDIATE (low low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x03,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsOperand1 |
                         S390OpProp_UsesTarget
@@ -3136,7 +3136,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IPK,
    /* .name        = */ "IPK",
-   /* .description = */ "Insert PSW Key",
+   /* .description = */ "INSERT PSW KEY",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ S_FORMAT,
@@ -3147,7 +3147,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IPM,
    /* .name        = */ "IPM",
-   /* .description = */ "Insert Program mask",
+   /* .description = */ "INSERT PROGRAM MASK",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x22,
    /* .format      = */ RRE_FORMAT,
@@ -3159,7 +3159,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ISKE,
    /* .name        = */ "ISKE",
-   /* .description = */ "Insert Storage Key Extended",
+   /* .description = */ "INSERT STORAGE KEY EXTENDED",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x29,
    /* .format      = */ RRE_FORMAT,
@@ -3171,7 +3171,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IVSK,
    /* .name        = */ "IVSK",
-   /* .description = */ "Insert Virtual Storage Key",
+   /* .description = */ "INSERT VIRTUAL STORAGE KEY",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x23,
    /* .format      = */ RRE_FORMAT,
@@ -3183,10 +3183,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::L,
    /* .name        = */ "L",
-   /* .description = */ "Load (32)",
+   /* .description = */ "LOAD (32)",
    /* .opcode[0]   = */ 0x58,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -3197,10 +3197,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LA,
    /* .name        = */ "LA",
-   /* .description = */ "Load Address",
+   /* .description = */ "LOAD ADDRESS",
    /* .opcode[0]   = */ 0x41,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -3209,10 +3209,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAE,
    /* .name        = */ "LAE",
-   /* .description = */ "Load Address Extended",
+   /* .description = */ "LOAD ADDRESS EXTENDED",
    /* .opcode[0]   = */ 0x51,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -3221,10 +3221,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAM,
    /* .name        = */ "LAM",
-   /* .description = */ "Load Access Multiple",
+   /* .description = */ "LOAD ACCESS MULTIPLE",
    /* .opcode[0]   = */ 0x9A,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -3235,10 +3235,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LARL,
    /* .name        = */ "LARL",
-   /* .description = */ "Load Address Relative Long",
+   /* .description = */ "LOAD ADDRESS RELATIVE LONG",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsOperand1
    },
@@ -3246,7 +3246,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCDBR,
    /* .name        = */ "LCDBR",
-   /* .description = */ "Load Complement (LB)",
+   /* .description = */ "LOAD COMPLEMENT (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x13,
    /* .format      = */ RRE_FORMAT,
@@ -3260,7 +3260,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCDR,
    /* .name        = */ "LCDR",
-   /* .description = */ "Load Complement, Long HFP",
+   /* .description = */ "LOAD COMPLEMENT (long HFP)",
    /* .opcode[0]   = */ 0x23,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3274,7 +3274,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCEBR,
    /* .name        = */ "LCEBR",
-   /* .description = */ "Load Complement (SB)",
+   /* .description = */ "LOAD COMPLEMENT (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x03,
    /* .format      = */ RRE_FORMAT,
@@ -3288,7 +3288,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCER,
    /* .name        = */ "LCER",
-   /* .description = */ "Load Complement, short HFP",
+   /* .description = */ "LOAD COMPLEMENT (short HFP)",
    /* .opcode[0]   = */ 0x33,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3302,7 +3302,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCGFR,
    /* .name        = */ "LCGFR",
-   /* .description = */ "Load Complement (64 < 32)",
+   /* .description = */ "LOAD COMPLEMENT (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x13,
    /* .format      = */ RRE_FORMAT,
@@ -3317,7 +3317,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCGR,
    /* .name        = */ "LCGR",
-   /* .description = */ "Load Complement (64)",
+   /* .description = */ "LOAD COMPLEMENT (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x03,
    /* .format      = */ RRE_FORMAT,
@@ -3332,7 +3332,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCR,
    /* .name        = */ "LCR",
-   /* .description = */ "Load Complement (32)",
+   /* .description = */ "LOAD COMPLEMENT (32)",
    /* .opcode[0]   = */ 0x13,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3347,10 +3347,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCTL,
    /* .name        = */ "LCTL",
-   /* .description = */ "Load Control",
+   /* .description = */ "LOAD CONTROL (32)",
    /* .opcode[0]   = */ 0xB7,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad
@@ -3359,7 +3359,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCXBR,
    /* .name        = */ "LCXBR",
-   /* .description = */ "Load Complement (EB)",
+   /* .description = */ "LOAD COMPLEMENT (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x43,
    /* .format      = */ RRE_FORMAT,
@@ -3375,7 +3375,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCXR,
    /* .name        = */ "LCXR",
-   /* .description = */ "Load Complement, extended HFP",
+   /* .description = */ "LOAD COMPLEMENT (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x63,
    /* .format      = */ RRE_FORMAT,
@@ -3391,10 +3391,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LD,
    /* .name        = */ "LD",
-   /* .description = */ "Load (L)",
+   /* .description = */ "LOAD (long)",
    /* .opcode[0]   = */ 0x68,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_DoubleFP |
@@ -3405,7 +3405,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDE,
    /* .name        = */ "LDE",
-   /* .description = */ "Load Lengthened short to long HFP",
+   /* .description = */ "LOAD LENGTHENED (short to long HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x24,
    /* .format      = */ RXE_FORMAT,
@@ -3419,7 +3419,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDEB,
    /* .name        = */ "LDEB",
-   /* .description = */ "Load Lengthened (LB < SB)",
+   /* .description = */ "LOAD LENGTHENED (short to long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x04,
    /* .format      = */ RXE_FORMAT,
@@ -3433,7 +3433,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDEBR,
    /* .name        = */ "LDEBR",
-   /* .description = */ "Load Leeeengthened (LB < SB)",
+   /* .description = */ "LOAD LENGTHENED (short to long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x04,
    /* .format      = */ RRE_FORMAT,
@@ -3446,7 +3446,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDER,
    /* .name        = */ "LDER",
-   /* .description = */ "Load Rounded, long to short HFP",
+   /* .description = */ "LOAD LENGTHENED (short to long HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x24,
    /* .format      = */ RRE_FORMAT,
@@ -3458,7 +3458,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDR,
    /* .name        = */ "LDR",
-   /* .description = */ "Load (L)",
+   /* .description = */ "LOAD (long)",
    /* .opcode[0]   = */ 0x28,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3470,7 +3470,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDXBR,
    /* .name        = */ "LDXBR",
-   /* .description = */ "Load Rounded (LB < EB)",
+   /* .description = */ "LOAD ROUNDED (extended to long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x45,
    /* .format      = */ RRE_FORMAT,
@@ -3484,7 +3484,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDXR,
    /* .name        = */ "LDXR",
-   /* .description = */ "Load Rounded, extended to long HFP",
+   /* .description = */ "LOAD ROUNDED (extended to long HFP)",
    /* .opcode[0]   = */ 0x25,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3497,10 +3497,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LE,
    /* .name        = */ "LE",
-   /* .description = */ "Load (S)",
+   /* .description = */ "LOAD (short)",
    /* .opcode[0]   = */ 0x78,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_SingleFP |
@@ -3511,7 +3511,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LEDBR,
    /* .name        = */ "LEDBR",
-   /* .description = */ "Load Rounded (SB < LB)",
+   /* .description = */ "LOAD ROUNDED (long to short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x44,
    /* .format      = */ RRE_FORMAT,
@@ -3522,7 +3522,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LEDR,
    /* .name        = */ "LEDR",
-   /* .description = */ "Load Rounded, long to short HFP",
+   /* .description = */ "LOAD ROUNDED (long to short HFP)",
    /* .opcode[0]   = */ 0x35,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3534,7 +3534,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LER,
    /* .name        = */ "LER",
-   /* .description = */ "Load (S)",
+   /* .description = */ "LOAD (short)",
    /* .opcode[0]   = */ 0x38,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3546,7 +3546,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LEXBR,
    /* .name        = */ "LEXBR",
-   /* .description = */ "Load Rounded (SB < EB)",
+   /* .description = */ "LOAD ROUNDED (extended to short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x46,
    /* .format      = */ RRE_FORMAT,
@@ -3560,7 +3560,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LEXR,
    /* .name        = */ "LEXR",
-   /* .description = */ "Load Rounded, extended to short HFP",
+   /* .description = */ "LOAD ROUNDED (extended to short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x66,
    /* .format      = */ RRE_FORMAT,
@@ -3573,7 +3573,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LFPC,
    /* .name        = */ "LFPC",
-   /* .description = */ "Load FPC",
+   /* .description = */ "LOAD FPC",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x9D,
    /* .format      = */ S_FORMAT,
@@ -3584,7 +3584,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGFR,
    /* .name        = */ "LGFR",
-   /* .description = */ "(LongDisp) Load (64 < 32)",
+   /* .description = */ "LOAD (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x14,
    /* .format      = */ RRE_FORMAT,
@@ -3597,10 +3597,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGHI,
    /* .name        = */ "LGHI",
-   /* .description = */ "Load Halfword Immediate",
+   /* .description = */ "LOAD HALFWORD IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x09,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1
@@ -3609,7 +3609,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGR,
    /* .name        = */ "LGR",
-   /* .description = */ "Load (64)",
+   /* .description = */ "LOAD (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x04,
    /* .format      = */ RRE_FORMAT,
@@ -3622,10 +3622,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LH,
    /* .name        = */ "LH",
-   /* .description = */ "Load Halfword",
+   /* .description = */ "LOAD HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0x48,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -3636,10 +3636,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LHI,
    /* .name        = */ "LHI",
-   /* .description = */ "Load Halfword Immediate",
+   /* .description = */ "LOAD HALFWORD IMMEDIATE (32) <- 16",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsOperand1
@@ -3648,7 +3648,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGFR,
    /* .name        = */ "LLGFR",
-   /* .description = */ "Load Logical Halfword(64)",
+   /* .description = */ "LOAD LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x16,
    /* .format      = */ RRE_FORMAT,
@@ -3660,7 +3660,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGTR,
    /* .name        = */ "LLGTR",
-   /* .description = */ "Load Logical Thirty One Bits",
+   /* .description = */ "LOAD LOGICAL THIRTY ONE BITS (64 <- 31)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x17,
    /* .format      = */ RRE_FORMAT,
@@ -3672,10 +3672,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLIHH,
    /* .name        = */ "LLIHH",
-   /* .description = */ "Load Logical Halfword Immediate",
+   /* .description = */ "LOAD LOGICAL IMMEDIATE (high high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1
@@ -3684,10 +3684,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLIHL,
    /* .name        = */ "LLIHL",
-   /* .description = */ "Load Logical Halfword Immediate",
+   /* .description = */ "LOAD LOGICAL IMMEDIATE (high low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1
@@ -3696,10 +3696,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLILH,
    /* .name        = */ "LLILH",
-   /* .description = */ "Load Logical Halfword Immediate",
+   /* .description = */ "LOAD LOGICAL IMMEDIATE (low high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1
@@ -3708,10 +3708,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLILL,
    /* .name        = */ "LLILL",
-   /* .description = */ "Load Logical Halfword Immediate",
+   /* .description = */ "LOAD LOGICAL IMMEDIATE (low low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1
@@ -3720,10 +3720,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LM,
    /* .name        = */ "LM",
-   /* .description = */ "Load Multiple",
+   /* .description = */ "LOAD MULTIPLE (32)",
    /* .opcode[0]   = */ 0x98,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -3736,7 +3736,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNDBR,
    /* .name        = */ "LNDBR",
-   /* .description = */ "Load Negative (LB)",
+   /* .description = */ "LOAD NEGATIVE (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x11,
    /* .format      = */ RRE_FORMAT,
@@ -3750,7 +3750,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNDR,
    /* .name        = */ "LNDR",
-   /* .description = */ "Load Negative, Long HFP",
+   /* .description = */ "LOAD NEGATIVE (long HFP)",
    /* .opcode[0]   = */ 0x21,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3764,7 +3764,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNEBR,
    /* .name        = */ "LNEBR",
-   /* .description = */ "Load Negative (SB)",
+   /* .description = */ "LOAD NEGATIVE (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x01,
    /* .format      = */ RRE_FORMAT,
@@ -3778,7 +3778,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNER,
    /* .name        = */ "LNER",
-   /* .description = */ "Load Negative, short HFP",
+   /* .description = */ "LOAD NEGATIVE (short HFP)",
    /* .opcode[0]   = */ 0x31,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3792,7 +3792,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNGFR,
    /* .name        = */ "LNGFR",
-   /* .description = */ "Load Negative",
+   /* .description = */ "LOAD NEGATIVE (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x11,
    /* .format      = */ RRE_FORMAT,
@@ -3807,7 +3807,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNGR,
    /* .name        = */ "LNGR",
-   /* .description = */ "Load Negative (64)",
+   /* .description = */ "LOAD NEGATIVE (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x01,
    /* .format      = */ RRE_FORMAT,
@@ -3821,7 +3821,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNR,
    /* .name        = */ "LNR",
-   /* .description = */ "Load Negative (32)",
+   /* .description = */ "LOAD NEGATIVE (32)",
    /* .opcode[0]   = */ 0x11,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3835,7 +3835,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNXBR,
    /* .name        = */ "LNXBR",
-   /* .description = */ "Load Negative (EB)",
+   /* .description = */ "LOAD NEGATIVE (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x41,
    /* .format      = */ RRE_FORMAT,
@@ -3851,7 +3851,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNXR,
    /* .name        = */ "LNXR",
-   /* .description = */ "Load Negative, extended HFP",
+   /* .description = */ "LOAD NEGATIVE (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x61,
    /* .format      = */ RRE_FORMAT,
@@ -3867,7 +3867,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPDBR,
    /* .name        = */ "LPDBR",
-   /* .description = */ "Load Positive (LB)",
+   /* .description = */ "LOAD POSITIVE (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x10,
    /* .format      = */ RRE_FORMAT,
@@ -3881,7 +3881,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPDR,
    /* .name        = */ "LPDR",
-   /* .description = */ "Load Positive, Long HFP",
+   /* .description = */ "LOAD POSITIVE (long HFP)",
    /* .opcode[0]   = */ 0x20,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3895,7 +3895,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPEBR,
    /* .name        = */ "LPEBR",
-   /* .description = */ "Load Positive (SB)",
+   /* .description = */ "LOAD POSITIVE (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RRE_FORMAT,
@@ -3909,7 +3909,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPER,
    /* .name        = */ "LPER",
-   /* .description = */ "Load Positive, short HFP",
+   /* .description = */ "LOAD POSITIVE (short HFP)",
    /* .opcode[0]   = */ 0x30,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3923,7 +3923,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPGFR,
    /* .name        = */ "LPGFR",
-   /* .description = */ "Load Positive (64 < 32)",
+   /* .description = */ "LOAD POSITIVE (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x10,
    /* .format      = */ RRE_FORMAT,
@@ -3938,7 +3938,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPGR,
    /* .name        = */ "LPGR",
-   /* .description = */ "Load Positive (64)",
+   /* .description = */ "LOAD POSITIVE (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RRE_FORMAT,
@@ -3953,7 +3953,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPR,
    /* .name        = */ "LPR",
-   /* .description = */ "Load Positive (32)",
+   /* .description = */ "LOAD POSITIVE (32)",
    /* .opcode[0]   = */ 0x10,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -3968,10 +3968,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPSW,
    /* .name        = */ "LPSW",
-   /* .description = */ "Load PSW",
+   /* .description = */ "LOAD PSW",
    /* .opcode[0]   = */ 0x82,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ S_FORMAT,
+   /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_SetsCC
@@ -3980,7 +3980,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPSWE,
    /* .name        = */ "LPSWE",
-   /* .description = */ "Load PSW Extended",
+   /* .description = */ "LOAD PSW EXTENDED",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xB2,
    /* .format      = */ S_FORMAT,
@@ -3993,7 +3993,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPXBR,
    /* .name        = */ "LPXBR",
-   /* .description = */ "Load Positive (EB)",
+   /* .description = */ "LOAD POSITIVE (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x40,
    /* .format      = */ RRE_FORMAT,
@@ -4009,7 +4009,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPXR,
    /* .name        = */ "LPXR",
-   /* .description = */ "Load Positive, extended HFP",
+   /* .description = */ "LOAD POSITIVE (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x60,
    /* .format      = */ RRE_FORMAT,
@@ -4025,7 +4025,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LR,
    /* .name        = */ "LR",
-   /* .description = */ "Load (32)",
+   /* .description = */ "LOAD (32)",
    /* .opcode[0]   = */ 0x18,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4038,10 +4038,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRA,
    /* .name        = */ "LRA",
-   /* .description = */ "Load Real Address",
+   /* .description = */ "LOAD REAL ADDRESS (32)",
    /* .opcode[0]   = */ 0xB1,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsCC |
@@ -4051,7 +4051,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRVGR,
    /* .name        = */ "LRVGR",
-   /* .description = */ "Load Reversed (64)",
+   /* .description = */ "LOAD REVERSED (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x0F,
    /* .format      = */ RRE_FORMAT,
@@ -4063,7 +4063,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRVR,
    /* .name        = */ "LRVR",
-   /* .description = */ "Load Reversed (32)",
+   /* .description = */ "LOAD REVERSED (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x1F,
    /* .format      = */ RRE_FORMAT,
@@ -4075,7 +4075,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTDBR,
    /* .name        = */ "LTDBR",
-   /* .description = */ "Load and Test (LB)",
+   /* .description = */ "LOAD AND TEST (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x12,
    /* .format      = */ RRE_FORMAT,
@@ -4090,7 +4090,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTDR,
    /* .name        = */ "LTDR",
-   /* .description = */ "Load and Test, Long HFP",
+   /* .description = */ "LOAD AND TEST (long HFP)",
    /* .opcode[0]   = */ 0x22,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4105,7 +4105,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTEBR,
    /* .name        = */ "LTEBR",
-   /* .description = */ "Load and Test (SB)",
+   /* .description = */ "LOAD AND TEST (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x02,
    /* .format      = */ RRE_FORMAT,
@@ -4119,7 +4119,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTER,
    /* .name        = */ "LTER",
-   /* .description = */ "Load and Test, Short HFP",
+   /* .description = */ "LOAD AND TEST (short HFP)",
    /* .opcode[0]   = */ 0x32,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4134,7 +4134,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTGFR,
    /* .name        = */ "LTGFR",
-   /* .description = */ "Load and Test (64 < 32)",
+   /* .description = */ "LOAD AND TEST (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x12,
    /* .format      = */ RRE_FORMAT,
@@ -4149,7 +4149,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTGR,
    /* .name        = */ "LTGR",
-   /* .description = */ "Load and Test (64)",
+   /* .description = */ "LOAD AND TEST (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x02,
    /* .format      = */ RRE_FORMAT,
@@ -4164,7 +4164,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTR,
    /* .name        = */ "LTR",
-   /* .description = */ "Load and Test (32)",
+   /* .description = */ "LOAD AND TEST (32)",
    /* .opcode[0]   = */ 0x12,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4179,7 +4179,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTXBR,
    /* .name        = */ "LTXBR",
-   /* .description = */ "Load and Test (DFP64)",
+   /* .description = */ "LOAD AND TEST (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x42,
    /* .format      = */ RRE_FORMAT,
@@ -4196,7 +4196,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTXR,
    /* .name        = */ "LTXR",
-   /* .description = */ "Load and Test, extended HFP",
+   /* .description = */ "LOAD AND TEST (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x62,
    /* .format      = */ RRE_FORMAT,
@@ -4213,7 +4213,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LURA,
    /* .name        = */ "LURA",
-   /* .description = */ "Load Using Real Address",
+   /* .description = */ "LOAD USING REAL ADDRESS (32)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x4B,
    /* .format      = */ RRE_FORMAT,
@@ -4225,7 +4225,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LURAG,
    /* .name        = */ "LURAG",
-   /* .description = */ "Load Using Real Address",
+   /* .description = */ "LOAD USING REAL ADDRESS (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x05,
    /* .format      = */ RRE_FORMAT,
@@ -4237,7 +4237,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXD,
    /* .name        = */ "LXD",
-   /* .description = */ "Load Lengthened short to long HFP",
+   /* .description = */ "LOAD LENGTHENED (long to extended HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x25,
    /* .format      = */ RXE_FORMAT,
@@ -4251,7 +4251,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXDB,
    /* .name        = */ "LXDB",
-   /* .description = */ "Load Lengthened (EB < LB)",
+   /* .description = */ "LOAD LENGTHENED (long to extended BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x05,
    /* .format      = */ RXE_FORMAT,
@@ -4266,7 +4266,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXDBR,
    /* .name        = */ "LXDBR",
-   /* .description = */ "Load Leeeengthened (EB < DB)",
+   /* .description = */ "LOAD LENGTHENED (long to extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x05,
    /* .format      = */ RRE_FORMAT,
@@ -4279,7 +4279,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXDR,
    /* .name        = */ "LXDR",
-   /* .description = */ "Load Lengthened, long to extended HFP",
+   /* .description = */ "LOAD LENGTHENED (long to extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x25,
    /* .format      = */ RRE_FORMAT,
@@ -4293,7 +4293,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXE,
    /* .name        = */ "LXE",
-   /* .description = */ "Load Lengthened short to long HFP",
+   /* .description = */ "LOAD LENGTHENED (short to extended HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x26,
    /* .format      = */ RXE_FORMAT,
@@ -4307,7 +4307,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXEB,
    /* .name        = */ "LXEB",
-   /* .description = */ "Load Lengthened (EB < SB)",
+   /* .description = */ "LOAD LENGTHENED (short to extended BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x06,
    /* .format      = */ RXE_FORMAT,
@@ -4321,7 +4321,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXEBR,
    /* .name        = */ "LXEBR",
-   /* .description = */ "Load Leeeengthened (EB < SB)",
+   /* .description = */ "LOAD LENGTHENED (short to extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x06,
    /* .format      = */ RRE_FORMAT,
@@ -4334,7 +4334,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXER,
    /* .name        = */ "LXER",
-   /* .description = */ "Load Rounded, short to extended HFP",
+   /* .description = */ "LOAD LENGTHENED (short to extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x26,
    /* .format      = */ RRE_FORMAT,
@@ -4347,7 +4347,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXR,
    /* .name        = */ "LXR",
-   /* .description = */ "Load Leeeengthened (EB < SB)",
+   /* .description = */ "LOAD (extended)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x65,
    /* .format      = */ RRE_FORMAT,
@@ -4361,7 +4361,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LZDR,
    /* .name        = */ "LZDR",
-   /* .description = */ "Load Zero (L)",
+   /* .description = */ "LOAD ZERO (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x75,
    /* .format      = */ RRE_FORMAT,
@@ -4373,7 +4373,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LZER,
    /* .name        = */ "LZER",
-   /* .description = */ "Load Zero (S)",
+   /* .description = */ "LOAD ZERO (short)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x74,
    /* .format      = */ RRE_FORMAT,
@@ -4385,7 +4385,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LZXR,
    /* .name        = */ "LZXR",
-   /* .description = */ "Load Zero (EB)",
+   /* .description = */ "LOAD ZERO (extended)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x76,
    /* .format      = */ RRE_FORMAT,
@@ -4398,10 +4398,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::M,
    /* .name        = */ "M",
-   /* .description = */ "Multiply (64 < 32)",
+   /* .description = */ "MULTIPLY (64 <- 32)",
    /* .opcode[0]   = */ 0x5C,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -4413,7 +4413,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MADB,
    /* .name        = */ "MADB",
-   /* .description = */ "Multiply and Add (LB)",
+   /* .description = */ "MULTIPLY AND ADD (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x1E,
    /* .format      = */ RXF_FORMAT,
@@ -4427,10 +4427,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MADBR,
    /* .name        = */ "MADBR",
-   /* .description = */ "Multiply and Add (LB)",
+   /* .description = */ "MULTIPLY AND ADD (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x1E,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -4440,7 +4440,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAEB,
    /* .name        = */ "MAEB",
-   /* .description = */ "Multiply and Add (SB)",
+   /* .description = */ "MULTIPLY AND ADD (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x0E,
    /* .format      = */ RXF_FORMAT,
@@ -4454,10 +4454,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAEBR,
    /* .name        = */ "MAEBR",
-   /* .description = */ "Multiply and Add (SB)",
+   /* .description = */ "MULTIPLY AND ADD (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -4467,10 +4467,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MD,
    /* .name        = */ "MD",
-   /* .description = */ "Multiply, long HFP source and result",
+   /* .description = */ "MULTIPLY (long HFP)",
    /* .opcode[0]   = */ 0x6C,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -4481,7 +4481,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MDB,
    /* .name        = */ "MDB",
-   /* .description = */ "Multiply (LB)",
+   /* .description = */ "MULTIPLY (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x1C,
    /* .format      = */ RXE_FORMAT,
@@ -4495,7 +4495,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MDBR,
    /* .name        = */ "MDBR",
-   /* .description = */ "Multiply (LB)",
+   /* .description = */ "MULTIPLY (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x1C,
    /* .format      = */ RRE_FORMAT,
@@ -4508,10 +4508,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MDE,
    /* .name        = */ "MDE",
-   /* .description = */ "Multiply, short HFP source, long HFP result",
+   /* .description = */ "MULTIPLY (short to long HFP)",
    /* .opcode[0]   = */ 0x7C,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -4522,7 +4522,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MDER,
    /* .name        = */ "MDER",
-   /* .description = */ "Multiply, short HFP source, long HFP result",
+   /* .description = */ "MULTIPLY (short to long HFP)",
    /* .opcode[0]   = */ 0x3C,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4535,7 +4535,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MDR,
    /* .name        = */ "MDR",
-   /* .description = */ "Multiply, long HFP source and result",
+   /* .description = */ "MULTIPLY (long HFP)",
    /* .opcode[0]   = */ 0x2C,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4548,7 +4548,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MEE,
    /* .name        = */ "MEE",
-   /* .description = */ "Multiply short HFP",
+   /* .description = */ "MULTIPLY (short HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x37,
    /* .format      = */ RXE_FORMAT,
@@ -4562,7 +4562,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MEEB,
    /* .name        = */ "MEEB",
-   /* .description = */ "Multiply (SB)",
+   /* .description = */ "MULTIPLY (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x17,
    /* .format      = */ RXE_FORMAT,
@@ -4576,7 +4576,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MEEBR,
    /* .name        = */ "MEEBR",
-   /* .description = */ "Multiply (SB)",
+   /* .description = */ "MULTIPLY (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x17,
    /* .format      = */ RRE_FORMAT,
@@ -4589,7 +4589,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MEER,
    /* .name        = */ "MEER",
-   /* .description = */ "Multiply, short HFP source and result",
+   /* .description = */ "MULTIPLY (short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x37,
    /* .format      = */ RRE_FORMAT,
@@ -4602,10 +4602,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MGHI,
    /* .name        = */ "MGHI",
-   /* .description = */ "Multiply Halfword Immediate",
+   /* .description = */ "MULTIPLY HALFWORD IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -4615,10 +4615,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MH,
    /* .name        = */ "MH",
-   /* .description = */ "Multiply Halfword (32)",
+   /* .description = */ "MULTIPLY HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0x4C,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -4629,10 +4629,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MHI,
    /* .name        = */ "MHI",
-   /* .description = */ "Multiply Halfword Immediate (32)",
+   /* .description = */ "MULTIPLY HALFWORD IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -4642,7 +4642,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MLGR,
    /* .name        = */ "MLGR",
-   /* .description = */ "Multiply Logical ( 128<64 )",
+   /* .description = */ "MULTIPLY LOGICAL (128 <- 64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x86,
    /* .format      = */ RRE_FORMAT,
@@ -4656,7 +4656,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MLR,
    /* .name        = */ "MLR",
-   /* .description = */ "Multiply Logical ( 64<32 )",
+   /* .description = */ "MULTIPLY LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x96,
    /* .format      = */ RRE_FORMAT,
@@ -4670,10 +4670,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MP,
    /* .name        = */ "MP",
-   /* .description = */ "Multiple Decimal",
+   /* .description = */ "MULTIPLY DECIMAL",
    /* .opcode[0]   = */ 0xFC,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4685,7 +4685,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MR,
    /* .name        = */ "MR",
-   /* .description = */ "Multiple (64 < 32)",
+   /* .description = */ "MULTIPLY (64 <- 32)",
    /* .opcode[0]   = */ 0x1C,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4699,10 +4699,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MS,
    /* .name        = */ "MS",
-   /* .description = */ "Multiply Single",
+   /* .description = */ "MULTIPLY SINGLE (32)",
    /* .opcode[0]   = */ 0x71,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -4714,7 +4714,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSCH,
    /* .name        = */ "MSCH",
-   /* .description = */ "Modify Subchannel",
+   /* .description = */ "MODIFY SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x32,
    /* .format      = */ S_FORMAT,
@@ -4726,7 +4726,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSDB,
    /* .name        = */ "MSDB",
-   /* .description = */ "Multiply and Subtract (LB)",
+   /* .description = */ "MULTIPLY AND SUBTRACT (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x1F,
    /* .format      = */ RXF_FORMAT,
@@ -4740,10 +4740,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSDBR,
    /* .name        = */ "MSDBR",
-   /* .description = */ "Multiply and Subtract (LB)",
+   /* .description = */ "MULTIPLY AND SUBTRACT (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x1F,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -4753,7 +4753,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSEB,
    /* .name        = */ "MSEB",
-   /* .description = */ "Multiply and Subtract (SB)",
+   /* .description = */ "MULTIPLY AND SUBTRACT (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x0F,
    /* .format      = */ RXF_FORMAT,
@@ -4767,10 +4767,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSEBR,
    /* .name        = */ "MSEBR",
-   /* .description = */ "Multiply and Subtract (SB)",
+   /* .description = */ "MULTIPLY AND SUBTRACT (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -4780,7 +4780,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSGFR,
    /* .name        = */ "MSGFR",
-   /* .description = */ "Multiply Single (64 < 32)",
+   /* .description = */ "MULTIPLY SINGLE (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x1C,
    /* .format      = */ RRE_FORMAT,
@@ -4793,7 +4793,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSGR,
    /* .name        = */ "MSGR",
-   /* .description = */ "Multiply Single (64)",
+   /* .description = */ "MULTIPLY SINGLE (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x0C,
    /* .format      = */ RRE_FORMAT,
@@ -4806,7 +4806,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSR,
    /* .name        = */ "MSR",
-   /* .description = */ "Multiply Single Register",
+   /* .description = */ "MULTIPLY SINGLE (32)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x52,
    /* .format      = */ RRE_FORMAT,
@@ -4819,7 +4819,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSTA,
    /* .name        = */ "MSTA",
-   /* .description = */ "Modify Stacked State",
+   /* .description = */ "MODIFY STACKED STATE",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x47,
    /* .format      = */ RRE_FORMAT,
@@ -4830,10 +4830,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVC,
    /* .name        = */ "MVC",
-   /* .description = */ "Move (character)",
+   /* .description = */ "MOVE (character)",
    /* .opcode[0]   = */ 0xD2,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4844,7 +4844,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCDK,
    /* .name        = */ "MVCDK",
-   /* .description = */ "Move With Destination Key",
+   /* .description = */ "MOVE WITH DESTINATION KEY",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x0F,
    /* .format      = */ SSE_FORMAT,
@@ -4860,10 +4860,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCK,
    /* .name        = */ "MVCK",
-   /* .description = */ "Move With Key",
+   /* .description = */ "MOVE WITH KEY",
    /* .opcode[0]   = */ 0xD9,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4875,7 +4875,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCL,
    /* .name        = */ "MVCL",
-   /* .description = */ "Move Long",
+   /* .description = */ "MOVE LONG",
    /* .opcode[0]   = */ 0x0E,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -4893,10 +4893,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCLE,
    /* .name        = */ "MVCLE",
-   /* .description = */ "Move Long Extended",
+   /* .description = */ "MOVE LONG EXTENDED",
    /* .opcode[0]   = */ 0xA8,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -4911,10 +4911,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCP,
    /* .name        = */ "MVCP",
-   /* .description = */ "Move to Primary",
+   /* .description = */ "MOVE TO PRIMARY",
    /* .opcode[0]   = */ 0xDA,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4926,10 +4926,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCS,
    /* .name        = */ "MVCS",
-   /* .description = */ "Move to Secondary",
+   /* .description = */ "MOVE TO SECONDARY",
    /* .opcode[0]   = */ 0xDB,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4941,7 +4941,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCSK,
    /* .name        = */ "MVCSK",
-   /* .description = */ "Move With Source Key",
+   /* .description = */ "MOVE WITH SOURCE KEY",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x0E,
    /* .format      = */ SSE_FORMAT,
@@ -4957,7 +4957,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVI,
    /* .name        = */ "MVI",
-   /* .description = */ "Move (Immediate)",
+   /* .description = */ "MOVE (immediate)",
    /* .opcode[0]   = */ 0x92,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -4970,10 +4970,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVN,
    /* .name        = */ "MVN",
-   /* .description = */ "Move Numerics",
+   /* .description = */ "MOVE NUMERICS",
    /* .opcode[0]   = */ 0xD1,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4984,10 +4984,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVO,
    /* .name        = */ "MVO",
-   /* .description = */ "Move With Offset",
+   /* .description = */ "MOVE WITH OFFSET",
    /* .opcode[0]   = */ 0xF1,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -4998,7 +4998,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVST,
    /* .name        = */ "MVST",
-   /* .description = */ "Move String",
+   /* .description = */ "MOVE STRING",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x55,
    /* .format      = */ RRE_FORMAT,
@@ -5015,10 +5015,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVZ,
    /* .name        = */ "MVZ",
-   /* .description = */ "Move Zones",
+   /* .description = */ "MOVE ZONES",
    /* .opcode[0]   = */ 0xD3,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -5029,7 +5029,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MXBR,
    /* .name        = */ "MXBR",
-   /* .description = */ "Multiply (EB)",
+   /* .description = */ "MULTIPLY (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x4C,
    /* .format      = */ RRE_FORMAT,
@@ -5044,10 +5044,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MXD,
    /* .name        = */ "MXD",
-   /* .description = */ "Multiply, long HFP source, extended HFP result",
+   /* .description = */ "MULTIPLY (long to extended HFP)",
    /* .opcode[0]   = */ 0x67,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForTarget |
@@ -5058,7 +5058,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MXDR,
    /* .name        = */ "MXDR",
-   /* .description = */ "Multiply, long HFP source, extended HFP result",
+   /* .description = */ "MULTIPLY (long to extended HFP)",
    /* .opcode[0]   = */ 0x27,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5071,7 +5071,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MXR,
    /* .name        = */ "MXR",
-   /* .description = */ "Multiply, extended HFP source and result",
+   /* .description = */ "MULTIPLY (extended HFP)",
    /* .opcode[0]   = */ 0x26,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5085,10 +5085,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::N,
    /* .name        = */ "N",
-   /* .description = */ "And (32)",
+   /* .description = */ "AND (32)",
    /* .opcode[0]   = */ 0x54,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5102,10 +5102,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NC,
    /* .name        = */ "NC",
-   /* .description = */ "And (character)",
+   /* .description = */ "AND (character)",
    /* .opcode[0]   = */ 0xD4,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5119,7 +5119,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NGR,
    /* .name        = */ "NGR",
-   /* .description = */ "And (64)",
+   /* .description = */ "AND (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x80,
    /* .format      = */ RRE_FORMAT,
@@ -5134,7 +5134,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NI,
    /* .name        = */ "NI",
-   /* .description = */ "And (Immediate)",
+   /* .description = */ "AND (immediate)",
    /* .opcode[0]   = */ 0x94,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -5151,10 +5151,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NIHH,
    /* .name        = */ "NIHH",
-   /* .description = */ "And Immediate (high high)",
+   /* .description = */ "AND IMMEDIATE (high high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -5165,10 +5165,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NIHL,
    /* .name        = */ "NIHL",
-   /* .description = */ "And Immediate (high low)",
+   /* .description = */ "AND IMMEDIATE (high low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x05,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -5179,10 +5179,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NILH,
    /* .name        = */ "NILH",
-   /* .description = */ "And Immediate (low high)",
+   /* .description = */ "AND IMMEDIATE (low high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x06,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5192,10 +5192,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NILL,
    /* .name        = */ "NILL",
-   /* .description = */ "And Immediate (low low)",
+   /* .description = */ "AND IMMEDIATE (low low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x07,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5216,7 +5216,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NR,
    /* .name        = */ "NR",
-   /* .description = */ "And (32)",
+   /* .description = */ "AND (32)",
    /* .opcode[0]   = */ 0x14,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5231,10 +5231,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::O,
    /* .name        = */ "O",
-   /* .description = */ "Or (32)",
+   /* .description = */ "OR (32)",
    /* .opcode[0]   = */ 0x56,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5248,10 +5248,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OC,
    /* .name        = */ "OC",
-   /* .description = */ "Or (character)",
+   /* .description = */ "OR (character)",
    /* .opcode[0]   = */ 0xD6,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5265,7 +5265,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OGR,
    /* .name        = */ "OGR",
-   /* .description = */ "Or (64)",
+   /* .description = */ "OR (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x81,
    /* .format      = */ RRE_FORMAT,
@@ -5280,7 +5280,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OI,
    /* .name        = */ "OI",
-   /* .description = */ "Or (Immediate)",
+   /* .description = */ "OR (immediate)",
    /* .opcode[0]   = */ 0x96,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -5297,10 +5297,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OIHH,
    /* .name        = */ "OIHH",
-   /* .description = */ "Or Immediate (high high)",
+   /* .description = */ "OR IMMEDIATE (high high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -5311,10 +5311,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OIHL,
    /* .name        = */ "OIHL",
-   /* .description = */ "Or Immediate (high low)",
+   /* .description = */ "OR IMMEDIATE (high low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x09,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -5325,10 +5325,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OILH,
    /* .name        = */ "OILH",
-   /* .description = */ "Or Immediate (low high)",
+   /* .description = */ "OR IMMEDIATE (low high)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5338,10 +5338,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OILL,
    /* .name        = */ "OILL",
-   /* .description = */ "Or Immediate (low low)",
+   /* .description = */ "OR IMMEDIATE (low low)",
    /* .opcode[0]   = */ 0xA5,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5351,7 +5351,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OR,
    /* .name        = */ "OR",
-   /* .description = */ "Or (32)",
+   /* .description = */ "OR (32)",
    /* .opcode[0]   = */ 0x16,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5366,10 +5366,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PACK,
    /* .name        = */ "PACK",
-   /* .description = */ "Pack",
+   /* .description = */ "PACK",
    /* .opcode[0]   = */ 0xF2,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -5380,7 +5380,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PALB,
    /* .name        = */ "PALB",
-   /* .description = */ "Purge ALB",
+   /* .description = */ "PURGE ALB",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x48,
    /* .format      = */ RRE_FORMAT,
@@ -5391,7 +5391,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PC,
    /* .name        = */ "PC",
-   /* .description = */ "Program Call",
+   /* .description = */ "PROGRAM CALL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x18,
    /* .format      = */ S_FORMAT,
@@ -5404,10 +5404,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PKA,
    /* .name        = */ "PKA",
-   /* .description = */ "Pack ASCII",
+   /* .description = */ "PACK ASCII",
    /* .opcode[0]   = */ 0xE9,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -5418,10 +5418,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PKU,
    /* .name        = */ "PKU",
-   /* .description = */ "Pack Unicode",
+   /* .description = */ "PACK UNICODE",
    /* .opcode[0]   = */ 0xE1,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -5432,10 +5432,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PLO,
    /* .name        = */ "PLO",
-   /* .description = */ "Perform Locked Operation",
+   /* .description = */ "PERFORM LOCKED OPERATION",
    /* .opcode[0]   = */ 0xEE,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_ImplicitlyUsesGPR1 |
                         S390OpProp_ImplicitlyUsesGPR0 |
@@ -5452,7 +5452,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PR,
    /* .name        = */ "PR",
-   /* .description = */ "Program Return",
+   /* .description = */ "PROGRAM RETURN",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x01,
    /* .format      = */ E_FORMAT,
@@ -5463,7 +5463,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PT,
    /* .name        = */ "PT",
-   /* .description = */ "Program Transfer",
+   /* .description = */ "PROGRAM TRANSFER",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x28,
    /* .format      = */ RRE_FORMAT,
@@ -5474,7 +5474,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RCHP,
    /* .name        = */ "RCHP",
-   /* .description = */ "Reset Channel Path",
+   /* .description = */ "RESET CHANNEL PATH",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x3B,
    /* .format      = */ S_FORMAT,
@@ -5486,7 +5486,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RSCH,
    /* .name        = */ "RSCH",
-   /* .description = */ "Resume Subchannel",
+   /* .description = */ "RESUME SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x38,
    /* .format      = */ S_FORMAT,
@@ -5498,10 +5498,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::S,
    /* .name        = */ "S",
-   /* .description = */ "Subtract (32)",
+   /* .description = */ "SUBTRACT (32)",
    /* .opcode[0]   = */ 0x5B,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5516,7 +5516,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SAC,
    /* .name        = */ "SAC",
-   /* .description = */ "Set Address Control",
+   /* .description = */ "SET ADDRESS SPACE CONTROL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x19,
    /* .format      = */ S_FORMAT,
@@ -5527,7 +5527,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SAL,
    /* .name        = */ "SAL",
-   /* .description = */ "Set Address Limit",
+   /* .description = */ "SET ADDRESS LIMIT",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x37,
    /* .format      = */ S_FORMAT,
@@ -5538,7 +5538,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SAM24,
    /* .name        = */ "SAM24",
-   /* .description = */ "Set 24 bit addressing mode",
+   /* .description = */ "SET ADDRESSING MODE (24)",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x0C,
    /* .format      = */ E_FORMAT,
@@ -5549,7 +5549,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SAM31,
    /* .name        = */ "SAM31",
-   /* .description = */ "Set 31 bit addressing mode",
+   /* .description = */ "SET ADDRESSING MODE (31)",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x0D,
    /* .format      = */ E_FORMAT,
@@ -5560,7 +5560,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SAM64,
    /* .name        = */ "SAM64",
-   /* .description = */ "Set 64 bit addressing mode",
+   /* .description = */ "SET ADDRESSING MODE (64)",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x0E,
    /* .format      = */ E_FORMAT,
@@ -5571,7 +5571,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SAR,
    /* .name        = */ "SAR",
-   /* .description = */ "Set Access Register",
+   /* .description = */ "SET ACCESS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x4E,
    /* .format      = */ RRE_FORMAT,
@@ -5582,7 +5582,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SCHM,
    /* .name        = */ "SCHM",
-   /* .description = */ "Set Channel Monitor",
+   /* .description = */ "SET CHANNEL MONITOR",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x3C,
    /* .format      = */ S_FORMAT,
@@ -5595,7 +5595,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SCK,
    /* .name        = */ "SCK",
-   /* .description = */ "Set Clock",
+   /* .description = */ "SET CLOCK",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x04,
    /* .format      = */ S_FORMAT,
@@ -5607,7 +5607,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SCKC,
    /* .name        = */ "SCKC",
-   /* .description = */ "Set Clock Comparator",
+   /* .description = */ "SET CLOCK COMPARATOR",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x06,
    /* .format      = */ S_FORMAT,
@@ -5618,10 +5618,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SD,
    /* .name        = */ "SD",
-   /* .description = */ "Subtract Normalized,long HFP",
+   /* .description = */ "SUBTRACT NORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x6B,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -5634,7 +5634,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SDB,
    /* .name        = */ "SDB",
-   /* .description = */ "Subtract (LB)",
+   /* .description = */ "SUBTRACT (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x1B,
    /* .format      = */ RXE_FORMAT,
@@ -5650,7 +5650,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SDBR,
    /* .name        = */ "SDBR",
-   /* .description = */ "Subtract (LB)",
+   /* .description = */ "SUBTRACT (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x1B,
    /* .format      = */ RRE_FORMAT,
@@ -5665,7 +5665,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SDR,
    /* .name        = */ "SDR",
-   /* .description = */ "Subtract Normalized,long HFP",
+   /* .description = */ "SUBTRACT NORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x2B,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5680,10 +5680,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SE,
    /* .name        = */ "SE",
-   /* .description = */ "Subtract Normalized,short HFP",
+   /* .description = */ "SUBTRACT NORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x7B,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -5696,7 +5696,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SEB,
    /* .name        = */ "SEB",
-   /* .description = */ "Subtract (SB)",
+   /* .description = */ "SUBTRACT (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ RXE_FORMAT,
@@ -5712,7 +5712,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SEBR,
    /* .name        = */ "SEBR",
-   /* .description = */ "Subtract (SB)",
+   /* .description = */ "SUBTRACT (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ RRE_FORMAT,
@@ -5727,7 +5727,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SER,
    /* .name        = */ "SER",
-   /* .description = */ "Subtract Normalized,short HFP",
+   /* .description = */ "SUBTRACT NORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x3B,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5742,7 +5742,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SFPC,
    /* .name        = */ "SFPC",
-   /* .description = */ "Set FPC",
+   /* .description = */ "SET FPC",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x84,
    /* .format      = */ RRE_FORMAT,
@@ -5754,7 +5754,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SGFR,
    /* .name        = */ "SGFR",
-   /* .description = */ "Subtract (64 < 32)",
+   /* .description = */ "SUBTRACT (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x19,
    /* .format      = */ RRE_FORMAT,
@@ -5770,7 +5770,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SGR,
    /* .name        = */ "SGR",
-   /* .description = */ "Subtract (64)",
+   /* .description = */ "SUBTRACT (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x09,
    /* .format      = */ RRE_FORMAT,
@@ -5786,10 +5786,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SH,
    /* .name        = */ "SH",
-   /* .description = */ "Subtract Halfword",
+   /* .description = */ "SUBTRACT HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0x4B,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5804,10 +5804,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SIGP,
    /* .name        = */ "SIGP",
-   /* .description = */ "Signal Processor",
+   /* .description = */ "SIGNAL PROCESSOR",
    /* .opcode[0]   = */ 0xAE,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesRegPairForTarget |
                         S390OpProp_SetsCC |
@@ -5817,10 +5817,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SL,
    /* .name        = */ "SL",
-   /* .description = */ "Subtract Logical (32)",
+   /* .description = */ "SUBTRACT LOGICAL (32)",
    /* .opcode[0]   = */ 0x5F,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5834,10 +5834,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLA,
    /* .name        = */ "SLA",
-   /* .description = */ "Shift Left Single (32)",
+   /* .description = */ "SHIFT LEFT SINGLE (32)",
    /* .opcode[0]   = */ 0x8B,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5850,7 +5850,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLBGR,
    /* .name        = */ "SLBGR",
-   /* .description = */ "Subtract Logical With Borrow (64)",
+   /* .description = */ "SUBTRACT LOGICAL WITH BORROW (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x89,
    /* .format      = */ RRE_FORMAT,
@@ -5866,7 +5866,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLBR,
    /* .name        = */ "SLBR",
-   /* .description = */ "Subtract Logical With Borrow (32)",
+   /* .description = */ "SUBTRACT LOGICAL WITH BORROW (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x99,
    /* .format      = */ RRE_FORMAT,
@@ -5882,10 +5882,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLDA,
    /* .name        = */ "SLDA",
-   /* .description = */ "Shift Left Double",
+   /* .description = */ "SHIFT LEFT DOUBLE (64)",
    /* .opcode[0]   = */ 0x8F,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -5898,10 +5898,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLDL,
    /* .name        = */ "SLDL",
-   /* .description = */ "Shift Left Double Logical",
+   /* .description = */ "SHIFT LEFT DOUBLE LOGICAL (64)",
    /* .opcode[0]   = */ 0x8D,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_UsesRegPairForTarget |
@@ -5911,7 +5911,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLGFR,
    /* .name        = */ "SLGFR",
-   /* .description = */ "Subtract Logical (64 < 32)",
+   /* .description = */ "SUBTRACT LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x1B,
    /* .format      = */ RRE_FORMAT,
@@ -5926,7 +5926,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLGR,
    /* .name        = */ "SLGR",
-   /* .description = */ "Subtract Logical (64)",
+   /* .description = */ "SUBTRACT LOGICAL (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ RRE_FORMAT,
@@ -5941,10 +5941,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLL,
    /* .name        = */ "SLL",
-   /* .description = */ "Shift Left Single Logical",
+   /* .description = */ "SHIFT LEFT SINGLE LOGICAL (32)",
    /* .opcode[0]   = */ 0x89,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -5954,7 +5954,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLR,
    /* .name        = */ "SLR",
-   /* .description = */ "Subtract Logical (32)",
+   /* .description = */ "SUBTRACT LOGICAL (32)",
    /* .opcode[0]   = */ 0x1F,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -5969,10 +5969,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SP,
    /* .name        = */ "SP",
-   /* .description = */ "Subtract Decimal",
+   /* .description = */ "SUBTRACT DECIMAL",
    /* .opcode[0]   = */ 0xFB,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
@@ -5987,7 +5987,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SPKA,
    /* .name        = */ "SPKA",
-   /* .description = */ "Set PSW Key From Address",
+   /* .description = */ "SET PSW KEY FROM ADDRESS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ S_FORMAT,
@@ -5998,7 +5998,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SPM,
    /* .name        = */ "SPM",
-   /* .description = */ "Set Program Mask",
+   /* .description = */ "SET PROGRAM MASK",
    /* .opcode[0]   = */ 0x04,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -6009,7 +6009,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SPT,
    /* .name        = */ "SPT",
-   /* .description = */ "Set CPU Timer",
+   /* .description = */ "SET CPU TIMER",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x08,
    /* .format      = */ S_FORMAT,
@@ -6020,7 +6020,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SPX,
    /* .name        = */ "SPX",
-   /* .description = */ "Set Prefix",
+   /* .description = */ "SET PREFIX",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x10,
    /* .format      = */ S_FORMAT,
@@ -6031,7 +6031,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQD,
    /* .name        = */ "SQD",
-   /* .description = */ "Square Root Long HFP",
+   /* .description = */ "SQUARE ROOT (long HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x35,
    /* .format      = */ RXE_FORMAT,
@@ -6043,7 +6043,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQDB,
    /* .name        = */ "SQDB",
-   /* .description = */ "Square Root Long BFP",
+   /* .description = */ "SQUARE ROOT (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x15,
    /* .format      = */ RXE_FORMAT,
@@ -6055,7 +6055,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQDBR,
    /* .name        = */ "SQDBR",
-   /* .description = */ "Square Root Long BFP",
+   /* .description = */ "SQUARE ROOT (long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x15,
    /* .format      = */ RRE_FORMAT,
@@ -6067,7 +6067,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQDR,
    /* .name        = */ "SQDR",
-   /* .description = */ "Square Root Long HFP",
+   /* .description = */ "SQUARE ROOT (long HFP)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x44,
    /* .format      = */ RRE_FORMAT,
@@ -6079,7 +6079,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQE,
    /* .name        = */ "SQE",
-   /* .description = */ "Square Root short HFP",
+   /* .description = */ "SQUARE ROOT (short HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x34,
    /* .format      = */ RXE_FORMAT,
@@ -6091,7 +6091,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQEB,
    /* .name        = */ "SQEB",
-   /* .description = */ "Square Root Long BFP",
+   /* .description = */ "SQUARE ROOT (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x14,
    /* .format      = */ RXE_FORMAT,
@@ -6103,7 +6103,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQEBR,
    /* .name        = */ "SQEBR",
-   /* .description = */ "Square Root Long BFP",
+   /* .description = */ "SQUARE ROOT (short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x14,
    /* .format      = */ RRE_FORMAT,
@@ -6115,7 +6115,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQER,
    /* .name        = */ "SQER",
-   /* .description = */ "Square Root short HFP",
+   /* .description = */ "SQUARE ROOT (short HFP)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x45,
    /* .format      = */ RRE_FORMAT,
@@ -6127,7 +6127,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQXBR,
    /* .name        = */ "SQXBR",
-   /* .description = */ "Square Root (EB)",
+   /* .description = */ "SQUARE ROOT (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x16,
    /* .format      = */ RRE_FORMAT,
@@ -6141,7 +6141,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SQXR,
    /* .name        = */ "SQXR",
-   /* .description = */ "Square Root extended HFP",
+   /* .description = */ "SQUARE ROOT (extended HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x36,
    /* .format      = */ RRE_FORMAT,
@@ -6154,7 +6154,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SR,
    /* .name        = */ "SR",
-   /* .description = */ "Subtract (32)",
+   /* .description = */ "SUBTRACT (32)",
    /* .opcode[0]   = */ 0x1B,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -6170,10 +6170,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRA,
    /* .name        = */ "SRA",
-   /* .description = */ "Shift Right Single (32)",
+   /* .description = */ "SHIFT RIGHT SINGLE (32)",
    /* .opcode[0]   = */ 0x8A,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -6185,10 +6185,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRDA,
    /* .name        = */ "SRDA",
-   /* .description = */ "Shift Right Double",
+   /* .description = */ "SHIFT RIGHT DOUBLE (64)",
    /* .opcode[0]   = */ 0x8E,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -6200,10 +6200,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRDL,
    /* .name        = */ "SRDL",
-   /* .description = */ "Shift Right Double Logical",
+   /* .description = */ "SHIFT RIGHT DOUBLE LOGICAL (64)",
    /* .opcode[0]   = */ 0x8C,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_UsesRegPairForTarget |
@@ -6213,10 +6213,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRL,
    /* .name        = */ "SRL",
-   /* .description = */ "Shift Right Single Logical",
+   /* .description = */ "SHIFT RIGHT SINGLE LOGICAL (32)",
    /* .opcode[0]   = */ 0x88,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -6226,7 +6226,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRNM,
    /* .name        = */ "SRNM",
-   /* .description = */ "Set BFP Rounding Mode",
+   /* .description = */ "SET BFP ROUNDING MODE (2 bit)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x99,
    /* .format      = */ S_FORMAT,
@@ -6237,10 +6237,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRP,
    /* .name        = */ "SRP",
-   /* .description = */ "Shift and Round Decimal",
+   /* .description = */ "SHIFT AND ROUND DECIMAL",
    /* .opcode[0]   = */ 0xF0,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -6252,7 +6252,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRST,
    /* .name        = */ "SRST",
-   /* .description = */ "Search String",
+   /* .description = */ "SEARCH STRING",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x5E,
    /* .format      = */ RRE_FORMAT,
@@ -6268,7 +6268,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SSAR,
    /* .name        = */ "SSAR",
-   /* .description = */ "Set Secondary ASN",
+   /* .description = */ "SET SECONDARY ASN",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x25,
    /* .format      = */ RRE_FORMAT,
@@ -6279,7 +6279,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SSCH,
    /* .name        = */ "SSCH",
-   /* .description = */ "Start Subchannel",
+   /* .description = */ "START SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x33,
    /* .format      = */ S_FORMAT,
@@ -6291,10 +6291,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SSM,
    /* .name        = */ "SSM",
-   /* .description = */ "Set System Mask",
+   /* .description = */ "SET SYSTEM MASK",
    /* .opcode[0]   = */ 0x80,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ S_FORMAT,
+   /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad
    },
@@ -6302,10 +6302,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ST,
    /* .name        = */ "ST",
-   /* .description = */ "Store (32)",
+   /* .description = */ "STORE (32)",
    /* .opcode[0]   = */ 0x50,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -6316,10 +6316,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STAM,
    /* .name        = */ "STAM",
-   /* .description = */ "Set Access Multiple",
+   /* .description = */ "STORE ACCESS MULTIPLE",
    /* .opcode[0]   = */ 0x9B,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -6329,7 +6329,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STAP,
    /* .name        = */ "STAP",
-   /* .description = */ "Store CPU Address",
+   /* .description = */ "STORE CPU ADDRESS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x12,
    /* .format      = */ S_FORMAT,
@@ -6341,10 +6341,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STC,
    /* .name        = */ "STC",
-   /* .description = */ "Store Character",
+   /* .description = */ "STORE CHARACTER",
    /* .opcode[0]   = */ 0x42,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -6355,7 +6355,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCK,
    /* .name        = */ "STCK",
-   /* .description = */ "Store Clock",
+   /* .description = */ "STORE CLOCK",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x05,
    /* .format      = */ S_FORMAT,
@@ -6368,7 +6368,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCKC,
    /* .name        = */ "STCKC",
-   /* .description = */ "Store Clock Comparator",
+   /* .description = */ "STORE CLOCK COMPARATOR",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x07,
    /* .format      = */ S_FORMAT,
@@ -6380,7 +6380,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCKE,
    /* .name        = */ "STCKE",
-   /* .description = */ "Store Clock Extended",
+   /* .description = */ "STORE CLOCK EXTENDED",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x78,
    /* .format      = */ S_FORMAT,
@@ -6393,10 +6393,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCM,
    /* .name        = */ "STCM",
-   /* .description = */ "Store Character under Mask (low)",
+   /* .description = */ "STORE CHARACTERS UNDER MASK (low)",
    /* .opcode[0]   = */ 0xBE,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -6407,7 +6407,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCPS,
    /* .name        = */ "STCPS",
-   /* .description = */ "Store Channel Path Status",
+   /* .description = */ "STORE CHANNEL PATH STATUS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x3A,
    /* .format      = */ S_FORMAT,
@@ -6419,7 +6419,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCRW,
    /* .name        = */ "STCRW",
-   /* .description = */ "Store Channel Report Word",
+   /* .description = */ "STORE CHANNEL REPORT WORD",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x39,
    /* .format      = */ S_FORMAT,
@@ -6432,10 +6432,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCTL,
    /* .name        = */ "STCTL",
-   /* .description = */ "Store Control",
+   /* .description = */ "STORE CONTROL (32)",
    /* .opcode[0]   = */ 0xB6,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -6445,10 +6445,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STD,
    /* .name        = */ "STD",
-   /* .description = */ "Store (S)",
+   /* .description = */ "STORE (long)",
    /* .opcode[0]   = */ 0x60,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_SingleFP |
@@ -6458,10 +6458,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STE,
    /* .name        = */ "STE",
-   /* .description = */ "Store (L)",
+   /* .description = */ "STORE (short)",
    /* .opcode[0]   = */ 0x70,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_DoubleFP |
@@ -6471,7 +6471,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STFPC,
    /* .name        = */ "STFPC",
-   /* .description = */ "Store FPC",
+   /* .description = */ "STORE FPC",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x9C,
    /* .format      = */ S_FORMAT,
@@ -6483,10 +6483,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STH,
    /* .name        = */ "STH",
-   /* .description = */ "Store Halfword",
+   /* .description = */ "STORE HALFWORD (16)",
    /* .opcode[0]   = */ 0x40,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -6497,7 +6497,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STIDP,
    /* .name        = */ "STIDP",
-   /* .description = */ "Store CPU ID",
+   /* .description = */ "STORE CPU ID",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x02,
    /* .format      = */ S_FORMAT,
@@ -6509,10 +6509,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STM,
    /* .name        = */ "STM",
-   /* .description = */ "Store Multiple (32)",
+   /* .description = */ "STORE MULTIPLE (32)",
    /* .opcode[0]   = */ 0x90,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RS_FORMAT,
+   /* .format      = */ RSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -6524,7 +6524,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STNSM,
    /* .name        = */ "STNSM",
-   /* .description = */ "Store Then and System Mask",
+   /* .description = */ "STORE THEN AND SYSTEM MASK",
    /* .opcode[0]   = */ 0xAC,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -6536,7 +6536,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STOSM,
    /* .name        = */ "STOSM",
-   /* .description = */ "Store Then or System Mask",
+   /* .description = */ "STORE THEN OR SYSTEM MASK",
    /* .opcode[0]   = */ 0xAD,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -6548,7 +6548,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STPT,
    /* .name        = */ "STPT",
-   /* .description = */ "Store CPU Timer",
+   /* .description = */ "STORE CPU TIMER",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x09,
    /* .format      = */ S_FORMAT,
@@ -6560,7 +6560,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STPX,
    /* .name        = */ "STPX",
-   /* .description = */ "Store Prefix",
+   /* .description = */ "STORE PREFIX",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x11,
    /* .format      = */ S_FORMAT,
@@ -6572,7 +6572,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STRAG,
    /* .name        = */ "STRAG",
-   /* .description = */ "Store Real Address",
+   /* .description = */ "STORE REAL ADDRESS",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x02,
    /* .format      = */ SSE_FORMAT,
@@ -6586,7 +6586,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STSCH,
    /* .name        = */ "STSCH",
-   /* .description = */ "Store Subchannel",
+   /* .description = */ "STORE SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x34,
    /* .format      = */ S_FORMAT,
@@ -6600,7 +6600,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STURA,
    /* .name        = */ "STURA",
-   /* .description = */ "Store Using Real Address",
+   /* .description = */ "STORE USING REAL ADDRESS (32)",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x46,
    /* .format      = */ RRE_FORMAT,
@@ -6611,7 +6611,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STURG,
    /* .name        = */ "STURG",
-   /* .description = */ "Store Using Real Address",
+   /* .description = */ "STORE USING REAL ADDRESS (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x25,
    /* .format      = */ RRE_FORMAT,
@@ -6622,10 +6622,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SU,
    /* .name        = */ "SU",
-   /* .description = */ "Subtract Unnormalized,short HFP",
+   /* .description = */ "SUBTRACT UNNORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x7F,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -6638,7 +6638,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SUR,
    /* .name        = */ "SUR",
-   /* .description = */ "Subtract Unnormalized,short HFP",
+   /* .description = */ "SUBTRACT UNNORMALIZED (short HFP)",
    /* .opcode[0]   = */ 0x3F,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -6653,7 +6653,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SVC,
    /* .name        = */ "SVC",
-   /* .description = */ "Supervisor Call",
+   /* .description = */ "SUPERVISOR CALL",
    /* .opcode[0]   = */ 0x0A,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ I_FORMAT,
@@ -6664,10 +6664,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SW,
    /* .name        = */ "SW",
-   /* .description = */ "Subtract Unnormalized,long HFP",
+   /* .description = */ "SUBTRACT UNNORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x6F,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -6680,7 +6680,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SWR,
    /* .name        = */ "SWR",
-   /* .description = */ "Subtract Unnormalized,long HFP",
+   /* .description = */ "SUBTRACT UNNORMALIZED (long HFP)",
    /* .opcode[0]   = */ 0x2F,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -6695,7 +6695,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SXBR,
    /* .name        = */ "SXBR",
-   /* .description = */ "Subtract (EB)",
+   /* .description = */ "SUBTRACT (extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x4B,
    /* .format      = */ RRE_FORMAT,
@@ -6712,7 +6712,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SXR,
    /* .name        = */ "SXR",
-   /* .description = */ "Subtract Normalized, extended HFP",
+   /* .description = */ "SUBTRACT NORMALIZED (extended HFP)",
    /* .opcode[0]   = */ 0x37,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -6728,7 +6728,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TAM,
    /* .name        = */ "TAM",
-   /* .description = */ "Test addressing mode",
+   /* .description = */ "TEST ADDRESSING MODE",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ E_FORMAT,
@@ -6739,7 +6739,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TAR,
    /* .name        = */ "TAR",
-   /* .description = */ "Test Access",
+   /* .description = */ "TEST ACCESS",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x4C,
    /* .format      = */ RRE_FORMAT,
@@ -6750,10 +6750,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TBDR,
    /* .name        = */ "TBDR",
-   /* .description = */ "Convert HFP to BFP,long HFP,long BFP",
+   /* .description = */ "CONVERT HFP TO BFP (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x51,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -6764,10 +6764,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TBEDR,
    /* .name        = */ "TBEDR",
-   /* .description = */ "Convert HFP to BFP,long HFP,short BFP",
+   /* .description = */ "CONVERT HFP TO BFP (long to short)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x50,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_DoubleFP |
@@ -6779,7 +6779,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TCDB,
    /* .name        = */ "TCDB",
-   /* .description = */ "Test Data Class (LB)",
+   /* .description = */ "TEST DATA CLASS (long BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x11,
    /* .format      = */ RXE_FORMAT,
@@ -6791,7 +6791,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TCEB,
    /* .name        = */ "TCEB",
-   /* .description = */ "Test Data Class (SB)",
+   /* .description = */ "TEST DATA CLASS (short BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x10,
    /* .format      = */ RXE_FORMAT,
@@ -6803,7 +6803,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TCXB,
    /* .name        = */ "TCXB",
-   /* .description = */ "Test Data Class (EB)",
+   /* .description = */ "TEST DATA CLASS (extended BFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x12,
    /* .format      = */ RXE_FORMAT,
@@ -6816,10 +6816,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::THDER,
    /* .name        = */ "THDER",
-   /* .description = */ "Convert BFP to HFP,short BFP,long HFP",
+   /* .description = */ "CONVERT BFP TO HFP (short to long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x58,
-   /* .format      = */ RR_FORMAT,
+   /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_DoubleFP |
@@ -6831,10 +6831,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::THDR,
    /* .name        = */ "THDR",
-   /* .description = */ "Convert BFP to HFP,long BFP,long HFP",
+   /* .description = */ "CONVERT BFP TO HFP (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x59,
-   /* .format      = */ RR_FORMAT,
+   /* .format      = */ RRE_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -6845,7 +6845,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TM,
    /* .name        = */ "TM",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK",
    /* .opcode[0]   = */ 0x91,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -6858,10 +6858,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TMH,
    /* .name        = */ "TMH",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK HIGH",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -6869,10 +6869,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TMHH,
    /* .name        = */ "TMHH",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK (high high)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x02,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_TargetHW
@@ -6881,10 +6881,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TMHL,
    /* .name        = */ "TMHL",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK (high low)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x03,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_TargetHW
@@ -6893,10 +6893,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TML,
    /* .name        = */ "TML",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK LOW",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -6904,10 +6904,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TMLH,
    /* .name        = */ "TMLH",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK (low high)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -6915,10 +6915,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TMLL,
    /* .name        = */ "TMLL",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK (low low)",
    /* .opcode[0]   = */ 0xA7,
    /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RI_FORMAT,
+   /* .format      = */ RIa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -6926,10 +6926,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TP,
    /* .name        = */ "TP",
-   /* .description = */ "Test Decimal",
+   /* .description = */ "TEST DECIMAL",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xC0,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -6939,7 +6939,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TPI,
    /* .name        = */ "TPI",
-   /* .description = */ "Test Pending Interruption",
+   /* .description = */ "TEST PENDING INTERRUPTION",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x36,
    /* .format      = */ S_FORMAT,
@@ -6952,7 +6952,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TPROT,
    /* .name        = */ "TPROT",
-   /* .description = */ "Test Protection",
+   /* .description = */ "TEST PROTECTION",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x01,
    /* .format      = */ SSE_FORMAT,
@@ -6965,10 +6965,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TR,
    /* .name        = */ "TR",
-   /* .description = */ "Translate",
+   /* .description = */ "TRANSLATE",
    /* .opcode[0]   = */ 0xDC,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -6980,7 +6980,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRE,
    /* .name        = */ "TRE",
-   /* .description = */ "Translate Extended",
+   /* .description = */ "TRANSLATE EXTENDED",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xA5,
    /* .format      = */ RRE_FORMAT,
@@ -6996,10 +6996,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRT,
    /* .name        = */ "TRT",
-   /* .description = */ "Translate and Test",
+   /* .description = */ "TRANSLATE AND TEST",
    /* .opcode[0]   = */ 0xDD,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_ImplicitlySetsGPR2 |
                         S390OpProp_ImplicitlySetsGPR1 |
@@ -7011,10 +7011,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TS,
    /* .name        = */ "TS",
-   /* .description = */ "Test and Set",
+   /* .description = */ "TEST AND SET",
    /* .opcode[0]   = */ 0x93,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ S_FORMAT,
+   /* .format      = */ SI_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -7025,7 +7025,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TSCH,
    /* .name        = */ "TSCH",
-   /* .description = */ "Test Subchannel",
+   /* .description = */ "TEST SUBCHANNEL",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x35,
    /* .format      = */ S_FORMAT,
@@ -7039,10 +7039,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::UNPK,
    /* .name        = */ "UNPK",
-   /* .description = */ "Unpack",
+   /* .description = */ "UNPACK",
    /* .opcode[0]   = */ 0xF3,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7053,10 +7053,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::UNPKA,
    /* .name        = */ "UNPKA",
-   /* .description = */ "Unpack ASCII",
+   /* .description = */ "UNPACK ASCII",
    /* .opcode[0]   = */ 0xEA,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7068,10 +7068,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::UNPKU,
    /* .name        = */ "UNPKU",
-   /* .description = */ "Unpack Unicode",
+   /* .description = */ "UNPACK UNICODE",
    /* .opcode[0]   = */ 0xE2,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -7083,7 +7083,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::UPT,
    /* .name        = */ "UPT",
-   /* .description = */ "Update Tree",
+   /* .description = */ "UPDATE TREE",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x02,
    /* .format      = */ E_FORMAT,
@@ -7102,10 +7102,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::X,
    /* .name        = */ "X",
-   /* .description = */ "Exclusive Or (32)",
+   /* .description = */ "EXCLUSIVE OR (32)",
    /* .opcode[0]   = */ 0x57,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RX_FORMAT,
+   /* .format      = */ RXa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -7119,10 +7119,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XC,
    /* .name        = */ "XC",
-   /* .description = */ "Exclusive Or (character)",
+   /* .description = */ "EXCLUSIVE OR (character)",
    /* .opcode[0]   = */ 0xD7,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS1_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -7136,7 +7136,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XGR,
    /* .name        = */ "XGR",
-   /* .description = */ "Exclusive Or (64)",
+   /* .description = */ "EXCLUSIVE OR (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x82,
    /* .format      = */ RRE_FORMAT,
@@ -7151,7 +7151,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XI,
    /* .name        = */ "XI",
-   /* .description = */ "Exclusive Or (immediate)",
+   /* .description = */ "EXCLUSIVE OR (immediate)",
    /* .opcode[0]   = */ 0x97,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -7168,7 +7168,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XR,
    /* .name        = */ "XR",
-   /* .description = */ "Exclusive Or (32)",
+   /* .description = */ "EXCLUSIVE OR (32)",
    /* .opcode[0]   = */ 0x17,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ RR_FORMAT,
@@ -7183,10 +7183,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ZAP,
    /* .name        = */ "ZAP",
-   /* .description = */ "Zero and Add",
+   /* .description = */ "ZERO AND ADD",
    /* .opcode[0]   = */ 0xF8,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z900,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsOverflowFlag |
@@ -7200,10 +7200,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AG,
    /* .name        = */ "AG",
-   /* .description = */ "(LongDisp) Add (64)",
+   /* .description = */ "ADD (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -7218,10 +7218,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGF,
    /* .name        = */ "AGF",
-   /* .description = */ "(LongDisp) Add (64 < 32)",
+   /* .description = */ "ADD (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x18,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_SetsCC |
@@ -7236,10 +7236,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AHY,
    /* .name        = */ "AHY",
-   /* .description = */ "(LongDisp) Add Halfword",
+   /* .description = */ "ADD HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x7A,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -7255,10 +7255,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALC,
    /* .name        = */ "ALC",
-   /* .description = */ "(LongDisp) Add Logical with Carry (32)",
+   /* .description = */ "ADD LOGICAL WITH CARRY (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x98,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -7273,10 +7273,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALCG,
    /* .name        = */ "ALCG",
-   /* .description = */ "(LongDisp) Add Logical with Carry (64)",
+   /* .description = */ "ADD LOGICAL WITH CARRY (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x88,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -7291,10 +7291,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALG,
    /* .name        = */ "ALG",
-   /* .description = */ "(LongDisp) Add Logical (64)",
+   /* .description = */ "ADD LOGICAL (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -7308,10 +7308,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGF,
    /* .name        = */ "ALGF",
-   /* .description = */ "(LongDisp) Add Logical (64 < 32)",
+   /* .description = */ "ADD LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x1A,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_SetsCC |
@@ -7325,10 +7325,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALY,
    /* .name        = */ "ALY",
-   /* .description = */ "(LongDisp) Add Logical",
+   /* .description = */ "ADD LOGICAL (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x5E,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -7342,10 +7342,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AY,
    /* .name        = */ "AY",
-   /* .description = */ "(LongDisp) Add",
+   /* .description = */ "ADD (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x5A,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -7360,10 +7360,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BCTG,
    /* .name        = */ "BCTG",
-   /* .description = */ "(LongDisp) Branch on Count (64)",
+   /* .description = */ "BRANCH ON COUNT (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x46,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is64Bit |
@@ -7376,10 +7376,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BXHG,
    /* .name        = */ "BXHG",
-   /* .description = */ "(LongDisp) Branch on Index High",
+   /* .description = */ "BRANCH ON INDEX HIGH (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x44,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is64Bit |
@@ -7392,10 +7392,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BXLEG,
    /* .name        = */ "BXLEG",
-   /* .description = */ "(LongDisp) Branch on Index Low or Equ. (64)",
+   /* .description = */ "BRANCH ON INDEX LOW OR EQUAL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x45,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_Is64Bit |
@@ -7408,10 +7408,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDSG,
    /* .name        = */ "CDSG",
-   /* .description = */ "Compare Double and Swap",
+   /* .description = */ "COMPARE DOUBLE AND SWAP (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x3E,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -7430,10 +7430,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDSY,
    /* .name        = */ "CDSY",
-   /* .description = */ "Compare Double and Swap",
+   /* .description = */ "COMPARE DOUBLE AND SWAP (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x31,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7453,10 +7453,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CG,
    /* .name        = */ "CG",
-   /* .description = */ "(LongDisp) Compare (64)",
+   /* .description = */ "COMPARE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x20,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -7469,10 +7469,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGF,
    /* .name        = */ "CGF",
-   /* .description = */ "(LongDisp) Compare (64 < 32)",
+   /* .description = */ "COMPARE (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x30,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
@@ -7485,10 +7485,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHY,
    /* .name        = */ "CHY",
-   /* .description = */ "(LongDisp) Compare Halfword",
+   /* .description = */ "COMPARE HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x79,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7501,10 +7501,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLCLU,
    /* .name        = */ "CLCLU",
-   /* .description = */ "Compare Logical Long Unicode",
+   /* .description = */ "COMPARE LOGICAL LONG UNICODE",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x8F,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -7520,10 +7520,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLG,
    /* .name        = */ "CLG",
-   /* .description = */ "(LongDisp) Compare Logical (64)",
+   /* .description = */ "COMPARE LOGICAL (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x21,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -7536,10 +7536,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGF,
    /* .name        = */ "CLGF",
-   /* .description = */ "(LongDisp) Compare Logical (64 < 32)",
+   /* .description = */ "COMPARE LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x31,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
@@ -7552,7 +7552,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLIY,
    /* .name        = */ "CLIY",
-   /* .description = */ "Compare Logical Immediate",
+   /* .description = */ "COMPARE LOGICAL (immediate)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x55,
    /* .format      = */ SIY_FORMAT,
@@ -7567,10 +7567,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLMH,
    /* .name        = */ "CLMH",
-   /* .description = */ "Compare Logical Characters under Mask High",
+   /* .description = */ "COMPARE LOGICAL CHAR. UNDER MASK (high)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x20,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7584,10 +7584,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLMY,
    /* .name        = */ "CLMY",
-   /* .description = */ "Compare Logical Characters under Mask Y Form",
+   /* .description = */ "COMPARE LOGICAL CHAR. UNDER MASK (low)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x21,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7600,10 +7600,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLY,
    /* .name        = */ "CLY",
-   /* .description = */ "(LongDisp) Compare Logical (32)",
+   /* .description = */ "COMPARE LOGICAL (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x55,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7617,10 +7617,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CSG,
    /* .name        = */ "CSG",
-   /* .description = */ "(LongDisp) Compare and Swap (64)",
+   /* .description = */ "COMPARE AND SWAP (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x30,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -7638,10 +7638,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CSY,
    /* .name        = */ "CSY",
-   /* .description = */ "(LongDisp) Compare and Swap (32)",
+   /* .description = */ "COMPARE AND SWAP (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x14,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7659,10 +7659,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CVBG,
    /* .name        = */ "CVBG",
-   /* .description = */ "Convert to Binary",
+   /* .description = */ "CONVERT TO BINARY (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -7672,10 +7672,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CVBY,
    /* .name        = */ "CVBY",
-   /* .description = */ "(LongDisp) Convert to Binary",
+   /* .description = */ "CONVERT TO BINARY (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x06,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7685,10 +7685,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CVDG,
    /* .name        = */ "CVDG",
-   /* .description = */ "Convert to Decimal (64)",
+   /* .description = */ "CONVERT TO DECIMAL (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x2E,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
@@ -7698,10 +7698,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CVDY,
    /* .name        = */ "CVDY",
-   /* .description = */ "(LongDisp) Convert to Decimal (32)",
+   /* .description = */ "CONVERT TO DECIMAL (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x26,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -7711,10 +7711,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CY,
    /* .name        = */ "CY",
-   /* .description = */ "(LongDisp) Compare (32)",
+   /* .description = */ "COMPARE (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x59,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -7727,10 +7727,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DL,
    /* .name        = */ "DL",
-   /* .description = */ "(LongDisp) Divide",
+   /* .description = */ "DIVIDE LOGICAL (32 <- 64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x97,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -7743,10 +7743,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DSG,
    /* .name        = */ "DSG",
-   /* .description = */ "(LongDisp) Divide Single (64)",
+   /* .description = */ "DIVIDE SINGLE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -7759,10 +7759,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DSGF,
    /* .name        = */ "DSGF",
-   /* .description = */ "(LongDisp) Divide Single (64 < 32)",
+   /* .description = */ "DIVIDE SINGLE (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x1D,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
@@ -7775,10 +7775,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ICMH,
    /* .name        = */ "ICMH",
-   /* .description = */ "(LongDisp) Insert Characters under Mask (high)",
+   /* .description = */ "INSERT CHARACTERS UNDER MASK (high)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x80,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_SetsCC |
@@ -7791,10 +7791,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ICMY,
    /* .name        = */ "ICMY",
-   /* .description = */ "(LongDisp) Insert Character under Mask",
+   /* .description = */ "INSERT CHARACTERS UNDER MASK (low)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x81,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -7806,10 +7806,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ICY,
    /* .name        = */ "ICY",
-   /* .description = */ "(LongDisp) Insert Character",
+   /* .description = */ "INSERT CHARACTER",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x73,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7820,7 +7820,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KIMD,
    /* .name        = */ "KIMD",
-   /* .description = */ "Compute Intermediate Message Digest",
+   /* .description = */ "COMPUTE INTERMEDIATE MESSAGE DIGEST",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x3E,
    /* .format      = */ RRE_FORMAT,
@@ -7837,7 +7837,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KLMD,
    /* .name        = */ "KLMD",
-   /* .description = */ "Compute Last Message Digest",
+   /* .description = */ "COMPUTE LAST MESSAGE DIGEST",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x3F,
    /* .format      = */ RRE_FORMAT,
@@ -7854,7 +7854,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KM,
    /* .name        = */ "KM",
-   /* .description = */ "Cipher Message",
+   /* .description = */ "CIPHER MESSAGE",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x2E,
    /* .format      = */ RRE_FORMAT,
@@ -7871,7 +7871,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KMAC,
    /* .name        = */ "KMAC",
-   /* .description = */ "Compute Message Authentication Code",
+   /* .description = */ "COMPUTE MESSAGE AUTHENTICATION CODE",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x1E,
    /* .format      = */ RRE_FORMAT,
@@ -7888,7 +7888,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KMC,
    /* .name        = */ "KMC",
-   /* .description = */ "Cipher Message with Chaining",
+   /* .description = */ "CIPHER MESSAGE WITH CHAINING",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x2F,
    /* .format      = */ RRE_FORMAT,
@@ -7905,10 +7905,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAMY,
    /* .name        = */ "LAMY",
-   /* .description = */ "(LongDisp) Load Access Multiple",
+   /* .description = */ "LOAD ACCESS MULTIPLE",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x9A,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7919,10 +7919,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAY,
    /* .name        = */ "LAY",
-   /* .description = */ "(LongDisp) Load Address",
+   /* .description = */ "LOAD ADDRESS",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x71,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -7931,10 +7931,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LB,
    /* .name        = */ "LB",
-   /* .description = */ "(LongDisp) Load Byte (31) - note it is called LB in the PoP",
+   /* .description = */ "LOAD BYTE (32 <- 8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x76,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -7945,10 +7945,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCTLG,
    /* .name        = */ "LCTLG",
-   /* .description = */ "Load Control",
+   /* .description = */ "LOAD CONTROL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x2F,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad
@@ -7957,10 +7957,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDY,
    /* .name        = */ "LDY",
-   /* .description = */ "(LongDisp) Load (L)",
+   /* .description = */ "LOAD (long)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x65,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7970,10 +7970,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LEY,
    /* .name        = */ "LEY",
-   /* .description = */ "(LongDisp) Load (S)",
+   /* .description = */ "LOAD (short)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x64,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -7983,10 +7983,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LG,
    /* .name        = */ "LG",
-   /* .description = */ "(LongDisp) Load (64)",
+   /* .description = */ "LOAD (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -7997,10 +7997,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGB,
    /* .name        = */ "LGB",
-   /* .description = */ "(LongDisp) Load Byte (64)",
+   /* .description = */ "LOAD BYTE (64 <- 8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x77,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -8011,10 +8011,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGF,
    /* .name        = */ "LGF",
-   /* .description = */ "(LongDisp) Load (64 < 32)",
+   /* .description = */ "LOAD (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x14,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32To64Bit |
@@ -8025,10 +8025,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGH,
    /* .name        = */ "LGH",
-   /* .description = */ "(LongDisp) Load Halfword",
+   /* .description = */ "LOAD HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x15,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -8039,10 +8039,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LHY,
    /* .name        = */ "LHY",
-   /* .description = */ "(LongDisp)Load Halfword",
+   /* .description = */ "LOAD HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x78,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -8053,10 +8053,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGC,
    /* .name        = */ "LLGC",
-   /* .description = */ "(LongDisp) Load Logical Character",
+   /* .description = */ "LOAD LOGICAL CHARACTER (64 <- 8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x90,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -8067,10 +8067,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGF,
    /* .name        = */ "LLGF",
-   /* .description = */ "(LongDisp) Load Logical Halfword",
+   /* .description = */ "LOAD LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x16,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -8081,10 +8081,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGH,
    /* .name        = */ "LLGH",
-   /* .description = */ "(LongDisp) Load Logical Halfword",
+   /* .description = */ "LOAD LOGICAL HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x91,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -8095,10 +8095,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGT,
    /* .name        = */ "LLGT",
-   /* .description = */ "(LongDisp) Load Logical Thirty One Bits",
+   /* .description = */ "LOAD LOGICAL THIRTY ONE BITS (64 <- 31)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x17,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -8109,10 +8109,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LMG,
    /* .name        = */ "LMG",
-   /* .description = */ "(LongDisp) Load Multiple (64)",
+   /* .description = */ "LOAD MULTIPLE (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -8125,10 +8125,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LMH,
    /* .name        = */ "LMH",
-   /* .description = */ "Load Multiple High",
+   /* .description = */ "LOAD MULTIPLE HIGH (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x96,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_UsesRegRangeForTarget |
@@ -8140,10 +8140,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LMY,
    /* .name        = */ "LMY",
-   /* .description = */ "(LongDisp) Load Multiple",
+   /* .description = */ "LOAD MULTIPLE (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x98,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -8156,10 +8156,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPQ,
    /* .name        = */ "LPQ",
-   /* .description = */ "(LongDisp) Load Pair from Quadword",
+   /* .description = */ "LOAD PAIR FROM QUADWORD (64&64 <- 128)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x8F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -8171,10 +8171,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRAG,
    /* .name        = */ "LRAG",
-   /* .description = */ "Load Real Address",
+   /* .description = */ "LOAD REAL ADDRESS (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x03,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsOperand1
@@ -8183,10 +8183,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRAY,
    /* .name        = */ "LRAY",
-   /* .description = */ "Load Real Address Y Form",
+   /* .description = */ "LOAD REAL ADDRESS (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x13,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsCC |
@@ -8196,10 +8196,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRV,
    /* .name        = */ "LRV",
-   /* .description = */ "(LongDisp) Load Reversed (32)",
+   /* .description = */ "LOAD REVERSED (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x1E,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -8210,10 +8210,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRVG,
    /* .name        = */ "LRVG",
-   /* .description = */ "(LongDisp) Load Reversed (64)",
+   /* .description = */ "LOAD REVERSED (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -8224,10 +8224,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRVH,
    /* .name        = */ "LRVH",
-   /* .description = */ "(LongDisp) Load Reversed Halfword",
+   /* .description = */ "LOAD REVERSED (16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x1F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -8238,10 +8238,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LY,
    /* .name        = */ "LY",
-   /* .description = */ "(LongDisp) Load (32)",
+   /* .description = */ "LOAD (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x58,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -8252,7 +8252,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAD,
    /* .name        = */ "MAD",
-   /* .description = */ "Multiply and Add, long HFP sources and result",
+   /* .description = */ "MULTIPLY AND ADD (long HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x3E,
    /* .format      = */ RXF_FORMAT,
@@ -8266,10 +8266,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MADR,
    /* .name        = */ "MADR",
-   /* .description = */ "Multiply and Add, long HFP sources and result",
+   /* .description = */ "MULTIPLY AND ADD (long HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x3E,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -8279,7 +8279,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAE,
    /* .name        = */ "MAE",
-   /* .description = */ "Multiply and Add, short HFP sources and result",
+   /* .description = */ "MULTIPLY AND ADD (short HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x2E,
    /* .format      = */ RXF_FORMAT,
@@ -8293,10 +8293,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAER,
    /* .name        = */ "MAER",
-   /* .description = */ "Multiply and Add, short HFP sources and result",
+   /* .description = */ "MULTIPLY AND ADD (short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x2E,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -8306,10 +8306,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MLG,
    /* .name        = */ "MLG",
-   /* .description = */ "(LongDisp) Multiply Logical ( 128<64 )",
+   /* .description = */ "MULTIPLY LOGICAL (128 <- 64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x86,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8322,7 +8322,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSD,
    /* .name        = */ "MSD",
-   /* .description = */ "Multiply and Subtract, long HFP sources and result",
+   /* .description = */ "MULTIPLY AND SUBTRACT (long HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x3F,
    /* .format      = */ RXF_FORMAT,
@@ -8336,10 +8336,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSDR,
    /* .name        = */ "MSDR",
-   /* .description = */ "Multiply and Subtract, long HFP sources and result",
+   /* .description = */ "MULTIPLY AND SUBTRACT (long HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x3F,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -8349,7 +8349,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSE,
    /* .name        = */ "MSE",
-   /* .description = */ "Multiply and Subtract, short HFP sources and result",
+   /* .description = */ "MULTIPLY AND SUBTRACT (short HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x2F,
    /* .format      = */ RXF_FORMAT,
@@ -8363,10 +8363,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSER,
    /* .name        = */ "MSER",
-   /* .description = */ "Multiply and Subtract, short HFP sources and result",
+   /* .description = */ "MULTIPLY AND SUBTRACT (short HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x2F,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_UsesTarget |
@@ -8376,10 +8376,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSG,
    /* .name        = */ "MSG",
-   /* .description = */ "(LongDisp) Multiply Single (64)",
+   /* .description = */ "MULTIPLY SINGLE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8391,10 +8391,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSGF,
    /* .name        = */ "MSGF",
-   /* .description = */ "(LongDisp) Multiply Single (64 < 32)",
+   /* .description = */ "MULTIPLY SINGLE (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x1C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
@@ -8406,10 +8406,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSY,
    /* .name        = */ "MSY",
-   /* .description = */ "(LongDisp) Multiply Single",
+   /* .description = */ "MULTIPLY SINGLE (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x51,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -8421,10 +8421,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVCLU,
    /* .name        = */ "MVCLU",
-   /* .description = */ "Move Long Unicode",
+   /* .description = */ "MOVE LONG UNICODE",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x8E,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -8439,7 +8439,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVIY,
    /* .name        = */ "MVIY",
-   /* .description = */ "(LongDisp) Move (Immediate)",
+   /* .description = */ "MOVE (immediate)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x52,
    /* .format      = */ SIY_FORMAT,
@@ -8452,10 +8452,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NG,
    /* .name        = */ "NG",
-   /* .description = */ "(LongDisp) And (64)",
+   /* .description = */ "AND (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x80,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8469,7 +8469,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NIY,
    /* .name        = */ "NIY",
-   /* .description = */ "(LongDisp) And (Immediate)",
+   /* .description = */ "AND (immediate)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x54,
    /* .format      = */ SIY_FORMAT,
@@ -8486,10 +8486,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NY,
    /* .name        = */ "NY",
-   /* .description = */ "(LongDisp) And (32)",
+   /* .description = */ "AND (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x54,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -8503,10 +8503,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OG,
    /* .name        = */ "OG",
-   /* .description = */ "(LongDisp) Or (64)",
+   /* .description = */ "OR (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x81,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8520,7 +8520,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OIY,
    /* .name        = */ "OIY",
-   /* .description = */ "(LongDisp) Or (Immediate)",
+   /* .description = */ "OR (immediate)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x56,
    /* .format      = */ SIY_FORMAT,
@@ -8537,10 +8537,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OY,
    /* .name        = */ "OY",
-   /* .description = */ "(LongDisp) Or (32)",
+   /* .description = */ "OR (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x56,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -8554,10 +8554,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RLL,
    /* .name        = */ "RLL",
-   /* .description = */ "Rotate Left Single Logical (32)",
+   /* .description = */ "ROTATE LEFT SINGLE LOGICAL (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x1D,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_LongDispSupported |
@@ -8567,10 +8567,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RLLG,
    /* .name        = */ "RLLG",
-   /* .description = */ "Rotate Left Single Logical (64)",
+   /* .description = */ "ROTATE LEFT SINGLE LOGICAL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x1C,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_LongDispSupported |
@@ -8580,10 +8580,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SG,
    /* .name        = */ "SG",
-   /* .description = */ "(LongDisp) Subtract (64)",
+   /* .description = */ "SUBTRACT (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x09,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8598,10 +8598,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SGF,
    /* .name        = */ "SGF",
-   /* .description = */ "(LongDisp) Subtract (64 < 32)",
+   /* .description = */ "SUBTRACT (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x19,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
@@ -8616,10 +8616,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SHY,
    /* .name        = */ "SHY",
-   /* .description = */ "(LongDisp) Subtract Halfword",
+   /* .description = */ "SUBTRACT HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x7B,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -8634,10 +8634,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLAG,
    /* .name        = */ "SLAG",
-   /* .description = */ "(LongDisp) Shift Left Single (64)",
+   /* .description = */ "SHIFT LEFT SINGLE (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -8650,10 +8650,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLB,
    /* .name        = */ "SLB",
-   /* .description = */ "(LongDisp) Subtract Logical with Borrow (32)",
+   /* .description = */ "SUBTRACT LOGICAL WITH BORROW (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x99,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -8668,10 +8668,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLBG,
    /* .name        = */ "SLBG",
-   /* .description = */ "(LongDisp) Subtract Logical With Borrow (64)",
+   /* .description = */ "SUBTRACT LOGICAL WITH BORROW (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x89,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8686,10 +8686,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLG,
    /* .name        = */ "SLG",
-   /* .description = */ "(LongDisp) Subtract Logical (64)",
+   /* .description = */ "SUBTRACT LOGICAL (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -8703,10 +8703,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLGF,
    /* .name        = */ "SLGF",
-   /* .description = */ "(LongDisp) Subtract Logical (64 < 32)",
+   /* .description = */ "SUBTRACT LOGICAL (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x1B,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
@@ -8720,10 +8720,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLLG,
    /* .name        = */ "SLLG",
-   /* .description = */ "(LongDisp) Shift Left Logical (64)",
+   /* .description = */ "SHIFT LEFT SINGLE LOGICAL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_LongDispSupported |
@@ -8733,10 +8733,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLY,
    /* .name        = */ "SLY",
-   /* .description = */ "(LongDisp) Subtract Logical (32)",
+   /* .description = */ "SUBTRACT LOGICAL (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x5F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -8750,10 +8750,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRAG,
    /* .name        = */ "SRAG",
-   /* .description = */ "(LongDisp) Shift Right Single (64)",
+   /* .description = */ "SHIFT RIGHT SINGLE (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -8765,10 +8765,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRLG,
    /* .name        = */ "SRLG",
-   /* .description = */ "(LongDisp) Shift Right Logical (64)",
+   /* .description = */ "SHIFT RIGHT SINGLE LOGICAL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_LongDispSupported |
@@ -8778,10 +8778,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STAMY,
    /* .name        = */ "STAMY",
-   /* .description = */ "(LongDisp) Set Access Multiple",
+   /* .description = */ "STORE ACCESS MULTIPLE",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x9B,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -8791,10 +8791,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCMH,
    /* .name        = */ "STCMH",
-   /* .description = */ "(LongDisp) Store Characters under Mask (high)",
+   /* .description = */ "STORE CHARACTERS UNDER MASK (high)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x2C,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -8806,10 +8806,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCMY,
    /* .name        = */ "STCMY",
-   /* .description = */ "(LongDisp) Store Characters under Mask (low)",
+   /* .description = */ "STORE CHARACTERS UNDER MASK (low)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x2D,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -8820,10 +8820,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCTG,
    /* .name        = */ "STCTG",
-   /* .description = */ "Store Control",
+   /* .description = */ "STORE CONTROL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x25,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is64Bit |
@@ -8833,10 +8833,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCY,
    /* .name        = */ "STCY",
-   /* .description = */ "(LongDisp) Store Character",
+   /* .description = */ "STORE CHARACTER",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x72,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -8847,10 +8847,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STDY,
    /* .name        = */ "STDY",
-   /* .description = */ "(LongDisp) Store (S)",
+   /* .description = */ "STORE (long)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x67,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported
@@ -8859,10 +8859,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STEY,
    /* .name        = */ "STEY",
-   /* .description = */ "(LongDisp) Store (L)",
+   /* .description = */ "STORE (short)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x66,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported
@@ -8871,10 +8871,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STG,
    /* .name        = */ "STG",
-   /* .description = */ "(LongDisp) Store (64)",
+   /* .description = */ "STORE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x24,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is64Bit |
@@ -8885,10 +8885,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STHY,
    /* .name        = */ "STHY",
-   /* .description = */ "(LongDisp) Store Halfword",
+   /* .description = */ "STORE HALFWORD (16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x70,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -8899,10 +8899,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STMG,
    /* .name        = */ "STMG",
-   /* .description = */ "(LongDisp) Store Multiple (64)",
+   /* .description = */ "STORE MULTIPLE (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x24,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is64Bit |
@@ -8914,10 +8914,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STMH,
    /* .name        = */ "STMH",
-   /* .description = */ "Store Multiple High",
+   /* .description = */ "STORE MULTIPLE HIGH (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x26,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -8927,10 +8927,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STMY,
    /* .name        = */ "STMY",
-   /* .description = */ "(LongDisp) Store Multiple",
+   /* .description = */ "STORE MULTIPLE (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x90,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -8942,10 +8942,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STPQ,
    /* .name        = */ "STPQ",
-   /* .description = */ "(LongDisp) Store Pair to Quadword",
+   /* .description = */ "STORE PAIR TO QUADWORD",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x8E,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
@@ -8956,10 +8956,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STRV,
    /* .name        = */ "STRV",
-   /* .description = */ "(LongDisp) Store (32)",
+   /* .description = */ "STORE REVERSED (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x3E,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -8969,10 +8969,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STRVG,
    /* .name        = */ "STRVG",
-   /* .description = */ "(LongDisp) Store Reversed (64)",
+   /* .description = */ "STORE REVERSED (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x2F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is64Bit |
@@ -8982,10 +8982,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STRVH,
    /* .name        = */ "STRVH",
-   /* .description = */ "(LongDisp) Store Reversed Halfword",
+   /* .description = */ "STORE REVERSED (16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x3F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsStore |
@@ -8995,10 +8995,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STY,
    /* .name        = */ "STY",
-   /* .description = */ "(LongDisp) Store (32)",
+   /* .description = */ "STORE (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x50,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -9009,10 +9009,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SY,
    /* .name        = */ "SY",
-   /* .description = */ "(LongDisp) Subtract (32)",
+   /* .description = */ "SUBTRACT (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x5B,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -9027,7 +9027,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TMY,
    /* .name        = */ "TMY",
-   /* .description = */ "Test under Mask",
+   /* .description = */ "TEST UNDER MASK",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x51,
    /* .format      = */ SIY_FORMAT,
@@ -9040,10 +9040,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XG,
    /* .name        = */ "XG",
-   /* .description = */ "(LongDisp) Exclusive Or (64)",
+   /* .description = */ "EXCLUSIVE OR (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x82,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -9057,7 +9057,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XIY,
    /* .name        = */ "XIY",
-   /* .description = */ "(LongDisp) Exclusive Or (immediate)",
+   /* .description = */ "EXCLUSIVE OR (immediate)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x57,
    /* .format      = */ SIY_FORMAT,
@@ -9074,10 +9074,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XY,
    /* .name        = */ "XY",
-   /* .description = */ "(LongDisp) Exclusive Or (32)",
+   /* .description = */ "EXCLUSIVE OR (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x57,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z990,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -9091,10 +9091,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ADTR,
    /* .name        = */ "ADTR",
-   /* .description = */ "Add (DFP64)",
+   /* .description = */ "ADD (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD2,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9106,10 +9106,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AFI,
    /* .name        = */ "AFI",
-   /* .description = */ "Add Immediate (32)",
+   /* .description = */ "ADD IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x09,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -9123,10 +9123,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGFI,
    /* .name        = */ "AGFI",
-   /* .description = */ "Add Immediate (64<32)",
+   /* .description = */ "ADD IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_SetsCC |
@@ -9140,10 +9140,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALFI,
    /* .name        = */ "ALFI",
-   /* .description = */ "Add Logical Immediate (32)",
+   /* .description = */ "ADD LOGICAL IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -9156,10 +9156,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGFI,
    /* .name        = */ "ALGFI",
-   /* .description = */ "Add Logical Immediate (64<32)",
+   /* .description = */ "ADD LOGICAL IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_SetsCC |
@@ -9172,7 +9172,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AXTR,
    /* .name        = */ "AXTR",
-   /* .description = */ "Add (DFP128)",
+   /* .description = */ "ADD (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDA,
    /* .format      = */ RRFa_FORMAT,
@@ -9189,7 +9189,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDGTR,
    /* .name        = */ "CDGTR",
-   /* .description = */ "Convert from Fixed (DFP64)",
+   /* .description = */ "CONVERT FROM FIXED (64 to long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF1,
    /* .format      = */ RRE_FORMAT,
@@ -9202,7 +9202,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDSTR,
    /* .name        = */ "CDSTR",
-   /* .description = */ "Convert from Signed Packed",
+   /* .description = */ "CONVERT FROM SIGNED PACKED (64 to long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF3,
    /* .format      = */ RRE_FORMAT,
@@ -9215,7 +9215,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDTR,
    /* .name        = */ "CDTR",
-   /* .description = */ "Compare (DFP64)",
+   /* .description = */ "COMPARE (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE4,
    /* .format      = */ RRE_FORMAT,
@@ -9231,7 +9231,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDUTR,
    /* .name        = */ "CDUTR",
-   /* .description = */ "Convert From Unsigned BCD (DFP64)",
+   /* .description = */ "CONVERT FROM UNSIGNED PACKED (64 to long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF2,
    /* .format      = */ RRE_FORMAT,
@@ -9244,7 +9244,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEDTR,
    /* .name        = */ "CEDTR",
-   /* .description = */ "Compare biased exponent (DFP64)",
+   /* .description = */ "COMPARE BIASED EXPONENT (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF4,
    /* .format      = */ RRE_FORMAT,
@@ -9259,7 +9259,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CEXTR,
    /* .name        = */ "CEXTR",
-   /* .description = */ "Compare biased exponent (DFP128)",
+   /* .description = */ "COMPARE BIASED EXPONENT (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xFC,
    /* .format      = */ RRE_FORMAT,
@@ -9276,10 +9276,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CFI,
    /* .name        = */ "CFI",
-   /* .description = */ "Compare Immediate (32)",
+   /* .description = */ "COMPARE IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -9291,10 +9291,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGDTR,
    /* .name        = */ "CGDTR",
-   /* .description = */ "Convert to Fixed (DFP64)",
+   /* .description = */ "CONVERT TO FIXED (long DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE1,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9308,10 +9308,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGFI,
    /* .name        = */ "CGFI",
-   /* .description = */ "Compare Immediate (64<32)",
+   /* .description = */ "COMPARE IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
@@ -9323,10 +9323,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGXTR,
    /* .name        = */ "CGXTR",
-   /* .description = */ "Convert to Fixed (DFP128)",
+   /* .description = */ "CONVERT TO FIXED (extended DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE9,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9341,10 +9341,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLFI,
    /* .name        = */ "CLFI",
-   /* .description = */ "Compare Logical Immediate (32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -9357,10 +9357,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGFI,
    /* .name        = */ "CLGFI",
-   /* .description = */ "Compare Logical Immediate (64<32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
@@ -9373,10 +9373,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CPSDR,
    /* .name        = */ "CPSDR",
-   /* .description = */ "Copy Sign",
+   /* .description = */ "COPY SIGN (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x72,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_DoubleFP
@@ -9385,10 +9385,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CSDTR,
    /* .name        = */ "CSDTR",
-   /* .description = */ "Convert to signed packed",
+   /* .description = */ "CONVERT TO SIGNED PACKED (long DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE3,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9398,10 +9398,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CSXTR,
    /* .name        = */ "CSXTR",
-   /* .description = */ "Convert to signed packed(DFP128)",
+   /* .description = */ "CONVERT TO SIGNED PACKED (extended DFP to 128)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xEB,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9413,10 +9413,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CU14,
    /* .name        = */ "CU14",
-   /* .description = */ "Convert UTF-8 to UTF-32",
+   /* .description = */ "CONVERT UTF-8 TO UTF-32",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xB0,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -9428,10 +9428,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CU24,
    /* .name        = */ "CU24",
-   /* .description = */ "Convert UTF-16 to UTF-32",
+   /* .description = */ "CONVERT UTF-16 TO UTF-32",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xB1,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -9443,7 +9443,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CU41,
    /* .name        = */ "CU41",
-   /* .description = */ "Convert UTF-32 to UTF-8",
+   /* .description = */ "CONVERT UTF-32 TO UTF-8",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xB2,
    /* .format      = */ RRE_FORMAT,
@@ -9458,7 +9458,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CU42,
    /* .name        = */ "CU42",
-   /* .description = */ "Convert UTF-32 to UTF-16",
+   /* .description = */ "CONVERT UTF-32 TO UTF-16",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xB3,
    /* .format      = */ RRE_FORMAT,
@@ -9473,7 +9473,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CUDTR,
    /* .name        = */ "CUDTR",
-   /* .description = */ "Convert to Unsigned BCD (DFP64)",
+   /* .description = */ "CONVERT TO UNSIGNED PACKED (long DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE2,
    /* .format      = */ RRE_FORMAT,
@@ -9486,10 +9486,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CUTFU,
    /* .name        = */ "CUTFU",
-   /* .description = */ "Convert UTF-8 to Unicode",
+   /* .description = */ "CONVERT UTF-8 TO UNICODE",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xA7,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -9503,10 +9503,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CUUTF,
    /* .name        = */ "CUUTF",
-   /* .description = */ "Convert Unicode to UTF-8",
+   /* .description = */ "CONVERT UNICODE TO UTF-8",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xA6,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_IsStore |
@@ -9520,7 +9520,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CUXTR,
    /* .name        = */ "CUXTR",
-   /* .description = */ "Convert to Unsigned BCD (DFP64)",
+   /* .description = */ "CONVERT TO UNSIGNED PACKED (extended DFP to 128)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xEA,
    /* .format      = */ RRE_FORMAT,
@@ -9535,7 +9535,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXGTR,
    /* .name        = */ "CXGTR",
-   /* .description = */ "Convert from Fixed (DFP128)",
+   /* .description = */ "CONVERT FROM FIXED (64 to extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF9,
    /* .format      = */ RRE_FORMAT,
@@ -9550,7 +9550,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXSTR,
    /* .name        = */ "CXSTR",
-   /* .description = */ "Convert from Signed Packed to DFP128",
+   /* .description = */ "CONVERT FROM SIGNED PACKED (128 to extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xFB,
    /* .format      = */ RRE_FORMAT,
@@ -9564,7 +9564,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXTR,
    /* .name        = */ "CXTR",
-   /* .description = */ "Compare (DFP128)",
+   /* .description = */ "COMPARE (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xEC,
    /* .format      = */ RRE_FORMAT,
@@ -9581,7 +9581,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXUTR,
    /* .name        = */ "CXUTR",
-   /* .description = */ "Convert From Unsigned BCD (DFP128)",
+   /* .description = */ "CONVERT FROM UNSIGNED PACKED (128 to ext. DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xFA,
    /* .format      = */ RRE_FORMAT,
@@ -9595,10 +9595,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DDTR,
    /* .name        = */ "DDTR",
-   /* .description = */ "Divide (DFP64)",
+   /* .description = */ "DIVIDE (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD1,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9609,7 +9609,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::DXTR,
    /* .name        = */ "DXTR",
-   /* .description = */ "Divide (DFP128)",
+   /* .description = */ "DIVIDE (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD9,
    /* .format      = */ RRFa_FORMAT,
@@ -9625,7 +9625,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EEDTR,
    /* .name        = */ "EEDTR",
-   /* .description = */ "Extract Biased Exponent (DFP64)",
+   /* .description = */ "EXTRACT BIASED EXPONENT (long DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE5,
    /* .format      = */ RRE_FORMAT,
@@ -9638,7 +9638,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EEXTR,
    /* .name        = */ "EEXTR",
-   /* .description = */ "Extract Biased Exponent (DFP128)",
+   /* .description = */ "EXTRACT BIASED EXPONENT (extended DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xED,
    /* .format      = */ RRE_FORMAT,
@@ -9652,7 +9652,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ESDTR,
    /* .name        = */ "ESDTR",
-   /* .description = */ "Extract Significance (DFP64)",
+   /* .description = */ "EXTRACT SIGNIFICANCE (long DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE7,
    /* .format      = */ RRE_FORMAT,
@@ -9665,7 +9665,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ESXTR,
    /* .name        = */ "ESXTR",
-   /* .description = */ "Extract Significance (DFP128)",
+   /* .description = */ "EXTRACT SIGNIFICANCE (extended DFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xEF,
    /* .format      = */ RRE_FORMAT,
@@ -9679,10 +9679,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIDTR,
    /* .name        = */ "FIDTR",
-   /* .description = */ "Load FP Integer (DFP64)",
+   /* .description = */ "LOAD FP INTEGER (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD7,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_SetsOperand1
@@ -9691,10 +9691,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FIXTR,
    /* .name        = */ "FIXTR",
-   /* .description = */ "Load FP Integer (DFP128)",
+   /* .description = */ "LOAD FP INTEGER (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDF,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForSource |
@@ -9705,7 +9705,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::FLOGR,
    /* .name        = */ "FLOGR",
-   /* .description = */ "Find Leftmost One",
+   /* .description = */ "FIND LEFTMOST ONE",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x83,
    /* .format      = */ RRE_FORMAT,
@@ -9719,10 +9719,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IEDTR,
    /* .name        = */ "IEDTR",
-   /* .description = */ "Insert Biased Exponent (DFP64)",
+   /* .description = */ "INSERT BIASED EXPONENT (64 to long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF6,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9732,10 +9732,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IEXTR,
    /* .name        = */ "IEXTR",
-   /* .description = */ "Insert Biased Exponent (DFP128)",
+   /* .description = */ "INSERT BIASED EXPONENT (64 to extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xFE,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -9747,10 +9747,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IIHF,
    /* .name        = */ "IIHF",
-   /* .description = */ "Insert Immediate (high)",
+   /* .description = */ "INSERT IMMEDIATE (high)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_IsExtendedImmediate |
@@ -9761,10 +9761,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::IILF,
    /* .name        = */ "IILF",
-   /* .description = */ "Insert Immediate (low)",
+   /* .description = */ "INSERT IMMEDIATE (low)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x09,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsExtendedImmediate |
                         S390OpProp_SetsOperand1 |
@@ -9774,7 +9774,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KDTR,
    /* .name        = */ "KDTR",
-   /* .description = */ "Compare (DFP64)",
+   /* .description = */ "COMPARE AND SIGNAL (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE0,
    /* .format      = */ RRE_FORMAT,
@@ -9789,7 +9789,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KXTR,
    /* .name        = */ "KXTR",
-   /* .description = */ "Compare (DFP128)",
+   /* .description = */ "COMPARE AND SIGNAL (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xE8,
    /* .format      = */ RRE_FORMAT,
@@ -9806,7 +9806,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LBR,
    /* .name        = */ "LBR",
-   /* .description = */ "Load Byte (32)",
+   /* .description = */ "LOAD BYTE (32 <- 8)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x26,
    /* .format      = */ RRE_FORMAT,
@@ -9818,7 +9818,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCDFR,
    /* .name        = */ "LCDFR",
-   /* .description = */ "Load Complement (DFP64)",
+   /* .description = */ "LOAD COMPLEMENT (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x73,
    /* .format      = */ RRE_FORMAT,
@@ -9831,10 +9831,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDETR,
    /* .name        = */ "LDETR",
-   /* .description = */ "Load Lengthened (64DFP < 32DFP)",
+   /* .description = */ "LOAD LENGTHENED (short to long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD4,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_DoubleFP |
@@ -9844,7 +9844,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDGR,
    /* .name        = */ "LDGR",
-   /* .description = */ "Load FPR from GR (SB, DB)",
+   /* .description = */ "LOAD FPR FROM GR (64 to long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xC1,
    /* .format      = */ RRE_FORMAT,
@@ -9858,10 +9858,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LDXTR,
    /* .name        = */ "LDXTR",
-   /* .description = */ "Load Rounded (64DFP < 128DFP)",
+   /* .description = */ "LOAD ROUNDED (extended to long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDD,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_DoubleFP |
@@ -9873,10 +9873,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LEDTR,
    /* .name        = */ "LEDTR",
-   /* .description = */ "Load Rounded (32DFP < 64DFP)",
+   /* .description = */ "LOAD ROUNDED (long to short DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD5,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_DoubleFP |
@@ -9886,7 +9886,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGBR,
    /* .name        = */ "LGBR",
-   /* .description = */ "Load Byte (64)",
+   /* .description = */ "LOAD BYTE (64 <- 8)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x06,
    /* .format      = */ RRE_FORMAT,
@@ -9898,7 +9898,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGDR,
    /* .name        = */ "LGDR",
-   /* .description = */ "Load GR from FPR (SB, DB)",
+   /* .description = */ "LOAD GR FROM FPR (long to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xCD,
    /* .format      = */ RRE_FORMAT,
@@ -9913,10 +9913,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGFI,
    /* .name        = */ "LGFI",
-   /* .description = */ "Load Immediate (64<32)",
+   /* .description = */ "LOAD IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsExtendedImmediate |
@@ -9926,7 +9926,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGHR,
    /* .name        = */ "LGHR",
-   /* .description = */ "Load Halfword (64)",
+   /* .description = */ "LOAD HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x07,
    /* .format      = */ RRE_FORMAT,
@@ -9938,7 +9938,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LHR,
    /* .name        = */ "LHR",
-   /* .description = */ "Load Halfword (32)",
+   /* .description = */ "LOAD HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x27,
    /* .format      = */ RRE_FORMAT,
@@ -9950,10 +9950,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLC,
    /* .name        = */ "LLC",
-   /* .description = */ "(LongDisp) Load Logical Character (32)",
+   /* .description = */ "LOAD LOGICAL CHARACTER (32 <- 8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x94,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -9964,7 +9964,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLCR,
    /* .name        = */ "LLCR",
-   /* .description = */ "Load Logical Character (32)",
+   /* .description = */ "LOAD LOGICAL CHARACTER (32 <- 8)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x94,
    /* .format      = */ RRE_FORMAT,
@@ -9976,7 +9976,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGCR,
    /* .name        = */ "LLGCR",
-   /* .description = */ "Load Logical Character (64)",
+   /* .description = */ "LOAD LOGICAL CHARACTER (64 <- 8)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x84,
    /* .format      = */ RRE_FORMAT,
@@ -9988,7 +9988,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGHR,
    /* .name        = */ "LLGHR",
-   /* .description = */ "Load Logical Halfword(64)",
+   /* .description = */ "LOAD LOGICAL HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x85,
    /* .format      = */ RRE_FORMAT,
@@ -10000,10 +10000,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLH,
    /* .name        = */ "LLH",
-   /* .description = */ "(LongDisp) Load Logical Halfword",
+   /* .description = */ "LOAD LOGICAL HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x95,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -10014,7 +10014,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLHR,
    /* .name        = */ "LLHR",
-   /* .description = */ "Load Logical Halfword(32)",
+   /* .description = */ "LOAD LOGICAL HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x95,
    /* .format      = */ RRE_FORMAT,
@@ -10026,10 +10026,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLIHF,
    /* .name        = */ "LLIHF",
-   /* .description = */ "Load Logical Immediate (high)",
+   /* .description = */ "LOAD LOGICAL IMMEDIATE (high)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsExtendedImmediate |
@@ -10039,10 +10039,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLILF,
    /* .name        = */ "LLILF",
-   /* .description = */ "Load Logical Immediate (low)",
+   /* .description = */ "LOAD LOGICAL IMMEDIATE (low)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsExtendedImmediate |
@@ -10052,7 +10052,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LNDFR,
    /* .name        = */ "LNDFR",
-   /* .description = */ "Load Negative (DFP64)",
+   /* .description = */ "LOAD NEGATIVE (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x71,
    /* .format      = */ RRE_FORMAT,
@@ -10065,7 +10065,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPDFR,
    /* .name        = */ "LPDFR",
-   /* .description = */ "Load Positive (DFP64)",
+   /* .description = */ "LOAD POSITIVE (long)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x70,
    /* .format      = */ RRE_FORMAT,
@@ -10078,10 +10078,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LT,
    /* .name        = */ "LT",
-   /* .description = */ "(LongDisp) Load and Test (32)",
+   /* .description = */ "LOAD AND TEST (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x12,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32Bit |
@@ -10094,7 +10094,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTDTR,
    /* .name        = */ "LTDTR",
-   /* .description = */ "Load and Test (DFP64)",
+   /* .description = */ "LOAD AND TEST (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD6,
    /* .format      = */ RRE_FORMAT,
@@ -10109,10 +10109,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTG,
    /* .name        = */ "LTG",
-   /* .description = */ "(LongDisp) Load and Test (64)",
+   /* .description = */ "LOAD AND TEST (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x02,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -10125,7 +10125,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTXTR,
    /* .name        = */ "LTXTR",
-   /* .description = */ "Load and Test (DFP128)",
+   /* .description = */ "LOAD AND TEST (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDE,
    /* .format      = */ RRE_FORMAT,
@@ -10142,10 +10142,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LXDTR,
    /* .name        = */ "LXDTR",
-   /* .description = */ "Load Lengthened(64DFP < 128DFP)",
+   /* .description = */ "LOAD LENGTHENED (long to extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDC,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForTarget |
@@ -10155,7 +10155,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAY,
    /* .name        = */ "MAY",
-   /* .description = */ "Multiply and Add Unnormalized, long HFP sources and extended HFP result",
+   /* .description = */ "MULTIPLY & ADD UNNORMALIZED (long to ext. HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x3A,
    /* .format      = */ RXF_FORMAT,
@@ -10169,10 +10169,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAYH,
    /* .name        = */ "MAYH",
-   /* .description = */ "Multiply and Add Unnormalized, long HFP sources and high-order part of extended HFP result",
+   /* .description = */ "MULTIPLY AND ADD UNNRM. (long to ext. high HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x3C,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RXF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -10183,10 +10183,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAYHR,
    /* .name        = */ "MAYHR",
-   /* .description = */ "Multiply and Add Unnormalized, long HFP sources and high-order part of extended HFP result",
+   /* .description = */ "MULTIPLY AND ADD UNNRM. (long to ext. high HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x3C,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -10196,10 +10196,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAYL,
    /* .name        = */ "MAYL",
-   /* .description = */ "Multiply and Add Unnormalized, long HFP sources and low-order part of extended HFP result",
+   /* .description = */ "MULTIPLY AND ADD UNNRM. (long to ext. low HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x38,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RXF_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -10210,10 +10210,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAYLR,
    /* .name        = */ "MAYLR",
-   /* .description = */ "Multiply and Add Unnormalized, long HFP sources and low-order part of extended HFP result",
+   /* .description = */ "MULTIPLY AND ADD UNNRM. (long to ext. low HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x38,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -10223,10 +10223,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MAYR,
    /* .name        = */ "MAYR",
-   /* .description = */ "Multiply and Add Unnormalized, long HFP sources and extended HFP result",
+   /* .description = */ "MULTIPLY & ADD UNNORMALIZED (long to ext. HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x3A,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForTarget |
@@ -10236,10 +10236,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MDTR,
    /* .name        = */ "MDTR",
-   /* .description = */ "Multiply (DFP64)",
+   /* .description = */ "MULTIPLY (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD0,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10249,7 +10249,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MXTR,
    /* .name        = */ "MXTR",
-   /* .description = */ "Multiply (DFP128)",
+   /* .description = */ "MULTIPLY (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD8,
    /* .format      = */ RRFa_FORMAT,
@@ -10264,7 +10264,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MY,
    /* .name        = */ "MY",
-   /* .description = */ "Multiply Unnormalized, long HFP sources and extended HFP result",
+   /* .description = */ "MULTIPLY UNNORMALIZED (long to ext. HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x3B,
    /* .format      = */ RXF_FORMAT,
@@ -10278,7 +10278,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MYH,
    /* .name        = */ "MYH",
-   /* .description = */ "Multiply Unnormalized, long HFP sources and high-order part of extended HFP result",
+   /* .description = */ "MULTIPLY UNNORM. (long to ext. high HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x3D,
    /* .format      = */ RXF_FORMAT,
@@ -10292,10 +10292,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MYHR,
    /* .name        = */ "MYHR",
-   /* .description = */ "Multiply Unnormalized, long HFP sources and high-order part of extended HFP result",
+   /* .description = */ "MULTIPLY UNNORM. (long to ext. high HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x3D,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -10305,7 +10305,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MYL,
    /* .name        = */ "MYL",
-   /* .description = */ "Multiply Unnormalized, long HFP sources and low-order part of extended HFP result",
+   /* .description = */ "MULTIPLY UNNORM. (long to ext. low HFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x39,
    /* .format      = */ RXF_FORMAT,
@@ -10319,10 +10319,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MYLR,
    /* .name        = */ "MYLR",
-   /* .description = */ "Multiply Unnormalized, long HFP sources and low-order part of extended HFP result",
+   /* .description = */ "MULTIPLY UNNORM. (long to ext. low HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x39,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesTarget |
@@ -10332,10 +10332,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MYR,
    /* .name        = */ "MYR",
-   /* .description = */ "Multiply Unnormalized, long HFP sources and extended HFP result",
+   /* .description = */ "MULTIPLY UNNORMALIZED (long to ext. HFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x3B,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRD_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForTarget |
@@ -10345,10 +10345,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NIHF,
    /* .name        = */ "NIHF",
-   /* .description = */ "And Immediate (high)",
+   /* .description = */ "AND IMMEDIATE (high)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -10360,10 +10360,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NILF,
    /* .name        = */ "NILF",
-   /* .description = */ "And Immediate (low)",
+   /* .description = */ "AND IMMEDIATE (low)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10374,10 +10374,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OIHF,
    /* .name        = */ "OIHF",
-   /* .description = */ "Or Immediate (high)",
+   /* .description = */ "OR IMMEDIATE (high)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -10389,10 +10389,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OILF,
    /* .name        = */ "OILF",
-   /* .description = */ "Or Immediate (low)",
+   /* .description = */ "OR IMMEDIATE (low)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10403,7 +10403,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PFPO,
    /* .name        = */ "PFPO",
-   /* .description = */ "perform floating point operations.",
+   /* .description = */ "PERFORM FLOATING-POINT OPERATION",
    /* .opcode[0]   = */ 0x01,
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ E_FORMAT,
@@ -10415,10 +10415,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::QADTR,
    /* .name        = */ "QADTR",
-   /* .description = */ "Quantize (DFP64)",
+   /* .description = */ "QUANTIZE (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF5,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10429,10 +10429,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::QAXTR,
    /* .name        = */ "QAXTR",
-   /* .description = */ "Quantize (DFP128)",
+   /* .description = */ "QUANTIZE (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xFD,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10445,10 +10445,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RRDTR,
    /* .name        = */ "RRDTR",
-   /* .description = */ "Reround (DFP64)",
+   /* .description = */ "REROUND (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xF7,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10458,10 +10458,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RRXTR,
    /* .name        = */ "RRXTR",
-   /* .description = */ "Reround (DFP128)",
+   /* .description = */ "REROUND (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xFF,
-   /* .format      = */ RRF3_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10473,10 +10473,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SDTR,
    /* .name        = */ "SDTR",
-   /* .description = */ "Subtract (DFP64)",
+   /* .description = */ "SUBTRACT (long DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xD3,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -10488,7 +10488,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SFASR,
    /* .name        = */ "SFASR",
-   /* .description = */ "Set FPC And Signal",
+   /* .description = */ "SET FPC AND SIGNAL",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x85,
    /* .format      = */ RRE_FORMAT,
@@ -10500,7 +10500,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLDT,
    /* .name        = */ "SLDT",
-   /* .description = */ "Shift Left Double (DFP64)",
+   /* .description = */ "SHIFT SIGNIFICAND LEFT (long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x40,
    /* .format      = */ RXF_FORMAT,
@@ -10513,10 +10513,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLFI,
    /* .name        = */ "SLFI",
-   /* .description = */ "Subtract Logical Immediate (32)",
+   /* .description = */ "SUBTRACT LOGICAL IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x05,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -10529,10 +10529,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLGFI,
    /* .name        = */ "SLGFI",
-   /* .description = */ "Subtract Logical Immediate (64<32)",
+   /* .description = */ "SUBTRACT LOGICAL IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_UsesTarget |
@@ -10545,7 +10545,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLXT,
    /* .name        = */ "SLXT",
-   /* .description = */ "Shift Left Double (DFP128)",
+   /* .description = */ "SHIFT SIGNIFICAND LEFT (extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x48,
    /* .format      = */ RXF_FORMAT,
@@ -10560,7 +10560,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRDT,
    /* .name        = */ "SRDT",
-   /* .description = */ "Shift Right Double (DFP64)",
+   /* .description = */ "SHIFT SIGNIFICAND RIGHT (long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x41,
    /* .format      = */ RXF_FORMAT,
@@ -10573,7 +10573,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRNMT,
    /* .name        = */ "SRNMT",
-   /* .description = */ "Set RoundingMode (DFP64)",
+   /* .description = */ "SET DFP ROUNDING MODE",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xB9,
    /* .format      = */ S_FORMAT,
@@ -10585,7 +10585,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRSTU,
    /* .name        = */ "SRSTU",
-   /* .description = */ "Search String Unicode",
+   /* .description = */ "SEARCH STRING UNICODE",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xBE,
    /* .format      = */ RRE_FORMAT,
@@ -10601,7 +10601,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRXT,
    /* .name        = */ "SRXT",
-   /* .description = */ "Shift Right LongDouble (DFP128)",
+   /* .description = */ "SHIFT SIGNIFICAND RIGHT (extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x49,
    /* .format      = */ RXF_FORMAT,
@@ -10616,10 +10616,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SSKE,
    /* .name        = */ "SSKE",
-   /* .description = */ "Set Storage Key Extended",
+   /* .description = */ "SET STORAGE KEY EXTENDED",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x2B,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -10627,7 +10627,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCKF,
    /* .name        = */ "STCKF",
-   /* .description = */ "Store Clock Fast",
+   /* .description = */ "STORE CLOCK FAST",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0x7C,
    /* .format      = */ S_FORMAT,
@@ -10640,7 +10640,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SXTR,
    /* .name        = */ "SXTR",
-   /* .description = */ "Subtract (DFP128)",
+   /* .description = */ "SUBTRACT (extended DFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xDB,
    /* .format      = */ RRFa_FORMAT,
@@ -10657,7 +10657,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TDCDT,
    /* .name        = */ "TDCDT",
-   /* .description = */ "Test Data Class (DFP64)",
+   /* .description = */ "TEST DATA CLASS (long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x54,
    /* .format      = */ RXE_FORMAT,
@@ -10669,7 +10669,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TDCET,
    /* .name        = */ "TDCET",
-   /* .description = */ "Test Data Class (DFP32)",
+   /* .description = */ "TEST DATA CLASS (short DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x50,
    /* .format      = */ RXE_FORMAT,
@@ -10681,7 +10681,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TDCXT,
    /* .name        = */ "TDCXT",
-   /* .description = */ "Test Data Class (DFP64)",
+   /* .description = */ "TEST DATA CLASS (extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x58,
    /* .format      = */ RXE_FORMAT,
@@ -10694,7 +10694,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TDGDT,
    /* .name        = */ "TDGDT",
-   /* .description = */ "Test Data Group (DFP64)",
+   /* .description = */ "TEST DATA GROUP (long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x55,
    /* .format      = */ RXE_FORMAT,
@@ -10707,7 +10707,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TDGET,
    /* .name        = */ "TDGET",
-   /* .description = */ "Test Data Group (DFP32)",
+   /* .description = */ "TEST DATA GROUP (short DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x51,
    /* .format      = */ RXE_FORMAT,
@@ -10720,7 +10720,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TDGXT,
    /* .name        = */ "TDGXT",
-   /* .description = */ "Test Data Group (DFP128)",
+   /* .description = */ "TEST DATA GROUP (extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0x59,
    /* .format      = */ RXE_FORMAT,
@@ -10734,10 +10734,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TROO,
    /* .name        = */ "TROO",
-   /* .description = */ "Translate One to One",
+   /* .description = */ "TRANSLATE ONE TO ONE",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x93,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10753,10 +10753,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TROT,
    /* .name        = */ "TROT",
-   /* .description = */ "Translate One to Two",
+   /* .description = */ "TRANSLATE ONE TO TWO",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x92,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10772,10 +10772,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRTO,
    /* .name        = */ "TRTO",
-   /* .description = */ "Translate Two to One",
+   /* .description = */ "TRANSLATE TWO TO ONE",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x91,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10791,10 +10791,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRTR,
    /* .name        = */ "TRTR",
-   /* .description = */ "Translate and Test Reverse",
+   /* .description = */ "TRANSLATE AND TEST REVERSE",
    /* .opcode[0]   = */ 0xD0,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ SS_FORMAT,
+   /* .format      = */ SSa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_ImplicitlyUsesGPR1 |
                         S390OpProp_ImplicitlyUsesGPR2 |
@@ -10809,10 +10809,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRTT,
    /* .name        = */ "TRTT",
-   /* .description = */ "Translate Two to Two",
+   /* .description = */ "TRANSLATE TWO TO TWO",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x90,
-   /* .format      = */ RRE_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10828,10 +10828,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XIHF,
    /* .name        = */ "XIHF",
-   /* .description = */ "Exclusive Or Immediate (high)",
+   /* .description = */ "EXCLUSIVE OR IMMEDIATE (high)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x06,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_UsesTarget |
@@ -10843,10 +10843,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XILF,
    /* .name        = */ "XILF",
-   /* .description = */ "Exclusive Or Immediate (low)",
+   /* .description = */ "EXCLUSIVE OR IMMEDIATE (low)",
    /* .opcode[0]   = */ 0xC0,
    /* .opcode[1]   = */ 0x07,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z9,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -10857,7 +10857,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGSI,
    /* .name        = */ "AGSI",
-   /* .description = */ "Add Direct to Memory (64)",
+   /* .description = */ "ADD IMMEDIATE (64 <- 8)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x7A,
    /* .format      = */ SIY_FORMAT,
@@ -10874,7 +10874,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGSI,
    /* .name        = */ "ALGSI",
-   /* .description = */ "Add Logical Direct to Memory (64)",
+   /* .description = */ "ADD LOGICAL WITH SIGNED IMMEDIATE (64 <- 8)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x7E,
    /* .format      = */ SIY_FORMAT,
@@ -10891,7 +10891,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALSI,
    /* .name        = */ "ALSI",
-   /* .description = */ "Add Logical Direct to Memory",
+   /* .description = */ "ADD LOGICAL WITH SIGNED IMMEDIATE (32 <- 8)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x6E,
    /* .format      = */ SIY_FORMAT,
@@ -10908,7 +10908,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ASI,
    /* .name        = */ "ASI",
-   /* .description = */ "Add Direct to Memory",
+   /* .description = */ "ADD IMMEDIATE (32 <- 8)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x6A,
    /* .format      = */ SIY_FORMAT,
@@ -10925,10 +10925,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGFRL,
    /* .name        = */ "CGFRL",
-   /* .description = */ "Compare Relative Long (32 < 64)",
+   /* .description = */ "COMPARE RELATIVE LONG (64 <- 32)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32To64Bit |
                         S390OpProp_IsCompare |
@@ -10942,10 +10942,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGHRL,
    /* .name        = */ "CGHRL",
-   /* .description = */ "Compare Halfword Relative Long (64)",
+   /* .description = */ "COMPARE HALFWORD RELATIVE LONG (64 <- 16)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -10958,7 +10958,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGHSI,
    /* .name        = */ "CGHSI",
-   /* .description = */ "Compare Direct to Memory Halfword Immediate (64)",
+   /* .description = */ "COMPARE HALFWORD IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x58,
    /* .format      = */ SIL_FORMAT,
@@ -10973,7 +10973,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGIB,
    /* .name        = */ "CGIB",
-   /* .description = */ "Compare Immediate And Branch (64)",
+   /* .description = */ "COMPARE IMMEDIATE AND BRANCH (64 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xFC,
    /* .format      = */ RIS_FORMAT,
@@ -10986,10 +10986,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGIJ,
    /* .name        = */ "CGIJ",
-   /* .description = */ "Compare Immediate And Branch Relative (64)",
+   /* .description = */ "COMPARE IMMEDIATE AND BRANCH RELATIVE (64 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x7C,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -10999,10 +10999,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGIT,
    /* .name        = */ "CGIT",
-   /* .description = */ "Compare Immidiate And Trap (64)",
+   /* .description = */ "COMPARE IMMEDIATE AND TRAP (64 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x70,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11012,7 +11012,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGRB,
    /* .name        = */ "CGRB",
-   /* .description = */ "Compare And Branch (64)",
+   /* .description = */ "COMPARE AND BRANCH (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xE4,
    /* .format      = */ RRS_FORMAT,
@@ -11025,10 +11025,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGRJ,
    /* .name        = */ "CGRJ",
-   /* .description = */ "Compare And Branch Relative (64)",
+   /* .description = */ "COMPARE AND BRANCH RELATIVE (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x64,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11038,10 +11038,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGRL,
    /* .name        = */ "CGRL",
-   /* .description = */ "Compare Relative Long (64)",
+   /* .description = */ "COMPARE RELATIVE LONG (64)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11055,10 +11055,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CGRT,
    /* .name        = */ "CGRT",
-   /* .description = */ "Compare And Trap (64)",
+   /* .description = */ "COMPARE AND TRAP (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x60,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11068,7 +11068,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHHSI,
    /* .name        = */ "CHHSI",
-   /* .description = */ "Compare Direct to Memory Halfword Immediate (16)",
+   /* .description = */ "COMPARE HALFWORD IMMEDIATE (16 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x54,
    /* .format      = */ SIL_FORMAT,
@@ -11083,10 +11083,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHRL,
    /* .name        = */ "CHRL",
-   /* .description = */ "Compare Halfword Relative Long (32)",
+   /* .description = */ "COMPARE HALFWORD RELATIVE LONG (32 <- 16)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x05,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11099,7 +11099,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHSI,
    /* .name        = */ "CHSI",
-   /* .description = */ "Compare Direct to Memory Halfword Immediate (32)",
+   /* .description = */ "COMPARE HALFWORD IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x5C,
    /* .format      = */ SIL_FORMAT,
@@ -11114,7 +11114,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CIB,
    /* .name        = */ "CIB",
-   /* .description = */ "Compare Immediate And Branch (32)",
+   /* .description = */ "COMPARE IMMEDIATE AND BRANCH (32 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xFE,
    /* .format      = */ RIS_FORMAT,
@@ -11127,10 +11127,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CIJ,
    /* .name        = */ "CIJ",
-   /* .description = */ "Compare Immediate And Branch Relative(32)",
+   /* .description = */ "COMPARE IMMEDIATE AND BRANCH RELATIVE (32 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x7E,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11140,10 +11140,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CIT,
    /* .name        = */ "CIT",
-   /* .description = */ "Compare Immidiate And Trap (32)",
+   /* .description = */ "COMPARE IMMEDIATE AND TRAP (32 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x72,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11153,7 +11153,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLFHSI,
    /* .name        = */ "CLFHSI",
-   /* .description = */ "Compare Logical Immediate (32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x5D,
    /* .format      = */ SIL_FORMAT,
@@ -11168,10 +11168,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLFIT,
    /* .name        = */ "CLFIT",
-   /* .description = */ "Compare Logical Immidiate And Trap (32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE AND TRAP (32 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x73,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11181,10 +11181,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGFRL,
    /* .name        = */ "CLGFRL",
-   /* .description = */ "Compare Logical Relative Long (32 < 64)",
+   /* .description = */ "COMPARE LOGICAL RELATIVE LONG (64 <- 32)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11198,10 +11198,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGHRL,
    /* .name        = */ "CLGHRL",
-   /* .description = */ "Compare Logical Relative Long Halfword (64)",
+   /* .description = */ "COMPARE LOGICAL RELATIVE LONG (64 <- 16)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x06,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11215,7 +11215,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGHSI,
    /* .name        = */ "CLGHSI",
-   /* .description = */ "Compare Logical Immediate (64)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x59,
    /* .format      = */ SIL_FORMAT,
@@ -11230,7 +11230,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGIB,
    /* .name        = */ "CLGIB",
-   /* .description = */ "Compare Logical Immediate And Branch (64)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE AND BRANCH (64 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xFD,
    /* .format      = */ RIS_FORMAT,
@@ -11243,10 +11243,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGIJ,
    /* .name        = */ "CLGIJ",
-   /* .description = */ "Compare Logical Immediate And Branch Relative (64)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE AND BRANCH RELATIVE (64 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x7D,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11256,10 +11256,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGIT,
    /* .name        = */ "CLGIT",
-   /* .description = */ "Compare Logical Immidiate And Trap (64)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE AND TRAP (64 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x71,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11269,7 +11269,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGRB,
    /* .name        = */ "CLGRB",
-   /* .description = */ "Compare Logical And Branch (64)",
+   /* .description = */ "COMPARE LOGICAL AND BRANCH (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xE5,
    /* .format      = */ RRS_FORMAT,
@@ -11282,10 +11282,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGRJ,
    /* .name        = */ "CLGRJ",
-   /* .description = */ "Compare Logical And Branch Relative (64)",
+   /* .description = */ "COMPARE LOGICAL AND BRANCH RELATIVE (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x65,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11295,10 +11295,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGRL,
    /* .name        = */ "CLGRL",
-   /* .description = */ "Compare Logical Relative Long (64)",
+   /* .description = */ "COMPARE LOGICAL RELATIVE LONG (64)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11312,10 +11312,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGRT,
    /* .name        = */ "CLGRT",
-   /* .description = */ "Compare Logical And Trap (64)",
+   /* .description = */ "COMPARE LOGICAL AND TRAP (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x61,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -11325,7 +11325,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLHHSI,
    /* .name        = */ "CLHHSI",
-   /* .description = */ "Compare Logical Immediate (16)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE (16 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x55,
    /* .format      = */ SIL_FORMAT,
@@ -11340,10 +11340,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLHRL,
    /* .name        = */ "CLHRL",
-   /* .description = */ "Compare Logical Relative Long Halfword (32)",
+   /* .description = */ "COMPARE LOGICAL RELATIVE LONG (32 <- 16)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x07,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11357,7 +11357,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLIB,
    /* .name        = */ "CLIB",
-   /* .description = */ "Compare Logical Immediate And Branch (32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE AND BRANCH (32 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xFF,
    /* .format      = */ RIS_FORMAT,
@@ -11370,10 +11370,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLIJ,
    /* .name        = */ "CLIJ",
-   /* .description = */ "Compare Logical Immidiate And Branch Relative (32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE AND BRANCH RELATIVE (32 <- 8)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x7F,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11383,7 +11383,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLRB,
    /* .name        = */ "CLRB",
-   /* .description = */ "Compare Logical And Branch (32)",
+   /* .description = */ "COMPARE LOGICAL AND BRANCH (32)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xF7,
    /* .format      = */ RRS_FORMAT,
@@ -11396,10 +11396,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLRJ,
    /* .name        = */ "CLRJ",
-   /* .description = */ "Compare Logical And Branch Relative (32)",
+   /* .description = */ "COMPARE LOGICAL AND BRANCH RELATIVE (32)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x77,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11409,10 +11409,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLRL,
    /* .name        = */ "CLRL",
-   /* .description = */ "Compare Logical Relative Long",
+   /* .description = */ "COMPARE LOGICAL RELATIVE LONG (32)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11426,10 +11426,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLRT,
    /* .name        = */ "CLRT",
-   /* .description = */ "Compare Logical And Trap (32)",
+   /* .description = */ "COMPARE LOGICAL AND TRAP (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x73,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11439,7 +11439,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CRB,
    /* .name        = */ "CRB",
-   /* .description = */ "Compare And Branch (32)",
+   /* .description = */ "COMPARE AND BRANCH (32)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xF6,
    /* .format      = */ RRS_FORMAT,
@@ -11452,10 +11452,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CRJ,
    /* .name        = */ "CRJ",
-   /* .description = */ "Compare And Branch Relative (32)",
+   /* .description = */ "COMPARE AND BRANCH RELATIVE (32)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x76,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11465,10 +11465,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CRL,
    /* .name        = */ "CRL",
-   /* .description = */ "Compare Relative Long",
+   /* .description = */ "COMPARE RELATIVE LONG (32)",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11482,10 +11482,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CRT,
    /* .name        = */ "CRT",
-   /* .description = */ "Compare And Trap (32)",
+   /* .description = */ "COMPARE AND TRAP (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x72,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -11495,10 +11495,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ECAG,
    /* .name        = */ "ECAG",
-   /* .description = */ "Extract Cache Attribute",
+   /* .description = */ "EXTRACT CPU ATTRIBUTE",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x4C,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_None
    },
@@ -11506,10 +11506,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::EXRL,
    /* .name        = */ "EXRL",
-   /* .description = */ "Execute Relative Long",
+   /* .description = */ "EXECUTE RELATIVE LONG",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_SetsCC
@@ -11518,10 +11518,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAEY,
    /* .name        = */ "LAEY",
-   /* .description = */ "Load Address Extended Y Form",
+   /* .description = */ "LOAD ADDRESS EXTENDED",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x75,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
@@ -11530,10 +11530,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGFRL,
    /* .name        = */ "LGFRL",
-   /* .description = */ "Load Relative Long (64 < 32)",
+   /* .description = */ "LOAD RELATIVE LONG (64 <- 32)",
    /* .opcode[0]   = */ 0xC4,
    /* .opcode[1]   = */ 0x0C,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -11543,10 +11543,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGRL,
    /* .name        = */ "LGRL",
-   /* .description = */ "Load Relative Long (64)",
+   /* .description = */ "LOAD RELATIVE LONG (64)",
    /* .opcode[0]   = */ 0xC4,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -11556,10 +11556,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGFRL,
    /* .name        = */ "LLGFRL",
-   /* .description = */ "Load Logical Relative Long (64 < 32)",
+   /* .description = */ "LOAD LOGICAL RELATIVE LONG (64 <- 32)",
    /* .opcode[0]   = */ 0xC4,
    /* .opcode[1]   = */ 0x0E,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -11569,10 +11569,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LRL,
    /* .name        = */ "LRL",
-   /* .description = */ "Load Relative Long (32)",
+   /* .description = */ "LOAD RELATIVE LONG (32)",
    /* .opcode[0]   = */ 0xC4,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -11582,10 +11582,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LTGF,
    /* .name        = */ "LTGF",
-   /* .description = */ "(LongDisp) Load and Test (64 < 32)",
+   /* .description = */ "LOAD AND TEST (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x32,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is32To64Bit |
@@ -11598,7 +11598,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MC,
    /* .name        = */ "MC",
-   /* .description = */ "Monitor Call",
+   /* .description = */ "MONITOR CALL",
    /* .opcode[0]   = */ 0xAF,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SI_FORMAT,
@@ -11609,10 +11609,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MFY,
    /* .name        = */ "MFY",
-   /* .description = */ "Multiply (64 < 32)",
+   /* .description = */ "MULTIPLY (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x5C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -11625,10 +11625,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MHY,
    /* .name        = */ "MHY",
-   /* .description = */ "Multiply Halfword (32)",
+   /* .description = */ "MULTIPLY HALFWORD (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x7C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -11640,10 +11640,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSFI,
    /* .name        = */ "MSFI",
-   /* .description = */ "Multiply Single Immediate",
+   /* .description = */ "MULTIPLY SINGLE IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -11654,10 +11654,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSGFI,
    /* .name        = */ "MSGFI",
-   /* .description = */ "Multiply Single Immediate",
+   /* .description = */ "MULTIPLY SINGLE IMMEDIATE (64 <- 32)",
    /* .opcode[0]   = */ 0xC2,
    /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -11668,7 +11668,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVGHI,
    /* .name        = */ "MVGHI",
-   /* .description = */ "Move and store immediate (64)",
+   /* .description = */ "MOVE (64 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x48,
    /* .format      = */ SIL_FORMAT,
@@ -11679,7 +11679,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVHHI,
    /* .name        = */ "MVHHI",
-   /* .description = */ "Move and store immediate (16)",
+   /* .description = */ "MOVE (16 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x44,
    /* .format      = */ SIL_FORMAT,
@@ -11690,7 +11690,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVHI,
    /* .name        = */ "MVHI",
-   /* .description = */ "Move and store immediate (32)",
+   /* .description = */ "MOVE (32 <- 16)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x4C,
    /* .format      = */ SIL_FORMAT,
@@ -11701,10 +11701,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PFD,
    /* .name        = */ "PFD",
-   /* .description = */ "Prefetch Data",
+   /* .description = */ "PREFETCH DATA",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x36,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_LongDispSupported
    },
@@ -11712,10 +11712,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PFDRL,
    /* .name        = */ "PFDRL",
-   /* .description = */ "Prefetch Data Relative Long",
+   /* .description = */ "PREFETCH DATA RELATIVE LONG",
    /* .opcode[0]   = */ 0xC6,
    /* .opcode[1]   = */ 0x02,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_None
    },
@@ -11723,10 +11723,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RISBG,
    /* .name        = */ "RISBG",
-   /* .description = */ "Rotate Then Insert Selected Bits",
+   /* .description = */ "ROTATE THEN INSERT SELECTED BITS (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x55,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_LongDispSupported |
@@ -11738,10 +11738,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RNSBG,
    /* .name        = */ "RNSBG",
-   /* .description = */ "Rotate Then AND Selected Bits",
+   /* .description = */ "ROTATE THEN AND SELECTED BITS (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x54,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -11753,10 +11753,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ROSBG,
    /* .name        = */ "ROSBG",
-   /* .description = */ "Rotate Then OR Selected Bits",
+   /* .description = */ "ROTATE THEN OR SELECTED BITS (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x56,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -11768,10 +11768,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RXSBG,
    /* .name        = */ "RXSBG",
-   /* .description = */ "Rotate Then XOR Selected Bits",
+   /* .description = */ "ROTATE THEN EXCLUSIVE OR SELECT. BITS (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x57,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -11783,10 +11783,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STGRL,
    /* .name        = */ "STGRL",
-   /* .description = */ "Store Relative Long (64)",
+   /* .description = */ "STORE RELATIVE LONG (64)",
    /* .opcode[0]   = */ 0xC4,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is64Bit
@@ -11795,10 +11795,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STRL,
    /* .name        = */ "STRL",
-   /* .description = */ "Store Relative Long (32)",
+   /* .description = */ "STORE RELATIVE LONG (32)",
    /* .opcode[0]   = */ 0xC4,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit
@@ -11807,10 +11807,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRTE,
    /* .name        = */ "TRTE",
-   /* .description = */ "Translate and Test Extended",
+   /* .description = */ "TRANSLATE AND TEST EXTENDED",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xBF,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -11823,10 +11823,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TRTRE,
    /* .name        = */ "TRTRE",
-   /* .description = */ "Translate and Test Reversed Extended",
+   /* .description = */ "TRANSLATE AND TEST REVERSE EXTENDED",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xBD,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z10,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_SetsCC |
@@ -11839,10 +11839,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGHIK,
    /* .name        = */ "AGHIK",
-   /* .description = */ "Add Immediate (64 < 16)",
+   /* .description = */ "ADD IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xD9,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -11855,7 +11855,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGRK,
    /* .name        = */ "AGRK",
-   /* .description = */ "Add (32)",
+   /* .description = */ "ADD (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE8,
    /* .format      = */ RRFa_FORMAT,
@@ -11870,7 +11870,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AHHHR,
    /* .name        = */ "AHHHR",
-   /* .description = */ "Add High (32)",
+   /* .description = */ "ADD HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xC8,
    /* .format      = */ RRFa_FORMAT,
@@ -11888,7 +11888,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AHHLR,
    /* .name        = */ "AHHLR",
-   /* .description = */ "Add High (32)",
+   /* .description = */ "ADD HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xD8,
    /* .format      = */ RRFa_FORMAT,
@@ -11905,10 +11905,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AHIK,
    /* .name        = */ "AHIK",
-   /* .description = */ "Add Immediate (32 < 16)",
+   /* .description = */ "ADD IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xD8,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -11921,10 +11921,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AIH,
    /* .name        = */ "AIH",
-   /* .description = */ "Add Immediate High (32)",
+   /* .description = */ "ADD IMMEDIATE HIGH (32)",
    /* .opcode[0]   = */ 0xCC,
    /* .opcode[1]   = */ 0x08,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsSignFlag |
@@ -11938,10 +11938,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGHSIK,
    /* .name        = */ "ALGHSIK",
-   /* .description = */ "Add Logicial With Signed Immediate (64 < 16)",
+   /* .description = */ "ADD LOGICAL WITH SIGNED IMMEDIATE (64 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xDB,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -11953,7 +11953,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALGRK,
    /* .name        = */ "ALGRK",
-   /* .description = */ "Add Logical (64)",
+   /* .description = */ "ADD LOGICAL (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xEA,
    /* .format      = */ RRFa_FORMAT,
@@ -11967,7 +11967,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALHHHR,
    /* .name        = */ "ALHHHR",
-   /* .description = */ "Add Logical High (32)",
+   /* .description = */ "ADD LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xCA,
    /* .format      = */ RRFa_FORMAT,
@@ -11984,7 +11984,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALHHLR,
    /* .name        = */ "ALHHLR",
-   /* .description = */ "Add Logical High (32)",
+   /* .description = */ "ADD LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xDA,
    /* .format      = */ RRFa_FORMAT,
@@ -12000,10 +12000,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALHSIK,
    /* .name        = */ "ALHSIK",
-   /* .description = */ "Add Logicial With Signed Immediate (32 < 16)",
+   /* .description = */ "ADD LOGICAL WITH SIGNED IMMEDIATE (32 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0xDA,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEd_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -12015,7 +12015,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALRK,
    /* .name        = */ "ALRK",
-   /* .description = */ "Add Logical (32)",
+   /* .description = */ "ADD LOGICAL (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xFA,
    /* .format      = */ RRFa_FORMAT,
@@ -12029,10 +12029,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALSIH,
    /* .name        = */ "ALSIH",
-   /* .description = */ "Add Logical with Signed Immediate High (32)",
+   /* .description = */ "ADD LOGICAL WITH SIGNED IMMEDIATE HIGH (32)",
    /* .opcode[0]   = */ 0xCC,
    /* .opcode[1]   = */ 0x0A,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_SetsZeroFlag |
@@ -12045,10 +12045,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ALSIHN,
    /* .name        = */ "ALSIHN",
-   /* .description = */ "Add Logical with Signed Immediate High (32)",
+   /* .description = */ "ADD LOGICAL WITH SIGNED IMMEDIATE HIGH (32)",
    /* .opcode[0]   = */ 0xCC,
    /* .opcode[1]   = */ 0x0B,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_IsExtendedImmediate |
@@ -12059,7 +12059,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ARK,
    /* .name        = */ "ARK",
-   /* .description = */ "Add (32)",
+   /* .description = */ "ADD (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF8,
    /* .format      = */ RRFa_FORMAT,
@@ -12074,10 +12074,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BRCTH,
    /* .name        = */ "BRCTH",
-   /* .description = */ "Branch Rel. on Count High (32)",
+   /* .description = */ "BRANCH RELATIVE ON COUNT HIGH (32)",
    /* .opcode[0]   = */ 0xCC,
    /* .opcode[1]   = */ 0x06,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_BranchOp |
                         S390OpProp_UsesTarget |
@@ -12089,10 +12089,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDLFBR,
    /* .name        = */ "CDLFBR",
-   /* .description = */ "Convert from Logical (LB < 32)",
+   /* .description = */ "CONVERT FROM LOGICAL (32 to long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x91,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is32Bit |
@@ -12102,10 +12102,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDLGBR,
    /* .name        = */ "CDLGBR",
-   /* .description = */ "Convert from Logical (LB < 64)",
+   /* .description = */ "CONVERT FROM LOGICAL (64 to long BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA1,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -12115,10 +12115,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CELFBR,
    /* .name        = */ "CELFBR",
-   /* .description = */ "Convert from Logical (SB < 32)",
+   /* .description = */ "CONVERT FROM LOGICAL (32 to short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x90,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SingleFP |
@@ -12128,10 +12128,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CELGBR,
    /* .name        = */ "CELGBR",
-   /* .description = */ "Convert from Logical (SB < 64)",
+   /* .description = */ "CONVERT FROM LOGICAL (64 to short BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA0,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1
@@ -12140,10 +12140,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHF,
    /* .name        = */ "CHF",
-   /* .description = */ "(LongDisp) Compare High (32)",
+   /* .description = */ "COMPARE HIGH (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xCD,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -12156,7 +12156,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHHR,
    /* .name        = */ "CHHR",
-   /* .description = */ "Compare High (32)",
+   /* .description = */ "COMPARE HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xCD,
    /* .format      = */ RRE_FORMAT,
@@ -12171,7 +12171,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CHLR,
    /* .name        = */ "CHLR",
-   /* .description = */ "Compare High (32)",
+   /* .description = */ "COMPARE HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xDD,
    /* .format      = */ RRE_FORMAT,
@@ -12185,10 +12185,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CIH,
    /* .name        = */ "CIH",
-   /* .description = */ "Compare Immediate High (32)",
+   /* .description = */ "COMPARE IMMEDIATE HIGH (32)",
    /* .opcode[0]   = */ 0xCC,
    /* .opcode[1]   = */ 0x0D,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -12200,10 +12200,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLFDBR,
    /* .name        = */ "CLFDBR",
-   /* .description = */ "Convert to Logical (LB < 32)",
+   /* .description = */ "CONVERT TO LOGICAL (long BFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x9D,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_SetsCC |
@@ -12217,10 +12217,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLFEBR,
    /* .name        = */ "CLFEBR",
-   /* .description = */ "Convert to Logical (SB < 32)",
+   /* .description = */ "CONVERT TO LOGICAL (short BFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x9C,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_SetsCC |
@@ -12234,10 +12234,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLFXBR,
    /* .name        = */ "CLFXBR",
-   /* .description = */ "Convert to Logical (EB < 32), note here",
+   /* .description = */ "CONVERT TO LOGICAL (extended BFP to 32)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x9E,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesRegPairForSource |
@@ -12251,10 +12251,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGDBR,
    /* .name        = */ "CLGDBR",
-   /* .description = */ "Convert to Logical (LB < 64)",
+   /* .description = */ "CONVERT TO LOGICAL (long BFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xAD,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_SetsCC |
@@ -12268,10 +12268,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGEBR,
    /* .name        = */ "CLGEBR",
-   /* .description = */ "Convert to Logical (SB < 64)",
+   /* .description = */ "CONVERT TO LOGICAL (short BFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xAC,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SingleFP |
                         S390OpProp_SetsCC |
@@ -12285,10 +12285,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGXBR,
    /* .name        = */ "CLGXBR",
-   /* .description = */ "Convert to Logical (EB < 64), note here",
+   /* .description = */ "CONVERT TO LOGICAL (extended BFP to 64)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xAE,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesRegPairForSource |
@@ -12302,10 +12302,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLHF,
    /* .name        = */ "CLHF",
-   /* .description = */ "(LongDisp) Compare Logical High (32)",
+   /* .description = */ "COMPARE LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xCF,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -12318,7 +12318,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLHHR,
    /* .name        = */ "CLHHR",
-   /* .description = */ "Compare Logical High (32)",
+   /* .description = */ "COMPARE LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xCF,
    /* .format      = */ RRE_FORMAT,
@@ -12333,7 +12333,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLHLR,
    /* .name        = */ "CLHLR",
-   /* .description = */ "Compare Logical High (32)",
+   /* .description = */ "COMPARE LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xDF,
    /* .format      = */ RRE_FORMAT,
@@ -12347,10 +12347,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLIH,
    /* .name        = */ "CLIH",
-   /* .description = */ "Compare Logical Immediate High (32)",
+   /* .description = */ "COMPARE LOGICAL IMMEDIATE HIGH (32)",
    /* .opcode[0]   = */ 0xCC,
    /* .opcode[1]   = */ 0x0F,
-   /* .format      = */ RIL_FORMAT,
+   /* .format      = */ RILa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsCompare |
                         S390OpProp_SetsCC |
@@ -12362,10 +12362,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXLFBR,
    /* .name        = */ "CXLFBR",
-   /* .description = */ "Convert from Logical (EB < 32)",
+   /* .description = */ "CONVERT FROM LOGICAL (32 to extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0x92,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForTarget |
@@ -12375,10 +12375,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXLGBR,
    /* .name        = */ "CXLGBR",
-   /* .description = */ "Convert from Logical (EB < 64)",
+   /* .description = */ "CONVERT FROM LOGICAL (64 to extended BFP)",
    /* .opcode[0]   = */ 0xB3,
    /* .opcode[1]   = */ 0xA2,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFe_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_UsesRegPairForTarget |
@@ -12388,10 +12388,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KMCTR,
    /* .name        = */ "KMCTR",
-   /* .description = */ "Cipher Message with Counter",
+   /* .description = */ "CIPHER MESSAGE WITH COUNTER",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x2D,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_SetsCC |
                         S390OpProp_IsLoad |
@@ -12405,7 +12405,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KMF,
    /* .name        = */ "KMF",
-   /* .description = */ "Cipher Message with CFB (Cipher Feedback)",
+   /* .description = */ "CIPHER MESSAGE WITH CIPHER FEEDBACK",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x2A,
    /* .format      = */ RRE_FORMAT,
@@ -12422,7 +12422,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KMO,
    /* .name        = */ "KMO",
-   /* .description = */ "Cipher Message with OFB (Output Feedback)",
+   /* .description = */ "CIPHER MESSAGE WITH OUTPUT FEEDBACK",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x2B,
    /* .format      = */ RRE_FORMAT,
@@ -12439,10 +12439,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAA,
    /* .name        = */ "LAA",
-   /* .description = */ "Load And Add (32)",
+   /* .description = */ "LOAD AND ADD (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xF8,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -12458,10 +12458,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAAG,
    /* .name        = */ "LAAG",
-   /* .description = */ "Load And Add (64)",
+   /* .description = */ "LOAD AND ADD (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE8,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -12477,10 +12477,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAAL,
    /* .name        = */ "LAAL",
-   /* .description = */ "Load And Add Logical (32)",
+   /* .description = */ "LOAD AND ADD LOGICAL (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xFA,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -12494,10 +12494,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAALG,
    /* .name        = */ "LAALG",
-   /* .description = */ "Load And Add Logical (64)",
+   /* .description = */ "LOAD AND ADD LOGICAL (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xEA,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -12511,10 +12511,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAN,
    /* .name        = */ "LAN",
-   /* .description = */ "(LongDisp) Load And AND (32)",
+   /* .description = */ "LOAD AND AND (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xF4,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -12529,10 +12529,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LANG,
    /* .name        = */ "LANG",
-   /* .description = */ "(LongDisp) Load And AND (64)",
+   /* .description = */ "LOAD AND AND (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE4,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -12547,10 +12547,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAO,
    /* .name        = */ "LAO",
-   /* .description = */ "(LongDisp) Load And OR (32)",
+   /* .description = */ "LOAD AND OR (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xF6,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -12565,10 +12565,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAOG,
    /* .name        = */ "LAOG",
-   /* .description = */ "(LongDisp) Load And OR (64)",
+   /* .description = */ "LOAD AND OR (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE6,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -12583,10 +12583,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAX,
    /* .name        = */ "LAX",
-   /* .description = */ "(LongDisp) Load And Exclusive OR (32)",
+   /* .description = */ "LOAD AND EXCLUSIVE OR (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xF7,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -12601,10 +12601,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAXG,
    /* .name        = */ "LAXG",
-   /* .description = */ "(LongDisp) Load And Exclusive OR (64)",
+   /* .description = */ "LOAD AND EXCLUSIVE OR (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE7,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -12619,10 +12619,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LBH,
    /* .name        = */ "LBH",
-   /* .description = */ "(LongDisp) Load Byte High (32 < 8)",
+   /* .description = */ "LOAD BYTE HIGH (32 <- 8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC0,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -12633,10 +12633,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LFH,
    /* .name        = */ "LFH",
-   /* .description = */ "(LongDisp) Load High (32)",
+   /* .description = */ "LOAD HIGH (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xCA,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -12647,10 +12647,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LHH,
    /* .name        = */ "LHH",
-   /* .description = */ "(LongDisp) Load Halfword High (32 < 16)",
+   /* .description = */ "LOAD HALFWORD HIGH (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC4,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -12661,10 +12661,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLCH,
    /* .name        = */ "LLCH",
-   /* .description = */ "(Long Disp)Load Logical Character High (32 < 8)",
+   /* .description = */ "LOAD LOGICAL CHARACTER HIGH (32 <- 8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC2,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -12675,10 +12675,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLHH,
    /* .name        = */ "LLHH",
-   /* .description = */ "(LongDisp) Load Logical Halfword High (32 < 8)",
+   /* .description = */ "LOAD LOGICAL HALFWORD HIGH (32 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC6,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -12689,10 +12689,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOC,
    /* .name        = */ "LOC",
-   /* .description = */ "(LongDisp) Load On Condition (32)",
+   /* .description = */ "LOAD ON CONDITION (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xF2,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_ReadsCC |
@@ -12705,10 +12705,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCG,
    /* .name        = */ "LOCG",
-   /* .description = */ "(LongDisp) Load On Condition (64)",
+   /* .description = */ "LOAD ON CONDITION (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE2,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_ReadsCC |
@@ -12721,10 +12721,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCGR,
    /* .name        = */ "LOCGR",
-   /* .description = */ "Load On Condition (64)",
+   /* .description = */ "LOAD ON CONDITION (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE2,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_ReadsCC |
@@ -12735,10 +12735,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCR,
    /* .name        = */ "LOCR",
-   /* .description = */ "Load On Condition (32)",
+   /* .description = */ "LOAD ON CONDITION (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF2,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_ReadsCC |
@@ -12749,7 +12749,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPD,
    /* .name        = */ "LPD",
-   /* .description = */ "Load Pair Disjoint (32)",
+   /* .description = */ "LOAD PAIR DISJOINT (32)",
    /* .opcode[0]   = */ 0xC8,
    /* .opcode[1]   = */ 0x04,
    /* .format      = */ SSF_FORMAT,
@@ -12765,7 +12765,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LPDG,
    /* .name        = */ "LPDG",
-   /* .description = */ "Load Pair Disjoint (64)",
+   /* .description = */ "LOAD PAIR DISJOINT (64)",
    /* .opcode[0]   = */ 0xC8,
    /* .opcode[1]   = */ 0x05,
    /* .format      = */ SSF_FORMAT,
@@ -12781,7 +12781,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NGRK,
    /* .name        = */ "NGRK",
-   /* .description = */ "And (64)",
+   /* .description = */ "AND (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE4,
    /* .format      = */ RRFa_FORMAT,
@@ -12795,7 +12795,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NRK,
    /* .name        = */ "NRK",
-   /* .description = */ "And (32)",
+   /* .description = */ "AND (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF4,
    /* .format      = */ RRFa_FORMAT,
@@ -12809,7 +12809,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::OGRK,
    /* .name        = */ "OGRK",
-   /* .description = */ "Or (64)",
+   /* .description = */ "OR (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE6,
    /* .format      = */ RRFa_FORMAT,
@@ -12823,7 +12823,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ORK,
    /* .name        = */ "ORK",
-   /* .description = */ "Or (32)",
+   /* .description = */ "OR (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF6,
    /* .format      = */ RRFa_FORMAT,
@@ -12837,7 +12837,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::POPCNT,
    /* .name        = */ "POPCNT",
-   /* .description = */ "Population Count",
+   /* .description = */ "POPULATION COUNT",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE1,
    /* .format      = */ RRE_FORMAT,
@@ -12852,10 +12852,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RISBHG,
    /* .name        = */ "RISBHG",
-   /* .description = */ "Rotate Then Insert Selected Bits High",
+   /* .description = */ "ROTATE THEN INSERT SELECTED BITS HIGH (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x5D,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_LongDispSupported |
@@ -12867,10 +12867,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RISBLG,
    /* .name        = */ "RISBLG",
-   /* .description = */ "Rotate Then Insert Selected Bits Low",
+   /* .description = */ "ROTATE THEN INSERT SELECTED BITS LOW (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x51,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_LongDispSupported |
@@ -12881,7 +12881,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SGRK,
    /* .name        = */ "SGRK",
-   /* .description = */ "Subtract (64)",
+   /* .description = */ "SUBTRACT (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE9,
    /* .format      = */ RRFa_FORMAT,
@@ -12896,7 +12896,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SHHHR,
    /* .name        = */ "SHHHR",
-   /* .description = */ "Subtract High (32)",
+   /* .description = */ "SUBTRACT HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xC9,
    /* .format      = */ RRFa_FORMAT,
@@ -12913,7 +12913,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SHHLR,
    /* .name        = */ "SHHLR",
-   /* .description = */ "Subtract High (32)",
+   /* .description = */ "SUBTRACT HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xD9,
    /* .format      = */ RRFa_FORMAT,
@@ -12930,10 +12930,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLAK,
    /* .name        = */ "SLAK",
-   /* .description = */ "(LongDisp) Shift Left Single (32)",
+   /* .description = */ "SHIFT LEFT SINGLE (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xDD,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -12946,7 +12946,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLGRK,
    /* .name        = */ "SLGRK",
-   /* .description = */ "Subtract (64)",
+   /* .description = */ "SUBTRACT LOGICAL (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xEB,
    /* .format      = */ RRFa_FORMAT,
@@ -12960,7 +12960,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLHHHR,
    /* .name        = */ "SLHHHR",
-   /* .description = */ "Subtract High (32)",
+   /* .description = */ "SUBTRACT LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xCB,
    /* .format      = */ RRFa_FORMAT,
@@ -12976,7 +12976,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLHHLR,
    /* .name        = */ "SLHHLR",
-   /* .description = */ "Subtract High (32)",
+   /* .description = */ "SUBTRACT LOGICAL HIGH (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xDB,
    /* .format      = */ RRFa_FORMAT,
@@ -12991,10 +12991,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLLK,
    /* .name        = */ "SLLK",
-   /* .description = */ "(LongDisp) Shift Left Logical (32)",
+   /* .description = */ "SHIFT LEFT SINGLE LOGICAL (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xDF,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_LongDispSupported |
@@ -13004,7 +13004,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SLRK,
    /* .name        = */ "SLRK",
-   /* .description = */ "Subtract (32)",
+   /* .description = */ "SUBTRACT LOGICAL (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xFB,
    /* .format      = */ RRFa_FORMAT,
@@ -13018,10 +13018,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRAK,
    /* .name        = */ "SRAK",
-   /* .description = */ "(LongDisp) Shift Right Single (32)",
+   /* .description = */ "SHIFT RIGHT SINGLE (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xDC,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsCC |
@@ -13033,7 +13033,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRK,
    /* .name        = */ "SRK",
-   /* .description = */ "Subtract (32)",
+   /* .description = */ "SUBTRACT (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF9,
    /* .format      = */ RRFa_FORMAT,
@@ -13048,10 +13048,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SRLK,
    /* .name        = */ "SRLK",
-   /* .description = */ "(LongDisp) Shift Right Logical (32)",
+   /* .description = */ "SHIFT RIGHT SINGLE LOGICAL (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xDE,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_LongDispSupported |
@@ -13061,10 +13061,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STCH,
    /* .name        = */ "STCH",
-   /* .description = */ "(LongDisp) Store Character High (8)",
+   /* .description = */ "STORE CHARACTER HIGH (8)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC3,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -13074,10 +13074,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STFH,
    /* .name        = */ "STFH",
-   /* .description = */ "(LongDisp) Store High (32)",
+   /* .description = */ "STORE HIGH (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xCB,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -13087,10 +13087,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STHH,
    /* .name        = */ "STHH",
-   /* .description = */ "(LongDisp) Store Halfword High (16)",
+   /* .description = */ "STORE HALFWORD HIGH (16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC7,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported |
@@ -13100,10 +13100,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STOC,
    /* .name        = */ "STOC",
-   /* .description = */ "(LongDisp) Store On Condition (32)",
+   /* .description = */ "STORE ON CONDITION (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xF3,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is32Bit |
@@ -13114,10 +13114,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STOCG,
    /* .name        = */ "STOCG",
-   /* .description = */ "(LongDisp) Store On Condition (64)",
+   /* .description = */ "STORE ON CONDITION (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE3,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z196,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_Is64Bit |
@@ -13128,7 +13128,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XGRK,
    /* .name        = */ "XGRK",
-   /* .description = */ "Exclusive Or (64)",
+   /* .description = */ "EXCLUSIVE OR (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE7,
    /* .format      = */ RRFa_FORMAT,
@@ -13142,7 +13142,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::XRK,
    /* .name        = */ "XRK",
-   /* .description = */ "Exclusive Or (32)",
+   /* .description = */ "EXCLUSIVE OR (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xF7,
    /* .format      = */ RRFa_FORMAT,
@@ -13156,7 +13156,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BPP,
    /* .name        = */ "BPP",
-   /* .description = */ "Branch Prediction Preload",
+   /* .description = */ "BRANCH PREDICTION PRELOAD",
    /* .opcode[0]   = */ 0xC7,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ SMI_FORMAT,
@@ -13167,7 +13167,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BPRP,
    /* .name        = */ "BPRP",
-   /* .description = */ "Branch Prediction Relative Preload",
+   /* .description = */ "BRANCH PREDICTION RELATIVE PRELOAD",
    /* .opcode[0]   = */ 0xC5,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ MII_FORMAT,
@@ -13178,10 +13178,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDZT,
    /* .name        = */ "CDZT",
-   /* .description = */ "Convert Zoned to DFP Long",
+   /* .description = */ "CONVERT FROM ZONED (to long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xAA,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13192,10 +13192,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLGT,
    /* .name        = */ "CLGT",
-   /* .description = */ "Compare Logical and Trap (64)",
+   /* .description = */ "COMPARE LOGICAL AND TRAP (64)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x2B,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsCompare |
@@ -13206,10 +13206,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CLT,
    /* .name        = */ "CLT",
-   /* .description = */ "Compare Logical and Trap (32)",
+   /* .description = */ "COMPARE LOGICAL AND TRAP (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0x23,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsCompare |
@@ -13220,10 +13220,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXZT,
    /* .name        = */ "CXZT",
-   /* .description = */ "Convert Zoned to DFP Extended",
+   /* .description = */ "CONVERT FROM ZONED (to extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xAB,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13235,10 +13235,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CZDT,
    /* .name        = */ "CZDT",
-   /* .description = */ "Convert DFP Long to Zoned",
+   /* .description = */ "CONVERT TO ZONED (from long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xA8,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13251,10 +13251,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CZXT,
    /* .name        = */ "CZXT",
-   /* .description = */ "Convert DFP Extended to Zoned",
+   /* .description = */ "CONVERT TO ZONED (from extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xA9,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13268,7 +13268,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::ETND,
    /* .name        = */ "ETND",
-   /* .description = */ "Extract Transaction Nesting Depth",
+   /* .description = */ "EXTRACT TRANSACTION NESTING DEPTH",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xEC,
    /* .format      = */ RRE_FORMAT,
@@ -13279,10 +13279,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LAT,
    /* .name        = */ "LAT",
-   /* .description = */ "Load and Trap",
+   /* .description = */ "LOAD AND TRAP (32L <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x9F,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -13294,10 +13294,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LFHAT,
    /* .name        = */ "LFHAT",
-   /* .description = */ "Load High and Trap",
+   /* .description = */ "LOAD HIGH AND TRAP (32H <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0xC8,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Trap |
@@ -13309,10 +13309,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGAT,
    /* .name        = */ "LGAT",
-   /* .description = */ "Load and Trap (64)",
+   /* .description = */ "LOAD AND TRAP (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x85,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -13324,10 +13324,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGFAT,
    /* .name        = */ "LLGFAT",
-   /* .description = */ "Load Logical and Trap",
+   /* .description = */ "LOAD LOGICAL AND TRAP (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x9D,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -13339,10 +13339,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGTAT,
    /* .name        = */ "LLGTAT",
-   /* .description = */ "Load Logical Thirty One Bits and Trap",
+   /* .description = */ "LOAD LOGICAL THIRTY ONE BITS AND TRAP (64 <- 31)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x9C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -13354,7 +13354,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NIAI,
    /* .name        = */ "NIAI",
-   /* .description = */ "Next Instruction Access Intent",
+   /* .description = */ "NEXT INSTRUCTION ACCESS INTENT",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xFA,
    /* .format      = */ IE_FORMAT,
@@ -13365,10 +13365,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::NTSTG,
    /* .name        = */ "NTSTG",
-   /* .description = */ "Nontransactional Store",
+   /* .description = */ "NONTRANSACTIONAL STORE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x25,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsStore |
@@ -13378,10 +13378,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PPA,
    /* .name        = */ "PPA",
-   /* .description = */ "Perform Processor Assist",
+   /* .description = */ "PERFORM PROCESSOR ASSIST",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xE8,
-   /* .format      = */ RRF2_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_UsesTarget
    },
@@ -13389,10 +13389,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::RISBGN,
    /* .name        = */ "RISBGN",
-   /* .description = */ "Rotate Then Insert Selected Bits",
+   /* .description = */ "ROTATE THEN INSERT SELECTED BITS (64)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x59,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEf_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_LongDispSupported |
@@ -13403,7 +13403,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TABORT,
    /* .name        = */ "TABORT",
-   /* .description = */ "Transaction Abort",
+   /* .description = */ "TRANSACTION ABORT",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xFC,
    /* .format      = */ S_FORMAT,
@@ -13415,7 +13415,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TBEGIN,
    /* .name        = */ "TBEGIN",
-   /* .description = */ "Transaction Begin",
+   /* .description = */ "TRANSACTION BEGIN (nonconstrained)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x60,
    /* .format      = */ SIL_FORMAT,
@@ -13427,7 +13427,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TBEGINC,
    /* .name        = */ "TBEGINC",
-   /* .description = */ "Constrained Transaction Begin",
+   /* .description = */ "TRANSACTION BEGIN (constrained)",
    /* .opcode[0]   = */ 0xE5,
    /* .opcode[1]   = */ 0x61,
    /* .format      = */ SIL_FORMAT,
@@ -13438,7 +13438,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::TEND,
    /* .name        = */ "TEND",
-   /* .description = */ "Transaction End",
+   /* .description = */ "TRANSACTION END",
    /* .opcode[0]   = */ 0xB2,
    /* .opcode[1]   = */ 0xF8,
    /* .format      = */ S_FORMAT,
@@ -13449,10 +13449,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CDPT,
    /* .name        = */ "CDPT",
-   /* .description = */ "Convert Packed to DFP Long",
+   /* .description = */ "CONVERT FROM PACKED (to long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xAE,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13463,10 +13463,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CPDT,
    /* .name        = */ "CPDT",
-   /* .description = */ "Convert DFP Long to Packed",
+   /* .description = */ "CONVERT TO PACKED (from long DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xAC,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13479,10 +13479,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CPXT,
    /* .name        = */ "CPXT",
-   /* .description = */ "Convert DFP Extended to Packed",
+   /* .description = */ "CONVERT TO PACKED (from extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xAD,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13496,10 +13496,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::CXPT,
    /* .name        = */ "CXPT",
-   /* .description = */ "Convert Packed to DFP Extended",
+   /* .description = */ "CONVERT FROM PACKED (to extended DFP)",
    /* .opcode[0]   = */ 0xED,
    /* .opcode[1]   = */ 0xAF,
-   /* .format      = */ RSL_FORMAT,
+   /* .format      = */ RSLb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_DoubleFP |
                         S390OpProp_Is64Bit |
@@ -13511,7 +13511,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LCBB,
    /* .name        = */ "LCBB",
-   /* .description = */ "Load Count To Block Boundary",
+   /* .description = */ "LOAD COUNT TO BLOCK BOUNDARY",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x27,
    /* .format      = */ RXE_FORMAT,
@@ -13524,10 +13524,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLZRGF,
    /* .name        = */ "LLZRGF",
-   /* .description = */ "Load Logical and Zero Rightmost Byte",
+   /* .description = */ "LOAD LOGICAL AND ZERO RIGHTMOST BYTE (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x3A,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -13538,10 +13538,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCFH,
    /* .name        = */ "LOCFH",
-   /* .description = */ "(LongDisp) Load High On Condition",
+   /* .description = */ "LOAD HIGH ON CONDITION (32)",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE0,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_ReadsCC |
@@ -13554,10 +13554,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCFHR,
    /* .name        = */ "LOCFHR",
-   /* .description = */ "Load High On Condition",
+   /* .description = */ "LOAD HIGH ON CONDITION (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xE0,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_ReadsCC |
@@ -13569,10 +13569,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCGHI,
    /* .name        = */ "LOCGHI",
-   /* .description = */ "Load Halfword Immediate On Condition (64)",
+   /* .description = */ "LOAD HALFWORD IMMEDIATE ON CONDITION (64 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x46,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEg_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_ReadsCC |
@@ -13584,10 +13584,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCHHI,
    /* .name        = */ "LOCHHI",
-   /* .description = */ "Load Halfword High Immediate On Condition",
+   /* .description = */ "LOAD HALFWORD HIGH IMMEDIATE ON CONDITION (32 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x4E,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEg_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_TargetHW |
                         S390OpProp_ReadsCC |
@@ -13599,10 +13599,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LOCHI,
    /* .name        = */ "LOCHI",
-   /* .description = */ "Load Halfword Immediate On Condition (32)",
+   /* .description = */ "LOAD HALFWORD IMMEDIATE ON CONDITION (32 <- 16)",
    /* .opcode[0]   = */ 0xEC,
    /* .opcode[1]   = */ 0x42,
-   /* .format      = */ RIE_FORMAT,
+   /* .format      = */ RIEg_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_ReadsCC |
@@ -13614,10 +13614,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LZRF,
    /* .name        = */ "LZRF",
-   /* .description = */ "Load and Zero Rightmost Byte",
+   /* .description = */ "LOAD AND ZERO RIGHTMOST BYTE (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x3B,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_IsLoad |
@@ -13628,10 +13628,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LZRG,
    /* .name        = */ "LZRG",
-   /* .description = */ "Load and Zero Rightmost Byte",
+   /* .description = */ "LOAD AND ZERO RIGHTMOST BYTE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x2A,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_IsLoad |
@@ -13642,7 +13642,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::PRNO,
    /* .name        = */ "PRNO",
-   /* .description = */ "perform random number operation",
+   /* .description = */ "PERFORM RANDOM NUMBER OPERATION",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x3C,
    /* .format      = */ RRE_FORMAT,
@@ -13653,10 +13653,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STOCFH,
    /* .name        = */ "STOCFH",
-   /* .description = */ "(LongDisp) Store High On Condition",
+   /* .description = */ "STORE HIGH ON CONDITION",
    /* .opcode[0]   = */ 0xEB,
    /* .opcode[1]   = */ 0xE1,
-   /* .format      = */ RSY_FORMAT,
+   /* .format      = */ RSYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z13,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_TargetHW |
@@ -13667,7 +13667,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VA,
    /* .name        = */ "VA",
-   /* .description = */ "vector add",
+   /* .description = */ "VECTOR ADD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF3,
    /* .format      = */ VRRc_FORMAT,
@@ -13680,7 +13680,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VAC,
    /* .name        = */ "VAC",
-   /* .description = */ "vector add with carry",
+   /* .description = */ "VECTOR ADD WITH CARRY",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xBB,
    /* .format      = */ VRRd_FORMAT,
@@ -13693,7 +13693,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VACC,
    /* .name        = */ "VACC",
-   /* .description = */ "vector add compute carry",
+   /* .description = */ "VECTOR ADD COMPUTE CARRY",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF1,
    /* .format      = */ VRRc_FORMAT,
@@ -13706,7 +13706,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VACCC,
    /* .name        = */ "VACCC",
-   /* .description = */ "vector add with carry compute carry",
+   /* .description = */ "VECTOR ADD WITH CARRY COMPUTE CARRY",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB9,
    /* .format      = */ VRRd_FORMAT,
@@ -13719,7 +13719,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VAVG,
    /* .name        = */ "VAVG",
-   /* .description = */ "vector average",
+   /* .description = */ "VECTOR AVERAGE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF2,
    /* .format      = */ VRRc_FORMAT,
@@ -13732,7 +13732,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VAVGL,
    /* .name        = */ "VAVGL",
-   /* .description = */ "vector average logical",
+   /* .description = */ "VECTOR AVERAGE LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF0,
    /* .format      = */ VRRc_FORMAT,
@@ -13745,7 +13745,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCDG,
    /* .name        = */ "VCDG",
-   /* .description = */ "vector floating-point convert from fixed 64-bit",
+   /* .description = */ "VECTOR FP CONVERT FROM FIXED 64-BIT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC3,
    /* .format      = */ VRRa_FORMAT,
@@ -13761,7 +13761,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCDLG,
    /* .name        = */ "VCDLG",
-   /* .description = */ "vector floating-point convert from logical 64-bit",
+   /* .description = */ "VECTOR FP CONVERT FROM LOGICAL 64-BIT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC1,
    /* .format      = */ VRRa_FORMAT,
@@ -13777,7 +13777,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCEQ,
    /* .name        = */ "VCEQ",
-   /* .description = */ "vector comp are equal CC Set",
+   /* .description = */ "VECTOR COMPARE EQUAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF8,
    /* .format      = */ VRRb_FORMAT,
@@ -13792,7 +13792,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCGD,
    /* .name        = */ "VCGD",
-   /* .description = */ "vector floating-point convert to fixed 64-bit",
+   /* .description = */ "VECTOR FP CONVERT TO FIXED 64-BIT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC2,
    /* .format      = */ VRRa_FORMAT,
@@ -13808,7 +13808,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCH,
    /* .name        = */ "VCH",
-   /* .description = */ "vector comp are high CC Set",
+   /* .description = */ "VECTOR COMPARE HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xFB,
    /* .format      = */ VRRb_FORMAT,
@@ -13823,7 +13823,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCHL,
    /* .name        = */ "VCHL",
-   /* .description = */ "vector comp are high logical CC Set",
+   /* .description = */ "VECTOR COMPARE HIGH LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF9,
    /* .format      = */ VRRb_FORMAT,
@@ -13838,7 +13838,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCKSM,
    /* .name        = */ "VCKSM",
-   /* .description = */ "vector checksum",
+   /* .description = */ "VECTOR CHECKSUM",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x66,
    /* .format      = */ VRRc_FORMAT,
@@ -13849,7 +13849,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCLGD,
    /* .name        = */ "VCLGD",
-   /* .description = */ "vector floating-point convert to logical 64-bit",
+   /* .description = */ "VECTOR FP CONVERT TO LOGICAL 64-BIT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC0,
    /* .format      = */ VRRa_FORMAT,
@@ -13865,7 +13865,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCLZ,
    /* .name        = */ "VCLZ",
-   /* .description = */ "vector count leading zeros",
+   /* .description = */ "VECTOR COUNT LEADING ZEROS",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x53,
    /* .format      = */ VRRa_FORMAT,
@@ -13878,7 +13878,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCTZ,
    /* .name        = */ "VCTZ",
-   /* .description = */ "vector count trailing zeros",
+   /* .description = */ "VECTOR COUNT TRAILING ZEROS",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x52,
    /* .format      = */ VRRa_FORMAT,
@@ -13891,7 +13891,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VEC,
    /* .name        = */ "VEC",
-   /* .description = */ "vector element comp are CC Set",
+   /* .description = */ "VECTOR ELEMENT COMPARE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xDB,
    /* .format      = */ VRRa_FORMAT,
@@ -13904,7 +13904,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VECL,
    /* .name        = */ "VECL",
-   /* .description = */ "vector element comp are logical CC Set",
+   /* .description = */ "VECTOR ELEMENT COMPARE LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xD9,
    /* .format      = */ VRRa_FORMAT,
@@ -13917,7 +13917,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VERIM,
    /* .name        = */ "VERIM",
-   /* .description = */ "vector element rotate and insert under mask",
+   /* .description = */ "VECTOR ELEMENT ROTATE AND INSERT UNDER MASK",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x72,
    /* .format      = */ VRId_FORMAT,
@@ -13931,7 +13931,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VERLL,
    /* .name        = */ "VERLL",
-   /* .description = */ "vector element rotate left logical",
+   /* .description = */ "VECTOR ELEMENT ROTATE LEFT LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x33,
    /* .format      = */ VRSa_FORMAT,
@@ -13944,7 +13944,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VERLLV,
    /* .name        = */ "VERLLV",
-   /* .description = */ "vector element rotate left logical",
+   /* .description = */ "VECTOR ELEMENT ROTATE LEFT LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x73,
    /* .format      = */ VRRc_FORMAT,
@@ -13957,7 +13957,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VESL,
    /* .name        = */ "VESL",
-   /* .description = */ "vector element shift left",
+   /* .description = */ "VECTOR ELEMENT SHIFT LEFT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x30,
    /* .format      = */ VRSa_FORMAT,
@@ -13970,7 +13970,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VESLV,
    /* .name        = */ "VESLV",
-   /* .description = */ "vector element shift left",
+   /* .description = */ "VECTOR ELEMENT SHIFT LEFT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x70,
    /* .format      = */ VRRc_FORMAT,
@@ -13983,7 +13983,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VESRA,
    /* .name        = */ "VESRA",
-   /* .description = */ "vector element shift right arithmetic",
+   /* .description = */ "VECTOR ELEMENT SHIFT RIGHT ARITHMETIC",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x3A,
    /* .format      = */ VRSa_FORMAT,
@@ -13996,7 +13996,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VESRAV,
    /* .name        = */ "VESRAV",
-   /* .description = */ "vector element shift right arithmetic",
+   /* .description = */ "VECTOR ELEMENT SHIFT RIGHT ARITHMETIC",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x7A,
    /* .format      = */ VRRc_FORMAT,
@@ -14009,7 +14009,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VESRL,
    /* .name        = */ "VESRL",
-   /* .description = */ "vector element shift right logical",
+   /* .description = */ "VECTOR ELEMENT SHIFT RIGHT LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x38,
    /* .format      = */ VRSa_FORMAT,
@@ -14022,7 +14022,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VESRLV,
    /* .name        = */ "VESRLV",
-   /* .description = */ "vector element shift right logical",
+   /* .description = */ "VECTOR ELEMENT SHIFT RIGHT LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x78,
    /* .format      = */ VRRc_FORMAT,
@@ -14035,7 +14035,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFA,
    /* .name        = */ "VFA",
-   /* .description = */ "vector floating-point add",
+   /* .description = */ "VECTOR FP ADD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xE3,
    /* .format      = */ VRRc_FORMAT,
@@ -14050,7 +14050,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFAE,
    /* .name        = */ "VFAE",
-   /* .description = */ "vector find any element equal CC Set* (*: If CS bit != 0)",
+   /* .description = */ "VECTOR FIND ANY ELEMENT EQUAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x82,
    /* .format      = */ VRRb_FORMAT,
@@ -14066,7 +14066,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFCE,
    /* .name        = */ "VFCE",
-   /* .description = */ "vector floating-point comp are equal CC Set*",
+   /* .description = */ "VECTOR FP COMPARE EQUAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xE8,
    /* .format      = */ VRRc_FORMAT,
@@ -14083,7 +14083,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFCH,
    /* .name        = */ "VFCH",
-   /* .description = */ "vector floating-point comp are high CC Set*",
+   /* .description = */ "VECTOR FP COMPARE HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xEB,
    /* .format      = */ VRRc_FORMAT,
@@ -14100,7 +14100,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFCHE,
    /* .name        = */ "VFCHE",
-   /* .description = */ "vector floating-point comp are high or equal CC Set*",
+   /* .description = */ "VECTOR FP COMPARE HIGH OR EQUAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xEA,
    /* .format      = */ VRRc_FORMAT,
@@ -14117,7 +14117,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFD,
    /* .name        = */ "VFD",
-   /* .description = */ "vector floating-point divide",
+   /* .description = */ "VECTOR FP DIVIDE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xE5,
    /* .format      = */ VRRc_FORMAT,
@@ -14132,7 +14132,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFEE,
    /* .name        = */ "VFEE",
-   /* .description = */ "vector find element equal CC Set*",
+   /* .description = */ "VECTOR FIND ELEMENT EQUAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x80,
    /* .format      = */ VRRb_FORMAT,
@@ -14148,7 +14148,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFENE,
    /* .name        = */ "VFENE",
-   /* .description = */ "vector find element not equal CC Set*",
+   /* .description = */ "VECTOR FIND ELEMENT NOT EQUAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x81,
    /* .format      = */ VRRb_FORMAT,
@@ -14164,7 +14164,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFI,
    /* .name        = */ "VFI",
-   /* .description = */ "vector load floating-point integer",
+   /* .description = */ "VECTOR LOAD FP INTEGER",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC7,
    /* .format      = */ VRRa_FORMAT,
@@ -14180,7 +14180,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFM,
    /* .name        = */ "VFM",
-   /* .description = */ "vector floating-point multiply",
+   /* .description = */ "VECTOR FP MULTIPLY",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xE7,
    /* .format      = */ VRRc_FORMAT,
@@ -14195,7 +14195,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFMA,
    /* .name        = */ "VFMA",
-   /* .description = */ "vector floating-point multiply and add",
+   /* .description = */ "VECTOR FP MULTIPLY AND ADD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x8F,
    /* .format      = */ VRRe_FORMAT,
@@ -14210,7 +14210,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFMS,
    /* .name        = */ "VFMS",
-   /* .description = */ "vector floating-point multiply and subtract",
+   /* .description = */ "VECTOR FP MULTIPLY AND SUBTRACT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x8E,
    /* .format      = */ VRRe_FORMAT,
@@ -14225,7 +14225,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFPSO,
    /* .name        = */ "VFPSO",
-   /* .description = */ "vector floating-point perform sign operation",
+   /* .description = */ "VECTOR FP PERFORM SIGN OPERATION",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xCC,
    /* .format      = */ VRRa_FORMAT,
@@ -14241,7 +14241,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFS,
    /* .name        = */ "VFS",
-   /* .description = */ "vector floating-point subtract",
+   /* .description = */ "VECTOR FP SUBTRACT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xE2,
    /* .format      = */ VRRc_FORMAT,
@@ -14256,7 +14256,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFSQ,
    /* .name        = */ "VFSQ",
-   /* .description = */ "vector floating-point square root",
+   /* .description = */ "VECTOR FP SQUARE ROOT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xCE,
    /* .format      = */ VRRa_FORMAT,
@@ -14271,7 +14271,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFTCI,
    /* .name        = */ "VFTCI",
-   /* .description = */ "vector floating-point test data class immediate CC Set",
+   /* .description = */ "VECTOR FP TEST DATA CLASS IMMEDIATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x4A,
    /* .format      = */ VRIe_FORMAT,
@@ -14287,7 +14287,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VGBM,
    /* .name        = */ "VGBM",
-   /* .description = */ "vector generate byte mask",
+   /* .description = */ "VECTOR GENERATE BYTE MASK",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x44,
    /* .format      = */ VRIa_FORMAT,
@@ -14298,7 +14298,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VGEF,
    /* .name        = */ "VGEF",
-   /* .description = */ "vector gather element (32)",
+   /* .description = */ "VECTOR GATHER ELEMENT (32)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x13,
    /* .format      = */ VRV_FORMAT,
@@ -14311,7 +14311,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VGEG,
    /* .name        = */ "VGEG",
-   /* .description = */ "vector gather element (64)",
+   /* .description = */ "VECTOR GATHER ELEMENT (64)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x12,
    /* .format      = */ VRV_FORMAT,
@@ -14324,7 +14324,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VGFM,
    /* .name        = */ "VGFM",
-   /* .description = */ "vector galois field multiply sum",
+   /* .description = */ "VECTOR GALOIS FIELD MULTIPLY SUM",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB4,
    /* .format      = */ VRRc_FORMAT,
@@ -14337,7 +14337,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VGFMA,
    /* .name        = */ "VGFMA",
-   /* .description = */ "vector galois field multiply sum and accumulate",
+   /* .description = */ "VECTOR GALOIS FIELD MULTIPLY SUM AND ACCUMULATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xBC,
    /* .format      = */ VRRd_FORMAT,
@@ -14350,7 +14350,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VGM,
    /* .name        = */ "VGM",
-   /* .description = */ "vector generate mask",
+   /* .description = */ "VECTOR GENERATE MASK",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x46,
    /* .format      = */ VRIb_FORMAT,
@@ -14363,7 +14363,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VISTR,
    /* .name        = */ "VISTR",
-   /* .description = */ "vector isolate string CC Set*",
+   /* .description = */ "VECTOR ISOLATE STRING",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x5C,
    /* .format      = */ VRRa_FORMAT,
@@ -14379,7 +14379,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VL,
    /* .name        = */ "VL",
-   /* .description = */ "vector load",
+   /* .description = */ "VECTOR LOAD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x06,
    /* .format      = */ VRX_FORMAT,
@@ -14391,7 +14391,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLBB,
    /* .name        = */ "VLBB",
-   /* .description = */ "vector load to block boundary",
+   /* .description = */ "VECTOR LOAD TO BLOCK BOUNDARY",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x07,
    /* .format      = */ VRX_FORMAT,
@@ -14404,7 +14404,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLC,
    /* .name        = */ "VLC",
-   /* .description = */ "vector load complement",
+   /* .description = */ "VECTOR LOAD COMPLEMENT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xDE,
    /* .format      = */ VRRa_FORMAT,
@@ -14432,7 +14432,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEB,
    /* .name        = */ "VLEB",
-   /* .description = */ "vector load element (8)",
+   /* .description = */ "VECTOR LOAD ELEMENT (8)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x00,
    /* .format      = */ VRX_FORMAT,
@@ -14462,7 +14462,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEF,
    /* .name        = */ "VLEF",
-   /* .description = */ "vector load element (32)",
+   /* .description = */ "VECTOR LOAD ELEMENT (32)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x03,
    /* .format      = */ VRX_FORMAT,
@@ -14476,7 +14476,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEG,
    /* .name        = */ "VLEG",
-   /* .description = */ "vector load element (64)",
+   /* .description = */ "VECTOR LOAD ELEMENT (64)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x02,
    /* .format      = */ VRX_FORMAT,
@@ -14490,7 +14490,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEH,
    /* .name        = */ "VLEH",
-   /* .description = */ "vector load element (16)",
+   /* .description = */ "VECTOR LOAD ELEMENT (16)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x01,
    /* .format      = */ VRX_FORMAT,
@@ -14504,7 +14504,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEIB,
    /* .name        = */ "VLEIB",
-   /* .description = */ "vector load element immediate (8)",
+   /* .description = */ "VECTOR LOAD ELEMENT IMMEDIATE (8)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x40,
    /* .format      = */ VRIa_FORMAT,
@@ -14517,7 +14517,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEIF,
    /* .name        = */ "VLEIF",
-   /* .description = */ "vector load element immediate (32)",
+   /* .description = */ "VECTOR LOAD ELEMENT IMMEDIATE (32)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x43,
    /* .format      = */ VRIa_FORMAT,
@@ -14530,7 +14530,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEIG,
    /* .name        = */ "VLEIG",
-   /* .description = */ "vector load element immediate (64)",
+   /* .description = */ "VECTOR LOAD ELEMENT IMMEDIATE (64)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x42,
    /* .format      = */ VRIa_FORMAT,
@@ -14543,7 +14543,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLEIH,
    /* .name        = */ "VLEIH",
-   /* .description = */ "vector load element immediate (16)",
+   /* .description = */ "VECTOR LOAD ELEMENT IMMEDIATE (16)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x41,
    /* .format      = */ VRIa_FORMAT,
@@ -14556,7 +14556,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLGV,
    /* .name        = */ "VLGV",
-   /* .description = */ "vector load gr from vr element",
+   /* .description = */ "VECTOR LOAD GR FROM VR ELEMENT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x21,
    /* .format      = */ VRSc_FORMAT,
@@ -14570,7 +14570,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLL,
    /* .name        = */ "VLL",
-   /* .description = */ "vector load with length",
+   /* .description = */ "VECTOR LOAD WITH LENGTH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x37,
    /* .format      = */ VRSb_FORMAT,
@@ -14582,7 +14582,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLLEZ,
    /* .name        = */ "VLLEZ",
-   /* .description = */ "vector load logical element and zero",
+   /* .description = */ "VECTOR LOAD LOGICAL ELEMENT AND ZERO",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x04,
    /* .format      = */ VRX_FORMAT,
@@ -14596,7 +14596,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLM,
    /* .name        = */ "VLM",
-   /* .description = */ "vector load multiple",
+   /* .description = */ "VECTOR LOAD MULTIPLE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x36,
    /* .format      = */ VRSa_FORMAT,
@@ -14610,7 +14610,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLP,
    /* .name        = */ "VLP",
-   /* .description = */ "vector load positive",
+   /* .description = */ "VECTOR LOAD POSITIVE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xDF,
    /* .format      = */ VRRa_FORMAT,
@@ -14623,7 +14623,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLR,
    /* .name        = */ "VLR",
-   /* .description = */ "vector load",
+   /* .description = */ "VECTOR LOAD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x56,
    /* .format      = */ VRRa_FORMAT,
@@ -14635,7 +14635,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLREP,
    /* .name        = */ "VLREP",
-   /* .description = */ "vector load and replicate",
+   /* .description = */ "VECTOR LOAD AND REPLICATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x05,
    /* .format      = */ VRX_FORMAT,
@@ -14649,7 +14649,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLVG,
    /* .name        = */ "VLVG",
-   /* .description = */ "vector load vr element from gr",
+   /* .description = */ "VECTOR LOAD VR ELEMENT FROM GR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x22,
    /* .format      = */ VRSb_FORMAT,
@@ -14665,7 +14665,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLVGP,
    /* .name        = */ "VLVGP",
-   /* .description = */ "vector load vr from grs disjoint",
+   /* .description = */ "VECTOR LOAD VR FROM GRS DISJOINT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x62,
    /* .format      = */ VRRf_FORMAT,
@@ -14677,7 +14677,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMAE,
    /* .name        = */ "VMAE",
-   /* .description = */ "vector multiply and add even",
+   /* .description = */ "VECTOR MULTIPLY AND ADD EVEN",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xAE,
    /* .format      = */ VRRd_FORMAT,
@@ -14690,7 +14690,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMAH,
    /* .name        = */ "VMAH",
-   /* .description = */ "vector multiply and add high",
+   /* .description = */ "VECTOR MULTIPLY AND ADD HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xAB,
    /* .format      = */ VRRd_FORMAT,
@@ -14703,7 +14703,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMAL,
    /* .name        = */ "VMAL",
-   /* .description = */ "vector multiply and add low",
+   /* .description = */ "VECTOR MULTIPLY AND ADD LOW",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xAA,
    /* .format      = */ VRRd_FORMAT,
@@ -14716,7 +14716,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMALE,
    /* .name        = */ "VMALE",
-   /* .description = */ "vector multiply and add logical even",
+   /* .description = */ "VECTOR MULTIPLY AND ADD LOGICAL EVEN",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xAC,
    /* .format      = */ VRRd_FORMAT,
@@ -14729,7 +14729,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMALH,
    /* .name        = */ "VMALH",
-   /* .description = */ "vector multiply and add logical high",
+   /* .description = */ "VECTOR MULTIPLY AND ADD LOGICAL HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA9,
    /* .format      = */ VRRd_FORMAT,
@@ -14742,7 +14742,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMALO,
    /* .name        = */ "VMALO",
-   /* .description = */ "vector multiply and add logical odd",
+   /* .description = */ "VECTOR MULTIPLY AND ADD LOGICAL ODD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xAD,
    /* .format      = */ VRRd_FORMAT,
@@ -14755,7 +14755,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMAO,
    /* .name        = */ "VMAO",
-   /* .description = */ "vector multiply and add odd",
+   /* .description = */ "VECTOR MULTIPLY AND ADD ODD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xAF,
    /* .format      = */ VRRd_FORMAT,
@@ -14768,7 +14768,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VME,
    /* .name        = */ "VME",
-   /* .description = */ "vector multiply even",
+   /* .description = */ "VECTOR MULTIPLY EVEN",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA6,
    /* .format      = */ VRRc_FORMAT,
@@ -14781,7 +14781,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMH,
    /* .name        = */ "VMH",
-   /* .description = */ "vector multiply high",
+   /* .description = */ "VECTOR MULTIPLY HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA3,
    /* .format      = */ VRRc_FORMAT,
@@ -14794,7 +14794,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VML,
    /* .name        = */ "VML",
-   /* .description = */ "vector multiply low",
+   /* .description = */ "VECTOR MULTIPLY LOW",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA2,
    /* .format      = */ VRRc_FORMAT,
@@ -14807,7 +14807,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMLE,
    /* .name        = */ "VMLE",
-   /* .description = */ "vector multiply logical even",
+   /* .description = */ "VECTOR MULTIPLY LOGICAL EVEN",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA4,
    /* .format      = */ VRRc_FORMAT,
@@ -14820,7 +14820,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMLH,
    /* .name        = */ "VMLH",
-   /* .description = */ "vector multiply logical high",
+   /* .description = */ "VECTOR MULTIPLY LOGICAL HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA1,
    /* .format      = */ VRRc_FORMAT,
@@ -14833,7 +14833,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMLO,
    /* .name        = */ "VMLO",
-   /* .description = */ "vector multiply logical odd",
+   /* .description = */ "VECTOR MULTIPLY LOGICAL ODD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA5,
    /* .format      = */ VRRc_FORMAT,
@@ -14846,7 +14846,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMN,
    /* .name        = */ "VMN",
-   /* .description = */ "vector minimum",
+   /* .description = */ "VECTOR MINIMUM",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xFE,
    /* .format      = */ VRRc_FORMAT,
@@ -14859,7 +14859,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMNL,
    /* .name        = */ "VMNL",
-   /* .description = */ "vector minimum logical",
+   /* .description = */ "VECTOR MINIMUM LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xFC,
    /* .format      = */ VRRc_FORMAT,
@@ -14872,7 +14872,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMO,
    /* .name        = */ "VMO",
-   /* .description = */ "vector multiply odd",
+   /* .description = */ "VECTOR MULTIPLY ODD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xA7,
    /* .format      = */ VRRc_FORMAT,
@@ -14885,7 +14885,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMRH,
    /* .name        = */ "VMRH",
-   /* .description = */ "vector merge high",
+   /* .description = */ "VECTOR MERGE HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x61,
    /* .format      = */ VRRc_FORMAT,
@@ -14898,7 +14898,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMRL,
    /* .name        = */ "VMRL",
-   /* .description = */ "vector merge low",
+   /* .description = */ "VECTOR MERGE LOW",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x60,
    /* .format      = */ VRRc_FORMAT,
@@ -14911,7 +14911,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMX,
    /* .name        = */ "VMX",
-   /* .description = */ "vector maximum",
+   /* .description = */ "VECTOR MAXIMUM",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xFF,
    /* .format      = */ VRRc_FORMAT,
@@ -14924,7 +14924,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMXL,
    /* .name        = */ "VMXL",
-   /* .description = */ "vector maximum logical",
+   /* .description = */ "VECTOR MAXIMUM LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xFD,
    /* .format      = */ VRRc_FORMAT,
@@ -14937,7 +14937,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VN,
    /* .name        = */ "VN",
-   /* .description = */ "vector and",
+   /* .description = */ "VECTOR AND",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x68,
    /* .format      = */ VRRc_FORMAT,
@@ -14948,7 +14948,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VNC,
    /* .name        = */ "VNC",
-   /* .description = */ "vector and with complement",
+   /* .description = */ "VECTOR AND WITH COMPLEMENT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x69,
    /* .format      = */ VRRc_FORMAT,
@@ -14959,7 +14959,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VNO,
    /* .name        = */ "VNO",
-   /* .description = */ "vector nor",
+   /* .description = */ "VECTOR NOR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x6B,
    /* .format      = */ VRRc_FORMAT,
@@ -14970,7 +14970,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VO,
    /* .name        = */ "VO",
-   /* .description = */ "vector or",
+   /* .description = */ "VECTOR OR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x6A,
    /* .format      = */ VRRc_FORMAT,
@@ -14981,7 +14981,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPDI,
    /* .name        = */ "VPDI",
-   /* .description = */ "vector permute doubleword immediate",
+   /* .description = */ "VECTOR PERMUTE DOUBLEWORD IMMEDIATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x84,
    /* .format      = */ VRRc_FORMAT,
@@ -14993,7 +14993,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPERM,
    /* .name        = */ "VPERM",
-   /* .description = */ "vector permute",
+   /* .description = */ "VECTOR PERMUTE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x8C,
    /* .format      = */ VRRe_FORMAT,
@@ -15004,7 +15004,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPK,
    /* .name        = */ "VPK",
-   /* .description = */ "vector pack",
+   /* .description = */ "VECTOR PACK",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x94,
    /* .format      = */ VRRc_FORMAT,
@@ -15017,7 +15017,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPKLS,
    /* .name        = */ "VPKLS",
-   /* .description = */ "vector pack logical saturate CC Set",
+   /* .description = */ "VECTOR PACK LOGICAL SATURATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x95,
    /* .format      = */ VRRb_FORMAT,
@@ -15032,7 +15032,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPKS,
    /* .name        = */ "VPKS",
-   /* .description = */ "vector pack saturate CC Set",
+   /* .description = */ "VECTOR PACK SATURATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x97,
    /* .format      = */ VRRb_FORMAT,
@@ -15047,7 +15047,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPOPCT,
    /* .name        = */ "VPOPCT",
-   /* .description = */ "vector population count",
+   /* .description = */ "VECTOR POPULATION COUNT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x50,
    /* .format      = */ VRRa_FORMAT,
@@ -15060,7 +15060,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VREP,
    /* .name        = */ "VREP",
-   /* .description = */ "vector replicate",
+   /* .description = */ "VECTOR REPLICATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x4D,
    /* .format      = */ VRIc_FORMAT,
@@ -15073,7 +15073,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VREPI,
    /* .name        = */ "VREPI",
-   /* .description = */ "vector replicate immediate",
+   /* .description = */ "VECTOR REPLICATE IMMEDIATE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x45,
    /* .format      = */ VRIa_FORMAT,
@@ -15086,7 +15086,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VS,
    /* .name        = */ "VS",
-   /* .description = */ "vector subtract",
+   /* .description = */ "VECTOR SUBTRACT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF7,
    /* .format      = */ VRRc_FORMAT,
@@ -15099,7 +15099,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSBCBI,
    /* .name        = */ "VSBCBI",
-   /* .description = */ "vector subtract with borrow compute borrow indication I",
+   /* .description = */ "VECTOR SUBTRACT WITH BORROW COMPUTE BORROW INDICATION",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xBD,
    /* .format      = */ VRRd_FORMAT,
@@ -15112,7 +15112,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSBI,
    /* .name        = */ "VSBI",
-   /* .description = */ "vector subtract with borrow indication I",
+   /* .description = */ "VECTOR SUBTRACT WITH BORROW INDICATION",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xBF,
    /* .format      = */ VRRd_FORMAT,
@@ -15125,7 +15125,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSCBI,
    /* .name        = */ "VSCBI",
-   /* .description = */ "vector subtract compute borrow indication I",
+   /* .description = */ "VECTOR SUBTRACT COMPUTE BORROW INDICATION",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xF5,
    /* .format      = */ VRRc_FORMAT,
@@ -15138,7 +15138,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSCEF,
    /* .name        = */ "VSCEF",
-   /* .description = */ "vector scatter element (32)",
+   /* .description = */ "VECTOR SCATTER ELEMENT (32)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x1B,
    /* .format      = */ VRV_FORMAT,
@@ -15150,7 +15150,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSCEG,
    /* .name        = */ "VSCEG",
-   /* .description = */ "vector scatter element (64)",
+   /* .description = */ "VECTOR SCATTER ELEMENT (64)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x1A,
    /* .format      = */ VRV_FORMAT,
@@ -15162,7 +15162,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSEG,
    /* .name        = */ "VSEG",
-   /* .description = */ "vector sign extend to doubleword",
+   /* .description = */ "VECTOR SIGN EXTEND TO DOUBLEWORD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x5F,
    /* .format      = */ VRRa_FORMAT,
@@ -15175,7 +15175,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSEL,
    /* .name        = */ "VSEL",
-   /* .description = */ "vector select",
+   /* .description = */ "VECTOR SELECT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x8D,
    /* .format      = */ VRRe_FORMAT,
@@ -15186,7 +15186,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSL,
    /* .name        = */ "VSL",
-   /* .description = */ "vector shift left",
+   /* .description = */ "VECTOR SHIFT LEFT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x74,
    /* .format      = */ VRRc_FORMAT,
@@ -15197,7 +15197,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSLB,
    /* .name        = */ "VSLB",
-   /* .description = */ "vector shift left by byte",
+   /* .description = */ "VECTOR SHIFT LEFT BY BYTE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x75,
    /* .format      = */ VRRc_FORMAT,
@@ -15208,7 +15208,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSLDB,
    /* .name        = */ "VSLDB",
-   /* .description = */ "vector shift left double by byte",
+   /* .description = */ "VECTOR SHIFT LEFT DOUBLE BY BYTE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x77,
    /* .format      = */ VRId_FORMAT,
@@ -15219,7 +15219,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSRA,
    /* .name        = */ "VSRA",
-   /* .description = */ "vector shift right arithmetic",
+   /* .description = */ "VECTOR SHIFT RIGHT ARITHMETIC",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x7E,
    /* .format      = */ VRRc_FORMAT,
@@ -15230,7 +15230,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSRAB,
    /* .name        = */ "VSRAB",
-   /* .description = */ "vector shift right arithmetic by byte",
+   /* .description = */ "VECTOR SHIFT RIGHT ARITHMETIC BY BYTE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x7F,
    /* .format      = */ VRRc_FORMAT,
@@ -15241,7 +15241,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSRL,
    /* .name        = */ "VSRL",
-   /* .description = */ "vector shift right logical",
+   /* .description = */ "VECTOR SHIFT RIGHT LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x7C,
    /* .format      = */ VRRc_FORMAT,
@@ -15252,7 +15252,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSRLB,
    /* .name        = */ "VSRLB",
-   /* .description = */ "vector shift right logical by byte",
+   /* .description = */ "VECTOR SHIFT RIGHT LOGICAL BY BYTE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x7D,
    /* .format      = */ VRRc_FORMAT,
@@ -15263,7 +15263,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VST,
    /* .name        = */ "VST",
-   /* .description = */ "vector store",
+   /* .description = */ "VECTOR STORE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x0E,
    /* .format      = */ VRX_FORMAT,
@@ -15274,7 +15274,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTEB,
    /* .name        = */ "VSTEB",
-   /* .description = */ "vector store element (8)",
+   /* .description = */ "VECTOR STORE ELEMENT (8)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x08,
    /* .format      = */ VRX_FORMAT,
@@ -15286,7 +15286,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTEF,
    /* .name        = */ "VSTEF",
-   /* .description = */ "vector store element (32)",
+   /* .description = */ "VECTOR STORE ELEMENT (32)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x0B,
    /* .format      = */ VRX_FORMAT,
@@ -15298,7 +15298,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTEG,
    /* .name        = */ "VSTEG",
-   /* .description = */ "vector store element (64)",
+   /* .description = */ "VECTOR STORE ELEMENT (64)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x0A,
    /* .format      = */ VRX_FORMAT,
@@ -15310,7 +15310,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTEH,
    /* .name        = */ "VSTEH",
-   /* .description = */ "vector store element (16)",
+   /* .description = */ "VECTOR STORE ELEMENT (16)",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x09,
    /* .format      = */ VRX_FORMAT,
@@ -15322,7 +15322,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTL,
    /* .name        = */ "VSTL",
-   /* .description = */ "vector store with length",
+   /* .description = */ "VECTOR STORE WITH LENGTH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x3F,
    /* .format      = */ VRSb_FORMAT,
@@ -15333,7 +15333,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTM,
    /* .name        = */ "VSTM",
-   /* .description = */ "vector store multiple",
+   /* .description = */ "VECTOR STORE MULTIPLE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x3E,
    /* .format      = */ VRSa_FORMAT,
@@ -15345,7 +15345,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTRC,
    /* .name        = */ "VSTRC",
-   /* .description = */ "vector string range compare CC Set*",
+   /* .description = */ "VECTOR STRING RANGE COMPARE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x8A,
    /* .format      = */ VRRd_FORMAT,
@@ -15361,7 +15361,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSUM,
    /* .name        = */ "VSUM",
-   /* .description = */ "vector sum across word",
+   /* .description = */ "VECTOR SUM ACROSS WORD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x64,
    /* .format      = */ VRRc_FORMAT,
@@ -15374,7 +15374,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSUMG,
    /* .name        = */ "VSUMG",
-   /* .description = */ "vector sum across doubleword",
+   /* .description = */ "VECTOR SUM ACROSS DOUBLEWORD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x65,
    /* .format      = */ VRRc_FORMAT,
@@ -15387,7 +15387,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSUMQ,
    /* .name        = */ "VSUMQ",
-   /* .description = */ "vector sum across quadword",
+   /* .description = */ "VECTOR SUM ACROSS QUADWORD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x67,
    /* .format      = */ VRRc_FORMAT,
@@ -15400,7 +15400,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VTM,
    /* .name        = */ "VTM",
-   /* .description = */ "vector test under mask CC Set",
+   /* .description = */ "VECTOR TEST UNDER MASK",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xD8,
    /* .format      = */ VRRa_FORMAT,
@@ -15411,7 +15411,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VUPH,
    /* .name        = */ "VUPH",
-   /* .description = */ "vector unpack high",
+   /* .description = */ "VECTOR UNPACK HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xD7,
    /* .format      = */ VRRa_FORMAT,
@@ -15424,7 +15424,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VUPL,
    /* .name        = */ "VUPL",
-   /* .description = */ "vector unpack low",
+   /* .description = */ "VECTOR UNPACK LOW",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xD6,
    /* .format      = */ VRRa_FORMAT,
@@ -15437,7 +15437,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VUPLH,
    /* .name        = */ "VUPLH",
-   /* .description = */ "vector unpack logical high",
+   /* .description = */ "VECTOR UNPACK LOGICAL HIGH",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xD5,
    /* .format      = */ VRRa_FORMAT,
@@ -15450,7 +15450,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VUPLL,
    /* .name        = */ "VUPLL",
-   /* .description = */ "vector unpack logical low",
+   /* .description = */ "VECTOR UNPACK LOGICAL LOW",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xD4,
    /* .format      = */ VRRa_FORMAT,
@@ -15463,7 +15463,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VX,
    /* .name        = */ "VX",
-   /* .description = */ "vector exclusive or",
+   /* .description = */ "VECTOR EXCLUSIVE OR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x6D,
    /* .format      = */ VRRc_FORMAT,
@@ -15474,7 +15474,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::WFC,
    /* .name        = */ "WFC",
-   /* .description = */ "vector floating-point comp are scalar CC Set",
+   /* .description = */ "VECTOR FP COMPARE SCALAR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xCB,
    /* .format      = */ VRRa_FORMAT,
@@ -15490,7 +15490,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::WFK,
    /* .name        = */ "WFK",
-   /* .description = */ "vector floating-point comp are and signal scalar CC Set",
+   /* .description = */ "VECTOR FP COMPARE AND SIGNAL SCALAR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xCA,
    /* .format      = */ VRRa_FORMAT,
@@ -15506,10 +15506,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::AGH,
    /* .name        = */ "AGH",
-   /* .description = */ "add halfword (64 <- 16)",
+   /* .description = */ "ADD HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x38,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsCC |
@@ -15525,10 +15525,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::BIC,
    /* .name        = */ "BIC",
-   /* .description = */ "branch indirect on condition",
+   /* .description = */ "BRANCH INDIRECT ON CONDITION",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x47,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported |
@@ -15539,10 +15539,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::KMA,
    /* .name        = */ "KMA",
-   /* .description = */ "Cipher Message with Authentication",
+   /* .description = */ "CIPHER MESSAGE WITH AUTHENTICATION",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0x29,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFb_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_SetsCC
    },
@@ -15550,10 +15550,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGG,
    /* .name        = */ "LGG",
-   /* .description = */ "load guarded",
+   /* .description = */ "LOAD GUARDED (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x4C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -15566,10 +15566,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LGSC,
    /* .name        = */ "LGSC",
-   /* .description = */ "load guarded storage controls",
+   /* .description = */ "LOAD GUARDED STORAGE CONTROLS",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x4D,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_LongDispSupported
@@ -15578,10 +15578,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::LLGFSG,
    /* .name        = */ "LLGFSG",
-   /* .description = */ "load logical and shift guarded (64 <- 32)",
+   /* .description = */ "LOAD LOGICAL AND SHIFT GUARDED (64 <- 32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x48,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
@@ -15594,10 +15594,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MG,
    /* .name        = */ "MG",
-   /* .description = */ "multiply (128 <- 64)",
+   /* .description = */ "MULTIPLY (128 <- 64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x84,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -15609,10 +15609,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MGH,
    /* .name        = */ "MGH",
-   /* .description = */ "multiply halfword (64 <- 16)",
+   /* .description = */ "MULTIPLY HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x3C,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_UsesTarget |
                         S390OpProp_IsLoad |
@@ -15623,10 +15623,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MGRK,
    /* .name        = */ "MGRK",
-   /* .description = */ "multiply (128 <- 64)",
+   /* .description = */ "MULTIPLY (128 <- 64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xEC,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_UsesRegPairForTarget |
                         S390OpProp_SetsOperand3
@@ -15635,10 +15635,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSC,
    /* .name        = */ "MSC",
-   /* .description = */ "multiply single (32)",
+   /* .description = */ "MULTIPLY SINGLE (32)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x53,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_UsesTarget |
@@ -15653,10 +15653,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSGC,
    /* .name        = */ "MSGC",
-   /* .description = */ "multiply single (64)",
+   /* .description = */ "MULTIPLY SINGLE (64)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x83,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_UsesTarget |
@@ -15671,10 +15671,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSGRKC,
    /* .name        = */ "MSGRKC",
-   /* .description = */ "multiply single (64)",
+   /* .description = */ "MULTIPLY SINGLE (64)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xED,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand3 |
@@ -15685,10 +15685,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::MSRKC,
    /* .name        = */ "MSRKC",
-   /* .description = */ "multiply single (32)",
+   /* .description = */ "MULTIPLY SINGLE (32)",
    /* .opcode[0]   = */ 0xB9,
    /* .opcode[1]   = */ 0xFD,
-   /* .format      = */ RRF_FORMAT,
+   /* .format      = */ RRFa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is32Bit |
                         S390OpProp_SetsOperand3 |
@@ -15700,10 +15700,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::SGH,
    /* .name        = */ "SGH",
-   /* .description = */ "subtract halfword (64 <- 16)",
+   /* .description = */ "SUBTRACT HALFWORD (64 <- 16)",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x39,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_Is64Bit |
                         S390OpProp_SetsOperand1 |
@@ -15717,10 +15717,10 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::STGSC,
    /* .name        = */ "STGSC",
-   /* .description = */ "store guarded storage controls",
+   /* .description = */ "STORE GUARDED STORAGE CONTROLS",
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x49,
-   /* .format      = */ RXY_FORMAT,
+   /* .format      = */ RXYa_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
    /* .properties  = */ S390OpProp_IsStore |
                         S390OpProp_LongDispSupported
@@ -15729,7 +15729,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VAP,
    /* .name        = */ "VAP",
-   /* .description = */ "vector Add Decimal",
+   /* .description = */ "VECTOR ADD DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x71,
    /* .format      = */ VRIf_FORMAT,
@@ -15742,7 +15742,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VBPERM,
    /* .name        = */ "VBPERM",
-   /* .description = */ "vector bit permute",
+   /* .description = */ "VECTOR BIT PERMUTE",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x85,
    /* .format      = */ VRRc_FORMAT,
@@ -15753,7 +15753,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCP,
    /* .name        = */ "VCP",
-   /* .description = */ "vector Compare decimal",
+   /* .description = */ "VECTOR COMPARE DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x77,
    /* .format      = */ VRRh_FORMAT,
@@ -15765,7 +15765,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCVB,
    /* .name        = */ "VCVB",
-   /* .description = */ "vector convert to binary",
+   /* .description = */ "VECTOR CONVERT TO BINARY",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x50,
    /* .format      = */ VRRi_FORMAT,
@@ -15778,7 +15778,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCVBG,
    /* .name        = */ "VCVBG",
-   /* .description = */ "vector convert to binary",
+   /* .description = */ "VECTOR CONVERT TO BINARY",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x52,
    /* .format      = */ VRRi_FORMAT,
@@ -15791,7 +15791,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCVD,
    /* .name        = */ "VCVD",
-   /* .description = */ "vector convert to decimal",
+   /* .description = */ "VECTOR CONVERT TO DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x58,
    /* .format      = */ VRIi_FORMAT,
@@ -15804,7 +15804,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VCVDG,
    /* .name        = */ "VCVDG",
-   /* .description = */ "vector convert to decmial",
+   /* .description = */ "VECTOR CONVERT TO DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x5A,
    /* .format      = */ VRIi_FORMAT,
@@ -15817,7 +15817,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VDP,
    /* .name        = */ "VDP",
-   /* .description = */ "vector divide decimal",
+   /* .description = */ "VECTOR DIVIDE DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x7A,
    /* .format      = */ VRIf_FORMAT,
@@ -15830,7 +15830,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFLL,
    /* .name        = */ "VFLL",
-   /* .description = */ "vector FP load lengthened",
+   /* .description = */ "VECTOR FP LOAD LENGTHENED",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC4,
    /* .format      = */ VRRa_FORMAT,
@@ -15845,7 +15845,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFLR,
    /* .name        = */ "VFLR",
-   /* .description = */ "vector FP load rounded",
+   /* .description = */ "VECTOR FP LOAD ROUNDED",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xC5,
    /* .format      = */ VRRa_FORMAT,
@@ -15861,7 +15861,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFMAX,
    /* .name        = */ "VFMAX",
-   /* .description = */ "vector FP maximum",
+   /* .description = */ "VECTOR FP MAXIMUM",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xEF,
    /* .format      = */ VRRc_FORMAT,
@@ -15877,7 +15877,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFMIN,
    /* .name        = */ "VFMIN",
-   /* .description = */ "vector FP minimum",
+   /* .description = */ "VECTOR FP MINIMUM",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xEE,
    /* .format      = */ VRRc_FORMAT,
@@ -15893,7 +15893,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFNMA,
    /* .name        = */ "VFNMA",
-   /* .description = */ "vector FP negative multiply and add",
+   /* .description = */ "VECTOR FP NEGATIVE MULTIPLY AND ADD",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x9F,
    /* .format      = */ VRRe_FORMAT,
@@ -15908,7 +15908,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VFNMS,
    /* .name        = */ "VFNMS",
-   /* .description = */ "vector FP negative multiply and subtract",
+   /* .description = */ "VECTOR FP NEGATIVE MULTIPLY AND SUBTRACT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x9E,
    /* .format      = */ VRRe_FORMAT,
@@ -15923,7 +15923,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLIP,
    /* .name        = */ "VLIP",
-   /* .description = */ "vector load immediate decimal",
+   /* .description = */ "VECTOR LOAD IMMEDIATE DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x49,
    /* .format      = */ VRIh_FORMAT,
@@ -15934,7 +15934,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLRL,
    /* .name        = */ "VLRL",
-   /* .description = */ "vector Load Rightmost with Length(Length is immediate value)",
+   /* .description = */ "VECTOR LOAD RIGHTMOST WITH LENGTH",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x35,
    /* .format      = */ VSI_FORMAT,
@@ -15946,7 +15946,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VLRLR,
    /* .name        = */ "VLRLR",
-   /* .description = */ "vector Load Rightmost with Length(Length is in register)",
+   /* .description = */ "VECTOR LOAD RIGHTMOST WITH LENGTH",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x37,
    /* .format      = */ VRSd_FORMAT,
@@ -15958,7 +15958,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMP,
    /* .name        = */ "VMP",
-   /* .description = */ "vector multiply decimal",
+   /* .description = */ "VECTOR MULTIPLY DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x78,
    /* .format      = */ VRIf_FORMAT,
@@ -15971,7 +15971,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMSL,
    /* .name        = */ "VMSL",
-   /* .description = */ "vector multiply sum logical",
+   /* .description = */ "VECTOR MULTIPLY SUM LOGICAL",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0xB8,
    /* .format      = */ VRRd_FORMAT,
@@ -15984,7 +15984,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VMSP,
    /* .name        = */ "VMSP",
-   /* .description = */ "vector multiply and shift decimal",
+   /* .description = */ "VECTOR MULTIPLY AND SHIFT DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x79,
    /* .format      = */ VRIf_FORMAT,
@@ -15997,7 +15997,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VNN,
    /* .name        = */ "VNN",
-   /* .description = */ "vector NAND",
+   /* .description = */ "VECTOR NAND",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x6E,
    /* .format      = */ VRRc_FORMAT,
@@ -16008,7 +16008,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VNX,
    /* .name        = */ "VNX",
-   /* .description = */ "vector not exclusive OR",
+   /* .description = */ "VECTOR NOT EXCLUSIVE OR",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x6C,
    /* .format      = */ VRRc_FORMAT,
@@ -16019,7 +16019,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VOC,
    /* .name        = */ "VOC",
-   /* .description = */ "vector OR with complement",
+   /* .description = */ "VECTOR OR WITH COMPLEMENT",
    /* .opcode[0]   = */ 0xE7,
    /* .opcode[1]   = */ 0x6F,
    /* .format      = */ VRRc_FORMAT,
@@ -16030,7 +16030,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPKZ,
    /* .name        = */ "VPKZ",
-   /* .description = */ "vector pack zoned",
+   /* .description = */ "VECTOR PACK ZONED",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x34,
    /* .format      = */ VSI_FORMAT,
@@ -16041,7 +16041,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VPSOP,
    /* .name        = */ "VPSOP",
-   /* .description = */ "vector perform sign operation decimal",
+   /* .description = */ "VECTOR PERFORM SIGN OPERATION DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x5B,
    /* .format      = */ VRIg_FORMAT,
@@ -16054,7 +16054,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VRP,
    /* .name        = */ "VRP",
-   /* .description = */ "vector remainder decimal",
+   /* .description = */ "VECTOR REMAINDER DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x7B,
    /* .format      = */ VRIf_FORMAT,
@@ -16067,7 +16067,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSDP,
    /* .name        = */ "VSDP",
-   /* .description = */ "vector shift and divide decimal",
+   /* .description = */ "VECTOR SHIFT AND DIVIDE DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x7E,
    /* .format      = */ VRIf_FORMAT,
@@ -16080,7 +16080,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSP,
    /* .name        = */ "VSP",
-   /* .description = */ "vector subtract decimal",
+   /* .description = */ "VECTOR SUBTRACT DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x73,
    /* .format      = */ VRIf_FORMAT,
@@ -16093,7 +16093,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSRP,
    /* .name        = */ "VSRP",
-   /* .description = */ "vector shift and round decimal",
+   /* .description = */ "VECTOR SHIFT AND ROUND DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x59,
    /* .format      = */ VRIg_FORMAT,
@@ -16106,7 +16106,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTRL,
    /* .name        = */ "VSTRL",
-   /* .description = */ "vector Store Rightmost with Length(Length is immediate value)",
+   /* .description = */ "VECTOR STORE RIGHTMOST WITH LENGTH",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x3D,
    /* .format      = */ VSI_FORMAT,
@@ -16117,7 +16117,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VSTRLR,
    /* .name        = */ "VSTRLR",
-   /* .description = */ "vector Store Rightmost with Length(Length is in register)",
+   /* .description = */ "VECTOR STORE RIGHTMOST WITH LENGTH",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x3F,
    /* .format      = */ VRSd_FORMAT,
@@ -16128,7 +16128,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VTP,
    /* .name        = */ "VTP",
-   /* .description = */ "vector test decimal",
+   /* .description = */ "VECTOR TEST DECIMAL",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x5F,
    /* .format      = */ VRRg_FORMAT,
@@ -16139,7 +16139,7 @@
    {
    /* .mnemonic    = */ OMR::InstOpCode::VUPKZ,
    /* .name        = */ "VUPKZ",
-   /* .description = */ "vector unpack zoned",
+   /* .description = */ "VECTOR UNPACK ZONED",
    /* .opcode[0]   = */ 0xE6,
    /* .opcode[1]   = */ 0x3C,
    /* .format      = */ VSI_FORMAT,

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -378,50 +378,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::RIEMIT,
-   /* .name        = */ "RIEMIT",
-   /* .description = */ "RUNTIME INSTRUMENTATION EMIT",
-   /* .opcode[0]   = */ 0xAA,
-   /* .opcode[1]   = */ 0x04,
-   /* .format      = */ RIa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_UsesTarget
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::RINEXT,
-   /* .name        = */ "RINEXT",
-   /* .description = */ "RUNTIME INSTRUMENTATION NEXT",
-   /* .opcode[0]   = */ 0xAA,
-   /* .opcode[1]   = */ 0x00,
-   /* .format      = */ RIa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_None
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::RIOFF,
-   /* .name        = */ "RIOFF",
-   /* .description = */ "RUNTIME INSTRUMENTATION OFF",
-   /* .opcode[0]   = */ 0xAA,
-   /* .opcode[1]   = */ 0x03,
-   /* .format      = */ RIa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_SetsCC
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::RION,
-   /* .name        = */ "RION",
-   /* .description = */ "RUNTIME INSTRUMENTATION ON",
-   /* .opcode[0]   = */ 0xAA,
-   /* .opcode[1]   = */ 0x01,
-   /* .format      = */ RIa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
-   /* .properties  = */ S390OpProp_SetsCC
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::SLLHH,
    /* .name        = */ "SLLHH",
    /* .description = */ "Shift Left Logical (High <- High)",
@@ -13120,6 +13076,50 @@
    /* .format      = */ RRFc_FORMAT,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
    /* .properties  = */ S390OpProp_UsesTarget
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::RIEMIT,
+   /* .name        = */ "RIEMIT",
+   /* .description = */ "RUNTIME INSTRUMENTATION EMIT",
+   /* .opcode[0]   = */ 0xAA,
+   /* .opcode[1]   = */ 0x04,
+   /* .format      = */ RIa_FORMAT,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
+   /* .properties  = */ S390OpProp_UsesTarget
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::RINEXT,
+   /* .name        = */ "RINEXT",
+   /* .description = */ "RUNTIME INSTRUMENTATION NEXT",
+   /* .opcode[0]   = */ 0xAA,
+   /* .opcode[1]   = */ 0x00,
+   /* .format      = */ RIa_FORMAT,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
+   /* .properties  = */ S390OpProp_None
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::RIOFF,
+   /* .name        = */ "RIOFF",
+   /* .description = */ "RUNTIME INSTRUMENTATION OFF",
+   /* .opcode[0]   = */ 0xAA,
+   /* .opcode[1]   = */ 0x03,
+   /* .format      = */ RIa_FORMAT,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
+   /* .properties  = */ S390OpProp_SetsCC
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::RION,
+   /* .name        = */ "RION",
+   /* .description = */ "RUNTIME INSTRUMENTATION ON",
+   /* .opcode[0]   = */ 0xAA,
+   /* .opcode[1]   = */ 0x01,
+   /* .format      = */ RIa_FORMAT,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_zEC12,
+   /* .properties  = */ S390OpProp_SetsCC
    },
 
    {

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -3328,21 +3328,9 @@ OMR::Z::Instruction::is4ByteLoad()
    }
 
 bool
-OMR::Z::Instruction::isAsmGen()
-   {
-   return self()->getOpCodeValue() == TR::InstOpCode::ASM;
-   }
-
-bool
 OMR::Z::Instruction::isRet()
    {
    return self()->getOpCodeValue() == TR::InstOpCode::RET;
-   }
-
-bool
-OMR::Z::Instruction::isTailCall()
-   {
-   return self()->getOpCodeValue() == TR::InstOpCode::TAILCALL;
    }
 
 int8_t

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -1878,11 +1878,15 @@ OMR::Z::Instruction::attemptOpAdjustmentForLongDisplacement()
    if (n_op != TR::InstOpCode::BAD)
       self()->setOpCodeValue(n_op);
 
-   if (self()->getOpCode().getInstructionFormat(self()->getOpCodeValue()) == RXY_FORMAT)
+   auto instructionFormat = self()->getOpCode().getInstructionFormat(self()->getOpCodeValue());
+
+   if (instructionFormat == RXYa_FORMAT ||
+       instructionFormat == RXYb_FORMAT)
       self()->setKind(IsRXY);
-   else if (self()->getOpCode().getInstructionFormat(self()->getOpCodeValue()) == RSY_FORMAT)
+   else if (instructionFormat == RSYa_FORMAT || 
+            instructionFormat == RSYb_FORMAT)
       self()->setKind(IsRSY);
-   else if (self()->getOpCode().getInstructionFormat(self()->getOpCodeValue()) == SIY_FORMAT)   // LL: Add SIY
+   else if (instructionFormat == SIY_FORMAT)
       self()->setKind(IsSIY);
    else if (self()->cg()->getDebug())
       TR_ASSERT(0, "only RX, RS and SI instructions can be safely mapped to long displacement: opCode: %s", self()->cg()->getDebug()->getOpCodeName(&self()->getOpCode()));

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -289,7 +289,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
       CCuseKnown                          = 0x0100, ///< Usage of CC set by current instruction is known.
       CCused                              = 0x0200, ///< CC set by current instruction is used by subsequent instructions.
       OutOfLineEX                         = 0x0400, ///< TR::InstOpCode::EX instruction references a ConstantInstructionSnippet object
-                                                    ///< or an SS_FORMAT instruction is the target of an TR::InstOpCode::EX instruction
+                                                    ///< or an SSx instruction is the target of an TR::InstOpCode::EX instruction
       ThrowsImplicitException             = 0x0800,
       ThrowsImplicitNullPointerException  = 0x1000,
       StartInternalControlFlow            = 0x2000,

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -202,9 +202,7 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    virtual bool isDebugFence()        { return false; }
 
    virtual bool is4ByteLoad();
-   virtual bool isAsmGen();
    virtual bool isRet();
-   virtual bool isTailCall();
 
    virtual bool implicitlyUsesGPR0() { return _opcode.implicitlyUsesGPR0() > 0; }
    virtual bool implicitlyUsesGPR1() { return _opcode.implicitlyUsesGPR1() > 0; }

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -3045,11 +3045,15 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
       TR_ASSERT(scratchReg!=NULL,
         "OMR::Z::MemoryReference::generateBinaryEncoding -- A scratch reg should always be found.");
 
+      auto instructionFormat = instr->getOpCode().getInstructionFormat(instr->getOpCodeValue());
+
       // If the instr is already of RSY/RXY/SIY form && its disp is within the range, no fixup is needed.
       if ((instr->hasLongDisplacementSupport() ||
-           instr->getOpCode().getInstructionFormat(instr->getOpCodeValue()) == RSY_FORMAT ||
-           instr->getOpCode().getInstructionFormat(instr->getOpCodeValue()) == RXY_FORMAT ||
-           instr->getOpCode().getInstructionFormat(instr->getOpCodeValue()) == SIY_FORMAT) &&
+           instructionFormat == RSYa_FORMAT ||
+           instructionFormat == RSYb_FORMAT ||
+           instructionFormat == RXYa_FORMAT ||
+           instructionFormat == RXYb_FORMAT ||
+           instructionFormat == SIY_FORMAT) &&
           disp < MAXLONGDISP && disp > MINLONGDISP)
          {
          instr->attemptOpAdjustmentForLongDisplacement();

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -4892,10 +4892,17 @@ genericLoadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference *
          }
       else //if (form == MemReg)
          {
-         if (TR::InstOpCode::getInstructionFormat(load) == RX_FORMAT)
+         auto instructionFormat = TR::InstOpCode::getInstructionFormat(load);
+
+         if (instructionFormat == RXa_FORMAT ||
+             instructionFormat == RXb_FORMAT)
+            {
             generateRXInstruction(cg, load, node, targetRegister, tempMR);
+            }
          else
+            {
             generateRXYInstruction(cg, load, node, targetRegister, tempMR);
+            }
          }
       }
    else if (numberOfBits == 31 && !useRegPairs)

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2679,7 +2679,11 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    TR::S390RILInstruction *LGRLinst = 0;
    TR::Compilation *comp = cg->comp();
 
-   if (TR::InstOpCode(op).getInstructionFormat() == RIL_FORMAT)
+   auto instructionFormat = TR::InstOpCode(op).getInstructionFormat();
+
+   if (instructionFormat == RILa_FORMAT ||
+       instructionFormat == RILb_FORMAT ||
+       instructionFormat == RILc_FORMAT)
       {
       TR::S390ConstantDataSnippet * constDataSnip = cg->create64BitLiteralPoolSnippet(TR::Int64, imm);
 

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2729,7 +2729,7 @@ TR::S390RRSInstruction::generateBinaryEncoding()
 /**
  *    RIE Format
  *
- *    RIE1: CRJ, GGRJ, CGFRJ
+ *    RIE1: CRJ, GGRJ
  *     ________ ____ ____ _________________ ___________________
  *    |Op Code | R1 | R2 |       I4        | M3 |////| Op Code |
  *    |________|____|____|_________________|____|____|_________|
@@ -2874,11 +2874,6 @@ TR::S390RIEInstruction::generateBinaryEncoding()
          bool isRIL=false;
          switch (getOpCodeValue())
             {
-            case TR::InstOpCode::CGFRJ  :
-                 cmpOp = TR::InstOpCode::CGFR;
-                 *(uint16_t *) (cursor) = bos(0xB930);
-                 isRRE = true;
-                 break;
             case TR::InstOpCode::CGRJ   :
                  cmpOp = TR::InstOpCode::CGR;
                  *(uint16_t *) (cursor) = bos(0xB920);
@@ -2887,11 +2882,6 @@ TR::S390RIEInstruction::generateBinaryEncoding()
             case TR::InstOpCode::CLGRJ  :
                  cmpOp = TR::InstOpCode::CLGR;
                  *(uint16_t *) (cursor) = bos(0xB921);
-                 isRRE = true;
-                 break;
-            case TR::InstOpCode::CLGFRJ :
-                 cmpOp = TR::InstOpCode::CLGFR;
-                 *(uint16_t *) (cursor) = bos(0xB931);
                  isRRE = true;
                  break;
             case TR::InstOpCode::CLRJ   :
@@ -3073,20 +3063,12 @@ TR::S390RIEInstruction::splitIntoCompareAndLongBranch(void)
    bool isRIL = false;
    switch (getOpCodeValue())
       {
-      case TR::InstOpCode::CGFRJ  :
-       cmpOp = TR::InstOpCode::CGFR;
-       isRRE = true;
-       break;
       case TR::InstOpCode::CGRJ   :
        cmpOp = TR::InstOpCode::CGR;
        isRRE = true;
        break;
       case TR::InstOpCode::CLGRJ  :
        cmpOp = TR::InstOpCode::CLGR;
-       isRRE = true;
-       break;
-      case TR::InstOpCode::CLGFRJ :
-       cmpOp = TR::InstOpCode::CLGFR;
        isRRE = true;
        break;
       case TR::InstOpCode::CLRJ   :
@@ -3168,20 +3150,12 @@ TR::S390RIEInstruction::splitIntoCompareAndBranch(TR::Instruction *insertBranchA
    bool isRIL = false;
    switch (getOpCodeValue())
       {
-      case TR::InstOpCode::CGFRJ  :
-       cmpOp = TR::InstOpCode::CGFR;
-       isRRE = true;
-       break;
       case TR::InstOpCode::CGRJ   :
        cmpOp = TR::InstOpCode::CGR;
        isRRE = true;
        break;
       case TR::InstOpCode::CLGRJ  :
        cmpOp = TR::InstOpCode::CLGR;
-       isRRE = true;
-       break;
-      case TR::InstOpCode::CLGFRJ :
-       cmpOp = TR::InstOpCode::CLGFR;
        isRRE = true;
        break;
       case TR::InstOpCode::CLRJ   :

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -625,11 +625,6 @@ class S390PseudoInstruction : public TR::Instruction
    TR::LabelSymbol *_callDescLabel;
    bool _shouldBeginNewLine;
 
-   // Following is used when ASM encoding is determined at compile time
-   // (e.g. for C/C++ when doing inlined asm and producing object file)
-   uint8_t *_asmDataEncoding;       ///< binary encoding values
-   int32_t  _asmDataEncodingLength; ///< binary encoding length
-
    public:
 
    S390PseudoInstruction(TR::InstOpCode::Mnemonic op,
@@ -641,8 +636,6 @@ class S390PseudoInstruction : public TR::Instruction
         _callDescValue(0),
         _padbytes(0),
         _callDescLabel(NULL),
-        _asmDataEncoding(NULL),
-        _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
    S390PseudoInstruction(TR::InstOpCode::Mnemonic op,
@@ -655,8 +648,6 @@ class S390PseudoInstruction : public TR::Instruction
         _callDescValue(0),
         _padbytes(0),
         _callDescLabel(NULL),
-        _asmDataEncoding(NULL),
-        _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
    S390PseudoInstruction(TR::InstOpCode::Mnemonic  op,
@@ -669,8 +660,6 @@ class S390PseudoInstruction : public TR::Instruction
         _callDescValue(0),
         _padbytes(0),
         _callDescLabel(NULL),
-        _asmDataEncoding(NULL),
-        _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
    S390PseudoInstruction(TR::InstOpCode::Mnemonic  op,
@@ -684,8 +673,6 @@ class S390PseudoInstruction : public TR::Instruction
         _callDescValue(0),
         _padbytes(0),
         _callDescLabel(NULL),
-        _asmDataEncoding(NULL),
-        _asmDataEncodingLength(0),
         _shouldBeginNewLine(false){}
 
    virtual char *description() { return "S390PseudoInstruction"; }
@@ -697,11 +684,6 @@ class S390PseudoInstruction : public TR::Instruction
 
    void setShouldBeginNewLine(bool sbnl) { _shouldBeginNewLine = sbnl; }
    bool shouldBeginNewLine() { return _shouldBeginNewLine; }
-
-   uint8_t *getASMDataEncoding() { return _asmDataEncoding; }
-   void setASMDataEncoding(uint8_t *encoding) { _asmDataEncoding = encoding; }
-   uint32_t  getASMDataEncodingLength() { return _asmDataEncodingLength; }
-   void setASMDataEncodingLength(int32_t encodingLength) { _asmDataEncodingLength = encodingLength; }
 
    virtual uint8_t *generateBinaryEncoding();
 

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -236,7 +236,7 @@ TR::Instruction* realInstruction(TR::Instruction* inst, bool forward)
 
 TR::Instruction* realInstructionWithLabels(TR::Instruction* inst, bool forward)
    {
-   while (inst && (inst->getKind() == TR::Instruction::IsPseudo && !inst->isAsmGen() ||
+   while (inst && (inst->getKind() == TR::Instruction::IsPseudo ||
                    inst->getKind() == TR::Instruction::IsNotExtended))
       {
       inst = forward ? inst->getNext() : inst->getPrev();
@@ -247,7 +247,7 @@ TR::Instruction* realInstructionWithLabels(TR::Instruction* inst, bool forward)
 
 TR::Instruction* realInstructionWithLabelsAndRET(TR::Instruction* inst, bool forward)
    {
-   while (inst && (inst->getKind() == TR::Instruction::IsPseudo && !inst->isAsmGen() ||
+   while (inst && (inst->getKind() == TR::Instruction::IsPseudo ||
                    inst->getKind() == TR::Instruction::IsNotExtended) && !inst->isRet())
       {
       inst = forward ? inst->getNext() : inst->getPrev();
@@ -272,7 +272,6 @@ TR_S390PostRAPeephole::isBarrierToPeepHoleLookback(TR::Instruction *current)
 
    if (s390current->isLabel()) return true;
    if (s390current->isCall())  return true;
-   if (s390current->isAsmGen()) return true;
    if (s390current->isBranchOp()) return true;
    if (s390current->getOpCodeValue() == TR::InstOpCode::DCB) return true;
 


### PR DESCRIPTION
This is the first step forward towards fixing #2848, among other issues. To keep things sane and avoid having several thousand line PRs we do this in lock step. This PR addresses the issue of formats and instruction descriptions, as well as cleanup in the area of unused instructions, incorrectly defined instructions, and automated validation.

The PR includes a set of logical commits addressing the following issues:

- Fix incorrect opcodes
- Add S390OpProp_SetsCC to instructions missing it
- Remove S390OpProp_SetsCC from instructions that shouldn't have it
- Add S390OpProp_BranchOp to instructions missing it
- Update all instruction descriptions and formats
- Deprecate several undefined instruction formats
- Deprecate several unused and undocumented pseudo-instructions
- Update RI instructions to minimum ALS of zEC12

The contents of many of the commits in this PR were aided by a Python script which parses PoPs and validates the data against the enum found in OMRInstOpCodeProperties.hpp. The Python script will be posted in the PR containing these commits for future reference.