### PR TITLE
CMake: Fix CheckSourceTree

### DIFF
--- a/cmake/CheckSourceTree.cmake
+++ b/cmake/CheckSourceTree.cmake
@@ -21,6 +21,6 @@
 
 # Ensure the source tree hasn't been used for building before.
 message(STATUS "SRC = ${CMAKE_SOURCE_DIR}")
-if(EXISTS "${omr_SOURCE_DIR}/omrcfg.h")
+if(EXISTS "${omr_SOURCE_DIR}/include_core/omrcfg.h")
 	message(FATAL_ERROR "An existing omrcfg.h has been detected in the source tree. This causes unexpected errors when compiling. Please build from a clean source tree.")
 endif()


### PR DESCRIPTION
The autotools build now outptus omrcfg.h into include core rather than
the top level source directory

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>