### PR TITLE
Compressedrefs - Map memory below 4GB - OSX

### DIFF
--- a/cmake/modules/platform/os/osx.cmake
+++ b/cmake/modules/platform/os/osx.cmake
@@ -28,3 +28,10 @@ list(APPEND OMR_PLATFORM_DEFINITIONS
 # of the OMR code should be heavily reduced. In the mean time, we keep
 # the distinction
 list(APPEND TR_COMPILE_DEFINITIONS -DSUPPORTS_THREAD_LOCAL -DOSX)
+
+if(OMR_ENV_DATA64)
+	# Set page zero size to 4KB for mapping memory below 4GB.
+	list(APPEND OMR_PLATFORM_EXE_LINKER_OPTIONS
+		-pagezero_size 0x1000
+	)
+endif()

--- a/fvtest/porttest/omrmemTest.cpp
+++ b/fvtest/porttest/omrmemTest.cpp
@@ -65,10 +65,8 @@ extern PortTestEnvironment *portTestEnv;
 #define COMPLETE_SUBALLOC_BLOCK 4
 #define COMPLETE_ALL_SIZES (COMPLETE_LARGE_REGION | COMPLETE_NEAR_REGION | COMPLETE_SUBALLOC_BLOCK)
 
-#if !(defined(OSX) && defined(OMR_ENV_DATA64))
 static void freeMemPointers(struct OMRPortLibrary *portLibrary, void **memPtrs, uintptr_t length);
 static void shuffleArray(struct OMRPortLibrary *portLibrary, uintptr_t *sizes, uintptr_t length);
-#endif /* !(defined(OSX) && defined(OMR_ENV_DATA64)) */
 
 /**
  * @internal
@@ -523,9 +521,6 @@ TEST(PortMemTest, mem_test6)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-/* 64bit OSX does not allow memory below 4GB to be mapped. */
-#if !(defined(OSX) && defined(OMR_ENV_DATA64))
-
 /* helper that shuffle contents of an array using a random number generator */
 static void
 shuffleArray(struct OMRPortLibrary *portLibrary, uintptr_t *array, uintptr_t length)
@@ -635,7 +630,6 @@ TEST(PortMemTest, mem_test7_allocate32)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !(defined(OSX) && defined(OMR_ENV_DATA64)) */
 
 
 /* Dummy categories for omrmem_test8_categories */
@@ -1064,8 +1058,6 @@ TEST(PortMemTest, mem_test8_categories)
 		}
 	}
 
-/* 64bit OSX does not allow memory below 4GB to be mapped. */
-#if !(defined(OSX) && defined(OMR_ENV_DATA64))
 	/* Try allocating with allocate32 */
 	{
 		uintptr_t initialBlocks = 0;
@@ -1226,8 +1218,7 @@ TEST(PortMemTest, mem_test8_categories)
 			goto end;
 		}
 	}
-#endif
-#endif /* !(defined(OSX) && defined(OMR_ENV_DATA64)) */
+#endif /* defined(OMR_ENV_DATA64) */
 
 	/* Try allocating and reallocating */
 	{
@@ -1473,7 +1464,6 @@ TEST(PortMemTest, mem_test9_category_walk)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !(defined(OSX) && defined(OMR_ENV_DATA64))
 /* attempt to free all mem pointers stored in memPtrs array with length */
 static void
 freeMemPointers(struct OMRPortLibrary *portLibrary, void **memPtrs, uintptr_t length)
@@ -1487,4 +1477,3 @@ freeMemPointers(struct OMRPortLibrary *portLibrary, void **memPtrs, uintptr_t le
 		omrmem_free_memory32(mem32Ptr);
 	}
 }
-#endif /* !(defined(OSX) && defined(OMR_ENV_DATA64)) */

--- a/port/common/omrmemtag.c
+++ b/port/common/omrmemtag.c
@@ -437,13 +437,13 @@ omrmem_allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmoun
 {
 
 	void *pointer = NULL;
-#if defined(OMR_ENV_DATA64) && !defined(OSX)
+#if defined(OMR_ENV_DATA64)
 	uintptr_t allocationByteAmount = byteAmount;
-#endif /* defined(OMR_ENV_DATA64) && !defined(OSX) */
+#endif /* defined(OMR_ENV_DATA64) */
 
 	Trc_PRT_mem_omrmem_allocate_memory32_Entry(byteAmount);
 
-#if defined(OMR_ENV_DATA64) && !defined(OSX)
+#if defined(OMR_ENV_DATA64)
 	allocationByteAmount = ROUNDED_BYTE_AMOUNT(byteAmount);
 	pointer = allocate_memory32(portLibrary, allocationByteAmount, callSite);
 	if (NULL == pointer) {
@@ -451,7 +451,7 @@ omrmem_allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmoun
 	} else {
 		pointer = wrapBlockAndSetTags(portLibrary, pointer, byteAmount, callSite, category);
 	}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OSX) */
+#endif /* defined(OMR_ENV_DATA64) */
 
 	Trc_PRT_mem_omrmem_allocate_memory32_Exit(pointer);
 


### PR DESCRIPTION
**1) Allow memory to be mapped below 4GB on OSX**

  On OSX 64-bit, linker sets page zero size to 4GB. This prevents memory
  to be mapped below 4GB.

  On OSX 32-bit, page zero size is set to 4KB by default.

  This change will set page zero size to 4KB on 64-bit architectures. This
  will allow memory to be mapped below 4GB.

**2) Enable support for compressedrefs feature in OMR**

  For compressedrefs, memory needs to be mapped below 4GB.

  Currently, code for allocating/mapping memory below 4GB is disabled on
  OSX.

  Specifying -pagezero_size <SIZE> while creating main executables will
  allow us to map memory below 4GB.

  Thus, re-enabling code for allocating/mapping memory below 4GB:
  omrmem_allocate_memory32 and supporting test code.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>