### PR TITLE
Use _extensions in VGC handler

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -254,7 +254,7 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 	if (_extensions->isConcurrentScavengerEnabled()) {
 		writer->formatAndOutput(env, 1, "<attribute name=\"concurrentScavenger\" value=\"%s\" />",
 #if defined(S390)
-				extensions->concurrentScavengerHWSupport ?
+				_extensions->concurrentScavengerHWSupport ?
 				"enabled, with H/W assistance" :
 				"enabled, without H/W assistance");
 #else /* defined(S390) */


### PR DESCRIPTION
There is no local extensions declared in Initialized staza handler. Use
the class member instead.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>