### PR TITLE
WIP: Remove dead function generateBinaryEncoding2 in z codegen

### DIFF
--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -2406,30 +2406,6 @@ OMR::Z::MemoryReference::assignRegisters(TR::Instruction * currentInstruction, T
       }
    }
 
-/**
- * Generate binary encoding for the second memory reference operand in an instruction
- *
- * SS Format (e.g. XC)  - generate B2(D2) field
- *  ________ _______ ____________________________
- * |Op Code |   L   | B1 |   D1  | B2 |   D2     |
- * |________|_______|____|_______|____|__________|
- * 0         8     16   20       32  36          47
- */
-uint8_t *
-OMR::Z::MemoryReference::generateBinaryEncoding2(uint8_t * cursor, TR::CodeGenerator * cg)
-   {
-   TR::RealRegister * base = (self()->getBaseRegister() ? toRealRegister(self()->getBaseRegister()) : 0);
-   int32_t disp = _offset;
-
-   (*(uint16_t *) cursor) &= bos(0xF000);
-   (*(uint16_t *) cursor) |= bos(disp);
-   if (base)
-      {
-      base->setBaseRegisterField((uint32_t *) (cursor - 2));
-      }
-   return cursor;
-   }
-
 bool
 OMR::Z::MemoryReference::needsAdjustDisp(TR::Instruction * instr, OMR::Z::MemoryReference * mRef, TR::CodeGenerator * cg)
    {

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -374,7 +374,6 @@ bool doEvaluate(TR::Node * subTree, TR::CodeGenerator * cg);
 TR::Snippet * getSnippet();
 int32_t generateBinaryEncoding(uint8_t *modRM, TR::CodeGenerator *cg, TR::Instruction *instr);
 int32_t estimateBinaryLength(int32_t currentEstimate, TR::CodeGenerator *cg, TR::Instruction *instr);
-uint8_t *generateBinaryEncoding2(uint8_t *modRM, TR::CodeGenerator *cg);
 int32_t generateBinaryEncodingTouchUpForLongDisp(uint8_t *modRM, TR::CodeGenerator *cg, TR::Instruction *instr);
 
 void blockRegisters()


### PR DESCRIPTION
Remove dead function generateBinaryEncoding2 in z codegen.

Signed-off-by: Daniel Hong <daniel.hong@live.com>