### PR TITLE
Add TR_J2IVirtualThunkPointer relocation kind

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -421,7 +421,8 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_NativeMethodRelative (57)",
    "TR_ArbitraryClassAddress (58)",
    "TR_DebugCounter (59)",
-   "TR_ClassUnloadAssumption (60)"
+   "TR_ClassUnloadAssumption (60)",
+   "TR_J2IVirtualThunkPointer (61)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -355,7 +355,8 @@ typedef enum
    TR_ArbitraryClassAddress               = 58,
    TR_DebugCounter                        = 59,
    TR_ClassUnloadAssumption               = 60, // this should not be used in AOT relocations
-   TR_NumExternalRelocationKinds          = 61,
+   TR_J2IVirtualThunkPointer              = 61,
+   TR_NumExternalRelocationKinds          = 62,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 


### PR DESCRIPTION
This kind can be used in downstream projects to describe a relocation
for JIT-compiled code that contains a pointer to a code sequence that
transitions control into an interpreter.