### PR TITLE
Report if CS is H/W assisted

### DIFF
--- a/gc/include/omrmm.hdf
+++ b/gc/include/omrmm.hdf
@@ -204,7 +204,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="const char*" name="gcPolicy" description="-Xgcpolicy value" />
-		<data type="uintptr_t" name="concurrentScavenger" description="Scavenger running Concurrently flag" />
+		<data type="uintptr_t" name="jitLoaded" description="JIT library loaded" />
 		<data type="uintptr_t" name="maxHeapSize" description="-Xmx value" />
 		<data type="uintptr_t" name="initialHeapSize" description="-Xms value" />
 		<data type="uint64_t" name="physicalMemory" description="the total amount of physical memory" />

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -251,8 +251,9 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 	writer->formatAndOutput(env, 0, "<initialized %s>", tagTemplate);
 	writer->formatAndOutput(env, 1, "<attribute name=\"gcPolicy\" value=\"%s\" />", event->gcPolicy);
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	if (gc_policy_gencon == _extensions->configurationOptions._gcPolicy) {
-		writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />", event->concurrentScavenger ? "true" : "false");
+	if (_extensions->isConcurrentScavengerEnabled()) {
+		writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />",
+			(event->jitLoaded && !_extensions->isSoftwareEvacuateReadBarrierEnabled()) ? "enabled, H/W assisted" : "enabled");
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	writer->formatAndOutput(env, 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", event->maxHeapSize);


### PR DESCRIPTION
Verbose GC change, 3 cases
1) CS enabled, running interpreted or Jitted with S/W based Read Barrier:
```
  <attribute name="concurrentScavenger" value="enabled" />
```
2) CS enabled, running Jitted with H/W based Read Barrier:
```
  <attribute name="concurrentScavenger" value="enabled, H/W assisted" />
```
3) CS disabled, the line is not reported

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>