### PR TITLE
WIP: Rename GC Mode to Write Barrier Kind [Phase 1/2]

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1890,25 +1890,30 @@ public:
    static bool createDebug();
    static TR_Debug * findOrCreateDebug();
 
-   TR_WriteBarrierKind getGcMode()           { return _gcMode; }
+   /**   \brief Returns the type of write barriers
+   */
+   TR_WriteBarrierKind getWriteBarrierKind() { return _writeBarrierKind; }
+   TR_WriteBarrierKind getGcMode()           { return _writeBarrierKind; } // DEPRECATED
    uintptr_t           getGcCardSize()       { return _gcCardSize; }
    uintptr_t           getHeapBase()         { return _heapBase; }
    uintptr_t           getHeapTop()         { return _heapTop; }
 
-   bool generateWriteBarriers() { return _gcMode != TR_WrtbarNone; }
-   bool alwaysCallWriteBarrier() { return _gcMode == TR_WrtbarAlways; }
-   bool gcIsUsingConcurrentMark()
-      {
-      return    _gcMode == TR_WrtbarCardMark
-             || _gcMode == TR_WrtbarCardMarkAndOldCheck
-             || _gcMode == TR_WrtbarCardMarkIncremental;
-      }
+   bool generateWriteBarriers();
+   bool alwaysCallWriteBarrier();
+   bool gcIsUsingConcurrentMark();
    bool needWriteBarriers();
 
-   void setGcMode(TR_WriteBarrierKind g) { _gcMode = g; }
-   void setGcCardSize(uintptr_t g)       { _gcCardSize = g; }
-   void setHeapBase(uintptr_t g)         { _heapBase = g; }
-   void setHeapTop(uintptr_t g)          { _heapTop = g; }
+   /**
+   * \brief Set the type of write barriers
+   *
+   * \param [in] g The type of write barriers
+   *
+   */
+   void setWriteBarrierKind(TR_WriteBarrierKind g) { _writeBarrierKind = g; }
+   void setGcMode(TR_WriteBarrierKind g)           { _writeBarrierKind = g; } // DEPRECATED
+   void setGcCardSize(uintptr_t g)                 { _gcCardSize = g; }
+   void setHeapBase(uintptr_t g)                   { _heapBase = g; }
+   void setHeapTop(uintptr_t g)                    { _heapTop = g; }
 
    void setIsVariableHeapBaseForBarrierRange0(uintptr_t b) { _isVariableHeapBaseForBarrierRange0 = b ? true : false; }
    bool isVariableHeapBaseForBarrierRange0() { return _isVariableHeapBaseForBarrierRange0; }
@@ -2311,7 +2316,7 @@ protected:
    TR::SimpleRegex *            _memUsage;
    TR::SimpleRegex *            _classesWithFolableFinalFields;
    TR::SimpleRegex *            _disabledIdiomPatterns;
-   TR_WriteBarrierKind         _gcMode;
+   TR_WriteBarrierKind         _writeBarrierKind;
    uintptr_t                   _gcCardSize;
    uintptr_t                   _heapBase;
    uintptr_t                   _heapTop;

--- a/compiler/control/OMROptions_inlines.hpp
+++ b/compiler/control/OMROptions_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,9 +88,29 @@ OMR::Options::getNumLimitedGRARegsWithheld()
       }
 
 inline bool
+OMR::Options::generateWriteBarriers()
+   {
+   return self()->getWriteBarrierKind() != TR_WrtbarNone;
+   }
+
+inline bool
+OMR::Options::alwaysCallWriteBarrier()
+   {
+   return self()->getWriteBarrierKind() == TR_WrtbarAlways;
+   }
+
+inline bool
+OMR::Options::gcIsUsingConcurrentMark()
+   {
+   return self()->getWriteBarrierKind() == TR_WrtbarCardMark            ||
+          self()->getWriteBarrierKind() == TR_WrtbarCardMarkAndOldCheck ||
+          self()->getWriteBarrierKind() == TR_WrtbarCardMarkIncremental;
+   }
+
+inline bool
 OMR::Options::needWriteBarriers()
    {
-   return (self()->gcIsUsingConcurrentMark() || _gcMode == TR_WrtbarOldCheck);
+   return self()->gcIsUsingConcurrentMark() || self()->getWriteBarrierKind() == TR_WrtbarOldCheck;
    }
 
 

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3461,8 +3461,8 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
                }
 
             //SPECpower Work
-            if ( comp()->getOptions()->getGcMode() == TR_WrtbarCardMarkAndOldCheck ||
-                 comp()->getOptions()->getGcMode() == TR_WrtbarOldCheck)
+            if ( comp()->getOptions()->getWriteBarrierKind() == TR_WrtbarCardMarkAndOldCheck ||
+                 comp()->getOptions()->getWriteBarrierKind() == TR_WrtbarOldCheck)
                {
                TR::Node *possibleIwrtbarNode = currentTree->getNode();
                if ((currentOpCode.getOpCodeValue() != TR::awrtbari) &&
@@ -4387,7 +4387,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          TR::TreeTop *nextTreeTop = arrayStoreCheckTree->getNextTreeTop();
          TR::TreeTop *firstNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getFirstChild()), NULL, NULL);
          TR::Node *child = arrayStoreCheckNode->getFirstChild();
-         if (child->getOpCodeValue() == TR::awrtbari && comp()->getOptions()->getGcMode() == TR_WrtbarNone &&
+         if (child->getOpCodeValue() == TR::awrtbari && comp()->getOptions()->getWriteBarrierKind() == TR_WrtbarNone &&
             performTransformation(comp(), "%sChanging iwrtbar node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
             {
             TR::Node::recreate(child, TR::astorei);
@@ -4401,7 +4401,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          TR_ASSERT((arrayStoreCheckNode->getNumChildren() == 2), "Unknown array store check tree\n");
          secondNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getSecondChild()), NULL, NULL);
          child = arrayStoreCheckNode->getSecondChild();
-         if (child->getOpCodeValue() == TR::awrtbari && comp()->getOptions()->getGcMode() == TR_WrtbarNone &&
+         if (child->getOpCodeValue() == TR::awrtbari && comp()->getOptions()->getWriteBarrierKind() == TR_WrtbarNone &&
              performTransformation(comp(), "%sChanging iwrtbar node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
             {
             TR::Node::recreate(child, TR::astorei);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2948,7 +2948,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
       doOpt = false;
       }
 
-   TR_WriteBarrierKind gcMode = vp->comp()->getOptions()->getGcMode();
+   TR_WriteBarrierKind gcMode = vp->comp()->getOptions()->getWriteBarrierKind();
 
    if (doOpt &&
        ((gcMode == TR_WrtbarCardMarkAndOldCheck) ||


### PR DESCRIPTION
The old GC mode field and its related queries are actually
for write barrier kind; fixing the naming.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>