### PR TITLE
Remove bogus assertion in TR_IndirectCallSite

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3805,8 +3805,6 @@ bool TR_IndirectCallSite::findCallTargetUsingArgumentPreexistence(TR_InlinerBase
       }
 
    TR_ResolvedMethod * targetMethod = getResolvedMethod(klass);
-   TR_ASSERT(targetMethod, "Couldn't resolve the method for klass %p", klass);
-
    if (!targetMethod)
       {
       heuristicTrace(inliner->tracer(), "ARGS PROPAGATION: couldn't get targetMethod\n");


### PR DESCRIPTION
In findCallTargetUsingArgumentPreexistence(), it is possible for
getResolvedMethod() to fail to find the target. In this case, we should
simply skip adding the target, as already happens in builds without
assertions.