### PR TITLE
Disable CGroup Calls in omrsysinfo for TPF

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -1511,6 +1511,7 @@ _cleanup:
 #define CGROUP_MEMORY_STAT_CACHE "cache"
 #define CGROUP_MEMORY_STAT_CACHE_SZ (sizeof(CGROUP_MEMORY_STAT_CACHE)-1)
 
+#if !defined(OMRZTPF)
 /**
  * Function collects memory usage statistics from the memory subsystem of the process's cgroup.
  *
@@ -1606,6 +1607,8 @@ _exit:
 
 	return rc;
 }
+
+#endif /* !defined(OMRZTPF) */
 
 /**
  * Function collects memory usage statistics on Linux platforms and returns the same.


### PR DESCRIPTION
A semi-recent update in the omrsysinfo segment added CGroup calls in the
retrieveLinuxCgroupMemoryStats function.  TPF currently doesn't support
CGroup calls and needs guard macros around such calls so that it can be
configured out during TPF builds.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>