### PR TITLE
Remove unused ParallelDispatcher API

### DIFF
--- a/gc/base/Dispatcher.cpp
+++ b/gc/base/Dispatcher.cpp
@@ -91,8 +91,6 @@ MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCo
 {
 	task->masterSetup(env);
 	prepareThreadsForTask(env, task, newThreadCount);
-	/* todo: remove this API once downstream OMR projects transition to the API with threadCount argument */
-	prepareThreadsForTask(env, task);
 	acceptTask(env);
 	task->run(env);
 	completeTask(env);

--- a/gc/base/Dispatcher.hpp
+++ b/gc/base/Dispatcher.hpp
@@ -55,9 +55,6 @@ private:
 protected:
 	bool initialize(MM_EnvironmentBase *env);
 	
-	/* todo: remove this API once downstream OMR projects transition to the API with threadCount argument */
-	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task) {}
-
 	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount);
 	virtual void acceptTask(MM_EnvironmentBase *env);
 	virtual void completeTask(MM_EnvironmentBase *env);

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -93,12 +93,9 @@ protected:
 
 	bool initialize(MM_EnvironmentBase *env);
 	
-	/* todo: remove this API once downstream OMR projects transition to the API with threadCount argument */
-	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task) {}
-	
 	virtual void prepareThreadsForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount);
 	virtual void cleanupAfterTask(MM_EnvironmentBase *env);
-	virtual uintptr_t getThreadPriority(); 
+	virtual uintptr_t getThreadPriority();
 
 	/**
 	 * Decides whether the dispatcher also start a separate thread to be the master


### PR DESCRIPTION
Now, that there are no more users of old prepareThreadsForTask()
(without explicit threadCount), remove it.


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>