### PR TITLE
AArch64: Implement loadConstant32() and loadConstant64()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -929,8 +929,22 @@ class ARM64Trg1ImmInstruction : public ARM64Trg1Instruction
     */
    void insertImmediateField(uint32_t *instruction)
       {
-      /* immediate width depends on InstOpCode */
-      TR_ASSERT(false, "Not implemented yet.");
+      TR::InstOpCode::Mnemonic op = getOpCodeValue();
+
+      if (op == TR::InstOpCode::movzx || op == TR::InstOpCode::movzw ||
+          op == TR::InstOpCode::movnx || op == TR::InstOpCode::movnw ||
+          op == TR::InstOpCode::movkx || op == TR::InstOpCode::movkw)
+         {
+         *instruction |= ((_sourceImmediate & 0x3ffff) << 5);
+         }
+      else if (op == TR::InstOpCode::adr || op == TR::InstOpCode::adrp)
+         {
+         *instruction |= ((_sourceImmediate & 0x7ffff) << 5) | ((_sourceImmediate & 0x3) << 29);
+         }
+      else
+         {
+         TR_ASSERT(false, "Unsupported opcode in ARM64Trg1ImmInstruction.");
+         }
       }
 
    /**

--- a/compiler/aarch64/codegen/ARM64ShiftCode.hpp
+++ b/compiler/aarch64/codegen/ARM64ShiftCode.hpp
@@ -48,6 +48,15 @@ typedef enum {
    EXT_SXTX,
 } ARM64ExtendCode;
 
+/*
+ * Shift codes used in "mov (wide immediate)" instructions
+ */
+enum {
+   MOV_LSL16 = 0x10000,
+   MOV_LSL32 = 0x20000,
+   MOV_LSL48 = 0x30000
+};
+
 } // TR
 
 #endif

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -42,6 +42,25 @@ class TR_ARM64OutOfLineCodeSection;
 namespace TR { class ARM64LinkageProperties; }
 namespace TR { class ConstantDataSnippet; }
 
+/**
+ * @brief Generates instructions for loading 32-bit integer value to a register
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] value : integer value
+ * @param[in] trgReg : target register
+ * @param[in] cursor : instruction cursor
+ */
+extern TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t value, TR::Register *trgReg, TR::Instruction *cursor = NULL);
+/**
+ * @brief Generates instructions for loading 64-bit integer value to a register
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] value : integer value
+ * @param[in] trgReg : target register
+ * @param[in] cursor : instruction cursor
+ */
+extern TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t value, TR::Register *trgReg, TR::Instruction *cursor = NULL);
+
 namespace OMR
 {
 


### PR DESCRIPTION
This commit implements loadConstant32() and loadConstant64()
utility functions for loading a integer value to a register for
aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>