### PR TITLE
Fix OSX implementation of omrsig_info()

### DIFF
--- a/port/osx/omrsignal_context.c
+++ b/port/osx/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,8 +35,6 @@ fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, stru
 uint32_t
 infoForSignal(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32_t index, const char **name, void **value)
 {
-	*name = "";
-
 	switch (index) {
 	case OMRPORT_SIG_SIGNAL_TYPE:
 	case 0:
@@ -83,9 +81,11 @@ infoForSignal(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32
 				return OMRPORT_SIG_VALUE_ADDRESS;
 			}
 		}
+		*name = "";
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 
 	default:
+		*name = "";
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 }
@@ -94,75 +94,75 @@ uint32_t
 infoForFPR(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32_t index, const char **name, void **value)
 {
 	mcontext_t *context = (mcontext_t *)&info->platformSignalInfo.context->uc_mcontext;
-	_STRUCT_X86_FLOAT_STATE64 floatState = (*context)->__fs;
-	*name = "";
+	_STRUCT_X86_FLOAT_STATE64 *floatState = &(*context)->__fs;
 
 	switch (index) {
 	case 0:
 		*name = "XMM0";
-		*value = &floatState.__fpu_xmm0;
+		*value = &floatState->__fpu_xmm0;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 1:
 		*name = "XMM1";
-		*value = &floatState.__fpu_xmm1;
+		*value = &floatState->__fpu_xmm1;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 2:
 		*name = "XMM2";
-		*value = &floatState.__fpu_xmm2;
+		*value = &floatState->__fpu_xmm2;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 3:
 		*name = "XMM3";
-		*value = &floatState.__fpu_xmm3;
+		*value = &floatState->__fpu_xmm3;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 4:
 		*name = "XMM4";
-		*value = &floatState.__fpu_xmm4;
+		*value = &floatState->__fpu_xmm4;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 5:
 		*name = "XMM5";
-		*value = &floatState.__fpu_xmm5;
+		*value = &floatState->__fpu_xmm5;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 6:
 		*name = "XMM6";
-		*value = &floatState.__fpu_xmm6;
+		*value = &floatState->__fpu_xmm6;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 7:
 		*name = "XMM7";
-		*value = &floatState.__fpu_xmm7;
+		*value = &floatState->__fpu_xmm7;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 8:
 		*name = "XMM8";
-		*value = &floatState.__fpu_xmm8;
+		*value = &floatState->__fpu_xmm8;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 9:
 		*name = "XMM9";
-		*value = &floatState.__fpu_xmm9;
+		*value = &floatState->__fpu_xmm9;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 10:
 		*name = "XMM10";
-		*value = &floatState.__fpu_xmm10;
+		*value = &floatState->__fpu_xmm10;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 11:
 		*name = "XMM11";
-		*value = &floatState.__fpu_xmm11;
+		*value = &floatState->__fpu_xmm11;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 12:
 		*name = "XMM12";
-		*value = &floatState.__fpu_xmm12;
+		*value = &floatState->__fpu_xmm12;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 13:
 		*name = "XMM13";
-		*value = &floatState.__fpu_xmm13;
+		*value = &floatState->__fpu_xmm13;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 14:
 		*name = "XMM14";
-		*value = &floatState.__fpu_xmm14;
+		*value = &floatState->__fpu_xmm14;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	case 15:
 		*name = "XMM15";
-		*value = &floatState.__fpu_xmm15;
+		*value = &floatState->__fpu_xmm15;
 		return OMRPORT_SIG_VALUE_FLOAT_64;
 	default:
+		*name = "";
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 }
@@ -171,81 +171,81 @@ uint32_t
 infoForGPR(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32_t index, const char **name, void **value)
 {
 	mcontext_t *context = (mcontext_t *)&info->platformSignalInfo.context->uc_mcontext;
-	_STRUCT_X86_THREAD_STATE64 threadState = (*context)->__ss;
-	*name = "";
+	_STRUCT_X86_THREAD_STATE64 *threadState = &(*context)->__ss;
 
 	switch (index) {
 	case OMRPORT_SIG_GPR_AMD64_RDI:
 	case 0:
 		*name = "RDI";
-		*value = &threadState.__rdi;
+		*value = &threadState->__rdi;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_RSI:
 	case 1:
 		*name = "RSI";
-		*value = &threadState.__rsi;
+		*value = &threadState->__rsi;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_RAX:
 	case 2:
 		*name = "RAX";
-		*value = &threadState.__rax;
+		*value = &threadState->__rax;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_RBX:
 	case 3:
 		*name = "RBX";
-		*value = &threadState.__rbx;
+		*value = &threadState->__rbx;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_RCX:
 	case 4:
 		*name = "RCX";
-		*value = &threadState.__rcx;
+		*value = &threadState->__rcx;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_RDX:
 	case 5:
 		*name = "RDX";
-		*value = &threadState.__rdx;
+		*value = &threadState->__rdx;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R8:
 	case 6:
 		*name = "R8";
-		*value = &threadState.__r8;
+		*value = &threadState->__r8;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R9:
 	case 7:
 		*name = "R9";
-		*value = &threadState.__r9;
+		*value = &threadState->__r9;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R10:
 	case 8:
 		*name = "R10";
-		*value = &threadState.__r10;
+		*value = &threadState->__r10;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R11:
 	case 9:
 		*name = "R11";
-		*value = &threadState.__r11;
+		*value = &threadState->__r11;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R12:
 	case 10:
 		*name = "R12";
-		*value = &threadState.__r12;
+		*value = &threadState->__r12;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R13:
 	case 11:
 		*name = "R13";
-		*value = &threadState.__r13;
+		*value = &threadState->__r13;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R14:
 	case 12:
 		*name = "R14";
-		*value = &threadState.__r14;
+		*value = &threadState->__r14;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_GPR_AMD64_R15:
 	case 13:
 		*name = "R15";
-		*value = &threadState.__r15;
+		*value = &threadState->__r15;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	default:
+		*name = "";
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 }
@@ -254,59 +254,59 @@ uint32_t
 infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32_t index, const char **name, void **value)
 {
 	mcontext_t *context = (mcontext_t *)&info->platformSignalInfo.context->uc_mcontext;
-	_STRUCT_X86_THREAD_STATE64 threadState = (*context)->__ss;
-	_STRUCT_X86_EXCEPTION_STATE64 exceptionState = (*context)->__es;
-	*name = "";
+	_STRUCT_X86_THREAD_STATE64 *threadState = &(*context)->__ss;
+	_STRUCT_X86_EXCEPTION_STATE64 *exceptionState = &(*context)->__es;
 
 	switch (index) {
 	case OMRPORT_SIG_CONTROL_PC:
 	case 0:
 		*name = "RIP";
-		*value = (void *)&(threadState.__rip);
+		*value = (void *)&(threadState->__rip);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 1:
 		*name = "GS";
-		*value = (void *)&(threadState.__gs);
+		*value = (void *)&(threadState->__gs);
 		return OMRPORT_SIG_VALUE_16;
 	case 2:
 		*name = "FS";
-		*value = (void *)&(threadState.__fs);
+		*value = (void *)&(threadState->__fs);
 		return OMRPORT_SIG_VALUE_16;
 	case OMRPORT_SIG_CONTROL_SP:
 	case 3:
 		*name = "RSP";
-		*value = (void *)&(threadState.__rsp);
+		*value = (void *)&(threadState->__rsp);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 4:
 		*name = "RFlags";
-		*value = (void *)&(threadState.__rflags);
+		*value = (void *)&(threadState->__rflags);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 5:
 		*name = "CS";
-		*value = (void *)&(threadState.__cs);
+		*value = (void *)&(threadState->__cs);
 		return OMRPORT_SIG_VALUE_16;
 	case OMRPORT_SIG_CONTROL_BP:
 	case 6:
 		*name = "RBP";
-		*value = &threadState.__rbp;
+		*value = &threadState->__rbp;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 7:
 		*name = "ERR";
-		*value = &exceptionState.__err;
+		*value = &exceptionState->__err;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 8:
 		*name = "TRAPNO";
-		*value = &exceptionState.__trapno;
+		*value = &exceptionState->__trapno;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 9:
 		*name = "CPU";
-		*value = &exceptionState.__cpu;
+		*value = &exceptionState->__cpu;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case 10:
 		*name = "FAULTVADDR";
-		*value = &exceptionState.__faultvaddr;
+		*value = &exceptionState->__faultvaddr;
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	default:
+		*name = "";
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 }
@@ -316,30 +316,27 @@ infoForModule(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32
 {
 	Dl_info *dl_info = &(info->platformSignalInfo.dl_info);
 	mcontext_t *context = (mcontext_t *)&info->platformSignalInfo.context->uc_mcontext;
-	_STRUCT_X86_THREAD_STATE64 threadState = (*context)->__ss;
-	*name = "";
-
-	int dl_result = dladdr((void *)threadState.__rip, dl_info);
+	int dl_result = dladdr((void *)(*context)->__ss.__rip, dl_info);
 
 	switch (index) {
 	case OMRPORT_SIG_MODULE_NAME:
 	case 0:
 		*name = "Module";
-		if (dl_result) {
+		if (0 != dl_result) {
 			*value = (void *)(dl_info->dli_fname);
 			return OMRPORT_SIG_VALUE_STRING;
 		}
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	case 1:
 		*name = "Module_base_address";
-		if (dl_result) {
+		if (0 != dl_result) {
 			*value = (void *)&(dl_info->dli_fbase);
 			return OMRPORT_SIG_VALUE_ADDRESS;
 		}
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	case 2:
 		*name = "Symbol";
-		if (dl_result) {
+		if (0 != dl_result) {
 			if (dl_info->dli_sname != NULL) {
 				*value = (void *)(dl_info->dli_sname);
 				return OMRPORT_SIG_VALUE_STRING;
@@ -348,12 +345,13 @@ infoForModule(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int32
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	case 3:
 		*name = "Symbol_address";
-		if (dl_result) {
+		if (0 != dl_result) {
 			*value = (void *)&(dl_info->dli_saddr);
 			return OMRPORT_SIG_VALUE_ADDRESS;
 		}
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	default:
+		*name = "";
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 }


### PR DESCRIPTION
The code was returning addresses into a _copy_ of parts of the thread state eliminating the possibility that a signal handler might update that state before allowing a thread to resume.

An example modification is in OpenJ9's handler for division by zero which wants to alter the instruction pointer to a trap handler, but writing to that copy of thread state is ineffective.