### PR TITLE
Fix for compilation error under certain compilers

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -11694,7 +11694,7 @@ template <class T>
 inline TR::Node* sqrtSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
    simplifyChildren(node, block, s);
-   auto child = node->getChild(0);
+   TR::Node* child = node->getChild(0);
    if (child->getOpCode().isLoadConst() &&
        performTransformation(s->comp(), "%sSimplify sqrt of const child at [" POINTER_PRINTF_FORMAT "]\n", s->optDetailString(), node))
       {


### PR DESCRIPTION
Type information getChild(0) doesn't seem to be propagated properly
when compiling with xlC under AIX. Making the the type of child
explicit seems succificient to get compiled.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>