### PR TITLE
Enable system cpu info for z/os

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -520,6 +520,7 @@ typedef struct J9SysinfoCPUTime {
 	int64_t timestamp; /* time in nanoseconds from a fixed but arbitrary point in time */
 	int64_t cpuTime; /* cumulative CPU utilization (sum of system and user time in nanoseconds) of all CPUs on the system. */
 	int32_t numberOfCpus; /* number of CPUs as reported by the operating system */
+	int32_t cpuLoad; /* CPU utilization % of all processors on the system including gcp and ziips (between 0 and 100) */
 } J9SysinfoCPUTime;
 
 /* Key memory categories are copied here for DDR access */

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -515,9 +515,10 @@ omrsysinfo_get_load_average(struct OMRPortLibrary *portLibrary, struct J9PortSys
  * The cpuTime and timestamp values have no absolute significance: they should be used only to compute
  * differences from previous values.
  * On an N-processor  system, cpuTimeStats.cpuTime may increase up to N times faster than real time.
+ * On z/OS use cpuLoad to hold real cpu for the system. Other platform should default to cpuLoad -1.
  *
  * @param[in] OMRPortLibrary portLibrary The port library.
- * @param[out] J9SysinfoCPUTime cpuTime  struct to receive the CPU time and a timestamp
+ * @param[out] J9SysinfoCPUTime cpuTime  struct to receive the CPU time or cpuLoad (z/os) and a timestamp
  *
  * @return 0 on success, negative portable error code on failure.
  *

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -368,6 +368,31 @@ static int32_t retrieveAIXMemoryStats(struct OMRPortLibrary *portLibrary, struct
 static int32_t retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 #endif
 
+#if defined(J9ZOS390)
+#define CVTBASE  (*(struct cvt * __ptr32 * __ptr32)16)
+	struct cvt {
+		char cvtxx1 [604];
+		struct rmct *  __ptr32 cvtrmct;
+	};
+	struct rmct {
+		char rmctxx1[4];
+		struct iracct *  __ptr32 rmctcct;
+	};
+	struct iracct {
+		char cctxx1 [102];
+		short ccvutilp;    /* system CPU utilization */
+		char cctxx2 [16];
+		short ccvifact;    /* number of online IFAs (zAAPs) */
+		short ccvutila;    /* processor utilization */
+		char cctxx3 [4];
+		short ccvsupct;    /* number of online SUPs (zIIPs) */
+		char cctxx4 [14];
+		short ccvutili;    /* IFA (zAAP) utilization */
+		short ccvutils;    /* SUP (zIIP) utilization */
+	};      
+	struct iracct *cctptr;
+#endif    
+
 /**
  * @internal
  * Determines the proper portable error code to return given a native error code
@@ -2368,12 +2393,13 @@ intptr_t
 omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9SysinfoCPUTime *cpuTime)
 {
 	intptr_t status = OMRPORT_ERROR_SYSINFO_OPFAILED;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) || defined(J9ZOS390)
 	/* omrtime_nano_time() gives monotonically increasing times as against omrtime_hires_clock() that
 	 * returns times that can (and does) decrease. Use this to compute timestamps.
 	 */
 	uint64_t preTimestamp = portLibrary->time_nano_time(portLibrary); /* ticks */
 	uint64_t postTimestamp; /* ticks */
+	cpuTime->cpuLoad = -1; /* initialize cpuLoad */ 
 
 #if defined(LINUX)
 	intptr_t bytesRead = -1;
@@ -2456,6 +2482,13 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	cpuTime->numberOfCpus = stats.ncpus; /* get the actual number of CPUs against which the time is reported */
 	cpuTime->cpuTime = (stats.user + stats.sys) * NS_PER_CPU_TICK;
 	status = 0;
+	
+#elif defined(J9ZOS390) /* ZOS */
+	cctptr = CVTBASE->cvtrmct->rmctcct;
+	cpuTime->numberOfCpus = portLibrary->sysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_ONLINE);
+	cpuTime->cpuLoad = cctptr->ccvutilp;
+	cpuTime->cpuTime = -1;
+	status = 0;
 #endif
 	postTimestamp = portLibrary->time_nano_time(portLibrary);
 
@@ -2466,7 +2499,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	/* Use the average of the timestamps before and after reading processor times to reduce bias. */
 	cpuTime->timestamp = (preTimestamp + postTimestamp) / 2;
 	return status;
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) */
+#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) || defined(J9ZOS390) */
 	/* Support on z/OS being temporarily removed to avoid wrong CPU stats being passed. */
 	return OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED;
 #endif

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -997,6 +997,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	uint64_t idleTime = 0;
 	uint64_t kernelActiveTime = 0;
 	uint64_t userTime = 0;
+	cpuTime->cpuLoad = -1;
 
 	/*
 	 * GetSystemTimes returns the sum of CPU times across all CPUs


### PR DESCRIPTION
Add field cpuLoad to hold % info from z/os. On z/os the query returns parentage and not time.
CpuLoad is the % value as int between 0 and 100.
Using cvt and SRM (system resource manager control) can access info about cpu utilization of the system. This includes both gcp and ziips.
It is returned as % (between 0 and 100).
Only zos make use of cpuLoad. Other platforms continue to provide time.
This change is used in openj9 change (separate PR) where the cpuLoad info is used to get the return value for systemGetCpuLoad mbean. 
To test this functionality I have run :
https://hyc-runtimes-jenkins.swg-devops.com/job/jvm.29.personal/4898/
And manually ran _testCpuUtilization_testSingleCpuLoadObject and _testCpuUtilization_testMxBean from JLM_Tests on xa,xz31/64 and mz31/64.
Also ran HC (enabling cpu info for zos) on those platform and inspected HC cpu info. 