### PR TITLE
Align heap for GS if necessary only

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -817,9 +817,7 @@ public:
 	isConcurrentScavengerHWSupported()
 	{
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		/* return concurrentScavenger temporary for consistency until VM part is not modified */
-		return concurrentScavenger;
-		/* return concurrentScavengerHWSupport; */
+		return concurrentScavengerHWSupport;
 #else
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */


### PR DESCRIPTION
Do heap memory alignments reqiured for GS in case if CS runs on
supported HW only. Request of using Software Barriers overwrites it.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>