### PR TITLE
Differentiate memory settings for CS HW support

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -420,6 +420,7 @@ public:
 	bool softwareEvacuateReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS */
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
 	bool concurrentScavengerForced; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
+	bool concurrentScavengerHWSupport; /**< set to true if CS runs with HW support */
 	uintptr_t concurrentScavengerBackgroundThreads; /**< number of background GC threads during concurrent phase of Scavenge */
 	bool concurrentScavengerBackgroundThreadsForced; /**< true if concurrentScavengerBackgroundThreads set via command line option */
 	uintptr_t concurrentScavengerSlack; /**< amount of bytes added on top of avearge allocated bytes during concurrent cycle, in calcualtion for survivor size */
@@ -807,6 +808,18 @@ public:
 	{
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		return concurrentScavenger;
+#else
+		return false;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+	}
+	
+	MMINLINE bool
+	isConcurrentScavengerHWSupported()
+	{
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+		/* return concurrentScavenger temporary for consistency until VM part is not modified */
+		return concurrentScavenger;
+		/* return concurrentScavengerHWSupport; */
 #else
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
@@ -1356,6 +1369,7 @@ public:
 		, softwareEvacuateReadBarrier(false)
 		, concurrentScavenger(false)
 		, concurrentScavengerForced(false)
+		, concurrentScavengerHWSupport(false)
 		, concurrentScavengerBackgroundThreads(1)
 		, concurrentScavengerBackgroundThreadsForced(false)
 		, concurrentScavengerSlack(0)

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -76,7 +76,7 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 	uintptr_t allocateSize = size;
 
 	uintptr_t concurrentScavengerPageSize = 0;
-	if (extensions->isConcurrentScavengerEnabled()) {
+	if (extensions->isConcurrentScavengerHWSupported()) {
 		OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 		/*
 		 * Allocate extra memory to guarantee proper alignment regardless start address location
@@ -166,7 +166,7 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 
 		void* requestedTopAddress = (void*)((uintptr_t)startAllocationAddress + allocateSize + tailPadding);
 
-		if (extensions->isConcurrentScavengerEnabled()) {
+		if (extensions->isConcurrentScavengerHWSupported()) {
 			void * ceilingToRequest = ceiling;
 			/* Requested top address might be higher then ceiling because of added chunk */
 			if ((requestedTopAddress > ceiling) && ((void *)((uintptr_t)requestedTopAddress - concurrentScavengerPageSize) <= ceiling)) {
@@ -303,7 +303,7 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 		 * - current Nursery location has crossed Concurrent Scavenger Page boundary so it needs to be pushed higher to
 		 *   have Nursery low address to be aligned to Concurrent Scavenger Page
 		 */
-		if (extensions->isConcurrentScavengerEnabled()) {
+		if (extensions->isConcurrentScavengerHWSupported()) {
 			OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 			/* projected Nursery base and top */
 			/* assumed Nursery location in high addresses of the heap */

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -242,7 +242,7 @@ MM_ConfigurationGenerational::calculateDefaultRegionSize(MM_EnvironmentBase *env
 	uintptr_t regionSize = STANDARD_REGION_SIZE_BYTES;
 
 	MM_GCExtensionsBase *extensions = env->getExtensions();
-	if (extensions->isConcurrentScavengerEnabled()) {
+	if (extensions->isConcurrentScavengerHWSupported()) {
 		/* set region size based at concurrentScavengerPageSectionSize */
 		regionSize = extensions->getConcurrentScavengerPageSectionSize();
 	}


### PR DESCRIPTION
Concurrent Scavengers runs without HW support (using Software Barriers)
don't require strict heap geometry alignments used for Guarded Storage.
Add new flag to extensions concurrentScavengerHWSupported and
isConcurrentScavengerHWSupported() helper to use in places where Guarded
Storage compatible settings are necessary.
Temporary make isConcurrentScavengerHWSupported() return value of
concurrentScavenger flag for compatibility purposes.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>