### PR TITLE
Rename evacuate read barrier type

### DIFF
--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -66,6 +66,7 @@ typedef enum MM_GCPolicy {
 #define OMR_GC_READ_BARRIER_TYPE_NONE 0x1
 #define OMR_GC_READ_BARRIER_TYPE_ALWAYS 0x2
 #define OMR_GC_READ_BARRIER_TYPE_EVACUATE 0x3
+#define OMR_GC_READ_BARRIER_TYPE_RANGE_CHECK 0x3
 #define OMR_GC_READ_BARRIER_TYPE_COUNT 0x4
 
 typedef enum MM_GCWriteBarrierType {
@@ -85,6 +86,7 @@ typedef enum MM_GCReadBarrierType {
 	gc_modron_readbar_illegal = OMR_GC_READ_BARRIER_TYPE_ILLEGAL,
 	gc_modron_readbar_none = OMR_GC_READ_BARRIER_TYPE_NONE,
 	gc_modron_readbar_evacuate = OMR_GC_READ_BARRIER_TYPE_EVACUATE,
+	gc_modron_readbar_range_check = OMR_GC_READ_BARRIER_TYPE_RANGE_CHECK,
 	gc_modron_readbar_always = OMR_GC_READ_BARRIER_TYPE_ALWAYS,
 	gc_modron_readbar_count = OMR_GC_READ_BARRIER_TYPE_COUNT
 } MM_GCReadBarrierType;


### PR DESCRIPTION
Rename the barrier type to range check, which represents the trigger
criteria, rather then the action that barrier will perform. Evacuate is
a specific action performed by Concurrent Scavenger read barrier. Some
other GCs or profiling/debug tools could use the same read barrier
trigger but with its own action (that is not evacuate).

Temporarily keeping the old types, until downstream projects (OpenJ9)
are updated to use the new type.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>