### PR TITLE
Enable vbpermq support in the Power codegen

### DIFF
--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -552,6 +552,7 @@
    vxor,             // vector xor
    vnor,             // vector nor
    vperm,            // vector permute
+   vbpermq,          // Vector Bit Permute Qword
    vsel,             // vector conditional select
    vsumsws,          // vector sum across signed word saturate
    vsum2sws,         // vector sum across partial signed word saturate

--- a/compiler/p/codegen/OpBinary.cpp
+++ b/compiler/p/codegen/OpBinary.cpp
@@ -551,6 +551,7 @@ const TR_PPCOpCodeBinaryEntry OMR::Power::InstOpCode::binaryEncodings[PPCNumOpCo
    0x100004c4,  // vxor
    0x10000504,  // vnor
    0x1000002b,  // vperm
+   0x1000054c,  // vbpermq
    0x1000002a,  // vsel
    0x10000788,  // vsumsws
    0x10000688,  // vsum2sws

--- a/compiler/p/codegen/OpProperties.cpp
+++ b/compiler/p/codegen/OpProperties.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2497,6 +2497,10 @@ PPCOpProp_IsVMX |
 PPCOpProp_SyncSideEffectFree,
 
 // vperm
+PPCOpProp_IsVMX |
+PPCOpProp_SyncSideEffectFree,
+
+// vbpermq
 PPCOpProp_IsVMX |
 PPCOpProp_SyncSideEffectFree,
 

--- a/compiler/p/codegen/PPCOps.ops
+++ b/compiler/p/codegen/PPCOps.ops
@@ -1,5 +1,5 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! Copyright (c) 2000, 2016 IBM Corp. and others
+!! Copyright (c) 2000, 2018 IBM Corp. and others
 !!
 !! This program and the accompanying materials are made available under
 !! the terms of the Eclipse Public License 2.0 which accompanies this
@@ -586,7 +586,7 @@ vnor       vnor       10000504 IsVMX,SyncSideEffectFree                         
 vperm      vperm      1000002B IsVMX,SyncSideEffectFree                                                      // vector permute
 !vpermr     vpermr     1000003b IsVMX,SyncSideEffectFree                                                      // vector permute right-indexed
 !vbpermd    vbpermd    100005cc IsVMX,SyncSideEffectFree                                                      // vector bit permute DWord
-!vbpermq    vbpermq    1000054c IsVMX,SyncSideEffectFree                                                      // Vector Bit Permute Qword
+vbpermq    vbpermq    1000054c IsVMX,SyncSideEffectFree                                                      // Vector Bit Permute Qword
 !vrld       vrld       100000c4 IsRotateOrShift,IsVMX,SyncSideEffectFree                                      // Vector Rotate Left Dword
 !vsbox      vsbox      100005c8 IsVMX,SyncSideEffectFree                                                      // Vector AES SubBytes
 vsel       vsel       1000002A IsVMX,SyncSideEffectFree                                                      // vector conditional select

--- a/compiler/ras/PPCOpNames.cpp
+++ b/compiler/ras/PPCOpNames.cpp
@@ -552,6 +552,7 @@ const char * ppcOpCodeToNameMap[][2] =
    {"vxor", "vxor"},
    {"vnor", "vnor"},
    {"vperm", "vperm"},
+   {"vbpermq", "vbpermq"},
    {"vsel", "vsel"},
    {"vsumsws", "vsumsws"},
    {"vsum2sws", "vsum2sws"},


### PR DESCRIPTION
The vbpermq instruction was added in Power 8 and allows performing a
bitwise permutation on a vector, similar to how vperm allows a bytewise
permutation.

[ci skip]

Signed-off-by: Ben Thomas <ben@benthomas.ca>