### PR TITLE
Add bcLength to BytecodeBuilder

### DIFF
--- a/compiler/ilgen/BytecodeBuilder.hpp
+++ b/compiler/ilgen/BytecodeBuilder.hpp
@@ -29,8 +29,8 @@ namespace TR
    class BytecodeBuilder : public OMR::BytecodeBuilder
       {
       public:
-         BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL)
-            : OMR::BytecodeBuilder(methodBuilder, bcIndex, name)
+         BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL, int32_t bcLength=-1)
+            : OMR::BytecodeBuilder(methodBuilder, bcIndex, name, bcLength)
             { }
          void initialize(TR::IlGeneratorMethodDetails * details,
                            TR::ResolvedMethodSymbol     * methodSymbol,

--- a/compiler/ilgen/OMRBytecodeBuilder.cpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.cpp
@@ -37,11 +37,13 @@
 
 OMR::BytecodeBuilder::BytecodeBuilder(TR::MethodBuilder *methodBuilder,
                                       int32_t bcIndex,
-                                      char *name)
+                                      char *name,
+                                      int32_t bcLength)
    : TR::IlBuilder(methodBuilder, methodBuilder->typeDictionary()),
    _fallThroughBuilder(0),
    _bcIndex(bcIndex),
    _name(name),
+   _bcLength(bcLength),
    _initialVMState(0),
    _vmState(0)
    {

--- a/compiler/ilgen/OMRBytecodeBuilder.hpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.hpp
@@ -36,7 +36,7 @@ class BytecodeBuilder : public TR::IlBuilder
 public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
-   BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL);
+   BytecodeBuilder(TR::MethodBuilder *methodBuilder, int32_t bcIndex, char *name=NULL, int32_t bcLength=-1);
 
    virtual bool isBytecodeBuilder() { return true; }
 
@@ -51,6 +51,11 @@ public:
 
    /* The name for this BytecodeBuilder. This can be very helpful for debug output */
    char *name() { return _name; }
+
+   /**
+    * @brief bytecode length for this builder object
+    */
+   int32_t bcLength() { return _bcLength; }
 
    virtual uint32_t countBlocks();
 
@@ -122,6 +127,7 @@ protected:
    List<TR::BytecodeBuilder> * _successorBuilders;
    int32_t                     _bcIndex;
    char                      * _name;
+   int32_t                     _bcLength;
    TR::VirtualMachineState   * _initialVMState;
    TR::VirtualMachineState   * _vmState;
 


### PR DESCRIPTION
BytecodeBuilders have an bcIndex which describes the index for the
bytecode. Similarly a bytecode should be able to describe how many
pc indexes each bytecode represents.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>