### PR TITLE
State explicitly CS witout H/W assistance

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -417,7 +417,6 @@ public:
 	bool scavengerEnabled;
 	bool scavengerRsoScanUnsafe;
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	bool softwareEvacuateReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS */
 	bool softwareRangeCheckReadBarrier; /**< enable software read barrier instead of hardware guarded loads when running with CS */
 	bool concurrentScavenger; /**< CS enabled/disabled flag */
 	bool concurrentScavengerForced; /**< set to true if CS is requested (by cmdline option), but there are more checks to do before deciding whether the request is to be obeyed */
@@ -823,16 +822,6 @@ public:
 		return false;
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
-	
-   MMINLINE bool
-   isSoftwareEvacuateReadBarrierEnabled()
-   {
-#if defined(OMR_GC_CONCURRENT_SCAVENGER)
-      return softwareEvacuateReadBarrier;
-#else
-      return false;
-#endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
-   }	
 	
    MMINLINE bool
    isSoftwareRangeCheckReadBarrierEnabled()
@@ -1375,7 +1364,6 @@ public:
 		, scvTenureStrategyHistory(true)
 		, scavengerEnabled(false)
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		, softwareEvacuateReadBarrier(false)
 		, softwareRangeCheckReadBarrier(false)
 		, concurrentScavenger(false)
 		, concurrentScavengerForced(false)

--- a/gc/include/omrmm.hdf
+++ b/gc/include/omrmm.hdf
@@ -204,7 +204,7 @@ typedef uintptr_t (*condYieldFromGCFunctionPtr) (OMR_VMThread *omrVMThread, uint
 		<data type="struct OMR_VMThread*" name="currentThread" description="current thread" />
 		<data type="uint64_t" name="timestamp" description="time of event" />
 		<data type="const char*" name="gcPolicy" description="-Xgcpolicy value" />
-		<data type="uintptr_t" name="jitLoaded" description="JIT library loaded" />
+		<data type="uintptr_t" name="unused" description="UNUSED" />
 		<data type="uintptr_t" name="maxHeapSize" description="-Xmx value" />
 		<data type="uintptr_t" name="initialHeapSize" description="-Xms value" />
 		<data type="uint64_t" name="physicalMemory" description="the total amount of physical memory" />

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -253,7 +253,13 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->isConcurrentScavengerEnabled()) {
 		writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />",
-			(event->jitLoaded && !_extensions->isSoftwareEvacuateReadBarrierEnabled()) ? "enabled, H/W assisted" : "enabled");
+#if defined(S390)
+				extensions->concurrentScavengerHWSupport ?
+				"enabled, with H/W assistance" :
+				"enabled, without H/W assistance");
+#else /* defined(S390) */
+				"enabled");
+#endif /* defined(S390) */
 	}
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 	writer->formatAndOutput(env, 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", event->maxHeapSize);


### PR DESCRIPTION
Slighly modify the verbose GC stanza where we state if Concurrent
Scavenger is enabled:

1) on H/W capable platforms we will state one of two:

enabled, with H/W assistance
enabled, without H/W assistance

2) on plaforms with no H/W assistance we will just state:

enabled

3) if CS is not enabled, regardless of platform, the stanza is not
issued

Since there is an overlap, also piggybacking to this change removal of
unused softwareEvacuateReadBarrier flag and retirment of jitLoaded field
in Initialized hook.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>