### PR TITLE
AArch64: Add support for ARM64 in Debug.cpp

### DIFF
--- a/compiler/aarch64/CMakeLists.txt
+++ b/compiler/aarch64/CMakeLists.txt
@@ -42,4 +42,5 @@ compiler_library(aarch64
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRTreeEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OpBinary.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
+	${CMAKE_CURRENT_LIST_DIR}/env/OMRDebugEnv.cpp
 )

--- a/compiler/aarch64/env/OMRDebugEnv.cpp
+++ b/compiler/aarch64/env/OMRDebugEnv.cpp
@@ -19,39 +19,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_ARM64_DEBUG_ENV_INCL
-#define OMR_ARM64_DEBUG_ENV_INCL
+#include "env/DebugEnv.hpp"
 
-/*
- * The following #define and typedef must appear before any #includes in this file
- */
-#ifndef OMR_DEBUG_ENV_CONNECTOR
-#define OMR_DEBUG_ENV_CONNECTOR
-namespace OMR { namespace ARM64 { class DebugEnv; } }
-namespace OMR { typedef OMR::ARM64::DebugEnv DebugEnvConnector; }
-#else
-#error OMR::ARM64::DebugEnv expected to be a primary connector, but an OMR connector is already defined
-#endif
-
-#include "compiler/env/OMRDebugEnv.hpp"
-#include "infra/Annotations.hpp"  // for OMR_EXTENSIBLE
-
-namespace OMR
-{
-
-namespace ARM64
-{
-
-class OMR_EXTENSIBLE DebugEnv : public OMR::DebugEnv
+OMR::ARM64::DebugEnv::DebugEnv() :
+      OMR::DebugEnv()
    {
-public:
-
-   DebugEnv();
-
-   };
-
-}
-
-}
-
-#endif //OMR_ARM64_DEBUG_ENV_INCL
+   _hexAddressWidthInChars = 16;
+   _hexAddressFieldWidthInChars = 18;
+   _codeByteColumnWidth = 10;
+   }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -751,14 +751,14 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction *instr, uint8_t *curso
       char *p0 = prefix;
       char *p1 = prefix + strlen(prefix);
 
-      // Print machine code in bytes on X86, in words on PPC,ARM
+      // Print machine code in bytes on X86, in words on PPC,ARM,ARM64
       // Stop if we try to run over the buffer.
       if (TR::Compiler->target.cpu.isX86())
          {
          for (int i = 0; i < size && p1 - p0 + 3 < prefixWidth; i++, p1 += 3)
             sprintf(p1, " %02x", *cursor++);
          }
-      else if (TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isARM())
+      else if (TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isARM() || TR::Compiler->target.cpu.isARM64())
          {
          for (int i = 0; i < size && p1 - p0 + 9 < prefixWidth; i += 4, p1 += 9, cursor += 4)
             sprintf(p1, " %08x", *((uint32_t *)cursor));
@@ -2870,6 +2870,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::GCRegisterMap * map)
       }
 #endif
 
+#if defined(TR_TARGET_ARM64)
+   if (TR::Compiler->target.cpu.isARM64())
+      {
+      printARM64GCRegisterMap(pOutFile, map);
+      return;
+      }
+#endif
+
    }
 
 void
@@ -2998,6 +3006,10 @@ TR_Debug::getName(TR::Register *reg, TR_RegisterSizes size)
 #if defined(TR_TARGET_S390)
       if (TR::Compiler->target.cpu.isZ())
          return getName(toRealRegister(reg), size);
+#endif
+#if defined(TR_TARGET_ARM64)
+      if (TR::Compiler->target.cpu.isARM64())
+         return getName((TR::RealRegister *)reg, size);
 #endif
       TR_ASSERT(0, "TR_Debug::getName() ==> unknown target platform for given real register\n");
       }
@@ -3171,6 +3183,13 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Register * reg, TR_RegisterSizes size)
       if (TR::Compiler->target.cpu.isZ())
          {
          print(pOutFile, toRealRegister(reg), size);
+         return;
+         }
+#endif
+#if defined(TR_TARGET_ARM64)
+      if (TR::Compiler->target.cpu.isARM64())
+         {
+         print(pOutFile, (TR::RealRegister *)reg, size);
          return;
          }
 #endif

--- a/jitbuilder/build/files/target/aarch64.mk
+++ b/jitbuilder/build/files/target/aarch64.mk
@@ -45,5 +45,6 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/UnaryEvaluator.cpp
 
 #environement files
-#JIT_PRODUCT_BACKEND_SOURCES+= \
-#    $(JIT_OMR_DIRTY_DIR)/aarch64/env/<file>.cpp
+
+JIT_PRODUCT_BACKEND_SOURCES+= \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/env/OMRDebugEnv.cpp


### PR DESCRIPTION
This commit adds some more code for aarch64 in the common Debug.cpp
and related files.

Signed-off-by: knn-k <konno@jp.ibm.com>