### PR TITLE
Fix cannot be narrowed to type 'uintptrj_t' error

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -58,9 +58,9 @@
 
 using namespace OMR;
 
-#define SET_OPTION_BIT(x)   TR::Options::setBit,   offsetof(OMR::Options,_options[(x)&TR_OWM]), ((x)&~TR_OWM)
-#define RESET_OPTION_BIT(x) TR::Options::resetBit, offsetof(OMR::Options,_options[(x)&TR_OWM]), ((x)&~TR_OWM)
-#define SET_TRACECG_BIT(x)  TR::Options::setBit,   offsetof(OMR::Options, _cgTrace), (x)
+#define SET_OPTION_BIT(x)   TR::Options::setBit,   offsetof(OMR::Options,_options[(x)&TR_OWM]), (static_cast<uintptrj_t>((x)&~TR_OWM))
+#define RESET_OPTION_BIT(x) TR::Options::resetBit, offsetof(OMR::Options,_options[(x)&TR_OWM]), (static_cast<uintptrj_t>((x)&~TR_OWM))
+#define SET_TRACECG_BIT(x)  TR::Options::setBit,   offsetof(OMR::Options, _cgTrace), (static_cast<uintptrj_t>(x))
 
 #define NoOptString                     "noOpt"
 #define DisableAllocationInliningString "disableAllocationInlining"


### PR DESCRIPTION
A lot of the following compilation errors occur on OMROptions.cpp during
compilation with Clang 8:

..\..\compiler\control\OMROptions.cpp(760,94):  error: constant expression evaluates to -2147483648 which cannot be narrowed to type 'uintptrj_t' (aka 'unsigned long long') [-Wc++11-narrowing]
{"enableTraps", "C\tenable trap instructions", RESET_OPTION_BIT(TR_DisableTraps), "F"},

The reason is a narrowing the latest component of the RESET_OPTION_BIT
macro '((x)&~TR_OWM)' to the 'uintptrj_t' aka
'unsigned long long' type. The expression must be explicitly converted
to 'uintptrj_t'.

Closes: #3121
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>