### PR TITLE
Remove OS X testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,8 @@
 language: cpp
 os:
   - linux
-  - osx
 compiler:
   - gcc
-  - clang
 sudo: false
 cache: ccache # https://docs.travis-ci.com/user/caching/
 dist: trusty
@@ -38,22 +36,11 @@ addons:
       - bison
       - libdwarf-dev
       - libelf-dev
-before_install:
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew update && brew install ccache; fi
 env:
   global:
     - GTEST_COLOR=1
     - BUILD_JOBS=2
-  matrix:
-    - BUILD_WITH_CMAKE=yes CMAKE_GENERATOR="Unix Makefiles"
 matrix:
-  exclude:
-    - os: osx
-      compiler: gcc
-    - os: linux
-      compiler: clang
-    - os: linux
-      env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR="Unix Makefiles"
   include:
     ## Auto tool builds
     # 64 bit Linux x86 compressed pointers
@@ -99,7 +86,6 @@ matrix:
       env: BUILD_WITH_CMAKE=yes CMAKE_GENERATOR=Ninja CMAKE_DEFINES="-DOMR_ENV_DATA32=ON -DOMR_DDR=OFF -DOMR_JITBUILDER=OFF"
 before_script:
   - ulimit -c unlimited
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH=/usr/local/opt/ccache/libexec:$PATH ; fi
   - ccache -s -z
 script:
   - bash ./scripts/build-on-travis.sh

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -39,24 +39,14 @@ function get_cc_toolchain
   export CHOST=$(eval $(find `pwd`/toolchain/bin -name "*-gcc") -dumpmachine)
 }
 
-if test "x$TRAVIS_OS_NAME" = "xosx"; then
-  export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:*DeathTest*
-else
-  # Disable the core dump tests as container based builds don't allow setting
-  # core_pattern and don't have apport installed.  This can be removed when
-  # apport is available in apt whitelist
-  export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
-fi
+# Disable the core dump tests as container based builds don't allow setting
+# core_pattern and don't have apport installed.  This can be removed when
+# apport is available in apt whitelist
+export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
 
 if test "x$BUILD_WITH_CMAKE" = "xyes"; then
   if test "x$CMAKE_GENERATOR" = "x"; then
     export CMAKE_GENERATOR="Ninja"
-  fi
-  
-  if test "x$TRAVIS_OS_NAME" = "xosx"; then
-    if test "x$CMAKE_GENERATOR" = "xNinja"; then
-      brew install ninja
-    fi
   fi
 
   mkdir build


### PR DESCRIPTION
With the new OS X OMR CI Jenkins machines we do not need to run
OS X testing on Travis.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>