### PR TITLE
Set Specialized for arraycopy direction on IBM Z

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -679,6 +679,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setSupportsBCDToDFPReduction();
    self()->setSupportsIntDFPConversions();
 
+   self()->setSupportsPostProcessArrayCopy();
+
    if (_processorInfo.supportsArch(TR_S390ProcessorInfo::TR_z10))
       {
       self()->setSupportsTranslateAndTestCharString();


### PR DESCRIPTION
ValuePropagation in OMR uses this flag to generate specialized trees for array copy direction if this flag is set. Currently Z platform expects optimizer to generate test for array copy direction. Set this flag in Z CodeGenerator.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>