### PR TITLE
Remove negative restriction in generateS390ImmOp for CLG

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1009,7 +1009,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
                return cursor;
                }
             }
-         if (value >= 0 && cg->canUseGoldenEagleImmediateInstruction(value))
+         if (cg->canUseGoldenEagleImmediateInstruction(value))
             {
             // LL: If Golden Eagle - can use Compare Logical Immediate with max 32-bit value.
             ei_immOp = TR::InstOpCode::CLGFI;


### PR DESCRIPTION
When attempting to generate a "compare with immediate" instruction in
the `generateS390ImmOp` API we have an unnecessary check that the
immediate value is non-negative. For "compare logical" instructions
this check is unnecessary since we eliminate all negative values from
the consideration, even though they can be encoded by the "compare
logical immediate" instructions.

A prime example of this is trying to compare against 0x80000000 with
CLG. We can definitely use CLGFI to carry out the comparison however
our function would instead say this is impossible and proceed to store
the aforementioned immediate into the literal pool and use a CLGF
instruction to compare in memory.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>