### PR TITLE
Set aladd internal pointer flag for VP arraycopy

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -2015,6 +2015,7 @@ TR::Node *generateArrayAddressTree(
       }
 
    array = TR::Node::create(is64BitTarget ? TR::aladd : TR::aiadd, 2, objNode, array);
+   array->setIsInternalPointer(true);
 
    return array;
    }


### PR DESCRIPTION
These nodes are internal pointers and flagging them as such prevents
code generators from including their registers in GC maps.

generateArrayletAddressTree() is left unchanged because it's unclear
whether the leaf element address should be considered an internal
pointer, but this function is currently unused anyhow: it is only called
when generateArraylets(), which with hybrid arraylets is always false.

Fixes #3040