### PR TITLE
Fix for missing platform check for Guarded Storage

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -439,7 +439,7 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
    {
    TR::Compilation *comp = cg->comp();
 
-   if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
+   if (TR::Compiler->target.cpu.isZ() && TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
       {
       // TODO (GuardedStorage): We need to come up with a better solution than anchoring aloadi's
       // to enforce certain evaluation order


### PR DESCRIPTION
Guarded Storage is a Z-only feature and hence should be guarded with
TR::Compiler->target.cpu.isZ().

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>