### PR TITLE
Remove unnecessary cast

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -4509,7 +4509,7 @@ omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, st
 	}
 	if (state->multiLineCounter < subsystemMetricMapElement->metricElementsCount) {
 		for (i = 0; i < state->multiLineCounter; i++) {
-			(OMRCgroupMetricInfoElement *)currentElement++;
+			currentElement++;
 		}
 		char *tempBuff = portLibrary->mem_allocate_memory(portLibrary, 1024, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 		strcpy(tempBuff, state->fileContent);


### PR DESCRIPTION
The cast serves no purpose and causes a compile error on some
compilers.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>