### PR TITLE
Add two helpers for OSR related optimizations

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -648,9 +648,15 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNo
       else if (node->getOpCode().isCall())
          {
          TR::SymbolReference *callSymRef = node->getSymbolReference();
-         if (callSymRef->getReferenceNumber() >=
+         if (node->isPotentialOSRPointHelperCall())
+            {
+            potentialOSRPoint = true;
+            }
+         else if (callSymRef->getReferenceNumber() >=
              self()->getSymRefTab()->getNonhelperIndex(self()->getSymRefTab()->getLastCommonNonhelperSymbol()))
+            {
             potentialOSRPoint = (disableGuardedCallOSR == NULL);
+            }
          }
       else if (node->getOpCodeValue() == TR::monent)
          potentialOSRPoint = (disableMonentOSR == NULL);
@@ -774,6 +780,11 @@ OMR::Compilation::getOSRInductionOffset(TR::Node *node)
    if (!self()->isPotentialOSRPoint(node, &osrNode))
       {
       TR_ASSERT(0, "getOSRInductionOffset should only be called on OSR points");
+      }
+
+   if (osrNode->isPotentialOSRPointHelperCall())
+      {
+      return osrNode->getOSRInductionOffset();
       }
 
    if (osrNode->getOpCode().isCall())

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1927,3 +1927,29 @@ TR_BitVector *OMR::SymbolReferenceTable::getSharedAliases(TR::SymbolReference *s
 
    return NULL;
    }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreatePotentialOSRPointHelperSymbolRef()
+   {
+   if (!element(potentialOSRPointHelperSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(), TR_None);
+      sym->setHelper();
+      TR::SymbolReference* symRef = new (trHeapMemory()) TR::SymbolReference(self(), potentialOSRPointHelperSymbol, sym);
+      element(potentialOSRPointHelperSymbol) = symRef;
+      }
+   return element(potentialOSRPointHelperSymbol);
+   }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateOSRFearPointHelperSymbolRef()
+   {
+   if (!element(osrFearPointHelperSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(), TR_None);
+      sym->setHelper();
+      TR::SymbolReference* symRef = new (trHeapMemory()) TR::SymbolReference(self(), osrFearPointHelperSymbol, sym);
+      element(osrFearPointHelperSymbol) = symRef;
+      }
+   return element(osrFearPointHelperSymbol);
+   }

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -146,6 +146,35 @@ class SymbolReferenceTable
       osrScratchBufferSymbol,    //osrScratchBuffer slot on  j9vmthread
       osrFrameIndexSymbol,       // osrFrameIndex slot on j9vmthread
       osrReturnAddressSymbol,       // osrFrameIndex slot on j9vmthread
+
+      /** \brief
+       *
+       *  A call with this symbol marks a place in the jitted code where OSR transition to the VM interpreter is supported.
+       *  The transition target bytecode is the bytecode index on the call plus an induction offset which is stored on the
+       *  call node.
+       *
+       *  \code
+       *    call <potentialOSRPointHelperSymbol>
+       *  \endcode
+       *
+       *  \note
+       *   The call is not to be codegen evaluated, it should be cleaned up before codegen.
+       */
+      potentialOSRPointHelperSymbol,
+      /** \brief
+       *
+       *  A call with this symbol marks a place that has been optimized with runtime assumptions. Such place needs protection of OSR
+       *  points. When the assumption becomes wrong, the execution of jitted code with the assumption has to be transition to the VM
+       *  interpreter before running the invalid code.
+       *
+       *  \code
+       *    call <osrFearPointHelperSymbol>
+       *  \endcode
+       *
+       *  \note
+       *   The call is not to be codegen evaluated, it should be cleaned up before codegen.
+       */
+      osrFearPointHelperSymbol,
       lowTenureAddressSymbol,    // on j9vmthread
       highTenureAddressSymbol,   // on j9vmthread
       fragmentParentSymbol,
@@ -329,6 +358,8 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
 
    TR::SymbolReference * findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbol index);
+   TR::SymbolReference * findOrCreatePotentialOSRPointHelperSymbolRef();
+   TR::SymbolReference * findOrCreateOSRFearPointHelperSymbolRef();
 
    TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType);
    TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -382,6 +382,20 @@ OMR::Node::setUseDefIndex(uint16_t udi)
  * UnionBase functions
  */
 
+int32_t
+OMR::Node::getOSRInductionOffset()
+   {
+   TR_ASSERT(self()->isPotentialOSRPointHelperCall(), "TR::Node::getOSRInductionOffset: used for a non potentialOSRPointHelper call node n%dn %p", self()->getGlobalIndex(), self());
+   return (int32_t)_unionBase._osrInductionOffset;
+   }
+
+int32_t
+OMR::Node::setOSRInductionOffset(int32_t offset)
+   {
+   TR_ASSERT(self()->isPotentialOSRPointHelperCall(), "TR::Node::setOSRInductionOffset: used for a non potentialOSRPointHelper call node n%dn %p", self()->getGlobalIndex(), self());
+   return (int32_t)(_unionBase._osrInductionOffset = (int64_t)offset);
+   }
+
 int64_t
 OMR::Node::getConstValue()
    {

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4584,6 +4584,8 @@ void TR_InlinerBase::inlineFromGraph(TR_CallStack *prevCallStack, TR_CallTarget 
           tt->getNode()->getChild(0)->getVisitCount() != _visitCount &&
           tt->getNode()->getChild(0)->getInlinedSiteIndex() == thisSiteIndex &&
           !tt->getNode()->getChild(0)->getSymbolReference()->getSymbol()->castToMethodSymbol()->isInlinedByCG() &&
+          !tt->getNode()->getChild(0)->isPotentialOSRPointHelperCall() &&
+          !tt->getNode()->getChild(0)->isOSRFearPointHelperCall() &&
           //induceOSR has the same bcIndex and caller index of the call that follows it
           //the following conditions allows up to skip it
           tt->getNode()->getChild(0)->getSymbolReference() != comp()->getSymRefTab()->element(TR_induceOSRAtCurrentPC)

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1655,6 +1655,10 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<atomicSwap64Bit>";
          case TR::SymbolReferenceTable::atomicCompareAndSwapSymbol:
              return "<atomicCompareAndSwap>";
+         case TR::SymbolReferenceTable::potentialOSRPointHelperSymbol:
+             return "<potentialOSRPointHelper>";
+         case TR::SymbolReferenceTable::osrFearPointHelperSymbol:
+             return "<osrFearPointHelper>";
          }
       }
 
@@ -2080,6 +2084,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<osrScratchBuffer>",
    "<osrFrameIndex>",
    "<osrReturnAddress>",
+   "<potentialOSRPointHelper>",
+   "<osrFearPointHelper>",
    "<lowTenureAddress>",
    "<highTenureAddress>",
    "<fragmentParent>",

--- a/doc/compiler/osr/OSR.md
+++ b/doc/compiler/osr/OSR.md
@@ -1,0 +1,45 @@
+<!--
+Copyright (c) 2018, 2018 IBM Corp. and others
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath 
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] http://openjdk.java.net/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+-->
+
+
+# OSR transition
+
+OSR transition is the process of transfering the execution from jitted code to the interpreter. OSR transition involves leaving the jitted code, reconstructing the runtime VM state and resuming the execution where the jitted code left off in the interpreter.
+
+# OSR point
+An OSR point is a place in the jitted code where OSR transition is supported.
+
+At an OSR point, the VM state can be correctly reconstructed and is consistent with the VM state needed by the interpreter to resume the execution at a given bytecode index.
+
+To achieve that, bookkeeping is required at all possible OSR points during ILGen. Due to the cost and complexity of bookkeeping, OSR transition is limited to some well-defined points, which are calls, asyncchecks and monitor enters, etc.
+
+Being part of the program, OSR points like calls, asyncchecks and monitor enters can be removed or optimized and no longer be identified as OSR points. However, OSR transition may still be supported at that position.
+
+# potentialOSRPointHelper
+potentialOSRPointHelper is a call that serves as a marker of places where OSR transition is supported. The target bytecode index to be executed in the interpreter can be obtained by adding an offset (an information stored in the call node, the size of OSR point's bytecode in post-execution OSR) to the bytecode index of the helper call node.
+
+The helper is not a must for OSR, but it can help locating the OSR points that are available at ILGen but disappear due to later transformations. It works as a bookkeeping tool, to track places that are OSR possible.
+
+# osrFearPointHelper
+This helper marks a place that has been optimized with runtime assumptions and requires protection of OSR mechnism. This means an OSR point is required between the invalidation point and the fear point.
+
+Similar to potentialOSRPointHelper, this helper is not a must for optimizations requiring OSR mechnism. It works as a tool to help locating the actual fear (being part of the program that may be removed or optimized to something else).


### PR DESCRIPTION
- Add a helper named osrFearPointHelper to mark an OSR fear point, a
  place that has been optimized with runtime assumptions and requires
  protection of OSR points. This helper helps to locate actual fear
  points, which as part of the program can be optimized, and allows the
  separation of OSR dependent optimization and OSR guard insertion.
  
- Add a helper named potentialOSRPointHelper to serve as a marker of OSR
  points. Currently, OSR points consist of calls, asyncchecks and
  monitor enters. As part of the program, they can be optimized and no
  longer be identified as OSR points. However, places where they reside
  may still be OSR possible. This helper works as a bookkeeping tool to
  track place that are OSR possible.
 
- Add a markdown file that covers a basic introduction to OSR.

- Fix some node APIs such that doNotProfile is set only for nodes
  created during ilgen. doNotProfile on a bytecode info is looked at by
  OSR APIs to determine if a node is created in ilgen. Only nodes
  created in ilgen will have the OSR bookkeeping  and are able to
  support OSR transition. Thus, nodes created after ILGen supposed to
  have doNotProfile set and cannot be OSR points.

Signed-off-by: liqunl <liqunl@ca.ibm.com>