### PR TITLE
Added the iterator mechanism for getting the Cgroup metrics in OMR

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -409,6 +409,22 @@ typedef struct OMRCgroupEntry {
 
 #endif /* defined(LINUX) */
 
+typedef struct OMRCgroupMetricElement {
+	char *key;
+	char *units;
+	char value[128];
+} OMRCgroupMetricElement;
+
+typedef struct OMRCgroupMetricIteratorState {
+	uint32_t count;
+	uint32_t numElements;
+	uint64_t subsystemid;
+	int32_t multiLineCounter;
+	char *fileContent;
+} OMRCgroupMetricIteratorState;
+
+
+
 /**
  * @name Virtual Memory Options
  * Flags used to create bitmap indicating vmem options
@@ -1520,12 +1536,16 @@ typedef struct OMRPortLibrary {
 	int32_t (*sysinfo_cgroup_get_memlimit)(struct OMRPortLibrary *portLibrary, uint64_t *limit);
 	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_is_memlimit_set "omrsysinfo_cgroup_is_memlimit_set"*/
 	BOOLEAN (*sysinfo_cgroup_is_memlimit_set)(struct OMRPortLibrary *portLibrary);
-	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_get_handle_subsystem_file "omrsysinfo_cgroup_get_handle_subsystem_file"*/
-	intptr_t (*sysinfo_cgroup_get_handle_subsystem_file)(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName);
 	/** see @ref omrsysinfo.c::omrsysinfo_get_cgroup_subsystem_list "omrsysinfo_get_cgroup_subsystem_list"*/
 	struct OMRCgroupEntry *(*sysinfo_get_cgroup_subsystem_list)(struct OMRPortLibrary *portLibrary);
 	/** see @ref omrsysinfo.c::omrsysinfo_is_running_in_container "omrsysinfo_is_running_in_container"*/
-	int32_t (*sysinfo_is_running_in_container)(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer);
+	BOOLEAN (*sysinfo_is_running_in_container)(struct OMRPortLibrary *portLibrary, int32_t *errorCode);
+	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_subsystem_iterator_init "omrsysinfo_cgroup_subsystem_iterator_init"*/
+	int32_t (*sysinfo_cgroup_subsystem_iterator_init)(struct OMRPortLibrary *portLibrary, uint64_t subsystem, struct OMRCgroupMetricIteratorState *state);
+	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_subsystem_iterator_hasNext "omrsysinfo_cgroup_subsystem_iterator_hasNext"*/
+	BOOLEAN (*sysinfo_cgroup_subsystem_iterator_hasNext)(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state);
+	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_subsystem_iterator_next "omrsysinfo_cgroup_subsystem_iterator_next"*/
+	int32_t (*sysinfo_cgroup_subsystem_iterator_next)(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement, BOOLEAN *printUnits, uint64_t sizeRef);
 	/** see @ref omrport.c::omrport_init_library "omrport_init_library"*/
 	int32_t (*port_init_library)(struct OMRPortLibrary *portLibrary, uintptr_t size) ;
 	/** see @ref omrport.c::omrport_startup_library "omrport_startup_library"*/
@@ -1981,9 +2001,11 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_cgroup_are_subsystems_enabled(param1) privateOmrPortLibrary->sysinfo_cgroup_are_subsystems_enabled(privateOmrPortLibrary, param1)
 #define omrsysinfo_cgroup_get_memlimit(param1) privateOmrPortLibrary->sysinfo_cgroup_get_memlimit(privateOmrPortLibrary, param1)
 #define omrsysinfo_cgroup_is_memlimit_set() privateOmrPortLibrary->sysinfo_cgroup_is_memlimit_set(privateOmrPortLibrary)
-#define omrsysinfo_cgroup_get_handle_subsystem_file(param1,param2) privateOmrPortLibrary->sysinfo_cgroup_get_handle_subsystem_file(privateOmrPortLibrary, param1, param2)
 #define omrsysinfo_get_cgroup_subsystem_list() privateOmrPortLibrary->sysinfo_get_cgroup_subsystem_list(privateOmrPortLibrary)
 #define omrsysinfo_is_running_in_container(param1) privateOmrPortLibrary->sysinfo_is_running_in_container(privateOmrPortLibrary, param1)
+#define omrsysinfo_cgroup_subsystem_iterator_init(param1, param2) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_init(privateOmrPortLibrary, param1, param2)
+#define omrsysinfo_cgroup_subsystem_iterator_hasNext(param1) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_hasNext(privateOmrPortLibrary, param1)
+#define omrsysinfo_cgroup_subsystem_iterator_next(param1, param2, param3, param4) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_next(privateOmrPortLibrary, param1, param2, param3, param4)
 #define omrintrospect_startup() privateOmrPortLibrary->introspect_startup(privateOmrPortLibrary)
 #define omrintrospect_shutdown() privateOmrPortLibrary->introspect_shutdown(privateOmrPortLibrary)
 #define omrintrospect_set_suspend_signal_offset(param1) privateOmrPortLibrary->introspect_set_suspend_signal_offset(privateOmrPortLibrary, param1)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -270,9 +270,11 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_cgroup_are_subsystems_enabled, /* sysinfo_cgroup_are_subsystems_enabled */
 	omrsysinfo_cgroup_get_memlimit, /* sysinfo_cgroup_get_memlimit */
 	omrsysinfo_cgroup_is_memlimit_set, /* sysinfo_cgroup_is_memlimit_set */
-	omrsysinfo_cgroup_get_handle_subsystem_file, /* sysinfo_cgroup_get_handle_subsystem_file */
 	omrsysinfo_get_cgroup_subsystem_list, /* sysinfo_get_cgroup_entry_list */
 	omrsysinfo_is_running_in_container, /* sysinfo_is_running_in_container */
+	omrsysinfo_cgroup_subsystem_iterator_init, /* sysinfo_cgroup_subsystem_iterator_init */
+	omrsysinfo_cgroup_subsystem_iterator_hasNext, /* omrsysinfo_cgroup_subsystem_iterator_hasNext */
+	omrsysinfo_cgroup_subsystem_iterator_next, /* omrsysinfo_cgroup_subsystem_iterator_next */
 	omrport_init_library, /* port_init_library */
 	omrport_startup_library, /* port_startup_library */
 	omrport_create_library, /* port_create_library */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -938,24 +938,6 @@ omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 }
 
 /**
- * Gets the file descriptor by opening the file passed as a param fileName with PortLibrary file_open API.
- * Caller should be using "omrfile_close" (Port Library API) to close the file descriptor after calling this API.
- *
- * @param[in] portLibrary pointer to OMRPortLibrary
- *
- * @param[in] subsystemFlag for checking the index of the subsystem
- *
- * @param[in] fileName pointer to cgroup subsystem filename
- *
- * @return file descriptor of file on success and OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM on failure
- */
-intptr_t
-omrsysinfo_cgroup_get_handle_subsystem_file(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName)
-{
-	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
-}
-
-/**
  * Gets the list of subsystems available
  *
  * @param[in] portLibrary pointer to OMRPortLibrary
@@ -969,16 +951,67 @@ omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
 }
 
 /**
- * States if JVM is running in a container
+ * States if Runtime is running in a container
  *
  * @param[in] portLibrary pointer to OMRPortLibrary
  *
- * @param[in] inContainer BOOLEAN pointer to state running in container or not
+ * @param[in] errorCode int32_t pointer to state error code from internal calls
  *
- * @return 0 on success and OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM on failure
+ * @return TRUE if Runtime is running in a container and FALSE if not
+ */
+BOOLEAN
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)
+{
+	return FALSE;
+}
+
+/**
+ * Initiates the iterator to get cgroup metric values based on the cgroup subsystem
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @param[in] subsystem flag of type OMR_CGROUP_SUBSYSTEMS_* representing the cgroup subsystem
+ *
+ * @param[in] state Pointer to the `OMRCgroupMetricIteratorState` struct
+ *
+ * @return 0 on success and error code on failure
  */
 int32_t
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
+omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, uint64_t subsystem, struct OMRCgroupMetricIteratorState *state)
 {
 	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
+}
+
+/**
+ * Checks if there are any cgroup metrics in the subsystem to iterated over
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @param[in] state Pointer to the `OMRCgroupMetricIteratorState` struct
+ *
+ * @return TRUE if any cgroup metric available else FALSE
+ */
+BOOLEAN
+omrsysinfo_cgroup_subsystem_iterator_hasNext(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state)
+{
+	return FALSE;
+}
+
+/**
+ * Reads the next cgroup metric and sets the value to return 
+ *
+ * @param[in] portLibrary pointer to OMRPortLibrary
+ *
+ * @param[in] state Pointer to the `OMRCgroupMetricIteratorState` struct
+ *
+ * @param[in] metricElement Pointer to the `OMRCgroupMetricElement` struct
+ *
+ * @param[in/out] printUnits Pointer to a BOOLEAN which states if the metric has units
+ *
+ * @return 0 on success and error code on failure
+ */
+int32_t
+omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement, BOOLEAN *printUnits, uint64_t sizeRef)
+{
+	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;	
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -533,12 +533,16 @@ extern J9_CFUNC int32_t
 omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *limit);
 extern J9_CFUNC BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary);
-extern J9_CFUNC intptr_t
-omrsysinfo_cgroup_get_handle_subsystem_file(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName);
 extern J9_CFUNC struct OMRCgroupEntry *
 omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC BOOLEAN
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode);
 extern J9_CFUNC int32_t
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer);
+omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, uint64_t subsystem, struct OMRCgroupMetricIteratorState *state);
+extern J9_CFUNC BOOLEAN
+omrsysinfo_cgroup_subsystem_iterator_hasNext(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state);
+extern J9_CFUNC int32_t
+omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement, BOOLEAN *printUnits, uint64_t sizeRef);
 
 /* J9SourceJ9Signal*/
 extern J9_CFUNC int32_t

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1672,20 +1672,32 @@ omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 	return FALSE;
 }
 
-intptr_t
-omrsysinfo_cgroup_get_handle_subsystem_file(struct OMRPortLibrary *portLibrary,  uint64_t subsystemFlag, const char *fileName)
-{
-	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
-}
-
 struct OMRCgroupEntry *
 omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
 {
 	return NULL;
 }
 
+BOOLEAN
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)
+{
+	return FALSE;
+}
+
 int32_t
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
+omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, uint64_t subsystem, struct OMRCgroupMetricIteratorState *state)
 {
 	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
+}
+
+BOOLEAN
+omrsysinfo_cgroup_subsystem_iterator_hasNext(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state)
+{
+	return FALSE;
+}
+
+int32_t
+omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement, BOOLEAN *printUnits, uint64_t sizeRef)
+{
+	return OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;	
 }


### PR DESCRIPTION
This PR adds the Iterator mechanism API's for reading and getting the Cgroup metrics which would be useful for any runtime to get the cgroup metrics.

**omrsysinfo_cgroup_subsystem_iterator_init :**
Initiates the iterator with respective to the cgroup subsystem.
**omrsysinfo_cgroup_subsystem_iterator_hasNext :**
Checks if any other metrics are there to be read.
**omrsysinfo_cgroup_subsystem_iterator_next :**
Reads the cgroup susbsystem file and returns the value of the metric.

This PR removes the API `omrsysinfo_cgroup_get_handle_subsystem_file` which is no longer required.