### PR TITLE
Fix MSVC error C2398 requires narrowing conversion

### DIFF
--- a/fvtest/compilertriltest/SimplifierFoldAbsNegTest.cpp
+++ b/fvtest/compilertriltest/SimplifierFoldAbsNegTest.cpp
@@ -42,7 +42,7 @@ template <> char* nameForType< double>() { return "Double"; }
 
 std::vector<int32_t> iTestData = { 0, 1, 2, -1, -2, 99999, -99999, std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::min() };
 std::vector<int64_t> lTestData = { 0, 1, 2, -1, -2, 99999, -99999, std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::min() };
-std::vector<  float> fTestData = { 0, 1, 2, -1, -2, 3.14, -3.14, std::numeric_limits<float>::min(), std::numeric_limits<float>::min() };
+std::vector<  float> fTestData = { 0, 1, 2, -1, -2, 3.14F, -3.14F, std::numeric_limits<float>::min(), std::numeric_limits<float>::min() };
 std::vector< double> dTestData = { 0, 1, 2, -1, -2, 3.14, -3.14, std::numeric_limits<double>::min(), std::numeric_limits<double>::min() };
 
 template <typename T> std::vector<T> dataForType();


### PR DESCRIPTION
The 'SimpifierFoldAbsNegTest' unit test from 'compilertriltest' contains
an initialization block for a vector of floats:

std::vector<  float> fTestData =
    { 0, 1, 2, -1, -2, 3.14, -3.14,
      std::numeric_limits<float>::min(), std::numeric_limits<float>::min() };

During a compilation with MSVC the following errors appears:

.\..\fvtest\compilertriltest\SimplifierFoldAbsNegTest.cpp(45): error
C2398: Element '6': conversion from 'double' to 'float' requires a
narrowing conversion
..\..\fvtest\compilertriltest\SimplifierFoldAbsNegTest.cpp(45): error
C2398: Element '7': conversion from 'double' to 'float' requires a
narrowing conversion

Literals '3.14' and '-3.14' can be represented as well 'double' as
'float', the 'f' suffix after the literal must be present to fix the
compilation error.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>