### PR TITLE
Add support for CUDA 10.0

### DIFF
--- a/port/common/omrcuda.cpp
+++ b/port/common/omrcuda.cpp
@@ -999,6 +999,10 @@ const J9CudaLibraryDescriptor runtimeLibraries[] = {
 /*
  * Include forward-compatible support for runtime libraries.
  */
+#if CUDA_VERSION <= 10000
+	OMRCUDA_LIBRARY_ENTRY(10, 0),
+#endif /* CUDA_VERSION <= 10000 */
+
 #if CUDA_VERSION <= 9020
 	OMRCUDA_LIBRARY_ENTRY(9, 2),
 #endif /* CUDA_VERSION <= 9020 */


### PR DESCRIPTION
According to [1], CUDA Toolkit version 10.0 was released in September 2018.

[1] https://developer.nvidia.com/cuda-toolkit-archive