### PR TITLE
Fix for incorrect conversionAnalyser evaluation on X86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3557,7 +3557,7 @@ TR::Register *OMR::X86::TreeEvaluator::conversionAnalyser(TR::Node          *nod
                child->getOpCode().isLoadIndirect() &&
                child->getSymbolReference()->getSymbol()->getDataType() == TR::Address)
             {
-            targetRegister = TR::TreeEvaluator::iloadEvaluator(child, cg);
+            targetRegister = cg->evaluate(child);
             }
          else
             {


### PR DESCRIPTION
conversionAnalyser() should use cg->evaluate() instead of calling the iload evaluator directly.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>