### PR TITLE
Explicit thread count for parallel GC task

### DIFF
--- a/gc/base/Dispatcher.cpp
+++ b/gc/base/Dispatcher.cpp
@@ -57,7 +57,7 @@ MM_Dispatcher::initialize(MM_EnvironmentBase *env)
 }
 
 void
-MM_Dispatcher::prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task)
+MM_Dispatcher::prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount)
 {
 	task->setThreadCount(1);
 	_task = task;
@@ -89,22 +89,15 @@ MM_Dispatcher::cleanupAfterTask(MM_EnvironmentBase *env)
 void
 MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
 {
-	uintptr_t defaultThreadCount = threadCount();
-	if (UDATA_MAX != newThreadCount) {
-		/* Let tasks run with different (typically reduced) thread count. */
-		setThreadCount(newThreadCount);
-	}
-
 	task->masterSetup(env);
+	prepareThreadsForTask(env, task, newThreadCount);
+	/* todo: remove this API once downstream OMR projects transition to the API with threadCount argument */
 	prepareThreadsForTask(env, task);
 	acceptTask(env);
 	task->run(env);
 	completeTask(env);
 	cleanupAfterTask(env);
 	task->masterCleanup(env);
-
-	/* restore the default thread count */
-	setThreadCount(defaultThreadCount);
 }
 
 bool 

--- a/gc/base/Dispatcher.hpp
+++ b/gc/base/Dispatcher.hpp
@@ -54,8 +54,11 @@ private:
 	
 protected:
 	bool initialize(MM_EnvironmentBase *env);
+	
+	/* todo: remove this API once downstream OMR projects transition to the API with threadCount argument */
+	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task) {}
 
-	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task);
+	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount);
 	virtual void acceptTask(MM_EnvironmentBase *env);
 	virtual void completeTask(MM_EnvironmentBase *env);
 	virtual void cleanupAfterTask(MM_EnvironmentBase *env);

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -93,7 +93,10 @@ protected:
 
 	bool initialize(MM_EnvironmentBase *env);
 	
-	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task);
+	/* todo: remove this API once downstream OMR projects transition to the API with threadCount argument */
+	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task) {}
+	
+	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount);
 	virtual void cleanupAfterTask(MM_EnvironmentBase *env);
 	virtual uintptr_t getThreadPriority(); 
 


### PR DESCRIPTION
Fixing 2 problems, when overriding thread count for a task (via run()
API), which may occur in a scenario when initial heap size is so small
to cause an early GC before even all GC threads are up and running: 

1) major: the overriding value should be no bigger than
_threadCount/_adjustedThreadCount, since there might not be
more slave threads available, yet. Otherwise, the task would hang
waiting for non-existant threads to complete.
2) minor: do not record the overriding value into Dispatcher's
_threadCount, since early at startup _threadCount might still be
constructed. Just pass the value to the task. Otherwise, the final
constructed value could be lost and subsequent GCs may run with reduced
GC counts.

Temporarily, keeping both old and new variant of prepareThreadsForTask()
API until downstream OMR projects start using the new API.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>