### PR TITLE
Implement ILBuilder Negate Service

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -993,6 +993,20 @@ OMR::IlBuilder::UnsignedConvertTo(TR::IlType *t, TR::IlValue *v)
    }
 
 TR::IlValue *
+OMR::IlBuilder::Negate(TR::IlValue *v)
+   {
+   TR::DataType dataType = v->getDataType();
+
+   TR::ILOpCodes negateOp = ILOpCode::negateOpCode(dataType);
+   TR_ASSERT(negateOp != TR::BadILOp, "Builder [ %p ] cannot negate value %d of type %s", this, v->getID(), dataType.toString());
+
+   TR::Node *result = TR::Node::create(negateOp, 1, loadValue(v));
+   TR::IlValue *negatedValue = newValue(dataType, result);
+   TraceIL("IlBuilder[ %p ]::%d is Negated %d\n", this, negatedValue->getID(), v->getID());
+   return negatedValue;
+   }
+
+TR::IlValue *
 OMR::IlBuilder::convertTo(TR::DataType typeTo, TR::IlValue *v, bool needUnsigned)
    {
    TR::DataType typeFrom = v->getDataType();

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -254,6 +254,7 @@ public:
    TR::IlValue *UnsignedGreaterOrEqualTo(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *ConvertTo(TR::IlType *t, TR::IlValue *v);
    TR::IlValue *UnsignedConvertTo(TR::IlType *t, TR::IlValue *v);
+   TR::IlValue *Negate(TR::IlValue *v);
 
    // memory
    TR::IlValue *CreateLocalArray(int32_t numElements, TR::IlType *elementType);

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -115,8 +115,8 @@
    TR::TreeEvaluator::lnegEvaluator,                    // TR::lneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::fneg
    TR::TreeEvaluator::fnegEvaluator,                    // TR::dneg
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::bneg
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::sneg
+   TR::TreeEvaluator::inegEvaluator,                    // TR::bneg
+   TR::TreeEvaluator::inegEvaluator,                    // TR::sneg
    TR::TreeEvaluator::iabsEvaluator,                    // TR::iabs
    TR::TreeEvaluator::labsEvaluator,                    // TR::labs
    TR::TreeEvaluator::fabsEvaluator,                    // TR::fabs

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -586,8 +586,6 @@ PPCOpCodesTest::UnsupportedOpCodesTests()
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sdiv, "sDiv", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::srem, "sRem", _argTypesBinaryShort, TR::Int16);
 
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::bneg, "bNeg", _argTypesUnaryByte, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::sneg, "sNeg", _argTypesUnaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sshl, "sShl", _argTypesBinaryShort, TR::Int16);
 
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bucmplt, "bucmplt", _argTypesBinaryByte, TR::Int32);
@@ -4449,6 +4447,8 @@ void
 PPCOpCodesTest::compileDisabledUnaryTestMethods()
    {
    int32_t rc = 0;
+   compileOpCodeMethod(_bNeg, _numberOfUnaryArgs, TR::bneg, "bNeg", _argTypesUnaryByte, TR::Int8, rc);
+   compileOpCodeMethod(_sNeg, _numberOfUnaryArgs, TR::sneg, "sNeg", _argTypesUnaryShort, TR::Int16, rc);
    //Jazz103 Work Item 109977
    compileOpCodeMethod(_dNeg, _numberOfUnaryArgs, TR::dneg, "dNeg", _argTypesUnaryDouble, TR::Double, rc);
    compileOpCodeMethod(_fNeg, _numberOfUnaryArgs, TR::fneg, "fNeg", _argTypesUnaryFloat, TR::Float, rc);
@@ -4470,6 +4470,8 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    int32_t rc = 0;
 
    int64_t longDataArray[] = {LONG_NEG, LONG_POS, LONG_MAXIMUM, LONG_MINIMUM, LONG_ZERO};
+   int16_t shortDataArray[] = {SHORT_NEG, SHORT_POS, SHORT_MAXIMUM, SHORT_MINIMUM, SHORT_ZERO};
+   int8_t byteDataArray[] = {BYTE_NEG, BYTE_POS, BYTE_MAXIMUM, BYTE_MINIMUM, BYTE_ZERO};
    float floatDataArray[] = {FLOAT_NEG, FLOAT_POS, FLOAT_ZERO, FLOAT_MAXIMUM, FLOAT_MINIMUM};
    double doubleDataArray[] = {DOUBLE_NEG, DOUBLE_POS, DOUBLE_ZERO, DOUBLE_MAXIMUM, DOUBLE_MINIMUM};
    uint32_t uintDataArray[] = {UINT_POS, UINT_MAXIMUM, UINT_MINIMUM};
@@ -4478,8 +4480,32 @@ PPCOpCodesTest::invokeDisabledUnaryTests()
    uint32_t testCaseNum = 0;
 
    signatureCharJ_J_testMethodType  *lUnaryCons = 0;
+   signatureCharS_S_testMethodType * sUnaryCons = 0;
+   signatureCharB_B_testMethodType * bUnaryCons = 0;
    signatureCharD_D_testMethodType  *dUnaryCons = 0;
    signatureCharF_F_testMethodType  *fUnaryCons = 0;
+
+   //bneg
+   testCaseNum = sizeof(byteDataArray) / sizeof(byteDataArray[0]);
+   for (uint32_t i = 0; i < testCaseNum; ++i)
+      {
+      OMR_CT_EXPECT_EQ(_bNeg, neg(byteDataArray[i]), _bNeg(byteDataArray[i]));
+      sprintf(resolvedMethodName, "bNegConst%d", i + 1);
+      compileOpCodeMethod(bUnaryCons, _numberOfUnaryArgs, TR::bneg,
+            resolvedMethodName, _argTypesUnaryByte, TR::Int8, rc, 2, 1, &byteDataArray[i]);
+      OMR_CT_EXPECT_EQ(bUnaryCons, neg(byteDataArray[i]), bUnaryCons(BYTE_PLACEHOLDER_1));
+      }
+
+   //sneg
+   testCaseNum = sizeof(shortDataArray) / sizeof(shortDataArray[0]);
+   for (uint32_t i = 0; i < testCaseNum; ++i)
+      {
+      OMR_CT_EXPECT_EQ(_sNeg, neg(shortDataArray[i]), _sNeg(shortDataArray[i]));
+      sprintf(resolvedMethodName, "sNegConst%d", i + 1);
+      compileOpCodeMethod(sUnaryCons, _numberOfUnaryArgs, TR::sneg,
+            resolvedMethodName, _argTypesUnaryShort, TR::Int16, rc, 2, 1, &shortDataArray[i]);
+      OMR_CT_EXPECT_EQ(sUnaryCons, neg(shortDataArray[i]), sUnaryCons(SHORT_PLACEHOLDER_1));
+      }
 
    //lneg
    testCaseNum = sizeof(longDataArray) / sizeof(longDataArray[0]);

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(jitbuildertest
 	FieldAddressTest.cpp
 	AnonymousTest.cpp
 	ControlFlowTest.cpp
+	NegateTest.cpp
 	SystemLinkageTest.cpp
 	WorklistTest.cpp
 	FieldNameTest.cpp

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -33,6 +33,7 @@ OBJECTS := \
 	AnonymousTest \
 	ControlFlowTest \
 	SystemLinkageTest \
+	NegateTest \
 	WorklistTest \
 	IfThenElseTest \
 	CallReturnTest \

--- a/fvtest/jitbuildertest/NegateTest.cpp
+++ b/fvtest/jitbuildertest/NegateTest.cpp
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+
+DEFINE_BUILDER(TestInt64Negate,
+               Int64,
+               PARAM("param", Int64))
+   {
+   TR::IlValue *param = Load("param");
+   TR::IlValue *result = Negate(param);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt32Negate,
+               Int32,
+               PARAM("param", Int32))
+   {
+   TR::IlValue *param = Load("param");
+   TR::IlValue *result = Negate(param);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt16Negate,
+               Int16,
+               PARAM("param", Int16))
+   {
+   TR::IlValue *param = Load("param");
+   TR::IlValue *result = Negate(param);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt8Negate,
+               Int8,
+               PARAM("param", Int8))
+   {
+   TR::IlValue *param = Load("param");
+   TR::IlValue *result = Negate(param);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestFloatNegate,
+               Float,
+               PARAM("param", Float))
+   {
+   TR::IlValue *param = Load("param");
+   TR::IlValue *result = Negate(param);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestDoubleNegate,
+               Double,
+               PARAM("param", Double))
+   {
+   TR::IlValue *param = Load("param");
+   TR::IlValue *result = Negate(param);
+   Return(result);
+   return true;
+   }
+
+class NegateTest : public JitBuilderTest {};
+
+typedef int64_t (*Int64ReturnType)(int64_t);
+TEST_F(NegateTest, Int64_Test)
+   {
+   Int64ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt64Negate, testFunction);
+   ASSERT_EQ(testFunction(0), 0);
+   ASSERT_EQ(testFunction(1), -1);
+   ASSERT_EQ(testFunction(-1), 1);
+   ASSERT_EQ(testFunction(INT64_MAX), INT64_MIN + 1);
+   ASSERT_EQ(testFunction(INT64_MIN + 1), INT64_MAX);
+   ASSERT_EQ(testFunction(INT64_MIN), INT64_MIN);
+   }
+
+typedef int32_t (*Int32ReturnType)(int32_t);
+TEST_F(NegateTest, Int32_Test)
+   {
+   Int32ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt32Negate, testFunction);
+   ASSERT_EQ(testFunction(0), 0);
+   ASSERT_EQ(testFunction(1), -1);
+   ASSERT_EQ(testFunction(-1), 1);
+   ASSERT_EQ(testFunction(INT32_MAX), INT32_MIN + 1);
+   ASSERT_EQ(testFunction(INT32_MIN + 1), INT32_MAX);
+   ASSERT_EQ(testFunction(INT32_MIN), INT32_MIN);
+   }
+
+typedef int16_t (*Int16ReturnType)(int16_t);
+TEST_F(NegateTest, Int16_Test)
+   {
+   Int16ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt16Negate, testFunction);
+   ASSERT_EQ(testFunction(0), 0);
+   ASSERT_EQ(testFunction(1), -1);
+   ASSERT_EQ(testFunction(-1), 1);
+   ASSERT_EQ(testFunction(INT16_MAX), INT16_MIN + 1);
+   ASSERT_EQ(testFunction(INT16_MIN + 1), INT16_MAX);
+   ASSERT_EQ(testFunction(INT16_MIN), INT16_MIN);
+   }
+
+typedef int8_t (*Int8ReturnType)(int8_t);
+TEST_F(NegateTest, Int8_Test)
+   {
+   Int8ReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestInt8Negate, testFunction);
+   ASSERT_EQ(testFunction(0), 0);
+   ASSERT_EQ(testFunction(1), -1);
+   ASSERT_EQ(testFunction(-1), 1);
+   ASSERT_EQ(testFunction(INT8_MAX), INT8_MIN + 1);
+   ASSERT_EQ(testFunction(INT8_MIN + 1), INT8_MAX);
+   ASSERT_EQ(testFunction(INT8_MIN), INT8_MIN);
+   }
+
+typedef float (*FloatReturnType)(float);
+TEST_F(NegateTest, Float_Test)
+   {
+   FloatReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestFloatNegate, testFunction);
+   ASSERT_EQ(testFunction(0), 0);
+   ASSERT_EQ(testFunction(1), -1);
+   ASSERT_EQ(testFunction(-1), 1);
+   ASSERT_EQ(testFunction(FLT_MIN), -FLT_MIN);
+   ASSERT_EQ(testFunction(FLT_MAX), -FLT_MAX);
+   }
+
+typedef double (*DoubleReturnType)(double);
+TEST_F(NegateTest, Double_Test)
+   {
+   DoubleReturnType testFunction;
+   ASSERT_COMPILE(TR::TypeDictionary, TestDoubleNegate, testFunction);
+   ASSERT_EQ(testFunction(0), 0);
+   ASSERT_EQ(testFunction(1), -1);
+   ASSERT_EQ(testFunction(-1), 1);
+   ASSERT_EQ(testFunction(DBL_MIN), -DBL_MIN);
+   ASSERT_EQ(testFunction(DBL_MAX), -DBL_MAX);
+   }


### PR DESCRIPTION
The OMR compiler supports negate opcodes so it makes sense to
provide a Negate service on ILBuilder. This change also includes
a jitbuildertest for negating.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>