### PR TITLE
Refactor recognition of standard types

### DIFF
--- a/ddr/include/ddr/error.hpp
+++ b/ddr/include/ddr/error.hpp
@@ -22,7 +22,8 @@
  #if !defined(DDR_ERROR_HPP)
  #define DDR_ERROR_HPP
 
-#include <ddr/config.hpp>
+#include "ddr/config.hpp"
+
 #include <stdio.h>
 
 #define ERRMSG(...) do { \

--- a/ddr/include/ddr/ir/Type.hpp
+++ b/ddr/include/ddr/ir/Type.hpp
@@ -22,13 +22,11 @@
 #ifndef TYPE_HPP
 #define TYPE_HPP
 
-#include "ddr/blobgen/genBlob.hpp"
-#include "ddr/ir/Symbol_IR.hpp"
 #include "ddr/ir/TypeVisitor.hpp"
-#include "ddr/scanner/Scanner.hpp"
 #include "ddr/std/string.hpp"
 
 #include <set>
+#include <vector>
 
 using std::set;
 using std::string;
@@ -39,6 +37,7 @@ class ClassType;
 class EnumUDT;
 class Macro;
 class NamespaceUDT;
+class Symbol_IR;
 class TypedefUDT;
 class UDT;
 class UnionUDT;
@@ -47,6 +46,8 @@ struct FieldOverride;
 class Type
 {
 public:
+	static bool isStandardType(const char *type, size_t typeLen, bool *isSigned, size_t *bitWidth);
+
 	bool _blacklisted;
 	bool _opaque;
 	string _name;

--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -270,8 +270,8 @@ JavaBlobGenerator::genBinaryBlob(OMRPortLibrary *portLibrary, Symbol_IR *ir, con
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
 	/* iterate ir:
-	 *  - count structs - update blob header
-	 *  - build string hash table
+	 * - count structs - update blob header
+	 * - build string hash table
 	 */
 	DDR_RC rc = countStructsAndStrings(ir);
 
@@ -342,8 +342,8 @@ JavaBlobGenerator::genBinaryBlob(OMRPortLibrary *portLibrary, Symbol_IR *ir, con
 }
 
 /* iterate ir:
- *  - count structs - update blob header
- *  - build string hash table
+ * - count structs - update blob header
+ * - build string hash table
  */
 DDR_RC
 JavaBlobGenerator::countStructsAndStrings(Symbol_IR *ir)
@@ -829,12 +829,24 @@ BlobFieldVisitor::visitTypedef(TypedefUDT *type) const
 		*_typePrefix += "void";
 	} else {
 		string prefix = opaqueType->getSymbolKindName();
+		string fullName = opaqueType->getFullName();
 
 		/* prefix "union" should not be included */
 		if (prefix.empty() || ("union" == prefix)) {
-			*_typePrefix += opaqueType->getFullName();
+			bool isSigned = false;
+			size_t bitWidth = 0;
+
+			if (Type::isStandardType(fullName.c_str(), (size_t)fullName.length(), &isSigned, &bitWidth)) {
+				stringstream newType;
+
+				newType << (isSigned ? "I" : "U") << bitWidth;
+
+				*_typePrefix += newType.str();
+			} else {
+				*_typePrefix += fullName;
+			}
 		} else {
-			*_typePrefix += prefix + " " + opaqueType->getFullName();
+			*_typePrefix += prefix + " " + fullName;
 		}
 	}
 

--- a/ddr/lib/ddr-ir/ClassType.cpp
+++ b/ddr/lib/ddr-ir/ClassType.cpp
@@ -21,6 +21,8 @@
 
 #include "ddr/ir/ClassType.hpp"
 
+#include "ddr/ir/Symbol_IR.hpp"
+
 ClassType::ClassType(size_t size, unsigned int lineNumber)
 	: NamespaceUDT(lineNumber)
 	, _isComplete(false)

--- a/ddr/lib/ddr-ir/EnumUDT.cpp
+++ b/ddr/lib/ddr-ir/EnumUDT.cpp
@@ -21,6 +21,8 @@
 
 #include "ddr/ir/EnumUDT.hpp"
 
+#include "ddr/ir/EnumMember.hpp"
+
 EnumUDT::EnumUDT(unsigned int lineNumber)
 	: UDT(4, lineNumber)
 	, _enumMembers()

--- a/ddr/lib/ddr-ir/NamespaceUDT.cpp
+++ b/ddr/lib/ddr-ir/NamespaceUDT.cpp
@@ -21,6 +21,8 @@
 
 #include "ddr/ir/NamespaceUDT.hpp"
 
+#include "ddr/ir/Symbol_IR.hpp"
+
 NamespaceUDT::NamespaceUDT(unsigned int lineNumber)
 	: UDT(0, lineNumber)
 	, _subUDTs()

--- a/ddr/lib/ddr-ir/TypePrinter.cpp
+++ b/ddr/lib/ddr-ir/TypePrinter.cpp
@@ -23,7 +23,7 @@
 
 #include "ddr/ir/ClassUDT.hpp"
 #include "ddr/ir/EnumUDT.hpp"
-#include "ddr/ir/Field.hpp"
+#include "ddr/ir/Symbol_IR.hpp"
 #include "ddr/ir/TypedefUDT.hpp"
 #include "ddr/ir/UnionUDT.hpp"
 

--- a/ddr/lib/ddr-ir/UDT.cpp
+++ b/ddr/lib/ddr-ir/UDT.cpp
@@ -19,9 +19,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "ddr/config.hpp"
 #include "ddr/ir/UDT.hpp"
+
 #include "ddr/ir/NamespaceUDT.hpp"
+#include "ddr/ir/Symbol_IR.hpp"
 
 UDT::UDT(size_t size, unsigned int lineNumber)
 	: Type(size)

--- a/ddr/lib/ddr-macros/MacroTool.cpp
+++ b/ddr/lib/ddr-macros/MacroTool.cpp
@@ -22,7 +22,7 @@
 #include "ddr/macros/MacroTool.hpp"
 
 #include "ddr/ir/NamespaceUDT.hpp"
-#include "ddr/std/unordered_map.hpp"
+#include "ddr/ir/Symbol_IR.hpp"
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Types names in the blob and the superset should be consistent. Previously, `unsigned short int` would appear in the blob while the superset would say `U16`.

The code from `Macro.cpp` has moved to `Type.cpp` and has been improved to handle `const` and `volatile`.

Also some minor cleanup:
* remove unnecessary #includes from header files
* break #include cycle involving Symbol_IR.hpp and Type.hpp
* add #includes to *.cpp files as needed