### PR TITLE
Software RangeCheck  Read Barrier

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -418,6 +418,7 @@ public:
 	bool scavengerRsoScanUnsafe;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	bool softwareEvacuateReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS */
+	bool softwareRangeCheckReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS */
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
 	bool concurrentScavengerForced; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
 	bool concurrentScavengerHWSupport; /**< set to true if CS runs with HW support */
@@ -830,6 +831,16 @@ public:
    {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
       return softwareEvacuateReadBarrier;
+#else
+      return false;
+#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
+   }	
+	
+   MMINLINE bool
+   isSoftwareRangeCheckReadBarrierEnabled()
+   {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+      return softwareRangeCheckReadBarrier;
 #else
       return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
@@ -1367,6 +1378,7 @@ public:
 		, scavengerEnabled(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 		, softwareEvacuateReadBarrier(false)
+		, softwareRangeCheckReadBarrier(false)
 		, concurrentScavenger(false)
 		, concurrentScavengerForced(false)
 		, concurrentScavengerHWSupport(false)


### PR DESCRIPTION
Renaming flag S/W Evacuate RB to S/W RangeCheck RB. 
Evacuate is an action that is required by RB in Concurrent Scavenger.
It's always executed in software. What has alternative implementation in
S/W vs H/W is the trigger mechanism, which is the range check against
Evacuate area boundaries (or a set of areas).

Temporarily, keeping the old variable and accessor, until downstream
projects are updated to use the new ones.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>