### PR TITLE
AArch64: Fix code generation of return

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -287,8 +287,8 @@ TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
          }
       }
 
-   // save the stack frame size, aligned to 8 bytes
-   stackIndex = (stackIndex + 7) & (~7);
+   // save the stack frame size, aligned to 16 bytes
+   stackIndex = (stackIndex + 15) & (~15);
    cg()->setFrameSizeInBytes(stackIndex);
 
    nextIntArgReg = 0;
@@ -483,8 +483,9 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // restore link register (x30)
+   TR::RealRegister *lr = machine->getARM64RealRegister(TR::RealRegister::lr);
    TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, bodySymbol->getLocalMappingCursor(), codeGen);
-   cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, machine->getARM64RealRegister(TR::RealRegister::lr), stackSlot, cursor);
+   cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
 
    // remove space for preserved registers
    uint32_t frameSize = codeGen->getFrameSizeInBytes();
@@ -498,7 +499,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // return
-   cursor = generateInstruction(codeGen, TR::InstOpCode::ret, lastNode, cursor);
+   cursor = generateRegBranchInstruction(codeGen, TR::InstOpCode::ret, lastNode, lr, cursor);
    }
 
 

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -33,10 +33,10 @@ genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rnum, TR_Registe
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *returnRegister = cg->evaluate(firstChild);
 
-   TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
-   addDependency(deps, returnRegister, rnum, rk, cg);
+   TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 0, cg->trMemory());
+   deps->addPreCondition(returnRegister, rnum);
+   generateAdminInstruction(cg, TR::InstOpCode::retn, node, deps);
 
-   generateAdminInstruction(cg, TR::InstOpCode::ret, node, deps);
    cg->comp()->setReturnInfo(i);
    cg->decReferenceCount(firstChild);
 
@@ -63,7 +63,7 @@ OMR::ARM64::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeGenerator *cg
    {
 	// TODO:ARM64: Enable TR::TreeEvaluator::ificmpeqEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
 
-   generateAdminInstruction(cg, TR::InstOpCode::ret, node);
+   generateAdminInstruction(cg, TR::InstOpCode::retn, node);
    cg->comp()->setReturnInfo(TR_VoidReturn);
    return NULL;
    }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -216,7 +216,7 @@ OMR::ARM64::CodeGenerator::doBinaryEncoding()
    bool skipOneReturn = false;
    while (cursorInstruction)
       {
-      if (cursorInstruction->getOpCodeValue() == TR::InstOpCode::ret)
+      if (cursorInstruction->getOpCodeValue() == TR::InstOpCode::retn)
          {
          if (skipOneReturn == false)
             {


### PR DESCRIPTION
This commit fixes the code generation of return for aarch64,
separating the machine instruction "ret" and the abstract representation
of return (ARM64AdminInstruction(TR::InstOpCode::retn)).

Signed-off-by: knn-k <konno@jp.ibm.com>