### PR TITLE
Fix overloaded virtual function hidden error

### DIFF
--- a/gc/base/segregated/MemorySubSpaceSegregated.cpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.cpp
@@ -212,13 +212,6 @@ MM_MemorySubSpaceSegregated::largestDesirableArraySpine()
 #endif /* defined(OMR_GC_ARRAYLETS) */
 
 void
-MM_MemorySubSpaceSegregated::collect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription)
-{
-	Assert_MM_unreachable();
-}
-
-
-void
 MM_MemorySubSpaceSegregated::abandonHeapChunk(void *addrBase, void *addrTop)
 {
 }

--- a/gc/base/segregated/MemorySubSpaceSegregated.hpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.hpp
@@ -89,7 +89,6 @@ public:
 	virtual const char *getName() { return MEMORY_SUBSPACE_NAME_UNDEFINED; }
 	virtual const char *getDescription() { return MEMORY_SUBSPACE_DESCRIPTION_UNDEFINED; }
 
-	virtual void collect(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription);
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
 
 #if defined(OMR_GC_ARRAYLETS)


### PR DESCRIPTION
While compiling **OpenJ9** with **Clang 9.1.0** on **OSX**, the following error was
seen:

```
In file included from MemorySubSpaceMetronome.cpp:39:
./MemorySubSpaceMetronome.hpp:69:8: error:
'MM_MemorySubSpaceMetronome::collect' hides overloaded virtual function
[-Werror,-Woverloaded-virtual]
        void collect(MM_EnvironmentBase *env, MM_GCCode gcCode);
             ^
../omr/gc/base/segregated/MemorySubSpaceSegregated.hpp:92:15: note:
hidden overloaded virtual function
'MM_MemorySubSpaceSegregated::collect' declared here: type mismatch at
2nd parameter ('MM_AllocateDescription *' vs 'MM_GCCode')
        virtual void collect(MM_EnvironmentBase *env,
MM_AllocateDescription *allocDescription);
```
 
The definition of `collect` differs in **MemorySubSpaceSegregated** (base
class) and **MemorySubSpaceMetronome** (derived class). This leads to the
above error.

In the base class, the virtual function `collect` doesn't get used. In
order to fix the above error, the unused definition of `collect` in the base class
has been removed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>