### PR TITLE
AArm64: Binary Encoding Fix

### DIFF
--- a/compiler/aarch64/codegen/ARM64Ops.hpp
+++ b/compiler/aarch64/codegen/ARM64Ops.hpp
@@ -23,7 +23,7 @@
 #define ARM64OPS_INCL
 
 typedef enum  {
-//		Opcode                                                         BINARY    	OPCODE    	comments
+//		Opcode                                                          	BINARY    	OPCODE    	comments
 /* UNALLOCATED */
 		bad,                                                    	/* 0x00000000	BAD       	invalid operation */
 /* Branch,exception generation and system Instruction */
@@ -44,7 +44,6 @@ typedef enum  {
 		br,                                                     	/* 0xD61F0000	BR        	 */
 		blr,                                                    	/* 0xD63F0000	BLR       	 */
 		ret,                                                    	/* 0xD65F0000	RET       	 */
-	/* Unconditional branch (immediate) */
 /* Loads and stores */
 	/* Load/store exclusive */
 		stxrb,                                                  	/* 0x08000000	STXRB     	 */
@@ -309,7 +308,7 @@ typedef enum  {
 		ubfmx,                                                  	/* 0xD3400000	UBFM      	 */
 	/* Extract */
 		extrw,                                                  	/* 0x13800000	EXTR      	 */
-		extrx,                                                  	/* 0x93C00000	EXTR      	 */
+		extrx,                                                  	/* 0x93C08000	EXTR      	 */
 /* Data Processing – register */
 	/* Logical (shifted register) */
 		andw,                                                   	/* 0x0A000000	AND       	 */
@@ -417,7 +416,7 @@ typedef enum  {
 		revx,                                                   	/* 0xDAC00C00	REV       	 */
 		rev16w,                                                 	/* 0xDAC00400	REV16     	 */
 		rev16x,                                                 	/* 0x5AC00400	REV16     	 */
-		rev32,                                                  	/* 0xDAC00800	REV32     	 */																						
+		rev32,                                                  	/* 0xDAC00800	REV32     	 */
 	/* Last VFP instructions */
 		LastOp = rev32,
 		NumOpCodes = LastOp + 1

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -23,7 +23,7 @@
 
 const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEncodings[ARM64NumOpCodes] =
 {
-//		BINARY			Opcode    	Opcode		comments
+//		BINARY    	Opcode    	Opcode	comments
 /* UNALLOCATED */
 		0x00000000,	/* BAD       	bad	invalid operation */
 /* Branch,exception generation and system Instruction */
@@ -44,7 +44,6 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xD61F0000,	/* BR        	br	 */
 		0xD63F0000,	/* BLR       	blr	 */
 		0xD65F0000,	/* RET       	ret	 */
-	/* Unconditional branch (immediate) */
 /* Loads and stores */
 	/* Load/store exclusive */
 		0x08000000,	/* STXRB     	stxrb	 */
@@ -271,7 +270,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xFD000000,	/* STR       	vstrimmd	 */
 		0xFD400000,	/* LDR       	vldrimmd	 */
 		0xF9800000,	/* PRFM      	prfmimm	 */
-/* Data processing - Immediate */
+/* Data processing – Immediate */
 	/* PC-rel. addressing */
 		0x10000000,	/* ADR       	adr	 */
 		0x90000000,	/* ADRP      	adrp	 */
@@ -309,8 +308,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xD3400000,	/* UBFM      	ubfmx	 */
 	/* Extract */
 		0x13800000,	/* EXTR      	extrw	 */
-		0x93C00000,	/* EXTR      	extrx	 */
-/* Data Processing - register */
+		0x93C08000,	/* EXTR      	extrx	 */
+/* Data Processing – register */
 	/* Logical (shifted register) */
 		0x0A000000,	/* AND       	andw	 */
 		0x0A200000,	/* BIC       	bicw	 */


### PR DESCRIPTION
Some binary encoding values mismatched with the actual value when copied.
Those values are being fixed and updated.