### PR TITLE
Add CODEOWNERS file for automated review requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,58 @@
+###############################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+# Global project leads/owners
+* @charliegracie @mstoodle
+
+# Build / Configure and CI
+*.mk @charliegracie
+*.yml @charliegracie
+
+# CMake
+*.cmake @youngar @charliegracie
+/cmake/ @youngar @charliegracie
+**/CMakeLists.txt @youngar @charliegracie
+
+# GC
+/gc/ @charliegracie @youngar
+/glue/ @charliegracie @youngar
+
+# Compiler
+/compiler/ @0xdaryl @mstoodle
+/compiler/optimizer/ @vijaysun-omr
+/compiler/il/ @vijaysun-omr @Leonardo2718
+/compiler/z/ @fjeremic
+
+# JitBuilder
+/jitbuilder/ @mstoodle @charliegracie @Leonardo2718
+/compiler/ilgen @mstoodle @Leonardo2718
+
+# Port Library
+/port/ @charliegracie @youngar
+
+# Thread Library
+/thread/ @charliegracie
+
+# Tril and Testing
+/test/tril/ @Leonardo2718 @fjeremic @0xdaryl
+/test/compilertriltest/ @Leonardo2718 @fjeremic @0xdaryl
+/test/jitbuildertest/ @mstoodle @charliegracie @Leonardo2718


### PR DESCRIPTION
As per the discussion in [1] and the subsequent discussion within the
PR itself we add a CODEOWNERS file at the top-level and specify the
code owners for particular areas within the Eclipse OMR project.

The owners of the corresponding areas will automatically get review
requests when a PR is opened touching files within their respective
area of expertise.

@charliegracie and @mstoodle are identified as global catch-all code
owners for general contributions to the repository.

[skip ci]

[1] https://eclipse-omr.slack.com/archives/CCQ8B4B39/p1541599655022400

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>