### PR TITLE
Improve maxMinHelper in z/codegen 

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -910,6 +910,9 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
  */
 static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool isMax)
    {
+   TR_ASSERT_FATAL(cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196),
+      "cannot evaluate %s on z10 or below", node->getOpCode().getName());
+
    TR::Register *registerA = cg->gprClobberEvaluate(node->getFirstChild());
    TR::Register *registerB = cg->evaluate(node->getSecondChild());
    // Mask is 4 to pick b when a is Lower for max, 2 to pick b when a is higher for min

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -707,6 +707,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
       }
    else
       {
+      // Max min optimization uses the maxMinHelper evaluator which
+      // requires conditional loads that are not supported below z196
       comp->setOption(TR_DisableMaxMinOptimization);
       }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -705,6 +705,10 @@ OMR::Z::CodeGenerator::CodeGenerator()
       {
       self()->setSupportsAtomicLoadAndAdd();
       }
+   else
+      {
+      comp->setOption(TR_DisableMaxMinOptimization);
+      }
 
    if (_processorInfo.supportsArch(TR_S390ProcessorInfo::TR_zEC12))
       {

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(comptest
 	LogicalTest.cpp
 	LinkageTest.cpp
 	BitPermuteTest.cpp
+	MaxMinTest.cpp
 )
 
 target_link_libraries(comptest

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,6 +242,60 @@ std::vector<T> const_values()
                     };
    
    return std::vector<T>(inputArray, inputArray + sizeof(inputArray) / sizeof(T));
+   }
+
+/**
+ * @brief Convenience function returning possible test inputs of the specified type
+ */
+template <>
+inline std::vector<int64_t> const_values<int64_t>()
+   {
+   int64_t inputArray[] = { zero_value<int64_t>(),
+                      one_value<int64_t>(),
+                      negative_one_value<int64_t>(),
+                      positive_value<int64_t>(),
+                      negative_value<int64_t>(),
+                      std::numeric_limits<int64_t>::min(),
+                      std::numeric_limits<int64_t>::max(),
+                      static_cast<int64_t>(std::numeric_limits<int64_t>::min() + 1),
+                      static_cast<int64_t>(std::numeric_limits<int64_t>::max() - 1),
+                      0x000000000000005FL,
+                      0x0000000000000088L,
+                      0x0000000080000000L,
+                      0x7FFFFFFF7FFFFFFFL,
+                      0x00000000FFFF0FF0L,
+                      static_cast<int64_t>(0x800000007FFFFFFFL),
+                      static_cast<int64_t>(0xFFFFFFF00FFFFFFFL),
+                      static_cast<int64_t>(0x08000FFFFFFFFFFFL),
+                    };
+
+   return std::vector<int64_t>(inputArray, inputArray + sizeof(inputArray) / sizeof(int64_t));
+   }
+
+/**
+ * @brief Convenience function returning possible test inputs of the specified type
+ */
+template <>
+inline std::vector<int32_t> const_values<int32_t>()
+   {
+   int32_t inputArray[] = { zero_value<int32_t>(),
+                      one_value<int32_t>(),
+                      negative_one_value<int32_t>(),
+                      positive_value<int32_t>(),
+                      negative_value<int32_t>(),
+                      std::numeric_limits<int32_t>::min(),
+                      std::numeric_limits<int32_t>::max(),
+                      static_cast<int32_t>(std::numeric_limits<int32_t>::min() + 1),
+                      static_cast<int32_t>(std::numeric_limits<int32_t>::max() - 1),
+                      0x0000005F,
+                      0x00000088,
+                      static_cast<int32_t>(0x80FF0FF0),
+                      static_cast<int32_t>(0x80000000),
+                      static_cast<int32_t>(0xFF000FFF),
+                      static_cast<int32_t>(0xFFFFFF0F)
+                    };
+
+   return std::vector<int32_t>(inputArray, inputArray + sizeof(inputArray) / sizeof(int32_t));
    }
 
 /**

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "OpCodeTest.hpp"
+#include "default_compiler.hpp"
+
+int32_t imax(int32_t l, int32_t r) {
+  return l > r ? l : r;
+}
+
+int32_t imin(int32_t l, int32_t r) {
+  return l < r ? l : r;
+}
+
+int64_t lmax(int64_t l, int64_t r) {
+  return l > r ? l : r;
+}
+
+int64_t lmin(int64_t l, int64_t r) {
+  return l < r ? l : r;
+}
+
+std::vector<int64_t> longMaxMinTestValues()
+   {
+   std::vector<int64_t> longValues =TRTest::const_values<int64_t>();
+   longValues.push_back(0x80000000L);
+   return longValues;
+   }
+
+class Int32MaxMin : public TRTest::BinaryOpTest<int32_t> {};
+
+TEST_P(Int32MaxMin, UsingConst) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int32 (block (ireturn (%s (iconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(void)>();
+    volatile auto exp = param.oracle(param.lhs, param.rhs);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
+}
+
+TEST_P(Int32MaxMin, UsingLoadParam) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int32 args=[Int32, Int32] (block (ireturn (%s (iload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int32_t (*)(int32_t, int32_t)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+
+INSTANTIATE_TEST_CASE_P(MaxMin, Int32MaxMin, ::testing::Combine(
+    ::testing::ValuesIn(TRTest::combine(TRTest::const_values<int32_t>(), TRTest::const_values<int32_t>())),
+    ::testing::Values(
+        std::make_tuple("imax", imax),
+        std::make_tuple("imin", imin))));
+
+class Int64MaxMin : public TRTest::BinaryOpTest<int64_t> {};
+
+TEST_P(Int64MaxMin, UsingConst) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int64 (block (lreturn (%s (lconst %ld) (lconst %ld)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(void)>();
+    volatile auto exp = param.oracle(param.lhs, param.rhs);
+    volatile auto act = entry_point();
+    ASSERT_EQ(exp, act);
+}
+
+TEST_P(Int64MaxMin, UsingLoadParam) {
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[120] = {0};
+    std::snprintf(inputTrees, 120, "(method return=Int64 args=[Int64, Int64] (block (lreturn (%s (lload parm=0) (lload parm=1)) )))", param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler{trees};
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<int64_t (*)(int64_t, int64_t)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+
+INSTANTIATE_TEST_CASE_P(MaxMin, Int64MaxMin, ::testing::Combine(
+    ::testing::ValuesIn(TRTest::combine(longMaxMinTestValues(), longMaxMinTestValues())),
+    ::testing::Values(
+        std::make_tuple("lmax", lmax),
+        std::make_tuple("lmin", lmin))));

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -23,25 +23,44 @@
 #include "default_compiler.hpp"
 
 int32_t imax(int32_t l, int32_t r) {
-  return l > r ? l : r;
+  return std::max(l,r);
 }
 
 int32_t imin(int32_t l, int32_t r) {
-  return l < r ? l : r;
+  return std::min(l,r);
 }
 
 int64_t lmax(int64_t l, int64_t r) {
-  return l > r ? l : r;
+  return std::max(l,r);
 }
 
 int64_t lmin(int64_t l, int64_t r) {
-  return l < r ? l : r;
+  return std::min(l,r);
 }
+
+std::vector<int32_t> intMaxMinTestValues()
+   {
+   std::vector<int32_t> intValues = TRTest::const_values<int32_t>();
+   intValues.push_back(0x0000005F);
+   intValues.push_back(0x00000088);
+   intValues.push_back(0x80FF0FF0);
+   intValues.push_back(0x80000000);
+   intValues.push_back(0xFF000FFF);
+   intValues.push_back(0xFFFFFF0F);
+   return intValues;
+   }
 
 std::vector<int64_t> longMaxMinTestValues()
    {
-   std::vector<int64_t> longValues =TRTest::const_values<int64_t>();
-   longValues.push_back(0x80000000L);
+   std::vector<int64_t> longValues = TRTest::const_values<int64_t>();
+   longValues.push_back(0x000000000000005FL);
+   longValues.push_back(0x0000000000000088L);
+   longValues.push_back(0x0000000080000000L);
+   longValues.push_back(0x800000007FFFFFFFL);
+   longValues.push_back(0x7FFFFFFF7FFFFFFFL);
+   longValues.push_back(0x00000000FFFF0FF0L);
+   longValues.push_back(0xFFFFFFF00FFFFFFFL);
+   longValues.push_back(0x08000FFFFFFFFFFFL);
    return longValues;
    }
 
@@ -50,8 +69,18 @@ class Int32MaxMin : public TRTest::BinaryOpTest<int32_t> {};
 TEST_P(Int32MaxMin, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int32 (block (ireturn (%s (iconst %d) (iconst %d)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    char inputTrees[150] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32"
+        "  (block"
+        "    (ireturn"
+        "      (%s"
+        "        (iconst %lld)"
+        "        (iconst %lld))"
+        ")))",
+        param.opcode.c_str(),
+        param.lhs,
+        param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -61,16 +90,22 @@ TEST_P(Int32MaxMin, UsingConst) {
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<int32_t (*)(void)>();
-    volatile auto exp = param.oracle(param.lhs, param.rhs);
-    volatile auto act = entry_point();
-    ASSERT_EQ(exp, act);
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point());
 }
 
 TEST_P(Int32MaxMin, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
-    char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int32 args=[Int32, Int32] (block (ireturn (%s (iload parm=0) (iload parm=1)) )))", param.opcode.c_str());
+    char inputTrees[150] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int32, Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (%s"
+        "        (iload parm=0)"
+        "        (iload parm=1))"
+        ")))",
+        param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -85,7 +120,7 @@ TEST_P(Int32MaxMin, UsingLoadParam) {
 
 
 INSTANTIATE_TEST_CASE_P(MaxMin, Int32MaxMin, ::testing::Combine(
-    ::testing::ValuesIn(TRTest::combine(TRTest::const_values<int32_t>(), TRTest::const_values<int32_t>())),
+    ::testing::ValuesIn(TRTest::combine(intMaxMinTestValues(), intMaxMinTestValues())),
     ::testing::Values(
         std::make_tuple("imax", imax),
         std::make_tuple("imin", imin))));
@@ -95,8 +130,18 @@ class Int64MaxMin : public TRTest::BinaryOpTest<int64_t> {};
 TEST_P(Int64MaxMin, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
 
-    char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int64 (block (lreturn (%s (lconst %ld) (lconst %ld)) )))", param.opcode.c_str(), param.lhs, param.rhs);
+    char inputTrees[150] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64"
+        "  (block"
+        "    (lreturn"
+        "      (%s"
+        "        (lconst %lld)"
+        "        (lconst %lld))"
+        ")))",
+        param.opcode.c_str(),
+        param.lhs,
+        param.rhs);
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);
@@ -106,16 +151,22 @@ TEST_P(Int64MaxMin, UsingConst) {
     ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
 
     auto entry_point = compiler.getEntryPoint<int64_t (*)(void)>();
-    volatile auto exp = param.oracle(param.lhs, param.rhs);
-    volatile auto act = entry_point();
-    ASSERT_EQ(exp, act);
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point());
 }
 
 TEST_P(Int64MaxMin, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
 
-    char inputTrees[120] = {0};
-    std::snprintf(inputTrees, 120, "(method return=Int64 args=[Int64, Int64] (block (lreturn (%s (lload parm=0) (lload parm=1)) )))", param.opcode.c_str());
+    char inputTrees[150] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64 args=[Int64, Int64]"
+        "  (block"
+        "    (lreturn"
+        "      (%s"
+        "        (lload parm=0)"
+        "        (lload parm=1))"
+        ")))",
+        param.opcode.c_str());
     auto trees = parseString(inputTrees);
 
     ASSERT_NOTNULL(trees);

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -37,33 +37,6 @@ int64_t lmax(int64_t l, int64_t r) {
 int64_t lmin(int64_t l, int64_t r) {
   return std::min(l,r);
 }
-
-std::vector<int32_t> intMaxMinTestValues()
-   {
-   std::vector<int32_t> intValues = TRTest::const_values<int32_t>();
-   intValues.push_back(0x0000005F);
-   intValues.push_back(0x00000088);
-   intValues.push_back(0x80FF0FF0);
-   intValues.push_back(0x80000000);
-   intValues.push_back(0xFF000FFF);
-   intValues.push_back(0xFFFFFF0F);
-   return intValues;
-   }
-
-std::vector<int64_t> longMaxMinTestValues()
-   {
-   std::vector<int64_t> longValues = TRTest::const_values<int64_t>();
-   longValues.push_back(0x000000000000005FL);
-   longValues.push_back(0x0000000000000088L);
-   longValues.push_back(0x0000000080000000L);
-   longValues.push_back(0x800000007FFFFFFFL);
-   longValues.push_back(0x7FFFFFFF7FFFFFFFL);
-   longValues.push_back(0x00000000FFFF0FF0L);
-   longValues.push_back(0xFFFFFFF00FFFFFFFL);
-   longValues.push_back(0x08000FFFFFFFFFFFL);
-   return longValues;
-   }
-
 class Int32MaxMin : public TRTest::BinaryOpTest<int32_t> {};
 
 TEST_P(Int32MaxMin, UsingConst) {
@@ -120,7 +93,7 @@ TEST_P(Int32MaxMin, UsingLoadParam) {
 
 
 INSTANTIATE_TEST_CASE_P(MaxMin, Int32MaxMin, ::testing::Combine(
-    ::testing::ValuesIn(TRTest::combine(intMaxMinTestValues(), intMaxMinTestValues())),
+    ::testing::ValuesIn(TRTest::const_value_pairs<int32_t, int32_t>()),
     ::testing::Values(
         std::make_tuple("imax", imax),
         std::make_tuple("imin", imin))));
@@ -181,7 +154,7 @@ TEST_P(Int64MaxMin, UsingLoadParam) {
 
 
 INSTANTIATE_TEST_CASE_P(MaxMin, Int64MaxMin, ::testing::Combine(
-    ::testing::ValuesIn(TRTest::combine(longMaxMinTestValues(), longMaxMinTestValues())),
+    ::testing::ValuesIn(TRTest::const_value_pairs<int64_t, int64_t>()),
     ::testing::Values(
         std::make_tuple("lmax", lmax),
         std::make_tuple("lmin", lmin))));


### PR DESCRIPTION
This pull request improves the `maxMinHelper` evaluator
in Z codegen in 3 ways.
- Add guards for z10  in the evaluator and lower and disable max/min optimisations on unsupported platforms
- Rewrites the evaluator for lmin and lmax when using register pairs
- Add Tril tests to capture corner cases for this evaluator