### PR TITLE
Introduce new VirtualMachine<Stack,Array> hierarchy

### DIFF
--- a/compiler/ilgen/CMakeLists.txt
+++ b/compiler/ilgen/CMakeLists.txt
@@ -29,6 +29,7 @@ compiler_library(ilgen
 	${CMAKE_CURRENT_LIST_DIR}/OMRMethodBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRThunkBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRTypeDictionary.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineInterpreterArray.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineInterpreterStack.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineOperandArray.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineOperandStack.cpp

--- a/compiler/ilgen/CMakeLists.txt
+++ b/compiler/ilgen/CMakeLists.txt
@@ -29,6 +29,7 @@ compiler_library(ilgen
 	${CMAKE_CURRENT_LIST_DIR}/OMRMethodBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRThunkBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRTypeDictionary.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineInterpreterStack.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineOperandArray.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineOperandStack.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVirtualMachineRegister.cpp

--- a/compiler/ilgen/OMRIlValue.cpp
+++ b/compiler/ilgen/OMRIlValue.cpp
@@ -84,6 +84,18 @@ OMR::IlValue::load(TR::Block *block)
    return TR::Node::createLoad(_symRefThatCanBeUsedInOtherBlocks);
    }
 
+int32_t
+OMR::IlValue::get32bitConstValue()
+   {
+   return _nodeThatComputesValue->get32bitIntegralValue();
+   }
+
+int64_t
+OMR::IlValue::get64bitConstValue()
+   {
+   return _nodeThatComputesValue->get64bitIntegralValue();
+   }
+
 void
 OMR::IlValue::storeOver(TR::IlValue *value, TR::Block *block)
    {

--- a/compiler/ilgen/OMRIlValue.hpp
+++ b/compiler/ilgen/OMRIlValue.hpp
@@ -66,6 +66,9 @@ public:
     */
    TR::DataType getDataType();
 
+   int32_t get32bitConstValue();
+   int64_t get64bitConstValue();
+
    /**
     * @brief returns the TR::SymbolReference holding the value, or NULL if willBeUsedInAnotherBlock() has not yet been called
     * Caller should ensure the current block is different than the block that computes the value; if the current block is the

--- a/compiler/ilgen/OMRVirtualMachineArray.hpp
+++ b/compiler/ilgen/OMRVirtualMachineArray.hpp
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEARRAY_INCL
+#define OMR_VIRTUALMACHINEARRAY_INCL
+
+#include <stdint.h>
+#include "ilgen/VirtualMachineState.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+namespace TR { class MethodBuilder; }
+namespace TR { class VirtualMachineRegister; }
+namespace TR { class VirtualMachineArray; }
+
+namespace OMR
+{
+
+/**
+ * @brief Interface for expressing a virtual machine array to JitBuilder
+ *
+ * VirtualMachineArray subclasses VirtualMachineState but does not provide any
+ * concrete implementations.
+ *
+ * VirtualMachineArray implementations provide several array-y operations:
+ *   Get() gets a TR::IlValue from the array
+ *   Set() sets an TR::IlValue at index in the array
+ *   Move() copies an element from srcIndex to dstIndex in the array
+ *
+ */
+
+class VirtualMachineArray : public TR::VirtualMachineState
+   {
+   public:
+   /**
+    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
+    */
+   VirtualMachineArray()
+      : TR::VirtualMachineState()
+      {
+      }
+
+   /**
+    * @brief update the values used to read and write the array
+    * @param b the builder where the values will be placed
+    * @param array the new array base address.
+    */
+   virtual void UpdateArray(TR::IlBuilder *b, TR::IlValue *array) = 0;
+
+   /**
+    * @brief Returns the expression at the given index of the array
+    * @param index the location of the expression to return
+    * @returns the expression at the given index
+    */
+   virtual TR::IlValue *Get(TR::IlBuilder *b, int32_t index) = 0;
+
+   /**
+    * @brief Returns the expression at the given index of the array
+    * @param index the location of the expression to return
+    * @returns the expression at the given index
+    */
+   virtual TR::IlValue *Get(TR::IlBuilder *b, TR::IlValue *index) = 0;
+
+   /**
+    * @brief Set the expression into the array at the given index
+    * @param index the location to store the expression
+    * @param value expression to store into the array
+    */
+   virtual void Set(TR::IlBuilder *b, int32_t index, TR::IlValue *value) = 0;
+
+   /**
+    * @brief Set the expression into the array at the given index
+    * @param index the location to store the expression
+    * @param value expression to store into the array
+    */
+   virtual void Set(TR::IlBuilder *b, TR::IlValue *index, TR::IlValue *value) = 0;
+
+   /**
+    * @brief Move the expression from one index to another index in the array
+    * @param dstIndex the location to store the expression
+    * @param srcIndex the location to copy the expression from
+    */
+   virtual void Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex) = 0;
+
+   /**
+    * @brief Move the expression from one index to another index in the array
+    * @param dstIndex the location to store the expression
+    * @param srcIndex the location to copy the expression from
+    */
+   virtual void Move(TR::IlBuilder *b, TR::IlValue *dstIndex, TR::IlValue *srcIndex) = 0;
+
+   protected:
+
+   private:
+   };
+}
+#endif // !defined(OMR_VIRTUALMACHINEARRAY_INCL)

--- a/compiler/ilgen/OMRVirtualMachineInterpreterArray.cpp
+++ b/compiler/ilgen/OMRVirtualMachineInterpreterArray.cpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ilgen/VirtualMachineInterpreterArray.hpp"
+
+#include "compile/Compilation.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "ilgen/BytecodeBuilder.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+
+OMR::VirtualMachineInterpreterArray::VirtualMachineInterpreterArray(TR::MethodBuilder *mb, TR::IlType *elementType, TR::VirtualMachineRegister *arrayBaseRegister)
+   : TR::VirtualMachineArray(),
+   _mb(mb),
+   _elementType(elementType),
+   _arrayBaseRegister(arrayBaseRegister)
+   {
+   }
+
+void
+OMR::VirtualMachineInterpreterArray::UpdateArray(TR::IlBuilder *b, TR::IlValue *array)
+   {
+   _arrayBaseRegister->Store(b, array);
+   }
+
+TR::VirtualMachineState *
+OMR::VirtualMachineInterpreterArray::MakeCopy()
+   {
+   return static_cast<TR::VirtualMachineState *>(this);
+   }
+
+TR::IlValue *
+OMR::VirtualMachineInterpreterArray::Get(TR::IlBuilder *b, int32_t index)
+   {
+   return Get(b, b->ConstInt32(index));
+   }
+
+TR::IlValue *
+OMR::VirtualMachineInterpreterArray::Get(TR::IlBuilder *b, TR::IlValue *index)
+   {
+   TR::IlType *pElementType = _mb->typeDictionary()->PointerTo(_elementType);
+   TR::IlValue *arrayBase = _arrayBaseRegister->Load(b);
+
+   return b->LoadAt(pElementType,
+          b->   IndexAt(pElementType, arrayBase, index));
+   }
+
+void
+OMR::VirtualMachineInterpreterArray::Set(TR::IlBuilder *b, int32_t index, TR::IlValue *value)
+   {
+   Set(b, b->ConstInt32(index), value);
+   }
+
+void
+OMR::VirtualMachineInterpreterArray::Set(TR::IlBuilder *b, TR::IlValue *index, TR::IlValue *value)
+   {
+   TR::IlType *pElementType = _mb->typeDictionary()->PointerTo(_elementType);
+   TR::IlValue *arrayBase = _arrayBaseRegister->Load(b);
+
+   b->StoreAt(
+   b->   IndexAt(pElementType, arrayBase, index),
+         value);
+   }
+
+void
+OMR::VirtualMachineInterpreterArray::Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex)
+   {
+   Move(b, b->ConstInt32(dstIndex), b->ConstInt32(srcIndex));
+   }
+
+void
+OMR::VirtualMachineInterpreterArray::Move(TR::IlBuilder *b, TR::IlValue *dstIndex, TR::IlValue *srcIndex)
+   {
+   TR::IlValue *value = Get(b, srcIndex);
+   Set(b, dstIndex, value);
+   }

--- a/compiler/ilgen/OMRVirtualMachineInterpreterArray.hpp
+++ b/compiler/ilgen/OMRVirtualMachineInterpreterArray.hpp
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEINTERPRETERARRAY_INCL
+#define OMR_VIRTUALMACHINEINTERPRETERARRAY_INCL
+
+#include <stdint.h>
+#include "ilgen/VirtualMachineArray.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+namespace TR { class MethodBuilder; }
+namespace TR { class VirtualMachineRegister; }
+namespace TR { class VirtualMachineInterpreterArray; }
+
+namespace OMR
+{
+/**
+ * @brief Implementation for reading / writing directly to a virtual machine array
+ *
+ * VirtualMachineInterpreterArray subclasses VirtualMachineArray to provide a concrete
+ * implementation that reads / writes directly to the VirtualMachineRegister arrayBase.
+ *
+ * VirtualMachineInterpreterArray implements VirtualMachineArray:
+ * Commit() no-op
+ * Reload() no-op
+ * MakeCopy() returns self
+ * MergeInto() no-op
+ *
+ * VirtualMachineInterpreterArray array-y operations:
+ *   Get() gets a TR::IlValue from the VirtualMachineRegister arrayBase
+ *   Set() sets a TR::IlValue into `index' of the VirtualMachineRegister arrayBase
+ *   Move() copies an element from srcIndex to dstIndex in the VirtualMachineRegister arrayBase
+ */
+
+class VirtualMachineInterpreterArray : public TR::VirtualMachineArray
+   {
+   public:
+   /**
+    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
+    * @param mb TR::MethodBuilder object of the method currently being compiled
+    * @param elementType TR::IlType representing the underlying type of the virtual machine's operand array entries
+    * @param arrayBase previously allocated and initialized VirtualMachineRegister representing the base of the array
+    */
+   VirtualMachineInterpreterArray(TR::MethodBuilder *mb, TR::IlType *elementType, TR::VirtualMachineRegister *arrayBase);
+
+   /**
+    * @brief does nothing since the implementation reads / writes directly to the virtual machine array
+    * @param b the builder where the operations will be placed to recreate the virtual machine operand array
+    */
+   virtual void Commit(TR::IlBuilder *b) {}
+   
+   /**
+    * @brief does nothing since the implementation reads / writes directly to the virtual machine array
+    * @param b the builder where the operations will be placed to recreate the array
+    */
+   virtual void Reload(TR::IlBuilder *b) {}
+
+   /**
+    * @brief returns self
+    * @returns the urrent object
+    */
+   virtual TR::VirtualMachineState *MakeCopy();
+
+   /**
+    * @brief does nothing since the implementation reads / writes directly to the virtual machine array
+    * @param other array for the builder object control is merging into
+    * @param b builder object where the operations will be added to make the current array the same as the other
+    */
+   virtual void MergeInto(TR::VirtualMachineState *other, TR::IlBuilder *b) {}
+   
+   /**
+    * @brief update the values used to read and write the virtual machine array
+    * @param b the builder where the values will be placed
+    * @param array the new array base address.
+    */
+   virtual void UpdateArray(TR::IlBuilder *b, TR::IlValue *array);
+
+   /**
+    * @brief Returns the expression at the given index of the array
+    * @param index the location of the expression to return
+    * @returns the expression at the given index
+    */
+   virtual TR::IlValue *Get(TR::IlBuilder *b, int32_t index);
+   
+   /**
+    * @brief Returns the expression at the given index of the array
+    * @param index an IlValue representing the location of the expression to return
+    * @returns the expression at the given index
+    */
+   virtual TR::IlValue *Get(TR::IlBuilder *b, TR::IlValue *index);
+
+   /**
+    * @brief Set the expression into the array at the given index
+    * @param index the location to store the expression
+    * @param value expression to store into the array
+    */
+   virtual void Set(TR::IlBuilder *b, int32_t index, TR::IlValue *value);
+
+   /**
+    * @brief Set the expression into the array at the given index
+    * @param index the location to store the expression
+    * @param value expression to store into the array
+    */
+   virtual void Set(TR::IlBuilder *b, TR::IlValue *index, TR::IlValue *value);
+  
+   /**
+    * @brief Move the expression from one index to another index in the array
+    * @param dstIndex the location to store the expression
+    * @param srcIndex the location to copy the expression from
+    */ 
+   virtual void Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex);
+
+   /**
+    * @brief Move the expression from one index to another index in the array
+    * @param dstIndex the location to store the expression
+    * @param srcIndex the location to copy the expression from
+    */
+   virtual void Move(TR::IlBuilder *b, TR::IlValue *dstIndex, TR::IlValue *srcIndex);
+
+   protected:
+   void init();
+
+   private:
+   TR::MethodBuilder *_mb;
+   TR::VirtualMachineRegister *_arrayBaseRegister;
+   TR::IlType *_elementType;
+   };
+}
+#endif // !defined(OMR_VIRTUALMACHINEINTERPRETERARRAY_INCL)

--- a/compiler/ilgen/OMRVirtualMachineInterpreterStack.cpp
+++ b/compiler/ilgen/OMRVirtualMachineInterpreterStack.cpp
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2016 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "env/TRMemory.hpp"   // include first to get correct TR_ALLOC definition
+#include "ilgen/VirtualMachineInterpreterStack.hpp"
+#include "ilgen/VirtualMachineRegister.hpp"
+#include "compile/Compilation.hpp"
+#include "il/SymbolReference.hpp"
+#include "il/symbol/AutomaticSymbol.hpp"
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/MethodBuilder.hpp"
+#include "ilgen/TypeDictionary.hpp"
+
+OMR::VirtualMachineInterpreterStack::VirtualMachineInterpreterStack(TR::MethodBuilder *mb, TR::VirtualMachineRegister *stackTopRegister, TR::IlType *elementType, bool growsUp, bool preAdjust)
+   : TR::VirtualMachineStack(),
+   _mb(mb),
+   _stackTopRegister(stackTopRegister),
+   _elementType(elementType),
+   _stackBaseName(NULL),
+   _growsUp(growsUp),
+   _preAdjust(preAdjust)
+   {
+   init();
+   }
+
+void
+OMR::VirtualMachineInterpreterStack::UpdateStack(TR::IlBuilder *b, TR::IlValue *stack)
+   {
+   TR::IlValue *initialBase = b->Load(_stackBaseName);
+   initialBase = b->ConvertTo(_mb->typeDictionary()->toIlType<int64_t>(), initialBase);
+   TR::IlValue *currentBase = _stackTopRegister->Load(b);
+   currentBase = b->ConvertTo(_mb->typeDictionary()->toIlType<int64_t>(), currentBase);
+   TR::IlValue *delta = b->Sub(currentBase, initialBase);
+
+   b->Store(_stackBaseName, stack);
+   TR::IlValue *newStackTop = b->Add(stack, delta);
+   _stackTopRegister->Store(b, newStackTop);
+   }
+
+TR::VirtualMachineState *
+OMR::VirtualMachineInterpreterStack::MakeCopy()
+   {
+   return static_cast<TR::VirtualMachineState *>(this);
+   } 
+
+void
+OMR::VirtualMachineInterpreterStack::Push(TR::IlBuilder *builder, TR::IlValue *value)
+   {
+   TR::IlValue *stackAddress = _stackTopRegister->Load(builder);
+   if (_growsUp)
+      _stackTopRegister->Adjust(builder, 1);
+   else
+      _stackTopRegister->Adjust(builder, -1);
+
+   if (_preAdjust)
+      stackAddress = _stackTopRegister->Load(builder);
+
+   builder->StoreAt(
+               stackAddress,
+   builder->   ConvertTo(_elementType, value));
+   }
+
+TR::IlValue *
+OMR::VirtualMachineInterpreterStack::Top(TR::IlBuilder *builder)
+   {
+   TR::IlValue *stackAddress = _stackTopRegister->Load(builder);
+   TR::IlType *pElementType = _mb->typeDictionary()->PointerTo(_elementType);
+
+   int32_t offset = 0;
+   if (!_preAdjust)
+      {
+      if (_growsUp)
+         {
+         offset = -1;
+         }
+      else
+         {
+         offset = 1;
+         }
+      }
+
+   TR::IlValue *value =
+   builder->LoadAt(pElementType,
+   builder->   IndexAt(pElementType,
+                  stackAddress,
+   builder->      ConstInt32(offset)));
+   return value;
+   }
+
+TR::IlValue *
+OMR::VirtualMachineInterpreterStack::Pop(TR::IlBuilder *builder)
+   {
+   TR::IlValue *stackAddress = _stackTopRegister->Load(builder);
+   if (_growsUp)
+      _stackTopRegister->Adjust(builder, -1);
+   else
+      _stackTopRegister->Adjust(builder, 1);
+
+   if (!_preAdjust)
+      stackAddress = _stackTopRegister->Load(builder);
+
+   TR::IlType *pElementType = _mb->typeDictionary()->PointerTo(_elementType);
+   return builder->LoadAt(pElementType, stackAddress);
+   }
+
+TR::IlValue *
+OMR::VirtualMachineInterpreterStack::Pick(TR::IlBuilder *builder, int32_t depth)
+   {
+   return Pick(builder, builder->ConstInt32(depth));
+   }
+
+TR::IlValue *
+OMR::VirtualMachineInterpreterStack::Pick(TR::IlBuilder *builder, TR::IlValue *depth)
+   {
+   if (!_preAdjust)
+      {
+      TR::IlValue *one = builder->ConstInt32(1);
+      depth = builder->Add(depth, one);
+      }
+   TR::IlValue *negatedDepth = builder->Negate(depth);
+   if (_growsUp)
+      _stackTopRegister->Adjust(builder, negatedDepth);
+   else
+      _stackTopRegister->Adjust(builder, depth);
+
+   TR::IlValue *stackAddress = _stackTopRegister->Load(builder);
+   TR::IlType *pElementType = _mb->typeDictionary()->PointerTo(_elementType);
+   TR::IlValue *result = builder->LoadAt(pElementType, stackAddress);
+
+   if (_growsUp)
+      _stackTopRegister->Adjust(builder, depth);
+   else
+      _stackTopRegister->Adjust(builder, negatedDepth);
+
+   return result;
+   }
+
+void
+OMR::VirtualMachineInterpreterStack::Drop(TR::IlBuilder *builder, int32_t depth)
+   {
+   Drop(builder, builder->ConstInt32(depth));
+   }
+
+void
+OMR::VirtualMachineInterpreterStack::Drop(TR::IlBuilder *builder, TR::IlValue *depth)
+   {
+   TR::IlValue *negatedDepth = builder->Negate(depth);
+   _stackTopRegister->Adjust(builder, negatedDepth);
+   }
+
+void
+OMR::VirtualMachineInterpreterStack::Dup(TR::IlBuilder *builder)
+   {
+   Push(builder, Top(builder));
+   }
+
+void
+OMR::VirtualMachineInterpreterStack::init()
+   {
+   TR::Compilation *comp = TR::comp();
+   // Create a temp for the OperandStack base
+   TR::SymbolReference *symRef = comp->getSymRefTab()->createTemporary(_mb->methodSymbol(), _mb->typeDictionary()->PointerTo(_elementType)->getPrimitiveType());
+   symRef->getSymbol()->setNotCollected();
+   char *name = (char *) comp->trMemory()->allocateHeapMemory((11+10+1) * sizeof(char)); // 11 ("_StackBase_") + max 10 digits + trailing zero
+   sprintf(name, "_StackBase_%u", symRef->getCPIndex());
+   symRef->getSymbol()->getAutoSymbol()->setName(name);
+   _mb->defineSymbol(name, symRef);
+   _stackBaseName = symRef->getSymbol()->getAutoSymbol()->getName();
+   // store current stack value so that we can use this when MoveStack is called
+   _mb->Store(_stackBaseName, _stackTopRegister->Load(_mb));
+   }

--- a/compiler/ilgen/OMRVirtualMachineInterpreterStack.hpp
+++ b/compiler/ilgen/OMRVirtualMachineInterpreterStack.hpp
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINEINTERPRETERSTACK_INCL
+#define OMR_VIRTUALMACHINEINTERPRETERSTACK_INCL
+
+#include <stdint.h>
+
+#include "ilgen/VirtualMachineStack.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class IlValue; }
+namespace TR { class IlType; }
+namespace TR { class MethodBuilder; }
+namespace TR { class VirtualMachineInterpreterStack; }
+namespace TR { class VirtualMachineRegister; }
+
+namespace OMR
+{
+
+/**
+ * @brief simulates an operand stack used by many bytecode based virtual machines
+ * In such virtual machines, the operand stack holds the intermediate expression values
+ * computed by the bytecodes. The compiler simulates this operand stack as well, but
+ * what is pushed to and popped from the simulated operand stack are expression nodes
+ * that represent the value computed by the bytecodes. As each bytecode pops expression
+ * nodes off the operand stack, it combines them to form more complicated expressions
+ * which are then pushed back onto the operand stack for consumption by other bytecodes.
+ *
+ * VirtualMachineInterpreterStack implements VirtualMachineState:
+ * Commit() no-op
+ * Reload() no-op
+ * MakeCopy() returns this
+ * MergeInto() no-op
+ *
+ * VirtualMachineInterpreterStack provides several stack-y operations:
+ *   Push() pushes a TR::IlValue onto the stack
+ *   Pop() pops and returns a TR::IlValue from the stack
+ *   Top() returns the TR::IlValue at the top of the stack
+ *   Pick() returns the TR::IlValue "depth" elements from the top
+ *   Drop() discards "depth" elements from the stack
+ *   Dup() is a convenience function for Push(Top())
+ *
+ */
+
+class VirtualMachineInterpreterStack : public TR::VirtualMachineStack
+   {
+   public:
+
+  /**
+    * @brief public constructor, must be instantiated inside a compilation because uses heap memory
+    * @param mb TR::MethodBuilder object of the method currently being compiled
+    * @param stackTop previously allocated and initialized VirtualMachineRegister representing the top of stack
+    * @param elementType TR::IlType representing the underlying type of the virtual machine's operand stack entries
+    * @param growsUp to configure virtual machine stack growth direction, set to true if virtual machine stack grows towards larger addresses, false otherwise
+    * @param preAdjust is true if the stack is to be adjusted before storing, false otherwise
+    */
+   VirtualMachineInterpreterStack(TR::MethodBuilder *mb, TR::VirtualMachineRegister *stackTopRegister, TR::IlType *elementType, bool growsUp = true, bool preAdjust = true);
+
+   /**
+    * @brief does not do anything since this stack reads//write directly to the virtual machine stack
+    * @param b the builder where the operations will be placed to recreate the virtual machine operand stack
+    */
+   virtual void Commit(TR::IlBuilder *b) {}
+
+   /**
+    * @brief does not do anything since this stack reads//write directly to the virtual machine stack
+    * @param b the builder where the operations will be placed to recreate the stack
+    */
+   virtual void Reload(TR::IlBuilder *b) {}
+
+   /**
+    * @brief return the current object.
+    * @returns the current object
+    */
+   virtual TR::VirtualMachineState *MakeCopy();
+
+   /**
+    * @brief does not do anything as the stacks should all be the same object
+    * @param other stack for the builder object control is merging into
+    * @param b builder object where the operations will be added to make the current stack the same as the other
+    */
+   virtual void MergeInto(TR::VirtualMachineState *other, TR::IlBuilder *b) {}
+
+   /**
+    * @brief update the values used to read and write the virtual machine stack
+    * @param b the builder where the values will be placed
+    * @param stack the new stack base address.  It is assumed that the address is already adjusted to _stackOffset
+    */
+   virtual void UpdateStack(TR::IlBuilder *b, TR::IlValue *stack);
+
+   /**
+    * @brief Push an expression onto the stack
+    * @param b builder object to use for any operations used to implement the push (e.g. update the top of stack)
+    * @param value expression to push onto the stack
+    */
+   virtual void Push(TR::IlBuilder *b, TR::IlValue *value);
+
+   /**
+    * @brief Pops an expression from the top of the stack
+    * @param b builder object to use for any operations used to implement the pop (e.g. to update the top of stack)
+    * @returns expression popped from the stack
+    */
+   virtual TR::IlValue *Pop(TR::IlBuilder *b);
+
+   /**
+    * @brief Returns the expression at the top of the stack
+    * @param b builder object to use for any operations used to implement the pop (e.g. to update the top of stack)
+    * @returns the expression at the top of the stack
+    */
+   virtual TR::IlValue *Top(TR::IlBuilder *b);
+
+   /**
+    * @brief Returns an expression below the top of the stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    * @returns the requested expression from the stack
+    */
+   virtual TR::IlValue *Pick(TR::IlBuilder *b, int32_t depth);
+
+   /**
+    * @brief Returns an expression below the top of the stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    * @returns the requested expression from the stack
+    */
+   virtual TR::IlValue *Pick(TR::IlBuilder *b, TR::IlValue *depth);
+
+   /**
+    * @brief Removes some number of expressions from the stack
+    * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
+    * @param depth how many values to drop from the stack
+    */
+   virtual void Drop(TR::IlBuilder *b, int32_t depth);
+
+   /**
+    * @brief Removes some number of expressions from the stack
+    * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
+    * @param depth how many values to drop from the stack
+    */
+   virtual void Drop(TR::IlBuilder *b, TR::IlValue *depth);
+
+   /**
+    * @brief Duplicates the expression on top of the stack
+    * @param b builder object to use for any operations used to duplicate the expression (e.g. to update the top of stack)
+    */
+   virtual void Dup(TR::IlBuilder *b);
+
+   protected:
+   void init();
+
+   private:
+   TR::MethodBuilder *_mb;
+   TR::VirtualMachineRegister *_stackTopRegister;
+   TR::IlType *_elementType;
+   const char *_stackBaseName;
+   bool _growsUp;
+   bool _preAdjust;
+   };
+}
+#endif // !defined(OMR_VIRTUALMACHINEINTERPRETERSTACK_INCL)

--- a/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
@@ -34,7 +34,7 @@
 #define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(TR::comp(), m, ##__VA_ARGS__);}}
 
 OMR::VirtualMachineOperandArray::VirtualMachineOperandArray(TR::MethodBuilder *mb, int32_t numOfElements, TR::IlType *elementType, TR::VirtualMachineRegister *arrayBaseRegister)
-   : TR::VirtualMachineState(),
+   : TR::VirtualMachineArray(),
    _mb(mb),
    _numberOfElements(numOfElements),
    _elementType(elementType),
@@ -44,7 +44,7 @@ OMR::VirtualMachineOperandArray::VirtualMachineOperandArray(TR::MethodBuilder *m
    }
 
 OMR::VirtualMachineOperandArray::VirtualMachineOperandArray(TR::VirtualMachineOperandArray *other)
-   : TR::VirtualMachineState(),
+   : TR::VirtualMachineArray(),
    _mb(other->_mb),
    _numberOfElements(other->_numberOfElements),
    _elementType(other->_elementType),
@@ -139,15 +139,22 @@ OMR::VirtualMachineOperandArray::MakeCopy()
    }
 
 TR::IlValue *
-OMR::VirtualMachineOperandArray::Get(int32_t index)
+OMR::VirtualMachineOperandArray::Get(TR::IlBuilder *b, int32_t index)
    {
    TR_ASSERT(index < _numberOfElements, "index has to be less than the number of elements");
    TR_ASSERT(index >= 0, "index can not be negative");
    return _values[index];
    }
 
+TR::IlValue *
+OMR::VirtualMachineOperandArray::Get(TR::IlBuilder *b, TR::IlValue *index)
+   {
+   TR_ASSERT(NULL != index, "index can not be NULL");
+   return Get(b, index->get32bitConstValue());
+   }
+
 void
-OMR::VirtualMachineOperandArray::Set(int32_t index, TR::IlValue *value)
+OMR::VirtualMachineOperandArray::Set(TR::IlBuilder *b, int32_t index, TR::IlValue *value)
    {
    TR_ASSERT(index < _numberOfElements, "index has to be less than the number of elements");
    TR_ASSERT(index >= 0, "index can not be negative");
@@ -164,6 +171,12 @@ OMR::VirtualMachineOperandArray::Set(int32_t index, TR::IlValue *value)
    _values[index] = value;
    }
 
+void
+OMR::VirtualMachineOperandArray::Set(TR::IlBuilder *b, TR::IlValue *index, TR::IlValue *value)
+   {
+   TR_ASSERT(NULL != index, "index can not be NULL");
+   Set(b, index->get32bitConstValue(), value);
+   }
 
 void
 OMR::VirtualMachineOperandArray::Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex)
@@ -175,6 +188,12 @@ OMR::VirtualMachineOperandArray::Move(TR::IlBuilder *b, int32_t dstIndex, int32_
 
    _values[dstIndex] = b->Copy(_values[srcIndex]);
    TraceIL("VirtualMachineOperandArray[ %p ]::Move builder %p move srcIndex %d %p(%d) to dstIndex %d %p(%d)\n", this, b, srcIndex, _values[srcIndex], _values[srcIndex]->getID(), dstIndex, _values[dstIndex], _values[dstIndex]->getID());
+   }
+
+void
+OMR::VirtualMachineOperandArray::Move(TR::IlBuilder *b, TR::IlValue *dstIndex, TR::IlValue *srcIndex)
+   {
+   Move(b, dstIndex->get32bitConstValue(), srcIndex->get32bitConstValue());
    }
 
 void

--- a/compiler/ilgen/OMRVirtualMachineOperandArray.hpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandArray.hpp
@@ -23,7 +23,7 @@
 #define OMR_VIRTUALMACHINEOPERANDARRAY_INCL
 
 #include <stdint.h>
-#include "ilgen/VirtualMachineState.hpp"
+#include "ilgen/VirtualMachineArray.hpp"
 
 namespace TR { class IlBuilder; }
 namespace TR { class IlType; }
@@ -64,7 +64,7 @@ namespace OMR
  *
  */
 
-class VirtualMachineOperandArray : public TR::VirtualMachineState
+class VirtualMachineOperandArray : public TR::VirtualMachineArray
    {
    public:
    /**
@@ -120,14 +120,28 @@ class VirtualMachineOperandArray : public TR::VirtualMachineState
     * @param index the location of the expression to return
     * @returns the expression at the given index
     */
-   virtual TR::IlValue *Get(int32_t index);
+   virtual TR::IlValue *Get(TR::IlBuilder *b, int32_t index);
    
+   /**
+    * @brief Returns the expression at the given index of the simulated operand array
+    * @param index the location of the expression to return
+    * @returns the expression at the given index
+    */
+   virtual TR::IlValue *Get(TR::IlBuilder *b, TR::IlValue *index);
+
    /**
     * @brief Set the expression into the simulated operand array at the given index
     * @param index the location to store the expression
     * @param value expression to store into the simulated operand array
     */
-   virtual void Set(int32_t index, TR::IlValue *value);
+   virtual void Set(TR::IlBuilder *b, int32_t index, TR::IlValue *value);
+
+   /**
+    * @brief Set the expression into the simulated operand array at the given index
+    * @param index the location to store the expression
+    * @param value expression to store into the simulated operand array
+    */
+   virtual void Set(TR::IlBuilder *b, TR::IlValue *index, TR::IlValue *value);
   
    /**
     * @brief Move the expression from one index to another index in the simulated operand array
@@ -135,6 +149,13 @@ class VirtualMachineOperandArray : public TR::VirtualMachineState
     * @param srcIndex the location to copy the expression from
     */ 
    virtual void Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex);
+
+   /**
+    * @brief Move the expression from one index to another index in the simulated operand array
+    * @param dstIndex the location to store the expression
+    * @param srcIndex the location to copy the expression from
+    */
+   virtual void Move(TR::IlBuilder *b, TR::IlValue *dstIndex, TR::IlValue *srcIndex);
 
    protected:
    void init();

--- a/compiler/ilgen/OMRVirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandStack.hpp
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 
-#include "ilgen/VirtualMachineState.hpp"
+#include "ilgen/VirtualMachineStack.hpp"
 
 namespace TR { class IlBuilder; }
 namespace TR { class IlValue; }
@@ -79,7 +79,7 @@ namespace OMR
  *
  */
 
-class VirtualMachineOperandStack : public TR::VirtualMachineState
+class VirtualMachineOperandStack : public TR::VirtualMachineStack
    {
    public:
   
@@ -135,7 +135,7 @@ class VirtualMachineOperandStack : public TR::VirtualMachineState
     * @param other operand stack for the builder object control is merging into
     * @param b builder object where the operations will be added to make the current operand stack the same as the other
     */
-   virtual void MergeInto(TR::VirtualMachineOperandStack *other, TR::IlBuilder *b);
+   virtual void MergeInto(TR::VirtualMachineState *other, TR::IlBuilder *b);
 
    /**
     * @brief update the values used to read and write the virtual machine stack
@@ -157,14 +157,22 @@ class VirtualMachineOperandStack : public TR::VirtualMachineState
     * @returns expression popped from the stack
     */
    virtual TR::IlValue *Pop(TR::IlBuilder *b);
-
+   
    /**
+    * @deprecated This API has been replaced by Top(TR::IlBuilder *)
     * @brief Returns the expression at the top of the simulated operand stack
     * @returns the expression at the top of the operand stack
     */
    virtual TR::IlValue *Top();
 
    /**
+    * @brief Returns the expression at the top of the simulated operand stack
+    * @returns the expression at the top of the operand stack
+    */
+   virtual TR::IlValue *Top(TR::IlBuilder *b);
+   
+   /**
+    * @deprecated This API has been replaced by Pick(TR::IlBuilder *, int32_t)
     * @brief Returns an expression below the top of the simulated operand stack
     * @param depth number of values below top (Pick(0) is same as Top())
     * @returns the requested expression from the operand stack
@@ -172,11 +180,36 @@ class VirtualMachineOperandStack : public TR::VirtualMachineState
    virtual TR::IlValue *Pick(int32_t depth);
 
    /**
+    * @brief Returns an expression below the top of the simulated operand stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    * @returns the requested expression from the operand stack
+    */
+   virtual TR::IlValue *Pick(TR::IlBuilder *b, int32_t depth);
+
+   /**
+    * @brief Returns an expression below the top of the simulated operand stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    *              The value for depth is required to be an IlValue created
+    *              using one of the IlBuilder::Const*() APIs
+    * @returns the requested expression from the operand stack
+    */
+   virtual TR::IlValue *Pick(TR::IlBuilder *b, TR::IlValue *depth);
+
+   /**
     * @brief Removes some number of expressions from the operand stack
     * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
     * @param depth how many values to drop from the stack
     */
    virtual void Drop(TR::IlBuilder *b, int32_t depth);
+
+   /**
+    * @brief Removes some number of expressions from the operand stack
+    * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
+    * @param depth how many values to drop from the stack
+    *              The value for depth is required to be an IlValue created
+    *              using one of the IlBuilder::Const*() APIs
+    */
+   virtual void Drop(TR::IlBuilder *b, TR::IlValue *depth);
 
    /**
     * @brief Duplicates the expression on top of the simulated operand stack

--- a/compiler/ilgen/OMRVirtualMachineStack.hpp
+++ b/compiler/ilgen/OMRVirtualMachineStack.hpp
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_VIRTUALMACHINESTACK_INCL
+#define OMR_VIRTUALMACHINESTACK_INCL
+
+#include <stdint.h>
+
+#include "ilgen/VirtualMachineState.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class IlValue; }
+namespace TR { class VirtualMachineStack; }
+namespace TR { class VirtualMachineRegister; }
+
+namespace OMR
+{
+
+/**
+ * @brief Interface for expressing a virtual machine stack to JitBuilder
+ *
+ * In such virtual machines, the stack holds the intermediate expression values
+ * computed by the bytecodes. This class is the basis for subclasses to provide
+ * different stack implementations such as a simulated stack which does not read
+ * or write values from the actual stack unless request via the Reload / Commit
+ * APIs.
+ *
+ * The current implementation does not share anything among different
+ * VirtualMachineOperandStack objects. Possibly, some of the state could be
+ * shared to save some memory. For now, simplicity is the goal.
+ *
+ * VirtualMachineStack subclasses VirtualMachineState but does not provide any
+ * concrete implementations.
+ *
+ * VirtualMachineStack implementations provide several stack-y operations:
+ *   Push() pushes a TR::IlValue onto the stack
+ *   Pop() pops and returns a TR::IlValue from the stack
+ *   Top() returns the TR::IlValue at the top of the stack
+ *   Pick() returns the TR::IlValue "depth" elements from the top
+ *   Drop() discards "depth" elements from the stack
+ *   Dup() is a convenience function for Push(Top())
+ */
+
+class VirtualMachineStack : public TR::VirtualMachineState
+   {
+   public:
+   VirtualMachineStack()
+      : TR::VirtualMachineState()
+      {
+      }
+
+   /**
+    * @brief update the values used to read and write the virtual machine stack
+    * @param b the builder where the values will be placed
+    * @param stack the new stack base address.  It is assumed that the address is already adjusted to _stackOffset
+    */
+   virtual void UpdateStack(TR::IlBuilder *b, TR::IlValue *stack) = 0;
+
+   /**
+    * @brief Push an expression onto the stack
+    * @param b builder object to use for any operations used to implement the push (e.g. update the top of stack)
+    * @param value expression to push onto the stack
+    */
+   virtual void Push(TR::IlBuilder *b, TR::IlValue *value) = 0;
+
+   /**
+    * @brief Pops an expression from the top of the stack
+    * @param b builder object to use for any operations used to implement the pop (e.g. to update the top of stack)
+    * @returns expression popped from the stack
+    */
+   virtual TR::IlValue *Pop(TR::IlBuilder *b) = 0;
+
+   /**
+    * @brief Returns the expression at the top of the stack
+    * @param b builder object to use for any operations used to implement the pop (e.g. to update the top of stack)
+    * @returns the expression at the top of the stack
+    */
+   virtual TR::IlValue *Top(TR::IlBuilder *b) = 0;
+
+   /**
+    * @brief Returns an expression below the top of the stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    * @returns the requested expression from the stack
+    */
+   virtual TR::IlValue *Pick(TR::IlBuilder *b, int32_t depth) = 0;
+
+   /**
+    * @brief Returns an expression below the top of the stack
+    * @param depth number of values below top (Pick(0) is same as Top())
+    *              The value for depth is required to be an IlValue created
+    *              using one of the IlBuilder::Const*() APIs
+    * @returns the requested expression from the operand stack
+    */
+   virtual TR::IlValue *Pick(TR::IlBuilder *b, TR::IlValue *depth) = 0;
+
+   /**
+    * @brief Removes some number of expressions from the stack
+    * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
+    * @param depth how many values to drop from the stack
+    */
+   virtual void Drop(TR::IlBuilder *b, int32_t depth) = 0;
+
+   /**
+    * @brief Removes some number of expressions from the operand stack
+    * @param b builder object to use for any operations used to implement the drop (e.g. to update the top of stack)
+    * @param depth how many values to drop from the stack
+    *              The value for depth is required to be an IlValue created
+    *              using one of the IlBuilder::Const*() APIs
+    */
+   virtual void Drop(TR::IlBuilder *b, TR::IlValue *depth) = 0;
+
+   /**
+    * @brief Duplicates the expression on top of the stack
+    * @param b builder object to use for any operations used to duplicate the expression (e.g. to update the top of stack)
+    */
+   virtual void Dup(TR::IlBuilder *b) = 0;
+
+   protected:
+   private:
+   };
+}
+
+#endif // !defined(OMR_VIRTUALMACHINESTACK_INCL)

--- a/compiler/ilgen/VirtualMachineArray.hpp
+++ b/compiler/ilgen/VirtualMachineArray.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_VIRTUALMACHINEARRAY_INCL
+#define TR_VIRTUALMACHINEARRAY_INCL
+
+#include "ilgen/OMRVirtualMachineArray.hpp"
+
+namespace TR
+{
+class VirtualMachineArray : public OMR::VirtualMachineArray
+   {
+   public:
+   VirtualMachineArray() :
+      OMR::VirtualMachineArray()
+      { }
+   };
+}
+#endif // !defined(TR_VIRTUALMACHINEARRAY_INCL)

--- a/compiler/ilgen/VirtualMachineInterpreterArray.hpp
+++ b/compiler/ilgen/VirtualMachineInterpreterArray.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_VIRTUALMACHINEINTERPRETERARRAY_INCL
+#define TR_VIRTUALMACHINEINTERPRETERARRAY_INCL
+
+#include "ilgen/OMRVirtualMachineInterpreterArray.hpp"
+
+namespace TR
+{
+class VirtualMachineInterpreterArray : public OMR::VirtualMachineInterpreterArray
+   {
+   public:
+   VirtualMachineInterpreterArray(TR::MethodBuilder *mb, TR::IlType *elementType, TR::VirtualMachineRegister *arrayBase) :
+      OMR::VirtualMachineInterpreterArray(mb, elementType, arrayBase)
+      { }
+   };
+}
+#endif // !defined(TR_VIRTUALMACHINEINTERPRETERARRAY_INCL)

--- a/compiler/ilgen/VirtualMachineInterpreterStack.hpp
+++ b/compiler/ilgen/VirtualMachineInterpreterStack.hpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_VIRTUALMACHINEINTERPRETERSTACK_INCL
+#define TR_VIRTUALMACHINEINTERPRETERSTACK_INCL
+
+#include "ilgen/OMRVirtualMachineInterpreterStack.hpp"
+
+namespace TR
+{
+class VirtualMachineInterpreterStack : public OMR::VirtualMachineInterpreterStack
+   {
+   public:
+   VirtualMachineInterpreterStack(
+                              TR::MethodBuilder *mb, TR::VirtualMachineRegister *stackTop,
+                              TR::IlType *elementType, bool growsUp = true, bool preAdjust = true) :
+      OMR::VirtualMachineInterpreterStack(mb, stackTop, elementType, growsUp, preAdjust)
+      { }
+   };
+}
+#endif // !defined(TR_VIRTUALMACHINEINTERPRETERSTACK_INCL)

--- a/compiler/ilgen/VirtualMachineStack.hpp
+++ b/compiler/ilgen/VirtualMachineStack.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_VIRTUALMACHINESTACK_INCL
+#define TR_VIRTUALMACHINESTACK_INCL
+
+#include "ilgen/OMRVirtualMachineStack.hpp"
+
+namespace TR
+{
+class VirtualMachineStack : public OMR::VirtualMachineStack
+   {
+   public:
+   VirtualMachineStack() :
+      OMR::VirtualMachineStack()
+      { }
+   };
+}
+#endif // !defined(TR_VIRTUALMACHINESTACK_INCL)

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -231,6 +231,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineState.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegister.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterArray.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.cpp \

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -231,6 +231,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineState.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegister.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.cpp \
     $(JIT_OMR_DIRTY_DIR)/runtime/Alignment.cpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -156,6 +156,12 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegisterInStruct.
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterArray.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterArray.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterArray.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterArray.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp -u $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
@@ -172,6 +178,12 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.hpp:
 	cp $< $@ || cp $< $@
 
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineArray.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineArray.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineArray.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineArray.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 	
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
@@ -220,12 +232,16 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegisterInStruct.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterArray.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineArray.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp \

--- a/jitbuilder/build/rules/common.mk
+++ b/jitbuilder/build/rules/common.mk
@@ -156,6 +156,12 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegisterInStruct.
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp -u $< $@ || cp $< $@
 
@@ -166,6 +172,12 @@ $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.hpp:
 	cp $< $@ || cp $< $@
 
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+	
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
+	cp $< $@ || cp $< $@
+
+$(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineStack.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineStack.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
 	cp $< $@ || cp $< $@
 
 $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp: $(FIXED_SRCBASE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen
@@ -208,10 +220,14 @@ JITBUILDER_FILES=$(RELEASE_DIR)/Makefile \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegister.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineRegisterInStruct.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineRegisterInStruct.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineInterpreterStack.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineInterpreterStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandArray.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineOperandStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineOperandStack.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/OMRVirtualMachineStack.hpp \
+             $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/VirtualMachineStack.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/ilgen/IlGen.hpp \
              $(RELEASE_INCLUDE)/$(JIT_OMR_DIRTY_DIR)/infra/Annotations.hpp \
              $(RELEASE_SRC)/Call.hpp \

--- a/jitbuilder/release/src/OperandArrayTests.cpp
+++ b/jitbuilder/release/src/OperandArrayTests.cpp
@@ -331,7 +331,7 @@ OperandArrayTestMethod::verify(const char *step, int32_t max, int32_t num, ...)
       REPORT2(_realArray[a] == val, "_realArray[a]", _realArray[a], "val", val);
       }
 
-   if (verbose) cout << "\tResult " << step << ": upper stack untouched: ";
+   if (verbose) cout << "\tResult " << step << ": end of array untouched: ";
    REPORT1(verifyUntouched(max), "max", max);
    }
 
@@ -370,13 +370,13 @@ OperandArrayTestMethod::OperandArrayTestMethod(TR::TypeDictionary *d)
    }
 
 // convenience macros
-#define STACK(b)         ((TR::VirtualMachineOperandArray *)(b)->vmState())
-#define UPDATEARRAY(b,s) (STACK(b)->UpdateArray(b, s))
-#define COMMIT(b)        (STACK(b)->Commit(b))
-#define RELOAD(b)        (STACK(b)->Reload(b))
-#define SET(b,i,v)       (STACK(b)->Set((i),(v)))
-#define GET(b,i)         (STACK(b)->Get((i)))
-#define MOVE(b, d, s)    (STACK(b)->Move(b, d, s))
+#define ARRAY(b)         ((TR::VirtualMachineOperandArray *)(b)->vmState())
+#define UPDATEARRAY(b,s) (ARRAY(b)->UpdateArray(b, s))
+#define COMMIT(b)        (ARRAY(b)->Commit(b))
+#define RELOAD(b)        (ARRAY(b)->Reload(b))
+#define SET(b,i,v)       (ARRAY(b)->Set((b),(i),(v)))
+#define GET(b,i)         (ARRAY(b)->Get((b),(i)))
+#define MOVE(b, d, s)    (ARRAY(b)->Move(b, d, s))
 
 bool
 OperandArrayTestMethod::testArray(TR::BytecodeBuilder *builder, bool useEqual)

--- a/jitbuilder/release/src/OperandStackTests.cpp
+++ b/jitbuilder/release/src/OperandStackTests.cpp
@@ -453,10 +453,10 @@ OperandStackTestMethod::OperandStackTestMethod(TR::TypeDictionary *d)
 #define UPDATESTACK(b,s)   (STACK(b)->UpdateStack(b, s))
 #define PUSH(b,v)          (STACK(b)->Push(b,v))
 #define POP(b)             (STACK(b)->Pop(b))
-#define TOP(b)             (STACK(b)->Top())
+#define TOP(b)             (STACK(b)->Top(b))
 #define DUP(b)             (STACK(b)->Dup(b))
 #define DROP(b,d)          (STACK(b)->Drop(b,d))
-#define PICK(b,d)          (STACK(b)->Pick(d))
+#define PICK(b,d)          (STACK(b)->Pick(b,d))
 
 bool
 OperandStackTestMethod::testStack(TR::BytecodeBuilder *b, bool useEqual)


### PR DESCRIPTION
This change introduces 2 new hierarchies.

VirtualMachineArray and VirtualMachineStack which are the superclasses for VirtualMachineOperandArray and VirtualMachineOperandStack respectively.  The change also introduces 2 more subclass VirtualMachineInterpreterArray and VirtualMachineInterpreterStack that do not simulate the virtual machine data structures but instead actually read and write directly to them.