### PR TITLE
AArch64: Initial version of UnaryEvaluator.cpp

### DIFF
--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/TreeEvaluator.hpp"
+
+TR::Register *OMR::ARM64::TreeEvaluator::iconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::iconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::sconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::sconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::bconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::bconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::cconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::aconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::lconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::inegEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::lnegEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::iabsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::iabsEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::labsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::labsEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::i2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::i2sEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::i2bEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::i2bEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::b2iEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::b2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::b2lEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::l2iEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::iu2lEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::su2lEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::bu2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::bu2iEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}
+
+TR::Register *OMR::ARM64::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+	{
+	// TODO:ARM64: Enable TR::TreeEvaluator::bu2lEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
+	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
+	}


### PR DESCRIPTION
This commit implements skeleton functions of UnaryEvaluator.cpp for
aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>