### PR TITLE
Map OS name "Darwin" to "Mac OS X"

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -497,6 +497,8 @@ omrsysinfo_get_OS_type(struct OMRPortLibrary *portLibrary)
 #if defined(J9OS_I5)
 	/* JCL on IBM i expects to see "OS/400" */
 	return "OS/400";
+#elif defined(OSX)
+	return "Mac OS X";
 #else
 	if (NULL == PPG_si_osType) {
 		int rc;


### PR DESCRIPTION
This is required for Java runtime compatibility.

Replaces https://github.com/eclipse/omr/pull/3052

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>