### PR TITLE
Rename getIA32*Instruction to getX86*Instruction

### DIFF
--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -2625,7 +2625,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerDivOrRemEvaluator(TR::Node *node, 
                                                       divisionLabel,
                                                       node->getOpCode(),
                                                       node->getType(),
-                                                      divideInstr->getIA32RegInstruction()->getIA32RegRegInstruction(),
+                                                      divideInstr->getX86RegInstruction()->getIA32RegRegInstruction(),
                                                       cg));
          }
 

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -180,7 +180,7 @@ bool isConditionCodeSetForCompareToZero(TR::Node *node, bool justTestZeroFlag)
         prevInstr;
         prevInstr = prevInstr->getPrev())
       {
-      prevRegInstr = prevInstr->getIA32RegInstruction();
+      prevRegInstr = prevInstr->getX86RegInstruction();
 
       // The register must be equal and the node size must be equal in order to
       // insure the instruction is setting the condition code based on the

--- a/compiler/x/codegen/OMRInstruction.hpp
+++ b/compiler/x/codegen/OMRInstruction.hpp
@@ -143,15 +143,15 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    void aboutToAssignRegDeps(TR_UpperHalfRefConditions usesUpperHalf=TR_ifUses64bitSourceOrTarget, TR_UpperHalfRefConditions defsUpperHalf=TR_never);
 
-   virtual TR::X86RegInstruction *getIA32RegInstruction() { return NULL; }
+   virtual TR::X86RegInstruction *getX86RegInstruction() { return NULL; }
 
-   virtual TR::X86LabelInstruction *getIA32LabelInstruction() { return NULL; }
+   virtual TR::X86LabelInstruction *getX86LabelInstruction() { return NULL; }
 
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
    // The following safe virtual downcast method is used under debug only
    // for assertion checking.
    //
-   virtual TR::X86ImmInstruction *getIA32ImmInstruction() { return NULL; }
+   virtual TR::X86ImmInstruction *getX86ImmInstruction() { return NULL; }
 
    virtual uint32_t getNumOperandReferencedGPRegisters() { return 0; }
    virtual uint32_t getNumOperandReferencedFPRegisters() { return 0; }

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -1175,7 +1175,7 @@ void TR_X86RegisterDependencyGroup::assignFPRegisters(TR::Instruction   *prevIns
       TR::X86LabelInstruction  *labelInstruction = NULL;
 
       if (prevInstruction->getNext())
-         labelInstruction = prevInstruction->getNext()->getIA32LabelInstruction();
+         labelInstruction = prevInstruction->getNext()->getX86LabelInstruction();
 
       if (labelInstruction &&
           labelInstruction->getNeedToClearFPStack())

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -209,7 +209,7 @@ TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction                    
       sym->setDirectlyTargeted();
    }
 
-TR::X86LabelInstruction  *TR::X86LabelInstruction::getIA32LabelInstruction()
+TR::X86LabelInstruction  *TR::X86LabelInstruction::getX86LabelInstruction()
    {
    return this;
    }
@@ -483,7 +483,7 @@ TR::X86ImmInstruction::X86ImmInstruction(TR::Instruction                     *pr
 // The following safe virtual downcast method is only used in an assertion
 // check within "toIA32ImmInstruction"
 //
-TR::X86ImmInstruction  *TR::X86ImmInstruction::getIA32ImmInstruction()
+TR::X86ImmInstruction  *TR::X86ImmInstruction::getX86ImmInstruction()
    {
    return this;
    }
@@ -648,7 +648,7 @@ TR::X86RegInstruction::X86RegInstruction(TR::Instruction                      *p
    getOpCode().trackUpperBitsOnReg(reg, cg);
    }
 
-TR::X86RegInstruction  *TR::X86RegInstruction::getIA32RegInstruction()
+TR::X86RegInstruction  *TR::X86RegInstruction::getX86RegInstruction()
    {
    return this;
    }

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -386,7 +386,7 @@ class X86LabelInstruction : public TR::Instruction
 
    virtual void addMetaDataForCodeAddress(uint8_t *cursor);
 
-   virtual TR::X86LabelInstruction  *getIA32LabelInstruction();
+   virtual TR::X86LabelInstruction  *getX86LabelInstruction();
 
    void assignOutlinedInstructions(TR_RegisterKinds kindsToBeAssigned, TR::X86LabelInstruction *labelInstruction);
    void addPostDepsToOutlinedInstructionsBranch();
@@ -662,7 +662,7 @@ class X86ImmInstruction : public TR::Instruction
    // The following safe virtual downcast method is used under debug only
    // for assertion checking.
    //
-   virtual X86ImmInstruction  *getIA32ImmInstruction();
+   virtual X86ImmInstruction  *getX86ImmInstruction();
 #endif
 
    virtual void adjustVFPState(TR_VFPState *state, TR::CodeGenerator *cg){ adjustVFPStateForCall(state, _adjustsFramePointerBy, cg); }
@@ -866,7 +866,7 @@ class X86RegInstruction : public TR::Instruction
 
    virtual Kind getKind() { return IsReg; }
 
-   virtual TR::X86RegInstruction  *getIA32RegInstruction();
+   virtual TR::X86RegInstruction  *getX86RegInstruction();
 
    virtual TR::X86RegRegInstruction  *getIA32RegRegInstruction() {return NULL;}
 
@@ -2953,7 +2953,7 @@ class X86VFPCallCleanupInstruction : public TR::Instruction
 
 inline TR::X86ImmInstruction  * toIA32ImmInstruction(TR::Instruction *i)
    {
-   TR_ASSERT(i->getIA32ImmInstruction() != NULL,
+   TR_ASSERT(i->getX86ImmInstruction() != NULL,
           "trying to downcast to an IA32ImmInstruction");
    return (TR::X86ImmInstruction  *)i;
    }


### PR DESCRIPTION
This patch renames the methods getIA32RegInstruction(), getIA32LabelInstruction(),
getIA32ImmInstruction() to getX86RegInstruction(), getX86LabelInstruction(),
getX86ImmInstruction() as requested in issue #3112 since they are used for both
32-bit and 64-bit.

Closes: #3112
Signed-off-by: Muzaffar Auhammud <muzaffar@cyberstorm.mu>