### PR TITLE
Change for supporting CopyForwardHybrid

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -390,6 +390,7 @@ public:
 	uintptr_t fvtest_forceReferenceChainWalkerMarkMapCommitFailure; /**< Force failure at Reference Chain Walker Mark Map commit operation */
 	uintptr_t fvtest_forceReferenceChainWalkerMarkMapCommitFailureCounter; /**< Force failure at Reference Chain Walker Mark Map commit operation counter */
 
+	uintptr_t fvtest_forceCopyForwardHybridRatio; /**< Force to run CopyForward Hybrid mode value = 1-100 the percentage of non evacuated eden regions */
 	uintptr_t softMx; /**< set through -Xsoftmx, depending on GC policy this number might differ from available heap memory, use MM_Heap::getActualSoftMxSize for calculations */
 
 #if defined(OMR_GC_BATCH_CLEAR_TLH)
@@ -700,6 +701,7 @@ public:
 	MM_UserSpecifiedParameterUDATA tarokMinimumGMPWorkTargetBytes; /**< Minimum used for GMP work targets.  This avoids the low-scan-rate -> low GMP work target -> low scan-rate feedback loop. */
 	double tarokConcurrentMarkingCostWeight; /**< How much we weigh concurrentMarking into our GMP scan time cost calculations */
 	bool tarokAutomaticDefragmentEmptinessThreshold; /**< Whether we should use the automatically derived value for tarokDefragmentEmptinessThreshold or not */
+	bool tarokEnableCopyForwardHybrid; /**< Enable CopyForward Hybrid mode */
 #endif /* defined (OMR_GC_VLHGC) */
 
 /* OMR_GC_VLHGC (in for all -- see 82589) */
@@ -1336,6 +1338,7 @@ public:
 		, fvtest_forceMarkMapDecommitFailureCounter(0)
 		, fvtest_forceReferenceChainWalkerMarkMapCommitFailure(0)
 		, fvtest_forceReferenceChainWalkerMarkMapCommitFailureCounter(0)
+		, fvtest_forceCopyForwardHybridRatio(0)
 		, softMx(0) /* softMx only set if specified */
 		, batchClearTLH(0)
 		, gcThreadCountForced(false)
@@ -1586,6 +1589,7 @@ public:
 		, tarokMinimumGMPWorkTargetBytes()
 		, tarokConcurrentMarkingCostWeight(0.05)
 		, tarokAutomaticDefragmentEmptinessThreshold(false)
+		, tarokEnableCopyForwardHybrid(false)
 #endif /* defined (OMR_GC_VLHGC) */
 		, tarokEnableExpensiveAssertions(false)
 		, sweepPoolManagerAddressOrderedList(NULL)

--- a/gc/base/WorkPackets.hpp
+++ b/gc/base/WorkPackets.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -176,6 +176,17 @@ public:
 	{
 		return(_deferredPacketList.getCount() + _deferredFullPacketList.getCount());
 	};
+
+
+	MMINLINE omrthread_monitor_t* getInputListMonitorPtr()
+	{
+		return &_inputListMonitor;
+	}
+
+	MMINLINE volatile uintptr_t* getInputListWaitCountPtr()
+	{
+		return &_inputListWaitCount;
+	}
 
 	/**
 	 * Returns current value of overflow flag

--- a/gc/base/WorkStack.hpp
+++ b/gc/base/WorkStack.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -208,6 +208,20 @@ public:
 			return popNoWaitFailed(env);
 		}
 	}
+
+	/**
+	 * Pop a reference from input packet (inlined part)
+	 * Pop a reference from the stacks input packet. If no references remain
+	 * in current packet then return NULL (and put input packet back to output list for reuse
+	 */
+	void *popNoWaitFromCurrentInputPacket(MM_EnvironmentBase *env);
+
+	/**
+	 *
+	 */
+	bool retrieveInputPacket(MM_EnvironmentBase *env);
+
+	bool inputPacketAvailableFromWorkPackets(MM_EnvironmentBase *env);
 
 	/**
 	 * Create a WorkStack object.

--- a/gc/stats/CopyForwardStatsCore.hpp
+++ b/gc/stats/CopyForwardStatsCore.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,6 +75,7 @@ public:
 
 	bool _aborted;  /**< Flag indicating if the copy forward mechanism was aborted */
 
+	uintptr_t  _nonEvacuateRegionCount; /**< Counts the number of regions which are not scheduled to be evacuated in collection set(mark/compact regions) - unused in per-thread stats)*/
 	uintptr_t _edenEvacuateRegionCount;	/**< Counts the number of Eden regions selected to be evacuated in this copy-forward (only counted globally - unused in per-thread stats) */
 	uintptr_t _nonEdenEvacuateRegionCount;	/**< Counts the number of non-Eden selected to be evacuated in this copy-forward (only counted globally - unused in per-thread stats) */
 	uintptr_t _edenSurvivorRegionCount;	/**< Counts the number of Eden regions allocated for survivor space in this copy-forward (only counted globally - unused in per-thread stats) */
@@ -227,6 +228,7 @@ public:
 		_scanCacheOverflow = false;
 		_aborted = false;
 
+		_nonEvacuateRegionCount = 0;
 		_edenEvacuateRegionCount = 0;
 		_nonEdenEvacuateRegionCount = 0;
 		_edenSurvivorRegionCount = 0;
@@ -356,6 +358,7 @@ public:
 		,_bytesCardClean(0)
 		,_scanCacheOverflow(false)
 		,_aborted(false)
+		,_nonEvacuateRegionCount(0)
 		,_edenEvacuateRegionCount(0)
 		,_nonEdenEvacuateRegionCount(0)
 		,_edenSurvivorRegionCount(0)


### PR DESCRIPTION
 CopyForwardHybrid is hybrid mode of CopyForward Scheme that 
 GC can run both copyforward and markcompact on the collection set
 simultaneously (for balanced PGC only). During precollection, 
 GC can reserve some regions for markcompact only(non evacuated 
 regions -- such as jni critical regions) and copyforward for 
 the rest of collection set. 

 - new global flag tarokEnableCopyForwardHybrid for indicating if
 CopyForwardHybrid mode is on, default is off.
 - new global test option fvtest_forceCopyForwardHybridRatio, which 
can set the percentage of collection set to be reserved for markcompact.
 - update workpackets for allow synchronizing with the threads pull
 the work from another queue(such as copycache).
 -  add new nonEvacuateRegionCount in CopyForwardStats for verbose
 gc reporting.
 
Signed-off-by: Lin Hu <linhu@ca.ibm.com>