### PR TITLE
Fix RPATH and dylib install_name on OSX

### DIFF
--- a/omrmakefiles/rules.osx.mk
+++ b/omrmakefiles/rules.osx.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2016 IBM Corp. and others
+# Copyright (c) 2016, 2018 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,7 +69,7 @@ endif
 ifneq (,$(findstring executable,$(ARTIFACT_TYPE)))
   # Default Libraries
   GLOBAL_SHARED_LIBS+=m pthread c dl util
-  GLOBAL_LDFLAGS+=-Wl,-rpath,\$$ORIGIN
+  GLOBAL_LDFLAGS+=-Wl,-rpath,@loader_path
 endif
 
 ###
@@ -125,12 +125,12 @@ ifeq (1,$(OMR_DEBUG))
 ifeq (1,$(USE_GNU_DEBUG))
 
 define LINK_C_SHARED_COMMAND
-$(CCLINKSHARED) -o $@ $(OBJECTS) $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS) -install_name lib$(MODULE_NAME).dylib
+$(CCLINKSHARED) -o $@ $(OBJECTS) $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS) -install_name @rpath/lib$(MODULE_NAME).dylib
 cp $@ $@.dbg
 endef
 
 define LINK_CXX_SHARED_COMMAND
-$(CXXLINKSHARED) -o $@ $(OBJECTS) $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS) -install_name lib$(MODULE_NAME).dylib
+$(CXXLINKSHARED) -o $@ $(OBJECTS) $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS) -install_name @rpath/lib$(MODULE_NAME).dylib
 cp $@ $@.dbg
 endef
 


### PR DESCRIPTION
On OSX, -rpath,\\$$ORIGIN doesn't work. -rpath needs to correspond to
either @executable_path, @loader_path or some other path. More
information can be seen in the man pages of dyld. I have chosen to set
rpath as "-rpath,@loader_path/.". @loader_path points to the directory
where dylib being loaded exists.

When naming dylibs, @rpath/ should be appended to dylib names. Example:
@rpath/libomrsig.dylib. Appending @rpath to the dylib name instructs the
dynamic linker to search the list of run paths for the dylib.

Reference:
https://wincent.com/wiki/%40executable_path%2C_%40load_path_and_%40rpath

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>