### PR TITLE
Flush GC caches for concurrent marker thread

### DIFF
--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1047,6 +1047,7 @@ MM_ConcurrentGC::conHelperEntryPoint(OMR_VMThread *omrThread, uintptr_t slaveID)
 	MM_SpinLimiter spinLimiter(env);
 
 	/* Thread not a mutator so identify its type */
+	env->initializeGCThread();
 	env->setThreadType(CON_MARK_HELPER_THREAD);
 
 	while (CONCURRENT_HELPER_SHUTDOWN != request) {


### PR DESCRIPTION
GC threads at startup act briefly as mutators since they allocate from
heap (various thread specific objects). Before transitioning the thread
type to its specific GC role, they need to flush any GC specific caches,
as any mutators do.

Specifically, in Concurrent Scavenger, if a GC thread is created during
a very early cycle, it may trigger a read barrier and create a copy
cache. This cache has to by flushed (to scan queue for further scanning
in final STW GC phase).

This problem has already been addressed for Master and Slave GC threads
(https://github.com/eclipse/omr/pull/2696). Here Concurrent Marking
Background threads are treated with the identical fix. 

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>