### PR TITLE
Restore Nursery allocation after aborted Scavenge

### DIFF
--- a/gc/base/MemorySubSpaceGeneric.cpp
+++ b/gc/base/MemorySubSpaceGeneric.cpp
@@ -275,6 +275,8 @@ MM_MemorySubSpaceGeneric::getAllocationFailureStats()
 void*
 MM_MemorySubSpaceGeneric::allocateObject(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure)
 {
+	Trc_MM_MSSGeneric_allocate_entry(env->getLanguageVMThread(), "Object", allocDescription->getBytesRequested(), this, getName(), baseSubSpace, previousSubSpace, (uintptr_t)_allocateAtSafePointOnly, (uintptr_t)shouldCollectOnFailure, (uintptr_t)_isAllocatable);
+
 	void *result = NULL;
 
 	/* Typically, JIT stack frame is not built (shouldCollectOnFailure is false) and concurrent mark is not running or not complete (_allocateAtSafePointOnly is false),
@@ -295,12 +297,16 @@ MM_MemorySubSpaceGeneric::allocateObject(MM_EnvironmentBase* env, MM_AllocateDes
 		} else {
 			/* Allocate failed - try the parent */
 			if (shouldCollectOnFailure) {
+				Trc_MM_MSSGeneric_allocate(env->getLanguageVMThread(), "Object", allocDescription->getBytesRequested(), 1, this, _parent);
 				result = _parent->allocationRequestFailed(env, allocDescription, ALLOCATION_TYPE_OBJECT, NULL, this, this);
 			} else {
+				Trc_MM_MSSGeneric_allocate(env->getLanguageVMThread(), "Object", allocDescription->getBytesRequested(), 2, this, _parent);
 				result = _parent->allocateObject(env, allocDescription, baseSubSpace, this, shouldCollectOnFailure);
 			}
 		}
 	}
+
+	Trc_MM_MSSGeneric_allocate_exit(env->getLanguageVMThread(), "Object", allocDescription->getBytesRequested(), this, result);
 
 	return result;
 }
@@ -351,6 +357,8 @@ MM_MemorySubSpaceGeneric::allocationRequestFailed(MM_EnvironmentBase* env, MM_Al
 void*
 MM_MemorySubSpaceGeneric::allocateTLH(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_ObjectAllocationInterface* objectAllocationInterface, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure)
 {
+	Trc_MM_MSSGeneric_allocate_entry(env->getLanguageVMThread(), "TLH", allocDescription->getBytesRequested(), this, getName(), baseSubSpace, previousSubSpace, (uintptr_t)_allocateAtSafePointOnly, (uintptr_t)shouldCollectOnFailure, (uintptr_t)_isAllocatable);
+
 	void *result = NULL;
 
 	/* Typically, JIT stack frame is not built (shouldCollectOnFailure is false) and concurrent mark is not running or not complete (_allocateAtSafePointOnly is false),
@@ -366,14 +374,18 @@ MM_MemorySubSpaceGeneric::allocateTLH(MM_EnvironmentBase* env, MM_AllocateDescri
 
 		if (NULL == result) {
 			if (shouldCollectOnFailure) {
+				Trc_MM_MSSGeneric_allocate3(env->getLanguageVMThread(), "TLH", allocDescription->getBytesRequested(), this, _parent, (uintptr_t)allocDescription->shouldCollectAndClimb());
 				if (allocDescription->shouldCollectAndClimb()) {
 					result = _parent->allocationRequestFailed(env, allocDescription, ALLOCATION_TYPE_TLH, objectAllocationInterface, this, this);
 				}
 			} else {
+				Trc_MM_MSSGeneric_allocate(env->getLanguageVMThread(), "TLH", allocDescription->getBytesRequested(), 2, this, _parent);
 				result = _parent->allocateTLH(env, allocDescription, objectAllocationInterface, baseSubSpace, this, false);
 			}
 		}
 	}
+
+	Trc_MM_MSSGeneric_allocate_exit(env->getLanguageVMThread(), "TLH", allocDescription->getBytesRequested(), this, result);
 
 	return result;
 }

--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -55,6 +55,7 @@ public:
 		set_evacuate,
 		set_allocate,
 		disable_allocation,
+		restore_allocation,
 		restore_allocation_and_set_survivor,
 		backout,
 		restore_tilt_after_percolate

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -867,3 +867,34 @@ TraceEvent=Trc_MM_SchedulingDelegate_calculatePGCCompactionRate_liveToFreeRatio4
 TraceEvent=Trc_MM_SchedulingDelegate_estimateTotalFreeMemory Overhead=1 Level=1 Group=reclaim Template="estimatedFreeMemory=%zu, reservedFreeMemory=%zu, (defragmentedMemory=%zu, freeRegionMemory=%zu)"
 TraceEvent=Trc_MM_SchedulingDelegate_calculateKickoffHeadroom Overhead=1 Level=1 Group=reclaim Template="calculateKickoffHeadroom oldHeadroomInBytes=%zu, newHeadroomInBytes=%zu"
 TraceExit=Trc_MM_SchedulingDelegate_calculateAutomaticGMPIntermission_1_Exit Overhead=1 Level=1 Group=kickoff Template="MM_SchedulingDelegate_calculateAutomaticGMPIntermission remaining=%zu, kickoffHeadroomInBytes=%zu"
+
+TraceEntry=Trc_MM_MSSGeneric_allocate_entry Overhead=1 Level=3 Group=allocate Template="MSSGeneric::allocate type %s size %zu subspace this %llx/%s base %llx prev %llx _allocateAtSafePointOnly %zu shouldCollectOnFailure %zu _isAllocatable %zu"
+TraceEvent=Trc_MM_MSSGeneric_allocate Overhead=1 Level=3 Group=allocate Template="MSSGeneric::allocate type %s size %zu event %u subspace %llx failed, trying parent %llx"
+TraceEvent=Trc_MM_MSSGeneric_allocate3 Overhead=1 Level=3 Group=allocate Template="MSSGeneric::allocate type %s size %zu event 3 subspace %llx failed, trying parent %llx shouldCollectAndClimb %zu"
+TraceExit=Trc_MM_MSSGeneric_allocate_exit Overhead=1 Level=3 Group=allocate Template="MSSGeneric::allocate type %s size %zu subspace %llx  result %llx"
+
+TraceEntry=Trc_MM_MSSSS_allocate_entry Overhead=1 Level=1 Group=allocate Template="MSSSS::allocate type %s size %zu subspace this %llx/%s base %llx prev %llx shouldCollectOnFailure %zu"
+TraceEvent=Trc_MM_MSSSS_allocate Overhead=1 Level=1 Group=allocate Template="MSSSS::allocate type %s size %zu event %u"
+TraceEvent=Trc_MM_MSSSS_allocate4 Overhead=1 Level=1 Group=allocate Template="MSSSS::allocate type %s size %zu event 4 shouldClimb %zu"
+TraceExit=Trc_MM_MSSSS_allocate_exit Overhead=1 Level=1 Group=allocate Template="MSSSS::allocate type %s size %zu result %llx"
+
+TraceEntry=Trc_MM_MSSSS_allocationRequestFailed_entry Overhead=1 Level=1 Group=allocate Template="MSSSS::allocationRequestFailed size %zu subspace this %llx/%s base %llx prev %llx allocationType %zu"
+TraceEvent=Trc_MM_MSSSS_allocationRequestFailed Overhead=1 Level=1 Group=allocate Template="MSSSS::allocationRequestFailed size %zu event %u"
+TraceExit=Trc_MM_MSSSS_allocationRequestFailed_exit Overhead=1 Level=1 Group=allocate Template="MSSSS::allocationRequestFailed size %zu exit %zu result %llx"
+
+TraceEntry=Trc_MM_MSSFlat_allocate_entry Overhead=1 Level=1 Group=allocate Template="MSSFlat::allocate type %s size %zu subspace this %llx/%s base %llx prev %llx shouldCollectOnFailure %zu"
+TraceEvent=Trc_MM_MSSFlat_allocate Overhead=1 Level=1 Group=allocate Template="MSSFlat::allocate type %s size %zu event %u"
+TraceExit=Trc_MM_MSSFlat_allocate_exit Overhead=1 Level=1 Group=allocate Template="MSSFlat::allocate type %s size %zu result %llx"
+
+TraceEntry=Trc_MM_MSSFlat_allocationRequestFailed_entry Overhead=1 Level=1 Group=allocate Template="MSSFlat::allocationRequestFailed size %zu subspace this %llx/%s base %llx prev %llx allocationType %zu"
+TraceEvent=Trc_MM_MSSFlat_allocationRequestFailed Overhead=1 Level=1 Group=allocate Template="MSSFlat::allocationRequestFailed size %zu event %u"
+TraceExit=Trc_MM_MSSFlat_allocationRequestFailed_exit Overhead=1 Level=1 Group=allocate Template="MSSFlat::allocationRequestFailed size %zu exit %zu result %llx"
+
+TraceEntry=Trc_MM_MSSGenerational_allocate_entry Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocate type %s size %zu subspace this %llx/%s base %llx prev %llx shouldCollectOnFailure %zu"
+TraceEvent=Trc_MM_MSSGenerational_allocate Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocate type %s size %zu prev != new %llx, allocate from old %llx"
+TraceExit=Trc_MM_MSSGenerational_allocate_exit Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocate type %s size %zu exit %zu result %llx"
+
+TraceEntry=Trc_MM_MSSGenerational_allocationRequestFailed_entry Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu subspace this %llx/%s base %llx prev %llx allocationType %zu"
+TraceEvent=Trc_MM_MSSGenerational_allocationRequestFailed1 Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu prev != new %llx, allocate from old %llx"
+TraceEvent=Trc_MM_MSSGenerational_allocationRequestFailed Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu event %u"
+TraceExit=Trc_MM_MSSGenerational_allocationRequestFailed_exit Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu exit %zu result %llx"


### PR DESCRIPTION
Fixing a regression where an unnecessary scavenge cycle would be
triggered right after aborted scavenge (and percolate global GC), and
only then allocation in Nursery would be restored.
Typically, it was a really minor perf penalty (relative to already
expensive but also very infrequent aborted handling). But in some very
malicious cases if a subsequnt Scavenge also aborts, it would cause a
whole series of frequent aborts. 

The regression was introduced as a part of aborted Concurrent Scavenger
handling, but would affect just the standard (non-CS) Scavenger.

Also adding a lot of trace points in SubSpace allocate path.
SubSpace Generic path which is frequently executed (like TLH refresh),
has the lower trace level of 3 (hence, won't show by default), while the
rest of them, which are rather infreqent (a few per a GC cycle) has
default 1 (and will show by default).

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>