### PR TITLE
Provide classes to record JitBuilder API calls

### DIFF
--- a/compiler/ilgen/CMakeLists.txt
+++ b/compiler/ilgen/CMakeLists.txt
@@ -26,6 +26,10 @@ compiler_library(ilgen
 	${CMAKE_CURRENT_LIST_DIR}/OMRIlBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRIlType.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRIlValue.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRJitBuilderRecorder.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRJitBuilderRecorderBinaryBuffer.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRJitBuilderRecorderBinaryFile.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRJitBuilderRecorderTextFile.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRMethodBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRThunkBuilder.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRTypeDictionary.cpp

--- a/compiler/ilgen/JitBuilderRecorder.hpp
+++ b/compiler/ilgen/JitBuilderRecorder.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_JITBUILDERRECORDER_INCL
+#define TR_JITBUILDERRECORDER_INCL
+
+#include "ilgen/OMRJitBuilderRecorder.hpp"
+
+namespace TR
+{
+   class JitBuilderRecorder : public OMR::JitBuilderRecorder
+      {
+      public:
+         JitBuilderRecorder(const TR::MethodBuilder *mb, const char *fileName)
+            : OMR::JitBuilderRecorder(mb, fileName)
+            { }
+         virtual ~JitBuilderRecorder()
+            { }
+      };
+
+} // namespace TR
+
+#endif // !defined(TR_JITBUILDERRECORDER_INCL)

--- a/compiler/ilgen/JitBuilderRecorderBinaryBuffer.hpp
+++ b/compiler/ilgen/JitBuilderRecorderBinaryBuffer.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_JITBUILDERRECORDER_BINARYBUFFER_INCL
+#define TR_JITBUILDERRECORDER_BINARYBUFFER_INCL
+
+#include "ilgen/OMRJitBuilderRecorderBinaryBuffer.hpp"
+
+namespace TR
+{
+   class JitBuilderRecorderBinaryBuffer : public OMR::JitBuilderRecorderBinaryBuffer
+      {
+      public:
+         JitBuilderRecorderBinaryBuffer(const TR::MethodBuilder *mb, const char *fileName)
+            : OMR::JitBuilderRecorderBinaryBuffer(mb, fileName)
+            { }
+         virtual ~JitBuilderRecorderBinaryBuffer()
+            { }
+      };
+
+} // namespace TR
+
+#endif // !defined(TR_JITBUILDERRECORDER_BINARYBUFFER_INCL)

--- a/compiler/ilgen/JitBuilderRecorderBinaryFile.hpp
+++ b/compiler/ilgen/JitBuilderRecorderBinaryFile.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_JITBUILDERRECORDER_BINARYFILE_INCL
+#define TR_JITBUILDERRECORDER_BINARYFILE_INCL
+
+#include "ilgen/OMRJitBuilderRecorderBinaryFile.hpp"
+
+namespace TR
+{
+   class JitBuilderRecorderBinaryFile : public OMR::JitBuilderRecorderBinaryFile
+      {
+      public:
+         JitBuilderRecorderBinaryFile(const TR::MethodBuilder *mb, const char *fileName)
+            : OMR::JitBuilderRecorderBinaryFile(mb, fileName)
+            { }
+         virtual ~JitBuilderRecorderBinaryFile()
+            { }
+      };
+
+} // namespace TR
+
+#endif // !defined(TR_JITBUILDERRECORDER_BINARYFILE_INCL)

--- a/compiler/ilgen/JitBuilderRecorderTextFile.hpp
+++ b/compiler/ilgen/JitBuilderRecorderTextFile.hpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_JITBUILDERRECORDER_TEXTFILE_INCL
+#define TR_JITBUILDERRECORDER_TEXTFILE_INCL
+
+#include "ilgen/OMRJitBuilderRecorderTextFile.hpp"
+
+namespace TR
+{
+   class JitBuilderRecorderTextFile : public OMR::JitBuilderRecorderTextFile
+      {
+      public:
+         JitBuilderRecorderTextFile(const TR::MethodBuilder *mb, const char *fileName)
+            : OMR::JitBuilderRecorderTextFile(mb, fileName)
+            { }
+         virtual ~JitBuilderRecorderTextFile()
+            { }
+      };
+
+} // namespace TR
+
+#endif // !defined(TR_JITBUILDERRECORDER_TEXTFILE_INCL)

--- a/compiler/ilgen/OMRJitBuilderRecorder.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorder.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "infra/Assert.hpp"
+#include "ilgen/JitBuilderRecorder.hpp"
+
+namespace TR { class MethodBuilder; }
+
+OMR::JitBuilderRecorder::JitBuilderRecorder(const TR::MethodBuilder *mb, const char *fileName)
+: _mb(mb), _nextID(0), _idSize(8),  _file(fileName, std::fstream::out | std::fstream::trunc)
+   {
+   start(); // initializes IDs 0 and 1 (reserved)
+   }
+
+OMR::JitBuilderRecorder::~JitBuilderRecorder()
+   {
+   }
+
+void
+OMR::JitBuilderRecorder::start()
+   {
+   // special reserved value, must do it first !
+   StoreID(0);
+
+   // another special reserved value, so do it first
+   StoreID((const void *)1);
+
+   String(StatementName::RECORDER_SIGNATURE);
+   Number(StatementName::VERSION_MAJOR);
+   Number(StatementName::VERSION_MINOR);
+   Number(StatementName::VERSION_PATCH);
+   EndStatement();
+   }
+
+void 
+OMR::JitBuilderRecorder::Close()                                       
+   { 
+   end();
+   EndStatement();
+   }
+
+OMR::JitBuilderRecorder::TypeID
+OMR::JitBuilderRecorder::getNewID()
+   {
+   // support for variable sized ID encoding
+   //  to avoid any synchronization issues in how decoders/encoders count IDs, use a statement to signal change
+   // check if we're close to 8-bit / 16-bit boundary
+   // need to leave space for one ID because these statements will not have been defined yet
+   //  and defining the statement needs an ID!
+   if (_nextID == (1 << 8) - 2)
+      {
+      _idSize = 16;
+      Statement(StatementName::STATEMENT_ID16BIT);
+      }
+   else if (_nextID == (1 << 16) - 2)
+      {
+      _idSize = 32;
+      Statement(StatementName::STATEMENT_ID32BIT);
+      }
+
+   return _nextID++;
+   }
+
+OMR::JitBuilderRecorder::TypeID
+OMR::JitBuilderRecorder::myID()
+   {
+   return lookupID(_mb);
+   }
+
+bool
+OMR::JitBuilderRecorder::knownID(const void *ptr)
+   {
+   TypeMapID::iterator it = _idMap.find(ptr);
+   return (it != _idMap.end());
+   }
+
+OMR::JitBuilderRecorder::TypeID
+OMR::JitBuilderRecorder::lookupID(const void *ptr)
+   {
+   TypeMapID::iterator it = _idMap.find(ptr);
+   if (it == _idMap.end())
+      TR_ASSERT_FATAL(0, "Attempt to lookup a builder object that has not yet been created");
+
+   TypeID id = it->second;
+   return id;
+   }
+
+void
+OMR::JitBuilderRecorder::ensureStatementDefined(const char *s)
+   {
+   if (knownID(s))
+      return;
+
+   StoreID(s);
+   Builder(0);
+   Statement(s);
+   String(s);
+   EndStatement();
+   }
+
+void
+OMR::JitBuilderRecorder::end()
+   {
+   ID(1); // reserved ID to indicate end of file
+   String(StatementName::JBIL_COMPLETE);
+   }
+
+void
+OMR::JitBuilderRecorder::BeginStatement(const char *s)
+   {
+   BeginStatement(_mb, s);
+   }
+
+void
+OMR::JitBuilderRecorder::BeginStatement(const TR::MethodBuilder *b, const char *s)
+   {
+   ensureStatementDefined(s);
+   Builder(b);
+   Statement(s);
+   }
+
+void
+OMR::JitBuilderRecorder::StoreID(const void *ptr)
+   {
+   TypeMapID::iterator it = _idMap.find(ptr);
+   if (it != _idMap.end())
+      TR_ASSERT_FATAL(0, "Unexpected ID already defined for address %p", ptr);
+
+   _idMap.insert(std::make_pair(ptr, getNewID()));
+   }
+
+bool
+OMR::JitBuilderRecorder::EnsureAvailableID(const void *ptr)
+   {
+   if (knownID(ptr)) // already available, so just return
+      return true;
+
+   StoreID(ptr);
+   return false; // ID was not available, but is now
+   }

--- a/compiler/ilgen/OMRJitBuilderRecorder.hpp
+++ b/compiler/ilgen/OMRJitBuilderRecorder.hpp
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_JITBUILDERRECORDER_INCL
+#define OMR_JITBUILDERRECORDER_INCL
+
+#include <iostream>
+#include <fstream>
+#include <map>
+#include "ilgen/StatementNames.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class MethodBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+
+namespace OMR
+{
+
+class JitBuilderRecorder
+   {
+   public:
+
+   typedef uint32_t                      TypeID;
+   typedef std::map<const void *,TypeID> TypeMapID;
+
+   JitBuilderRecorder(const TR::MethodBuilder *mb, const char *fileName);
+   virtual ~JitBuilderRecorder();
+
+   void setMethodBuilderRecorder(TR::MethodBuilder *mb) {_mb = mb;}
+
+   /**
+    * @brief Subclasses override these functions to record to different output formats
+    */
+   virtual void Close();
+   virtual void String(const char * const string)             { }
+   virtual void Number(int8_t num)                            { }
+   virtual void Number(int16_t num)                           { }
+   virtual void Number(int32_t num)                           { }
+   virtual void Number(int64_t num)                           { }
+   virtual void Number(float num)                             { }
+   virtual void Number(double num)                            { }
+   virtual void ID(TypeID id)                                 { }
+   virtual void Statement(const char *s)                      { }
+   virtual void Type(const TR::IlType *type)                  { }
+   virtual void Value(const TR::IlValue *v)                   { }
+   virtual void Builder(const TR::MethodBuilder *b)           { }
+   virtual void Builder()                                     { }
+   virtual void Location(const void * location)               { }
+
+   virtual void BeginStatement(const TR::MethodBuilder *b, const char *s);
+   virtual void BeginStatement(const char *s);
+   virtual void EndStatement()                                { }
+
+   void StoreID(const void *ptr);
+   bool EnsureAvailableID(const void *ptr);
+
+   protected:
+
+   void start();
+   bool knownID(const void *ptr);
+   TypeID lookupID(const void *ptr);
+   void ensureStatementDefined(const char *s);
+   void end();
+
+   TypeID getNewID();
+   TypeID myID();
+
+   const TR::MethodBuilder * _mb;
+   TypeID                            _nextID;
+   TypeMapID                         _idMap;
+   uint8_t                           _idSize;
+
+   std::fstream _file;
+   
+   };
+
+} // namespace OMR
+
+#endif // !defined(OMR_JITBUILDERRECORDER_INCL)

--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdint.h>
+#include <cstring>
+
+#include "ilgen/JitBuilderRecorderBinaryBuffer.hpp"
+#include "infra/Assert.hpp"
+
+OMR::JitBuilderRecorderBinaryBuffer::JitBuilderRecorderBinaryBuffer(const TR::MethodBuilder *mb, const char *fileName)
+   : TR::JitBuilderRecorder(mb, fileName), _buf()
+   {
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Close()
+   {
+   TR::JitBuilderRecorder::Close();
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::String(const char * const string)
+   {
+   // length(int16) characters
+   int32_t len = strlen(string);
+   TR_ASSERT(len < INT16_MAX, "JBIL: binary String format limited to %d characters", INT16_MAX);
+
+   Number((int16_t)len);
+   for (int16_t i=0;i < len;i++)
+      _buf.push_back((uint8_t)string[i]);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Number(int8_t num)
+   {
+   _buf.push_back(*(uint8_t *)&num);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Number(int16_t num)
+   {
+   _buf.push_back((uint8_t)num&0xFF);
+   _buf.push_back((uint8_t)(num&0xFF00)>>8);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Number(int32_t signedNum)
+   {
+   uint32_t *num = (uint32_t *)&signedNum;
+   uint8_t b0 = (uint8_t)  (*num & 0x000000FF);
+   uint8_t b1 = (uint8_t) ((*num & 0x0000FF00) >> 8);
+   uint8_t b2 = (uint8_t) ((*num & 0x00FF0000) >> 16);
+   uint8_t b3 = (uint8_t) ((*num & 0xFF000000) >> 24);
+   _buf.push_back(b0);
+   _buf.push_back(b1);
+   _buf.push_back(b2);
+   _buf.push_back(b3);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Number(int64_t signedNum)
+   {
+   uint64_t *num = (uint64_t *)&signedNum;
+   uint8_t b0 = (uint8_t)  (*num & 0x00000000000000FFUL);
+   uint8_t b1 = (uint8_t) ((*num & 0x000000000000FF00UL) >> 8);
+   uint8_t b2 = (uint8_t) ((*num & 0x0000000000FF0000UL) >> 16);
+   uint8_t b3 = (uint8_t) ((*num & 0x00000000FF000000UL) >> 24);
+   uint8_t b4 = (uint8_t) ((*num & 0x000000FF00000000UL) >> 32);
+   uint8_t b5 = (uint8_t) ((*num & 0x0000FF0000000000UL) >> 40);
+   uint8_t b6 = (uint8_t) ((*num & 0x00FF000000000000UL) >> 48);
+   uint8_t b7 = (uint8_t) ((*num & 0xFF00000000000000UL) >> 56);
+   _buf.push_back(b0);
+   _buf.push_back(b1);
+   _buf.push_back(b2);
+   _buf.push_back(b3);
+   _buf.push_back(b4);
+   _buf.push_back(b5);
+   _buf.push_back(b6);
+   _buf.push_back(b7);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Number(float floatNum)
+   {
+   int32_t *num = (int32_t *)&floatNum;
+   Number(*num);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Number(double doubleNum)
+   {
+   int64_t *num = (int64_t *)&doubleNum;
+   Number(*num);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::ID(TypeID id)
+   {
+   if (_idSize == 8)
+      {
+      // all known IDs fit in 8 bits
+      uint8_t idUnsigned = (uint8_t)id;
+      int8_t *num = (int8_t *)&idUnsigned;
+      Number(*num);
+      }
+   else if (_idSize == 16)
+      {
+      // all known IDs fit in 16 bits
+      uint16_t idUnsigned = (uint16_t)id;
+      int16_t *num = (int16_t *)&idUnsigned;
+      Number(*num);
+      }
+   else if (_idSize == 32)
+      {
+      // TypeID can only hold 32-bits so that's the most we'll need
+      uint32_t idUnsigned = (uint32_t)id;
+      int32_t *num = (int32_t *)&idUnsigned;
+      Number(*num);
+      }
+   else
+      TR_ASSERT(0, "Unexpected id size value %d", _idSize);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Statement(const char *s)
+   {
+   ID(lookupID(s));
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Type(const TR::IlType *type)
+   {
+   ID(lookupID(type));
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Value(const TR::IlValue *v)
+   {
+   ID(lookupID(v));
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Builder(const TR::IlBuilder *b)
+   {
+   ID(lookupID(b));
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::Location(const void *location)
+   {
+   int64_t num = (int64_t)location;
+   Number(num);
+   }
+
+void
+OMR::JitBuilderRecorderBinaryBuffer::EndStatement()
+   {
+   }

--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.hpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.hpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_JITBUILDERRECORDER_BINARYBUFFER_INCL
+#define OMR_JITBUILDERRECORDER_BINARYBUFFER_INCL
+
+#include "ilgen/JitBuilderRecorder.hpp"
+#include <vector>
+
+namespace TR { class IlBuilder; }
+namespace TR { class MethodBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+
+namespace OMR
+{
+
+class JitBuilderRecorderBinaryBuffer : public TR::JitBuilderRecorder
+   {
+   public:
+   JitBuilderRecorderBinaryBuffer(const TR::MethodBuilder *mb, const char *fileName);
+   virtual ~JitBuilderRecorderBinaryBuffer() { }
+
+   virtual void Close();
+   virtual void String(const char * const string);
+   virtual void Number(int8_t num);
+   virtual void Number(int16_t num);
+   virtual void Number(int32_t num);
+   virtual void Number(int64_t num);
+   virtual void Number(float num);
+   virtual void Number(double num);
+   virtual void ID(TypeID id);
+   virtual void Statement(const char *s);
+   virtual void Type(const TR::IlType *type);
+   virtual void Value(const TR::IlValue *v);
+   virtual void Builder(const TR::IlBuilder *b);
+   virtual void Location(const void * location);
+   virtual void EndStatement();
+
+   std::vector<uint8_t> & buffer() { return _buf; }
+
+   protected:
+   std::vector<uint8_t> _buf;
+   };
+
+} // namespace OMR
+
+#endif // !defined(OMR_JITBUILDERRECORDER_BINARYBUFFER_INCL)

--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryFile.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryFile.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdint.h>
+
+#include "ilgen/JitBuilderRecorderBinaryFile.hpp"
+#include "infra/Assert.hpp"
+
+OMR::JitBuilderRecorderBinaryFile::JitBuilderRecorderBinaryFile(const TR::MethodBuilder *mb, const char *fileName)
+   : TR::JitBuilderRecorderBinaryBuffer(mb, fileName)
+   {
+   }
+
+void
+OMR::JitBuilderRecorderBinaryFile::Close()
+   {
+   TR::JitBuilderRecorder::Close();
+
+   _file.write(reinterpret_cast<const char *>(&_buf[0]), _buf.size());
+
+   _file.close();
+   }

--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryFile.hpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryFile.hpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_JITBUILDERRECORDER_BINARYFILE_INCL
+#define OMR_JITBUILDERRECORDER_BINARYFILE_INCL
+
+#include "ilgen/JitBuilderRecorderBinaryBuffer.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class MethodBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+
+namespace OMR
+{
+
+class JitBuilderRecorderBinaryFile : public TR::JitBuilderRecorderBinaryBuffer
+   {
+   public:
+   JitBuilderRecorderBinaryFile(const TR::MethodBuilder *mb, const char *fileName);
+   virtual ~JitBuilderRecorderBinaryFile() { }
+
+   virtual void Close();
+
+   };
+
+} // namespace OMR
+
+#endif // !defined(OMR_JITBUILDERRECORDER_BINARYFILE_INCL)

--- a/compiler/ilgen/OMRJitBuilderRecorderTextFile.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderTextFile.cpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdint.h>
+#include <cstring>
+
+#include "infra/Assert.hpp"
+#include "ilgen/JitBuilderRecorderTextFile.hpp"
+
+OMR::JitBuilderRecorderTextFile::JitBuilderRecorderTextFile(const TR::MethodBuilder *mb, const char *fileName)
+   : TR::JitBuilderRecorder(mb, fileName)
+   {
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Close()
+   {
+   TR::JitBuilderRecorder::Close();
+   _file.close();
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::String(const char * const string)
+   {
+   _file << "\"" << strlen(string) << " [" << string << "]\" ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Number(int8_t num)
+   {
+   _file << (int32_t) num << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Number(int16_t num)
+   {
+   _file << num << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Number(int32_t num)
+   {
+   _file << num << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Number(int64_t num)
+   {
+   _file << num << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Number(float num)
+   {
+   _file << num << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Number(double num)
+   {
+   _file << num << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::ID(TypeID id)
+   {
+   _file << "ID" << id << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Statement(const char *s)
+   {
+   _file << "S" << lookupID(s) << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Type(const TR::IlType *type)
+   {
+   _file << "T" << lookupID(type) << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Value(const TR::IlValue *v)
+   {
+   _file << "V" << lookupID(v) << " ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Builder(const TR::IlBuilder *b)
+   {
+   if (b)
+      _file << "B" << lookupID(b) << " ";
+   else
+      _file << "Def ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::Location(const void *location)
+   {
+   _file << "{" << location << "} ";
+   }
+
+void
+OMR::JitBuilderRecorderTextFile::EndStatement()
+   {
+   _file << "\n";
+   }

--- a/compiler/ilgen/OMRJitBuilderRecorderTextFile.hpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderTextFile.hpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_JITBUILDERRECORDER_TEXTFILE_INCL
+#define OMR_JITBUILDERRECORDER_TEXTFILE_INCL
+
+#include "ilgen/JitBuilderRecorder.hpp"
+
+namespace TR { class IlBuilder; }
+namespace TR { class MethodBuilder; }
+namespace TR { class IlType; }
+namespace TR { class IlValue; }
+
+namespace OMR
+{
+
+class JitBuilderRecorderTextFile : public TR::JitBuilderRecorder
+   {
+   public:
+   JitBuilderRecorderTextFile(const TR::MethodBuilder *mb, const char *fileName);
+   virtual ~JitBuilderRecorderTextFile() { }
+
+   virtual void Close();
+   virtual void String(const char * const string);
+   virtual void Number(int8_t num);
+   virtual void Number(int16_t num);
+   virtual void Number(int32_t num);
+   virtual void Number(int64_t num);
+   virtual void Number(float num);
+   virtual void Number(double num);
+   virtual void ID(TypeID id);
+   virtual void Statement(const char *s);
+   virtual void Type(const TR::IlType *type);
+   virtual void Value(const TR::IlValue *v);
+   virtual void Builder(const TR::IlBuilder *b);
+   virtual void Location(const void * location);
+   virtual void EndStatement();
+
+   };
+
+} // namespace OMR
+
+#endif // !defined(OMR_JITBUILDERRECORDER_TEXTFILE_INCL)

--- a/compiler/ilgen/StatementNames.hpp
+++ b/compiler/ilgen/StatementNames.hpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_STATEMENTNAMES_INCL
+#define OMR_STATEMENTNAMES_INCL
+
+#include <cstdint>
+
+namespace OMR
+{
+
+namespace StatementName {
+
+static const int16_t VERSION_MAJOR              = 0;
+static const int16_t VERSION_MINOR              = 0;
+static const int16_t VERSION_PATCH              = 0;
+static const char * const RECORDER_SIGNATURE    = "JBIL";
+static const char * const JBIL_COMPLETE         = "Done";
+
+static const char * const STATEMENT_DEFINENAME                   = "DefineName";
+static const char * const STATEMENT_DEFINEFILE                   = "DefineFile";
+static const char * const STATEMENT_DEFINELINESTRING             = "DefineLineString";
+static const char * const STATEMENT_DEFINELINENUMBER             = "DefineLineNumber";
+static const char * const STATEMENT_DEFINEPARAMETER              = "DefineParameter";
+static const char * const STATEMENT_DEFINEARRAYPARAMETER         = "DefineArrayParameter";
+static const char * const STATEMENT_DEFINERETURNTYPE             = "DefineReturnType";
+static const char * const STATEMENT_DEFINELOCAL                  = "DefineLocal";
+static const char * const STATEMENT_DEFINEMEMORY                 = "DefineMemory";
+static const char * const STATEMENT_DEFINEFUNCTION               = "DefineFunction";
+static const char * const STATEMENT_DEFINESTRUCT                 = "DefineStruct";
+static const char * const STATEMENT_DEFINEUNION                  = "DefineUnion";
+static const char * const STATEMENT_DEFINEFIELD                  = "DefineField";
+static const char * const STATEMENT_PRIMITIVETYPE                = "PrimitiveType";
+static const char * const STATEMENT_POINTERTYPE                  = "PointerType";
+static const char * const STATEMENT_NEWMETHODBUILDER             = "NewMethodBuilder";
+static const char * const STATEMENT_NEWILBUILDER                 = "NewIlBuilder";
+static const char * const STATEMENT_NEWBYTECODEBUILDER           = "NewBytecodeBuilder";
+static const char * const STATEMENT_ALLLOCALSHAVEBEENDEFINED     = "AllLocalsHaveBeenDefined";
+static const char * const STATEMENT_NULLADDRESS                  = "NullAddress";
+static const char * const STATEMENT_CONSTINT8                    = "ConstInt8";
+static const char * const STATEMENT_CONSTINT16                   = "ConstInt16";
+static const char * const STATEMENT_CONSTINT32                   = "ConstInt32";
+static const char * const STATEMENT_CONSTINT64                   = "ConstInt64";
+static const char * const STATEMENT_CONSTFLOAT                   = "ConstFloat";
+static const char * const STATEMENT_CONSTDOUBLE                  = "ConstDouble";
+static const char * const STATEMENT_CONSTSTRING                  = "ConstString";
+static const char * const STATEMENT_CONSTADDRESS                 = "ConstAddress";
+static const char * const STATEMENT_INDEXAT                      = "IndexAt";
+static const char * const STATEMENT_LOAD                         = "Load";
+static const char * const STATEMENT_LOADAT                       = "LoadAt";
+static const char * const STATEMENT_LOADINDIRECT                 = "LoadIndirect";
+static const char * const STATEMENT_STORE                        = "Store";
+static const char * const STATEMENT_STOREOVER                    = "StoreOver";
+static const char * const STATEMENT_STOREAT                      = "StoreAt";
+static const char * const STATEMENT_STOREINDIRECT                = "StoreIndirect";
+static const char * const STATEMENT_CREATELOCALARRAY             = "CreateLocalArray";
+static const char * const STATEMENT_CREATELOCALSTRUCT            = "CreateLocalStruct";
+static const char * const STATEMENT_VECTORLOAD                   = "VectorLoad";
+static const char * const STATEMENT_VECTORLOADAT                 = "VectorLoadAt";
+static const char * const STATEMENT_VECTORSTORE                  = "VectorStore";
+static const char * const STATEMENT_VECTORSTOREAT                = "VectorStoreAt";
+static const char * const STATEMENT_STRUCTFIELDINSTANCEADDRESS   = "StructFieldInstance";
+static const char * const STATEMENT_UNIONFIELDINSTANCEADDRESS    = "UnionFieldInstance";
+static const char * const STATEMENT_CONVERTTO                    = "ConvertTo";
+static const char * const STATEMENT_UNSIGNEDCONVERTTO            = "UnsignedConvertTo";
+static const char * const STATEMENT_ATOMICADD                    = "AtomicAdd";
+static const char * const STATEMENT_ADD                          = "Add";
+static const char * const STATEMENT_ADDWITHOVERFLOW              = "AddWithOverflow";
+static const char * const STATEMENT_ADDWITHUNSIGNEDOVERFLOW      = "AddWithUnsignedOverflow";
+static const char * const STATEMENT_SUB                          = "Sub";
+static const char * const STATEMENT_SUBWITHOVERFLOW              = "SubWithOverflow";
+static const char * const STATEMENT_SUBWITHUNSIGNEDOVERFLOW      = "SubWithUnsignedOverflow";
+static const char * const STATEMENT_MUL                          = "Mul";
+static const char * const STATEMENT_MULWITHOVERFLOW              = "MulWithOverflow";
+static const char * const STATEMENT_DIV                          = "Div";
+static const char * const STATEMENT_REM                          = "Rem";
+static const char * const STATEMENT_AND                          = "And";
+static const char * const STATEMENT_OR                           = "Or";
+static const char * const STATEMENT_XOR                          = "Xor";
+static const char * const STATEMENT_LESSTHAN                     = "LessThan";
+static const char * const STATEMENT_UNSIGNEDLESSTHAN             = "UnsignedLessThan";
+static const char * const STATEMENT_UNSIGNEDLESSOREQUALTO        = "UnsignedLessOrEqualTo";
+static const char * const STATEMENT_NEGATE                       = "Negate";
+static const char * const STATEMENT_CONVERTBITSTO                = "ConvertBitsTo";
+static const char * const STATEMENT_GREATERTHAN                  = "GreaterThan";
+static const char * const STATEMENT_GREATEROREQUALTO             = "GreaterOrEqualTo";
+static const char * const STATEMENT_UNSIGNEDGREATERTHAN          = "UnsignedGreaterThan";
+static const char * const STATEMENT_UNSIGNEDGREATEROREQUALTO     = "UnsignedGreaterOrEqualTo";
+static const char * const STATEMENT_EQUALTO                      = "EqualTo";
+static const char * const STATEMENT_LESSOREQUALTO                = "LessOrEqualTo";
+static const char * const STATEMENT_NOTEQUALTO                   = "NotEqualTo";
+static const char * const STATEMENT_APPENDBUILDER                = "AppendBuilder";
+static const char * const STATEMENT_APPENDBYTECODEBUILDER        = "AppendBytecodeBuilder";
+static const char * const STATEMENT_GOTO                         = "Goto";
+static const char * const STATEMENT_SHIFTL                       = "ShiftL";
+static const char * const STATEMENT_SHIFTR                       = "ShiftR";
+static const char * const STATEMENT_UNSIGNEDSHIFTR               = "UnsignedShiftR";
+static const char * const STATEMENT_RETURN                       = "Return";
+static const char * const STATEMENT_RETURNVALUE                  = "ReturnValue";
+static const char * const STATEMENT_IFTHENELSE                   = "IfThenElse";
+static const char * const STATEMENT_IFCMPEQUALZERO               = "IfCmpEqualZero";
+static const char * const STATEMENT_IFCMPNOTEQUALZERO            = "IfCmpNotEqualZero";
+static const char * const STATEMENT_IFCMPNOTEQUAL                = "IfCmpNotEqual";
+static const char * const STATEMENT_IFCMPEQUAL                   = "IfCmpEqual";
+static const char * const STATEMENT_IFCMPLESSTHAN                = "IfCmpLessThan";
+static const char * const STATEMENT_IFCMPLESSOREQUAL             = "IfCmpLessOrEqual";
+static const char * const STATEMENT_IFCMPUNSIGNEDLESSOREQUAL     = "IfCmpUnsignedLessOrEqual";
+static const char * const STATEMENT_IFCMPUNSIGNEDLESSTHAN        = "IfCmpUnsignedLessThan";
+static const char * const STATEMENT_IFCMPGREATERTHAN             = "IfCmpGreaterThan";
+static const char * const STATEMENT_IFCMPUNSIGNEDGREATERTHAN     = "IfCmpUnsignedGreaterThan";
+static const char * const STATEMENT_IFCMPGREATEROREQUAL          = "IfCmpGreaterOrEqual";
+static const char * const STATEMENT_IFCMPUNSIGNEDGREATEROREQUAL  = "IfCmpUnsignedGreaterOrEqual";
+static const char * const STATEMENT_DOWHILELOOP                  = "DoWhileLoop";
+static const char * const STATEMENT_WHILEDOLOOP                  = "WhileDoLoop";
+static const char * const STATEMENT_FORLOOP                      = "ForLoop";
+static const char * const STATEMENT_CALL                         = "Call";
+static const char * const STATEMENT_COMPUTEDCALL                 = "ComputedCall";
+static const char * const STATEMENT_DONECONSTRUCTOR              = "DoneConstructor";
+static const char * const STATEMENT_IFAND                        = "IfAnd";
+static const char * const STATEMENT_IFOR                         = "IfOr";
+static const char * const STATEMENT_SWITCH                       = "Switch";
+static const char * const STATEMENT_TRANSACTION                  = "Transaction";
+static const char * const STATEMENT_TRANSACTIONABORT             = "TransactionAbort";
+
+/*
+* @brief constant strings only used internally by recorders
+*/
+static const char * const STATEMENT_ID16BIT                      = "ID16BIT";
+static const char * const STATEMENT_ID32BIT                      = "ID32BIT";
+}
+
+} // namespace OMR
+
+#endif // !defined(OMR_STATEMENTNAMES_INCL)

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -254,6 +254,10 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlType.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlValue.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorderBinaryFile.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorderTextFile.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRMethodBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRThunkBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.cpp \

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -223,6 +223,10 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlType.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRIlValue.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorder.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorderBinaryFile.cpp \
+    $(JIT_OMR_DIRTY_DIR)/ilgen/OMRJitBuilderRecorderTextFile.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRMethodBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRThunkBuilder.cpp \
     $(JIT_OMR_DIRTY_DIR)/ilgen/OMRTypeDictionary.cpp \


### PR DESCRIPTION
Recorder is part of the record and replay functionality.
The ultimate goal for such feature is to remove the JIT from
runtimes and provide it as a service. The recorder part of this
feature, as the name implies, will record the IL at the client side
and send it to be compiled in the server. The server then
replays/parses the IL and compiles it, to then send machine code
back to the client so that it can execute the requested IL. The IL
contains services that have recording support (e.g. Add, Sub, Xor,
Store, Loop, etc. More to come). This commit is dedicated to the
Recorder initial functionality. More details as follows.

JitBuilderRecorder defines the basic structure of a JitBuilder IL
(ljbil) representation. The following files provide implementations
that write this representation to a binary buffer, binary file, text
file, respectively:
OMRJitBuilderRecorderBinaryBuffer
OMRJitBuilderRecorderBinaryFile
OMRJitBuilderRecorderTextFile

To enable replay compilation and a host of other useful facilities,
I have implemented a very simple format that can capture the calls
made to JitBuilder services on builder objects in a readily persisted
(stored to disk, saved in buffers, etc) form.

More details:

This commit defines the basic structure of a JitBuilder IL (ljbil)
representation along with representations as a binary buffer,
binary file, and text file.

The fundamental elements of the jbil representation are (currently):
	String (length then characters)
	Number (8, 16, 32, 64, float, double)
	ID (32-bit)
		Statement
		Type
		Value
		Builder
		Location

An ID is just a number used to identify different Strings, Builder
objects, Values, Types, Locations, and Statements. A std::map is
used to associate an ID with pointers corresponding to these
different categories. Rather than embed pointers into the jbil
output, we embed IDs.

IlBuilder, MethodBuilder, and BytecodeBuilder objects will need
to create some jbil output for each service that is called on
these objects. New objects need to be assigned IDs (by calling
StoreID() ) before they can be referenced by their ID.

Each time an IlBuilder object is created, for example, the NewIlBuilder
can be used to assign it an ID, and that ID can be referenced by
subsequent statements to call new services on it.

Every jbil output starts with (see start() function):
	String(RECORDER_SIGNATURE); // 4 (16 bits) "JBIL"
	Number(VERSION_MAJOR);      // 0 (16 bits)
	Number(VERSION_MINOR);      // 0 (16 bits)
	Number(VERSION_PATCH);      // 0 (16 bits)

This header can be encoded in as little as 12 bytes. This version
can be used to understand how the jbil was produced and enables
processing tools to precisely understand the format of the jbil.

Following the header is a sequence of statements.  There are only
two predefined statements. The first predefined statement assigns
an ID to a string:
	0 "Statement String"

All statements begin with the builder object they apply to.
The predefined statement references the special builder ID
0 which cannot be used by any other builder object. This
statement causes the provided string to be assigned the
next available ID (starting at 1). Subsequent statements
are all of the form:

	<BuilderID> <StatementID> <required values>

Depending on the statement, any number of additional
values may be required, but each statement has a
particular set of values it requires.

The statement strings are defined in StatementNames.hpp
as STATEMENT_<statement name> . For example, STATEMENT_LOAD
represents a call to IlBuilder::Load() while STATEMENT_ADD
represents a call to IlBuilder::Add().

The sequence of statements ends when the second predefined
statement is encountered using the special Builder(1)
object followed by the JBIL_COMPLETE string ("Done");

At the end of the representation, the following trailer is
added (see end() function):
	Builder(1);
	String(JBIL_COMPLETE);      // 4 (16 bits) "Done"

This commit doesn't show how IlBuilder, MethodBuilder, or
BytecodeBuilder can use JitBuilderRecorder to record
jbil; that will come in later commits.

Co-authored-by: Sharon Wang <sharon-wang-cpsc@outlook.com>
Co-authored-by: Mark Stoodley <mstoodle@ca.ibm.com>
Co-authored-by: Andrew Young <youngar17@gmail.com>
Co-authored-by: Charlie Gracie <charlie.gracie@gmail.com>

Signed-off-by: Igor Braga <higorb1@gmail.com>