### PR TITLE
Remove TRMemory dependence on jitConfig

### DIFF
--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -175,12 +175,10 @@ class TR_MemoryBase
    {
 protected:
 
-   TR_MemoryBase(void * jitConfig) :
-      _jitConfig(jitConfig)
+   TR_MemoryBase()
       {}
 
-   TR_MemoryBase(const TR_MemoryBase &prototype) :
-      _jitConfig(prototype._jitConfig)
+   TR_MemoryBase(void * jitConfig)
       {}
 
 public:
@@ -460,16 +458,16 @@ public:
    static void *  jitPersistentAlloc(size_t size, ObjectType = UnknownType);
    static void    jitPersistentFree(void *mem);
 
-   protected:
-
-   void *    _jitConfig;
-
    };
 
 class TR_PersistentMemory : public TR_MemoryBase
    {
 public:
    static const uintptr_t MEMINFO_SIGNATURE = 0x1CEDD1CE;
+
+   TR_PersistentMemory (
+      TR::PersistentAllocator &persistentAllocator
+      );
 
    TR_PersistentMemory (
       void * jitConfig,
@@ -1029,7 +1027,7 @@ namespace TR
       {
       return GlobalAllocator(GlobalSingletonAllocator::instance());
       }
- 
+
    /*
     * some common CS2 datatypes
     */

--- a/compiler/env/TRPersistentMemory.cpp
+++ b/compiler/env/TRPersistentMemory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -64,10 +64,21 @@ void   TR_MemoryBase::jitPersistentFree(void * mem)                  { ::trPersi
 TR::PersistentInfo * TR_PersistentMemory::getNonThreadSafePersistentInfo() { return ::trPersistentMemory->getPersistentInfo(); }
 
 TR_PersistentMemory::TR_PersistentMemory(
+   TR::PersistentAllocator &persistentAllocator
+   ) :
+   TR_MemoryBase(),
+   _signature(MEMINFO_SIGNATURE),
+   _persistentInfo(this),
+   _persistentAllocator(TR::ref(persistentAllocator)),
+   _totalPersistentAllocations()
+   {
+   }
+
+TR_PersistentMemory::TR_PersistentMemory(
    void *   jitConfig,
    TR::PersistentAllocator &persistentAllocator
    ) :
-   TR_MemoryBase(jitConfig),
+   TR_MemoryBase(),
    _signature(MEMINFO_SIGNATURE),
    _persistentInfo(this),
    _persistentAllocator(TR::ref(persistentAllocator)),


### PR DESCRIPTION
The provided jitConfig is not used for anything any longer in the TRMemory
hierarchy.  Prepare to remove it.

This commit adds new constructors to the TRMemory hierarchy that do not take
a jitConfig argument to facilitate necessary changes to downstream projects.
The constructors that take a jitConfig will be removed once all known
downstream projects have been modified to use the new constructors without
jitConfig.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>