### PR TITLE
Remove arm and aarch64 builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,12 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-    packages:
-      - libnuma-dev
-      - bison
-      - libdwarf-dev
-      - libelf-dev
 env:
   global:
-    - GTEST_COLOR=1
     - BUILD_JOBS=2
 matrix:
   include:
     ## Auto tool builds
-    # 64 bit Linux AArch64
-    - os: linux
-      env: SPEC=linux_aarch64 PLATFORM=aarch64-linux-gcc RUN_TEST=no
-    # 32-bit linux arm
-    - os: linux
-      env: SPEC=linux_arm PLATFORM=arm-linux-gcc RUN_TEST=no
     # Linter
     - os: linux
       addons:

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -23,37 +23,7 @@
 
 set -evx
 
-AARCH64_TOOLCHAIN_URL="https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz"
-ARM_TOOLCHAIN_URL="https://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabihf/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf.tar.xz"
-
-function get_cc_toolchain
-{
-  URL=$1
-  # Get the toolchain from input
-  
-  wget ${URL} -O toolchain.tar.xz
-  mkdir toolchain && tar xf toolchain.tar.xz --directory toolchain --strip-components 1
-  ls toolchain
-
-  export PATH="`pwd`/toolchain/bin:${PATH}"
-  export CHOST=$(eval $(find `pwd`/toolchain/bin -name "*-gcc") -dumpmachine)
-}
-
-# Cross Compile Toolchain and Configuration Options for AArch64
-if test $SPEC = "linux_aarch64"; then
-  get_cc_toolchain ${AARCH64_TOOLCHAIN_URL}
-elif test $SPEC = "linux_arm"; then
-  get_cc_toolchain ${ARM_TOOLCHAIN_URL}
-fi
-
 time make -f run_configure.mk OMRGLUE=./example/glue SPEC=${SPEC} PLATFORM=${PLATFORM} HAS_AUTOCONF=1 distclean all
-if test "x$RUN_BUILD" != "xno"; then
-  # Normal build system
-  time make --jobs $BUILD_JOBS
-  if test "x$RUN_TESTS" != "xno"; then
-    time make test
-  fi
-fi
 if test "x$RUN_LINT" = "xyes"; then
   llvm-config --version
   clang++ --version


### PR DESCRIPTION
The recently created arm and aarch64 jobs on the OMR CI supersede
the Travis jobs so they are being removed.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>