### PR TITLE
Set ICF flags on labels instead of instructions in the Z codegen

### DIFF
--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -539,7 +539,7 @@ OMR::Symbol::isStartOfColdInstructionStream()
 void
 OMR::Symbol::setStartInternalControlFlow()
    {
-   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(StartInternalControlFlow);
+   TR_ASSERT(self()->isLabel(), "can only set start ICF on a label"); _flags.set(StartInternalControlFlow);
    }
 
 bool
@@ -551,13 +551,13 @@ OMR::Symbol::isStartInternalControlFlow()
 void
 OMR::Symbol::setEndInternalControlFlow()
    {
-   TR_ASSERT(self()->isLabel(), "assertion failure"); _flags.set(EndInternalControlFlow);
+   TR_ASSERT(self()->isLabel(), "can only set end ICF on a label"); _flags.set(EndInternalControlFlow);
    }
 
 bool
 OMR::Symbol::isEndInternalControlFlow()
    {
-   return self()->isLabel() && !self()->isGlobalLabel() && _flags.testAny(EndInternalControlFlow) && !self()->isGlobalLabel();
+   return self()->isLabel() && !self()->isGlobalLabel() && _flags.testAny(EndInternalControlFlow);
    }
 
 void

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -397,7 +397,7 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
       bool zArchTrexsupported = performTransformation(comp, "O^O Use SL/SLB for long sub.");
 
       TR::Register * highDiff = NULL;
-      TR::LabelSymbol * doneLSub = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
+      TR::LabelSymbol * doneLSub = generateLabelSymbol(cg());
       if (getCopyReg1())
          {
          TR::Register * lowThird = cg()->allocateRegister();

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -1471,7 +1471,7 @@ TR_S390BinaryCommutativeAnalyser::longAddAnalyser(TR::Node * root, TR::InstOpCod
    TR::Node * firstChild;
    TR::Node * secondChild;
    TR::Register * highSum = NULL;
-   TR::LabelSymbol * doneLAdd = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
+   TR::LabelSymbol * doneLAdd = generateLabelSymbol(cg());
    TR::Instruction * cursor = NULL;
    TR::RegisterDependencyConditions * dependencies = NULL;
    TR::Register * twoLow;

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -87,8 +87,8 @@ extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
  */
 TR::RegisterPair * lnegFor32Bit(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegisterPair, TR::RegisterDependencyConditions * dep = 0)
    {
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
    TR::RegisterDependencyConditions * localDeps = NULL;
 
 
@@ -130,8 +130,8 @@ TR::RegisterPair * lnegFor32Bit(TR::Node * node, TR::CodeGenerator * cg, TR::Reg
  */
 TR::RegisterPair * lnegFor128Bit(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegisterPair, TR::RegisterDependencyConditions * dep = 0)
    {
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
 
    TR::RegisterDependencyConditions * localDeps = NULL;
 
@@ -213,8 +213,8 @@ laddConst(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegi
       // Add low value
       if ( l_value != 0 )
          {
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+         TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
 
          TR::RegisterDependencyConditions * dependencies = NULL;
          // tempReg is used to hold the immediate on GoldenEagle or better.
@@ -272,7 +272,7 @@ laddHelper(TR::Node * node, TR::CodeGenerator * cg)
 
    if (secondChild->getOpCodeValue() == TR::lconst && secondChild->getRegister() == NULL)
       {
-      TR::LabelSymbol * doneLAdd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * doneLAdd = generateLabelSymbol(cg);
       TR::Node * firstChild = node->getFirstChild();
 
       targetRegisterPair = (TR::RegisterPair *) cg->gprClobberEvaluate(firstChild);
@@ -766,11 +766,11 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
             dep->addPostCondition(dividendPair->getHighOrder(), TR::RealRegister::LegalEvenOfPair);
             dep->addPostCondition(dividendPair->getLowOrder(), TR::RealRegister::LegalOddOfPair);
 
-            TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-            TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+            TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
 
             //special case, need to check if dividend is 0x8000000000000000 - but need to check it in 2 steps
-            TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            TR::LabelSymbol * doDiv = generateLabelSymbol(cg);
             generateS390ImmOp(cg, TR::InstOpCode::C, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(), (int32_t) 0x80000000);
 
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
@@ -809,7 +809,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
             performTransformation(comp, "O^O Denominator is powerOfTwo (%d) for ldir/lrem.\n",denominator))
          {
          int64_t absValueOfDenominator = denominator>0 ? denominator : -denominator;
-         TR::LabelSymbol * done = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * done = generateLabelSymbol(cg);
 
          //setup dependencies for shift instructions for division or remainder
          TR::RegisterDependencyConditions * dep = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 5, cg);
@@ -821,8 +821,8 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
             {
             if (!firstChild->isNonNegative())
                {
-               TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-               TR::LabelSymbol * skipSet = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+               TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+               TR::LabelSymbol * skipSet = generateLabelSymbol(cg);
 
                generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
                cFlowRegionStart->setStartInternalControlFlow();
@@ -894,9 +894,9 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    if (performTransformation(comp, "O^O Using 64bit ldiv on 32bit driver.\n"))
       {
       TR::Instruction * cursor = NULL;
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * gotoDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * dontDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * gotoDiv = generateLabelSymbol(cg);
+      TR::LabelSymbol * dontDiv = generateLabelSymbol(cg);
       TR::RegisterPair * divisorPair = (TR::RegisterPair *) cg->gprClobberEvaluate(secondChild);
       TR::Register     * litPoolBase = NULL;
       bool highWordRADisabled = !cg->supportsHighWordFacility() || comp->getOption(TR_DisableHighWordRA);
@@ -1008,7 +1008,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
 
       // The label is necessary so that RA does not insert 32-bit register moves
       // inbetween the 64-bit operations
-      TR::LabelSymbol * depLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * depLabel = generateLabelSymbol(cg);
       cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, depLabel, dependencies);
 
       node->setRegister(dividendPair);
@@ -1105,7 +1105,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
 inline TR::Register *
 lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivision)
    {
-   TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * doDiv = generateLabelSymbol(cg);
    TR::LabelSymbol * skipDiv = NULL;
 
    TR::Node * firstChild = node->getFirstChild();
@@ -1161,9 +1161,9 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             }
          else
             {
-            TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-            TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-            TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+            TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
+            TR::LabelSymbol * doDiv = generateLabelSymbol(cg);
 
             //special case, need to check if dividend is 0x8000000000000000 - but need to check it in 2 steps
             generateS390ImmOp(cg, TR::InstOpCode::CG, node, firstRegister, firstRegister, (int64_t) CONSTANT64(0x8000000000000000));
@@ -1213,8 +1213,8 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             firstRegister = cg->gprClobberEvaluate(firstChild);
             if (!firstChild->isNonNegative())
                {
-               TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-               TR::LabelSymbol * skipSet = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+               TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+               TR::LabelSymbol * skipSet = generateLabelSymbol(cg);
 
                generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
                cFlowRegionStart->setStartInternalControlFlow();
@@ -1242,7 +1242,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             {
             firstRegister = cg->gprClobberEvaluate(firstChild);
 
-            TR::LabelSymbol * done = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            TR::LabelSymbol * done = generateLabelSymbol(cg);
             TR::RegisterDependencyConditions *deps = NULL;
             if (!firstChild->isNonNegative())
                {
@@ -1328,7 +1328,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
       genLoadLongConstant(cg, node, 0, remRegister);
 
-      skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      skipDiv = generateLabelSymbol(cg);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, skipDiv);
 
       // Label to do the division
@@ -1343,7 +1343,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
          TR_ASSERT(secondChild->getOpCode().isLoadConst() && secondChild->getType().isInt64(),"secondChild %s (%p) of rem should be int64 constant\n",
             secondChild->getOpCode().getName(),secondChild);
          if (skipDiv == NULL)
-            skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            skipDiv = generateLabelSymbol(cg);
          skipDiv->setEndInternalControlFlow();
          dependencies->addPostCondition(sourceRegister, TR::RealRegister::AssignAny);
 
@@ -1369,7 +1369,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             {
             generateRRInstruction(cg, TR::InstOpCode::CLGR, node, absDividendReg, sourceRegister);
             }
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();
          generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK4, node, skipDiv); // branch to done on <
@@ -1418,7 +1418,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
 TR::Register *
 iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision, TR::MemoryReference * divchkDivisorMR)
    {
-   TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * doDiv = generateLabelSymbol(cg);
    TR::LabelSymbol * skipDiv = NULL;
 
    TR::Node * firstChild = node->getFirstChild();
@@ -1520,7 +1520,7 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    //  JAVA requires we return 0x80000000 rem 0x00000000
    if (needCheck)
       {
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
 
       generateS390ImmOp(cg, TR::InstOpCode::C, node, remRegister, remRegister, (int32_t) 0x80000000);
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
@@ -1540,7 +1540,7 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
       // TODO: Can we allow setting the condition code here by moving the load before the compare?
       generateLoad32BitConstant(cg, node, 0, remRegister, false);
 
-      skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      skipDiv = generateLabelSymbol(cg);
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, skipDiv);
 
       // Label to do the division
@@ -1946,7 +1946,7 @@ lsubHelper(TR::Node * node, TR::CodeGenerator * cg)
       {
       TR::Node * firstChild = node->getFirstChild();
       targetRegisterPair = (TR::RegisterPair *) cg->gprClobberEvaluate(firstChild);
-      TR::LabelSymbol * doneLSub = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * doneLSub = generateLabelSymbol(cg);
       int32_t h_value = secondChild->getLongIntHigh();
       int32_t l_value = secondChild->getLongIntLow();
 
@@ -2935,9 +2935,9 @@ lmulHelper(TR::Node * node, TR::CodeGenerator * cg)
 
       TR::RegisterPair * tempRegisterPair = cg->allocateConsecutiveRegisterPair(lowRegister, highRegister);
 
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * lmul1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * lmul2 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * lmul1 = generateLabelSymbol(cg);
+      TR::LabelSymbol * lmul2 = generateLabelSymbol(cg);
 
 
       TR::RegisterPair * src2RegPair = (TR::RegisterPair *) cg->gprClobberEvaluate(secondChild);
@@ -3645,9 +3645,9 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       int64_t value = secondChild->getLongInt();
       int64_t absValue = value > 0 ? value : -value;
 
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * posMulh = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * doneMulh = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * posMulh = generateLabelSymbol(cg);
+      TR::LabelSymbol * doneMulh = generateLabelSymbol(cg);
 
       // positive first child, branch to posMulh label
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
@@ -3977,9 +3977,9 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
       if (value == -1 && !node->getOpCode().isUnsigned())
          {
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         TR::LabelSymbol * skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+         TR::LabelSymbol * doDiv = generateLabelSymbol(cg);
+         TR::LabelSymbol * skipDiv = generateLabelSymbol(cg);
 
          // If the divisor is -1 we need to check the dividend for 0x80000000
          generateS390ImmOp(cg, TR::InstOpCode::C, node, targetRegister, targetRegister, (int32_t )0x80000000);
@@ -4006,8 +4006,8 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       else if ((shftAmnt = TR::TreeEvaluator::checkNonNegativePowerOfTwo(value)) > 0)
          {
          // Strength reduction
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         TR::LabelSymbol * doShift = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+         TR::LabelSymbol * doShift = generateLabelSymbol(cg);
 
          if (!firstChild->isNonNegative() && !node->getOpCode().isUnsigned())
             {
@@ -4164,7 +4164,7 @@ OMR::Z::TreeEvaluator::iremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       else if ((!isUnsigned || isNonNegativePowerOf2(value)) &&
          ((shftAmnt = TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(value)) > 0))
          {
-         TR::LabelSymbol * done = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * done = generateLabelSymbol(cg);
          TR::RegisterDependencyConditions *deps = NULL;
 
          if (!isUnsigned && !firstChild->isNonNegative())

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -87,9 +87,9 @@ extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
  */
 TR::RegisterPair * lnegFor32Bit(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegisterPair, TR::RegisterDependencyConditions * dep = 0)
    {
+   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * doneLNeg = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::RegisterDependencyConditions * localDeps = NULL;
-   TR::Instruction *cursor;
 
 
    // If deps are passed in, we assume that there is a wider scoped set of deps that are
@@ -112,8 +112,9 @@ TR::RegisterPair * lnegFor32Bit(TR::Node * node, TR::CodeGenerator * cg, TR::Reg
 
 
    // Check to see if we need to propagate an overflow bit from LS int to MS int.
-   cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneLNeg);
-   cursor->setStartInternalControlFlow();
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneLNeg);
 
    // Increment MS int due to overflow in LS int
    generateRIInstruction(cg, TR::InstOpCode::AHI, node, targetRegisterPair->getHighOrder(), -1);
@@ -129,8 +130,8 @@ TR::RegisterPair * lnegFor32Bit(TR::Node * node, TR::CodeGenerator * cg, TR::Reg
  */
 TR::RegisterPair * lnegFor128Bit(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegisterPair, TR::RegisterDependencyConditions * dep = 0)
    {
+   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * doneLNeg = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::Instruction *cursor;
 
    TR::RegisterDependencyConditions * localDeps = NULL;
 
@@ -155,8 +156,9 @@ TR::RegisterPair * lnegFor128Bit(TR::Node * node, TR::CodeGenerator * cg, TR::Re
 
 
    // Check to see if we need to propagate an overflow bit from low word long to high word long.
-   cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneLNeg);
-   cursor->setStartInternalControlFlow();
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneLNeg);
 
 
    // Subtract 1 from high word that was added in first LCGR if low word is not 0, i.e.
@@ -178,11 +180,8 @@ laddConst(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegi
    int32_t h_value = (int32_t)(value>>32);
    int32_t l_value = (int32_t)value;
 
-   TR::LabelSymbol * doneLAdd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-
    TR::Register * lowOrder = targetRegisterPair->getLowOrder();
    TR::Register * highOrder = targetRegisterPair->getHighOrder();
-
 
    if ( ENABLE_ZARCH_FOR_32 &&
          performTransformation(comp, "O^O Use AL/ALC to perform long add.\n")
@@ -208,15 +207,16 @@ laddConst(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegi
       }
    else
       {
-      TR::RegisterDependencyConditions * dependencies = NULL;
-      TR::Instruction *cursor = NULL;
-
       // Add high value
       generateS390ImmOp(cg, TR::InstOpCode::A, node, highOrder, highOrder, h_value);
 
       // Add low value
       if ( l_value != 0 )
          {
+         TR::LabelSymbol * doneLAdd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+
+         TR::RegisterDependencyConditions * dependencies = NULL;
          // tempReg is used to hold the immediate on GoldenEagle or better.
          // On other hardware, we use highOrder
          //
@@ -228,20 +228,18 @@ laddConst(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegi
          generateS390ImmOp(cg, TR::InstOpCode::AL, node, tempReg, lowOrder, l_value);
 
          // Check for overflow in LS(h_value) int. If overflow, increment MS(l_value) int.
-         cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK12, node, doneLAdd);
-         cursor->setStartInternalControlFlow();
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+         cFlowRegionStart->setStartInternalControlFlow();
+         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK12, node, doneLAdd);
 
          // Increment MS int due to overflow in LS int
          generateRIInstruction(cg, TR::InstOpCode::AHI, node, highOrder, 1);
 
          cg->stopUsingRegister(tempReg);
+
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneLAdd, dependencies);
+         doneLAdd->setEndInternalControlFlow();
          }
-      cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneLAdd);
-      if(dependencies)
-        {
-        cursor->setDependencyConditions(dependencies);
-        cursor->setEndInternalControlFlow();
-        }
       }
    return targetRegisterPair;
    }
@@ -709,7 +707,6 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    {
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
-   TR::Instruction *cursor=NULL;
    TR::Compilation *comp = cg->comp();
 
    TR::RegisterPair * dividendPair = (TR::RegisterPair *) cg->gprClobberEvaluate(firstChild);
@@ -769,20 +766,24 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
             dep->addPostCondition(dividendPair->getHighOrder(), TR::RealRegister::LegalEvenOfPair);
             dep->addPostCondition(dividendPair->getLowOrder(), TR::RealRegister::LegalOddOfPair);
 
+            TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
             TR::LabelSymbol * endDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
             //special case, need to check if dividend is 0x8000000000000000 - but need to check it in 2 steps
             TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
             generateS390ImmOp(cg, TR::InstOpCode::C, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(), (int32_t) 0x80000000);
-            cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
-            cursor->setStartInternalControlFlow();
+
+            generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+            cFlowRegionStart->setStartInternalControlFlow();
+
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
             generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node, dividendPair->getLowOrder(), (signed char)0, TR::InstOpCode::COND_BE, endDiv);
-            cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doDiv);
-            endDiv->setEndInternalControlFlow();
+            generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doDiv);
 
             dividendPair = lnegFor32Bit(node, cg, dividendPair, dep);
 
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, endDiv, dep);
+            endDiv->setEndInternalControlFlow();
             }
          node->setRegister(dividendPair);
          cg->decReferenceCount(firstChild);
@@ -820,10 +821,12 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
             {
             if (!firstChild->isNonNegative())
                {
+               TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
                TR::LabelSymbol * skipSet = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
-               cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node, dividendPair->getHighOrder(), (signed char)0, TR::InstOpCode::COND_BNL, skipSet);
-               cursor->setStartInternalControlFlow();
+               generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+               cFlowRegionStart->setStartInternalControlFlow();
+               generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node, dividendPair->getHighOrder(), (signed char)0, TR::InstOpCode::COND_BNL, skipSet);
 
                //adjustment to dividend if dividend is negative
                dividendPair = laddConst(node, cg, dividendPair,absValueOfDenominator-1, dep);
@@ -891,6 +894,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    if (performTransformation(comp, "O^O Using 64bit ldiv on 32bit driver.\n"))
       {
       TR::Instruction * cursor = NULL;
+      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol * gotoDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol * dontDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::RegisterPair * divisorPair = (TR::RegisterPair *) cg->gprClobberEvaluate(secondChild);
@@ -920,16 +924,16 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
          }
 
       //shift all 64 bits of dividend into dividendPair->getLowOrder()
-      cursor = generateRSInstruction(cg, TR::InstOpCode::SLLG, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(), 32);
+      generateRSInstruction(cg, TR::InstOpCode::SLLG, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(), 32);
 
-      cursor = generateRRInstruction(cg, TR::InstOpCode::LR, node, dividendPair->getHighOrder(), dividendPair->getLowOrder());
+      generateRRInstruction(cg, TR::InstOpCode::LR, node, dividendPair->getHighOrder(), dividendPair->getLowOrder());
 
-      cursor = generateRRInstruction(cg, TR::InstOpCode::LGR, node, dividendPair->getLowOrder(), dividendPair->getHighOrder());
+      generateRRInstruction(cg, TR::InstOpCode::LGR, node, dividendPair->getLowOrder(), dividendPair->getHighOrder());
 
       //shift all 64 bits of divisor into divisorPair->getHighOrder()
-      cursor = generateRSInstruction(cg, TR::InstOpCode::SLLG, node, divisorPair->getHighOrder(), divisorPair->getHighOrder(), 32);
+      generateRSInstruction(cg, TR::InstOpCode::SLLG, node, divisorPair->getHighOrder(), divisorPair->getHighOrder(), 32);
 
-      cursor = generateRRInstruction(cg, TR::InstOpCode::LR, node, divisorPair->getHighOrder(), divisorPair->getLowOrder());
+      generateRRInstruction(cg, TR::InstOpCode::LR, node, divisorPair->getHighOrder(), divisorPair->getLowOrder());
 
       if (!node->getOpCode().isUnsigned()) // Signed Divide Code
          {
@@ -945,8 +949,10 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
             generateS390ImmOp(cg, TR::InstOpCode::CG, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(),
                   (int64_t)(CONSTANT64(0x8000000000000000)) , dependencies, litPoolBase);
 
-            cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, gotoDiv);
-            cursor->setStartInternalControlFlow();
+            generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+            cFlowRegionStart->setStartInternalControlFlow();
+
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, gotoDiv);
             dontDiv->setEndInternalControlFlow();
 
             //  Fix up for remainder case
@@ -959,7 +965,7 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
                  {
                  dependencies->addPostCondition(compareInstr->getRegisterOperand(2), TR::RealRegister::AssignAny);
                  }
-               cursor = generateRIInstruction(cg, TR::InstOpCode::LGHI, node, dividendPair->getHighOrder(), 0);
+               generateRIInstruction(cg, TR::InstOpCode::LGHI, node, dividendPair->getHighOrder(), 0);
 
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, dontDiv);
                }
@@ -974,30 +980,30 @@ lDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
 
 
          //do division
-         cursor = generateRRInstruction(cg, TR::InstOpCode::DSGR, node, dividendPair, divisorPair->getHighOrder());
+         generateRRInstruction(cg, TR::InstOpCode::DSGR, node, dividendPair, divisorPair->getHighOrder());
 
          // Label to skip the division
-         cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, dontDiv, dependencies);
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, dontDiv, dependencies);
          }
       else // Unsigned Divide Code
          {
          //clear high order 64 bits of register pair
-         cursor = generateRRInstruction(cg, TR::InstOpCode::XGR, node, dividendPair->getHighOrder(), dividendPair->getHighOrder());
+         generateRRInstruction(cg, TR::InstOpCode::XGR, node, dividendPair->getHighOrder(), dividendPair->getHighOrder());
 
          //do division
-         cursor = generateRRInstruction(cg, TR::InstOpCode::DLGR, node, dividendPair, divisorPair->getHighOrder());
+         generateRRInstruction(cg, TR::InstOpCode::DLGR, node, dividendPair, divisorPair->getHighOrder());
          }
 
       // mainly common clean-up code
       if (isDivision)
          {
-         cursor = generateRSInstruction(cg, TR::InstOpCode::SRLG, node, dividendPair->getHighOrder(), dividendPair->getLowOrder(), 32);
+         generateRSInstruction(cg, TR::InstOpCode::SRLG, node, dividendPair->getHighOrder(), dividendPair->getLowOrder(), 32);
          }
       else //remainder
          {
-         cursor = generateRRInstruction(cg, TR::InstOpCode::LR, node, dividendPair->getLowOrder(), dividendPair->getHighOrder());
+         generateRRInstruction(cg, TR::InstOpCode::LR, node, dividendPair->getLowOrder(), dividendPair->getHighOrder());
 
-         cursor = generateRSInstruction(cg, TR::InstOpCode::SRLG, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(), 32);
+         generateRSInstruction(cg, TR::InstOpCode::SRLG, node, dividendPair->getHighOrder(), dividendPair->getHighOrder(), 32);
          }
 
       // The label is necessary so that RA does not insert 32-bit register moves
@@ -1104,7 +1110,6 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
 
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
-   TR::Instruction * cursor = NULL;
 
    int32_t shiftAmnt;
    // A/A, return 1 (div) or 0 (rem).
@@ -1156,24 +1161,26 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             }
          else
             {
+            TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
             TR::LabelSymbol * endDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
             TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
             //special case, need to check if dividend is 0x8000000000000000 - but need to check it in 2 steps
             generateS390ImmOp(cg, TR::InstOpCode::CG, node, firstRegister, firstRegister, (int64_t) CONSTANT64(0x8000000000000000));
 
-            cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, endDiv);
-            cursor->setStartInternalControlFlow();
+            generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+            cFlowRegionStart->setStartInternalControlFlow();
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, endDiv);
 
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doDiv);
 
             // Do complements on reg
             generateRRInstruction(cg, TR::InstOpCode::LCGR, node, firstRegister, firstRegister);
 
-            endDiv->setEndInternalControlFlow();
             TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);
             deps->addPostCondition(firstRegister, TR::RealRegister::AssignAny);
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, endDiv, deps);
+            endDiv->setEndInternalControlFlow();
             }
          node->setRegister(firstRegister);
          cg->decReferenceCount(firstChild);
@@ -1206,17 +1213,19 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             firstRegister = cg->gprClobberEvaluate(firstChild);
             if (!firstChild->isNonNegative())
                {
+               TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
                TR::LabelSymbol * skipSet = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
-               cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CG, node, firstRegister, (signed char)0,TR::InstOpCode::COND_BNL, skipSet);
-               cursor->setStartInternalControlFlow();
+               generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+               cFlowRegionStart->setStartInternalControlFlow();
+               generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CG, node, firstRegister, (signed char)0,TR::InstOpCode::COND_BNL, skipSet);
 
                //adjustment to dividend if dividend is negative
                TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 2, cg);
                deps->addPostCondition(firstRegister, TR::RealRegister::AssignAny);
                generateS390ImmOp(cg, TR::InstOpCode::AG, node, firstRegister, firstRegister, absValueOfDenominator-1, deps);
-               skipSet->setEndInternalControlFlow();
                generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipSet, deps);
+               skipSet->setEndInternalControlFlow();
                }
 
             //divide
@@ -1360,9 +1369,9 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             {
             generateRRInstruction(cg, TR::InstOpCode::CLGR, node, absDividendReg, sourceRegister);
             }
-         TR::LabelSymbol *startLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         startLabel->setStartInternalControlFlow();
-         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, startLabel, dependencies);
+         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+         cFlowRegionStart->setStartInternalControlFlow();
          generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK4, node, skipDiv); // branch to done on <
          }
 
@@ -1511,9 +1520,13 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    //  JAVA requires we return 0x80000000 rem 0x00000000
    if (needCheck)
       {
+      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+
       generateS390ImmOp(cg, TR::InstOpCode::C, node, remRegister, remRegister, (int32_t) 0x80000000);
-      cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
-      cursor->setStartInternalControlFlow();
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      cFlowRegionStart->setStartInternalControlFlow();
+
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
 
       generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node, sourceRegister, (signed char)-1, TR::InstOpCode::COND_BNE, doDiv);
       cursor =
@@ -1528,7 +1541,6 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
       generateLoad32BitConstant(cg, node, 0, remRegister, false);
 
       skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      skipDiv->setEndInternalControlFlow();
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, skipDiv);
 
       // Label to do the division
@@ -1545,27 +1557,27 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    if (sourceMR)
       {
       if (node->getOpCode().isUnsigned())
-         cursor = generateRXInstruction(cg, TR::InstOpCode::DL, node, targetRegisterPair, sourceMR);
+         generateRXInstruction(cg, TR::InstOpCode::DL, node, targetRegisterPair, sourceMR);
       else
-         cursor = generateRXInstruction(cg, TR::InstOpCode::D, node, targetRegisterPair, sourceMR);
+         generateRXInstruction(cg, TR::InstOpCode::D, node, targetRegisterPair, sourceMR);
       }
    else
       {
       if (node->getOpCode().isUnsigned())
-         cursor = generateRRInstruction(cg, TR::InstOpCode::DLR, node, targetRegisterPair, sourceRegister);
+         generateRRInstruction(cg, TR::InstOpCode::DLR, node, targetRegisterPair, sourceRegister);
       else
-         cursor = generateRRInstruction(cg, TR::InstOpCode::DR, node, targetRegisterPair, sourceRegister);
+         generateRRInstruction(cg, TR::InstOpCode::DR, node, targetRegisterPair, sourceRegister);
       }
 
    // Label to skip the division
    if (skipDiv)
      {
-     cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipDiv);
-     // Add a dependency to make the regist assignment a pair
-     cursor->setDependencyConditions(dependencies);
+     // Add a dependency to make the register assignment a pair
+     generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipDiv, dependencies);
+     skipDiv->setEndInternalControlFlow();
      }
    else
-     TR::Instruction * cursor = generateS390PseudoInstruction(cg, TR::InstOpCode::DEPEND, node, dependencies);
+     generateS390PseudoInstruction(cg, TR::InstOpCode::DEPEND, node, dependencies);
 
    node->setRegister(returnRegister);
    cg->decReferenceCount(firstChild);
@@ -2923,6 +2935,7 @@ lmulHelper(TR::Node * node, TR::CodeGenerator * cg)
 
       TR::RegisterPair * tempRegisterPair = cg->allocateConsecutiveRegisterPair(lowRegister, highRegister);
 
+      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol * lmul1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol * lmul2 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
@@ -2960,8 +2973,9 @@ lmulHelper(TR::Node * node, TR::CodeGenerator * cg)
       // Prod = Al*Bl
       generateRRInstruction(cg, TR::InstOpCode::MR, node, trgtRegPair, src2RegPair->getLowOrder());
 
-      cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, lmul1);
-      cursor->setStartInternalControlFlow();
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      cFlowRegionStart->setStartInternalControlFlow();
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, lmul1);
 
       generateRRInstruction(cg, TR::InstOpCode::ALR, node, trgtRegPair->getHighOrder(), src2RegPair->getLowOrder());
 
@@ -3590,7 +3604,6 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * targetRegister = cg->allocate64bitRegister();
    TR::Register * sourceRegister;
    TR::Register * resultRegister;
-   TR::Instruction * cursor;
    TR::Compilation *comp = cg->comp();
    bool highWordRADisabled = !cg->supportsHighWordFacility() || comp->getOption(TR_DisableHighWordRA);
 
@@ -3604,11 +3617,11 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       TR::Register * srcRegH = firstRegister->getHighOrder();
       TR::Register * srcRegL = firstRegister->getLowOrder();
 
-      cursor = generateRSInstruction(cg, TR::InstOpCode::SLLG, node, srcRegH, srcRegH, 32);
+      generateRSInstruction(cg, TR::InstOpCode::SLLG, node, srcRegH, srcRegH, 32);
 
-      cursor = generateRRInstruction(cg, TR::InstOpCode::LR, node, srcRegH, srcRegL);
+      generateRRInstruction(cg, TR::InstOpCode::LR, node, srcRegH, srcRegL);
 
-      cursor = generateRRInstruction(cg, TR::InstOpCode::LGR, node, srcRegL, srcRegH);
+      generateRRInstruction(cg, TR::InstOpCode::LGR, node, srcRegL, srcRegH);
 
       sourceRegister = srcRegL;
       }
@@ -3632,18 +3645,20 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       int64_t value = secondChild->getLongInt();
       int64_t absValue = value > 0 ? value : -value;
 
+      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol * posMulh = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
       TR::LabelSymbol * doneMulh = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
       // positive first child, branch to posMulh label
-      cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CG, node, sourceRegister, (signed char)0, TR::InstOpCode::COND_BNL, posMulh);
-      cursor->setStartInternalControlFlow();
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      cFlowRegionStart->setStartInternalControlFlow();
+      generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::CG, node, sourceRegister, (signed char)0, TR::InstOpCode::COND_BNL, posMulh);
 
       // Negative first child, do complements on register
       generateRRInstruction(cg, TR::InstOpCode::LCGR, node, sourceRegister, sourceRegister);
 
       // MLG
-      cursor = generateS390ImmOp(cg, TR::InstOpCode::MLG, node, targetRegisterPair, targetRegisterPair, absValue, dependencies);
+      generateS390ImmOp(cg, TR::InstOpCode::MLG, node, targetRegisterPair, targetRegisterPair, absValue, dependencies);
 
       // Undo earlier complement
       targetRegisterPair = lnegFor128Bit(node, cg, targetRegisterPair, dependencies);
@@ -3654,11 +3669,11 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       // Label for positive first child
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, posMulh);
 
-      cursor = generateS390ImmOp(cg, TR::InstOpCode::MLG, node, targetRegisterPair, targetRegisterPair, absValue, dependencies);
+      generateS390ImmOp(cg, TR::InstOpCode::MLG, node, targetRegisterPair, targetRegisterPair, absValue, dependencies);
 
       // Label for done
-      cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneMulh, dependencies);
-      cursor->setEndInternalControlFlow();
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneMulh, dependencies);
+      doneMulh->setEndInternalControlFlow();
 
       // second child is negative
       if (value < 0)
@@ -3679,9 +3694,11 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       //  We need to split this into two 32-bit values with the high word going into
       //  the even register's low word and the low word going into the odd register's low word
       //
-      cursor = generateRRInstruction(cg, TR::InstOpCode::LGR, node, targetRegisterPair->getLowOrder(), targetRegisterPair->getHighOrder());
+      generateRRInstruction(cg, TR::InstOpCode::LGR, node, targetRegisterPair->getLowOrder(), targetRegisterPair->getHighOrder());
 
+      TR::Instruction * cursor;
       cursor = generateRSInstruction(cg, TR::InstOpCode::SRLG, node, targetRegisterPair->getHighOrder(), targetRegisterPair->getHighOrder(), 32);
+      cursor->setDependencyConditions(dependencies);
 
       resultRegister = targetRegisterPair;
       cg->stopUsingRegister(firstRegister);
@@ -3690,8 +3707,6 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       {
       resultRegister = targetRegister;
       }
-
-   cursor->setDependencyConditions(dependencies);
 
    node->setRegister(resultRegister);
    cg->decReferenceCount(firstChild);
@@ -3951,7 +3966,6 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
    TR::Register * targetRegister = NULL;
-   TR::Instruction *cursor = NULL;
 
 
    if (secondChild->getOpCode().isLoadConst())
@@ -3963,28 +3977,36 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
       if (value == -1 && !node->getOpCode().isUnsigned())
          {
+         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::LabelSymbol * doDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::LabelSymbol * skipDiv = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
          // If the divisor is -1 we need to check the dividend for 0x80000000
          generateS390ImmOp(cg, TR::InstOpCode::C, node, targetRegister, targetRegister, (int32_t )0x80000000);
-         cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
-         cursor->setStartInternalControlFlow();
+
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+         cFlowRegionStart->setStartInternalControlFlow();
+         generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, doDiv);
+
          TR::RegisterDependencyConditions * dependencies
            = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);
          dependencies->addPostCondition(targetRegister, TR::RealRegister::AssignAny);
          generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, skipDiv);
+
          // Label to do the division
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doDiv);
+
          // Do division by -1 (take complement)
          generateRRInstruction(cg, TR::InstOpCode::LCR, node, targetRegister, targetRegister);
+
          // Label to skip the division
-         cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipDiv, dependencies);
-         cursor->setEndInternalControlFlow();
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, skipDiv, dependencies);
+         skipDiv->setEndInternalControlFlow();
          }
       else if ((shftAmnt = TR::TreeEvaluator::checkNonNegativePowerOfTwo(value)) > 0)
          {
          // Strength reduction
+         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
          TR::LabelSymbol * doShift = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
          if (!firstChild->isNonNegative() && !node->getOpCode().isUnsigned())
@@ -3997,15 +4019,16 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             generateRRInstruction(cg, TR::InstOpCode::LTR, node, targetRegister, targetRegister);
 
             // if positive value, branch to doShift
-            cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, doShift);
-            cursor->setStartInternalControlFlow();
-            doShift->setEndInternalControlFlow();
+            generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+            cFlowRegionStart->setStartInternalControlFlow();
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, doShift);
 
             // add (divisor-1) before the shift if negative value
             generateS390ImmOp(cg, TR::InstOpCode::A, node, targetRegister, targetRegister, value-1, dependencies);
 
             // Label to do the shift
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doShift, dependencies);
+            doShift->setEndInternalControlFlow();
             }
 
          // do the division by shifting
@@ -4209,8 +4232,8 @@ OMR::Z::TreeEvaluator::iremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
          if (doneLabel)
             {
-            doneLabel->setEndInternalControlFlow();
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneLabel, deps);
+            doneLabel->setEndInternalControlFlow();
             }
          }
       node->setRegister(targetRegister);

--- a/compiler/z/codegen/CompareAnalyser.cpp
+++ b/compiler/z/codegen/CompareAnalyser.cpp
@@ -291,7 +291,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
 
       if (firstHighZero == false || secondHighZero == false)
          {
-         TR::LabelSymbol * cflowRegionStart = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+         TR::LabelSymbol * cflowRegionStart = generateLabelSymbol(_cg);
          cflowRegionStart->setStartInternalControlFlow();
          internalControlFlowStarted = true;
          generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, root, cflowRegionStart);
@@ -401,7 +401,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
 
       if (firstHighZero == false || secondHighZero == false)
          {
-         TR::LabelSymbol * cflowRegionStart = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+         TR::LabelSymbol * cflowRegionStart = generateLabelSymbol(_cg);
          cflowRegionStart->setStartInternalControlFlow();
          internalControlFlowStarted = true;
          generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, root, cflowRegionStart);
@@ -508,7 +508,7 @@ TR_S390CompareAnalyser::longOrderedCompareAndBranchAnalyser(TR::Node * root, TR:
 
       if (firstHighZero == false || secondHighZero == false)
          {
-         TR::LabelSymbol * cflowRegionStart = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+         TR::LabelSymbol * cflowRegionStart = generateLabelSymbol(_cg);
          cflowRegionStart->setStartInternalControlFlow();
          internalControlFlowStarted = true;
          generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, root, cflowRegionStart);

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -67,7 +67,7 @@
 #endif
 
 TR::S390ConstantDataSnippet::S390ConstantDataSnippet(TR::CodeGenerator * cg, TR::Node * n, void * c, uint16_t size) :
-   TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false)
+   TR::Snippet(cg, n, generateLabelSymbol(cg), false)
    {
 
    if (c)
@@ -443,7 +443,7 @@ TR::S390JNICallDataSnippet::getLength(int32_t estimatedSnippetStart)
 
 TR::S390JNICallDataSnippet::S390JNICallDataSnippet(TR::CodeGenerator * cg,
                                TR::Node * node)
-: TR::S390ConstantDataSnippet(cg, node, TR::LabelSymbol::create(cg->trHeapMemory(),cg),0),
+: TR::S390ConstantDataSnippet(cg, node, generateLabelSymbol(cg),0),
  _baseRegister(0),
  _ramMethod(0),
  _JNICallOutFrameFlags(0),

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -603,7 +603,7 @@ generateS390lcmpEvaluator(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCod
       deps->addPostConditionIfNotAlreadyInserted(targetRegister, TR::RealRegister::AssignAny);
 
       // TRUE, set up deps here
-      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, isTrue,deps);
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, isTrue, deps);
       isTrue->setEndInternalControlFlow();
       }
 
@@ -617,10 +617,9 @@ generateS390lcmpEvaluator64(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpC
    {
    TR_ASSERT( TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit(),"lcmpEvaluator64() is for 64bit code-gen only!");
    TR::RegisterDependencyConditions * deps = NULL;
+   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * isTrue = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   isTrue->setEndInternalControlFlow();
    bool isUnsigned = node->getOpCode().isUnsignedCompare();
-   TR::Instruction *instr;
 
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
@@ -643,7 +642,8 @@ generateS390lcmpEvaluator64(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpC
       int64_t long_value = secondChild->getLongInt();
       TR::Register * cmpRegister = cg->evaluate(firstChild);
       generateS390ImmOp(cg, isUnsigned ? TR::InstOpCode::CLG : TR::InstOpCode::CG, node, cmpRegister, cmpRegister, long_value);
-      instr = generateS390BranchInstruction(cg, brOp, brCond, node, isTrue);
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      generateS390BranchInstruction(cg, brOp, brCond, node, isTrue);
       }
    else
       {
@@ -654,16 +654,17 @@ generateS390lcmpEvaluator64(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpC
       deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 3, cg);
       deps->addPostConditionIfNotAlreadyInserted(cmpRegister,TR::RealRegister::AssignAny);
       deps->addPostConditionIfNotAlreadyInserted(srcReg,TR::RealRegister::AssignAny);
-      instr = generateS390CompareAndBranchInstruction(cg, isUnsigned ? TR::InstOpCode::CLGR : TR::InstOpCode::CGR, node, cmpRegister, srcReg, brCond, isTrue, false, false);
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      generateS390CompareAndBranchInstruction(cg, isUnsigned ? TR::InstOpCode::CLGR : TR::InstOpCode::CGR, node, cmpRegister, srcReg, brCond, isTrue, false, false);
       }
 
-   instr->setStartInternalControlFlow();
+   cFlowRegionStart->setStartInternalControlFlow();
    deps->addPostConditionIfNotAlreadyInserted(targetRegister,TR::RealRegister::AssignAny);
 
    // FALSE
    genLoadLongConstant(cg, node, 0, targetRegister);
    // TRUE
-   instr = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, isTrue,deps);
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, isTrue, deps);
    isTrue->setEndInternalControlFlow();
 
    node->setRegister(targetRegister);
@@ -685,6 +686,8 @@ OMR::Z::TreeEvaluator::fcmplEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::InstOpCode::Mnemonic branchOp;
    TR::InstOpCode::S390BranchCondition brCond ;
 
+   // Create ICF start label
+   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    // Create a label
    TR::LabelSymbol * doneCmp = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    // Create a register
@@ -701,8 +704,10 @@ OMR::Z::TreeEvaluator::fcmplEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    // done if A==B
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);
    deps->addPostCondition(targetRegister,TR::RealRegister::AssignAny);
-   TR::Instruction *cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneCmp);
-   cursor->setStartInternalControlFlow();
+
+   generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+   cFlowRegionStart->setStartInternalControlFlow();
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, doneCmp);
 
    // Found A != B, assume A > B, set targetRegister value to 1
    generateLoad32BitConstant(cg, node, 1, targetRegister, false);
@@ -722,8 +727,8 @@ OMR::Z::TreeEvaluator::fcmplEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    generateLoad32BitConstant(cg, node, -1, targetRegister, true);
 
    // DONE
-   doneCmp->setEndInternalControlFlow();
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, doneCmp, deps);
+   doneCmp->setEndInternalControlFlow();
 
    node->setRegister(targetRegister);
    return targetRegister;
@@ -748,6 +753,7 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
    // There is probably a better way to implement this.  Should re-visit if we get the chance.
    // As things stand now, we will to LCR R1,R1 when R1=0 which is useless...  But still probably
    // cheaper than an extra branch.
+   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * labelGT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * labelLT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
@@ -761,6 +767,8 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
    TR::Instruction * cursor = NULL;
    TR::Instruction * cursor2 = NULL;
    TR::RegisterDependencyConditions * dependencies = NULL;
+
+   bool startedICF = false;
 
 
    // Do high Order first
@@ -834,7 +842,9 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
          generateRRInstruction(cg, TR::InstOpCode::CR, node, src1RegPair->getHighOrder(), src2RegPair->getHighOrder());
          }
       // If LT we are done
-      cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, node, labelLT);
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      cFlowRegionStart->setStartInternalControlFlow();
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, node, labelLT);
 
       // If GT, we invert the result register
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, node, labelGT);
@@ -856,12 +866,7 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
          }
 
       // If LT, we are done
-      cursor2 = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, node, labelLT);
-      if(cursor)
-        cursor->setStartInternalControlFlow();
-      else
-        cursor2->setStartInternalControlFlow();
-
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, node, labelLT);
 
       // If GT, invert the result
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, node, labelGT);
@@ -875,8 +880,8 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
       generateRRInstruction(cg, TR::InstOpCode::LCR, node, targetRegister, targetRegister);
 
       // We branch here when LT (no change to assumed -1 result)
-      labelLT->setEndInternalControlFlow();
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelLT, dependencies);
+      labelLT->setEndInternalControlFlow();
       }
 
    node->setRegister(targetRegister);
@@ -997,6 +1002,7 @@ lcmpHelper64(TR::Node * node, TR::CodeGenerator * cg)
    // TODO:There is probably a better way to implement this.  Should re-visit if we get the chance.
    // As things stand now, we will to LCR R1,R1 when R1=0 which is useless...  But still probably
    // cheaper than an extra branch.
+   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * labelGT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
    TR::LabelSymbol * labelLT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
 
@@ -1040,8 +1046,9 @@ lcmpHelper64(TR::Node * node, TR::CodeGenerator * cg)
          generateRRInstruction(cg, TR::InstOpCode::CGR, node, src1Reg, src2Reg);
          }
       // If LT we are done
-      TR::Instruction *cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, node, labelLT);
-      cursor->setStartInternalControlFlow();
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+      cFlowRegionStart->setStartInternalControlFlow();
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, node, labelLT);
 
       // If GT, we invert the result register
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, node, labelGT);
@@ -1059,8 +1066,8 @@ lcmpHelper64(TR::Node * node, TR::CodeGenerator * cg)
       TR::RegisterDependencyConditions * dependencies = NULL;
       dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);
       dependencies->addPostCondition(targetRegister, TR::RealRegister::AssignAny);
-      labelLT->setEndInternalControlFlow();
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelLT, dependencies);
+      labelLT->setEndInternalControlFlow();
       }
 
    node->setRegister(targetRegister);
@@ -3802,11 +3809,12 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       else
          {
-         TR::LabelSymbol *branchDestination = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-         branchDestination->setEndInternalControlFlow();
+         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+         TR::LabelSymbol * branchDestination = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
-         TR::Instruction *compareInst = generateS390CompareAndBranchInstruction(cg, compareOp, node, firstReg, secondReg, bc, branchDestination, false);
-         compareInst->setStartInternalControlFlow();
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+         cFlowRegionStart->setStartInternalControlFlow();
+         generateS390CompareAndBranchInstruction(cg, compareOp, node, firstReg, secondReg, bc, branchDestination, false);
 
          TR::RegisterDependencyConditions* conditions = NULL;
 
@@ -3869,6 +3877,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
             }
 
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, branchDestination, conditions);
+         branchDestination->setEndInternalControlFlow();
 
          if (comp->getOption(TR_TraceCG))
             {
@@ -3915,11 +3924,12 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       else
          {
-         TR::LabelSymbol *branchDestination = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-         branchDestination->setEndInternalControlFlow();
+         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+         TR::LabelSymbol * branchDestination = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
+         generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
+         cFlowRegionStart->setStartInternalControlFlow();
          TR::Instruction *branchInst = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, node, branchDestination);
-         branchInst->setStartInternalControlFlow();
 
          TR::RegisterDependencyConditions* conditions = NULL;
 
@@ -3972,6 +3982,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
             }
 
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, branchDestination, conditions);
+         branchDestination->setEndInternalControlFlow();
          }
       }
 

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -231,9 +231,9 @@ generateS390lcmpEvaluator(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCod
    TR::InstOpCode::S390BranchCondition condCmpLowTrue, bool           isBoolean)
    {
    TR::LabelSymbol * falseTarget;
-   TR::LabelSymbol * isFalse = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * isFalse = generateLabelSymbol(cg);
    TR::LabelSymbol * trueTarget;
-   TR::LabelSymbol * isTrue = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * isTrue = generateLabelSymbol(cg);
    bool internalControlFlowStarted=false;
 
    TR::Register * targetRegister = NULL;
@@ -458,7 +458,7 @@ generateS390lcmpEvaluator(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCod
    if (secondChild->getOpCode().isLoadConst())
      {
      // if second child is complicated then control flow region start will be generated later
-     TR::LabelSymbol * cflowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+     TR::LabelSymbol * cflowRegionStart = generateLabelSymbol(cg);
      cflowRegionStart->setStartInternalControlFlow();
      internalControlFlowStarted = true;
 
@@ -617,8 +617,8 @@ generateS390lcmpEvaluator64(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpC
    {
    TR_ASSERT( TR::Compiler->target.is64Bit() || cg->use64BitRegsOn32Bit(),"lcmpEvaluator64() is for 64bit code-gen only!");
    TR::RegisterDependencyConditions * deps = NULL;
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * isTrue = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * isTrue = generateLabelSymbol(cg);
    bool isUnsigned = node->getOpCode().isUnsignedCompare();
 
    TR::Register * targetRegister = NULL;
@@ -687,9 +687,9 @@ OMR::Z::TreeEvaluator::fcmplEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::InstOpCode::S390BranchCondition brCond ;
 
    // Create ICF start label
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
    // Create a label
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
    // Create a register
    TR::Register * targetRegister = cg->allocateRegister();
 
@@ -753,9 +753,9 @@ lcmpHelper(TR::Node * node, TR::CodeGenerator * cg)
    // There is probably a better way to implement this.  Should re-visit if we get the chance.
    // As things stand now, we will to LCR R1,R1 when R1=0 which is useless...  But still probably
    // cheaper than an extra branch.
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * labelGT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * labelLT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelGT = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelLT = generateLabelSymbol(cg);
 
    TR::Register * targetRegister = cg->allocateRegister();
 
@@ -939,7 +939,7 @@ static TR::Register * maxMinHelper(TR::Node *node, TR::CodeGenerator *cg, bool i
          }
       else
          {
-         TR::LabelSymbol * done = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * done = generateLabelSymbol(cg);
          TR::Instruction* cursor = NULL;
          registerA = cg->evaluate(node->getFirstChild());
 
@@ -1002,9 +1002,9 @@ lcmpHelper64(TR::Node * node, TR::CodeGenerator * cg)
    // TODO:There is probably a better way to implement this.  Should re-visit if we get the chance.
    // As things stand now, we will to LCR R1,R1 when R1=0 which is useless...  But still probably
    // cheaper than an extra branch.
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * labelGT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * labelLT = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelGT = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelLT = generateLabelSymbol(cg);
 
    TR::Register * targetRegister = cg->allocate64bitRegister();
 
@@ -2623,7 +2623,7 @@ OMR::Z::TreeEvaluator::lookupEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       // for 31bit mode with 64 bit values
       TR::LabelSymbol *skipLoCompareLabel = NULL;
       if (type.isInt64() && TR::Compiler->target.is32Bit())
-         skipLoCompareLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         skipLoCompareLabel = generateLabelSymbol(cg);
 
       // Compare a key value
       TR::InstOpCode::S390BranchCondition brCond = TR::InstOpCode::COND_NOP;
@@ -2955,7 +2955,7 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
       else
          {
          // NULLCHK snippet label.
-         TR::LabelSymbol * snippetLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * snippetLabel = generateLabelSymbol(cg);
          TR::SymbolReference *symRef = node->getSymbolReference();
          cg->addSnippet(new (cg->trHeapMemory()) TR::S390HelperCallSnippet(cg, node, snippetLabel, symRef));
 
@@ -3172,8 +3172,8 @@ OMR::Z::TreeEvaluator::ZEROCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    PRINT_ME("ZEROCHK", node, cg);
 
    // Labels for OOL path with helper and the merge point back from OOL path
-   TR::LabelSymbol *slowPathOOLLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);;
-   TR::LabelSymbol *doneLabel  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);;
+   TR::LabelSymbol *slowPathOOLLabel = generateLabelSymbol(cg);;
+   TR::LabelSymbol *doneLabel  = generateLabelSymbol(cg);;
 
    // Need to check the first child of ZEROCHK to determine whether we need to
    // make the helper call.
@@ -3809,8 +3809,8 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       else
          {
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-         TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol( cg);
+         TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol( cg);
 
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();
@@ -3924,8 +3924,8 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
          }
       else
          {
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-         TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol( cg);
+         TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol( cg);
 
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -463,8 +463,8 @@ convertToFixed(TR::Node * node, TR::CodeGenerator * cg)
 
       // Java expect that for signed conversion to fixed, if src float is NaN, target to have 0.0.
       //2) NaN test and branch to done
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
 
       generateRRInstruction(cg, compareOp, node, srcRegister, srcRegister);
 
@@ -566,8 +566,8 @@ convertFromFixed(TR::Node * node, TR::CodeGenerator * cg)
    generateRRInstruction(cg, convertOpCode, node, targetRegister, srcRegister);
    if (isUint32Src)
       {
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * skipAddLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * skipAddLabel = generateLabelSymbol(cg);
       TR::RegisterDependencyConditions * deps = NULL;
       generateRRInstruction(cg, TR::InstOpCode::LTR, node, srcRegister, srcRegister);
       // If positive or zero, done BNL
@@ -667,7 +667,7 @@ commonLong2FloatEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    generateRRInstruction(cg, convertOp, node, targetReg, gprTemp64);
 
    // For unsigned, we need to fix case where long_max < unsignedSrc <= ulong_max
-   TR::LabelSymbol *cFlowRegionEnd = deps ? TR::LabelSymbol::create(cg->trHeapMemory(),cg) : NULL; // attach all deps to this label at end
+   TR::LabelSymbol *cFlowRegionEnd = deps ? generateLabelSymbol(cg) : NULL; // attach all deps to this label at end
    if (isUnsigned)
       {
       TR::Register *litBase = NULL;
@@ -725,7 +725,7 @@ commonLong2FloatEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       generateRRInstruction(cg, TR::InstOpCode::LTGR, node, gprTemp64, gprTemp64);
       // the fixed to float convertOp only handles signed source operands so if the converted value is negative and the
       // source was an unsigned number then add 2^64 to correct the value
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
       cFlowRegionStart->setStartInternalControlFlow();
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart, deps);
       TR::Instruction *cursor =generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, cFlowRegionEnd);
@@ -1060,9 +1060,9 @@ OMR::Z::TreeEvaluator::floatRemHelper(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * secondRegister = cg->fprClobberEvaluate(node->getSecondChild());
    TR::Register * tempRegister = cg->allocateRegister(TR_FPR);
    TR::Register * targetRegister = cg->allocateRegister(TR_FPR);
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * labelNotExact = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * labelOK = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelNotExact = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelOK = generateLabelSymbol(cg);
    TR::ILOpCodes opCode = node->getOpCodeValue();
    //
    // Algorithm: c = a rem b;
@@ -1384,11 +1384,11 @@ OMR::Z::TreeEvaluator::dbits2lEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * targetReg = NULL;
    TR::Register * sourceReg = NULL;
    TR::Instruction * cursor = NULL;
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * infinityNumber = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * negativeInfinityNumber = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * positiveInfinityNumber = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cleansedNumber = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * infinityNumber = generateLabelSymbol(cg);
+   TR::LabelSymbol * negativeInfinityNumber = generateLabelSymbol(cg);
+   TR::LabelSymbol * positiveInfinityNumber = generateLabelSymbol(cg);
+   TR::LabelSymbol * cleansedNumber = generateLabelSymbol(cg);
    TR::Register * litBase = NULL;
    if (node->getNumChildren() == 2)
       {
@@ -1611,8 +1611,8 @@ l2dHelper64(TR::Node * node, TR::CodeGenerator * cg)
    //if(firstChild->getDataType() == TR_UInt64)
    if (node->getOpCodeValue() == TR::lu2d)
       {
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * skipAddLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * skipAddLabel = generateLabelSymbol(cg);
       TR::RegisterDependencyConditions * deps = generateRegisterDependencyConditions(0, 1, cg);
 
       generateRRInstruction(cg, TR::InstOpCode::LTGR, node, longRegister, longRegister);
@@ -1663,8 +1663,8 @@ l2fHelper64(TR::Node * node, TR::CodeGenerator * cg)
    //if(firstChild->getDataType() == TR_UInt64)
    if (!IntToFloatLogicalConverted && node->getOpCodeValue() == TR::lu2f)
       {
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * skipAddLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+      TR::LabelSymbol * skipAddLabel = generateLabelSymbol(cg);
       TR::RegisterDependencyConditions * deps = generateRegisterDependencyConditions(0, 1, cg);
 
       generateRRInstruction(cg, TR::InstOpCode::LTGR, node, longRegister, longRegister);
@@ -1745,14 +1745,14 @@ f2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    TR::Instruction * cursor;
    TR::Node * firstChild = node->getFirstChild();
 
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label2 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label3 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label4 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label5 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label6 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label7 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label8 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * label2 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label3 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label4 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label5 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label6 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label7 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label8 = generateLabelSymbol(cg);
 
    TR::Register * floatRegister = cg->evaluate(firstChild);
    TR::Register * tempFloatRegister = cg->allocateRegister(TR_FPR);
@@ -1908,8 +1908,8 @@ f2lHelper64(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * floatRegister = cg->evaluate(firstChild);
    TR::Register * targetRegister = cg->allocate64bitRegister();
 
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
 
    //Assume Float.NaN
    generateRRInstruction(cg, TR::InstOpCode::XGR, node, targetRegister, targetRegister);
@@ -1975,14 +1975,14 @@ d2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Node * firstChild = node->getFirstChild();
 
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label2 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label3 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label4 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label5 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label6 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label7 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * label8 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * label2 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label3 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label4 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label5 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label6 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label7 = generateLabelSymbol(cg);
+   TR::LabelSymbol * label8 = generateLabelSymbol(cg);
 
    TR::Register * floatRegister = cg->evaluate(firstChild);
    TR::Register * tempFloatRegister = cg->allocateRegister(TR_FPR);
@@ -2133,8 +2133,8 @@ d2lHelper64(TR::Node * node, TR::CodeGenerator * cg)
    if (checkNaN)
       {
       generateRRInstruction(cg, TR::InstOpCode::XGR, node, targetRegister, targetRegister);
-      label1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      label1 = generateLabelSymbol(cg);
+      cFlowRegionStart = generateLabelSymbol(cg);
       // if NaN
       generateRXInstruction(cg, TR::InstOpCode::TCDB, node, floatRegister, (uint32_t) 0x00f);
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1488,7 +1488,7 @@ OMR::Z::CodeGenerator::insertInstructionPrefetches()
             if (!op.isAdmin())
                {
                real = first;
-               if (op.isLabel() || op.isCall() || first->isEndInternalControlFlow())
+               if (op.isLabel() || op.isCall())
                   {
                   break;
                   }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2396,10 +2396,6 @@ OMR::Z::CodeGenerator::upgradeToHPRInstruction(TR::Instruction * inst)
          s390NewInst->setThrowsImplicitException();
       if (s390Inst->isOutOfLineEX())
          s390NewInst->setOutOfLineEX();
-      if (s390Inst->isStartInternalControlFlow())
-         s390NewInst->setStartInternalControlFlow();
-      if (s390Inst->isEndInternalControlFlow())
-         s390NewInst->setEndInternalControlFlow();
       if (s390Inst->getIndex())
          s390NewInst->setIndex(s390Inst->getIndex());
       if (s390Inst->getGCMap())
@@ -2437,14 +2433,6 @@ static TR::Instruction *skipInternalControlFlow(TR::Instruction *insertInstr)
       if (ls->isEndInternalControlFlow())
         nestingDepth++;
       }
-    if (insertInstr->isStartInternalControlFlow())
-      {
-      nestingDepth--;
-      if(nestingDepth==0)
-        break;
-      }
-    else if (insertInstr->isEndInternalControlFlow())
-      nestingDepth++;
     } // for
   return insertInstr;
   }
@@ -2676,7 +2664,7 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
       while (currInst)
          {
          TR::LabelSymbol *labelSym = currInst->isLabel() ? toS390LabelInstruction(currInst)->getLabelSymbol() : NULL;
-         if (currInst->isEndInternalControlFlow() || (labelSym && labelSym->isEndInternalControlFlow()))
+         if (labelSym && labelSym->isEndInternalControlFlow())
             {
             if (currInst->getDependencyConditions())
                {
@@ -2775,19 +2763,6 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
 
       // Maintain Internal Control Flow Depth
 
-      // Track internal control flow on instructions
-      if (instructionCursor->isStartInternalControlFlow())
-         {
-         _internalControlFlowNestingDepth--;
-         if(_internalControlFlowNestingDepth==0)
-            self()->endInternalControlFlow(instructionCursor);        // Walking backwards so start is end
-         }
-      if (instructionCursor->isEndInternalControlFlow())
-         {
-         _internalControlFlowNestingDepth++;
-         self()->startInternalControlFlow(instructionCursor);
-         }
-
       // Track internal control flow on labels
       if (instructionCursor->getOpCode().getOpCodeValue() == TR::InstOpCode::LABEL)
          {
@@ -2797,16 +2772,12 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
             {
             if (li->getLabelSymbol()->isStartInternalControlFlow())
                {
-               TR_ASSERT(!li->isStartInternalControlFlow(),
-                       "An instruction should not be both the start of internal control flow and have a lebel that is pegged as the start of internal control flow, because we should only count it once");
                _internalControlFlowNestingDepth--;
                if (_internalControlFlowNestingDepth == 0)
                   self()->endInternalControlFlow(instructionCursor);        // Walking backwards so start is end
                }
             if (li->getLabelSymbol()->isEndInternalControlFlow())
                {
-               TR_ASSERT(!li->isEndInternalControlFlow(),
-                       "An instruction should not be both the end of internal control flow and have a lebel that is pegged as the end of internal control flow, because we should only count it once");
                _internalControlFlowNestingDepth++;
                self()->startInternalControlFlow(instructionCursor);
                }

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -81,7 +81,7 @@
    _targetRegSize(0), _sourceRegSize(0), _sourceMemSize(0), _targetMemSize(0), _sourceStart(-1), _targetStart(-1)
 
 OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* node)
-   : 
+   :
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
@@ -91,7 +91,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    }
 
 OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedingInstruction, TR::InstOpCode::Mnemonic op, TR::Node* node)
-   : 
+   :
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
@@ -1151,11 +1151,6 @@ static bool isInternalControlFlowOneEntryOneExit(TR::Instruction *regionEnd, TR:
       done=true;
       regionStart=curr->getPrev();
       }
-    else if(curr->isStartInternalControlFlow())
-      {
-      done=true;
-      regionStart=curr->getPrev();
-      }
     }
 
   // Now check if all branches jump to lables inside region
@@ -1883,7 +1878,7 @@ OMR::Z::Instruction::attemptOpAdjustmentForLongDisplacement()
    if (instructionFormat == RXYa_FORMAT ||
        instructionFormat == RXYb_FORMAT)
       self()->setKind(IsRXY);
-   else if (instructionFormat == RSYa_FORMAT || 
+   else if (instructionFormat == RSYa_FORMAT ||
             instructionFormat == RSYb_FORMAT)
       self()->setKind(IsRSY);
    else if (instructionFormat == SIY_FORMAT)

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -125,12 +125,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    bool isCCuseKnown() { return _flags.testAny(CCuseKnown); }
    void setCCuseKnown() {_flags.set(CCuseKnown);}
 
-   bool isStartInternalControlFlow(){ return _flags.testAny(StartInternalControlFlow); }
-   void setStartInternalControlFlow() {_flags.set(StartInternalControlFlow);}
-
-   bool isEndInternalControlFlow(){ return _flags.testAny(EndInternalControlFlow); }
-   void setEndInternalControlFlow() {_flags.set(EndInternalControlFlow);}
-
    // Region numbers start life as just the inline indexes
    // but are later extended by any optimization that duplicates
    // IL (e.g. loopCanonicalizer)

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3567,8 +3567,8 @@ generateS390CompareBool(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode:
 
 
    // Create a label
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
    // Create a register
    TR::Register * targetRegister = cg->allocateRegister();
 
@@ -6963,10 +6963,10 @@ OMR::Z::TreeEvaluator::genNullTestForCompressedPointers(TR::Node *node,
             //node->setRegister(targetRegister);
             }
 
-         skipAdd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         skipAdd = generateLabelSymbol(cg);
          skipAdd->setEndInternalControlFlow();
 
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol( cg);
 
          if (addOrSubNode->getFirstChild()->getOpCode().isShift() && addOrSubNode->getFirstChild()->getRegister())
             {
@@ -7544,8 +7544,8 @@ OMR::Z::TreeEvaluator::performCall(TR::Node * node, bool isIndirect, TR::CodeGen
 TR::Register *
 OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg, TR::Register *inReg, TR::Register *outReg)
    {
-   TR::LabelSymbol *cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol *cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
 
    TR::InstOpCode::Mnemonic subOp = TR::Compiler->target.is64Bit() ? TR::InstOpCode::SGR : TR::InstOpCode::SR;
    TR::InstOpCode::Mnemonic addOp = TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGR : TR::InstOpCode::AR;
@@ -7705,8 +7705,8 @@ inlineTrailingZerosQuadWordAtATime(
    TR::Register * rInput          = cg->allocateRegister();      // to use as temp
    TR::Register * rBranchCounter  = cg->allocateRegister();      // used for BRCT
 
-   TR::LabelSymbol * LabelProcessNext8Bytes = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-   TR::LabelSymbol * cFlowRegionEnd         = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+   TR::LabelSymbol * LabelProcessNext8Bytes = generateLabelSymbol( cg);
+   TR::LabelSymbol * cFlowRegionEnd         = generateLabelSymbol( cg);
 
    TR::Compilation * comp   = cg->comp();
    TR_Debug     * debug  = cg->getDebug();
@@ -9843,9 +9843,9 @@ forwardArraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    regDeps->addPostCondition(rResult       ,TR::RealRegister::AssignAny);
    regDeps->addPostCondition(vBuf          ,TR::RealRegister::AssignAny);
 
-   TR::LabelSymbol * cFlowRegionStart  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processNext16Bytes = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart  = generateLabelSymbol(cg);
+   TR::LabelSymbol * processNext16Bytes = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd     = generateLabelSymbol(cg);
 
 
    generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, rIdx, rIdx);
@@ -9978,7 +9978,7 @@ void setStartInternalControlFlow(TR::CodeGenerator * cg, TR::Node * node, TR::In
    TR_ASSERT(cursor && cursor->getPrev(), "cannot set ICF without previous instruction");
    if (!isStartInternalControlFlowSet)
       {
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart, cursor->getPrev());
       cFlowRegionStart->setStartInternalControlFlow();
@@ -10192,9 +10192,9 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             }
          }
 
-      TR::LabelSymbol *condLabel = isCondLabelNeeded ? TR::LabelSymbol::create(cg->trHeapMemory(),cg) : NULL;
+      TR::LabelSymbol *condLabel = isCondLabelNeeded ? generateLabelSymbol(cg) : NULL;
 
-      TR::LabelSymbol *endLabel = isEndLabelNeeded ? TR::LabelSymbol::create(cg->trHeapMemory(),cg) : NULL;
+      TR::LabelSymbol *endLabel = isEndLabelNeeded ? generateLabelSymbol(cg) : NULL;
 
       if (!isFoldedIf && needResultReg)
          generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
@@ -10312,7 +10312,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
          }
       else
          {
-         cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         cFlowRegionEnd = generateLabelSymbol(cg);
          cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, cursor);
          }
 
@@ -10352,7 +10352,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
       bool lenMinusOne = false;
       bool needs64BitOpCode = false;
 
-      TR::LabelSymbol *cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
 
       TR::Register *loopCountReg = NULL;
 
@@ -10473,7 +10473,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
                generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
                }
 
-            //cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            //cFlowRegionEnd = generateLabelSymbol(cg);
 
             generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LTGR : TR::InstOpCode::LTR, node, lengthReg, lengthReg);
 
@@ -10500,7 +10500,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
                }
             generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, lengthCopyReg, lengthReg);
 
-            TR::LabelSymbol *continueLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            TR::LabelSymbol *continueLabel = generateLabelSymbol(cg);
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, continueLabel);
             cursor = generateRSWithImplicitPairStoresInstruction(cg, isWideChar ? TR::InstOpCode::CLCLU : TR::InstOpCode::CLCLE, node, source1Pair, source2Pair, generateS390MemoryReference(NULL, 64, cg));
 
@@ -10554,9 +10554,9 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             branchDeps->addPostConditionIfNotAlreadyInserted(lengthReg, TR::RealRegister::AssignAny);
             branchDeps->addPostConditionIfNotAlreadyInserted(loopCountReg, TR::RealRegister::AssignAny);
 
-            TR::LabelSymbol *topOfLoop    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-            TR::LabelSymbol *bottomOfLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-            TR::LabelSymbol *outOfCompare = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            TR::LabelSymbol *topOfLoop    = generateLabelSymbol(cg);
+            TR::LabelSymbol *bottomOfLoop = generateLabelSymbol(cg);
+            TR::LabelSymbol *outOfCompare = generateLabelSymbol(cg);
 
            if (needs64BitOpCode)
               generateRSInstruction(cg, TR::InstOpCode::SRAG, node, loopCountReg, lengthReg, 8);
@@ -12075,8 +12075,8 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
       generateRXInstruction(cg, TR::InstOpCode::LA, node, endReg, endMR);
       generateRXInstruction(cg, TR::InstOpCode::LA, node, startReg, startMR);
 
-      TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * topOfLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
+      TR::LabelSymbol * topOfLoop = generateLabelSymbol(cg);
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, topOfLoop, dependencies);
       topOfLoop->setStartInternalControlFlow();
@@ -12160,11 +12160,11 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
       TR::RegisterDependencyConditions * dependencies;
       TR::Register * ptrReg = cg->allocateRegister();
       TR::Register * tmpReg = cg->allocateRegister();
-      TR::LabelSymbol * label256Top = TR::LabelSymbol::create(cg->trHeapMemory());
-      TR::LabelSymbol * labelFind = TR::LabelSymbol::create(cg->trHeapMemory());
-      TR::LabelSymbol * labelEnd = TR::LabelSymbol::create(cg->trHeapMemory());
-      TR::LabelSymbol * boundCheckFailureLabel = TR::LabelSymbol::create(cg->trHeapMemory());
-      TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory());
+      TR::LabelSymbol * label256Top = generateLabelSymbol(cg);
+      TR::LabelSymbol * labelFind = generateLabelSymbol(cg);
+      TR::LabelSymbol * labelEnd = generateLabelSymbol(cg);
+      TR::LabelSymbol * boundCheckFailureLabel = generateLabelSymbol(cg);
+      TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
       dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, numRegister, cg);
 
       // For chars, scale the index and array/search length by 2 (size of char) to convert into bytes.
@@ -12191,8 +12191,8 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
       // and translate/search length.
       if (isAdditionalLen)
          {
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory());
-         TR::LabelSymbol * labelSkip = TR::LabelSymbol::create(cg->trHeapMemory());
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+         TR::LabelSymbol * labelSkip = generateLabelSymbol(cg);
 
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, minReg, alenReg);
          generateRRInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, minReg, lenReg);
@@ -12230,7 +12230,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
          // to allocate a register at this point for the literal pool base address.
          intptrj_t helper = (intptrj_t) cg->symRefTab()->findOrCreateRuntimeHelper(TR_S390arrayTranslateAndTestHelper, false, false, false)->getMethodAddress();
 
-         TR::LabelSymbol * labelEntryElementChar = TR::LabelSymbol::create(cg->trHeapMemory());
+         TR::LabelSymbol * labelEntryElementChar = generateLabelSymbol(cg);
          TR::Instruction * cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, labelEntryElementChar);
 
          genLoadAddressConstant(cg, node, helper, raReg, cursor, dependencies);
@@ -12241,7 +12241,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
          generateRIInstruction(cg, TR::InstOpCode::AHI, node, indexReg, TRTSIZE);
 
          // Label for the helper code to handle TRT < 256 bytes.
-         TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory());
+         TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
          TR::MemoryReference * inputTRTMR = generateS390MemoryReference(ptrReg, 0, cg);
          TR::MemoryReference * tableMR = generateS390MemoryReference(tableReg, 0, cg);
 
@@ -12306,7 +12306,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
          //
          // Bounds Checking
 
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory());
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
 
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();
@@ -12343,7 +12343,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
 
          if (elementChar)
             {
-            TR::LabelSymbol * label2ByteOk = TR::LabelSymbol::create(cg->trHeapMemory());
+            TR::LabelSymbol * label2ByteOk = generateLabelSymbol(cg);
             TR::MemoryReference * ptr0MR = generateS390MemoryReference(ptrReg, 0, 0, cg);
 
             generateRIInstruction(cg, TR::InstOpCode::NILL, node, ptrReg, 0xFFFE);
@@ -12453,7 +12453,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
          if (emulateSRSTUusingSRST)
             {
             TR::MemoryReference * ptr0MR = generateS390MemoryReference(tmpReg, 0, 0, cg);
-            TR::LabelSymbol * label2ByteOk = TR::LabelSymbol::create(cg->trHeapMemory());
+            TR::LabelSymbol * label2ByteOk = generateLabelSymbol(cg);
 
             // Align the pointer to nearest halfword.
             generateRIInstruction(cg, TR::InstOpCode::NILL, node, tmpReg, 0xFFFE);
@@ -12626,8 +12626,8 @@ OMR::Z::TreeEvaluator::arraytranslateEvaluator(TR::Node * node, TR::CodeGenerato
       tableReg = tableStorageReg;
       }
 
-   TR::LabelSymbol * topOfLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * topOfLoop = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, topOfLoop);
    topOfLoop->setStartInternalControlFlow();
@@ -13057,8 +13057,8 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
       TR::RegisterDependencyConditions * regDeps = cg->createDepsForRRMemoryInstructions(node, sourcePairReg, targetPairReg);
 
       //MVCLU
-      TR::LabelSymbol *continueLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol *cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol *continueLabel = generateLabelSymbol(cg);
+      TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, continueLabel);
       continueLabel->setStartInternalControlFlow();
@@ -13089,8 +13089,8 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
       uint16_t value = (uint16_t) constExpr->getShortInt();
       TR::Register* itersReg = cg->allocateRegister();
       TR::Register* indexReg = cg->allocateRegister();
-      TR::LabelSymbol * topOfLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * topOfLoop = generateLabelSymbol(cg);
+      TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
       TR::LabelSymbol * endOfLoop = NULL;
       TR::RegisterDependencyConditions * dependencies = NULL;
 
@@ -13102,7 +13102,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
            SRAG  GPR_Iteration, GPR_elemsReg, 6 ; unroll=8, 8 bytes per each STG
            BRC  eq, Label L0097; start of internal control flow
          */
-         endOfLoop = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         endOfLoop = generateLabelSymbol(cg);
 
          if (elemsExpr->getDataType() == TR::Int64)
             {
@@ -13146,8 +13146,8 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
       if (varLength)
          {
-         TR::LabelSymbol * topOfLoop1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         TR::LabelSymbol * endOfLoop1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * topOfLoop1 = generateLabelSymbol(cg);
+         TR::LabelSymbol * endOfLoop1 = generateLabelSymbol(cg);
          TR::Register* residueReg = cg->allocateRegister();
          dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 6, cg);
          dependencies->addPostCondition(itersReg, TR::RealRegister::AssignAny);
@@ -13885,9 +13885,9 @@ OMR::Z::TreeEvaluator::long2StringEvaluator(TR::Node * node, TR::CodeGenerator *
    dependencies->addPostCondition(countReg, TR::RealRegister::AssignAny);
    dependencies->addPostCondition(raReg, cg->getReturnAddressRegister());
 
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory());
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory());
-   TR::LabelSymbol * labelDigit1 = TR::LabelSymbol::create(cg->trHeapMemory());
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
+   TR::LabelSymbol * labelDigit1 = generateLabelSymbol(cg);
 
    generateRIInstruction(cg, TR::InstOpCode::CHI, node, countReg, (int32_t) 1);
 
@@ -14973,8 +14973,8 @@ TR::Register *arraycmpWithPadHelper::generateCLCLE()
    //CLCLE/CLCLU
    TR::MemoryReference *paddingRef = generateS390MemoryReference(paddingReg, 0, cg);
 
-   TR::LabelSymbol *continueLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol *cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *continueLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, continueLabel, regDeps);
    continueLabel->setStartInternalControlFlow();
@@ -15110,7 +15110,7 @@ void arraycmpWithPadHelper::generateConstCLCSetup()
          }
       }
 
-   unequalLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   unequalLabel = generateLabelSymbol(cg);
    if(!isFoldedIf)
       brCond = TR::InstOpCode::COND_MASK6;
    }
@@ -15152,7 +15152,7 @@ void arraycmpWithPadHelper::generateVarCLCSetup()
       else
          generateLoad32BitConstant(cg, node, 2, paddingUnequalRetValReg, true);
 
-      TR::LabelSymbol *doneAssignLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol *doneAssignLabel = generateLabelSymbol(cg);
       generateS390CompareAndBranchInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGR : TR::InstOpCode::CR, node, source2LenReg, source1LenReg, TR::InstOpCode::COND_BHR, doneAssignLabel);
 
       generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, countReg, source2LenReg);
@@ -15213,7 +15213,7 @@ void arraycmpWithPadHelper::generateVarCLCSetup()
       regDeps->addPostCondition(paddingLenReg, TR::RealRegister::AssignAny);
       regDeps->addPostCondition(paddingUnequalRetValReg, TR::RealRegister::AssignAny);
       }
-   unequalLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   unequalLabel = generateLabelSymbol(cg);
    }
 
 void arraycmpWithPadHelper::generateConstCLCMainLoop()
@@ -15251,7 +15251,7 @@ void arraycmpWithPadHelper::generateConstCLCMainLoop()
 
       if (!(isPerfectMultiple && (i == loopCount - 1) && isEqual))
          {
-         TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
 
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();
@@ -15264,8 +15264,8 @@ void arraycmpWithPadHelper::generateConstCLCMainLoop()
 
 void arraycmpWithPadHelper::generateVarCLCMainLoop()
    {
-   TR::LabelSymbol *loopStartLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol *loopTopLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *loopStartLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *loopTopLabel = generateLabelSymbol(cg);
 
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK15, node, loopStartLabel);
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, loopTopLabel);
@@ -15415,7 +15415,7 @@ void arraycmpWithPadHelper::setupConstCLCPadding()
 
    if ((source1Len != 0) && (source2Len != 0))
       {
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
       cFlowRegionStart->setStartInternalControlFlow();
@@ -15528,7 +15528,7 @@ void arraycmpWithPadHelper::generateConstCLCSpacePaddingLoop()
       else
          generateSS1Instruction(cg, TR::InstOpCode::CLC, node, MAX_PADDING_SIZE - 1, paddingRef, posRef);
 
-      TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
 
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
       cFlowRegionStart->setStartInternalControlFlow();
@@ -15594,8 +15594,8 @@ void arraycmpWithPadHelper::generateConstCLCSpacePaddingLoop()
 void arraycmpWithPadHelper::generateConstCLCPaddingLoop()
    {
    // use EX->CLI to compare one character at a time
-   TR::LabelSymbol *paddingUnequalLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *paddingUnequalLabel = generateLabelSymbol(cg);
+   doneLabel = generateLabelSymbol(cg);
    if(isUTF16)
       paddingLen /= 2;
 
@@ -15638,9 +15638,9 @@ void arraycmpWithPadHelper::generateConstCLCPaddingLoop()
 
 void arraycmpWithPadHelper::generateVarCLCPaddingLoop()
    {
-   TR::LabelSymbol *loopTopLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol *loopStartLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol *paddingUnequalLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol *loopTopLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *loopStartLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *paddingUnequalLabel = generateLabelSymbol(cg);
 
    generateRXInstruction(cg, TR::InstOpCode::LA, node, paddingLenReg, generateS390MemoryReference(paddingLenReg, 1, cg));
 
@@ -15859,7 +15859,7 @@ TR::Register* arraycmpWithPadHelper::generate()
    //Notice that when (maxLen == 0) && !isConst both their real lengths and maximum lengths are unknown.
    if ((maxLen < CLC_THRESHOLD) && (maxLen != 0 || isConst) && !forceCLCL)
       {
-      cmpDoneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      cmpDoneLabel = generateLabelSymbol(cg);
 
       //choose the branch conditions
       if (isFoldedIf)
@@ -16585,17 +16585,17 @@ OMR::Z::TreeEvaluator::arraytranslateDecodeSIMDEvaluator(TR::Node * node, TR::Co
 
 
    // Create the necessary labels
-   TR::LabelSymbol * processMultiple16Bytes    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processMultiple16BytesEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processMultiple16Bytes    = generateLabelSymbol(cg);
+   TR::LabelSymbol * processMultiple16BytesEnd = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processUnder16Bytes    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnder16BytesEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processUnder16Bytes    = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnder16BytesEnd = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processSaturated         = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processSaturatedEnd      = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnSaturatedInput1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnSaturatedInput2 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd           = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processSaturated         = generateLabelSymbol(cg);
+   TR::LabelSymbol * processSaturatedEnd      = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnSaturatedInput1 = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnSaturatedInput2 = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd           = generateLabelSymbol(cg);
 
    // Create the necessary vector registers
    TR::Register* vOutput1   = cg->allocateRegister(TR_VRF); // 1st 16 bytes of output (8 chars)
@@ -16874,19 +16874,19 @@ OMR::Z::TreeEvaluator::arraytranslateEncodeSIMDEvaluator(TR::Node * node, TR::Co
       }
 
    // Create the necessary labels
-   TR::LabelSymbol * processMultiple16Chars    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processMultiple16CharsEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processMultiple16Chars    = generateLabelSymbol(cg);
+   TR::LabelSymbol * processMultiple16CharsEnd = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processUnder16Chars    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnder16CharsEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processUnder16Chars    = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnder16CharsEnd = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processUnder8Chars    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnder8CharsEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processUnder8Chars    = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnder8CharsEnd = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processSaturatedInput1 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processSaturatedInput2 = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnSaturated     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd         = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processSaturatedInput1 = generateLabelSymbol(cg);
+   TR::LabelSymbol * processSaturatedInput2 = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnSaturated     = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd         = generateLabelSymbol(cg);
 
    // Create the necessary vector registers
    TR::Register* vInput1    = cg->allocateRegister(TR_VRF); // 1st 16 bytes of input (8 chars)
@@ -17610,14 +17610,14 @@ inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg)
    generateVRIaInstruction(cg, TR::InstOpCode::VLEIH, node, vRangeControl, surrogateControl2, 1);
 
    // Create the necessary labels
-   TR::LabelSymbol * process8Chars         = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * process8CharsEnd      = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * process8Chars         = generateLabelSymbol(cg);
+   TR::LabelSymbol * process8CharsEnd      = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processUnder8Chars    = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processUnder8CharsEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processUnder8Chars    = generateLabelSymbol(cg);
+   TR::LabelSymbol * processUnder8CharsEnd = generateLabelSymbol(cg);
 
-   TR::LabelSymbol * processSurrogate      = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * processSurrogateEnd   = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * processSurrogate      = generateLabelSymbol(cg);
+   TR::LabelSymbol * processSurrogateEnd   = generateLabelSymbol(cg);
 
    // Branch to the end if there are no more multiples of 8 chars left to process
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpLogicalOpCode(), node, inputLen16, 0, TR::InstOpCode::COND_MASK8, process8CharsEnd, false, false);
@@ -17780,11 +17780,11 @@ inlineUTF16BEEncode(TR::Node *node, TR::CodeGenerator *cg)
    generateRREInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, translated, translated);
 
    // Create the necessary labels
-   TR::LabelSymbol * processChar4     = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-   TR::LabelSymbol * processChar4End  = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-   TR::LabelSymbol * processChar1     = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-   TR::LabelSymbol * processChar1End  = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-   TR::LabelSymbol * processChar1Copy = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+   TR::LabelSymbol * processChar4     = generateLabelSymbol( cg);
+   TR::LabelSymbol * processChar4End  = generateLabelSymbol( cg);
+   TR::LabelSymbol * processChar1     = generateLabelSymbol( cg);
+   TR::LabelSymbol * processChar1End  = generateLabelSymbol( cg);
+   TR::LabelSymbol * processChar1Copy = generateLabelSymbol( cg);
 
    const uint16_t surrogateRange1 = 0xD800;
    const uint16_t surrogateRange2 = 0xDFFF;
@@ -17954,9 +17954,9 @@ OMR::Z::TreeEvaluator::arraycmpSIMDHelper(TR::Node *node,
    if(needResultReg && isArrayCmp && node->isArrayCmpLen())
       generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, resultReg, lastByteIndexReg);
 
-   TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-   TR::LabelSymbol * mismatch = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+   TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(cg);
+   TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(cg);
+   TR::LabelSymbol * mismatch = generateLabelSymbol(cg);
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
    cFlowRegionStart->setStartInternalControlFlow();

--- a/compiler/z/codegen/OpMemToMem.hpp
+++ b/compiler/z/codegen/OpMemToMem.hpp
@@ -22,21 +22,22 @@
 #ifndef OPMEMTOMEM_INCL
 #define OPMEMTOMEM_INCL
 
-#include <stddef.h>                       // for NULL
-#include <stdint.h>                       // for int32_t, int64_t, int8_t, etc
-#include "codegen/CodeGenerator.hpp"      // for CodeGenerator
-#include "codegen/InstOpCode.hpp"         // for InstOpCode, etc
-#include "codegen/Instruction.hpp"        // for Instruction
-#include "codegen/Machine.hpp"            // for MAXDISP
+#include <stddef.h>                               // for NULL
+#include <stdint.h>                               // for int32_t, int64_t, int8_t, etc
+#include "codegen/CodeGenerator.hpp"              // for CodeGenerator
+#include "codegen/InstOpCode.hpp"                 // for InstOpCode, etc
+#include "codegen/Instruction.hpp"                // for Instruction
+#include "codegen/Machine.hpp"                    // for MAXDISP
 #include "codegen/MemoryReference.hpp"
-#include "codegen/RegisterPair.hpp"       // for RegisterPair
-#include "compile/Compilation.hpp"        // for Compilation, comp
+#include "codegen/RegisterPair.hpp"               // for RegisterPair
+#include "compile/Compilation.hpp"                // for Compilation, comp
 #include "env/CompilerEnv.hpp"
-#include "env/TRMemory.hpp"               // for TR_Memory, etc
-#include "env/jittypes.h"                 // for intptrj_t
-#include "il/DataTypes.hpp"               // for DataTypes, etc
-#include "il/symbol/LabelSymbol.hpp"      // for LabelSymbol
-#include "infra/Assert.hpp"               // for TR_ASSERT
+#include "env/TRMemory.hpp"                       // for TR_Memory, etc
+#include "env/jittypes.h"                         // for intptrj_t
+#include "il/DataTypes.hpp"                       // for DataTypes, etc
+#include "il/symbol/LabelSymbol.hpp"              // for LabelSymbol
+#include "infra/Assert.hpp"                       // for TR_ASSERT
+#include "z/codegen/S390GenerateInstructions.hpp" // for generate label instructions
 
 namespace TR { class Node; }
 namespace TR { class Register; }
@@ -89,9 +90,14 @@ class MemToMemMacroOp
                  }
                if(_startControlFlow != _cursor)
                  {
-                 _startControlFlow->setDependencyConditions(dependencies);
-                 _cursor->setEndInternalControlFlow();
-                 _startControlFlow->setStartInternalControlFlow();
+                 TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+                 TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+
+                 generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _rootNode, cFlowRegionStart, dependencies, _startControlFlow->getPrev());
+                 cFlowRegionStart->setStartInternalControlFlow();
+
+                 generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _rootNode, cFlowRegionEnd, _cursor->getPrev());
+                 cFlowRegionEnd->setEndInternalControlFlow();
                  }
                }
             }

--- a/compiler/z/codegen/OpMemToMem.hpp
+++ b/compiler/z/codegen/OpMemToMem.hpp
@@ -90,8 +90,8 @@ class MemToMemMacroOp
                  }
                if(_startControlFlow != _cursor)
                  {
-                 TR::LabelSymbol * cFlowRegionStart = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
-                 TR::LabelSymbol * cFlowRegionEnd = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+                 TR::LabelSymbol * cFlowRegionStart = generateLabelSymbol(_cg);
+                 TR::LabelSymbol * cFlowRegionEnd = generateLabelSymbol(_cg);
 
                  generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _rootNode, cFlowRegionStart, dependencies, _startControlFlow->getPrev());
                  cFlowRegionStart->setStartInternalControlFlow();
@@ -357,9 +357,9 @@ class MemCmpConstLenMacroOp : public MemToMemConstLenMacroOp
       MemCmpConstLenMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, int64_t length)
          : MemToMemConstLenMacroOp(rootNode, dstNode, srcNode, cg, length)
       {
-      _falseLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      _trueLabel  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-      _doneLabel  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      _falseLabel = generateLabelSymbol(cg);
+      _trueLabel  = generateLabelSymbol(cg);
+      _doneLabel  = generateLabelSymbol(cg);
       }
       TR::Register * resultReg() { return _resultReg; }
       virtual TR::Instruction *generate(TR::Register* dstReg, TR::Register* srcReg, TR::Register* tmpReg, int32_t offset, TR::Instruction *cursor);
@@ -384,7 +384,7 @@ class MemCmpConstLenSignMacroOp : public MemCmpConstLenMacroOp
       MemCmpConstLenSignMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, int64_t length)
          : MemCmpConstLenMacroOp(rootNode, dstNode, srcNode, cg, length)
       {
-      _gtLabel     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+      _gtLabel     = generateLabelSymbol(cg);
       }
       virtual TR::Instruction *generate(TR::Register* dstReg, TR::Register* srcReg, TR::Register* tmpReg, int32_t offset, TR::Instruction *cursor);
       virtual TR::Instruction *generate(TR::Register* dstReg, TR::Register* srcReg)
@@ -473,10 +473,10 @@ class MemCmpVarLenMacroOp : public MemToMemVarLenMacroOp
          : MemToMemVarLenMacroOp(rootNode, dstNode, srcNode, cg, regLen, lenNode, lengthMinusOne, TR::InstOpCode::CLC)
          {
          _litPoolReg = NULL;
-         _falseLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
-         _trueLabel  = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         _falseLabel = generateLabelSymbol(cg);
+         _trueLabel  = generateLabelSymbol(cg);
          if (!doneLabel)
-            _doneLabel = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+            _doneLabel = generateLabelSymbol(cg);
          else
             _doneLabel = doneLabel;
          }
@@ -506,7 +506,7 @@ class MemCmpVarLenSignMacroOp : public MemCmpVarLenMacroOp
       MemCmpVarLenSignMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::Register* regLen, TR::Node * lenNode)
          : MemCmpVarLenMacroOp(rootNode, dstNode, srcNode, cg, regLen, lenNode)
          {
-         _gtLabel     = TR::LabelSymbol::create(cg->trHeapMemory(),cg);
+         _gtLabel     = generateLabelSymbol(cg);
          }
       virtual TR::Instruction * generate(TR::Register* dstReg, TR::Register* srcReg, TR::Register* tmpReg, int32_t offset, TR::Instruction *cursor);
       virtual TR::Instruction *generate(TR::Register* dstReg, TR::Register* srcReg)

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -369,16 +369,6 @@ TR_Debug::printz(TR::FILE *pOutFile, TR::Instruction * instr)
    //  dump the inst's post deps
    if (instr->getOpCodeValue() != TR::InstOpCode::ASSOCREGS && _comp->cg()->getCodeGeneratorPhase() <= TR::CodeGenPhase::BinaryEncodingPhase)
       dumpDependencies(pOutFile, instr, false, true);
-
-   if(instr->isStartInternalControlFlow())
-      {
-      trfprintf(pOutFile, "\t# (Start of internal control flow)");
-      }
-   if(instr->isEndInternalControlFlow())
-      {
-      trfprintf(pOutFile, "\t# (End of internal control flow)");
-      }
-
    }
 
 TR::Instruction*

--- a/compiler/z/codegen/S390Evaluator.hpp
+++ b/compiler/z/codegen/S390Evaluator.hpp
@@ -280,7 +280,6 @@ class arraycmpWithPadHelper
    void generateCLCLitPoolPadding();
    void generateCLCFoldedIfResult();
    void chooseCLCBranchConditions();
-   void setStartInternalControlFlow(TR::Instruction * cursor);
    TR::MemoryReference *  convertToShortDispMemRef(TR::Node * node,
                                                       TR::MemoryReference * largeDispMemRef,
                                                       TR::Register * &largeDispReg,

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -940,7 +940,7 @@ generateRXFInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::
    if (preced)
       instr = new (INSN_HEAP) TR::S390RXFInstruction(op, n, treg, sreg, mf, preced, cg);
    else
-   	  instr = new (INSN_HEAP) TR::S390RXFInstruction(op, n, treg, sreg, mf, cg);
+           instr = new (INSN_HEAP) TR::S390RXFInstruction(op, n, treg, sreg, mf, cg);
 
    return instr;
    }
@@ -1362,7 +1362,7 @@ generateS390MemInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, 
    if (preced)
       instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, constantField, memAccessMode, mf, preced, cg);
    else
-   	  instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, constantField, memAccessMode, mf, cg);
+           instr = new (INSN_HEAP) TR::S390MemInstruction(op, n, constantField, memAccessMode, mf, cg);
 
    return instr;
    }
@@ -1442,7 +1442,7 @@ generateSS1Instruction(TR::CodeGenerator * cg,
    if (preced)
       instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, cond, preced, cg);
    else
-   	  instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, cond, cg);
+           instr = new (INSN_HEAP) TR::S390SS1Instruction(op, n, len, mf1, mf2, cond, cg);
 
    return instr;
    }
@@ -2186,7 +2186,7 @@ generateS390PseudoInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic o
       instr=new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cond, preced, cg);
       }
    else
-   	  {
+           {
       instr= new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, cond, cg);
       }
 
@@ -2306,7 +2306,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
 
    // Direct calls on 64-bit systems may require a trampoline. As the trampoline will kill the EP register we should
    // always see the EP register defined in the post-dependencies of such calls.
-#if defined(TR_TARGET_64BIT) 
+#if defined(TR_TARGET_64BIT)
 #if defined(J9ZOS390)
    if (comp->getOption(TR_EnableRMODE64))
 #endif
@@ -2355,11 +2355,11 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
             {
             static int minFR = (feGetEnv("TR_minFR") != NULL) ? atoi(feGetEnv("TR_minFR")) : 0;
             static int maxFR = (feGetEnv("TR_maxFR") != NULL) ? atoi(feGetEnv("TR_maxFR")) : 0;
-             
+
             int32_t frequency = comp->getCurrentBlock()->getFrequency();
             if (frequency > 6 && frequency >= minFR && (maxFR == 0 || frequency > maxFR))
                {
-               TR::LabelSymbol * callLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
+               TR::LabelSymbol * callLabel = generateLabelSymbol(cg);
                TR::Instruction * instr = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, callLabel);
                cg->createBranchPreloadCallData(callLabel, callSymRef, instr);
                }
@@ -2400,7 +2400,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
          }
 #endif
 
-      }  
+      }
    }
 
 TR::Instruction* generateDataConstantInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op, TR::Node* node, uint32_t data, TR::Instruction* preced)
@@ -2440,7 +2440,7 @@ generateSnippetCall(TR::CodeGenerator * cg, TR::Node * callNode, TR::Snippet * s
       // Need to put the preDeps on the label, and not on the BRASL
       // because we use virtual reg from preDeps after the BRASL
       // In particular, we use the this pointer reg, which  has a preDep to GPR1
-      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, TR::LabelSymbol::create(INSN_HEAP, cg), preDeps);
+      generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, callNode, generateLabelSymbol(cg), preDeps);
 
       callInstr = new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, killRegRA, s,
          postDeps, callSymRef, cg);
@@ -2536,7 +2536,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
          {
          TR_OpaqueClassBlock* unloadableClass = NULL;
          bool isMethod = node->getOpCodeValue() == TR::loadaddr ? false : node->isMethodPointerConstant();
-	 if (isMethod)
+       if (isMethod)
             {
             unloadableClass = (TR_OpaqueClassBlock *) cg->fe()->createResolvedMethod(cg->trMemory(), (TR_OpaqueMethodBlock *)(intptr_t)imm,
                comp->getCurrentMethod())->classOfMethod();
@@ -3459,7 +3459,7 @@ generateS390DAAExceptionRestoreSnippet(TR::CodeGenerator* cg,
       TR::LabelSymbol * handlerLabel = cg->getCurrentBCDCHKHandlerLabel();
       TR_ASSERT(handlerLabel, "BCDCHK node handler label should not be null");
 
-      TR::LabelSymbol* restoreGPR7SnippetHandler = TR::LabelSymbol::create(INSN_HEAP,cg);
+      TR::LabelSymbol* restoreGPR7SnippetHandler = generateLabelSymbol(cg);
       TR::S390RestoreGPR7Snippet * restoreSnippet =
                      new (INSN_HEAP) TR::S390RestoreGPR7Snippet(cg, n, restoreGPR7SnippetHandler, handlerLabel);
       cg->addSnippet(restoreSnippet);

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -37,6 +37,7 @@
 #include "codegen/RegisterDependency.hpp"
 #include "codegen/RegisterPair.hpp"                 // for RegisterPair
 #include "codegen/Snippet.hpp"                      // for TR::S390Snippet, etc
+#include "il/symbol/LabelSymbol.hpp"                // for LabelSymbol
 #include "ras/Debug.hpp"                            // for TR_DebugBase, etc
 #include "ras/DebugCounter.hpp"
 #include "ras/Delimiter.hpp"                        // for Delimiter
@@ -532,11 +533,11 @@ TR_S390PostRAPeephole::replaceGuardedLoadWithSoftwareReadBarrier()
    _cursor = generateS390BranchInstruction(_cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_CC0, load->getNode(), concurrentScavangeNotActiveLabel, _cursor);
 
    _cursor = generateRXInstruction(_cg, TR::InstOpCode::CG, load->getNode(), loadTargetReg,
-   		generateS390MemoryReference(vmReg, TR::Compiler->vm.thisThreadGetEvacuateBaseAddressOffset(comp()), _cg), _cursor);
+       generateS390MemoryReference(vmReg, TR::Compiler->vm.thisThreadGetEvacuateBaseAddressOffset(comp()), _cg), _cursor);
    _cursor = generateS390BranchInstruction(_cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_CC1, load->getNode(), concurrentScavangeNotActiveLabel, _cursor);
 
    _cursor = generateRXInstruction(_cg, TR::InstOpCode::CG, load->getNode(), loadTargetReg,
-   		generateS390MemoryReference(vmReg, TR::Compiler->vm.thisThreadGetEvacuateTopAddressOffset(comp()), _cg), _cursor);
+       generateS390MemoryReference(vmReg, TR::Compiler->vm.thisThreadGetEvacuateTopAddressOffset(comp()), _cg), _cursor);
    _cursor = generateS390BranchInstruction(_cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_CC2, load->getNode(), concurrentScavangeNotActiveLabel, _cursor);
 
    // Save result of LA to gsParameters.operandAddr as invokeJ9ReadBarrier helper expects it to be set
@@ -2256,7 +2257,7 @@ TR_S390PostRAPeephole::inlineEXtargetHelper(TR::Instruction *inst, TR::Instructi
          }
 
       // generate new label
-      TR::LabelSymbol * ssInstrLabel = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+      TR::LabelSymbol * ssInstrLabel = generateLabelSymbol(_cg);
       TR::Instruction * labelInstr = generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _cursor->getNode(), ssInstrLabel, inst);
 
       //cnstDataInstr->move(labelInstr);
@@ -2331,7 +2332,7 @@ TR_S390PostRAPeephole::inlineEXtarget()
           }
 
        // Generate branch and label
-       TR::LabelSymbol *targetLabel = TR::LabelSymbol::create(_cg->trHeapMemory(),_cg);
+       TR::LabelSymbol *targetLabel = generateLabelSymbol(_cg);
        TR::Instruction *branchInstr = generateS390BranchInstruction(_cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, _cursor->getNode(), targetLabel, prev);
        TR::Instruction *labelInstr = generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _cursor->getNode(), targetLabel, branchInstr);
        inlineEXtargetHelper(branchInstr,instrB4EX);


### PR DESCRIPTION
Set ICF flags on labels instead of instructions in the Z codegen
and deprecate the usage of ICF flags on instructions to prevent
future use.

Closes: #2833 