### PR TITLE
AArch64: Binary Encoding Fix and Addition of 'B' and 'BL' Instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -90,6 +90,8 @@ static const char *opCodeToNameMap[] =
    "br",
    "blr",
    "ret",
+   "b",
+   "bl",
    "stxrb",
    "stlxrb",
    "ldxrb",

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -46,6 +46,8 @@
 		blr,                                                    	/* 0xD63F0000	BLR       	 */
 		ret,                                                    	/* 0xD65F0000	RET       	 */
 	/* Unconditional branch (immediate) */
+		b,                                                      	/* 0x14000000	B         	 */
+		bl,                                                     	/* 0x94000000	BL        	 */
 /* Loads and stores */
 	/* Load/store exclusive */
 		stxrb,                                                  	/* 0x08000000	STXRB     	 */
@@ -310,7 +312,7 @@
 		ubfmx,                                                  	/* 0xD3400000	UBFM      	 */
 	/* Extract */
 		extrw,                                                  	/* 0x13800000	EXTR      	 */
-		extrx,                                                  	/* 0x93C00000	EXTR      	 */
+		extrx,                                                  	/* 0x93C08000	EXTR      	 */
 /* Data Processing - register */
 	/* Logical (shifted register) */
 		andw,                                                   	/* 0x0A000000	AND       	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -45,6 +45,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xD63F0000,	/* BLR       	blr	 */
 		0xD65F0000,	/* RET       	ret	 */
 	/* Unconditional branch (immediate) */
+		0x14000000,	/* B         	b	 */
+		0x94000000,	/* BL        	bl	 */
 /* Loads and stores */
 	/* Load/store exclusive */
 		0x08000000,	/* STXRB     	stxrb	 */
@@ -309,7 +311,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xD3400000,	/* UBFM      	ubfmx	 */
 	/* Extract */
 		0x13800000,	/* EXTR      	extrw	 */
-		0x93C00000,	/* EXTR      	extrx	 */
+		0x93C08000,	/* EXTR      	extrx	 */
 /* Data Processing - register */
 	/* Logical (shifted register) */
 		0x0A000000,	/* AND       	andw	 */


### PR DESCRIPTION
Some binary encoding values mismatched because of the mismatch in opcodes.
Those values are being updated. 'B' and 'BL' instructions are being added
 to ORMInstOpCodeEnum.cpp and OpBinary.cpp

Fixes #3017 
Signed-off-by: marufunb <mrahma15@unb.ca>