### PR TITLE
Introduce CodeGen support queries for intrinsics

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2961,7 +2961,7 @@ OMR::CodeGenerator::canNullChkBeImplicit(TR::Node *node, bool doChecks)
    return false;
    }
 
-bool OMR::CodeGenerator::ilOpCodeIsSupported(TR::ILOpCodes o)
+bool OMR::CodeGenerator::isILOpCodeSupported(TR::ILOpCodes o)
    {
 	return (_nodeToInstrEvaluators[o] != TR::TreeEvaluator::unImpOpEvaluator) &&
 	      (_nodeToInstrEvaluators[o] != TR::TreeEvaluator::badILOpEvaluator);

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -489,8 +489,38 @@ class OMR_EXTENSIBLE CodeGenerator
    bool isRegisterClobberable(TR::Register *reg, uint16_t count);
 
    // ilgen
-   bool ilOpCodeIsSupported(TR::ILOpCodes); // no virt, default, cast
 
+   /**
+    * @brief Returns if an IL OpCode is supported by current CodeGen
+    *
+    * @param op The IL OpCode being checked.
+    *
+    * @return True if the IL OpCode is supported otherwise false.
+    */
+   static bool isILOpCodeSupported(TR::ILOpCodes op);
+
+   /**
+    * @brief Returns the corresponding IL OpCode for an intrinsic method
+    *
+    * This query maps an intrinsic method to an IL OpCode, with the requirement that
+    * the method's child(ren) corresponds to the OpCode's child(ren) exactly.
+    * It is usually used by the IL Gen transforming the intrinsic method to IL OpCode
+    * so that it can leverage existing framework for better optimization.
+    *
+    * @param method The intrinsic method being checked.
+    *
+    * @return The corresponding IL OpCode for the intrinsic method.
+    */
+   static TR::ILOpCodes ilOpCodeForIntrinsicMethod(TR::RecognizedMethod method) { return TR::BadILOp; }
+
+   /**
+    * @brief Returns if an intrinsic method is supported by current CodeGen
+    *
+    * @param method The intrinsic method being checked.
+    *
+    * @return True if the intrinsic method is supported otherwise false.
+    */
+   static inline bool isIntrinsicMethodSupported(TR::RecognizedMethod method);
 
 
    TR::Recompilation *allocateRecompilationInfo() { return NULL; }
@@ -592,7 +622,7 @@ class OMR_EXTENSIBLE CodeGenerator
     * @param method : the recognized method to consider
     * @return true if inlining should be suppressed; false otherwise
     */
-   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method) {return false;}
+   bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
    // --------------------------------------------------------------------------
    // Optimizer, not code generator

--- a/compiler/codegen/OMRCodeGenerator_inlines.hpp
+++ b/compiler/codegen/OMRCodeGenerator_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,10 +24,19 @@
 
 #include "codegen/OMRCodeGenerator.hpp"
 
-TR::CodeGenerator*
-OMR::CodeGenerator::self()
+inline TR::CodeGenerator* OMR::CodeGenerator::self()
    {
    return static_cast<TR::CodeGenerator*>(this);
+   }
+
+inline bool OMR::CodeGenerator::isIntrinsicMethodSupported(TR::RecognizedMethod m)
+   {
+   return TR::CodeGenerator::isILOpCodeSupported(TR::CodeGenerator::ilOpCodeForIntrinsicMethod(m));
+   }
+
+inline bool OMR::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod method)
+   {
+   return TR::CodeGenerator::isIntrinsicMethodSupported(method);
    }
 
 #endif

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3212,9 +3212,9 @@ TR::Snippet *OMR::Power::CodeGenerator::findSnippetInstructionsFromLabel(TR::Lab
    return NULL;
    }
 
-bool OMR::Power::CodeGenerator::ilOpCodeIsSupported(TR::ILOpCodes o)
+bool OMR::Power::CodeGenerator::isILOpCodeSupported(TR::ILOpCodes o)
    {
-   if (!OMR::CodeGenerator::ilOpCodeIsSupported(o))
+   if (!OMR::CodeGenerator::isILOpCodeSupported(o))
       {
       return false;
       }

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -436,7 +436,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    int64_t getSmallestPosConstThatMustBeMaterialized() {return 32768;}  // maximum 16-bit signed int plus 1
    bool shouldValueBeInACommonedNode(int64_t); // no virt, cast
 
-   bool ilOpCodeIsSupported(TR::ILOpCodes);
+   static bool isILOpCodeSupported(TR::ILOpCodes);
    // Constant Data update
    bool checkAndFetchRequestor(TR::Instruction *instr, TR::Instruction **q);
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6759,9 +6759,9 @@ OMR::Z::CodeGenerator::clearHighOrderBits( TR::Node * node, TR::Register * targe
    return true;
    }
 
-bool OMR::Z::CodeGenerator::ilOpCodeIsSupported(TR::ILOpCodes o)
+bool OMR::Z::CodeGenerator::isILOpCodeSupported(TR::ILOpCodes o)
    {
-   if (!OMR::CodeGenerator::ilOpCodeIsSupported(o))
+   if (!OMR::CodeGenerator::isILOpCodeSupported(o))
       {
       return false;
       }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -794,7 +794,7 @@ public:
 
    void deleteInst(TR::Instruction* old);
 
-   bool ilOpCodeIsSupported(TR::ILOpCodes);
+   static bool isILOpCodeSupported(TR::ILOpCodes);
 
    void setUsesZeroBasePtr( bool v = true );
    bool getUsesZeroBasePtr();

--- a/fvtest/compilertest/tests/injectors/OpIlInjector.cpp
+++ b/fvtest/compilertest/tests/injectors/OpIlInjector.cpp
@@ -296,7 +296,7 @@ OpIlInjector::setDataType()
 bool
 OpIlInjector::isOpCodeSupported()
    {
-   return comp()->cg()->ilOpCodeIsSupported(_opCode);
+   return comp()->cg()->isILOpCodeSupported(_opCode);
    }
 
 TR::Node *


### PR DESCRIPTION
Two CodeGen queries are introduced:
```
    ilOpCodeForIntrinsicMethod()
    isIntrinsicMethodSupported()
```
Two CodeGen queries are updated:
```
    isILOpCodeSupported()
    suppressInliningOfRecognizedMethod()
```
Signed-off-by: Victor Ding <dvictor@ca.ibm.com>