### PR TITLE
Enable DDR to work with VS2017

### DIFF
--- a/ddr/include/ddr/ir/Field.hpp
+++ b/ddr/include/ddr/ir/Field.hpp
@@ -37,6 +37,7 @@ public:
 	bool _isStatic;
 
 	Field();
+	virtual ~Field();
 
 	const std::string &getTypeName() const;
 };

--- a/ddr/include/ddr/ir/Members.hpp
+++ b/ddr/include/ddr/ir/Members.hpp
@@ -30,6 +30,7 @@ class Members
 public:
 	std::string _name;
 
+	Members() : _name() {}
 	virtual ~Members();
 };
 

--- a/ddr/include/ddr/ir/NamespaceUDT.hpp
+++ b/ddr/include/ddr/ir/NamespaceUDT.hpp
@@ -35,7 +35,7 @@ public:
 	vector<EnumMember *> _enumMembers; /* used for anonymous enums */
 
 	explicit NamespaceUDT(unsigned int lineNumber = 0);
-	~NamespaceUDT();
+	virtual ~NamespaceUDT();
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 	virtual bool insertUnique(Symbol_IR *ir);

--- a/ddr/include/ddr/ir/Type.hpp
+++ b/ddr/include/ddr/ir/Type.hpp
@@ -57,8 +57,9 @@ public:
 
 	bool isAnonymousType() const;
 
-	virtual string getFullName();
+	virtual string getFullName() const;
 	virtual const string &getSymbolKindName() const;
+	string getTypeNameKey() const;
 
 	/* Visitor pattern function to allow the scanner/generator/IR to dispatch functionality based on type. */
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);

--- a/ddr/include/ddr/ir/TypedefUDT.hpp
+++ b/ddr/include/ddr/ir/TypedefUDT.hpp
@@ -32,7 +32,7 @@ public:
 	Modifiers _modifiers;
 
 	explicit TypedefUDT(unsigned int lineNumber = 0);
-	~TypedefUDT();
+	virtual ~TypedefUDT();
 
 	virtual DDR_RC acceptVisitor(const TypeVisitor &visitor);
 	virtual const string &getSymbolKindName() const;

--- a/ddr/include/ddr/ir/UDT.hpp
+++ b/ddr/include/ddr/ir/UDT.hpp
@@ -33,7 +33,7 @@ public:
 	explicit UDT(size_t size, unsigned int lineNumber = 0);
 	virtual ~UDT();
 
-	virtual string getFullName();
+	virtual string getFullName() const;
 	virtual bool insertUnique(Symbol_IR *ir);
 	virtual NamespaceUDT * getNamespace();
 

--- a/ddr/lib/ddr-ir/EnumUDT.cpp
+++ b/ddr/lib/ddr-ir/EnumUDT.cpp
@@ -23,6 +23,7 @@
 
 EnumUDT::EnumUDT(unsigned int lineNumber)
 	: UDT(4, lineNumber)
+	, _enumMembers()
 {
 }
 

--- a/ddr/lib/ddr-ir/Field.cpp
+++ b/ddr/lib/ddr-ir/Field.cpp
@@ -32,6 +32,10 @@ Field::Field()
 {
 }
 
+Field::~Field()
+{
+}
+
 const string &
 Field::getTypeName() const
 {

--- a/ddr/lib/ddr-ir/Field.cpp
+++ b/ddr/lib/ddr-ir/Field.cpp
@@ -23,7 +23,8 @@
 #include "ddr/ir/Type.hpp"
 
 Field::Field()
-	: _fieldType(NULL)
+	: Members()
+	, _fieldType(NULL)
 	, _offset(0)
 	, _modifiers()
 	, _bitField(0)

--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -589,21 +589,12 @@ Symbol_IR::replaceTypeUsingMap(Type **type, Type *outer)
 	return rc;
 }
 
-static string
-getTypeNameKey(Type *type)
-{
-	string prefix = type->getSymbolKindName();
-	string fullname = type->getFullName();
-
-	return prefix.empty() ? fullname : (prefix + " " + fullname);
-}
-
 Type *
 Symbol_IR::findTypeInMap(Type *typeToFind)
 {
 	Type *returnType = NULL;
 	if ((NULL != typeToFind) && !typeToFind->isAnonymousType()) {
-		const string nameKey = getTypeNameKey(typeToFind);
+		const string nameKey = typeToFind->getTypeNameKey();
 		unordered_map<string, set<Type *> >::const_iterator map_it = _typeMap.find(nameKey);
 
 		if (_typeMap.end() != map_it) {
@@ -635,7 +626,7 @@ Symbol_IR::addTypeToMap(Type *type)
 
 	while (NULL != type) {
 		if (!type->isAnonymousType()) {
-			_typeMap[getTypeNameKey(type)].insert(type);
+			_typeMap[type->getTypeNameKey()].insert(type);
 		}
 		_typeSet.insert(type);
 

--- a/ddr/lib/ddr-ir/Type.cpp
+++ b/ddr/lib/ddr-ir/Type.cpp
@@ -40,7 +40,7 @@ Type::isAnonymousType() const
 }
 
 string
-Type::getFullName()
+Type::getFullName() const
 {
 	return _name;
 }
@@ -51,6 +51,15 @@ Type::getSymbolKindName() const
 	static const string typeKind("");
 
 	return typeKind;
+}
+
+string
+Type::getTypeNameKey() const
+{
+	string prefix = getSymbolKindName();
+	string fullname = getFullName();
+
+	return prefix.empty() ? fullname : (prefix + " " + fullname);
 }
 
 DDR_RC

--- a/ddr/lib/ddr-ir/TypedefUDT.cpp
+++ b/ddr/lib/ddr-ir/TypedefUDT.cpp
@@ -22,7 +22,9 @@
 #include "ddr/ir/TypedefUDT.hpp"
 
 TypedefUDT::TypedefUDT(unsigned int lineNumber)
-	: UDT(0, lineNumber), _aliasedType(NULL)
+	: UDT(0, lineNumber)
+	, _aliasedType(NULL)
+	, _modifiers()
 {
 	/* A typedef is opaque only if an overrides file says so. */
 	_opaque = false;

--- a/ddr/lib/ddr-ir/UDT.cpp
+++ b/ddr/lib/ddr-ir/UDT.cpp
@@ -35,7 +35,7 @@ UDT::~UDT()
 }
 
 string
-UDT::getFullName()
+UDT::getFullName() const
 {
 	return (NULL == _outerNamespace)
 			? _name

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -463,10 +463,10 @@ DwarfScanner::getTypeInfo(Dwarf_Die die, Dwarf_Die *dieOut, string *typeName, Mo
 							break;
 						}
 						/* New array length is upperBound + 1. */
-						modifiers->_arrayLengths.push_back(upperBound + 1);
+						modifiers->addArrayDimension(upperBound + 1);
 					} else {
 						/* Arrays declared as "[]" have no size attributes. */
-						modifiers->_arrayLengths.push_back(0);
+						modifiers->addArrayDimension(0);
 					}
 				} while (DDR_RC_OK == getNextSibling(&child));
 				dwarf_dealloc(_debug, child, DW_DLA_DIE);

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -277,6 +277,7 @@ PdbScanner::updatePostponedFieldNames()
 			(*type)->_blacklisted = checkBlacklistedType((*type)->_name);
 		}
 	}
+	_postponedFields.clear();
 
 	return rc;
 }
@@ -1131,7 +1132,7 @@ PdbScanner::setSuperClassName(IDiaSymbol *symbol, ClassUDT *newUDT)
 
 	if (DDR_RC_OK == rc) {
 		/* Find the superclass UDT from the map by size and name.
-		 * If its not found, add it to a list to check later.
+		 * If it's not found, add it to a list to check later.
 		 */
 		if (!name.empty()) {
 			unordered_map<string, Type *>::const_iterator map_it = _typeMap.find(name);

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -550,7 +550,8 @@ PdbScanner::createEnumUDT(IDiaSymbol *symbol, NamespaceUDT *outerNamespace)
 			} else {
 				fullName = outerNamespace->getFullName() + "::" + name;
 			}
-			if (_typeMap.end() == _typeMap.find(fullName)) {
+			unordered_map<string, Type *>::const_iterator it = _typeMap.find(fullName);
+			if (_typeMap.end() == it) {
 				/* If this is a new enum, get its members and add it to the IR. */
 				EnumUDT *enumUDT = new EnumUDT;
 				enumUDT->_name = name;
@@ -565,13 +566,16 @@ PdbScanner::createEnumUDT(IDiaSymbol *symbol, NamespaceUDT *outerNamespace)
 					delete enumUDT;
 				}
 			} else {
-				EnumUDT *enumUDT = (EnumUDT *)getType(fullName);
-				if ((NULL != outerNamespace) && (NULL == enumUDT->_outerNamespace)) {
-					enumUDT->_outerNamespace = outerNamespace;
-					outerNamespace->_subUDTs.push_back(enumUDT);
-				}
-				if (enumUDT->_enumMembers.empty()) {
-					rc = addEnumMembers(symbol, enumUDT);
+				Type *existingType = it->second;
+				if ("enum" == existingType->getSymbolKindName()) {
+					EnumUDT *enumUDT = (EnumUDT *)existingType;
+					if ((NULL != outerNamespace) && (NULL == enumUDT->_outerNamespace)) {
+						enumUDT->_outerNamespace = outerNamespace;
+						outerNamespace->_subUDTs.push_back(enumUDT);
+					}
+					if (enumUDT->_enumMembers.empty()) {
+						rc = addEnumMembers(symbol, enumUDT);
+					}
 				}
 			}
 		}

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -399,7 +399,10 @@ PdbScanner::createTypedef(IDiaSymbol *symbol, NamespaceUDT *outerNamespace)
 		/* Get the base type. */
 		rc = setType(symbol, &newTypedef->_aliasedType, &newTypedef->_modifiers, NULL);
 		if (DDR_RC_OK == rc) {
-			newTypedef->_sizeOf = newTypedef->_aliasedType->_sizeOf;
+			Type *aliasedType = newTypedef->_aliasedType;
+			if (NULL != aliasedType) {
+				newTypedef->_sizeOf = aliasedType->_sizeOf;
+			}
 			addType(newTypedef, outerNamespace);
 		} else {
 			delete newTypedef;


### PR DESCRIPTION
Only add enum literals to enum types

* Consider the source pattern `typedef enum E { Ea, Eb } E;`: With Visual Studio 2017, the PDB description for the typedef may precede that of the enum. Thus `_typeMap["E"]` will refer to a TypedefUDT object which is not safe to cast to an EnumUDT.

Minor cleanup

* Be careful capturing the size of a typedef: The call to setType() isn't guaranteed to set _aliasedType immediately so it's not safe to dereference it. Typedef types are omitted from the generated blob and superset files so we don't really need to capture the size of typedef types.

* Explicitly construct base types and initialize all fields. The compiler ought to do the same implicitly, but there's no cost to being explicit.

* Use Modifiers::addArrayDimension. This is preferable to accessing the field _arrayLengths directly.

* Explicitly mark virtual destructors. If a class has a virtual destructor, then destructors of derived classes should be implicitly virtual as well. Being explicit makes the code easier to understand.

* Add Type::getTypeNameKey(). Refactor the static function from Symbol_IR.cpp; it's still only used by Symbol_IR at this time. Type::getFullName() was made a 'const' method so getTypeNameKey() can be const.