### PR TITLE
Rename Symbol::staticName to staticFieldName

### DIFF
--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -445,10 +445,10 @@ int32_t      TR_ResolvedMethod::classCPIndexOfFieldOrStatic(int32_t)       { not
 const char * TR_ResolvedMethod::signature(TR_Memory *, TR_AllocationKind)  { notImplemented("signature"); return 0; }
 const char * TR_ResolvedMethod::externalName(TR_Memory *, TR_AllocationKind)  { notImplemented("signature"); return 0; }
 char *       TR_ResolvedMethod::fieldName (int32_t, TR_Memory *, TR_AllocationKind kind)           { notImplemented("fieldName"); return 0; }
-char *       TR_ResolvedMethod::staticName(int32_t, TR_Memory *, TR_AllocationKind kind)           { notImplemented("staticName"); return 0; }
+char *       TR_ResolvedMethod::staticFieldName(int32_t, TR_Memory *, TR_AllocationKind kind)           { notImplemented("staticFieldName"); return 0; }
 char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, TR_Memory *){ /*notImplemented("localName");*/ return 0; }
 char *       TR_ResolvedMethod::fieldName (int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind){ notImplemented("fieldName"); return 0; }
-char *       TR_ResolvedMethod::staticName(int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind){ notImplemented("staticName"); return 0; }
+char *       TR_ResolvedMethod::staticFieldName(int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind){ notImplemented("staticFieldName"); return 0; }
 char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, int32_t&, TR_Memory *){ /*notImplemented("localName");*/ return 0; }
 char *       TR_ResolvedMethod::fieldNameChars(int32_t, int32_t &)         { notImplemented("fieldNameChars"); return 0; }
 char *       TR_ResolvedMethod::fieldSignatureChars(int32_t, int32_t &)    { notImplemented("fieldSignatureChars"); return 0; }
@@ -468,7 +468,7 @@ bool         TR_ResolvedMethod::fieldsAreSame(int32_t, TR_ResolvedMethod *, int3
 bool         TR_ResolvedMethod::staticsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame)   { notImplemented("staticsAreSame"); return false; }
 char *       TR_ResolvedMethod::classNameOfFieldOrStatic(int32_t, int32_t &)            { notImplemented("classNameOfFieldOrStatic"); return 0; }
 char *       TR_ResolvedMethod::classSignatureOfFieldOrStatic(int32_t, int32_t &)       { notImplemented("classSignatureOfFieldOrStatic"); return 0; }
-char *       TR_ResolvedMethod::staticNameChars(int32_t, int32_t &)                     { notImplemented("staticNameChars"); return 0; }
+char *       TR_ResolvedMethod::staticFieldNameChars(int32_t, int32_t &)                     { notImplemented("staticFieldNameChars"); return 0; }
 const char * TR_ResolvedMethod::newInstancePrototypeSignature(TR_Memory *, TR_AllocationKind)        { notImplemented("newInstancePrototypeSignature"); return 0; }
 
 bool

--- a/compiler/compile/ResolvedMethod.hpp
+++ b/compiler/compile/ResolvedMethod.hpp
@@ -186,14 +186,14 @@ public:
 
    // These functions actually return a complete description of the field/static
    virtual char *fieldName (int32_t cpIndex, TR_Memory *, TR_AllocationKind kind=heapAlloc);
-   virtual char *staticName(int32_t cpIndex, TR_Memory *, TR_AllocationKind kind=heapAlloc);
+   virtual char *staticFieldName(int32_t cpIndex, TR_Memory *, TR_AllocationKind kind=heapAlloc);
    virtual char *localName (uint32_t slotNumber, uint32_t bcIndex, TR_Memory *);
    virtual char *fieldName (int32_t cpIndex, int32_t & len, TR_Memory *, TR_AllocationKind kind=heapAlloc);
-   virtual char *staticName(int32_t cpIndex, int32_t & len, TR_Memory *, TR_AllocationKind kind=heapAlloc);
+   virtual char *staticFieldName(int32_t cpIndex, int32_t & len, TR_Memory *, TR_AllocationKind kind=heapAlloc);
    virtual char *localName (uint32_t slotNumber, uint32_t bcIndex, int32_t &len, TR_Memory *);
 
    virtual char *fieldNameChars(int32_t cpIndex, int32_t & len);
-   virtual char *staticNameChars(int32_t cpIndex, int32_t & len);
+   virtual char *staticFieldNameChars(int32_t cpIndex, int32_t & len);
    virtual char *fieldSignatureChars(int32_t cpIndex, int32_t & len);
    virtual char *staticSignatureChars(int32_t cpIndex, int32_t & len);
 

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7925,14 +7925,14 @@ void OMR::ValuePropagation::doDelayedTransformations()
       if ((origFirst->getOpCodeValue() == TR::aload) &&
           origFirst->getSymbol()->isStaticField())
          {
-         int32_t staticNameLen = -1;
-         char *staticName = NULL;
-         staticName = origFirst->getSymbolReference()->getOwningMethod(comp())->staticName(origFirst->getSymbolReference()->getCPIndex(), staticNameLen, comp()->trMemory());
+         int32_t staticFieldNameLen = -1;
+         char *staticFieldName = NULL;
+         staticFieldName = origFirst->getSymbolReference()->getOwningMethod(comp())->staticFieldName(origFirst->getSymbolReference()->getCPIndex(), staticFieldNameLen, comp()->trMemory());
 
-         if ((staticName && (staticNameLen > 0) &&
-             (!strncmp(staticName, "com/ibm/websphere/ras/TraceComponent.fineTracingEnabled", 55) ||
-              !strncmp(staticName, "com/ibm/ejs/ras/TraceComponent.anyTracingEnabled", 48) ||
-              !strncmp(staticName, "java/lang/String.compressionFlag", 32))) ||
+         if ((staticFieldName && (staticFieldNameLen > 0) &&
+             (!strncmp(staticFieldName, "com/ibm/websphere/ras/TraceComponent.fineTracingEnabled", 55) ||
+              !strncmp(staticFieldName, "com/ibm/ejs/ras/TraceComponent.anyTracingEnabled", 48) ||
+              !strncmp(staticFieldName, "java/lang/String.compressionFlag", 32))) ||
              ((cii->_len == 41) && !strncmp(cii->_sig, "Lcom/ibm/websphere/ras/TraceEnabledToken;", cii->_len)) ||
              ((cii->_len == 35) && !strncmp(cii->_sig, "Lcom/ibm/ejs/ras/TraceEnabledToken;", cii->_len)) ||
              ((cii->_len == 40) && !strncmp(cii->_sig, "Ljava/lang/String$StringCompressionFlag;", cii->_len)))

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2623,7 +2623,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
                         if (underlyingArray->getSymbolReference()->getSymbol()->isShadow())
                            fieldName = underlyingArray->getSymbolReference()->getOwningMethod(vp->comp())->fieldName(underlyingArray->getSymbolReference()->getCPIndex(), fieldNameLen, vp->comp()->trMemory());
                         else
-                           fieldName = underlyingArray->getSymbolReference()->getOwningMethod(vp->comp())->staticName(underlyingArray->getSymbolReference()->getCPIndex(), fieldNameLen, vp->comp()->trMemory());
+                           fieldName = underlyingArray->getSymbolReference()->getOwningMethod(vp->comp())->staticFieldName(underlyingArray->getSymbolReference()->getCPIndex(), fieldNameLen, vp->comp()->trMemory());
                         }
 
                      if (fieldName && (fieldNameLen > 0) &&

--- a/compiler/p/codegen/PPCTableOfConstants.cpp
+++ b/compiler/p/codegen/PPCTableOfConstants.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -546,7 +546,7 @@ int32_t TR_PPCTableOfConstants::lookUp(TR::SymbolReference *symRef, TR::CodeGene
          }
       else
          {
-         name = (int8_t *)comp->getOwningMethodSymbol(symRef->getOwningMethodIndex())->getResolvedMethod()->staticName(symRef->getCPIndex(), cg->trMemory());
+         name = (int8_t *)comp->getOwningMethodSymbol(symRef->getOwningMethodIndex())->getResolvedMethod()->staticFieldName(symRef->getCPIndex(), cg->trMemory());
          TR_ASSERT(name!=NULL, "Variable name is expected");
          nlen = strlen((char *)name);
          }

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1666,7 +1666,7 @@ TR_Debug::getName(TR::SymbolReference * symRef)
       case TR::Symbol::IsParameter:
          return getParmName(symRef);
       case TR::Symbol::IsStatic:
-         return getStaticName(symRef);
+         return getStaticFieldName(symRef);
       case TR::Symbol::IsResolvedMethod:
       case TR::Symbol::IsMethod:
          return getMethodName(symRef);
@@ -1873,7 +1873,7 @@ TR_Debug::getMethodName(TR::SymbolReference * symRef)
 
 
 const char *
-TR_Debug::getStaticName_ForListing(TR::SymbolReference * symRef)
+TR_Debug::getStaticFieldName_ForListing(TR::SymbolReference * symRef)
    {
    TR::StaticSymbol * sym = symRef->getSymbol()->castToStaticSymbol();
 
@@ -1888,7 +1888,7 @@ TR_Debug::getStaticName_ForListing(TR::SymbolReference * symRef)
 
 
 const char *
-TR_Debug::getStaticName(TR::SymbolReference * symRef)
+TR_Debug::getStaticFieldName(TR::SymbolReference * symRef)
    {
    TR::StaticSymbol * sym = symRef->getSymbol()->castToStaticSymbol();
    void * staticAddress;
@@ -1924,9 +1924,9 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
          const intptrj_t PIECE_LIMIT=20;
 
 #ifdef J9_PROJECT_SPECIFIC
-         TR::VMAccessCriticalSection getStaticNameCriticalSection(comp(),
+         TR::VMAccessCriticalSection getStaticFieldNameCriticalSection(comp(),
                                                                    TR::VMAccessCriticalSection::tryToAcquireVMAccess);
-         if (!symRef->isUnresolved() && getStaticNameCriticalSection.acquiredVMAccess())
+         if (!symRef->isUnresolved() && getStaticFieldNameCriticalSection.acquiredVMAccess())
             {
             uintptrj_t stringLocation = (uintptrj_t)sym->castToStaticSymbol()->getStaticAddress();
             if (stringLocation)
@@ -1992,7 +1992,7 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
       if (sym->isConst())
          return "<constant>";
 
-      return getOwningMethod(symRef)->staticName(symRef->getCPIndex(), comp()->trMemory());
+      return getOwningMethod(symRef)->staticFieldName(symRef->getCPIndex(), comp()->trMemory());
       }
 
    if (_comp->getSymRefTab()->isVtableEntrySymbolRef(symRef))

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -714,8 +714,8 @@ public:
 
    const char * getAutoName(TR::SymbolReference *);
    const char * getParmName(TR::SymbolReference *);
-   const char * getStaticName(TR::SymbolReference *);
-   const char * getStaticName_ForListing(TR::SymbolReference *);
+   const char * getStaticFieldName(TR::SymbolReference *);
+   const char * getStaticFieldName_ForListing(TR::SymbolReference *);
 
    virtual const char * getMethodName(TR::SymbolReference *);
 


### PR DESCRIPTION

Rename Symbol::staticName to staticFieldName

This PR renames staticName  to staticFieldName.

Closes: #3034

Signed-off-by: nanjekyejoannah <nanjekyejoannah@gmail.com>