### PR TITLE
Avoid inlining TR_ScratchBufferInfo::writeToBuffer

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -1490,7 +1490,9 @@ bool TR_OSRCompilationData::TR_ScratchBufferInfo::operator==(const TR_ScratchBuf
       scratchBufferOffset == info.scratchBufferOffset && symSize == info.symSize;
    }
 
-#if defined(TR_HOST_POWER) && defined(TR_TARGET_POWER) && defined(__IBMCPP__)
+#if (defined(TR_HOST_POWER) && defined(TR_TARGET_POWER)                       \
+           || defined(TR_HOST_S390) && defined(TR_TARGET_S390))               \
+        && defined(__IBMCPP__)
 __attribute__((__noinline__))
 //This tiny function when inlined by xlC 12 at -O3 breaks java -version
 #endif

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -1494,7 +1494,8 @@ bool TR_OSRCompilationData::TR_ScratchBufferInfo::operator==(const TR_ScratchBuf
            || defined(TR_HOST_S390) && defined(TR_TARGET_S390))               \
         && defined(__IBMCPP__)
 __attribute__((__noinline__))
-//This tiny function when inlined by xlC 12 at -O3 breaks java -version
+//This tiny function when inlined by xlC 12 or later at -O3 breaks java -version
+//on Power and causes intermittent crashes on z/OS with xlC 2.1.1
 #endif
 int32_t TR_OSRCompilationData::TR_ScratchBufferInfo::writeToBuffer(uint8_t* buffer) const
    {


### PR DESCRIPTION
If TR_ScratchBufferInfo::writeToBuffer is inlined, it appears to expose
a bug in code generated by the IBM xlC compiler on z-Series.  The same
(or a similar) problem was previously seen on p-Series compiling with
xlC, and the work-around was to avoid inlining when compiling with xlC
on POWER.  This extends the same work-around to z compiling with xlC

Fixes: #3084

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>