### PR TITLE
 z/TPF OMR configuration update

### DIFF
--- a/glue/configure_includes/configure_linux_ztpf_390.mk
+++ b/glue/configure_includes/configure_linux_ztpf_390.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2017 IBM Corp. and others
+# Copyright (c) 2015, 2018 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,60 +20,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-# Detect 64-bit vs. 31-bit
-ifneq (,$(findstring -64,$(SPEC)))
-	TEMP_TARGET_DATASIZE:=64
-else
-	TEMP_TARGET_DATASIZE:=31
-endif
 
-ifeq (linux_ztpf_390-64_cmprssptrs_codecov, $(SPEC))
-  	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_COMPRESSED_POINTERS \
-		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
-		--enable-OMR_PORT_RUNTIME_INSTRUMENTATION \
-		--enable-OMR_THR_FORK_SUPPORT \
-		--enable-OMR_THR_THREE_TIER_LOCKING \
-		--enable-OMR_THR_YIELD_ALG \
-		--enable-OMR_GC_ARRAYLETS
-#    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
-#    --enable-OMR_RTTI
-endif
-
-ifeq (linux_ztpf_390-64_cmprssptrs, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_GC_COMPRESSED_POINTERS \
-		--enable-OMR_INTERP_COMPRESSED_OBJECT_HEADER \
-		--enable-OMR_INTERP_SMALL_MONITOR_SLOT \
-		--enable-OMR_PORT_RUNTIME_INSTRUMENTATION \
-		--enable-OMR_THR_FORK_SUPPORT \
-		--enable-OMR_THR_THREE_TIER_LOCKING \
-		--enable-OMR_THR_YIELD_ALG \
-		--enable-OMR_GC_ARRAYLETS
-#    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
-#    --enable-OMR_RTTI
-endif
-
-ifeq (linux_ztpf_390-64_codecov, $(SPEC))
-	CONFIGURE_ARGS += \
-		--enable-OMRTHREAD_LIB_UNIX \
-		--enable-OMR_ARCH_S390 \
-		--enable-OMR_ENV_DATA64 \
-		--enable-OMR_PORT_RUNTIME_INSTRUMENTATION \
-		--enable-OMR_THR_FORK_SUPPORT \
-		--enable-OMR_THR_THREE_TIER_LOCKING \
-		--enable-OMR_THR_YIELD_ALG \
-		--enable-OMR_GC_ARRAYLETS
-#    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
-#    --enable-OMR_RTTI
-endif
+TEMP_TARGET_DATASIZE:=64
 
 ifeq (linux_ztpf_390-64, $(SPEC))
 	CONFIGURE_ARGS += \
@@ -85,8 +33,6 @@ ifeq (linux_ztpf_390-64, $(SPEC))
 		--enable-OMR_THR_THREE_TIER_LOCKING \
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
-#    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
-#    --enable-OMR_RTTI
 endif
 
 ifeq (linux_ztpf_390, $(SPEC))
@@ -98,8 +44,6 @@ ifeq (linux_ztpf_390, $(SPEC))
 		--enable-OMR_THR_THREE_TIER_LOCKING \
 		--enable-OMR_THR_YIELD_ALG \
 		--enable-OMR_GC_ARRAYLETS
-#    --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS
-#    --enable-OMR_RTTI
 endif
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.so arlibext=.a objext=.o
@@ -109,7 +53,6 @@ CONFIGURE_ARGS += --build=s390x-ibm-linux-gnu
 CONFIGURE_ARGS += 'AS=as'
 CONFIGURE_ARGS += 'CC=tpf-gcc'
 CONFIGURE_ARGS += 'CXX=tpf-g++'
-#CONFIGURE_ARGS += 'CPP=cpp -E -P'
 CONFIGURE_ARGS += 'CCLINKEXE=tpf-gcc'
 CONFIGURE_ARGS += 'CCLINKSHARED=tpf-gcc'
 CONFIGURE_ARGS += 'CXXLINKEXE=tpf-gcc'
@@ -118,4 +61,10 @@ CONFIGURE_ARGS += 'AR=ar'
 CONFIGURE_ARGS += 'OMR_HOST_OS=linux_ztpf'
 CONFIGURE_ARGS += 'OMR_HOST_ARCH=s390'
 CONFIGURE_ARGS += 'OMR_TARGET_DATASIZE=$(TEMP_TARGET_DATASIZE)'
+CONFIGURE_ARGS += 'OMR_BUILD_DATASIZE=$(TEMP_TARGET_DATASIZE)'
+CONFIGURE_ARGS += 'OMR_ENV_DATA64=1'
 CONFIGURE_ARGS += 'OMR_TOOLCHAIN=gcc'
+CONFIGURE_ARGS += 'OMR_BUILD_TOOLCHAIN=gcc'
+CONFIGURE_ARGS += 'OMR_TOOLS_CC=gcc'
+CONFIGURE_ARGS += 'OMR_TOOLS_CXX=g++'
+


### PR DESCRIPTION
Pull Request 2406 changed the way platforms that require
cross-configuration are configured. New directives need to be specified
to control OMR Tool build options such as type of compiler.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>