### PR TITLE
Call generateCatchBlockBBStartPrologue in ARM BBStartEvaluator

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1362,8 +1362,10 @@ TR::Register *OMR::ARM::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
    TR::Node * fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
    TR::Instruction * fence = generateAdminInstruction(cg, ARMOp_fence, node, deps, fenceNode);
 
-   if (block->isCatchBlock() && comp->getOption(TR_FullSpeedDebug))
-      fence->setNeedsGCMap(); // a catch entry is a gc point in FSD mode
+   if (block->isCatchBlock())
+      {
+      cg->generateCatchBlockBBStartPrologue(node, fence);
+      }
 
    return NULL;
    }


### PR DESCRIPTION
We need to call the common code generator API in the BBStartEvaluator
on ARM as downstream projects may choose to override behavior of what
happens in catch blocks.

This synchronizes all the platforms in terms of catch block handling.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>