### PR TITLE
WIP: Insert a GC map at catch block entry on X86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3434,6 +3434,9 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
 
       inst->setNeedToClearFPStack(true);
 
+      if (block->isCatchBlock())
+         inst->setNeedsGCMap(0xFF00FFFF);
+
       node->getLabel()->setInstruction(inst);
       block->setFirstInstruction(inst);
 


### PR DESCRIPTION
A GC map may be needed at the entry of a catch block.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>