### PR TITLE
Correct the comment of indirectCallEvaluator on X86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3124,7 +3124,7 @@ TR::Register *OMR::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::C
    return returnRegister;
    }
 
-// TR::icalli, TR::acalli, TR::lcalli, TR::fcalli, TR::dcalli, TR::calli handled by directCallEvaluator
+// TR::icalli, TR::acalli, TR::lcalli, TR::fcalli, TR::dcalli, TR::calli handled by indirectCallEvaluator
 TR::Register *OMR::X86::TreeEvaluator::indirectCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    // If the method to be called is marked as an inline method, see if it can


### PR DESCRIPTION
Comment above indirectCallEvaluator was incorrect, fixing.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>