### PR TITLE
Ignore VS and CLion specifics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,9 @@ port/omrsyslogmessages.rc
 port/MSG00001.bin
 x64/
 
+# CLion
+.idea/
+
 # Test Output
 core
 core.*

--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ Testing/
 *.suo
 *.vcxproj
 *.vcxproj.filters
+CMakeSettings.json
 Debug/
 gc/example/Debug/
 omr_test/Debug/


### PR DESCRIPTION
Visual Studio is now providing a useful integration with CMake.
The configuration of an CMake environment is stored in a CMakeSettings.json
file. The file is developer-specific, so it must be ignored by Git.

CLion is a cross-platform C/C++ IDE from JetBrains (they are famous in
the Java community as the authors of IntelliJ IDEA).
The configuration of a CLion project is stored in an .idea folder
inside the root of the project. The configuration is developer-specific,
so the folder must be ignored by Git.

no-ci