### PR TITLE
AArch64: Add missing files in aarch64.mk for jitbuilder

### DIFF
--- a/jitbuilder/build/files/target/aarch64.mk
+++ b/jitbuilder/build/files/target/aarch64.mk
@@ -23,6 +23,7 @@
 
 JIT_PRODUCT_BACKEND_SOURCES+= \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64BinaryEncoding.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64Debug.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64OutOfLineCodeSection.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64SystemLinkage.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/BinaryEvaluator.cpp \
@@ -39,7 +40,8 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRRegisterIterator.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRSnippet.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRTreeEvaluator.cpp \
-    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OpBinary.cpp
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OpBinary.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/UnaryEvaluator.cpp
 
 #environement files
 #JIT_PRODUCT_BACKEND_SOURCES+= \


### PR DESCRIPTION
This commit adds some files that have been missing to
jitbuilder/build/files/target/aarch64.mk.

Signed-off-by: knn-k <konno@jp.ibm.com>