### PR TITLE
Implement atomic add and swap codegen support for Z

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -389,10 +389,8 @@ class OMR_EXTENSIBLE CodeGenerator
    /** \brief
     *     Determines whether intrinsics on the following atomic symbols is supported:
     *
-    *     - atomicAdd32BitSymbol
-    *     - atomicAdd64BitSymbol
-    *     - atomicFetchAndAdd32BitSymbol
-    *     - atomicFetchAndAdd64BitSymbol
+    *     - atomicAddSymbol
+    *     - atomicFetchAndAddSymbol
     *
     *  \return
     *     \c true if intrinsics are supported; \c false otherwise.
@@ -405,12 +403,9 @@ class OMR_EXTENSIBLE CodeGenerator
    /** \brief
     *     Determines whether intrinsics on the following atomic symbols is supported:
     *
-    *     - atomicSwap32BitSymbol
-    *     - atomicSwap64BitSymbol
-    *     - atomicCompareAndSwap32BitSymbol
-    *     - atomicCompareAndSwap64BitSymbol
-    *     - atomicCompareAndSwapReturnValue32BitSymbol
-    *     - atomicCompareAndSwapReturnValue64BitSymbol
+    *     - atomicSwapSymbol
+    *     - atomicCompareAndSwapSymbol
+    *     - atomicCompareAndSwapReturnValueSymbol
     *
     *  \return
     *     \c true if intrinsics are supported; \c false otherwise.

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -43,6 +43,7 @@ namespace OMR { typedef OMR::CodeGenerator CodeGeneratorConnector; }
 #include "codegen/StorageInfo.hpp"
 #include "codegen/TreeEvaluator.hpp"
 #include "compile/Compilation.hpp"              // for Compilation
+#include "compile/SymbolReferenceTable.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "cs2/hashtab.h"                        // for HashTable, etc
@@ -387,30 +388,15 @@ class OMR_EXTENSIBLE CodeGenerator
    TR_HasRandomGenerator randomizer;
 
    /** \brief
-    *     Determines whether intrinsics on the following atomic symbols is supported:
+    *     Determines whether the code generator supports inlining intrinsics for \p symbol.
     *
-    *     - atomicAddSymbol
-    *     - atomicFetchAndAddSymbol
-    *
-    *  \return
-    *     \c true if intrinsics are supported; \c false otherwise.
-    */
-   bool supportsAtomicAdd()
-      {
-      return false;
-      }
-
-   /** \brief
-    *     Determines whether intrinsics on the following atomic symbols is supported:
-    *
-    *     - atomicSwapSymbol
-    *     - atomicCompareAndSwapSymbol
-    *     - atomicCompareAndSwapReturnValueSymbol
+    *  \param symbol
+    *     The symbol which to check.
     *
     *  \return
-    *     \c true if intrinsics are supported; \c false otherwise.
+    *     \c true if intrinsics on \p symbol are supported; \c false otherwise.
     */
-   bool supportsAtomicSwap()
+   bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
       {
       return false;
       }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -386,7 +386,40 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR_HasRandomGenerator randomizer;
 
-   bool supportsAtomicAdd() {return false;}
+   /** \brief
+    *     Determines whether intrinsics on the following atomic symbols is supported:
+    *
+    *     - atomicAdd32BitSymbol
+    *     - atomicAdd64BitSymbol
+    *     - atomicFetchAndAdd32BitSymbol
+    *     - atomicFetchAndAdd64BitSymbol
+    *
+    *  \return
+    *     \c true if intrinsics are supported; \c false otherwise.
+    */
+   bool supportsAtomicAdd()
+      {
+      return false;
+      }
+
+   /** \brief
+    *     Determines whether intrinsics on the following atomic symbols is supported:
+    *
+    *     - atomicSwap32BitSymbol
+    *     - atomicSwap64BitSymbol
+    *     - atomicCompareAndSwap32BitSymbol
+    *     - atomicCompareAndSwap64BitSymbol
+    *     - atomicCompareAndSwapReturnValue32BitSymbol
+    *     - atomicCompareAndSwapReturnValue64BitSymbol
+    *
+    *  \return
+    *     \c true if intrinsics are supported; \c false otherwise.
+    */
+   bool supportsAtomicSwap()
+      {
+      return false;
+      }
+
    bool hasTMEvaluator()    {return false;}
 
    // --------------------------------------------------------------------------

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -191,7 +191,7 @@ class SymbolReferenceTable
        *  This symbol represents an intrinsic call of the following format:
        *
        *  \code
-       *    icall <atomicAdd32BitSymbol>
+       *    icall <atomicAddSymbol>
        *      <address>
        *      <value>
        *  \endcode
@@ -202,9 +202,10 @@ class SymbolReferenceTable
        *    [address] = [address] + <value>
        *    return <value>
        *  \endcode
+       *
+       *  The data type of \c <value> indicates the width of the operation.
        */
-      atomicAdd32BitSymbol,
-      atomicAdd64BitSymbol,
+      atomicAddSymbol,
 
       /** \brief
        *

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -186,11 +186,65 @@ class SymbolReferenceTable
        */
       synchronizedFieldLoadSymbol,
 
-      // common atomic primitives
+      /** \brief
+       *
+       *  This symbol represents an intrinsic call of the following format:
+       *
+       *  \code
+       *    icall <atomicAdd32BitSymbol>
+       *      <address>
+       *      <value>
+       *  \endcode
+       *
+       *  Which performs the following operation atomically:
+       *
+       *  \code
+       *    [address] = [address] + <value>
+       *    return <value>
+       *  \endcode
+       */
       atomicAdd32BitSymbol,
       atomicAdd64BitSymbol,
+
+      /** \brief
+       *
+       *  This symbol represents an intrinsic call of the following format:
+       *
+       *  \code
+       *    icall <atomicFetchAndAdd32BitSymbol>
+       *      <address>
+       *      <value>
+       *  \endcode
+       *
+       *  Which performs the following operation atomically:
+       *
+       *  \code
+       *    temp = [address]
+       *    [address] = [address] + <value>
+       *    return temp
+       *  \endcode
+       */
       atomicFetchAndAdd32BitSymbol,
       atomicFetchAndAdd64BitSymbol,
+
+      /** \brief
+       *
+       *  This symbol represents an intrinsic call of the following format:
+       *
+       *  \code
+       *    icall <atomicSwap32BitSymbol>
+       *      <address>
+       *      <value>
+       *  \endcode
+       *
+       *  Which performs the following operation atomically:
+       *
+       *  \code
+       *    temp = [address]
+       *    [address] = <value>
+       *    return temp
+       *  \endcode
+       */
       atomicSwap32BitSymbol,
       atomicSwap64BitSymbol,
       atomicCompareAndSwap32BitSymbol,

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -212,7 +212,7 @@ class SymbolReferenceTable
        *  This symbol represents an intrinsic call of the following format:
        *
        *  \code
-       *    icall <atomicFetchAndAdd32BitSymbol>
+       *    icall <atomicFetchAndAddSymbol>
        *      <address>
        *      <value>
        *  \endcode
@@ -224,7 +224,10 @@ class SymbolReferenceTable
        *    [address] = [address] + <value>
        *    return temp
        *  \endcode
+       *
+       *  The data type of \c <value> indicates the width of the operation.
        */
+      atomicFetchAndAddSymbol,
       atomicFetchAndAdd32BitSymbol,
       atomicFetchAndAdd64BitSymbol,
 
@@ -233,7 +236,7 @@ class SymbolReferenceTable
        *  This symbol represents an intrinsic call of the following format:
        *
        *  \code
-       *    icall <atomicSwap32BitSymbol>
+       *    icall <atomicSwapSymbol>
        *      <address>
        *      <value>
        *  \endcode
@@ -245,11 +248,13 @@ class SymbolReferenceTable
        *    [address] = <value>
        *    return temp
        *  \endcode
+       *
+       *  The data type of \c <value> indicates the width of the operation.
        */
+      atomicSwapSymbol,
       atomicSwap32BitSymbol,
       atomicSwap64BitSymbol,
-      atomicCompareAndSwap32BitSymbol,
-      atomicCompareAndSwap64BitSymbol,
+      atomicCompareAndSwapSymbol,
 
       // python symbols start here
       pythonFrameCodeObjectSymbol,   // code object from the frame object

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2076,8 +2076,7 @@ OMR::IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
    TR_ASSERT(returnType == TR::Int32 || (returnType == TR::Int64 && TR::Compiler->target.is64Bit()), "AtomicAdd currently only supports Int32/64 values");
    TraceIL("IlBuilder[ %p ]::AtomicAdd(%d, %d)\n", this, baseAddress->getID(), value->getID());
 
-   OMR::SymbolReferenceTable::CommonNonhelperSymbol atomicBitSymbol = returnType == TR::Int32 ? TR::SymbolReferenceTable::atomicAdd32BitSymbol : TR::SymbolReferenceTable::atomicAdd64BitSymbol;//lock add
-   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(atomicBitSymbol); 
+   TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(TR::SymbolReferenceTable::atomicAddSymbol);
    TR::Node *callNode;
    callNode = TR::Node::createWithSymRef(TR::ILOpCode::getDirectCall(returnType), 2, methodSymRef);
    callNode->setAndIncChild(0, loadValue(baseAddress));

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2068,7 +2068,6 @@ OMR::IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::
 TR::IlValue *
 OMR::IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
    {
-   TR_ASSERT(comp()->cg()->supportsAtomicAdd(), "This platform doesn't support atomic add intrinsics");
    TR_ASSERT(baseAddress->getDataType() == TR::Address, "baseAddress must be TR::Address");
 
    //Determine the implementation type and returnType by detecting "value"'s type

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2068,7 +2068,7 @@ OMR::IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::
 TR::IlValue *
 OMR::IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
    {
-   TR_ASSERT(comp()->cg()->supportsAtomicAdd(), "this platform doesn't support AtomicAdd() yet");
+   TR_ASSERT(comp()->cg()->supportsAtomicAdd(), "This platform doesn't support atomic add intrinsics");
    TR_ASSERT(baseAddress->getDataType() == TR::Address, "baseAddress must be TR::Address");
 
    //Determine the implementation type and returnType by detecting "value"'s type

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1639,10 +1639,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
             return "<usesAllMethod>";
          case TR::SymbolReferenceTable::synchronizedFieldLoadSymbol:
             return "<synchronizedFieldLoad>";
-         case TR::SymbolReferenceTable::atomicAdd32BitSymbol:
-             return "<atomicAdd32Bit>";
-         case TR::SymbolReferenceTable::atomicAdd64BitSymbol:
-             return "<atomicAdd64Bit>";
+         case TR::SymbolReferenceTable::atomicAddSymbol:
+             return "<atomicAdd>";
          case TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol:
              return "<atomicFetchAndAdd32Bit>";
          case TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol:

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1641,18 +1641,20 @@ TR_Debug::getName(TR::SymbolReference * symRef)
             return "<synchronizedFieldLoad>";
          case TR::SymbolReferenceTable::atomicAddSymbol:
              return "<atomicAdd>";
+         case TR::SymbolReferenceTable::atomicFetchAndAddSymbol:
+             return "<atomicFetchAndAdd>";
          case TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol:
              return "<atomicFetchAndAdd32Bit>";
          case TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol:
              return "<atomicFetchAndAdd64Bit>";
+         case TR::SymbolReferenceTable::atomicSwapSymbol:
+             return "<atomicSwap>";
          case TR::SymbolReferenceTable::atomicSwap32BitSymbol:
              return "<atomicSwap32Bit>";
          case TR::SymbolReferenceTable::atomicSwap64BitSymbol:
              return "<atomicSwap64Bit>";
-         case TR::SymbolReferenceTable::atomicCompareAndSwap32BitSymbol:
-             return "<atomicCompareAndSwap32Bit>";
-         case TR::SymbolReferenceTable::atomicCompareAndSwap64BitSymbol:
-             return "<atomicCompareAndSwap64Bit>";
+         case TR::SymbolReferenceTable::atomicCompareAndSwapSymbol:
+             return "<atomicCompareAndSwap>";
          }
       }
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1067,6 +1067,25 @@ OMR::X86::CodeGenerator::supportsMergingGuards()
           self()->allowGuardMerging();
    }
 
+bool
+OMR::X86::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
+   {
+   bool result = false;
+
+   switch (symbol)
+      {
+      case TR::SymbolReferenceTable::atomicAddSymbol:
+      case TR::SymbolReferenceTable::atomicFetchAndAddSymbol:
+      case TR::SymbolReferenceTable::atomicSwapSymbol:
+         {
+         result = true;
+         break;
+         }
+      }
+
+   return result;
+   }
+
 TR::RealRegister *
 OMR::X86::CodeGenerator::getMethodMetaDataRegister()
    {

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -305,7 +305,16 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool supportsMergingGuards();
 
-   bool supportsAtomicAdd()                {return true;}
+   bool supportsAtomicAdd()
+      {
+      return true;
+      }
+
+   bool supportsAtomicSwap()
+      {
+      return true;
+      }
+
    bool hasTMEvaluator()                       {return true;}
 
    int64_t getLargestNegConstThatMustBeMaterialized() { TR_ASSERT(0, "Not Implemented on x86"); return 0; }

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -305,15 +305,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool supportsMergingGuards();
 
-   bool supportsAtomicAdd()
-      {
-      return true;
-      }
-
-   bool supportsAtomicSwap()
-      {
-      return true;
-      }
+   bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
 
    bool hasTMEvaluator()                       {return true;}
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3066,39 +3066,40 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
 
    if (SymRef && SymRef->getSymbol()->castToMethodSymbol()->isInlinedByCG())
       {
+      TR_X86OpCodes op = BADIA32Op;
+
       if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicAddSymbol))
          {
-         auto op = node->getChild(1)->getDataType().isInt32() ? LADD4MemReg : LADD8MemReg;
-
-         return inlineAtomicMemoryUpdate(node, op, cg);
+         op = node->getChild(1)->getDataType().isInt32() ? LADD4MemReg : LADD8MemReg;
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAddSymbol))
          {
-         auto op = node->getChild(1)->getDataType().isInt32() ? LXADD4MemReg : LXADD8MemReg;
-
-         return inlineAtomicMemoryUpdate(node, op, cg);
+         op = node->getChild(1)->getDataType().isInt32() ? LXADD4MemReg : LXADD8MemReg;
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))
          {
-         return inlineAtomicMemoryUpdate(node, LXADD4MemReg, cg);
+         op = LXADD4MemReg;
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol))
          {
-         return inlineAtomicMemoryUpdate(node, LXADD8MemReg, cg);
+         op = LXADD8MemReg;
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwapSymbol))
          {
-         auto op = node->getChild(1)->getDataType().isInt32() ? XCHG4MemReg : XCHG8MemReg;
-
-         return inlineAtomicMemoryUpdate(node, op, cg);
+         op = node->getChild(1)->getDataType().isInt32() ? XCHG4MemReg : XCHG8MemReg;
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap32BitSymbol))
          {
-         return inlineAtomicMemoryUpdate(node, XCHG4MemReg, cg);
+         op = XCHG4MemReg;
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap64BitSymbol))
          {
-         return inlineAtomicMemoryUpdate(node, XCHG8MemReg, cg);
+         op = XCHG8MemReg;
+         }
+
+      if (op != BADIA32Op)
+         {
+         return inlineAtomicMemoryUpdate(node, op, cg);
          }
       }
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3066,27 +3066,25 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
 
    if (SymRef && SymRef->getSymbol()->castToMethodSymbol()->isInlinedByCG())
       {
-      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicAdd32BitSymbol))
+      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicAddSymbol))
          {
-         return inlineAtomicMemoryUpdate(node, LADD4MemReg, cg);
+         auto op = node->getChild(1)->getDataType().isInt32() ? LADD4MemReg : LADD8MemReg;
+
+         return inlineAtomicMemoryUpdate(node, op, cg);
          }
-      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicAdd64BitSymbol))
-         {
-         return inlineAtomicMemoryUpdate(node, LADD8MemReg, cg);
-         }
-      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))
+      else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))
          {
          return inlineAtomicMemoryUpdate(node, LXADD4MemReg, cg);
          }
-      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol))
+      else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol))
          {
          return inlineAtomicMemoryUpdate(node, LXADD8MemReg, cg);
          }
-      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap32BitSymbol))
+      else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap32BitSymbol))
          {
          return inlineAtomicMemoryUpdate(node, XCHG4MemReg, cg);
          }
-      if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap64BitSymbol))
+      else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap64BitSymbol))
          {
          return inlineAtomicMemoryUpdate(node, XCHG8MemReg, cg);
          }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3072,6 +3072,12 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
 
          return inlineAtomicMemoryUpdate(node, op, cg);
          }
+      else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAddSymbol))
+         {
+         auto op = node->getChild(1)->getDataType().isInt32() ? LXADD4MemReg : LXADD8MemReg;
+
+         return inlineAtomicMemoryUpdate(node, op, cg);
+         }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))
          {
          return inlineAtomicMemoryUpdate(node, LXADD4MemReg, cg);
@@ -3079,6 +3085,12 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol))
          {
          return inlineAtomicMemoryUpdate(node, LXADD8MemReg, cg);
+         }
+      else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwapSymbol))
+         {
+         auto op = node->getChild(1)->getDataType().isInt32() ? XCHG4MemReg : XCHG8MemReg;
+
+         return inlineAtomicMemoryUpdate(node, op, cg);
          }
       else if (comp->getSymRefTab()->isNonHelper(SymRef, TR::SymbolReferenceTable::atomicSwap32BitSymbol))
          {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -3069,15 +3069,27 @@ OMR::Z::CodeGenerator::supportsMergingGuards()
    }
 
 bool
-OMR::Z::CodeGenerator::supportsAtomicAdd()
+OMR::Z::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
    {
-   return self()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196) && (TR::Compiler->target.is64Bit() || self()->use64BitRegsOn32Bit());
-   }
+   bool result = false;
 
-bool
-OMR::Z::CodeGenerator::supportsAtomicSwap()
-   {
-   return true;
+   switch (symbol)
+      {
+      case TR::SymbolReferenceTable::atomicAddSymbol:
+      case TR::SymbolReferenceTable::atomicFetchAndAddSymbol:
+         {
+         result = self()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196) && (TR::Compiler->target.is64Bit() || self()->use64BitRegsOn32Bit());
+         break;
+         }
+
+      case TR::SymbolReferenceTable::atomicSwapSymbol:
+         {
+         result = true;
+         break;
+         }
+      }
+
+   return result;
    }
 
 // Helpers for profiled interface slots

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -3068,6 +3068,18 @@ OMR::Z::CodeGenerator::supportsMergingGuards()
           !self()->comp()->compileRelocatableCode();
    }
 
+bool
+OMR::Z::CodeGenerator::supportsAtomicAdd()
+   {
+   return self()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196) && (TR::Compiler->target.is64Bit() || self()->use64BitRegsOn32Bit());
+   }
+
+bool
+OMR::Z::CodeGenerator::supportsAtomicSwap()
+   {
+   return true;
+   }
+
 // Helpers for profiled interface slots
 void
 OMR::Z::CodeGenerator::addPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist)

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -275,8 +275,7 @@ public:
 
    bool supportsMergingGuards();
 
-   bool supportsAtomicAdd();
-   bool supportsAtomicSwap();
+   bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
 
    bool supportsDirectJNICallsForAOT() { return true;}
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -275,6 +275,9 @@ public:
 
    bool supportsMergingGuards();
 
+   bool supportsAtomicAdd();
+   bool supportsAtomicSwap();
+
    bool supportsDirectJNICallsForAOT() { return true;}
 
    bool shouldYankCompressedRefs() { return true; }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -11249,16 +11249,8 @@ OMR::Z::TreeEvaluator::directCallEvaluator(TR::Node * node, TR::CodeGenerator * 
          {
          TR::Compilation* comp = cg->comp();
 
-         if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicAdd32BitSymbol))
+         if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicAddSymbol))
             {
-            TR_ASSERT_FATAL(node->getChild(1)->getDataType().isInt32(), "Value child of atomicAdd32BitSymbol call should have 32-bit data type");
-
-            resultReg = intrinsicAtomicAdd(node, cg);
-            }
-         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicAdd64BitSymbol))
-            {
-            TR_ASSERT_FATAL(node->getChild(1)->getDataType().isInt64(), "Value child of atomicAdd64BitSymbol call should have 64-bit data type");
-
             resultReg = intrinsicAtomicAdd(node, cg);
             }
          else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -11253,28 +11253,12 @@ OMR::Z::TreeEvaluator::directCallEvaluator(TR::Node * node, TR::CodeGenerator * 
             {
             resultReg = intrinsicAtomicAdd(node, cg);
             }
-         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicFetchAndAdd32BitSymbol))
+         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicFetchAndAddSymbol))
             {
-            TR_ASSERT_FATAL(node->getChild(1)->getDataType().isInt32(), "Value child of atomicFetchAndAdd32BitSymbol call should have 32-bit data type");
-
             resultReg = intrinsicAtomicFetchAndAdd(node, cg);
             }
-         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicFetchAndAdd64BitSymbol))
+         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicSwapSymbol))
             {
-            TR_ASSERT_FATAL(node->getChild(1)->getDataType().isInt64(), "Value child of atomicFetchAndAdd64BitSymbol call should have 64-bit data type");
-
-            resultReg = intrinsicAtomicFetchAndAdd(node, cg);
-            }
-         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicSwap32BitSymbol))
-            {
-            TR_ASSERT_FATAL(node->getChild(1)->getDataType().isInt32(), "Value child of atomicAtomicSwap32BitSymbol call should have 32-bit data type");
-
-            resultReg = intrinsicAtomicSwap(node, cg);
-            }
-         else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicSwap64BitSymbol))
-            {
-            TR_ASSERT_FATAL(node->getChild(1)->getDataType().isInt64(), "Value child of atomicAtomicSwap64BitSymbol call should have 64-bit data type");
-
             resultReg = intrinsicAtomicSwap(node, cg);
             }
          }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -11251,15 +11251,15 @@ OMR::Z::TreeEvaluator::directCallEvaluator(TR::Node * node, TR::CodeGenerator * 
 
          if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicAddSymbol))
             {
-            resultReg = intrinsicAtomicAdd(node, cg);
+            resultReg = TR::TreeEvaluator::intrinsicAtomicAdd(node, cg);
             }
          else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicFetchAndAddSymbol))
             {
-            resultReg = intrinsicAtomicFetchAndAdd(node, cg);
+            resultReg = TR::TreeEvaluator::intrinsicAtomicFetchAndAdd(node, cg);
             }
          else if (comp->getSymRefTab()->isNonHelper(symRef, TR::SymbolReferenceTable::atomicSwapSymbol))
             {
-            resultReg = intrinsicAtomicSwap(node, cg);
+            resultReg = TR::TreeEvaluator::intrinsicAtomicSwap(node, cg);
             }
          }
 

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -697,6 +697,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *         <value>
     *     \endcode
     *
+    *     Which performs the following operation atomically:
+    *
+    *     \code
+    *       [address] = [address] + <value>
+    *       return <value>
+    *     \endcode
+    *
     *  \param node
     *     The respective (i|l)call node.
     *
@@ -718,6 +725,14 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *         <value>
     *     \endcode
     *
+    *     Which performs the following operation atomically:
+    *
+    *     \code
+    *       temp = [address]
+    *       [address] = [address] + <value>
+    *       return temp
+    *     \endcode
+    *
     *  \param node
     *     The respective (i|l)call node.
     *
@@ -737,6 +752,14 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *       icall <atomicSwapSymbol>
     *         <address>
     *         <value>
+    *     \endcode
+    *
+    *     Which performs the following operation atomically:
+    *
+    *     \code
+    *       temp = [address]
+    *       [address] = <value>
+    *       return temp
     *     \endcode
     *
     *  \param node

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -688,8 +688,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    private:
 
    /** \brief
-    *     Inlines an intrinsic for calls to atomicAddSymbol which are represented by a call node of the form for 32-bit
-    *     (64-bit similar):
+    *     Inlines an intrinsic for calls to atomicAddSymbol which are represented by a call node of the form for
+    *     32-bit (64-bit similar):
     * 
     *     \code
     *       icall <atomicAddSymbol>
@@ -709,15 +709,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register* intrinsicAtomicAdd(TR::Node* node, TR::CodeGenerator* cg);
    
    /** \brief
-    *     Inlines an intrinsic for calls to the following two symbols:
-    *
-    *        - atomicFetchAndAdd32BitSymbol
-    *        - atomicFetchAndAdd64BitSymbol
-    *
-    *     which are represented by a call node of the form for 32-bit (64-bit similar):
+    *     Inlines an intrinsic for calls to atomicFetchAndAddSymbol which are represented by a call node of the form for
+    *     32-bit (64-bit similar):
     * 
     *     \code
-    *       icall <atomicFetchAndAdd32BitSymbol>
+    *       icall <atomicFetchAndAddSymbol>
     *         <address>
     *         <value>
     *     \endcode
@@ -734,15 +730,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register* intrinsicAtomicFetchAndAdd(TR::Node* node, TR::CodeGenerator* cg);
    
    /** \brief
-    *     Inlines an intrinsic for calls to the following two symbols:
-    *
-    *        - atomicSwap32BitSymbol
-    *        - atomicSwap64BitSymbol
-    *
-    *     which are represented by a call node of the form for 32-bit (64-bit similar):
+    *     Inlines an intrinsic for calls to atomicSwapSymbol which are represented by a call node of the form for
+    *     32-bit (64-bit similar):
     * 
     *     \code
-    *       icall <atomicSwap32BitSymbol>
+    *       icall <atomicSwapSymbol>
     *         <address>
     *         <value>
     *     \endcode

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -687,6 +687,81 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
 
    private:
 
+   /** \brief
+    *     Inlines an intrinsic for calls to the following two symbols:
+    *
+    *        - atomicAdd32BitSymbol
+    *        - atomicAdd64BitSymbol
+    *
+    *     which are represented by a call node of the form for 32-bit (64-bit similar):
+    * 
+    *     \code
+    *       icall <atomicAdd32BitSymbol>
+    *         <address>
+    *         <value>
+    *     \endcode
+    *
+    *  \param node
+    *     The respective (i|l)call node.
+    *
+    *  \param cg
+    *     The code generator used to generate the instructions.
+    *
+    *  \return
+    *     A register holding the <value> node.
+    */
+   static TR::Register* intrinsicAtomicAdd(TR::Node* node, TR::CodeGenerator* cg);
+   
+   /** \brief
+    *     Inlines an intrinsic for calls to the following two symbols:
+    *
+    *        - atomicFetchAndAdd32BitSymbol
+    *        - atomicFetchAndAdd64BitSymbol
+    *
+    *     which are represented by a call node of the form for 32-bit (64-bit similar):
+    * 
+    *     \code
+    *       icall <atomicFetchAndAdd32BitSymbol>
+    *         <address>
+    *         <value>
+    *     \endcode
+    *
+    *  \param node
+    *     The respective (i|l)call node.
+    *
+    *  \param cg
+    *     The code generator used to generate the instructions.
+    *
+    *  \return
+    *     A register holding the original value in memory (before the addition) at the <address> location.
+    */
+   static TR::Register* intrinsicAtomicFetchAndAdd(TR::Node* node, TR::CodeGenerator* cg);
+   
+   /** \brief
+    *     Inlines an intrinsic for calls to the following two symbols:
+    *
+    *        - atomicSwap32BitSymbol
+    *        - atomicSwap64BitSymbol
+    *
+    *     which are represented by a call node of the form for 32-bit (64-bit similar):
+    * 
+    *     \code
+    *       icall <atomicSwap32BitSymbol>
+    *         <address>
+    *         <value>
+    *     \endcode
+    *
+    *  \param node
+    *     The respective (i|l)call node.
+    *
+    *  \param cg
+    *     The code generator used to generate the instructions.
+    *
+    *  \return
+    *     A register holding the original value in memory (before the swap) at the <address> location.
+    */
+   static TR::Register* intrinsicAtomicSwap(TR::Node* node, TR::CodeGenerator* cg);
+   
    static void         commonButestEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register* ifFoldingHelper(TR::Node *node, TR::CodeGenerator *cg, bool &handledBIF);
    static bool         isCandidateForBIFEvaluation(TR::Node * node);

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -688,15 +688,11 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    private:
 
    /** \brief
-    *     Inlines an intrinsic for calls to the following two symbols:
-    *
-    *        - atomicAdd32BitSymbol
-    *        - atomicAdd64BitSymbol
-    *
-    *     which are represented by a call node of the form for 32-bit (64-bit similar):
+    *     Inlines an intrinsic for calls to atomicAddSymbol which are represented by a call node of the form for 32-bit
+    *     (64-bit similar):
     * 
     *     \code
-    *       icall <atomicAdd32BitSymbol>
+    *       icall <atomicAddSymbol>
     *         <address>
     *         <value>
     *     \endcode


### PR DESCRIPTION
In support of #2958 we implement the existing intrinsics for Z. Another follow-up PR will address the new intrinsics which are proposed in #2174.

- Implement Z codegen support for several atomic symbols
- Document atomic symbol semantics
- Document supportsAtomicAdd and introduce supportsAtomicSwap 

Issue: #2958

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>