### PR TITLE
Remove usages of LA instruction when loading constants in Z codegen

### DIFF
--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -459,7 +459,7 @@ convertToFixed(TR::Node * node, TR::CodeGenerator * cg)
    else  // Signed Target Path
       {
       //1) Reset targetRegister
-      generateRIInstruction(cg, TR::InstOpCode::LA, node, targetRegister, 0);
+      generateRRInstruction(cg, TR::InstOpCode::XGR, node, targetRegister, targetRegister);
 
       // Java expect that for signed conversion to fixed, if src float is NaN, target to have 0.0.
       //2) NaN test and branch to done
@@ -1783,8 +1783,8 @@ f2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    dependencies->addPostCondition(tempFloatRegister, TR::RealRegister::AssignAny);
 
    //Assume result (long)0x0
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, evenRegister, 0);
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, oddRegister, 0);
+   generateRRInstruction(cg, TR::InstOpCode::XR, node, evenRegister, evenRegister);
+   generateRRInstruction(cg, TR::InstOpCode::XR, node, oddRegister, oddRegister);
    // Round FP towards zero
    generateRRFInstruction(cg, TR::InstOpCode::FIEBR, node, tempFloatRegister, floatRegister, (int8_t) 0x5, true);
    generateRXInstruction(cg, TR::InstOpCode::TCEB, node, tempFloatRegister, (uint32_t) 0xccf);
@@ -1814,7 +1814,7 @@ f2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, node, label6);
    //clear exponent bits, odd register will have only fraction
    generateS390ImmOp(cg, TR::InstOpCode::N, node, oddRegister, oddRegister, (int32_t) 0x007fffff, dependencies);
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, tempRegister2, 1);
+   generateRIInstruction(cg, TR::InstOpCode::LHI, node, tempRegister2, 1);
    generateRSInstruction(cg, TR::InstOpCode::SLL, node, tempRegister2, 23);
    //tempRegister = 0x00800000
    generateRRInstruction(cg, TR::InstOpCode::OR, node, oddRegister, tempRegister2);
@@ -1869,7 +1869,7 @@ f2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    //LABEL6
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, label6);
 
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, oddRegister, 1);
+   generateRIInstruction(cg, TR::InstOpCode::LHI, node, oddRegister, 1);
    generateRSInstruction(cg, TR::InstOpCode::SLDL, node, targetRegisterPair, 63);
    TR::MemoryReference * evenMRcopy3 = generateS390MemoryReference(*evenMR, 0, cg); // prevent duplicate use of memory reference
    generateSIInstruction(cg, TR::InstOpCode::TM, node, evenMRcopy3, (uint32_t) 0x00000080);
@@ -2013,8 +2013,8 @@ d2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    dependencies->addPostCondition(tempFloatRegister, TR::RealRegister::AssignAny);
 
    //Assume result (long)0x0
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, evenRegister, 0);
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, oddRegister, 0);
+   generateRRInstruction(cg, TR::InstOpCode::XR, node, evenRegister, evenRegister);
+   generateRRInstruction(cg, TR::InstOpCode::XR, node, oddRegister, oddRegister);
    // Round double towards zero
    generateRRFInstruction(cg, TR::InstOpCode::FIDBR, node, tempFloatRegister, floatRegister, (int8_t) 0x5, true);
    generateRXInstruction(cg, TR::InstOpCode::TCDB, node, tempFloatRegister, (uint32_t) 0xccf);
@@ -2045,7 +2045,7 @@ d2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    //clear exponent bits, evenRegister will have only fraction
 
    generateS390ImmOp(cg, TR::InstOpCode::N, node, evenRegister, evenRegister, (int32_t) 0x000fffff, dependencies);
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, tempRegister2, 1);
+   generateRIInstruction(cg, TR::InstOpCode::LHI, node, tempRegister2, 1);
    generateRSInstruction(cg, TR::InstOpCode::SLL, node, tempRegister2, 20);
    generateRRInstruction(cg, TR::InstOpCode::OR, node, evenRegister, tempRegister2);
    // 20th bit of evenRegister is made 1
@@ -2087,7 +2087,7 @@ d2lHelper(TR::Node * node, TR::CodeGenerator * cg)
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, label7);
    //LABEL6
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, label6);
-   generateRIInstruction(cg, TR::InstOpCode::LA, node, oddRegister, 1);
+   generateRIInstruction(cg, TR::InstOpCode::LHI, node, oddRegister, 1);
    generateRSInstruction(cg, TR::InstOpCode::SLDL, node, targetRegisterPair, 63);
    TR::MemoryReference * tempMR1copy2 = generateS390MemoryReference(*tempMR1, 0, cg);
    generateSIInstruction(cg, TR::InstOpCode::TM, node, tempMR1copy2, (uint32_t) 0x00000080);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -7551,7 +7551,7 @@ OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg,
    TR::InstOpCode::Mnemonic addOp = TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGR : TR::InstOpCode::AR;
 
    // check if 0 to skip below instructions
-   generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI, node, outReg, 0);
+   generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, outReg, outReg);
    generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGHI : TR::InstOpCode::CHI, node, inReg, 0);
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
    cFlowRegionStart->setStartInternalControlFlow();
@@ -10071,7 +10071,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
       else
          {
          if (needResultReg)
-            generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
+            generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, retValReg, retValReg);
          }
 
       cg->recursivelyDecReferenceCount(lengthNode);
@@ -10197,7 +10197,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
       TR::LabelSymbol *endLabel = isEndLabelNeeded ? generateLabelSymbol(cg) : NULL;
 
       if (!isFoldedIf && needResultReg)
-         generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
+         generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, retValReg, retValReg);
 
       if (earlyCLCEnabled && length > earlyCLCThreshold)
          {
@@ -10288,17 +10288,17 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             {
             if (return102)
                {
-               generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 2);
+               generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, 2);
 
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK2, node, endLabel);
-               cursor = generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI, node, retValReg, 1);
+               cursor = generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, 1);
                }
             else
                {
-               generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 1);
+               generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, 1);
 
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK2, node, endLabel);
-               cursor = generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI, node, retValReg, -1);
+               cursor = generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, -1);
                }
             }
          }
@@ -10413,7 +10413,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
          if (!isFoldedIf && needResultReg)
             {
             branchDeps->addPostCondition(retValReg, TR::RealRegister::AssignAny);
-            generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
+            generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, retValReg, retValReg);
             }
 
          if (!lenMinusOne)
@@ -10470,7 +10470,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             if(!isFoldedIf && needResultReg)
                {
                branchDeps->addPostCondition(retValReg, TR::RealRegister::AssignAny);
-               generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
+               generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, retValReg, retValReg);
                }
 
             //cFlowRegionEnd = generateLabelSymbol(cg);
@@ -10518,7 +10518,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             if (!isFoldedIf && needResultReg)
                {
                branchDeps->addPostCondition(retValReg, TR::RealRegister::AssignAny);
-               generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 0);
+               generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, retValReg, retValReg);
                }
 
             loopCountReg = cg->allocateRegister();
@@ -10638,21 +10638,21 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
                {
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK8, node, cFlowRegionEnd);
 
-               generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 2);
+               generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, 2);
 
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK2, node, cFlowRegionEnd);
 
-               generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI, node, retValReg, 1);
+               generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, 1);
                }
             else
                {
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK8, node, cFlowRegionEnd);
 
-               generateRIInstruction(cg, TR::InstOpCode::LA, node, retValReg, 1);
+               generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, 1);
 
                generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK2, node, cFlowRegionEnd);
 
-               generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI, node, retValReg, -1);
+               generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, retValReg, -1);
                }
             }
          }
@@ -10844,7 +10844,7 @@ OMR::Z::TreeEvaluator::ixfrsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       {
       generateRRInstruction(cg, TR::InstOpCode::LPR, node, valueReg, valueReg);
       generateRSInstruction(cg, TR::InstOpCode::SRA, node, signReg, 31);
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::XGR : TR::InstOpCode::XR, node, valueReg, signReg);
+      generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, valueReg, signReg);
       generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::SLGR : TR::InstOpCode::SLR, node, valueReg, signReg);
 
       node->setRegister(valueReg);
@@ -10943,8 +10943,8 @@ OMR::Z::TreeEvaluator::lxfrsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
             TR::Register *oneTemp = cg->allocateRegister();
             TR::Register *zeroTemp = cg->allocateRegister();
-            generateRIInstruction(cg, TR::InstOpCode::LA, node, oneTemp, 1);
-            generateRIInstruction(cg, TR::InstOpCode::LA, node, zeroTemp, 0);
+            generateRIInstruction(cg, TR::InstOpCode::LHI, node, oneTemp, 1);
+            generateRIInstruction(cg, TR::InstOpCode::XR, node, zeroTemp, 0);
 
             generateRRInstruction(cg, TR::InstOpCode::ALR, node, valueLowReg, oneTemp);
             generateRRInstruction(cg, TR::InstOpCode::ALCR, node, valueHighReg, zeroTemp);
@@ -13046,7 +13046,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
       //Set the source length register to 0
       TR::Register *sourceLenReg =  cg->allocateRegister();
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::XGR : TR::InstOpCode::XR, node, sourceLenReg, sourceLenReg);
+      generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, sourceLenReg, sourceLenReg);
 
       uint16_t disp = (uint16_t) constExpr->getShortInt();
       TR::MemoryReference *paddingRef = generateS390MemoryReference(NULL, disp, cg);
@@ -17994,7 +17994,7 @@ OMR::Z::TreeEvaluator::arraycmpSIMDHelper(TR::Node *node,
       if(isArrayCmp && node->isArrayCmpLen())
          generateRIInstruction(cg, TR::InstOpCode::getAddHalfWordImmOpCode(), node, resultReg, 1);//Return length of the arrays, which is resultReg += 1
       else
-         generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, resultReg, 0);//Return zero to indicate equal
+         generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, resultReg, resultReg);//Return zero to indicate equal
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, cFlowRegionEnd);
       }
 


### PR DESCRIPTION
This patch replaces TR::InstOpCode::LA with TR::InstOpCode::XR or
TR::InstOpCode::XGR when loading 0 into a register since XOR operation
is faster. Also, the LHI instruction is used instead of LA when loading
small constants. See issue #3047.

Closes: #3047

Signed-off-by: Muzaffar Auhammud <muzaffar@cyberstorm.mu>