### PR TITLE
Remove unused packed decimal IL OpCode

### DIFF
--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -738,13 +738,6 @@ int32_t TR::DeadTreesElimination::process(TR::TreeTop *startTree, TR::TreeTop *e
             if (child->getReferenceCount() == 1)
                {
                safeToReplaceNode = true;
-#ifdef J9_PROJECT_SPECIFIC
-               if (child->getOpCode().isPackedExponentiation())
-                  {
-                  // pdexp has a possible message side effect in truncating or no significant digits left cases
-                  safeToReplaceNode = false;
-                  }
-#endif
                if (opCodeValue == TR::loadaddr)
                   treeTopCanBeEliminated = true;
                }

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -8383,9 +8383,6 @@ TR_TrivialDeadTreeRemoval::preProcessTreetop(TR::TreeTop *treeTop, List<TR::Tree
       if (firstChild->getReferenceCount() == 1)
          {
          if (!firstChild->getOpCode().hasSymbolReference() &&
-#ifdef J9_PROJECT_SPECIFIC
-             !firstChild->getOpCode().isPackedExponentiation() && // pdexp has a possible message side effect in truncating or no significant digits left cases
-#endif
              performTransformation(comp, "%sUnlink trivial %s (%p) of %s (%p) with refCount==1\n",
                 optDetails, treeTop->getNode()->getOpCode().getName(),treeTop->getNode(),firstChild->getOpCode().getName(),firstChild))
             {

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -565,7 +565,7 @@ bool isNZDoublePowerOfTwo(double value)
    }
 
 // Exponentiation operations must be sensitive to the signedness of the exponent (the base signedness does not matter)
-// If the exp operation itself is unsigned (for example from pduexp) then the exponent value is interpreted as an unsigned number.
+// If the exp operation itself is unsigned, then the exponent value is interpreted as an unsigned number.
 // This matters because otherwise (for example) an 8 bit exponent with the encoding 0xFF would be interpreted as base ** -1
 // instead of base ** 255
 bool isIntegralExponentInRange(TR::Node *parent, TR::Node *exponent, int64_t maxNegativeExponent, int64_t maxPositiveExponent, TR::Simplifier * s)

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1369,12 +1369,8 @@ const ValuePropagationPtr constraintHandlers[] =
 
    constrainChildren,           // TR::pdshrSetSign
    constrainChildren,           // TR::pdshlSetSign
-   constrainChildren,           // TR::pdshrPreserveSign
-   constrainChildren,           // TR::pdshlPreserveSign
    constrainChildren,           // TR::pdshlOverflow
-//#if defined(TR_TARGET_S390)
    constrainChildren,           // TR::pdchk
-//#endif
    constrainBCDToIntegral,      // TR::pd2i
    constrainChildren,           // TR::pd2iOverflow
    constrainBCDToIntegral,      // TR::pd2iu
@@ -1397,20 +1393,11 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,           // TR::pdcmpgt
    constrainChildren,           // TR::pdcmple
 
-   constrainChildren,           // TR::pdcheck
-   constrainChildren,           // TR::pdfix
-
    constrainChildren,           // TR::pdclean
-
-   constrainChildren,           // TR::pdexp
-   constrainChildren,           // TR::pduexp
-
    constrainChildren,           // TR::pdclear
    constrainChildren,           // TR::pdclearSetSign
 
    constrainChildren,           // TR::pdSetSign
-
-   constrainChildren,           // TR::pddivrem
 
    constrainChildren,           // TR::pdModifyPrecision
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -3463,8 +3463,6 @@ int32_t childTypes[] =
 
    TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdshrSetSign
    TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdshlSetSign
-   TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdshrPreserveSign
-   TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdshlPreserveSign
    TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdshlOverflow
    TR::PackedDecimal,                                        // TR::pdchk
 
@@ -3489,20 +3487,12 @@ int32_t childTypes[] =
    TR::PackedDecimal,                                        // TR::pdcmpge
    TR::PackedDecimal,                                        // TR::pdcmpgt
    TR::PackedDecimal,                                        // TR::pdcmple
-
-   TR::PackedDecimal,                                        // TR::pdcheck
-   TR::PackedDecimal,                                        // TR::pdfix
-
    TR::PackedDecimal,                                        // TR::pdclean
-   TR::PackedDecimal,                                        // TR::pdexp
-   TR::PackedDecimal,                                        // TR::pduexp
 
    TR::PackedDecimal,                                        // TR::pdclear
    TR::PackedDecimal,                                        // TR::pdclearSetSign
 
    TR::PackedDecimal | (TR::Int32<<16),                      // TR::pdSetSign
-
-   TR::PackedDecimal,                                        // TR::pddivrem
 
    TR::PackedDecimal,                                        // TR::pdModifyPrecision
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6308,11 +6308,7 @@ bool OMR::Z::CodeGenerator::nodeMayCauseException(TR::Node *node)
 #endif
       {
       TR::ILOpCode& opcode = node->getOpCode();
-      return opcode.isDiv() || opcode.isExponentiation() || opcode.isRem()
-#ifdef J9_PROJECT_SPECIFIC
-         || opcode.getOpCodeValue() == TR::pddivrem
-#endif
-         ;
+      return opcode.isDiv() || opcode.isExponentiation() || opcode.isRem();
       }
    }
 
@@ -6891,9 +6887,6 @@ bool OMR::Z::CodeGenerator::reliesOnAParticularSignEncoding(TR::Node *node)
       return false;
 
    if (op.isAnyBCDArithmetic())
-      return false;
-
-   if (op.getOpCodeValue() == TR::pddivrem)
       return false;
 
    if (op.isSimpleBCDClean())


### PR DESCRIPTION
Remove the following unused packed decimal opCode from the codebase:
pddivRem, pduexp, pdexp, pdfix, pdcheck, pdshlPreserveSign, and
pdshrPreserveSign.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>