### PR TITLE
Experimental Build For Aliasing Threshold Investigation

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -430,6 +430,7 @@ public:
 	uintptr_t scvArraySplitMinimumAmount; /**< minimum number of elements to split array scanning work in the scavenger */
 	uintptr_t scavengerScanCacheMaximumSize; /**< maximum size of scan and copy caches before rounding, zero (default) means calculate them */
 	uintptr_t scavengerScanCacheMinimumSize; /**< minimum size of scan and copy caches before rounding, zero (default) means calculate them */
+	uintptr_t waitCountThreshold;
 	bool tiltedScavenge;
 	bool debugTiltedScavenge;
 	double survivorSpaceMinimumSizeRatio;
@@ -1366,6 +1367,7 @@ public:
 		, scvArraySplitMinimumAmount(DEFAULT_ARRAY_SPLIT_MINIMUM_SIZE)
 		, scavengerScanCacheMaximumSize(DEFAULT_SCAN_CACHE_MAXIMUM_SIZE)
 		, scavengerScanCacheMinimumSize(DEFAULT_SCAN_CACHE_MINIMUM_SIZE)
+		, waitCountThreshold(0)
 		, tiltedScavenge(true)
 		, debugTiltedScavenge(false)
 		, survivorSpaceMinimumSizeRatio(0.10)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -26,8 +26,9 @@
 #define OMR_SCAVENGER_TRACE_REMEMBERED_SET
 #define OMR_SCAVENGER_TRACE_BACKOUT
 #define OMR_SCAVENGER_TRACE_COPY
-#define OMR_SCAVENGER_TRACK_COPY_DISTANCE
 #endif
+
+#define OMR_SCAVENGER_TRACK_COPY_DISTANCE
 
 #include <math.h>
 
@@ -3117,7 +3118,9 @@ MM_Scavenger::aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scann
 	 *
 	 * @NOTE this is likely too aggressive and should be relaxed.
 	 */
-	if (0 == _waitingCount) {
+
+	if (_waitingCount <=  _extensions->waitCountThreshold) {
+
 		/* Only alias if the scanCache != copyCache. IF the caches are the same there is no benefit
 		 * to aliasing. The checks afterwards will ensure that a very similar copy order will happen
 		 * if the copyCache changes from the currently aliased scan cache


### PR DESCRIPTION

### Summary
The goal of this investigation is to relax Scavenger's aliasing inhibiting condition _(mechanism used to improve parallelism & GC pause time)_  to increase object locality and ultimately improve application throughput. From Scavenger's Aliasing perspective, object locality and parallelism/pause times are inversely proportional. A gain in one will cause a loss in the other, however throughput gains can result from improvements in either. As a result, with correct tuning between the two, optimal throughput gains can be achieved. That is, through tuning aliasing activity, throughput gains can be achieved by:

1. Increasing parallelism (results in a decrease in aliasing/object locality)
2. Increasing aliasing activity (results in decrease in parallelism)

By relaxing Scavenger's aliasing inhibiting condition an "equilibrium" between the the two can achieved to provide optimal throughput  gains. 


_A background has been provided to outline work that's been done in the past which relates to the investigation discussed in this issue._
### Background
In the context of Parallel Scavenger, a thread is said to be stalled if it has no caches to scan. In other words, a thread is left ideal and "starved" when it has exhausted all work. These stalled threads are accounted by  Scavenger's `_waitingCount` member, which is incremented for each stalled thread.

In the past, an increase in mean GC pause times (Approx. 18%) was observed, it was found to be related to a decrease in parallelism resulting from stalled threads. Overall, this was determined to be a consequence of hierarchical scan aliasing which forces threads to "consume their own produce". Threads with scan work resulting in greater number of cache copies continue running while other threads with less copy work eventually stall. As a result, threads are stalled for a proportion of GC, parallelism drops and pause times increase.

To alleviate thread stalling, work sharing was introduce by making Aliasing conditional, this would act as a mechanism to inhabit aliasing  and release newly copied work when threads were found to be stalled _(i.e., wait count greater than 0)_, as outlined in the following code: 

```C++
MMINLINE MM_CopyScanCacheStandard *
MM_Scavenger::aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scannedSlot, MM_CopyScanCacheStandard* scanCache, MM_CopyScanCacheStandard* copyCache)
{
	/* Only alias a copy cache IF there are 0 threads waiting.  If the current thread is the only producer and
	 * it aliases a copy cache then it will be the only thread able to consume.  This will alleviate the stalling issues
	 * described in VMDESIGN 1359.
	 *
	 * @NOTE this is likely too aggressive and should be relaxed.
	 */

	if (_waitingCount == 0) {
                ....
		}
	} else if (NULL != env->_deferredScanCache) {
		/* If there are threads waiting and this thread has a deferredScanCache push
		 * it to the scanCache to make work for the stalled threads.
		 */
                  ...
	}
	return NULL;
}
```
**By decreasing pause times (18% reduction) , a increase in throughput was also observed (~0.5%).**

### Investigation
The main objective of this investigation is to look into the condition inhibiting aliasing _(used to promote work sharing for stalled threads, as discussed in the background section)_. It was noted that: 

> @NOTE this is likely too aggressive and should be relaxed.

Currently, the condition is too aggressive as aliasing is inhibited when any one thread is stalled (_i.e., waitingCount must be 0 for aliasing to occur)_. Aliasing should only be inhibited *when absolutely required* as aliasing results in better object locality and consequently better application throughput. **By being aggressive, we will ensure most optimal parallelism, however we may give up throughput improvements.** For this reason, we must look into possible throughput improvements by sacrificing parallelism/GC pause time gains and increasing aliasing. Overall, the benefits and loss of relaxing the aliasing inhibiting condition must be determined. 

 **A favourable gain in throughput with a tolerable loss in GC pause times (decrease in parallelism) is expected with an optimal condition.**

### Testing Methods 
The aim is to find the percentage of GC threads which can be stalled while gaining favourable increase in throughput. Currently 0% of threads can be stalled, hence throughout and pause times data must be gathered for various thresholds. This will be done by benchmarking  an experimental build with a runtime option to modify the threshold:
```C++
if (_waitingCount <=  _extensions->waitCountThreshold) 
```

Benchmarking will be done on a 24 threaded system with the following thresholds: 0 (baseline), 2, 4, 6, 12, 18,  ∞ (no wait count)

Relative gains throughput and pause time will be measured and plotted for analysis.


