### PR TITLE
AArch64: Add ARM64RegBranchInstruction for br/blr/ret

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -102,11 +102,27 @@ uint8_t *TR::ARM64CompareBranchInstruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64RegBranchInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 uint8_t *TR::ARM64AdminInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   TR::InstOpCode::Mnemonic op = getOpCodeValue();
 
-   TR_ASSERT(false, "Not implemented yet.");
+   if (op != OMR::InstOpCode::proc && op != OMR::InstOpCode::fence && op != OMR::InstOpCode::retn)
+      {
+      TR_ASSERT(false, "Unsupported opcode in AdminInstruction.");
+      }
 
    setBinaryLength(0);
    setBinaryEncoding(instructionStart);

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -434,6 +434,7 @@ static const char *opCodeToNameMap[] =
    "rev32",
    "proc",
    "fence",
+   "return",
    "dd",
    "label"
    };
@@ -486,6 +487,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
          break;
       case OMR::Instruction::IsCompareBranch:
          print(pOutFile, (TR::ARM64CompareBranchInstruction *)instr);
+         break;
+      case OMR::Instruction::IsRegBranch:
+         print(pOutFile, (TR::ARM64RegBranchInstruction *)instr);
          break;
       case OMR::Instruction::IsAdmin:
          print(pOutFile, (TR::ARM64AdminInstruction *)instr);
@@ -634,6 +638,15 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64CompareBranchInstruction *instr)
    {
    printPrefix(pOutFile, instr);
    TR_ASSERT(false, "Not implemented yet.");
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64RegBranchInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+   print(pOutFile, instr->getTargetRegister(), TR_DoubleWordReg);
+   trfflush(_comp->getOutFile());
    }
 
 void
@@ -895,8 +908,8 @@ getRegisterName(TR::RealRegister::RegNum num, bool is64bit)
       case TR::RealRegister::x27: return (is64bit ? "x27" : "w27");
       case TR::RealRegister::x28: return (is64bit ? "x28" : "w28");
       case TR::RealRegister::x29: return (is64bit ? "x29" : "w29");
-      case TR::RealRegister::x30: return (is64bit ? "x30" : "w30");
-      case TR::RealRegister::sp: return (is64bit ? "sp" : "sp");
+      case TR::RealRegister::x30: return "lr";
+      case TR::RealRegister::sp: return "sp";
 
       case TR::RealRegister::v0: return (is64bit ? "d0" : "s0");
       case TR::RealRegister::v1: return (is64bit ? "d1" : "s1");

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -210,8 +210,6 @@ public:
 
 class ARM64DepInstruction : public TR::Instruction
    {
-   TR::RegisterDependencyConditions *_conditions;
-
    public:
 
    /*
@@ -223,7 +221,7 @@ class ARM64DepInstruction : public TR::Instruction
     */
    ARM64DepInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
                        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, cg), _conditions(cond)
+      : TR::Instruction(op, node, cond, cg)
       {
       }
    /*
@@ -237,7 +235,7 @@ class ARM64DepInstruction : public TR::Instruction
    ARM64DepInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
                        TR::RegisterDependencyConditions *cond,
                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, precedingInstruction, cg), _conditions(cond)
+      : TR::Instruction(op, node, cond, precedingInstruction, cg)
       {
       }
 
@@ -246,24 +244,6 @@ class ARM64DepInstruction : public TR::Instruction
     * @return instruction kind
     */
    virtual Kind getKind() { return IsDep; }
-
-   /**
-    * @brief Gets register dependency condition
-    * @return register dependency condition
-    */
-   virtual TR::RegisterDependencyConditions *getDependencyConditions()
-      {
-      return _conditions;
-      }
-   /**
-    * @brief Sets register dependency condition
-    * @param[in] cond : register dependency condition
-    * @return register dependency condition
-    */
-   TR::RegisterDependencyConditions *setDependencyConditions(TR::RegisterDependencyConditions *cond)
-      {
-      return (_conditions = cond);
-      }
    };
 
 class ARM64LabelInstruction : public TR::Instruction
@@ -608,6 +588,7 @@ class ARM64CompareBranchInstruction : public ARM64LabelInstruction
       : ARM64LabelInstruction(op, node, sym, cg), _source1Register(sreg),
         _estimatedBinaryLocation(0)
       {
+      useRegister(sreg);
       }
 
    /*
@@ -624,6 +605,7 @@ class ARM64CompareBranchInstruction : public ARM64LabelInstruction
       : ARM64LabelInstruction(op, node, sym, precedingInstruction, cg), _source1Register(sreg),
         _estimatedBinaryLocation(0)
       {
+      useRegister(sreg);
       }
 
    /**
@@ -675,6 +657,75 @@ class ARM64CompareBranchInstruction : public ARM64LabelInstruction
       {
       TR::RealRegister *source1 = toRealRegister(_source1Register);
       source1->setRegisterFieldRD(instruction);
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
+class ARM64RegBranchInstruction : public TR::Instruction
+   {
+   TR::Register *_register;
+
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : branch target
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64RegBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cg), _register(treg)
+      {
+      useRegister(treg);
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : branch target
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64RegBranchInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, precedingInstruction, cg), _register(treg)
+      {
+      useRegister(treg);
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsRegBranch; }
+
+   /**
+    * @brief Gets target register
+    * @return target register
+    */
+   TR::Register *getTargetRegister() {return _register;}
+   /**
+    * @brief Sets target register
+    * @param[in] tr : target register
+    * @return target register
+    */
+   TR::Register *setTargetRegister(TR::Register *tr) {return (_register = tr);}
+
+   /**
+    * @brief Sets target register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertTargetRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *target = toRealRegister(_register);
+      target->setRegisterFieldRN(instruction);
       }
 
    /**
@@ -788,6 +839,7 @@ class ARM64Trg1Instruction : public TR::Instruction
    ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, cg), _target1Register(treg)
       {
+      useRegister(treg);
       }
 
    /*
@@ -802,6 +854,7 @@ class ARM64Trg1Instruction : public TR::Instruction
                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : TR::Instruction(op, node, precedingInstruction, cg), _target1Register(treg)
       {
+      useRegister(treg);
       }
 
    /**
@@ -972,6 +1025,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
                              TR::Register *sreg, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, cg), _source1Register(sreg)
       {
+      useRegister(sreg);
       setDependencyConditions(NULL);
       }
 
@@ -989,6 +1043,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _source1Register(sreg)
       {
+      useRegister(sreg);
       setDependencyConditions(NULL);
       }
 
@@ -1005,6 +1060,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
                              TR::Register *sreg, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, cg), _source1Register(sreg)
       {
+      useRegister(sreg);
       setDependencyConditions(cond);
       }
 
@@ -1023,6 +1079,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _source1Register(sreg)
       {
+      useRegister(sreg);
       setDependencyConditions(cond);
       }
 
@@ -1227,6 +1284,7 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
                              TR::Register *s2reg, TR::CodeGenerator *cg)
       : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cg), _source2Register(s2reg)
       {
+      useRegister(s2reg);
       }
 
    /*
@@ -1248,6 +1306,7 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
       : ARM64Trg1Src1Instruction(op, node, treg, s1reg, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
+      useRegister(s2reg);
       }
 
    /*
@@ -1269,6 +1328,7 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
                              TR::CodeGenerator *cg)
       : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cond, cg), _source2Register(s2reg)
       {
+      useRegister(s2reg);
       }
 
    /*
@@ -1292,6 +1352,7 @@ class ARM64Trg1Src2Instruction : public ARM64Trg1Src1Instruction
       : ARM64Trg1Src1Instruction(op, node, treg, s1reg, cond, precedingInstruction, cg),
                              _source2Register(s2reg)
       {
+      useRegister(s2reg);
       }
 
    /**
@@ -1591,6 +1652,7 @@ class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
                              TR::Register *s3reg, TR::CodeGenerator *cg)
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg), _source3Register(s3reg)
       {
+      useRegister(s3reg);
       }
 
    /*
@@ -1614,6 +1676,7 @@ class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg),
                              _source3Register(s3reg)
       {
+      useRegister(s3reg);
       }
 
    /*
@@ -1637,6 +1700,7 @@ class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
                              TR::CodeGenerator *cg)
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, cg), _source3Register(s3reg)
       {
+      useRegister(s3reg);
       }
 
    /*
@@ -1662,6 +1726,7 @@ class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, precedingInstruction, cg),
                              _source3Register(s3reg)
       {
+      useRegister(s3reg);
       }
 
    /**
@@ -1936,6 +2001,7 @@ class ARM64MemSrc1Instruction : public ARM64MemInstruction
                             TR::Register *sreg, TR::CodeGenerator *cg)
       : ARM64MemInstruction(op, node, mr, cg), _source1Register(sreg)
       {
+      useRegister(sreg);
       }
 
    /*
@@ -1981,7 +2047,7 @@ class ARM64MemSrc1Instruction : public ARM64MemInstruction
    void insertSource1Register(uint32_t *instruction)
       {
       TR::RealRegister *source1 = toRealRegister(_source1Register);
-      TR_ASSERT(false, "Not implemented yet.");
+      source1->setRegisterFieldRT(instruction);
       }
 
    /**

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -114,6 +114,14 @@ TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::Ins
    return new (cg->trHeapMemory()) TR::ARM64CompareBranchInstruction(op, node, sreg, sym, cg);
    }
 
+TR::Instruction *generateRegBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64RegBranchInstruction(op, node, treg, cg);
+   }
+
 TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::Node *fenceNode, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -216,6 +216,22 @@ TR::Instruction *generateCompareBranchInstruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates branch-to-register instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateRegBranchInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::Register *treg,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates admin instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -423,6 +423,7 @@
 	/* Last VFP instructions */
 		proc,  // Entry to the method
 		fence, // Fence
+		retn,  // Return
 		dd,    // Define word
 		label, // Destination of a jump
 		ARM64LastOp = label,

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -32,6 +32,7 @@
       IsConditionalBranch,
          IsDepConditionalBranch,
       IsCompareBranch,
+   IsRegBranch,
    IsAdmin,
    IsTrg1,
       IsTrg1Imm,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -344,6 +344,7 @@ namespace TR { class ARM64DepLabelInstruction; }
 namespace TR { class ARM64ConditionalBranchInstruction; }
 namespace TR { class ARM64DepConditionalBranchInstruction; }
 namespace TR { class ARM64CompareBranchInstruction; }
+namespace TR { class ARM64RegBranchInstruction; }
 namespace TR { class ARM64AdminInstruction; }
 namespace TR { class ARM64Trg1Instruction; }
 namespace TR { class ARM64Trg1ImmInstruction; }
@@ -1098,6 +1099,7 @@ public:
    void print(TR::FILE *, TR::ARM64ConditionalBranchInstruction *);
    void print(TR::FILE *, TR::ARM64DepConditionalBranchInstruction *);
    void print(TR::FILE *, TR::ARM64CompareBranchInstruction *);
+   void print(TR::FILE *, TR::ARM64RegBranchInstruction *);
    void print(TR::FILE *, TR::ARM64AdminInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1ImmInstruction *);


### PR DESCRIPTION
This commit adds ARM64RegBranchInstruction for aarch64 branch
instructions that take a register as the target address.
It also introduces a new opcode that represents a return from a method,
which is separate from the opcode for aarch64 machine instruction "ret".

Signed-off-by: knn-k <konno@jp.ibm.com>