### PR TITLE
Remove obsolete RB type

### DIFF
--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -65,7 +65,6 @@ typedef enum MM_GCPolicy {
 #define OMR_GC_READ_BARRIER_TYPE_ILLEGAL 0x0
 #define OMR_GC_READ_BARRIER_TYPE_NONE 0x1
 #define OMR_GC_READ_BARRIER_TYPE_ALWAYS 0x2
-#define OMR_GC_READ_BARRIER_TYPE_EVACUATE 0x3
 #define OMR_GC_READ_BARRIER_TYPE_RANGE_CHECK 0x3
 #define OMR_GC_READ_BARRIER_TYPE_COUNT 0x4
 
@@ -85,7 +84,6 @@ typedef enum MM_GCWriteBarrierType {
 typedef enum MM_GCReadBarrierType {
 	gc_modron_readbar_illegal = OMR_GC_READ_BARRIER_TYPE_ILLEGAL,
 	gc_modron_readbar_none = OMR_GC_READ_BARRIER_TYPE_NONE,
-	gc_modron_readbar_evacuate = OMR_GC_READ_BARRIER_TYPE_EVACUATE,
 	gc_modron_readbar_range_check = OMR_GC_READ_BARRIER_TYPE_RANGE_CHECK,
 	gc_modron_readbar_always = OMR_GC_READ_BARRIER_TYPE_ALWAYS,
 	gc_modron_readbar_count = OMR_GC_READ_BARRIER_TYPE_COUNT


### PR DESCRIPTION
Now that Evacuate RB type is not used any more, remove it.

Related changes:
https://github.com/eclipse/omr/pull/3132
https://github.com/eclipse/openj9/pull/3507

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>