### PR TITLE
Provide an API to get the constant values from an ILValue

### DIFF
--- a/compiler/ilgen/OMRIlValue.cpp
+++ b/compiler/ilgen/OMRIlValue.cpp
@@ -120,6 +120,18 @@ OMR::IlValue::storeOver(TR::IlValue *value, TR::Block *block)
       }
    }
 
+int32_t
+OMR::IlValue::get32bitConstValue()
+   {
+   return _nodeThatComputesValue->get32bitIntegralValue();
+   }
+
+int64_t
+OMR::IlValue::get64bitConstValue()
+   {
+   return _nodeThatComputesValue->get64bitIntegralValue();
+   }
+
 void *
 OMR::IlValue::client()
    {

--- a/compiler/ilgen/OMRIlValue.hpp
+++ b/compiler/ilgen/OMRIlValue.hpp
@@ -91,6 +91,18 @@ public:
       }
 
    /**
+    * @brief returns the 32 bit constant value for this IlValue. Caller should ensure that this IlValue represents
+    * a 32 bit (or less) constant value before it calls this function or an assertion will be triggered
+    */
+   int32_t get32bitConstValue();
+
+   /**
+    * @brief returns the 64 bit constant value for this IlValue. Caller should ensure that this IlValue represents
+    * a 64 bit (or less) constant value before it calls this function or an assertion will be triggered
+    */
+   int64_t get64bitConstValue();
+
+   /**
     * @brief associates this object with a particular client object
     */
    void setClient(void *client)


### PR DESCRIPTION
I have been working on an InterpreterBuilder class for generating
an Interpreter using JitBuilder. One of the main goals is to allow
the BytecodeBuilder objects used by the InterpreterBuilder to be
consumed without any changes to generate a JIT method. When using
the VirtualMachineState hierarchy some operations require getting
the constant value out of an ILValue so that calls to VMOS Push
and Pop can index into its array of IlValues.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>