### PR TITLE
Guard code with SVM check

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1303,7 +1303,7 @@ OMR::SymbolReferenceTable::findOrCreateClassSymbol(
    sym->setClassObject();
 
 #ifdef J9_PROJECT_SPECIFIC
-   if (cpIndex == -1 && comp()->compileRelocatableCode())
+   if (cpIndex == -1 && comp()->compileRelocatableCode() && !comp()->getOption(TR_UseSymbolValidationManager))
       {
       // Restricting TR_ArbitraryClassAddress to classes loaded by the
       // bootstrap loader ensures that there is no ambiguity when correlating


### PR DESCRIPTION
This commit is for J9_PROJECT_SPECIFIC code. With the new Symbol
Validation Manager code, it is possible for the compiler to create a
class symbol with cpIndex -1 under AOT even if the class is not loaded
by the system class loader. However, as the code stands, this will
trigger a TR_ASSERT_FATAL. This commit ensures that the code that checks
for the system class loader only runs when the SVM is not enabled.

Signed-off-by: Irwin D'Souza <dsouzai@ca.ibm.com>