### PR TITLE
AArch64: Add incRegisterTotalUseCounts() to RegisterDependencyConditions

### DIFF
--- a/compiler/aarch64/codegen/OMRInstruction.cpp
+++ b/compiler/aarch64/codegen/OMRInstruction.cpp
@@ -49,6 +49,8 @@ OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
      _conditions(cond)
    {
    self()->setBlockIndex(cg->getCurrentBlockIndex());
+   if (cond)
+      cond->incRegisterTotalUseCounts(cg);
    }
 
 
@@ -57,6 +59,8 @@ OMR::ARM64::Instruction::Instruction(TR::CodeGenerator *cg, TR::Instruction *pre
      _conditions(cond)
    {
    self()->setBlockIndex(cg->getCurrentBlockIndex());
+   if (cond)
+      cond->incRegisterTotalUseCounts(cg);
    }
 
 

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -131,6 +131,18 @@ bool OMR::ARM64::RegisterDependencyConditions::usesRegister(TR::Register *r)
    return false;
    }
 
+void OMR::ARM64::RegisterDependencyConditions::incRegisterTotalUseCounts(TR::CodeGenerator *cg)
+   {
+   for (int i = 0; i < _addCursorForPre; i++)
+      {
+      _preConditions->getRegisterDependency(i)->getRegister()->incTotalUseCount();
+      }
+   for (int j = 0; j < _addCursorForPost; j++)
+      {
+      _postConditions->getRegisterDependency(j)->getRegister()->incTotalUseCount();
+      }
+   }
+
 TR::RegisterDependencyConditions *
 OMR::ARM64::RegisterDependencyConditions::clone(
    TR::CodeGenerator *cg,

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -432,6 +432,12 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
     * @return true when it uses the register
     */
    bool usesRegister(TR::Register *r);
+
+   /**
+    * @brief Increment totalUseCounts of registers in the RegisterDependencyConditions
+    * @param[in] cg : CodeGenerator
+    */
+   void incRegisterTotalUseCounts(TR::CodeGenerator *cg);
    };
 
 } // ARM64


### PR DESCRIPTION
The totalUseCounts of registers in RegisterDependencyConditions were
not counted properly.  This commit adds a new function to
RegisterDependencyConditions, and calls to the function.

Signed-off-by: knn-k <konno@jp.ibm.com>