### PR TITLE
AArch64: Add utility functions for generating MOV, MUL, etc.

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1221,10 +1221,10 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
     * @param[in] cg : CodeGenerator
     */
    ARM64Trg1Src2Instruction( TR::InstOpCode::Mnemonic op,
-                              TR::Node *node,
-                              TR::Register *treg,
-                              TR::Register *s1reg,
-                              TR::Register *s2reg, TR::CodeGenerator *cg)
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg, TR::CodeGenerator *cg)
       : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cg), _source2Register(s2reg)
       {
       }
@@ -1240,12 +1240,56 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
     * @param[in] cg : CodeGenerator
     */
    ARM64Trg1Src2Instruction( TR::InstOpCode::Mnemonic op,
-                              TR::Node *node,
-                              TR::Register *treg,
-                              TR::Register *s1reg,
-                              TR::Register *s2reg,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Src1Instruction(op, node, treg, s1reg, precedingInstruction, cg),
+                             _source2Register(s2reg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] cond : register dependency conditions
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2Instruction( TR::InstOpCode::Mnemonic op,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
+                             TR::RegisterDependencyConditions *cond,
+                             TR::CodeGenerator *cg)
+      : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cond, cg), _source2Register(s2reg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] cond : register dependency conditions
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2Instruction( TR::InstOpCode::Mnemonic op,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
+                             TR::RegisterDependencyConditions *cond,
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cond, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
       }
@@ -1568,6 +1612,54 @@ class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
                              TR::Register *s3reg,
                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg),
+                             _source3Register(s3reg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] s3reg : source register 3
+    * @param[in] cond : register dependency conditions
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src3Instruction( TR::InstOpCode::Mnemonic op,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
+                             TR::Register *s3reg,
+                             TR::RegisterDependencyConditions *cond,
+                             TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, cg), _source3Register(s3reg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] s3reg : source register 3
+    * @param[in] cond : register dependency conditions
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src3Instruction( TR::InstOpCode::Mnemonic op,
+                             TR::Node *node,
+                             TR::Register *treg,
+                             TR::Register *s1reg,
+                             TR::Register *s2reg,
+                             TR::Register *s3reg,
+                             TR::RegisterDependencyConditions *cond,
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, precedingInstruction, cg),
                              _source3Register(s3reg)
       {
       }

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -280,7 +280,7 @@ TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *
    /* Alias of SUBS instruction */
 
    bool is64bit = node->getDataType().isInt64();
-   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::Mnemonic::subsimmx : TR::InstOpCode::Mnemonic::subsimmw;
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subsimmx : TR::InstOpCode::subsimmw;
 
    return generateSrc1ImmInstruction(cg, op, node, sreg, imm, preced);
    }
@@ -291,7 +291,95 @@ TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *nod
    /* Alias of ANDS instruction */
 
    bool is64bit = node->getDataType().isInt64();
-   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::Mnemonic::andsimmx : TR::InstOpCode::Mnemonic::andsimmw;
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsimmx : TR::InstOpCode::andsimmw;
 
    return generateSrc1ImmInstruction(cg, op, node, sreg, imm, preced);
+   }
+
+/* Use xzr as the target register */
+static TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+   {
+   TR::Register *zeroReg = cg->allocateRegister();
+   TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
+   addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
+
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, zeroReg, s1reg, s2reg, cond, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, zeroReg, s1reg, s2reg, cond, cg);
+   }
+
+TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+   {
+   /* Alias of SUBS instruction */
+
+   bool is64bit = node->getDataType().isInt64();
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subsx : TR::InstOpCode::subsw;
+
+   return generateSrc2Instruction(cg, op, node, s1reg, s2reg, preced);
+   }
+
+TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+   {
+   /* Alias of ANDS instruction */
+
+   bool is64bit = node->getDataType().isInt64();
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsx : TR::InstOpCode::andsw;
+
+   return generateSrc2Instruction(cg, op, node, s1reg, s2reg, preced);
+   }
+
+/* Use xzr as the first source register */
+static TR::Instruction *generateTrg1ZeroSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, TR::Instruction *preced)
+   {
+   TR::Register *zeroReg = cg->allocateRegister();
+   TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
+   addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
+
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, zeroReg, sreg, cond, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, zeroReg, sreg, cond, cg);
+   }
+
+TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, TR::Instruction *preced)
+   {
+   /* Alias of ORR instruction */
+
+   bool is64bit = node->getDataType().isInt64();
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::orrx : TR::InstOpCode::orrw;
+
+   return generateTrg1ZeroSrc1Instruction(cg, op, node, treg, sreg, preced);
+   }
+
+TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::Register *sreg, TR::Instruction *preced)
+   {
+   /* Alias of SUB instruction */
+
+   bool is64bit = node->getDataType().isInt64();
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subx : TR::InstOpCode::subw;
+
+   return generateTrg1ZeroSrc1Instruction(cg, op, node, treg, sreg, preced);
+   }
+
+TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+   {
+   /* Alias of MADD instruction */
+
+   bool is64bit = node->getDataType().isInt64();
+   TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::maddx : TR::InstOpCode::maddw;
+
+   /* Use xzr as the third source register */
+   TR::Register *zeroReg = cg->allocateRegister();
+   TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
+   addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
+
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, cg);
    }

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -465,7 +465,7 @@ TR::Instruction *generateLogicalShiftRightImmInstruction(
                    TR::Register *treg,
                    TR::Register *sreg,
                    uint32_t shiftAmount,
-                   TR::Instruction *preced);
+                   TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates LSL instruction
@@ -499,7 +499,23 @@ TR::Instruction *generateCompareImmInstruction(
                   TR::Node *node,
                   TR::Register *sreg,
                   int32_t imm,
-                  TR::Instruction *preced);
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates CMP (register) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] s1reg : source register 1
+ * @param[in] s2reg : source register 2
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateCompareInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *s1reg,
+                  TR::Register *s2reg,
+                  TR::Instruction *preced = NULL);
 
 /*
  * @brief Generates TST (immediate) instruction
@@ -515,6 +531,72 @@ TR::Instruction *generateTestImmInstruction(
                   TR::Node *node,
                   TR::Register *sreg,
                   int32_t imm,
-                  TR::Instruction *preced);
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates TST (register) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] s1reg : source register 1
+ * @param[in] s2reg : source register 2
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTestInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *s1reg,
+                  TR::Register *s2reg,
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates MOV (register) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] sreg : source register
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateMovInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates NEG (register) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] sreg : source register
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateNegInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *sreg,
+                  TR::Instruction *preced = NULL);
+
+/*
+ * @brief Generates MUL (register) instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] s1reg : source register 1
+ * @param[in] s2reg : source register 2
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateMulInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::Register *s1reg,
+                  TR::Register *s2reg,
+                  TR::Instruction *preced = NULL);
 
 #endif


### PR DESCRIPTION
This commit implements some more utility functions in
GenerateInstructions.* for aarch64 for generating instructions
that take xzr as one of target/source registers, in addition to the
functions added in #2888.

Signed-off-by: knn-k <konno@jp.ibm.com>