### PR TITLE
Clean up GC test shutdown; don't run GC tests for disabled features

### DIFF
--- a/fvtest/gctest/GCConfigTest.cpp
+++ b/fvtest/gctest/GCConfigTest.cpp
@@ -40,14 +40,21 @@
 #define STRINGFY(str) DO_STRINGFY(str)
 #define DO_STRINGFY(str) #str
 
-const char *gcTests[] = {"fvtest/gctest/configuration/sample_GC_config.xml",
-                                "fvtest/gctest/configuration/test_system_gc.xml",
-                                "fvtest/gctest/configuration/gencon_GC_config.xml",
-                                "fvtest/gctest/configuration/gencon_GC_backout_config.xml",
-                                "fvtest/gctest/configuration/scavenger_GC_config.xml",
-                                "fvtest/gctest/configuration/scavenger_GC_backout_config.xml",
-                               	"fvtest/gctest/configuration/global_GC_config.xml",
-								"fvtest/gctest/configuration/optavgpause_GC_config.xml"};
+const char *gcTests[] = {"fvtest/gctest/configuration/sample_GC_config.xml"
+                        , "fvtest/gctest/configuration/test_system_gc.xml"
+                        , "fvtest/gctest/configuration/global_GC_config.xml"
+#if defined(OMR_GC_MODRON_CONCURRENT_MARK)
+                        , "fvtest/gctest/configuration/optavgpause_GC_config.xml"
+#endif
+#if defined(OMR_GC_MODRON_SCAVENGER)
+                        , "fvtest/gctest/configuration/scavenger_GC_config.xml"
+                        , "fvtest/gctest/configuration/scavenger_GC_backout_config.xml"
+#endif
+#if defined(OMR_GC_MODRON_SCAVENGER) && defined(OMR_GC_MODRON_CONCURRENT_MARK)
+                        , "fvtest/gctest/configuration/gencon_GC_config.xml"
+                        , "fvtest/gctest/configuration/gencon_GC_backout_config.xml"
+#endif
+                        };
 
 const char *perfTests[] = {"perftest/gctest/configuration/21645_core.20150126.202455.11862202.0001.xml",
 								"perftest/gctest/configuration/24404_core.20140723.091737.5812.0002.xml"};

--- a/fvtest/gctest/GCConfigTest.cpp
+++ b/fvtest/gctest/GCConfigTest.cpp
@@ -178,12 +178,14 @@ GCConfigTest::TearDown()
 		cli->kill(env);
 	}
 
-	/* Shut down the dispatcher threads */
-	omr_error_t rc = OMR_GC_ShutdownDispatcherThreads(exampleVM->_omrVMThread);
-	ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_GC_ShutdownDispatcherThreads failed, rc=" << rc;
+	if (NULL != exampleVM->_omrVMThread) {
+		/* Shut down the dispatcher threads */
+		omr_error_t rc = OMR_GC_ShutdownDispatcherThreads(exampleVM->_omrVMThread);
+		ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_GC_ShutdownDispatcherThreads failed, rc=" << rc;
+	}
 
 	/* Detach from VM */
-	rc = OMR_Thread_Free(exampleVM->_omrVMThread);
+	omr_error_t rc = OMR_Thread_Free(exampleVM->_omrVMThread);
 	ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_Thread_Free failed, rc=" << rc;
 
 	/* Shut down collector */

--- a/fvtest/gctest/GCConfigTest.cpp
+++ b/fvtest/gctest/GCConfigTest.cpp
@@ -174,23 +174,20 @@ GCConfigTest::TearDown()
 	omrmem_free_memory((void *)verboseFile);
 	verboseFile = NULL;
 
-	cli->kill(env);
+	if (NULL != cli) {
+		cli->kill(env);
+	}
 
 	/* Shut down the dispatcher threads */
 	omr_error_t rc = OMR_GC_ShutdownDispatcherThreads(exampleVM->_omrVMThread);
 	ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_GC_ShutdownDispatcherThreads failed, rc=" << rc;
 
-	/* Shut down collector */
-	rc = OMR_GC_ShutdownCollector(exampleVM->_omrVMThread);
-	ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_GC_ShutdownCollector failed, rc=" << rc;
-
 	/* Detach from VM */
 	rc = OMR_Thread_Free(exampleVM->_omrVMThread);
 	ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_Thread_Free failed, rc=" << rc;
 
-	/* Shut down heap */
-	rc = OMR_GC_ShutdownHeap(exampleVM->_omrVM);
-	ASSERT_EQ(OMR_ERROR_NONE, rc) << "TearDown(): OMR_GC_ShutdownHeap failed, rc=" << rc;
+	/* Shut down collector */
+	ASSERT_EQ(OMR_GC_ShutdownHeapAndCollector(exampleVM->_omrVM), OMR_ERROR_NONE);
 
 	exampleVM->_omrVMThread = NULL;
 

--- a/gc/startup/omrgcstartup.cpp
+++ b/gc/startup/omrgcstartup.cpp
@@ -291,16 +291,25 @@ OMR_GC_InitializeCollector(OMR_VMThread* omrVMThread)
 }
 
 omr_error_t
-OMR_GC_ShutdownCollector(OMR_VMThread* omrVMThread)
+OMR_GC_ShutdownCollector(OMR_VM* vm)
 {
-	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(omrVMThread->_vm);
-	MM_Collector *globalCollector = extensions->getGlobalCollector();
-	
-	if (NULL != globalCollector) {
-		globalCollector->collectorShutdown(extensions);
+	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(vm);
+
+	if (NULL != extensions) {
+		MM_Collector *globalCollector = extensions->getGlobalCollector();
+
+		if (NULL != globalCollector) {
+			globalCollector->collectorShutdown(extensions);
+		}
 	}
 
 	return OMR_ERROR_NONE;
+}
+
+omr_error_t
+OMR_GC_ShutdownCollector(OMR_VMThread* vmThread)
+{
+	return OMR_GC_ShutdownCollector(vmThread->_vm);
 }
 
 omr_error_t
@@ -332,6 +341,13 @@ OMR_GC_ShutdownHeap(OMR_VM *omrVM)
 		omrthread_detach(self);
 	}
 
+	return OMR_ERROR_NONE;
+}
+
+omr_error_t
+OMR_GC_ShutdownHeapAndCollector(OMR_VM* omrVM) {
+	OMR_GC_ShutdownCollector(omrVM);
+	OMR_GC_ShutdownHeap(omrVM);
 	return OMR_ERROR_NONE;
 }
 

--- a/gc/startup/omrgcstartup.hpp
+++ b/gc/startup/omrgcstartup.hpp
@@ -44,6 +44,10 @@ omr_error_t OMR_GC_InitializeCollector(OMR_VMThread* omrVMThread);
 
 omr_error_t OMR_GC_ShutdownCollector(OMR_VMThread* omrVMThread);
 
+omr_error_t OMR_GC_ShutdownCollector(OMR_VM* vm);
+
 omr_error_t OMR_GC_ShutdownHeap(OMR_VM* omrVM);
+
+omr_error_t OMR_GC_ShutdownHeapAndCollector(OMR_VM* vm);
 
 #endif /* MM_OMRGCSTARTUPAPI_HPP_ */


### PR DESCRIPTION
In the GC tests, If the collector fails to initialize, then the testcase will abort before a VM thread is attached. Unfortunately, some of the GC shutdown APIs require a valid thread.  This dependency is bogus--the thread is not really needed. This PR adds some new shutdown APIs that instead take an OMR VM. With these new APIs, the tests can bring everything down safely, even when the test aborts very early.

This error condition was exposed when trying to run testing for GC features that are disabled. This is bad--obviously a scavenger test will fail when the scavenger is ifdef'd out. This PR moves the offending tests under the relevant feature ifdefs, so we only run tests when they're actually supported.

/cc @youngar @charliegracie