### PR TITLE
Remove J9 project specific arraycopy code on X86

### DIFF
--- a/compiler/il/ILOpCodeProperties.hpp
+++ b/compiler/il/ILOpCodeProperties.hpp
@@ -10070,6 +10070,10 @@
     *  - dest address
     *  - number of bytes to copy
     *
+    * Normally the 5-child variant indicates the operation is a reference
+    * array copy and hence it should be only generated when the CodeGen
+    * sets SupportsReferenceArrayCopy flag.
+    *
     * In the future we may extract the 3-child version into a distinct
     * opcode named memcpy.
     *

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -311,7 +311,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
 
    // VM dependent routines
    static TR::Register *VMmergenewEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *VMarrayStoreCheckArrayCopyEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static bool VMinlineCallEvaluator(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg);
    static TR::Instruction *VMtestForReferenceArray(TR::Node *, TR::Register *objectReg, TR::CodeGenerator *cg);
    static bool genNullTestSequence(TR::Node *node, TR::Register *opReg, TR::Register *targetReg, TR::CodeGenerator *cg);


### PR DESCRIPTION
J9 project specific code related to ArrayCopy has been deprecated,
removing them.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>