### PR TITLE
Remove Linux x86-64 compressed references testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ env:
 matrix:
   include:
     ## Auto tool builds
-    # 64 bit Linux x86 compressed pointers
-    - os: linux
-      env: SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc
     # 64 bit Linux AArch64
     - os: linux
       env: SPEC=linux_aarch64 PLATFORM=aarch64-linux-gcc RUN_TEST=no

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -39,20 +39,11 @@ function get_cc_toolchain
   export CHOST=$(eval $(find `pwd`/toolchain/bin -name "*-gcc") -dumpmachine)
 }
 
-# Disable the core dump tests as container based builds don't allow setting
-# core_pattern and don't have apport installed.  This can be removed when
-# apport is available in apt whitelist
-export GTEST_FILTER=-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended
-
 # Cross Compile Toolchain and Configuration Options for AArch64
 if test $SPEC = "linux_aarch64"; then
   get_cc_toolchain ${AARCH64_TOOLCHAIN_URL}
 elif test $SPEC = "linux_arm"; then
   get_cc_toolchain ${ARM_TOOLCHAIN_URL}
-else
-  # Linux 64 compressed references build and the 	Lint builds do not run in CMake
-  # Remove the Linux 64 compressed references build once the Autotool build infrastructure is retired
-  export EXTRA_CONFIGURE_ARGS="--enable-DDR"
 fi
 
 time make -f run_configure.mk OMRGLUE=./example/glue SPEC=${SPEC} PLATFORM=${PLATFORM} HAS_AUTOCONF=1 distclean all


### PR DESCRIPTION
The Linux x86-64 compressed references testing has moved to the
OMR CI so the testing can be removed from Travis.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>