### PR TITLE
fix error propagation from init_thread_library in omrthread_attach_ex

### DIFF
--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -1183,11 +1183,12 @@ omrthread_attach(omrthread_t *handle)
 intptr_t
 omrthread_attach_ex(omrthread_t *handle, omrthread_attr_t *attr)
 {
-	intptr_t retVal = J9THREAD_SUCCESS;
+	intptr_t retVal = J9THREAD_ERR;
 	omrthread_t thread;
 	omrthread_library_t lib;
 
 	if (init_thread_library()) {
+		retVal = J9THREAD_ERR;
 		goto cleanup0;
 	}
 


### PR DESCRIPTION
Without this change, I get a segfault dereferencing a NULL pointer retrieved from a TLS entry that was never set. With this change I get:

Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
