### PR TITLE
AArch64: Fix generation of instructions with zero register

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -165,6 +165,83 @@ void TR::ARM64Trg1Src2Instruction::assignRegisters(TR_RegisterKinds kindToBeAssi
    setSource2Register(assignedSource2Register);
    }
 
+// TR::ARM64Trg1Src3Instruction:: member functions
+
+bool TR::ARM64Trg1Src3Instruction::refsRegister(TR::Register *reg)
+   {
+   return (reg == getTargetRegister() ||
+           reg == getSource1Register() ||
+           reg == getSource2Register() ||
+           reg == getSource3Register());
+   }
+
+bool TR::ARM64Trg1Src3Instruction::usesRegister(TR::Register *reg)
+   {
+   return (reg == getSource1Register() || reg == getSource2Register() || reg == getSource3Register());
+   }
+
+bool TR::ARM64Trg1Src3Instruction::defsRegister(TR::Register *reg)
+   {
+   return (reg == getTargetRegister());
+   }
+
+bool TR::ARM64Trg1Src3Instruction::defsRealRegister(TR::Register *reg)
+   {
+   return (reg == getTargetRegister()->getAssignedRegister());
+   }
+
+void TR::ARM64Trg1Src3Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
+   {
+   TR::Machine *machine = cg()->machine();
+   TR::Register *target1Virtual = getTargetRegister();
+   TR::Register *source1Virtual = getSource1Register();
+   TR::Register *source2Virtual = getSource2Register();
+   TR::Register *source3Virtual = getSource3Register();
+
+   if (getDependencyConditions())
+      getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
+
+   source2Virtual->block();
+   source1Virtual->block();
+   target1Virtual->block();
+   TR::RealRegister *assignedSource3Register = machine->assignOneRegister(this, source3Virtual);
+   target1Virtual->unblock();
+   source1Virtual->unblock();
+   source2Virtual->unblock();
+
+   source3Virtual->block();
+   source1Virtual->block();
+   target1Virtual->block();
+   TR::RealRegister *assignedSource2Register = machine->assignOneRegister(this, source2Virtual);
+   target1Virtual->unblock();
+   source1Virtual->unblock();
+   source3Virtual->unblock();
+
+   source3Virtual->block();
+   source2Virtual->block();
+   target1Virtual->block();
+   TR::RealRegister *assignedSource1Register = machine->assignOneRegister(this, source1Virtual);
+   target1Virtual->unblock();
+   source2Virtual->unblock();
+   source3Virtual->unblock();
+
+   source3Virtual->block();
+   source2Virtual->block();
+   source1Virtual->block();
+   TR::RealRegister *assignedTarget1Register = machine->assignOneRegister(this, target1Virtual);
+   source1Virtual->unblock();
+   source2Virtual->unblock();
+   source3Virtual->unblock();
+
+   if (getDependencyConditions())
+      getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
+
+   setTargetRegister(assignedTarget1Register);
+   setSource1Register(assignedSource1Register);
+   setSource2Register(assignedSource2Register);
+   setSource3Register(assignedSource3Register);
+   }
+
 // TR::ARM64MemSrc1Instruction:: member functions
 
 bool TR::ARM64MemSrc1Instruction::refsRegister(TR::Register *reg)

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -858,6 +858,38 @@ class ARM64Trg1Instruction : public TR::Instruction
       useRegister(treg);
       }
 
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] cond : register dependency conditions
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                        TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cond, cg), _target1Register(treg)
+      {
+      useRegister(treg);
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] cond : register dependency conditions
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
+                        TR::RegisterDependencyConditions *cond, TR::Instruction *precedingInstruction,
+                        TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cond, precedingInstruction, cg), _target1Register(treg)
+      {
+      useRegister(treg);
+      }
+
    /**
     * @brief Gets instruction kind
     * @return instruction kind
@@ -1108,7 +1140,6 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
       : ARM64Trg1Instruction(op, node, treg, cg), _source1Register(sreg)
       {
       useRegister(sreg);
-      setDependencyConditions(NULL);
       }
 
    /*
@@ -1126,7 +1157,6 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
       : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _source1Register(sreg)
       {
       useRegister(sreg);
-      setDependencyConditions(NULL);
       }
 
    /*
@@ -1140,10 +1170,9 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
     */
    ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
                              TR::Register *sreg, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg)
-      : ARM64Trg1Instruction(op, node, treg, cg), _source1Register(sreg)
+      : ARM64Trg1Instruction(op, node, treg, cond, cg), _source1Register(sreg)
       {
       useRegister(sreg);
-      setDependencyConditions(cond);
       }
 
    /*
@@ -1159,10 +1188,9 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
    ARM64Trg1Src1Instruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::Register *treg,
                              TR::Register *sreg, TR::RegisterDependencyConditions *cond,
                              TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _source1Register(sreg)
+      : ARM64Trg1Instruction(op, node, treg, cond, precedingInstruction, cg), _source1Register(sreg)
       {
       useRegister(sreg);
-      setDependencyConditions(cond);
       }
 
    /**
@@ -1847,6 +1875,36 @@ class ARM64Trg1Src3Instruction : public ARM64Trg1Src2Instruction
       TR::RealRegister *source3 = toRealRegister(_source3Register);
       source3->setRegisterFieldRA(instruction);
       }
+
+   /**
+    * @brief Answers whether this instruction references the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction references the virtual register
+    */
+   virtual bool refsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction uses the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction uses the virtual register
+    */
+   virtual bool usesRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction defines the virtual register
+    */
+   virtual bool defsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given real register
+    * @param[in] reg : real register
+    * @return true when the instruction defines the real register
+    */
+   virtual bool defsRealRegister(TR::Register *reg);
+   /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
 
    /**
     * @brief Generates binary encoding of the instruction

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -278,9 +278,14 @@ static TR::Instruction *generateSrc1ImmInstruction(TR::CodeGenerator *cg, TR::In
    TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
    addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
 
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, zeroReg, sreg, imm, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, zeroReg, sreg, imm, cond, cg);
+   TR::Instruction *instr =
+      (preced) ?
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, zeroReg, sreg, imm, cond, preced, cg) :
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src1ImmInstruction(op, node, zeroReg, sreg, imm, cond, cg);
+
+   cg->stopUsingRegister(zeroReg);
+
+   return instr;
    }
 
 TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
@@ -311,9 +316,14 @@ static TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstO
    TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
    addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
 
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, zeroReg, s1reg, s2reg, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, zeroReg, s1reg, s2reg, cond, cg);
+   TR::Instruction *instr =
+      (preced) ?
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, zeroReg, s1reg, s2reg, cond, preced, cg) :
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, zeroReg, s1reg, s2reg, cond, cg);
+
+   cg->stopUsingRegister(zeroReg);
+
+   return instr;
    }
 
 TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node,
@@ -344,15 +354,21 @@ static TR::Instruction *generateTrg1ZeroSrc1Instruction(TR::CodeGenerator *cg, T
    TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
    addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
 
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, zeroReg, sreg, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, zeroReg, sreg, cond, cg);
+   TR::Instruction *instr =
+      (preced) ?
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, zeroReg, sreg, cond, preced, cg) :
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src2Instruction(op, node, treg, zeroReg, sreg, cond, cg);
+
+   cg->stopUsingRegister(zeroReg);
+
+   return instr;
    }
 
 TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node,
    TR::Register *treg, TR::Register *sreg, TR::Instruction *preced)
    {
    /* Alias of ORR instruction */
+   TR_ASSERT(node->getDataType().isIntegral(), "Only GPRs are allowed.");
 
    bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::orrx : TR::InstOpCode::orrw;
@@ -384,9 +400,14 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node,
    TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
    addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
 
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, cg);
+   TR::Instruction *instr =
+      (preced) ?
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, preced, cg) :
+      new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, cg);
+
+   cg->stopUsingRegister(zeroReg);
+
+   return instr;
    }
 
 TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node,


### PR DESCRIPTION
This commit fixes the problem in register assignment for zero register.

Signed-off-by: knn-k <konno@jp.ibm.com>