### PR TITLE
Skip cold blocks in recognized call transformer

### DIFF
--- a/compiler/optimizer/OMRRecognizedCallTransformer.cpp
+++ b/compiler/optimizer/OMRRecognizedCallTransformer.cpp
@@ -38,6 +38,12 @@ int32_t OMR::RecognizedCallTransformer::perform()
    TR::NodeChecklist visited(comp());
    for (auto treetop = comp()->getMethodSymbol()->getFirstTreeTop(); treetop != NULL; treetop = treetop->getNextTreeTop())
       {
+      if (treetop->getEnclosingBlock()->isCold())
+         {
+         treetop = treetop->getEnclosingBlock()->getExit();
+         continue;
+         }
+
       if (treetop->getNode()->getNumChildren() > 0)
          {
          auto node = treetop->getNode()->getFirstChild();


### PR DESCRIPTION
Cold blocks are blocks that haven't run or blocks generated by
optimizations that are not to be optimized furthur.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>