### PR TITLE
WIP: Virtualizing MemoryReference Hierarchy

### DIFF
--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -113,7 +113,7 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node          *rootLoadOrStore,
    TR::Symbol           *symbol = ref->getSymbol();
    bool               isStore = rootLoadOrStore->getOpCode().isStore();
 
-   self()->setSymbol(symbol, cg);
+   setSymbol(symbol, cg);
    _symbolReference.setOwningMethodIndex(ref->getOwningMethodIndex());
    _symbolReference.setCPIndex(ref->getCPIndex());
    _symbolReference.copyFlags(ref);
@@ -123,10 +123,10 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node          *rootLoadOrStore,
       {
       if (ref->isUnresolved())
          {
-         self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, rootLoadOrStore, rootLoadOrStore->getSymbolReference(),isStore, false));
-         cg->addSnippet(self()->getUnresolvedSnippet());
+         setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, rootLoadOrStore, rootLoadOrStore->getSymbolReference(),isStore, false));
+         cg->addSnippet(getUnresolvedSnippet());
          }
-      self()->populateMemoryReference(rootLoadOrStore->getFirstChild(), cg);
+      populateMemoryReference(rootLoadOrStore->getFirstChild(), cg);
       }
    else
       {
@@ -134,13 +134,13 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node          *rootLoadOrStore,
          {
          if (ref->isUnresolved())
             {
-            self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, rootLoadOrStore, rootLoadOrStore->getSymbolReference(),isStore, false));
-            cg->addSnippet(self()->getUnresolvedSnippet());
+            setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, rootLoadOrStore, rootLoadOrStore->getSymbolReference(),isStore, false));
+            cg->addSnippet(getUnresolvedSnippet());
             }
          else
             {
             _baseRegister = cg->allocateRegister();
-            self()->setBaseModifiable();
+            setBaseModifiable();
             loadRelocatableConstant(rootLoadOrStore, ref, _baseRegister, self(), cg);
             }
          }
@@ -156,9 +156,9 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node          *rootLoadOrStore,
             }
          }
       }
-   self()->addToOffset(rootLoadOrStore, rootLoadOrStore->getSymbolReference()->getOffset(), cg);
-   if (self()->getUnresolvedSnippet() != NULL)
-      self()->adjustForResolution(cg);
+   addToOffset(rootLoadOrStore, rootLoadOrStore->getSymbolReference()->getOffset(), cg);
+   if (getUnresolvedSnippet() != NULL)
+      adjustForResolution(cg);
    // TODO: aliasing sets?
    }
 
@@ -181,13 +181,13 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference *
       {
       if (symRef->isUnresolved())
          {
-         self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, symRef,false, false));
-         cg->addSnippet(self()->getUnresolvedSnippet());
+         setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, symRef,false, false));
+         cg->addSnippet(getUnresolvedSnippet());
          }
       else
          {
          _baseRegister = cg->allocateRegister();
-         self()->setBaseModifiable();
+         setBaseModifiable();
          loadRelocatableConstant(node, symRef, _baseRegister, self(), cg);
          }
       }
@@ -203,12 +203,12 @@ OMR::ARM::MemoryReference::MemoryReference(TR::Node *node, TR::SymbolReference *
          }
       }
 
-   self()->setSymbol(symbol, cg);
+   setSymbol(symbol, cg);
    _symbolReference.copyFlags(symRef);
    _symbolReference.copyRefNumIfPossible(symRef, cg->comp()->getSymRefTab());
-   self()->addToOffset(0, symRef->getOffset(), cg);
-   if (self()->getUnresolvedSnippet() != NULL)
-      self()->adjustForResolution(cg);
+   addToOffset(0, symRef->getOffset(), cg);
+   if (getUnresolvedSnippet() != NULL)
+      adjustForResolution(cg);
    // TODO: aliasing sets?
    }
 
@@ -240,23 +240,23 @@ OMR::ARM::MemoryReference::MemoryReference(TR::MemoryReference &mr,
       {
       _unresolvedSnippet = NULL;
       }
-   self()->addToOffset(0, displacement, cg);
+   addToOffset(0, displacement, cg);
    }
 
 void OMR::ARM::MemoryReference::setSymbol(TR::Symbol *symbol, TR::CodeGenerator *cg)
    {
    _symbolReference.setSymbol(symbol);
    if (_baseRegister!=NULL && _indexRegister!=NULL &&
-       (self()->hasDelayedOffset() || self()->getOffset()!=0))
+       (hasDelayedOffset() || getOffset()!=0))
       {
-      self()->consolidateRegisters(NULL, NULL, false, cg);
+      consolidateRegisters(NULL, NULL, false, cg);
       }
    }
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
 void OMR::ARM::MemoryReference::fixupVFPOffset(TR::Node *node, TR::CodeGenerator *cg)
    {
-      if (self()->getUnresolvedSnippet() != NULL)
+      if (getUnresolvedSnippet() != NULL)
          {
          return;
          }
@@ -269,7 +269,7 @@ void OMR::ARM::MemoryReference::fixupVFPOffset(TR::Node *node, TR::CodeGenerator
 
           _symbolReference.setOffset(remainingOffset);
 
-          if (_baseRegister != NULL && self()->isBaseModifiable())
+          if (_baseRegister != NULL && isBaseModifiable())
              newBase = _baseRegister;
           else
              newBase = cg->allocateCollectedReferenceRegister();
@@ -305,17 +305,17 @@ void OMR::ARM::MemoryReference::fixupVFPOffset(TR::Node *node, TR::CodeGenerator
                    }
                 }
              }
-          self()->decNodeReferenceCounts();
+          decNodeReferenceCounts();
           _baseRegister = newBase;
           _baseNode = NULL;
-          self()->setBaseModifiable();
+          setBaseModifiable();
          }
    }
 #endif
 
 void OMR::ARM::MemoryReference::addToOffset(TR::Node *node, int32_t amount, TR::CodeGenerator *cg)
    {
-   if (self()->getUnresolvedSnippet() != NULL)
+   if (getUnresolvedSnippet() != NULL)
       {
       _symbolReference.setOffset(_symbolReference.getOffset() + amount);
       return;
@@ -326,7 +326,7 @@ void OMR::ARM::MemoryReference::addToOffset(TR::Node *node, int32_t amount, TR::
 
    if (_baseRegister != NULL && _indexRegister != NULL)
       {
-      self()->consolidateRegisters(NULL, NULL, false, cg);
+      consolidateRegisters(NULL, NULL, false, cg);
       }
 
    int32_t displacement = _symbolReference.getOffset() + amount;
@@ -343,7 +343,7 @@ void OMR::ARM::MemoryReference::addToOffset(TR::Node *node, int32_t amount, TR::
 
       _symbolReference.setOffset(remainingOffset);
 
-      if (_baseRegister != NULL && self()->isBaseModifiable())
+      if (_baseRegister != NULL && isBaseModifiable())
          newBase = _baseRegister;
       else
          newBase = cg->allocateCollectedReferenceRegister();
@@ -379,10 +379,10 @@ void OMR::ARM::MemoryReference::addToOffset(TR::Node *node, int32_t amount, TR::
                }
             }
          }
-      self()->decNodeReferenceCounts();
+      decNodeReferenceCounts();
       _baseRegister = newBase;
       _baseNode = NULL;
-      self()->setBaseModifiable();
+      setBaseModifiable();
       }
    else
       _symbolReference.setOffset(displacement);
@@ -427,7 +427,7 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
       {
       if (_baseRegister != NULL)
          {
-         self()->consolidateRegisters(cg->evaluate(subTree), subTree, false, cg);
+         consolidateRegisters(cg->evaluate(subTree), subTree, false, cg);
          }
       else
          {
@@ -445,26 +445,26 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
 
          if (integerChild->getOpCode().isLoadConst())
             {
-            self()->populateMemoryReference(addressChild, cg);
-            self()->addToOffset(integerChild, integerChild->getInt(), cg);
+            populateMemoryReference(addressChild, cg);
+            addToOffset(integerChild, integerChild->getInt(), cg);
             integerChild->decReferenceCount();
             }
          else if (integerChild->getEvaluationPriority(cg) > addressChild->getEvaluationPriority(cg))
             {
-            self()->populateMemoryReference(integerChild, cg);
-            self()->populateMemoryReference(addressChild, cg);
+            populateMemoryReference(integerChild, cg);
+            populateMemoryReference(addressChild, cg);
             }
          else
             {
-            self()->populateMemoryReference(addressChild, cg);
-            self()->populateMemoryReference(integerChild, cg);
+            populateMemoryReference(addressChild, cg);
+            populateMemoryReference(integerChild, cg);
             }
          }
       else if (subTree->getOpCodeValue() == TR::ishl &&
                subTree->getFirstChild()->getOpCode().isLoadConst() &&
                subTree->getSecondChild()->getOpCode().isLoadConst())
          {
-         self()->addToOffset(subTree, subTree->getFirstChild()->getInt() <<
+         addToOffset(subTree, subTree->getFirstChild()->getInt() <<
                      subTree->getSecondChild()->getInt(), cg);
          subTree->getFirstChild()->decReferenceCount();
          subTree->getSecondChild()->decReferenceCount();
@@ -473,26 +473,26 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
          {
          TR::SymbolReference *ref = subTree->getSymbolReference();
          TR::Symbol *symbol = ref->getSymbol();
-         self()->setSymbol(symbol, cg);
+         setSymbol(symbol, cg);
          _symbolReference.copyFlags(ref);
          if (symbol->isStatic())
             {
             if (ref->isUnresolved())
                {
-               self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, subTree, &_symbolReference, subTree->getOpCode().isStore(), false));
-               cg->addSnippet(self()->getUnresolvedSnippet());
+               setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, subTree, &_symbolReference, subTree->getOpCode().isStore(), false));
+               cg->addSnippet(getUnresolvedSnippet());
                }
             else
                {
                if (_baseRegister != NULL)
                   {
-                  self()->addToOffset(subTree, (uintptr_t)symbol->castToStaticSymbol()->getStaticAddress(), cg);
+                  addToOffset(subTree, (uintptr_t)symbol->castToStaticSymbol()->getStaticAddress(), cg);
                   }
                else
                   {
                   _baseRegister = cg->allocateRegister();
                   _baseNode = NULL;
-                  self()->setBaseModifiable();
+                  setBaseModifiable();
                   loadRelocatableConstant(subTree, ref, _baseRegister, self(), cg);
                   }
                }
@@ -510,7 +510,7 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
                   {
                   tempReg = cg->getMethodMetaDataRegister();
                   }
-               self()->consolidateRegisters(tempReg, NULL, false, cg);
+               consolidateRegisters(tempReg, NULL, false, cg);
                }
             else
                {
@@ -525,7 +525,7 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
                _baseNode = NULL;
                }
             }
-         self()->addToOffset(subTree, subTree->getSymbolReference()->getOffset(), cg);
+         addToOffset(subTree, subTree->getSymbolReference()->getOffset(), cg);
          // TODO: aliasing sets?
          subTree->decReferenceCount(); // need to decrement ref count because
                                        // nodes weren't set on memoryreference
@@ -535,13 +535,13 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
          {
          if (_baseRegister != NULL)
             {
-            self()->addToOffset(subTree, subTree->getInt(), cg);
+            addToOffset(subTree, subTree->getInt(), cg);
             }
          else
             {
             _baseRegister = cg->allocateRegister();
             _baseNode = subTree;
-            self()->setBaseModifiable();
+            setBaseModifiable();
             armLoadConstant(subTree, subTree->getInt(), _baseRegister, cg);
             }
          }
@@ -549,13 +549,13 @@ void OMR::ARM::MemoryReference::populateMemoryReference(TR::Node *subTree, TR::C
          {
          if (_baseRegister != NULL)
             {
-            self()->consolidateRegisters(cg->evaluate(subTree), subTree, true, cg);
+            consolidateRegisters(cg->evaluate(subTree), subTree, true, cg);
             }
          else
             {
             _baseRegister  = cg->evaluate(subTree);
             _baseNode      = subTree;
-            self()->setBaseModifiable();
+            setBaseModifiable();
             }
          }
       }
@@ -565,13 +565,13 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
    {
    TR::Register *tempTargetRegister;
 
-   if (self()->getUnresolvedSnippet() != NULL)
+   if (getUnresolvedSnippet() != NULL)
       {
       if (srcReg == NULL)
          return;
       if (_indexRegister != NULL)
          {
-         if (self()->isIndexModifiable())
+         if (isIndexModifiable())
             tempTargetRegister = _indexRegister;
          else if (srcReg->containsCollectedReference() ||
                   _indexRegister->containsCollectedReference())
@@ -592,23 +592,23 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
          else
             cg->stopUsingRegister(srcReg);
          _indexRegister = tempTargetRegister;
-         self()->setIndexModifiable();
+         setIndexModifiable();
          }
       else
          {
          _indexRegister = srcReg;
          _indexNode = srcTree;
          if (srcModifiable)
-            self()->setIndexModifiable();
+            setIndexModifiable();
          else
-            self()->clearIndexModifiable();
+            clearIndexModifiable();
          }
       }
    else
       {
       if (_indexRegister != NULL)
          {
-         if (self()->isBaseModifiable())
+         if (isBaseModifiable())
             tempTargetRegister = _baseRegister;
          else if (_baseRegister->containsCollectedReference() ||
                   _indexRegister->containsCollectedReference())
@@ -618,7 +618,7 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
          new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _baseRegister, _indexRegister, cg);
          if (_baseRegister != tempTargetRegister)
             {
-            self()->decNodeReferenceCounts();
+            decNodeReferenceCounts();
             _baseNode = NULL;
             }
          else
@@ -629,11 +629,11 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
                cg->stopUsingRegister(_indexRegister);
             }
          _baseRegister  = tempTargetRegister;
-         self()->setBaseModifiable();
+         setBaseModifiable();
          }
-      else if (srcReg!=NULL && (self()->getOffset()!=0 || self()->hasDelayedOffset()))
+      else if (srcReg!=NULL && (getOffset()!=0 || hasDelayedOffset()))
          {
-         if (self()->isBaseModifiable())
+         if (isBaseModifiable())
             tempTargetRegister = _baseRegister;
          else if (srcModifiable)
             tempTargetRegister = srcReg;
@@ -645,12 +645,12 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
          new (cg->trHeapMemory()) TR::ARMTrg1Src2Instruction(ARMOp_add, srcTree, tempTargetRegister, _baseRegister, srcReg, cg);
          if (_baseRegister != tempTargetRegister)
             {
-            self()->decNodeReferenceCounts();
+            decNodeReferenceCounts();
             _baseNode = NULL;
             }
          if (srcReg == tempTargetRegister)
             {
-            self()->decNodeReferenceCounts();
+            decNodeReferenceCounts();
             _baseNode = srcTree;
             }
          else
@@ -661,7 +661,7 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
                cg->stopUsingRegister(srcReg);
             }
          _baseRegister  = tempTargetRegister;
-         self()->setBaseModifiable();
+         setBaseModifiable();
          srcReg=NULL;
          srcTree=NULL;
          srcModifiable=false;
@@ -669,9 +669,9 @@ void OMR::ARM::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR::N
       _indexRegister = srcReg;
       _indexNode = srcTree;
       if (srcModifiable)
-         self()->setIndexModifiable();
+         setIndexModifiable();
       else
-         self()->clearIndexModifiable();
+         clearIndexModifiable();
       }
    }
 
@@ -825,7 +825,7 @@ void OMR::ARM::MemoryReference::assignRegisters(TR::Instruction *currentInstruct
          }
       _indexRegister = assignedIndexRegister;
       }
-   if (self()->getUnresolvedSnippet() != NULL)
+   if (getUnresolvedSnippet() != NULL)
       {
       currentInstruction->ARMNeedsGCMap(0xFFFFFFFF);
       }
@@ -843,17 +843,17 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
    {
    uint32_t           *wcursor = (uint32_t *)cursor;
    TR_ARMOpCodes       op      = currentInstruction->getOpCodeValue();
-   TR::RealRegister *base    = self()->getBaseRegister() ? toRealRegister(self()->getBaseRegister()) : NULL;
-   TR::RealRegister *index   = self()->getIndexRegister() ? toRealRegister(self()->getIndexRegister()) : NULL;
+   TR::RealRegister *base    = getBaseRegister() ? toRealRegister(getBaseRegister()) : NULL;
+   TR::RealRegister *index   = getIndexRegister() ? toRealRegister(getIndexRegister()) : NULL;
 
-   if (self()->getUnresolvedSnippet())
+   if (getUnresolvedSnippet())
       {
 #ifdef J9_PROJECT_SPECIFIC
       uint32_t preserve = *wcursor; // original instruction
-      TR::RealRegister *mBase = toRealRegister(self()->getModBase());
-      self()->getUnresolvedSnippet()->setAddressOfDataReference(cursor);
-      self()->getUnresolvedSnippet()->setMemoryReference(self());
-      cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, self()->getUnresolvedSnippet()->getSnippetLabel()));
+      TR::RealRegister *mBase = toRealRegister(getModBase());
+      getUnresolvedSnippet()->setAddressOfDataReference(cursor);
+      getUnresolvedSnippet()->setMemoryReference(self());
+      cg->addRelocation(new (cg->trHeapMemory()) TR::LabelRelative24BitRelocation(cursor, getUnresolvedSnippet()->getSnippetLabel()));
       *wcursor = 0xEA000000; // insert a branch to the snippet
       wcursor++;
       cursor += ARM_INSTRUCTION_LENGTH;
@@ -965,15 +965,15 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
             }
 #endif
-         displacement = self()->getOffset();
+         displacement = getOffset();
          if(displacement > 0)
             *wcursor |= 1 << 23;                   // set U bit for +ve
          else
             displacement = -displacement;
-         TR_ASSERT(!(self()->isImmediatePreIndexed() && self()->isPostIndexed()),"write back with post-index transfer redundant");
-         if (self()->isImmediatePreIndexed())
+         TR_ASSERT(!(isImmediatePreIndexed() && isPostIndexed()),"write back with post-index transfer redundant");
+         if (isImmediatePreIndexed())
             *wcursor |= 1 << 21;                   // set W bit for write-back
-         if (self()->isPostIndexed())
+         if (isPostIndexed())
             *wcursor &= (uint32_t)(~(1 << 24));    // unset P for post-index
          }
 
@@ -1008,7 +1008,7 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
                }
             else
                {
-               cursor = self()->encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
+               cursor = encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
                wcursor = (uint32_t *)cursor;
                }
             }
@@ -1023,14 +1023,14 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
             }
          else
             {
-            if (constantIsUnsignedImmed8(self()->getOffset()))
+            if (constantIsUnsignedImmed8(getOffset()))
                {
                *wcursor |= 1 << 22;                // set I bit for immediate index
                *wcursor |= splitOffset(displacement);
                }
             else
                {
-               cursor = self()->encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
+               cursor = encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
                wcursor = (uint32_t *)cursor;
                }
             }
@@ -1039,7 +1039,7 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
          {
          base->setRegisterFieldRN(wcursor);
          uint32_t immBase, rotate;
-         if (constantIsImmed8r(self()->getOffset(), &immBase, &rotate))
+         if (constantIsImmed8r(getOffset(), &immBase, &rotate))
             {
             *wcursor |= 1 << 25;                            // set I bit for immediate index
             *wcursor |= ((32 - rotate) << 7) & 0x00000f00;  // mask to deal with rotate == 0 case.
@@ -1047,7 +1047,7 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
             }
          else
             {
-            cursor = self()->encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
+            cursor = encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
             wcursor = (uint32_t *)cursor;
             }
          }
@@ -1065,7 +1065,7 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
             }
          else
             {
-            cursor = self()->encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
+            cursor = encodeLargeARMConstant(wcursor, cursor, currentInstruction, cg);
             wcursor = (uint32_t *)cursor;
             }
          }
@@ -1088,7 +1088,7 @@ uint8_t *OMR::ARM::MemoryReference::generateBinaryEncoding(TR::Instruction *curr
 
 uint32_t OMR::ARM::MemoryReference::estimateBinaryLength(TR_ARMOpCodes op)
    {
-   if (self()->getUnresolvedSnippet() != NULL)
+   if (getUnresolvedSnippet() != NULL)
       {
       if (_indexRegister != NULL)
          {
@@ -1113,7 +1113,7 @@ uint32_t OMR::ARM::MemoryReference::estimateBinaryLength(TR_ARMOpCodes op)
       }
    else if (op == ARMOp_ldr || op == ARMOp_str || op == ARMOp_ldrb || op == ARMOp_strb || op == ARMOp_ldrex || op == ARMOp_strex)
       {
-      if (constantIsImmed12(self()->getOffset()))
+      if (constantIsImmed12(getOffset()))
          {
          return ARM_INSTRUCTION_LENGTH;
          }
@@ -1124,7 +1124,7 @@ uint32_t OMR::ARM::MemoryReference::estimateBinaryLength(TR_ARMOpCodes op)
       }
    else if ( op == ARMOp_ldrsb || op == ARMOp_ldrh || op == ARMOp_ldrsh || op == ARMOp_strh )
       {
-      if(constantIsUnsignedImmed8(self()->getOffset()))
+      if(constantIsUnsignedImmed8(getOffset()))
          {
          return ARM_INSTRUCTION_LENGTH;
          }
@@ -1136,7 +1136,7 @@ uint32_t OMR::ARM::MemoryReference::estimateBinaryLength(TR_ARMOpCodes op)
    else if( op == ARMOp_add )
       {
       uint32_t base,rotate;
-      if(constantIsImmed8r(self()->getOffset(),&base,&rotate))
+      if(constantIsImmed8r(getOffset(),&base,&rotate))
          {
          return ARM_INSTRUCTION_LENGTH;
          }
@@ -1152,7 +1152,7 @@ uint32_t OMR::ARM::MemoryReference::estimateBinaryLength(TR_ARMOpCodes op)
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
    else if (op == ARMOp_flds || op == ARMOp_fldd || op == ARMOp_fsts || op == ARMOp_fstd)
       {
-         if (constantIsImmed10(self()->getOffset()))
+         if (constantIsImmed10(getOffset()))
          {
          return ARM_INSTRUCTION_LENGTH;
          }
@@ -1176,8 +1176,8 @@ uint8_t *OMR::ARM::MemoryReference::encodeLargeARMConstant(uint32_t *wcursor, ui
    TR::RealRegister   *rX;
    uint32_t             preserve = *wcursor; // original instruction
    TR_ARMOpCodes        op       = currentInstruction->getOpCodeValue();
-   TR::RealRegister   *base    = self()->getBaseRegister() ? toRealRegister(self()->getBaseRegister()) : NULL;
-   int32_t              offset   = self()->getOffset();
+   TR::RealRegister   *base    = getBaseRegister() ? toRealRegister(getBaseRegister()) : NULL;
+   int32_t              offset   = getOffset();
    bool vfpInstruction = false;
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
@@ -1205,11 +1205,11 @@ uint8_t *OMR::ARM::MemoryReference::encodeLargeARMConstant(uint32_t *wcursor, ui
 
    if (!vfpInstruction)
       {
-      self()->setIndexRegister(rX);
+      setIndexRegister(rX);
       }
    else
       {
-      self()->setBaseRegister(rX);
+      setBaseRegister(rX);
       }
 
    if(spillNeeded)

--- a/compiler/codegen/MemoryReference.hpp
+++ b/compiler/codegen/MemoryReference.hpp
@@ -26,7 +26,7 @@
 
 namespace TR
 {
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReferenceConnector
    {
    public:
 

--- a/compiler/codegen/OMRMemoryReference.hpp
+++ b/compiler/codegen/OMRMemoryReference.hpp
@@ -39,7 +39,7 @@ namespace TR { class MemoryReference; }
 namespace OMR
 {
 
-class OMR_EXTENSIBLE MemoryReference
+class /*OMR_EXTENSIBLE*/ MemoryReference
    {
    public:
 

--- a/compiler/p/codegen/MemoryReference.hpp
+++ b/compiler/p/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,7 +34,7 @@ namespace TR { class Register; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReferenceConnector
    {
    public:
 

--- a/compiler/p/codegen/OMRMemoryReference.hpp
+++ b/compiler/p/codegen/OMRMemoryReference.hpp
@@ -59,7 +59,7 @@ namespace OMR
 namespace Power
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReference
    {
    TR::Register *_baseRegister;
    TR::Node *_baseNode;

--- a/compiler/x/amd64/codegen/MemoryReference.hpp
+++ b/compiler/x/amd64/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ namespace TR { class SymbolReference; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReferenceConnector
    {
    public:
 

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -612,7 +612,7 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
 
       if (self()->getBaseRegister() && self()->getIndexRegister())
          {
-         TR::Instruction  *addressAddInstruction = generateRegRegInstruction(addressLoadInstruction, ADD8RegReg, self()->getAddressRegister(), self()->getBaseRegister(), cg);
+         TR::Instruction  *addressAddInstruction = generateRegRegInstruction(addressLoadInstruction, ADD8RegReg, getAddressRegister(), self()->getBaseRegister(), cg);
          cursor = addressAddInstruction->generateBinaryEncoding();
          cg->setBinaryBufferCursor(cursor);
          }

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -61,73 +61,73 @@ namespace TR { class Machine; }
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Register *br, TR::SymbolReference *sr, TR::Register *ir, uint8_t s, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(br, sr, ir, s, cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Register *br, TR::Register *ir, uint8_t s, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(br, ir, s, cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Register *br, intptrj_t disp, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(br, disp, cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(intptrj_t disp, TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm):
    OMR::X86::MemoryReference(disp, cg)
    {
-   self()->finishInitialization(cg, srm);
+   finishInitialization(cg, srm);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Register *br, TR::Register *ir, uint8_t s, intptrj_t disp, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(br, ir, s, disp, cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::X86DataSnippet *cds, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(cds, cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::LabelSymbol *label, TR::CodeGenerator *cg):
    OMR::X86::MemoryReference(label, cg)
    {
-   self()->finishInitialization(cg, NULL);
+   finishInitialization(cg, NULL);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::Node *rootLoadOrStore, TR::CodeGenerator *cg, bool canRematerializeAddressAdds, TR_ScratchRegisterManager *srm):
    OMR::X86::MemoryReference(rootLoadOrStore, cg, canRematerializeAddressAdds)
    {
-   self()->finishInitialization(cg, srm);
+   finishInitialization(cg, srm);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::SymbolReference *symRef, TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm):
    OMR::X86::MemoryReference(symRef, cg)
    {
-   self()->finishInitialization(cg, srm);
+   finishInitialization(cg, srm);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::SymbolReference *symRef, intptrj_t displacement, TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm):
    OMR::X86::MemoryReference(symRef, displacement, cg)
    {
-   self()->finishInitialization(cg, srm);
+   finishInitialization(cg, srm);
    }
 
 OMR::X86::AMD64::MemoryReference::MemoryReference(TR::MemoryReference& mr, intptrj_t n, TR::CodeGenerator *cg, TR_ScratchRegisterManager *srm):
    OMR::X86::MemoryReference(mr, n, cg)
    {
-   self()->finishInitialization(cg, srm);
+   finishInitialization(cg, srm);
    }
 
 void OMR::X86::AMD64::MemoryReference::finishInitialization(
@@ -136,20 +136,20 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(
    {
    _preferRIPRelative = false;
    TR::Machine *machine = cg->machine();
-   TR::SymbolReference &sr = self()->getSymbolReference();
+   TR::SymbolReference &sr = getSymbolReference();
    TR::Compilation *comp = cg->comp();
 
    // Figure out whether we need to allocate a register for the address
    //
    bool mightNeedAddressRegister;
-   if (self()->getDataSnippet())
+   if (getDataSnippet())
       {
       // Assume snippets are in RIP range
       //
       mightNeedAddressRegister = false;
       }
-   else if (!self()->getBaseRegister()  &&
-            !self()->getIndexRegister() &&
+   else if (!getBaseRegister()  &&
+            !getIndexRegister() &&
             (cg->needRelocationsForStatics()            ||
              cg->needClassAndMethodPointerRelocations() ||
              cg->needRelocationsForBodyInfoData()       ||
@@ -157,7 +157,7 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(
       {
       mightNeedAddressRegister = true;
       }
-   else if (self()->getBaseRegister() == cg->getFrameRegister())
+   else if (getBaseRegister() == cg->getFrameRegister())
       {
       // We should never see stack frames 2GB in size, so don't waste a register.
       // (Also, for the same reason, there's no need to consider the frame
@@ -189,7 +189,7 @@ void OMR::X86::AMD64::MemoryReference::finishInitialization(
       //    lea R4, [R2 + a]
       //    xxx R1, [R4 + scale*R3 + b]
       //
-      mightNeedAddressRegister = !IS_32BIT_SIGNED(self()->getDisplacement());
+      mightNeedAddressRegister = !IS_32BIT_SIGNED(getDisplacement());
       }
 
    // If we might need it, allocate it
@@ -238,8 +238,8 @@ void OMR::X86::AMD64::MemoryReference::useRegisters(TR::Instruction  *instr, TR:
 
 bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptrj_t rip, TR::CodeGenerator * cg)
    {
-   TR::SymbolReference &sr           = self()->getSymbolReference();
-   intptrj_t           displacement = self()->getDisplacement();
+   TR::SymbolReference &sr           = getSymbolReference();
+   intptrj_t           displacement = getDisplacement();
    TR::Compilation *comp = cg->comp();
    if (sr.getSymbol() != NULL && sr.isUnresolved())
       {
@@ -321,7 +321,7 @@ uint32_t OMR::X86::AMD64::MemoryReference::estimateBinaryLength(TR::CodeGenerato
    {
    uint32_t estimate;
 
-   if (0 && REGISTERS_CAN_CHANGE_AFTER_INITIALIZATION && self()->getBaseRegister() && self()->getIndexRegister() && _addressRegister)
+   if (0 && REGISTERS_CAN_CHANGE_AFTER_INITIALIZATION && getBaseRegister() && getIndexRegister() && _addressRegister)
       {
       // We thought we might need _addressRegister during initialization
       // because _baseRegister or _indexRegister NULL.  However, someone
@@ -370,12 +370,12 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       TR::CodeGenerator *cg,
       TR::SymbolReference *srCopy)
    {
-   intptrj_t displacement = self()->getDisplacement();
+   intptrj_t displacement = getDisplacement();
 
    if (_symbolReference.getSymbol())
       {
       TR::SymbolReference &sr = *srCopy;
-      if (self()->getUnresolvedDataSnippet())
+      if (getUnresolvedDataSnippet())
          {
          TR::Compilation *comp = cg->comp();
          if (comp->getOption(TR_EnableHCR)
@@ -470,7 +470,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
       }
    else
       {
-      if (self()->needsCodeAbsoluteExternalRelocation())
+      if (needsCodeAbsoluteExternalRelocation())
          {
          cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation,
                                                                                  (uint8_t *)0,
@@ -510,8 +510,8 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
       TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR::SymbolReference &sr = self()->getSymbolReference();
-   intptrj_t displacement = self()->getDisplacement();
+   TR::SymbolReference &sr = getSymbolReference();
+   intptrj_t displacement = getDisplacement();
 
    if (comp->getOption(TR_TraceCG))
       {
@@ -532,13 +532,13 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
    //
    intptrj_t rip = (intptrj_t)(modRM + 5) + containingInstruction->getOpCode().info().ImmediateSize();
 
-   if (self()->getDataSnippet() || self()->getLabel())
+   if (getDataSnippet() || getLabel())
       {
       // The inherited logic has a special case for RIP-based ConstantDataSnippet and label references.
       //
       return OMR::X86::MemoryReference::generateBinaryEncoding(modRM, containingInstruction, cg);
       }
-   else if (self()->needsAddressLoadInstruction(rip, cg))
+   else if (needsAddressLoadInstruction(rip, cg))
       {
       TR_ASSERT(_addressRegister != NULL, "OMR::X86::AMD64::MemoryReference should have allocated an address register");
 
@@ -559,7 +559,7 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
             containingInstruction->getPrev(),
             MOV8RegImm64,
             _addressRegister,
-            (!self()->getUnresolvedDataSnippet() &&
+            (!getUnresolvedDataSnippet() &&
               sr.getSymbol()->isStatic() &&
               sr.getSymbol()->isClassObject() &&
               cg->needClassAndMethodPointerRelocations())?
@@ -568,15 +568,15 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
             cg
             );
 
-         if (self()->getUnresolvedDataSnippet())
+         if (getUnresolvedDataSnippet())
             {
-            self()->getUnresolvedDataSnippet()->setDataReferenceInstruction(addressLoadInstruction);
-            self()->getUnresolvedDataSnippet()->setDataSymbolReference(symRef);
+            getUnresolvedDataSnippet()->setDataReferenceInstruction(addressLoadInstruction);
+            getUnresolvedDataSnippet()->setDataSymbolReference(symRef);
             }
          }
       else
          {
-         TR_ASSERT(!self()->getUnresolvedDataSnippet(), "Unresolved references should always have a symbol");
+         TR_ASSERT(!getUnresolvedDataSnippet(), "Unresolved references should always have a symbol");
 
          addressLoadInstruction = generateRegImm64Instruction(
             containingInstruction->getPrev(),
@@ -587,12 +587,12 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
             );
          }
 
-      self()->addMetaDataForCodeAddressWithLoad(displacementLocation, containingInstruction, cg, symRef);
+      addMetaDataForCodeAddressWithLoad(displacementLocation, containingInstruction, cg, symRef);
 
       // addressLoadInstruction's node should be that of containingInstruction
       //
       addressLoadInstruction->setNode(_baseNode ? _baseNode : containingInstruction->getNode());
-      if (TR::Compiler->target.isSMP() && self()->getUnresolvedDataSnippet())
+      if (TR::Compiler->target.isSMP() && getUnresolvedDataSnippet())
          {
          // Also adjust the node of the TR::X86PatchableCodeAlignmentInstruction
          //
@@ -610,17 +610,17 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
       cursor = addressLoadInstruction->generateBinaryEncoding();
       cg->setBinaryBufferCursor(cursor);
 
-      if (self()->getBaseRegister() && self()->getIndexRegister())
+      if (getBaseRegister() && getIndexRegister())
          {
-         TR::Instruction  *addressAddInstruction = generateRegRegInstruction(addressLoadInstruction, ADD8RegReg, getAddressRegister(), self()->getBaseRegister(), cg);
+         TR::Instruction  *addressAddInstruction = generateRegRegInstruction(addressLoadInstruction, ADD8RegReg, getAddressRegister(), getBaseRegister(), cg);
          cursor = addressAddInstruction->generateBinaryEncoding();
          cg->setBinaryBufferCursor(cursor);
          }
 
       // If it's unresolved, tell the snippet where the data reference is
       //
-      if (self()->getUnresolvedDataSnippet())
-         self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor-8);
+      if (getUnresolvedDataSnippet())
+         getUnresolvedDataSnippet()->setAddressOfDataReference(cursor-8);
 
       // Transform this memref from [whatever + offset64] to [whatever + _addressRegister]
       // Also transforms [base + index + offset64] to [_addressRegister + index]
@@ -641,7 +641,7 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
       _flags.reset(MemRef_NeedExternalCodeAbsoluteRelocation); // TODO:AMD64: Do I need this?
       _symbolReference.setSymbol(NULL);
       _symbolReference.setOffset(0);
-      self()->setUnresolvedDataSnippet(NULL); // Otherwise it will get damaged when we re-emit containingInstruction
+      setUnresolvedDataSnippet(NULL); // Otherwise it will get damaged when we re-emit containingInstruction
 
       // Indicate to caller that it must try again to emit its binary
       //
@@ -654,8 +654,8 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
          {
          // Addresses in the low 2GB (or high 2GB) can be accessed using a SIB byte
          //
-         self()->ModRM(modRM)->setBase()->setHasSIB();
-         self()->SIB(cursor++)->setScale()->setNoIndex()->setIndexDisp32();
+         ModRM(modRM)->setBase()->setHasSIB();
+         SIB(cursor++)->setScale()->setNoIndex()->setIndexDisp32();
          *(uint32_t*)cursor = (uint32_t)displacement;
          }
       else
@@ -663,11 +663,11 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
          TR_ASSERT(IS_32BIT_RIP(displacement, rip), "assertion failure");
          TR_ASSERT(!(comp->getOption(TR_EnableHCR) && sr.getSymbol() && sr.getSymbol()->isClassObject()),
             "HCR runtime assumptions currently can't patch RIP-relative offsets");
-         self()->ModRM(modRM)->setIndexOnlyDisp32();
+         ModRM(modRM)->setIndexOnlyDisp32();
          *(uint32_t*)cursor = (uint32_t)(displacement - (intptrj_t)rip);
          }
 
-      self()->addMetaDataForCodeAddressDisplacementOnly(displacement, cursor, cg);
+      addMetaDataForCodeAddressDisplacementOnly(displacement, cursor, cg);
 
       // Unresolved shadows whose base object is explicitly NULL need to report the
       // offset of the disp32 field.
@@ -675,11 +675,11 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
       // NOTE: this may not work in the highly unlikely case of a field offset > 64k
       //       where the implicit NULLCHK will not fire.
       //
-      if (self()->getUnresolvedDataSnippet())
+      if (getUnresolvedDataSnippet())
          {
-         self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+         getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
          traceMsg(comp, "found unresolved shadow with NULL base object : data reference instruction=%p, cursor=%p\n",
-            self()->getUnresolvedDataSnippet()->getDataReferenceInstruction(), cursor);
+            getUnresolvedDataSnippet()->getDataReferenceInstruction(), cursor);
          }
 
       return cursor+4;

--- a/compiler/x/amd64/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.hpp
@@ -51,7 +51,7 @@ namespace X86
 namespace AMD64
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::X86::MemoryReference
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::X86::MemoryReference
    {
 
    TR::Register *_addressRegister;   // Used when extra loads are required to compute the address

--- a/compiler/x/codegen/MemoryReference.hpp
+++ b/compiler/x/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ namespace TR { class SymbolReference; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReferenceConnector
    {
    public:
 

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -65,7 +65,7 @@ static void rematerializeAddressAdds(TR::Node *rootLoadOrStore, TR::CodeGenerato
 intptrj_t
 OMR::X86::MemoryReference::getDisplacement()
    {
-   TR::SymbolReference &symRef = self()->getSymbolReference();
+   TR::SymbolReference &symRef = getSymbolReference();
    intptrj_t  displacement = symRef.getOffset();
    TR::Symbol *symbol = symRef.getSymbol();
 
@@ -98,7 +98,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::X86DataSnippet *cds, TR::CodeGene
    _flags(0),
    _reloKind(-1)
    {
-   self()->setForceWideDisplacement();
+   setForceWideDisplacement();
    }
 
 OMR::X86::MemoryReference::MemoryReference(TR::LabelSymbol *label, TR::CodeGenerator *cg):
@@ -113,7 +113,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::LabelSymbol *label, TR::CodeGener
    _flags(0),
    _reloKind(-1)
    {
-   self()->setForceWideDisplacement();
+   setForceWideDisplacement();
    }
 
 OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, TR::CodeGenerator *cg):
@@ -128,7 +128,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, TR::Code
    _flags(0),
    _reloKind(-1)
    {
-   self()->initialize(symRef, cg);
+   initialize(symRef, cg);
    }
 
 OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, intptrj_t displacement, TR::CodeGenerator *cg):
@@ -143,7 +143,7 @@ OMR::X86::MemoryReference::MemoryReference(TR::SymbolReference *symRef, intptrj_
    _flags(0),
    _reloKind(-1)
    {
-   self()->initialize(symRef, cg);
+   initialize(symRef, cg);
    _symbolReference.addToOffset(displacement);
    }
 
@@ -210,8 +210,8 @@ OMR::X86::MemoryReference::MemoryReference(
                if (base->getOpCodeValue() == TR::loadaddr && base->getSymbol()->isLocalObject())
                   cg->evaluate(base);
 
-               self()->setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference, isStore, symRef->canCauseGC()));
-               cg->addSnippet(self()->getUnresolvedDataSnippet());
+               setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference, isStore, symRef->canCauseGC()));
+               cg->addSnippet(getUnresolvedDataSnippet());
                }
 
             if (!debug("noAddressAddRemat") && canRematerializeAddressAdds)
@@ -226,8 +226,8 @@ OMR::X86::MemoryReference::MemoryReference(
                }
 
             rcount_t refCount = base->getReferenceCount();
-            self()->populateMemoryReference(base, cg);
-            self()->checkAndDecReferenceCount(base, refCount, cg);
+            populateMemoryReference(base, cg);
+            checkAndDecReferenceCount(base, refCount, cg);
             }
          }
       else
@@ -236,8 +236,8 @@ OMR::X86::MemoryReference::MemoryReference(
             {
             if (isUnresolved)
                {
-               self()->setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference, isStore, symRef->canCauseGC()));
-               cg->addSnippet(self()->getUnresolvedDataSnippet());
+               setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, rootLoadOrStore, &_symbolReference, isStore, symRef->canCauseGC()));
+               cg->addSnippet(getUnresolvedDataSnippet());
                }
             _baseNode = rootLoadOrStore;
             }
@@ -262,7 +262,7 @@ OMR::X86::MemoryReference::MemoryReference(
          // Need a wide field because we don't know how big the displacement
          // may turn out to be once resolved.
          //
-         self()->setForceWideDisplacement();
+         setForceWideDisplacement();
          }
 
       }
@@ -279,20 +279,20 @@ OMR::X86::MemoryReference::MemoryReference(
 TR::UnresolvedDataSnippet *
 OMR::X86::MemoryReference::getUnresolvedDataSnippet()
    {
-   return self()->hasUnresolvedDataSnippet() ? (TR::UnresolvedDataSnippet *)_dataSnippet : NULL;
+   return hasUnresolvedDataSnippet() ? (TR::UnresolvedDataSnippet *)_dataSnippet : NULL;
    }
 
 TR::UnresolvedDataSnippet *
 OMR::X86::MemoryReference::setUnresolvedDataSnippet(TR::UnresolvedDataSnippet *s)
    {
-   self()->setHasUnresolvedDataSnippet();
+   setHasUnresolvedDataSnippet();
    return ( (TR::UnresolvedDataSnippet *) (_dataSnippet = s) );
    }
 
 TR::X86DataSnippet*
 OMR::X86::MemoryReference::getDataSnippet()
    {
-   return (self()->hasUnresolvedDataSnippet() || self()->hasUnresolvedVirtualCallSnippet()) ? NULL : (TR::X86DataSnippet*)_dataSnippet;
+   return (hasUnresolvedDataSnippet() || hasUnresolvedVirtualCallSnippet()) ? NULL : (TR::X86DataSnippet*)_dataSnippet;
    }
 
 
@@ -325,9 +325,9 @@ OMR::X86::MemoryReference::initialize(
 
    if (symRef->isUnresolved())
       {
-      self()->setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, 0, &_symbolReference, false, symRef->canCauseGC()));
-      cg->addSnippet(self()->getUnresolvedDataSnippet());
-      self()->setForceWideDisplacement();
+      setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, 0, &_symbolReference, false, symRef->canCauseGC()));
+      cg->addSnippet(getUnresolvedDataSnippet());
+      setForceWideDisplacement();
       }
    // TODO: aliasing sets?
 
@@ -524,20 +524,20 @@ OMR::X86::MemoryReference::populateMemoryReference(
       evalSubTree = false;
 
    if (evalSubTree &&
-       subTree->getReferenceCount() > 1 || subTree->getRegister() != NULL || (self()->inUpcastingMode() && !subTree->cannotOverflow()))
+       subTree->getReferenceCount() > 1 || subTree->getRegister() != NULL || (inUpcastingMode() && !subTree->cannotOverflow()))
       {
       if (_baseRegister != NULL)
          {
          if (_indexRegister != NULL)
             {
-            self()->consolidateRegisters(subTree, cg);
+            consolidateRegisters(subTree, cg);
             }
-         _indexRegister = self()->evaluate(subTree, cg, parent);
+         _indexRegister = evaluate(subTree, cg, parent);
          _indexNode     = subTree;
          }
       else
          {
-         _baseRegister  = self()->evaluate(subTree, cg, parent);
+         _baseRegister  = evaluate(subTree, cg, parent);
          _baseNode      = subTree;
          }
       }
@@ -554,35 +554,35 @@ OMR::X86::MemoryReference::populateMemoryReference(
          if (integerChild->getOpCode().isLoadConst())
             {
             rcount_t refCount = addressChild->getReferenceCount();
-            self()->populateMemoryReference(addressChild, cg);
-            self()->checkAndDecReferenceCount(addressChild, refCount, cg);
+            populateMemoryReference(addressChild, cg);
+            checkAndDecReferenceCount(addressChild, refCount, cg);
             _symbolReference.addToOffset(TR::TreeEvaluator::integerConstNodeValue(integerChild, cg));
             cg->decReferenceCount(integerChild);
             }
          else if (cg->whichNodeToEvaluate(addressChild, integerChild) == 1)
             {
             rcount_t refCount = integerChild->getReferenceCount();
-            self()->populateMemoryReference(integerChild, cg);
-            self()->checkAndDecReferenceCount(integerChild, refCount, cg);
+            populateMemoryReference(integerChild, cg);
+            checkAndDecReferenceCount(integerChild, refCount, cg);
 
             refCount = addressChild->getReferenceCount();
-            self()->populateMemoryReference(addressChild, cg);
-            self()->checkAndDecReferenceCount(addressChild, refCount, cg);
+            populateMemoryReference(addressChild, cg);
+            checkAndDecReferenceCount(addressChild, refCount, cg);
             }
          else
             {
             rcount_t refCount = addressChild->getReferenceCount();
-            self()->populateMemoryReference(addressChild, cg);
-            self()->checkAndDecReferenceCount(addressChild, refCount, cg);
+            populateMemoryReference(addressChild, cg);
+            checkAndDecReferenceCount(addressChild, refCount, cg);
 
             if (_baseRegister != NULL && _indexRegister != NULL)
                {
-               self()->consolidateRegisters(subTree, cg);
+               consolidateRegisters(subTree, cg);
                }
 
             refCount = integerChild->getReferenceCount();
-            self()->populateMemoryReference(integerChild, cg);
-            self()->checkAndDecReferenceCount(integerChild, refCount, cg);
+            populateMemoryReference(integerChild, cg);
+            checkAndDecReferenceCount(integerChild, refCount, cg);
             }
          }
       else if ((subTreeOp == TR::isub || subTreeOp == TR::lsub) &&
@@ -591,22 +591,22 @@ OMR::X86::MemoryReference::populateMemoryReference(
          {
          TR::Node *constChild = subTree->getSecondChild();
          rcount_t refCount = subTree->getFirstChild()->getReferenceCount();
-         self()->populateMemoryReference(subTree->getFirstChild(), cg);
-         self()->checkAndDecReferenceCount(subTree->getFirstChild(), refCount, cg);
+         populateMemoryReference(subTree->getFirstChild(), cg);
+         checkAndDecReferenceCount(subTree->getFirstChild(), refCount, cg);
          _symbolReference.addToOffset(-TR::TreeEvaluator::integerConstNodeValue(constChild, cg));
          cg->decReferenceCount(constChild);
          }
       else if (subTreeOp == TR::i2l || subTreeOp == TR::s2l || subTreeOp == TR::s2i)
          {
-         self()->setInUpcastingMode();
+         setInUpcastingMode();
 
          if (comp->getOption(TR_TraceCG))
             traceMsg(comp, "Entering UpcastingNoOverflow mode at node %x\n", subTree);
          rcount_t refCount = subTree->getFirstChild()->getReferenceCount();
-         self()->populateMemoryReference(subTree->getFirstChild(), cg, subTree);
-         self()->checkAndDecReferenceCount(subTree->getFirstChild(), refCount, cg);
+         populateMemoryReference(subTree->getFirstChild(), cg, subTree);
+         checkAndDecReferenceCount(subTree->getFirstChild(), refCount, cg);
 
-         self()->setInUpcastingMode(false);
+         setInUpcastingMode(false);
          }
       else if ((stride = TR::MemoryReference::getStrideForNode(subTree, cg)) != 0)
          {
@@ -614,7 +614,7 @@ OMR::X86::MemoryReference::populateMemoryReference(
             {
             if (_baseRegister != NULL || _stride != 0)
                {
-               self()->consolidateRegisters(subTree, cg);
+               consolidateRegisters(subTree, cg);
                }
             else
                {
@@ -631,7 +631,7 @@ OMR::X86::MemoryReference::populateMemoryReference(
             TR::Register *sourceReg = i2lChild->getRegister();
 
             if (!sourceReg)
-               self()->evaluate(i2lChild, cg, parent);
+               evaluate(i2lChild, cg, parent);
 
             sourceReg = i2lChild->getRegister();
 
@@ -650,7 +650,7 @@ OMR::X86::MemoryReference::populateMemoryReference(
                firstChild = i2lChild;
                }
             }
-         _indexRegister       = self()->evaluate(firstChild, cg, parent);
+         _indexRegister       = evaluate(firstChild, cg, parent);
          _indexNode           = firstChild;
          TR::Node *secondChild = subTree->getSecondChild();
          _stride              = stride;
@@ -668,7 +668,7 @@ OMR::X86::MemoryReference::populateMemoryReference(
                {
                if (_indexRegister != NULL)
                   {
-                  self()->consolidateRegisters(subTree, cg);
+                  consolidateRegisters(subTree, cg);
                   }
                if (!symbol->isMethodMetaData())
                   {
@@ -709,9 +709,9 @@ OMR::X86::MemoryReference::populateMemoryReference(
 
          if (symRef->isUnresolved())
             {
-            self()->setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, subTree, &_symbolReference, false, symRef->canCauseGC()));
-            cg->addSnippet(self()->getUnresolvedDataSnippet());
-            self()->setForceWideDisplacement();
+            setUnresolvedDataSnippet(TR::UnresolvedDataSnippet::create(cg, subTree, &_symbolReference, false, symRef->canCauseGC()));
+            cg->addSnippet(getUnresolvedDataSnippet());
+            setForceWideDisplacement();
             }
 
          // TODO: aliasing sets?
@@ -730,14 +730,14 @@ OMR::X86::MemoryReference::populateMemoryReference(
             {
             if (_indexRegister != NULL)
                {
-               self()->consolidateRegisters(subTree, cg);
+               consolidateRegisters(subTree, cg);
                }
-            _indexRegister = self()->evaluate(subTree, cg, parent);
+            _indexRegister = evaluate(subTree, cg, parent);
             _indexNode     = subTree;
             }
          else
             {
-            _baseRegister  = self()->evaluate(subTree, cg);
+            _baseRegister  = evaluate(subTree, cg);
             _baseNode      = subTree;
             }
          }
@@ -763,7 +763,7 @@ OMR::X86::MemoryReference::evaluate(TR::Node * node, TR::CodeGenerator * cg, TR:
 
    TR::Register *reg = cg->evaluate(node);
 
-   if (self()->inUpcastingMode())
+   if (inUpcastingMode())
       {
       if (node->skipSignExtension())
          {
@@ -841,7 +841,7 @@ OMR::X86::MemoryReference::consolidateRegisters(
 
    TR::MemoryReference  *interimMemoryReference = generateX86MemoryReference(_baseRegister, _indexRegister, _stride, cg);
    generateRegMemInstruction(LEARegMem(), node, tempTargetRegister, interimMemoryReference, cg);
-   self()->decNodeReferenceCounts(cg);
+   decNodeReferenceCounts(cg);
    _baseRegister  = tempTargetRegister;
    _baseNode      = NULL;
    _indexRegister = NULL;
@@ -856,7 +856,7 @@ OMR::X86::MemoryReference::assignRegisters(
    {
    TR::RealRegister *assignedBaseRegister = NULL;
    TR::RealRegister *assignedIndexRegister;
-   TR::UnresolvedDataSnippet *snippet = self()->getUnresolvedDataSnippet();
+   TR::UnresolvedDataSnippet *snippet = getUnresolvedDataSnippet();
 
    if (_baseRegister != NULL)
       {
@@ -931,23 +931,23 @@ OMR::X86::MemoryReference::assignRegisters(
 uint32_t
 OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
    {
-   if (self()->getBaseRegister() && toRealRegister(self()->getBaseRegister())->getRegisterNumber() == TR::RealRegister::vfp)
+   if (getBaseRegister() && toRealRegister(getBaseRegister())->getRegisterNumber() == TR::RealRegister::vfp)
       {
       // Rewrite VFP-relative memref in terms of an actual register
       //
       _baseRegister = cg->machine()->getX86RealRegister(cg->vfpState()._register);
-      self()->getSymbolReference().setOffset(self()->getSymbolReference().getOffset() + cg->vfpState()._displacement);
+      getSymbolReference().setOffset(getSymbolReference().getOffset() + cg->vfpState()._displacement);
       }
 
-   TR::RealRegister *base = toRealRegister(self()->getBaseRegister());
+   TR::RealRegister *base = toRealRegister(getBaseRegister());
 
    intptrj_t displacement;
    uint32_t addressTypes =
-      (self()->getBaseRegister() != NULL ? 1 : 0) |
-      (self()->getIndexRegister() != NULL ? 2 : 0) |
-      ((self()->getSymbolReference().getSymbol() != NULL ||
-        self()->getSymbolReference().getOffset() != 0    ||
-        self()->isForceWideDisplacement()) ? 4 : 0);
+      (getBaseRegister() != NULL ? 1 : 0) |
+      (getIndexRegister() != NULL ? 2 : 0) |
+      ((getSymbolReference().getSymbol() != NULL ||
+        getSymbolReference().getOffset() != 0    ||
+        isForceWideDisplacement()) ? 4 : 0);
    uint32_t length = 0;
 
    switch (addressTypes)
@@ -983,18 +983,18 @@ OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
          break;
 
       case 5:
-         displacement = self()->getDisplacement();
+         displacement = getDisplacement();
          TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
          if (displacement == 0 &&
              !base->needsDisp() &&
              !base->needsSIB() &&
-             !self()->isForceWideDisplacement())
+             !isForceWideDisplacement())
             {
             length = 0;
             }
          else if (displacement >= -128 &&
                   displacement <= 127  &&
-                  !self()->isForceWideDisplacement())
+                  !isForceWideDisplacement())
             {
             length = 1;
             }
@@ -1006,18 +1006,18 @@ OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
             length = 4;
             }
 
-         if (base->needsSIB() || self()->isForceSIBByte())
+         if (base->needsSIB() || isForceSIBByte())
             {
             length += 1;
             }
          break;
 
       case 7:
-         displacement = self()->getDisplacement();
+         displacement = getDisplacement();
          TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
          if (displacement >= -128 &&
              displacement <= 127  &&
-             !self()->isForceWideDisplacement())
+             !isForceWideDisplacement())
             {
             length = 2;
             }
@@ -1040,18 +1040,18 @@ OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator *cg)
    {
    intptrj_t displacement;
    uint32_t addressTypes =
-      (self()->getBaseRegister()     != NULL ? 1 : 0) |
-      (self()->getIndexRegister()    != NULL ? 2 : 0) |
-      ((self()->getSymbolReference().getSymbol() != NULL ||
-        self()->getSymbolReference().getOffset() != 0    ||
-        self()->isForceWideDisplacement()) ? 4 : 0);
+      (getBaseRegister()     != NULL ? 1 : 0) |
+      (getIndexRegister()    != NULL ? 2 : 0) |
+      ((getSymbolReference().getSymbol() != NULL ||
+        getSymbolReference().getOffset() != 0    ||
+        isForceWideDisplacement()) ? 4 : 0);
 
    uint32_t length = 0;
    TR::RealRegister::RegNum registerNumber = TR::RealRegister::NoReg;
 
-   if (self()->getBaseRegister())
+   if (getBaseRegister())
       {
-      registerNumber = toRealRegister(self()->getBaseRegister())->getRegisterNumber();
+      registerNumber = toRealRegister(getBaseRegister())->getRegisterNumber();
 
       if (registerNumber == TR::RealRegister::vfp)
          {
@@ -1091,18 +1091,18 @@ OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator *cg)
          break;
 
       case 5:
-         displacement = self()->getDisplacement();
+         displacement = getDisplacement();
 
          if (displacement == 0 &&
              !base->needsDisp() &&
              !base->needsSIB() &&
-             !self()->isForceWideDisplacement())
+             !isForceWideDisplacement())
             {
             length = 0;
             }
          else if (displacement >= -128 &&
                   displacement <= 127 &&
-                  !self()->isForceWideDisplacement())
+                  !isForceWideDisplacement())
             {
             if (displacement != 0)
                length = 1;
@@ -1114,15 +1114,15 @@ OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator *cg)
             // value)
             length = 4;
 
-         if (base->needsSIB() || self()->isForceSIBByte())
+         if (base->needsSIB() || isForceSIBByte())
             {
             length += 1;
             }
          break;
 
       case 7:
-         displacement = self()->getDisplacement();
-         if (!self()->isForceWideDisplacement())
+         displacement = getDisplacement();
+         if (!isForceWideDisplacement())
             length = 2;
          else
             length = 5;
@@ -1139,13 +1139,13 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
       return OMR::X86::EnlargementResult(0, 0);
 
    int32_t growth = 0;
-   if (!self()->isForceWideDisplacement())
+   if (!isForceWideDisplacement())
       {
-      int32_t currentEncodingAllocation = self()->estimateBinaryLength(cg);
-      int32_t currentPatchSize = self()->getBinaryLengthLowerBound(cg);
+      int32_t currentEncodingAllocation = estimateBinaryLength(cg);
+      int32_t currentPatchSize = getBinaryLengthLowerBound(cg);
       _flags.set(MemRef_ForceWideDisplacement);
-      int32_t potentialEncodingGrowth = self()->estimateBinaryLength(cg) - currentPatchSize;
-      int32_t potentialPatchGrowth = self()->getBinaryLengthLowerBound(cg) - currentEncodingAllocation;
+      int32_t potentialEncodingGrowth = estimateBinaryLength(cg) - currentPatchSize;
+      int32_t potentialPatchGrowth = getBinaryLengthLowerBound(cg) - currentEncodingAllocation;
 
       if (potentialPatchGrowth > 0 &&
           (potentialPatchGrowth >= requestedEnlargementSize || allowPartialEnlargement) &&
@@ -1157,7 +1157,7 @@ OMR::X86::EnlargementResult OMR::X86::MemoryReference::enlarge(TR::CodeGenerator
       else
          {
          _flags.reset(MemRef_ForceWideDisplacement);
-         self()->estimateBinaryLength(cg);
+         estimateBinaryLength(cg);
          return OMR::X86::EnlargementResult(0, 0);
          }
       }
@@ -1178,14 +1178,14 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
       case 6:
       case 2:
          {
-         if (self()->needsCodeAbsoluteExternalRelocation())
+         if (needsCodeAbsoluteExternalRelocation())
             {
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   0,
                                                                   TR_AbsoluteMethodAddress, cg),
                                  __FILE__,__LINE__, node);
             }
-         else if (self()->getReloKind() == TR_ACTIVE_CARD_TABLE_BASE)
+         else if (getReloKind() == TR_ACTIVE_CARD_TABLE_BASE)
             {
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                   (uint8_t*)TR_ActiveCardTableBase,
@@ -1193,11 +1193,11 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                                  __FILE__,__LINE__, node);
             }
 
-         if (self()->getSymbolReference().getSymbol()
-            && self()->getSymbolReference().getSymbol()->isClassObject()
+         if (getSymbolReference().getSymbol()
+            && getSymbolReference().getSymbol()->isClassObject()
             && cg->wantToPatchClassPointer(NULL, cursor)) // might not point to beginning of class
             {
-            cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, self()->getUnresolvedDataSnippet() != NULL);
+            cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, getUnresolvedDataSnippet() != NULL);
             }
 
          break;
@@ -1205,20 +1205,20 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
 
       case 4:
          {
-         TR::Symbol *symbol = self()->getSymbolReference().getSymbol();
+         TR::Symbol *symbol = getSymbolReference().getSymbol();
          if (symbol)
             {
             TR::StaticSymbol * staticSym = symbol->getStaticSymbol();
 
             if (staticSym)
                {
-               if (self()->getUnresolvedDataSnippet() == NULL)
+               if (getUnresolvedDataSnippet() == NULL)
                   {
                   if (symbol->isConst())
                      {
                      TR::Compilation *comp = cg->comp();
                      cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                            (uint8_t *)self()->getSymbolReference().getOwningMethod(comp)->constantPool(),
+                                                                            (uint8_t *)getSymbolReference().getOwningMethod(comp)->constantPool(),
                                                                             node ? (uint8_t *)(intptrj_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                            TR_ConstantPool, cg),
                                           __FILE__, __LINE__, node);
@@ -1227,11 +1227,11 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                      {
                      if (cg->needClassAndMethodPointerRelocations())
                         {
-                        *(int32_t *)cursor = (int32_t)(TR::Compiler->cls.persistentClassPointerFromClassPointer(cg->comp(), (TR_OpaqueClassBlock*)(self()->getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress())));
+                        *(int32_t *)cursor = (int32_t)(TR::Compiler->cls.persistentClassPointerFromClassPointer(cg->comp(), (TR_OpaqueClassBlock*)(getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress())));
                         if (cg->comp()->getOption(TR_UseSymbolValidationManager))
                            {
                            cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                                     (uint8_t *)(self()->getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress()),
+                                                                                                     (uint8_t *)(getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress()),
                                                                                                      (uint8_t *)TR::SymbolType::typeClass,
                                                                                                      TR_SymbolFromManager,
                                                                                                      cg),
@@ -1239,7 +1239,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                            }
                         else
                            {
-                           cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)&self()->getSymbolReference(),
+                           cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)&getSymbolReference(),
                                                                                                     node ? (uint8_t *)(intptrj_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                                                     TR_ClassAddress, cg), __FILE__, __LINE__, node);
                            }
@@ -1276,7 +1276,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                         }
                      else if (symbol->isDebugCounter())
                         {
-                        TR::DebugCounterBase *counter = cg->comp()->getCounterFromStaticAddress(&(self()->getSymbolReference()));
+                        TR::DebugCounterBase *counter = cg->comp()->getCounterFromStaticAddress(&(getSymbolReference()));
                         if (counter == NULL)
                            {
                            cg->comp()->failCompilation<TR::CompilationException>("Could not generate relocation for debug counter in OMR::X86::MemoryReference::addMetaDataForCodeAddress\n");
@@ -1289,7 +1289,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
                      else
                         {
                         cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                           (uint8_t *)&self()->getSymbolReference(),
+                                                                           (uint8_t *)&getSymbolReference(),
                                                                            node ? (uint8_t *)(uintptr_t)node->getInlinedSiteIndex() : (uint8_t *)-1,
                                                                            TR_DataAddress, cg),
                                              __FILE__,
@@ -1309,13 +1309,13 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
             }
          else
             {
-            TR::X86DataSnippet* cds = self()->getDataSnippet();
+            TR::X86DataSnippet* cds = getDataSnippet();
             TR::LabelSymbol *label = NULL;
 
             if (cds)
                label = cds->getSnippetLabel();
             else
-               label = self()->getLabel();
+               label = getLabel();
 
             if (label != NULL)
                {
@@ -1341,22 +1341,22 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
 
       case 5:
          {
-         intptrj_t displacement = self()->getDisplacement();
-         TR::RealRegister *base = toRealRegister(self()->getBaseRegister());
+         intptrj_t displacement = getDisplacement();
+         TR::RealRegister *base = toRealRegister(getBaseRegister());
 
          if (!(displacement == 0 &&
                !base->needsDisp() &&
                !base->needsDisp() &&
-               !self()->isForceWideDisplacement()) &&
+               !isForceWideDisplacement()) &&
              !(displacement >= -128 &&
                displacement <= 127  &&
-               !self()->isForceWideDisplacement()))
+               !isForceWideDisplacement()))
             {
-            if (self()->getSymbolReference().getSymbol()
-               && self()->getSymbolReference().getSymbol()->isClassObject()
+            if (getSymbolReference().getSymbol()
+               && getSymbolReference().getSymbol()->isClassObject()
                && cg->wantToPatchClassPointer(NULL, cursor)) // possibly unresolved, may not point to beginning of class
                {
-               cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, self()->getUnresolvedDataSnippet() != NULL);
+               cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *) cursor, getUnresolvedDataSnippet() != NULL);
                }
             }
 
@@ -1365,17 +1365,17 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
 
       case 7:
          {
-         intptrj_t displacement = self()->getDisplacement();
+         intptrj_t displacement = getDisplacement();
 
          if (!(displacement >= -128 &&
                displacement <= 127  &&
-               !self()->isForceWideDisplacement()))
+               !isForceWideDisplacement()))
             {
-            if (self()->getSymbolReference().getSymbol()
-               && self()->getSymbolReference().getSymbol()->isClassObject()
+            if (getSymbolReference().getSymbol()
+               && getSymbolReference().getSymbol()->isClassObject()
                && cg->wantToPatchClassPointer(NULL, cursor)) // possibly unresolved, may not point to beginning of class
                {
-               cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *)cursor, self()->getUnresolvedDataSnippet() != NULL);
+               cg->jitAdd32BitPicToPatchOnClassRedefinition((void*)(uintptr_t)*(int32_t*)cursor, (void *)cursor, getUnresolvedDataSnippet() != NULL);
                }
             }
 
@@ -1396,11 +1396,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
    TR::Compilation *comp = cg->comp();
 
    uint32_t addressTypes =
-      (self()->getBaseRegister() != NULL ? 1 : 0) |
-      (self()->getIndexRegister() != NULL ? 2 : 0) |
-      ((self()->getSymbolReference().getSymbol() != NULL ||
-        self()->getSymbolReference().getOffset() != 0    ||
-        self()->isForceWideDisplacement()) ? 4 : 0);
+      (getBaseRegister() != NULL ? 1 : 0) |
+      (getIndexRegister() != NULL ? 2 : 0) |
+      ((getSymbolReference().getSymbol() != NULL ||
+        getSymbolReference().getOffset() != 0    ||
+        isForceWideDisplacement()) ? 4 : 0);
 
    intptrj_t displacement;
 
@@ -1415,7 +1415,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
       {
       case 1:
          {
-         base = toRealRegister(self()->getBaseRegister());
+         base = toRealRegister(getBaseRegister());
          baseRegisterNumber = base->getRegisterNumber();
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
@@ -1426,25 +1426,25 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             base = toRealRegister(cg->machine()->
                getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
-            self()->setBaseRegister(base);
+            setBaseRegister(base);
             }
 
          if (base->needsDisp())
             {
-            self()->ModRM(modRM)->setBaseDisp8();
+            ModRM(modRM)->setBaseDisp8();
             base->setRMRegisterFieldInModRM(modRM);
             *++cursor = 0x00;
             }
          else if (base->needsSIB())
             {
-            self()->ModRM(modRM)->setBase()->setHasSIB();
+            ModRM(modRM)->setBase()->setHasSIB();
             *++cursor = 0x00;
-            self()->SIB(cursor)->setNoIndex();
+            SIB(cursor)->setNoIndex();
             base->setBaseRegisterFieldInSIB(cursor);
             }
          else
             {
-            self()->ModRM(modRM)->setBase();
+            ModRM(modRM)->setBase();
             base->setRMRegisterFieldInModRM(modRM);
             }
 
@@ -1455,21 +1455,21 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
       case 6:
       case 2:
          {
-         index = toRealRegister(self()->getIndexRegister());
-         self()->ModRM(modRM)->setBase()->setHasSIB();
+         index = toRealRegister(getIndexRegister());
+         ModRM(modRM)->setBase()->setHasSIB();
          *++cursor = 0x00;
-         self()->SIB(cursor)->setIndexDisp32();
+         SIB(cursor)->setIndexDisp32();
          index->setIndexRegisterFieldInSIB(cursor);
-         self()->setStrideFieldInSIB(cursor);
+         setStrideFieldInSIB(cursor);
          cursor++;
 
          immediateCursor = cursor;
 
-         *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+         *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
 
-         if (self()->getUnresolvedDataSnippet() != NULL)
+         if (getUnresolvedDataSnippet() != NULL)
             {
-            self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+            getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
             }
 
          cursor += 4;
@@ -1478,7 +1478,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
       case 3:
          {
-         base = toRealRegister(self()->getBaseRegister());
+         base = toRealRegister(getBaseRegister());
          baseRegisterNumber = base->getRegisterNumber();
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
@@ -1489,24 +1489,24 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             base = toRealRegister(cg->machine()->
                    getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
-            self()->setBaseRegister(base);
+            setBaseRegister(base);
             }
 
-         index = toRealRegister(self()->getIndexRegister());
+         index = toRealRegister(getIndexRegister());
          *++cursor = 0x00;
          base->setBaseRegisterFieldInSIB(cursor);
          index->setIndexRegisterFieldInSIB(cursor);
-         self()->setStrideFieldInSIB(cursor);
+         setStrideFieldInSIB(cursor);
          if (base->needsDisp())
             {
             // Need a sib byte with 8bit displacement field of zero to get ebp as a base register
             //
-            self()->ModRM(modRM)->setBaseDisp8()->setHasSIB();
+            ModRM(modRM)->setBaseDisp8()->setHasSIB();
             *++cursor = 0x00;
             }
          else
             {
-            self()->ModRM(modRM)->setBase()->setHasSIB();
+            ModRM(modRM)->setBase()->setHasSIB();
             }
          ++cursor;
          break;
@@ -1514,9 +1514,9 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
       case 4:
          {
-         self()->ModRM(modRM)->setIndexOnlyDisp32();
+         ModRM(modRM)->setIndexOnlyDisp32();
          cursor++;
-         symbol = self()->getSymbolReference().getSymbol();
+         symbol = getSymbolReference().getSymbol();
          immediateCursor = cursor;
 
          if (symbol)
@@ -1527,13 +1527,13 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             if (staticSym)
                {
 
-               if (self()->getUnresolvedDataSnippet() == NULL)
+               if (getUnresolvedDataSnippet() == NULL)
                   {
-                  *(int32_t *)cursor = (int32_t)(self()->getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress());
+                  *(int32_t *)cursor = (int32_t)(getSymbolReference().getOffset() + (intptrj_t)staticSym->getStaticAddress());
                   }
                else
                   {
-                  *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+                  *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                   }
                }
             else if (methodSym)
@@ -1546,28 +1546,28 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
                }
             else if (symbol->isRegisterMappedSymbol())
                {
-               displacement = self()->getSymbolReference().getOffset() +
+               displacement = getSymbolReference().getOffset() +
                                  symbol->getRegisterMappedSymbol()->getOffset();
                TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
                *(int32_t *)cursor = (int32_t)displacement;
                }
             else if (symbol->isShadow())
                {
-               *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+               *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                }
             else
                TR_ASSERT(0, "generateBinaryEncoding, new symbol hierarchy problem");
             }
          else
             {
-            TR::X86DataSnippet* cds = self()->getDataSnippet();
-            TR_ASSERT(cds == NULL || self()->getLabel() == NULL,
+            TR::X86DataSnippet* cds = getDataSnippet();
+            TR_ASSERT(cds == NULL || getLabel() == NULL,
                    "a memRef cannot have both a constant data snippet and a label");
             TR::LabelSymbol *label = NULL;
             if (cds)
                label = cds->getSnippetLabel();
             else
-               label = self()->getLabel();
+               label = getLabel();
 
             if (label != NULL)
                {
@@ -1585,13 +1585,13 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
                }
             else
                {
-               *(int32_t *)cursor = (int32_t)self()->getSymbolReference().getOffset();
+               *(int32_t *)cursor = (int32_t)getSymbolReference().getOffset();
                }
             }
 
-         if (self()->getUnresolvedDataSnippet() != NULL)
+         if (getUnresolvedDataSnippet() != NULL)
             {
-            self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+            getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
             }
 
          cursor += 4;
@@ -1600,7 +1600,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
       case 5:
          {
-         base = toRealRegister(self()->getBaseRegister());
+         base = toRealRegister(getBaseRegister());
          baseRegisterNumber = base->getRegisterNumber();
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
@@ -1611,17 +1611,17 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             base = toRealRegister(cg->machine()->
                    getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
-            self()->setBaseRegister(base);
+            setBaseRegister(base);
             }
 
-         if (base->needsSIB() || self()->isForceSIBByte())
+         if (base->needsSIB() || isForceSIBByte())
             {
             *++cursor = 0x00;
-            self()->ModRM(modRM)->setBase()->setHasSIB();
-            self()->SIB(cursor)->setNoIndex();
+            ModRM(modRM)->setBase()->setHasSIB();
+            SIB(cursor)->setNoIndex();
             }
 
-         displacement = self()->getDisplacement();
+         displacement = getDisplacement();
          TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
          base->setRMRegisterFieldInModRM(cursor++);
          immediateCursor = cursor;
@@ -1629,15 +1629,15 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
          if (displacement == 0 &&
              !base->needsDisp() &&
              !base->needsDisp() &&
-             !self()->isForceWideDisplacement())
+             !isForceWideDisplacement())
             {
-            self()->ModRM(modRM)->setBase();
+            ModRM(modRM)->setBase();
             }
          else if (displacement >= -128 &&
                   displacement <= 127  &&
-                  !self()->isForceWideDisplacement())
+                  !isForceWideDisplacement())
             {
-            self()->ModRM(modRM)->setBaseDisp8();
+            ModRM(modRM)->setBaseDisp8();
             *cursor = (uint8_t)displacement;
             ++cursor;
             }
@@ -1646,11 +1646,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             // If there is a symbol or if the displacement will not fit in a byte,
             // then displacement will be 4 bytes.
             //
-            self()->ModRM(modRM)->setBaseDisp32();
+            ModRM(modRM)->setBaseDisp32();
             *(int32_t *)cursor = (int32_t)displacement;
-            if (self()->getUnresolvedDataSnippet() != NULL)
+            if (getUnresolvedDataSnippet() != NULL)
                {
-               self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+               getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
                }
 
             cursor += 4;
@@ -1660,7 +1660,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
       case 7:
          {
-         base = toRealRegister(self()->getBaseRegister());
+         base = toRealRegister(getBaseRegister());
          baseRegisterNumber = base->getRegisterNumber();
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
@@ -1671,24 +1671,24 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             base = toRealRegister(cg->machine()->
                       getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
-            self()->setBaseRegister(base);
+            setBaseRegister(base);
             }
 
-         index = toRealRegister(self()->getIndexRegister());
+         index = toRealRegister(getIndexRegister());
          *++cursor = 0x00;
          base->setBaseRegisterFieldInSIB(cursor);
          index->setIndexRegisterFieldInSIB(cursor);
-         self()->setStrideFieldInSIB(cursor);
+         setStrideFieldInSIB(cursor);
          ++cursor;
-         displacement = self()->getDisplacement();
+         displacement = getDisplacement();
          immediateCursor = cursor;
 
          TR_ASSERT(IS_32BIT_SIGNED(displacement), "64-bit displacement should have been replaced in TR_AMD64MemoryReference::generateBinaryEncoding");
          if (displacement >= -128 &&
              displacement <= 127  &&
-             !self()->isForceWideDisplacement())
+             !isForceWideDisplacement())
             {
-            self()->ModRM(modRM)->setBaseDisp8()->setHasSIB();
+            ModRM(modRM)->setBaseDisp8()->setHasSIB();
             *cursor++ = (uint8_t)displacement;
             }
          else
@@ -1696,11 +1696,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
             // If there is a symbol or if the displacement will not fit in a byte,
             // then displacement will be 4 bytes.
             //
-            self()->ModRM(modRM)->setBaseDisp32()->setHasSIB();
+            ModRM(modRM)->setBaseDisp32()->setHasSIB();
             *(int32_t *)cursor = (int32_t)displacement;
-            if (self()->getUnresolvedDataSnippet() != NULL)
+            if (getUnresolvedDataSnippet() != NULL)
                {
-               self()->getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
+               getUnresolvedDataSnippet()->setAddressOfDataReference(cursor);
                }
 
             cursor += 4;
@@ -1709,7 +1709,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
          }
       }
 
-   self()->addMetaDataForCodeAddress(addressTypes, immediateCursor, containingInstruction->getNode(), cg);
+   addMetaDataForCodeAddress(addressTypes, immediateCursor, containingInstruction->getNode(), cg);
 
    return cursor;
    }
@@ -1783,7 +1783,7 @@ const uint8_t OMR::X86::MemoryReference::_multiplierToStrideMap[HIGHEST_STRIDE_M
 #ifdef DEBUG
 uint32_t OMR::X86::MemoryReference::getNumMRReferencedGPRegisters()
    {
-   return (self()->getBaseRegister() ? 1 : 0) + (self()->getIndexRegister() ? 1 : 0);
+   return (getBaseRegister() ? 1 : 0) + (getIndexRegister() ? 1 : 0);
    }
 #endif
 

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -225,7 +225,7 @@ class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReference
 
    TR::Node *getIndexNode()            {return _indexNode;}
    TR::Node *setIndexNode(TR::Node *in) {return (_indexNode = in);}
-   TR::Register *getAddressRegister(){ return NULL; }
+   virtual TR::Register *getAddressRegister(){ return NULL; }
    intptrj_t getDisplacement();
 
    // An unresolved data snippet, unresolved virtual call snippet, and constant data snippet are mutually exclusive for

--- a/compiler/x/codegen/OMRMemoryReference.hpp
+++ b/compiler/x/codegen/OMRMemoryReference.hpp
@@ -82,7 +82,7 @@ namespace OMR
 namespace X86
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReference
    {
 
    protected:

--- a/compiler/z/codegen/MemoryReference.hpp
+++ b/compiler/z/codegen/MemoryReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,7 +37,7 @@ namespace TR { class Register; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReferenceConnector
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReferenceConnector
    {
    public:
 

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -550,7 +550,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
 
          if (symRef->isUnresolved())
             {
-            self()->createUnresolvedDataSnippetForiaload(rootLoadOrStore, cg, symRef, tempReg, isStore);
+            createUnresolvedDataSnippetForiaload(rootLoadOrStore, cg, symRef, tempReg, isStore);
             }
          else
             {
@@ -575,7 +575,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
          }
       if (symRef && symRef->isUnresolved())
          {
-         self()->createUnresolvedDataSnippet(rootLoadOrStore, cg, symRef, tempReg, isStore);
+         createUnresolvedDataSnippet(rootLoadOrStore, cg, symRef, tempReg, isStore);
          }
 
       // indexRegister may setup in populateMemoryReference to hold the address for the load/store
@@ -600,8 +600,8 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
          // symbol is unresolved
          if (symRef && symRef->isUnresolved())
             {
-            TR::UnresolvedDataSnippet * uds = self()->createUnresolvedDataSnippet(rootLoadOrStore, cg, symRef, tempReg, isStore);
-            self()->createPatchableDataInLitpool(rootLoadOrStore, cg, tempReg, uds);
+            TR::UnresolvedDataSnippet * uds = createUnresolvedDataSnippet(rootLoadOrStore, cg, symRef, tempReg, isStore);
+            createPatchableDataInLitpool(rootLoadOrStore, cg, tempReg, uds);
             }
          else
             {
@@ -787,12 +787,12 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * node, TR::SymbolReference * 
 
    if (symRef->isUnresolved())
       {
-      self()->createUnresolvedSnippetWithNodeRegister(node, cg, symRef, writableLiteralPoolRegister);
+      createUnresolvedSnippetWithNodeRegister(node, cg, symRef, writableLiteralPoolRegister);
       }
 
    if (_baseNode != NULL && _baseNode->getOpCodeValue() == TR::loadaddr && self()->getUnresolvedSnippet() != NULL)
       {
-      self()->createUnresolvedDataSnippetForBaseNode(cg, writableLiteralPoolRegister);
+      createUnresolvedDataSnippetForBaseNode(cg, writableLiteralPoolRegister);
       }
 
    _indexRegister = NULL;
@@ -1953,7 +1953,7 @@ OMR::Z::MemoryReference::consolidateRegisters(TR::Node * node, TR::CodeGenerator
 bool OMR::Z::MemoryReference::ignoreNegativeOffset()
    {
    if (_offset < 0 &&
-       (self()->hasTemporaryNegativeOffset() || self()->symRefHasTemporaryNegativeOffset()))
+       (self()->hasTemporaryNegativeOffset() || symRefHasTemporaryNegativeOffset()))
       {
       return true;
       }
@@ -2466,7 +2466,7 @@ OMR::Z::MemoryReference::getSnippet()
 
    if (self()->getUnresolvedSnippet() != NULL)
       {
-      self()->setMemRefAndGetUnresolvedData(snippet);
+      setMemRefAndGetUnresolvedData(snippet);
       }
    else if (self()->getConstantDataSnippet() != NULL)
       {
@@ -2939,7 +2939,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
    int32_t displacement = self()->calcDisplacement(cursor, instr, cg);
 
    //add project specific relocations for specific instructions
-   self()->addInstrSpecificRelocation(cg, instr, displacement, cursor);
+   addInstrSpecificRelocation(cg, instr, displacement, cursor);
 
    // We may end up "upgrading" the instruction in case of long displacement, so this variable may change
    auto instructionFormat = instr->getKind();

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -100,7 +100,7 @@ void OMR::Z::MemoryReference::setupCausesImplicitNullPointerException(TR::CodeGe
       if (cg->getSupportsImplicitNullChecks() &&
          cg->getCurrentEvaluationTreeTop()->getNode()->getOpCode().isNullCheck())
          {
-         self()->setCausesImplicitNullPointerException();
+         setCausesImplicitNullPointerException();
          }
    }
 
@@ -117,15 +117,15 @@ void OMR::Z::MemoryReference::addToTemporaryNegativeOffset(TR::Node *node, int32
       {
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"\taddToTemporaryNegativeOffset : %s (%p) new offset %d, existing mr offset %d (existing mr hasTempNegOffset = %s)\n",
-            node?node->getOpCode().getName():"NULL",node,offset,self()->getOffset(),self()->hasTemporaryNegativeOffset()?"yes":"no");
-      if (self()->getOffset() < 0 && !self()->hasTemporaryNegativeOffset()) // if there is a 'real' negative offset then deal with this first before adding in the temporary negative offset
+            node?node->getOpCode().getName():"NULL",node,offset,getOffset(),hasTemporaryNegativeOffset()?"yes":"no");
+      if (getOffset() < 0 && !hasTemporaryNegativeOffset()) // if there is a 'real' negative offset then deal with this first before adding in the temporary negative offset
          {
          if (cg->traceBCDCodeGen())
-            traceMsg(comp,"\t\texisting mr->offset %d < 0 so call enforceSSFormatLimits to clear this up before setting HasTemporaryNegativeOffset\n",self()->getOffset());
-         self()->enforceSSFormatLimits(node, cg, NULL);  // call SSFormatLimits to also take this chance to fold in an index register if needed
+            traceMsg(comp,"\t\texisting mr->offset %d < 0 so call enforceSSFormatLimits to clear this up before setting HasTemporaryNegativeOffset\n",getOffset());
+         enforceSSFormatLimits(node, cg, NULL);  // call SSFormatLimits to also take this chance to fold in an index register if needed
          }
-      self()->addToOffset(offset);
-      self()->setHasTemporaryNegativeOffset();
+      addToOffset(offset);
+      setHasTemporaryNegativeOffset();
       }
    }
 
@@ -138,7 +138,7 @@ void OMR::Z::MemoryReference::setupCheckForLongDispFlag(TR::CodeGenerator *cg)
    // Enable a check for the long disp slot in generateBin phase
    if (cg->getCodeGeneratorPhase() == TR::CodeGenPhase::InstructionSelectionPhase)
       {
-      self()->setCheckForLongDispSlot();
+      setCheckForLongDispSlot();
       }
    }
 
@@ -259,7 +259,7 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
                   addressChild->getOpCode().getName(), addressChild);
          }
       cg->evaluate(addressChild->getFirstChild());
-      self()->setForceFolding();
+      setForceFolding();
       return true;
       }
 
@@ -275,7 +275,7 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
                   addressChild->getOpCode().getName(), addressChild);
          }
       cg->evaluate(addressChild->getFirstChild());
-      self()->setForceFolding();
+      setForceFolding();
       return true;
       }
 
@@ -317,7 +317,7 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
                   addressChild->getSecondChild()->get64bitIntegralValue(),
                   "setForceFirstTimeFolding");
          }
-      self()->setForceFirstTimeFolding(); // e.g. fold the top level add but not anything below the add
+      setForceFirstTimeFolding(); // e.g. fold the top level add but not anything below the add
       return true;
       }
 
@@ -358,7 +358,7 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
          traceMsg(comp," inside setForceFoldingIfAdvantageous, eventualNonConversion %s (%p) has no register and refCount==1 and is a aload+const so setForceFolding=true\n",
                   eventualNonConversion->getOpCode().getName(),eventualNonConversion);
          }
-      self()->setForceFolding();
+      setForceFolding();
       return true;
       }
    else // if (eventualNonConversion->getReferenceCount() == 1)
@@ -382,7 +382,7 @@ bool OMR::Z::MemoryReference::setForceFoldingIfAdvantageous(TR::CodeGenerator * 
                   eventualNonConversion->getOpCode().getName(),eventualNonConversion,
                   eventualNonConversion->getFirstChild()->getOpCode().getName(),eventualNonConversion->getFirstChild());
          }
-      self()->setForceFolding();
+      setForceFolding();
       cg->evaluate(addressChild->getFirstChild());
       return true;
       }
@@ -493,25 +493,25 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
       }
 
    // Enable a check for the long disp slot in generateBin phase
-   self()->setupCheckForLongDispFlag(cg);
+   setupCheckForLongDispFlag(cg);
 
-   self()->setupCausesImplicitNullPointerException(cg);
+   setupCausesImplicitNullPointerException(cg);
 
    _targetSnippetInstruction = NULL;
 
    TR_ASSERT(_incrementedNodesList.getHeadData() == 0,
               "_incrementedNodesList size is not zero at beginning of OMR::Z::MemoryReference constructor!");
 
-   self()->tryForceFolding(rootLoadOrStore, cg, storageReference, symRef, symbol, nodesAlreadyEvaluatedBeforeFoldingList);
+   tryForceFolding(rootLoadOrStore, cg, storageReference, symRef, symbol, nodesAlreadyEvaluatedBeforeFoldingList);
 
-   if (rootLoadOrStore->getOpCode().isIndirect() || self()->isExposedConstantAddressing())
+   if (rootLoadOrStore->getOpCode().isIndirect() || isExposedConstantAddressing())
       {
       TR::Node * subTree = rootLoadOrStore->getFirstChild();
 
       if (subTree->getOpCodeValue() == TR::aconst)
          {
-         if (!self()->ZeroBasePtr_EvaluateSubtree(subTree, cg, this))
-            self()->setBaseRegister(cg->evaluate(subTree), cg);
+         if (!ZeroBasePtr_EvaluateSubtree(subTree, cg, this))
+            setBaseRegister(cg->evaluate(subTree), cg);
          _baseNode = subTree;
          cg->decReferenceCount(subTree);
          }
@@ -521,10 +521,10 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
          bool tryBID = (addressChild->getOpCodeValue() == TR::aiadd ||
                         addressChild->getOpCodeValue() == TR::aladd) &&
                        _baseRegister == NULL && _indexRegister == NULL &&
-                       self()->tryBaseIndexDispl(cg, rootLoadOrStore, addressChild);
+                       tryBaseIndexDispl(cg, rootLoadOrStore, addressChild);
          if (!tryBID)
             {
-            self()->populateMemoryReference(subTree, cg);
+            populateMemoryReference(subTree, cg);
             recursivelyDecrementIncrementedNodesIfUnderRegister(cg, subTree, _incrementedNodesList, nodesAlreadyEvaluatedBeforeFoldingList, comp->incOrResetVisitCount(), false);
             cg->decReferenceCount(subTree);
             }
@@ -544,7 +544,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
             }
          return;
          }
-      if ((symbol && symbol->isStatic()) && symRef && symRef->isFromLiteralPool() && !self()->isExposedConstantAddressing())
+      if ((symbol && symbol->isStatic()) && symRef && symRef->isFromLiteralPool() && !isExposedConstantAddressing())
          {
          TR_ASSERT(cg->supportsOnDemandLiteralPool() == true, "May not be here with Literal Pool On Demand disabled\n");
 
@@ -565,7 +565,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
                targetsnippet = cg->findOrCreate4ByteConstant(0, staticAddressValue);
                }
 
-            self()->initSnippetPointers(targetsnippet, cg);
+            initSnippetPointers(targetsnippet, cg);
             }
          if (alloc)
             {
@@ -589,7 +589,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
           !canUseRX &&
           (storageReference == NULL))
          {
-         self()->separateIndexRegister(rootLoadOrStore, cg, false, NULL); // enforce4KDisplacementLimit=false
+         separateIndexRegister(rootLoadOrStore, cg, false, NULL); // enforce4KDisplacementLimit=false
          }
       }
    else
@@ -614,16 +614,16 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
                   tempReg = cg->allocate64bitRegister();
                else
                   tempReg = cg->allocateRegister();
-               self()->setBaseRegister(tempReg, cg);
+               setBaseRegister(tempReg, cg);
                cg->stopUsingRegister(_baseRegister);
                _baseNode = NULL;
                }
             else
                {
                if (symbol && symbol->isMethodMetaData())
-                  self()->setBaseRegister(cg->getMethodMetaDataRealRegister(), cg);
+                  setBaseRegister(cg->getMethodMetaDataRealRegister(), cg);
                else
-                  self()->setBaseRegister(tempReg, cg);
+                  setBaseRegister(tempReg, cg);
                }
             genLoadAddressConstant(cg, rootLoadOrStore, (uintptrj_t) symRef->getSymbol()->getStaticSymbol()->getStaticAddress(),
                _baseRegister);
@@ -638,7 +638,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
             //
             // for example, calling generateMemoryReference([node], cg) on an aiadd node will arrive here.
 
-            self()->populateMemoryReference(rootLoadOrStore, cg);
+            populateMemoryReference(rootLoadOrStore, cg);
             if (alloc)
                {
                cg->stopUsingRegister(tempReg);
@@ -652,7 +652,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
             //TR_ASSERT(rootLoadOrStore->getDataType() == TR::Address,
             //   "rootLoadOrStore %s %p should be an address type and not dt %d\n",rootLoadOrStore->getOpCode().getName(),rootLoadOrStore,rootLoadOrStore->getDataType());
 
-            self()->populateThroughEvaluation(rootLoadOrStore, cg);
+            populateThroughEvaluation(rootLoadOrStore, cg);
             if (alloc)
                {
                cg->stopUsingRegister(tempReg);
@@ -666,12 +666,12 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
          if (symbol && !symbol->isMethodMetaData())
             {
             // auto or parm is on stack
-            self()->setBaseRegister(cg->getStackPointerRealRegister(symbol), cg);
+            setBaseRegister(cg->getStackPointerRealRegister(symbol), cg);
             }
          else
             {
             // meta data
-            self()->setBaseRegister(cg->getMethodMetaDataRealRegister(), cg);
+            setBaseRegister(cg->getMethodMetaDataRealRegister(), cg);
             }
 
          _baseNode = NULL;
@@ -682,19 +682,19 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
    if (symRef && symRef->isLiteralPoolAddress())
       {
       TR_ASSERT(cg->supportsOnDemandLiteralPool() == true, "May not be here with Literal Pool On Demand disabled\n");
-      TR::S390ConstantDataSnippet * targetsnippet = self()->createLiteralPoolSnippet(rootLoadOrStore, cg);
+      TR::S390ConstantDataSnippet * targetsnippet = createLiteralPoolSnippet(rootLoadOrStore, cg);
 
-      self()->initSnippetPointers(targetsnippet, cg);
+      initSnippetPointers(targetsnippet, cg);
       }
    else
       {
-      if (self()->getUnresolvedSnippet() == NULL)
+      if (getUnresolvedSnippet() == NULL)
          {
          if (symRef)
             _offset += symRef->getOffset();
          }
 
-      self()->enforceDisplacementLimit(rootLoadOrStore, cg, NULL);
+      enforceDisplacementLimit(rootLoadOrStore, cg, NULL);
       }
    if (alloc)
       {
@@ -747,7 +747,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node *addressChild, bool canUseInde
    _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
    _originalSymbolReference = _symbolReference;
    _listingSymbolReference = _symbolReference;
-   self()->setupCausesImplicitNullPointerException(cg);
+   setupCausesImplicitNullPointerException(cg);
    }
 
 TR::S390ConstantDataSnippet *
@@ -767,20 +767,20 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * node, TR::SymbolReference * 
    TR::Compilation *comp = cg->comp();
 
    // Enable a check for the long disp slot in generateBin phase
-   self()->setupCheckForLongDispFlag(cg);
+   setupCheckForLongDispFlag(cg);
 
-   self()->setupCausesImplicitNullPointerException(cg);
+   setupCausesImplicitNullPointerException(cg);
 
    if (symbol->isRegisterMappedSymbol())
       {
       // must be either auto, parm, meta or error.
       if (!symbol->isMethodMetaData())
          {
-         self()->setBaseRegister(cg->getStackPointerRealRegister(symbol), cg);
+         setBaseRegister(cg->getStackPointerRealRegister(symbol), cg);
          }
       else
          {
-         self()->setBaseRegister(cg->getMethodMetaDataRealRegister(), cg);
+         setBaseRegister(cg->getMethodMetaDataRealRegister(), cg);
          }
       _baseNode = NULL;
       }
@@ -790,7 +790,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * node, TR::SymbolReference * 
       createUnresolvedSnippetWithNodeRegister(node, cg, symRef, writableLiteralPoolRegister);
       }
 
-   if (_baseNode != NULL && _baseNode->getOpCodeValue() == TR::loadaddr && self()->getUnresolvedSnippet() != NULL)
+   if (_baseNode != NULL && _baseNode->getOpCodeValue() == TR::loadaddr && getUnresolvedSnippet() != NULL)
       {
       createUnresolvedDataSnippetForBaseNode(cg, writableLiteralPoolRegister);
       }
@@ -799,7 +799,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * node, TR::SymbolReference * 
    _symbolReference = symRef;
    _originalSymbolReference = symRef;
    _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(symRef, cg)? symRef : NULL;
-   if (self()->getUnresolvedSnippet() == NULL)
+   if (getUnresolvedSnippet() == NULL)
       {
       _offset = symRef->getOffset();
       }
@@ -808,7 +808,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * node, TR::SymbolReference * 
       _offset = 0;
       }
 
-   self()->enforceDisplacementLimit(node, cg, NULL);
+   enforceDisplacementLimit(node, cg, NULL);
    // TODO: aliasing sets?
    }
 
@@ -817,13 +817,13 @@ OMR::Z::MemoryReference::initSnippetPointers(TR::Snippet * s, TR::CodeGenerator 
    {
    if (s->getKind() == TR::Snippet::IsUnresolvedData)
       {
-      self()->setUnresolvedSnippet((TR::UnresolvedDataSnippet *) s);
+      setUnresolvedSnippet((TR::UnresolvedDataSnippet *) s);
       }
    else if (s->getKind() == TR::Snippet::IsWritableData ||
             s->getKind() == TR::Snippet::IsConstantInstruction ||
             s->getKind() == TR::Snippet::IsConstantData)
       {
-      self()->setConstantDataSnippet((TR::S390ConstantDataSnippet *) s);
+      setConstantDataSnippet((TR::S390ConstantDataSnippet *) s);
       }
    }
 
@@ -837,12 +837,12 @@ OMR::Z::MemoryReference::MemoryReference(TR::Snippet * s, TR::Register * indx, i
    _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
 
    // Enable a check for the long disp slot in generateBin phase
-   self()->setupCheckForLongDispFlag(cg);
+   setupCheckForLongDispFlag(cg);
 
-   self()->setupCausesImplicitNullPointerException(cg);
+   setupCausesImplicitNullPointerException(cg);
 
-   self()->setBaseRegister(cg->getLitPoolRealRegister(), cg);
-   self()->initSnippetPointers(s, cg);
+   setBaseRegister(cg->getLitPoolRealRegister(), cg);
+   initSnippetPointers(s, cg);
    }
 
 OMR::Z::MemoryReference::MemoryReference(TR::Snippet * s, TR::CodeGenerator * cg, TR::Register * base, TR::Node * node)
@@ -859,13 +859,13 @@ OMR::Z::MemoryReference::MemoryReference(TR::Snippet * s, TR::CodeGenerator * cg
    _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
 
    // Enable a check for the long disp slot in generateBin phase
-   self()->setupCheckForLongDispFlag(cg);
+   setupCheckForLongDispFlag(cg);
 
-   self()->setupCausesImplicitNullPointerException(cg);
+   setupCausesImplicitNullPointerException(cg);
 
    if (base)
       {
-      self()->setBaseRegister(base, cg);
+      setBaseRegister(base, cg);
       //TR_ASSERT(cg->supportsOnDemandLiteralPool()==true, "May not be here with Literal Pool On Demand disabled\n");
       }
    else
@@ -873,19 +873,19 @@ OMR::Z::MemoryReference::MemoryReference(TR::Snippet * s, TR::CodeGenerator * cg
       if (cg->isLiteralPoolOnDemandOn())
          {
          if (TR::Compiler->target.is64Bit())
-            self()->setBaseRegister(cg->allocate64bitRegister(), cg);
+            setBaseRegister(cg->allocate64bitRegister(), cg);
          else
-            self()->setBaseRegister(cg->allocateRegister(), cg);
+            setBaseRegister(cg->allocateRegister(), cg);
          generateLoadLiteralPoolAddress(cg, node, _baseRegister);
          cg->stopUsingRegister(_baseRegister);
          }
       else
          {
-         self()->setBaseRegister(cg->getLitPoolRealRegister(), cg);
+         setBaseRegister(cg->getLitPoolRealRegister(), cg);
          }
       }
 
-   self()->initSnippetPointers(s, cg);
+   initSnippetPointers(s, cg);
    }
 
 OMR::Z::MemoryReference::MemoryReference(int32_t           disp,
@@ -911,7 +911,7 @@ OMR::Z::MemoryReference::MemoryReference(int32_t           disp,
      _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(comp->getSymRefTab());
      _originalSymbolReference = _symbolReference;
      _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
-     self()->setupCausesImplicitNullPointerException(cg);
+     setupCausesImplicitNullPointerException(cg);
      }
   }
 
@@ -935,7 +935,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::CodeGenerator *cg) :
   _originalSymbolReference = _symbolReference;
   _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
   _offset = _symbolReference->getOffset();
-  self()->setupCausesImplicitNullPointerException(cg);
+  setupCausesImplicitNullPointerException(cg);
   }
 
 OMR::Z::MemoryReference::MemoryReference(TR::Register      *br,
@@ -960,7 +960,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Register      *br,
   _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
   _originalSymbolReference = _symbolReference;
   _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
-  self()->setupCausesImplicitNullPointerException(cg);
+  setupCausesImplicitNullPointerException(cg);
 
   }
 
@@ -986,7 +986,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Register      *br,
   {
   _originalSymbolReference = _symbolReference;
   _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
-  self()->setupCausesImplicitNullPointerException(cg);
+  setupCausesImplicitNullPointerException(cg);
 
   }
 
@@ -1012,7 +1012,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Register      *br,
   _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
   _originalSymbolReference = _symbolReference;
   _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
-  self()->setupCausesImplicitNullPointerException(cg);
+  setupCausesImplicitNullPointerException(cg);
 
   }
 
@@ -1033,8 +1033,8 @@ OMR::Z::MemoryReference::MemoryReference(MemoryReference& mr, int32_t n, TR::Cod
    _leftMostByte      = mr._leftMostByte;
    _flags             = mr._flags;
    _name              = mr._name;
-   self()->resetIs2ndMemRef();
-   self()->resetMemRefUsedBefore();
+   resetIs2ndMemRef();
+   resetMemRefUsedBefore();
    }
 
 /**
@@ -1044,26 +1044,26 @@ OMR::Z::MemoryReference::MemoryReference(MemoryReference& mr, int32_t n, TR::Cod
 TR::UnresolvedDataSnippet *
 OMR::Z::MemoryReference::getUnresolvedSnippet()
    {
-   return self()->isUnresolvedDataSnippet() ? (TR::UnresolvedDataSnippet *)_targetSnippet : NULL;
+   return isUnresolvedDataSnippet() ? (TR::UnresolvedDataSnippet *)_targetSnippet : NULL;
    }
 
 TR::UnresolvedDataSnippet *
 OMR::Z::MemoryReference::setUnresolvedSnippet(TR::UnresolvedDataSnippet *s)
    {
-   self()->setUnresolvedDataSnippet();
+   setUnresolvedDataSnippet();
    return (TR::UnresolvedDataSnippet *) (_targetSnippet = (TR::Snippet *) s);
    }
 
 TR::S390ConstantDataSnippet *
 OMR::Z::MemoryReference::getConstantDataSnippet()
    {
-   return self()->isConstantDataSnippet() ? (TR::S390ConstantDataSnippet *)_targetSnippet : NULL;
+   return isConstantDataSnippet() ? (TR::S390ConstantDataSnippet *)_targetSnippet : NULL;
    }
 
 TR::S390ConstantDataSnippet *
 OMR::Z::MemoryReference::setConstantDataSnippet(TR::S390ConstantDataSnippet *s)
    {
-   self()->setConstantDataSnippet();
+   setConstantDataSnippet();
    return (TR::S390ConstantDataSnippet *) (_targetSnippet = s);
    }
 
@@ -1073,13 +1073,13 @@ OMR::Z::MemoryReference::setLeftAlignMemRef(int32_t leftMostByte)
    TR_ASSERT(leftMostByte > 0,"invalid leftMostByte of %d provided in setLeftAlignMemRef()\n");
     _flags.reset(TR_S390MemRef_RightAlignMemRef);
     _flags.set(TR_S390MemRef_LeftAlignMemRef);
-   self()->setLeftMostByte(leftMostByte);
+   setLeftMostByte(leftMostByte);
    }
 
 bool
 OMR::Z::MemoryReference::isAligned()
    {
-   return self()->rightAlignMemRef() || self()->leftAlignMemRef();
+   return rightAlignMemRef() || leftAlignMemRef();
    }
 
 void
@@ -1309,7 +1309,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
        (integerChild->getOpCodeValue() != TR::lconst) ||
        (integerChild->getLongInt() != TR::Compiler->vm.heapBaseAddress())))
       {
-      self()->populateMemoryReference(addressChild, cg);
+      populateMemoryReference(addressChild, cg);
       if ((subTree->getOpCodeValue() != TR::iadd) && (subTree->getOpCodeValue() != TR::aiadd) &&
           (subTree->getOpCodeValue() != TR::iuadd) && (subTree->getOpCodeValue() != TR::aiuadd) &&
           (subTree->getOpCodeValue() != TR::isub))
@@ -1370,7 +1370,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
             // not necessary to sign extend explicitly anymore due to aladd
             // when aladd is tested, remove the explicit sign extension code below
 
-            self()->setBaseRegister(cg->evaluate(addressChild), cg);
+            setBaseRegister(cg->evaluate(addressChild), cg);
             _offset -= value;
 
             if (firstSubChild->getReferenceCount() > 1)
@@ -1395,17 +1395,17 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
 
    if (!memRefPopulated && (integerChild->getEvaluationPriority(cg) > addressChild->getEvaluationPriority(cg)))
       {
-      self()->populateMemoryReference(addressChild, cg);
-      self()->populateMemoryReference(integerChild, cg);
+      populateMemoryReference(addressChild, cg);
+      populateMemoryReference(integerChild, cg);
       }
    else if (!memRefPopulated)
       {
-      self()->populateMemoryReference(addressChild, cg);
+      populateMemoryReference(addressChild, cg);
       if (_baseRegister != NULL && _indexRegister != NULL)
          {
-         self()->consolidateRegisters(subTree, cg);
+         consolidateRegisters(subTree, cg);
          }
-      self()->populateMemoryReference(integerChild, cg);
+      populateMemoryReference(integerChild, cg);
       }
 
    if ((integerChild->getOpCodeValue() == TR::isub || integerChild->getOpCodeValue() == TR::lsub))
@@ -1444,11 +1444,11 @@ OMR::Z::MemoryReference::populateShiftLeftTree(TR::Node * subTree, TR::CodeGener
       {
       if (_baseRegister != NULL)
          {
-         self()->consolidateRegisters(subTree, cg);
+         consolidateRegisters(subTree, cg);
          }
       else
          {
-         self()->setBaseRegister(_indexRegister, cg);
+         setBaseRegister(_indexRegister, cg);
          _baseNode = _indexNode;
          }
       }
@@ -1463,7 +1463,7 @@ OMR::Z::MemoryReference::populateShiftLeftTree(TR::Node * subTree, TR::CodeGener
       if (firstRegister && !_baseRegister && !_indexRegister)
          {
          strengthReducedShift = true;
-         self()->setBaseRegister(firstRegister, cg);
+         setBaseRegister(firstRegister, cg);
          _baseNode = firstChild;
          _indexRegister = firstRegister;
          _indexNode = firstChild;
@@ -1494,16 +1494,16 @@ OMR::Z::MemoryReference::populateAloadTree(TR::Node * subTree, TR::CodeGenerator
          {
          if (_indexRegister != NULL)
             {
-            self()->consolidateRegisters(subTree, cg);
+            consolidateRegisters(subTree, cg);
             }
          // switch base and index registers
          _indexRegister = _baseRegister;
-         self()->setBaseRegister(addReg, cg);
+         setBaseRegister(addReg, cg);
          _indexNode = NULL;
          }
       else
          {
-         self()->setBaseRegister(addReg, cg);
+         setBaseRegister(addReg, cg);
          _baseNode = NULL;
          }
       }
@@ -1544,16 +1544,16 @@ OMR::Z::MemoryReference::populateLoadAddrTree(TR::Node * subTree, TR::CodeGenera
          {
          if (_indexRegister != NULL)
             {
-            self()->consolidateRegisters(subTree, cg);
+            consolidateRegisters(subTree, cg);
             }
          // switch base and index registers
          _indexRegister = _baseRegister;
-         self()->setBaseRegister(addReg, cg);
+         setBaseRegister(addReg, cg);
          _indexNode = NULL;
          }
       else
          {
-         self()->setBaseRegister(addReg, cg);
+         setBaseRegister(addReg, cg);
          _baseNode = NULL;
          }
       }
@@ -1570,7 +1570,7 @@ OMR::Z::MemoryReference::populateLoadAddrTree(TR::Node * subTree, TR::CodeGenera
    // will generate
    //       L  +12+?(GPR5)  <-- <auto> symref will resolve the ? offset.
    //                           despite the proper symref should be <o.f>
-   if (!self()->isExposedConstantAddressing() && !noNeedToPropagateSymRef)
+   if (!isExposedConstantAddressing() && !noNeedToPropagateSymRef)
       _symbolReference = subTree->getSymbolReference();
 
    _offset += subTree->getSymbolReference()->getOffset();
@@ -1680,9 +1680,9 @@ bool OMR::Z::MemoryReference::tryBaseIndexDispl(TR::CodeGenerator* cg, TR::Node*
       traceMsg(comp, "&&& TBID folded %d\n", ++folded);
       }
 
-   self()->setBaseRegister(breg, cg);
+   setBaseRegister(breg, cg);
    _indexRegister = ireg;
-   self()->setOffset(offset);
+   setOffset(offset);
    cg->AddFoldedMemRefToStack(self());
    ArtificiallyInflateReferenceCountWhenNecessary(self(), "OMR::Z::MemoryReference::tryBaseIndexDispl", nodesBefore, cg, &_incrementedNodesList);
    return true;
@@ -1701,13 +1701,13 @@ OMR::Z::MemoryReference::populateThroughEvaluation(TR::Node * rootLoadOrStore, T
    _flags = 0;
    _fixedSizeForAlignment = 0;
    _leftMostByte = 0;
-   self()->setBaseRegister(cg->evaluate(rootLoadOrStore), cg);
+   setBaseRegister(cg->evaluate(rootLoadOrStore), cg);
    _symbolReference = new (cg->trHeapMemory()) TR::SymbolReference(cg->comp()->getSymRefTab());
    _originalSymbolReference = _symbolReference;
 
    _listingSymbolReference = TR::MemoryReference::shouldLabelForRAS(_symbolReference, cg)? _symbolReference : NULL;
 
-   self()->setupCausesImplicitNullPointerException(cg);
+   setupCausesImplicitNullPointerException(cg);
    }
 
 bool OMR::Z::MemoryReference::ZeroBasePtr_EvaluateSubtree(TR::Node * subTree, TR::CodeGenerator * cg, OMR::Z::MemoryReference * mr)
@@ -1782,23 +1782,23 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
       subTree = subTree->getFirstChild();
       }
 
-   if (self()->doEvaluate(subTree, cg))
+   if (doEvaluate(subTree, cg))
       {
       if (_baseRegister != NULL)
          {
          if (_indexRegister != NULL)
             {
-            self()->consolidateRegisters(subTree, cg);
+            consolidateRegisters(subTree, cg);
             }
-         self()->setIndexRegister(cg->evaluate(subTree));
+         setIndexRegister(cg->evaluate(subTree));
          _indexNode = subTree;
          }
       else
          {
-         if (!self()->ZeroBasePtr_EvaluateSubtree(subTree, cg, this))
+         if (!ZeroBasePtr_EvaluateSubtree(subTree, cg, this))
             {
             if (_baseRegister == NULL)
-               self()->setBaseRegister(cg->evaluate(subTree), cg);
+               setBaseRegister(cg->evaluate(subTree), cg);
             }
 
          _baseNode = subTree;
@@ -1816,26 +1816,26 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
             subTree->getChild(1)->getOpCode().isLoadConst() &&
             subTree->getChild(1)->getConst<int64_t>() <= 0)))
          {
-         self()->populateAddTree(subTree, cg);
+         populateAddTree(subTree, cg);
          }
       else if ((subTree->getOpCodeValue() == TR::ishl || subTree->getOpCodeValue() == TR::lshl) &&
          subTree->getSecondChild()->getOpCode().isLoadConst())
          {
-         self()->populateShiftLeftTree(subTree, cg);
+         populateShiftLeftTree(subTree, cg);
          }
       else if (subTree->getOpCodeValue() == TR::loadaddr)
          {
-         self()->populateLoadAddrTree(subTree, cg);
+         populateLoadAddrTree(subTree, cg);
          }
       else if (subTree->getOpCodeValue() == TR::aload &&
                cg->isAddressOfStaticSymRefWithLockedReg(subTree->getSymbolReference()))
          {
-         self()->populateAloadTree(subTree, cg, false);
+         populateAloadTree(subTree, cg, false);
          }
       else if (subTree->getOpCodeValue() == TR::aload &&
                cg->isAddressOfPrivateStaticSymRefWithLockedReg(subTree->getSymbolReference()))
          {
-         self()->populateAloadTree(subTree, cg, true);
+         populateAloadTree(subTree, cg, true);
          }
       else if (subTree->getOpCodeValue() == TR::aconst)
          {
@@ -1848,7 +1848,7 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
             _offset += subTree->getInt();
             }
          // set zero based ptr
-         self()->setBaseRegister(NULL, cg);
+         setBaseRegister(NULL, cg);
          }
       else
          {
@@ -1856,17 +1856,17 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
             {
             if (_indexRegister != NULL)
                {
-               self()->consolidateRegisters(subTree, cg);
+               consolidateRegisters(subTree, cg);
                }
             _indexRegister = cg->evaluate(subTree);
             _indexNode = subTree;
             }
          else
             {
-            if (!self()->ZeroBasePtr_EvaluateSubtree(subTree, cg, this))
+            if (!ZeroBasePtr_EvaluateSubtree(subTree, cg, this))
                {
                if (_baseRegister == NULL)
-                  self()->setBaseRegister(cg->evaluate(subTree), cg);
+                  setBaseRegister(cg->evaluate(subTree), cg);
                }
             _baseNode = subTree;
             }
@@ -1882,12 +1882,12 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
 
       if (_baseNode == subTree)
          {
-         self()->setBaseRegister(noopNode->getRegister(), cg);
+         setBaseRegister(noopNode->getRegister(), cg);
          _baseNode = noopNode;
          }
       else if (_indexNode == subTree)
          {
-         self()->setIndexRegister(noopNode->getRegister());
+         setIndexRegister(noopNode->getRegister());
          _indexNode = noopNode;
          }
          // pretend we evaluated the noopNode
@@ -1932,19 +1932,19 @@ OMR::Z::MemoryReference::consolidateRegisters(TR::Node * node, TR::CodeGenerator
    interimMemoryReference->setBaseRegister(_baseRegister, cg);
    interimMemoryReference->setIndexRegister(_indexRegister);
    TR::SymbolReference *interinSymRef=interimMemoryReference->getSymbolReference();
-   if (self()->isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
-   if (self()->getConstantDataSnippet())
+   if (isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
+   if (getConstantDataSnippet())
       {
-      interimMemoryReference->setConstantDataSnippet(self()->getConstantDataSnippet());
-      self()->setConstantDataSnippet(NULL);
+      interimMemoryReference->setConstantDataSnippet(getConstantDataSnippet());
+      setConstantDataSnippet(NULL);
       }
-   self()->propagateAlignmentInfo(interimMemoryReference);
+   propagateAlignmentInfo(interimMemoryReference);
    interimMemoryReference->setSymbolReference(_symbolReference);
    _symbolReference=interinSymRef;
    generateRXInstruction(cg, TR::InstOpCode::LA, node, tempTargetRegister, interimMemoryReference);
    cg->stopUsingRegister(tempTargetRegister);
 
-   self()->setBaseRegister(tempTargetRegister, cg);
+   setBaseRegister(tempTargetRegister, cg);
    _baseNode = NULL;
    _indexRegister = NULL;
    _targetSnippet = NULL;
@@ -1953,7 +1953,7 @@ OMR::Z::MemoryReference::consolidateRegisters(TR::Node * node, TR::CodeGenerator
 bool OMR::Z::MemoryReference::ignoreNegativeOffset()
    {
    if (_offset < 0 &&
-       (self()->hasTemporaryNegativeOffset() || symRefHasTemporaryNegativeOffset()))
+       (hasTemporaryNegativeOffset() || symRefHasTemporaryNegativeOffset()))
       {
       return true;
       }
@@ -1963,7 +1963,7 @@ bool OMR::Z::MemoryReference::ignoreNegativeOffset()
 TR::Register *OMR::Z::MemoryReference::swapBaseRegister(TR::Register *br, TR::CodeGenerator * cg)
    {
    br->setIsUsedInMemRef();
-   self()->setBaseRegister(br, cg);
+   setBaseRegister(br, cg);
    return br;
    }
 
@@ -2022,10 +2022,10 @@ OMR::Z::MemoryReference::alignmentBumpMayRequire4KFixup(TR::Node * node, TR::Cod
    // e.g. _offset=4088 and the node is 10 byte in size so the max possible alignment is 10-1 = 9 giving a max possible offset of 4088+9 = 4097 (>= MAXDISP of 4096)
    //
    if (_offset < MAXDISP &&               // skip if going to fixup naturally anyway
-       self()->getFixedSizeForAlignment() > 0 &&  // i.e. do not check temps -- these will have an offset of 0 anyway at instruction selection time
-       (self()->rightAlignMemRef() || self()->leftAlignMemRef() || TR::MemoryReference::typeNeedsAlignment(node)))
+       getFixedSizeForAlignment() > 0 &&  // i.e. do not check temps -- these will have an offset of 0 anyway at instruction selection time
+       (rightAlignMemRef() || leftAlignMemRef() || TR::MemoryReference::typeNeedsAlignment(node)))
       {
-      int32_t maxAlignmentBump = self()->getFixedSizeForAlignment() - 1; // alignment is getFixedSizeForAlignment() - (length or leftMostByte) and each of these must be at least 1
+      int32_t maxAlignmentBump = getFixedSizeForAlignment() - 1; // alignment is getFixedSizeForAlignment() - (length or leftMostByte) and each of these must be at least 1
       if (_offset + maxAlignmentBump >= MAXDISP)
          {
          if (cg->traceBCDCodeGen())
@@ -2041,28 +2041,28 @@ OMR::Z::MemoryReference::alignmentBumpMayRequire4KFixup(TR::Node * node, TR::Cod
 TR::Instruction *
 OMR::Z::MemoryReference::enforceSSFormatLimits(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction *preced)
    {
-   bool forceDueToAlignmentBump = self()->alignmentBumpMayRequire4KFixup(node, cg);
+   bool forceDueToAlignmentBump = alignmentBumpMayRequire4KFixup(node, cg);
    // call separateIndexRegister first so any large offset is handled along with the index register folding
-   preced = self()->separateIndexRegister(node, cg, true, preced, forceDueToAlignmentBump); // enforce4KDisplacementLimit=true
-   preced = self()->enforce4KDisplacementLimit(node, cg, preced, false, forceDueToAlignmentBump);
+   preced = separateIndexRegister(node, cg, true, preced, forceDueToAlignmentBump); // enforce4KDisplacementLimit=true
+   preced = enforce4KDisplacementLimit(node, cg, preced, false, forceDueToAlignmentBump);
    return preced;
    }
 
 TR::Instruction *
 OMR::Z::MemoryReference::enforceRSLFormatLimits(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction *preced)
    {
-   bool forceDueToAlignmentBump = self()->alignmentBumpMayRequire4KFixup(node, cg);
+   bool forceDueToAlignmentBump = alignmentBumpMayRequire4KFixup(node, cg);
    // call separateIndexRegister first so any large offset is handled along with the index register folding
-   preced = self()->separateIndexRegister(node, cg, true, preced, forceDueToAlignmentBump); // enforce4KDisplacementLimit=true
-   preced = self()->enforce4KDisplacementLimit(node, cg, preced, false, forceDueToAlignmentBump);
+   preced = separateIndexRegister(node, cg, true, preced, forceDueToAlignmentBump); // enforce4KDisplacementLimit=true
+   preced = enforce4KDisplacementLimit(node, cg, preced, false, forceDueToAlignmentBump);
    return preced;
    }
 
 TR::Instruction *
 OMR::Z::MemoryReference::enforceVRXFormatLimits(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction *preced)
    {
-   bool forceDueToAlignmentBump = self()->alignmentBumpMayRequire4KFixup(node, cg);
-   preced = self()->enforce4KDisplacementLimit(node, cg, preced, false, forceDueToAlignmentBump);
+   bool forceDueToAlignmentBump = alignmentBumpMayRequire4KFixup(node, cg);
+   preced = enforce4KDisplacementLimit(node, cg, preced, false, forceDueToAlignmentBump);
    return preced;
    }
 
@@ -2077,13 +2077,13 @@ OMR::Z::MemoryReference::enforceVRXFormatLimits(TR::Node * node, TR::CodeGenerat
 TR::Instruction *
 OMR::Z::MemoryReference::enforce4KDisplacementLimit(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction * preced, bool forcePLXFixup, bool forceFixup)
    {
-   if (self()->ignoreNegativeOffset())
+   if (ignoreNegativeOffset())
       return preced;
 
    TR_ASSERT(!forcePLXFixup, "This logic is only used for markAndAdjustForLongDisplacementIfNeeded. You probably want the other flag.");
 
    if ((_offset < 0 || _offset >= MAXDISP || forcePLXFixup || forceFixup) &&
-       !self()->isAdjustedForLongDisplacement())
+       !isAdjustedForLongDisplacement())
       {
       TR::Register * tempTargetRegister = NULL;
       if (TR::Compiler->target.is64Bit())
@@ -2099,34 +2099,34 @@ OMR::Z::MemoryReference::enforce4KDisplacementLimit(TR::Node * node, TR::CodeGen
       interimMemoryReference->setBaseRegister(_baseRegister, cg);
       interimMemoryReference->setIndexRegister(_indexRegister);
       TR::SymbolReference * interinSymRef = interimMemoryReference->getSymbolReference();
-      self()->propagateAlignmentInfo(interimMemoryReference);
+      propagateAlignmentInfo(interimMemoryReference);
       interimMemoryReference->setSymbolReference(_symbolReference);
       _symbolReference = interinSymRef;
 
-      if (self()->isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
-      if (self()->getConstantDataSnippet())
+      if (isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
+      if (getConstantDataSnippet())
          {
-         interimMemoryReference->setConstantDataSnippet(self()->getConstantDataSnippet());
-         self()->setConstantDataSnippet(NULL);
+         interimMemoryReference->setConstantDataSnippet(getConstantDataSnippet());
+         setConstantDataSnippet(NULL);
          }
-      preced = self()->handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, preced);
+      preced = handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, preced);
 
       if (forcePLXFixup)
          {
          tempTargetRegister->incTotalUseCount();
-         if (self()->getStorageReference() && interimMemoryReference->getSymbolReference()->isTempVariableSizeSymRef())
+         if (getStorageReference() && interimMemoryReference->getSymbolReference()->isTempVariableSizeSymRef())
             {
             }
          }
       cg->stopUsingRegister(tempTargetRegister);
 
       _baseNode = NULL;
-      tempTargetRegister = self()->swapBaseRegister(tempTargetRegister, cg);
+      tempTargetRegister = swapBaseRegister(tempTargetRegister, cg);
       cg->stopUsingRegister(tempTargetRegister);
       _indexRegister = NULL;
       _targetSnippet = NULL;
       _offset = 0;
-      self()->setAdjustedForLongDisplacement();
+      setAdjustedForLongDisplacement();
       }
    return preced;
    }
@@ -2146,7 +2146,7 @@ OMR::Z::MemoryReference::markAndAdjustForLongDisplacementIfNeeded(TR::Node * nod
 TR::Instruction *
 OMR::Z::MemoryReference::enforceDisplacementLimit(TR::Node * node, TR::CodeGenerator * cg, TR::Instruction * preced)
    {
-   if (self()->ignoreNegativeOffset())
+   if (ignoreNegativeOffset())
       return preced;
 
    TR::Compilation *comp = cg->comp();
@@ -2166,22 +2166,22 @@ OMR::Z::MemoryReference::enforceDisplacementLimit(TR::Node * node, TR::CodeGener
       interimMemoryReference->setBaseRegister(_baseRegister, cg);
       interimMemoryReference->setIndexRegister(_indexRegister);
       TR::SymbolReference *interinSymRef = interimMemoryReference->getSymbolReference();
-      if (self()->isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
-      if (self()->getConstantDataSnippet())
+      if (isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
+      if (getConstantDataSnippet())
          {
-         interimMemoryReference->setConstantDataSnippet(self()->getConstantDataSnippet());
-         self()->setConstantDataSnippet(NULL);
+         interimMemoryReference->setConstantDataSnippet(getConstantDataSnippet());
+         setConstantDataSnippet(NULL);
          }
-      self()->propagateAlignmentInfo(interimMemoryReference);
+      propagateAlignmentInfo(interimMemoryReference);
       interimMemoryReference->setSymbolReference(_symbolReference);
       _symbolReference = interinSymRef;
 
-      preced = self()->handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, preced);
+      preced = handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, preced);
 
       cg->stopUsingRegister(tempTargetRegister);
 
       _baseNode = NULL;
-      tempTargetRegister = self()->swapBaseRegister(tempTargetRegister, cg);
+      tempTargetRegister = swapBaseRegister(tempTargetRegister, cg);
       _indexRegister = NULL;
       _targetSnippet = NULL;
       _offset = 0;
@@ -2199,7 +2199,7 @@ OMR::Z::MemoryReference::enforceDisplacementLimit(TR::Node * node, TR::CodeGener
 void
 OMR::Z::MemoryReference::eliminateNegativeDisplacement(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (self()->ignoreNegativeOffset())
+   if (ignoreNegativeOffset())
       return;
 
    TR::Compilation *comp = cg->comp();
@@ -2218,20 +2218,20 @@ OMR::Z::MemoryReference::eliminateNegativeDisplacement(TR::Node * node, TR::Code
       interimMemoryReference->setBaseRegister(_baseRegister, cg);
       interimMemoryReference->setIndexRegister(_indexRegister);
       TR::SymbolReference *interinSymRef=interimMemoryReference->getSymbolReference();
-      if (self()->isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
-      if (self()->getConstantDataSnippet())
+      if (isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
+      if (getConstantDataSnippet())
          {
-         interimMemoryReference->setConstantDataSnippet(self()->getConstantDataSnippet());
-         self()->setConstantDataSnippet(NULL);
+         interimMemoryReference->setConstantDataSnippet(getConstantDataSnippet());
+         setConstantDataSnippet(NULL);
          }
-      self()->propagateAlignmentInfo(interimMemoryReference);
+      propagateAlignmentInfo(interimMemoryReference);
       interimMemoryReference->setSymbolReference(_symbolReference);
       _symbolReference=interinSymRef;
 
-      self()->handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, NULL);
+      handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, NULL);
 
       _baseNode = NULL;
-      tempTargetRegister = self()->swapBaseRegister(tempTargetRegister, cg);
+      tempTargetRegister = swapBaseRegister(tempTargetRegister, cg);
       _indexRegister = NULL;
       _targetSnippet = NULL;
       _offset = 0;
@@ -2267,20 +2267,20 @@ OMR::Z::MemoryReference::separateIndexRegister(TR::Node * node, TR::CodeGenerato
       interimMemoryReference->setBaseRegister(_baseRegister, cg);
       interimMemoryReference->setIndexRegister(_indexRegister);
       TR::SymbolReference *interinSymRef=interimMemoryReference->getSymbolReference();
-      self()->propagateAlignmentInfo(interimMemoryReference);
+      propagateAlignmentInfo(interimMemoryReference);
       interimMemoryReference->setSymbolReference(_symbolReference);
       _symbolReference = interinSymRef;
-      if (self()->isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
-      if (self()->getConstantDataSnippet())
+      if (isConstantDataSnippet()) interimMemoryReference->setConstantDataSnippet();
+      if (getConstantDataSnippet())
          {
-         interimMemoryReference->setConstantDataSnippet(self()->getConstantDataSnippet());
-         self()->setConstantDataSnippet(NULL);
+         interimMemoryReference->setConstantDataSnippet(getConstantDataSnippet());
+         setConstantDataSnippet(NULL);
          }
-      if (!self()->ignoreNegativeOffset() &&
+      if (!ignoreNegativeOffset() &&
                enforce4KDisplacementLimit &&
                (_offset < 0 || _offset >= MAXDISP || forceDueToAlignmentBump))
          {
-         preced = self()->handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, preced);
+         preced = handleLargeOffset(node, interimMemoryReference, tempTargetRegister, cg, preced);
          _offset = 0;
          }
       else
@@ -2292,7 +2292,7 @@ OMR::Z::MemoryReference::separateIndexRegister(TR::Node * node, TR::CodeGenerato
          }
 
       _baseNode = NULL;
-      tempTargetRegister = self()->swapBaseRegister(tempTargetRegister, cg);
+      tempTargetRegister = swapBaseRegister(tempTargetRegister, cg);
       _indexRegister = NULL;
       _targetSnippet = NULL;
 
@@ -2402,7 +2402,7 @@ OMR::Z::MemoryReference::assignRegisters(TR::Instruction * currentInstruction, T
             cg->traceRegFreed(_baseRegister, toRealRegister(assignedBaseRegister)->getHighWordRegister());
             }
          }
-      self()->setBaseRegister(assignedBaseRegister, cg);
+      setBaseRegister(assignedBaseRegister, cg);
       }
    }
 
@@ -2464,13 +2464,13 @@ OMR::Z::MemoryReference::getSnippet()
    {
    TR::Snippet * snippet = NULL;
 
-   if (self()->getUnresolvedSnippet() != NULL)
+   if (getUnresolvedSnippet() != NULL)
       {
       setMemRefAndGetUnresolvedData(snippet);
       }
-   else if (self()->getConstantDataSnippet() != NULL)
+   else if (getConstantDataSnippet() != NULL)
       {
-      snippet = self()->getConstantDataSnippet();
+      snippet = getConstantDataSnippet();
       }
 
    return snippet;
@@ -2564,16 +2564,16 @@ OMR::Z::MemoryReference::canUseTargetRegAsScratchReg (TR::Instruction * instr)
  */
 void OMR::Z::MemoryReference::setFixedSizeForAlignment(int32_t size)
    {
-   if (self()->getOriginalSymbolReference() &&
-       self()->getOriginalSymbolReference()->getSymbol() &&
-       self()->getOriginalSymbolReference()->getSymbol()->isVariableSizeSymbol())
+   if (getOriginalSymbolReference() &&
+       getOriginalSymbolReference()->getSymbol() &&
+       getOriginalSymbolReference()->getSymbol()->isVariableSizeSymbol())
       {
       TR_ASSERT(false,"variable sized symbols do not use _fixedSizeForAlignment a\n");
       _fixedSizeForAlignment = 0;
       }
-   else if (self()->getSymbolReference() &&
-            self()->getSymbolReference()->getSymbol() &&
-            self()->getSymbolReference()->getSymbol()->isVariableSizeSymbol())
+   else if (getSymbolReference() &&
+            getSymbolReference()->getSymbol() &&
+            getSymbolReference()->getSymbol()->isVariableSizeSymbol())
       {
       TR_ASSERT(false,"variable sized symbols do not use _fixedSizeForAlignment b\n");
       _fixedSizeForAlignment = 0;
@@ -2591,17 +2591,17 @@ void OMR::Z::MemoryReference::setFixedSizeForAlignment(int32_t size)
  */
 int32_t OMR::Z::MemoryReference::getTotalSizeForAlignment()
    {
-   if (self()->getOriginalSymbolReference() &&
-       self()->getOriginalSymbolReference()->getSymbol() &&
-       self()->getOriginalSymbolReference()->getSymbol()->isVariableSizeSymbol())
+   if (getOriginalSymbolReference() &&
+       getOriginalSymbolReference()->getSymbol() &&
+       getOriginalSymbolReference()->getSymbol()->isVariableSizeSymbol())
       {
-      return self()->getOriginalSymbolReference()->getSymbol()->getSize();
+      return getOriginalSymbolReference()->getSymbol()->getSize();
       }
-   else if (self()->getSymbolReference() &&
-            self()->getSymbolReference()->getSymbol() &&
-            self()->getSymbolReference()->getSymbol()->isVariableSizeSymbol())
+   else if (getSymbolReference() &&
+            getSymbolReference()->getSymbol() &&
+            getSymbolReference()->getSymbol()->isVariableSizeSymbol())
       {
-      return self()->getSymbolReference()->getSymbol()->getSize();
+      return getSymbolReference()->getSymbol()->getSize();
       }
    else
       {
@@ -2613,7 +2613,7 @@ int32_t OMR::Z::MemoryReference::getTotalSizeForAlignment()
 int32_t
 OMR::Z::MemoryReference::getRightAlignmentBump(TR::Instruction * instr, TR::CodeGenerator * cg)
    {
-   if (!self()->rightAlignMemRef()) return 0;
+   if (!rightAlignMemRef()) return 0;
 
    int32_t length = -1;
 
@@ -2654,8 +2654,8 @@ OMR::Z::MemoryReference::getRightAlignmentBump(TR::Instruction * instr, TR::Code
    if (needsBump)
       {
       TR_ASSERT( length != -1,"length should be set at this point\n");
-      TR_ASSERT(self()->getTotalSizeForAlignment() > 0,"getTotalSizeForAlignment() %d not initialized in getRightAlignmentBump()\n",self()->getTotalSizeForAlignment());
-      int32_t symSize = self()->getTotalSizeForAlignment();
+      TR_ASSERT(getTotalSizeForAlignment() > 0,"getTotalSizeForAlignment() %d not initialized in getRightAlignmentBump()\n",getTotalSizeForAlignment());
+      int32_t symSize = getTotalSizeForAlignment();
       bump = symSize - length;
       }
 
@@ -2667,12 +2667,12 @@ OMR::Z::MemoryReference::getRightAlignmentBump(TR::Instruction * instr, TR::Code
 int32_t
 OMR::Z::MemoryReference::getLeftAlignmentBump(TR::Instruction * instr, TR::CodeGenerator * cg)
    {
-   if (!self()->leftAlignMemRef()) return 0;
+   if (!leftAlignMemRef()) return 0;
 
-   TR_ASSERT(self()->getTotalSizeForAlignment() > 0,"getTotalSizeForAlignment() %d not initialized in getLeftAlignmentBump()\n",self()->getTotalSizeForAlignment());
-   TR_ASSERT( self()->getLeftMostByte() > 0,"_leftMostByte not initialized in getLeftAlignmentBump()\n");
+   TR_ASSERT(getTotalSizeForAlignment() > 0,"getTotalSizeForAlignment() %d not initialized in getLeftAlignmentBump()\n",getTotalSizeForAlignment());
+   TR_ASSERT( getLeftMostByte() > 0,"_leftMostByte not initialized in getLeftAlignmentBump()\n");
 
-   int32_t bump = self()->getTotalSizeForAlignment() - self()->getLeftMostByte();
+   int32_t bump = getTotalSizeForAlignment() - getLeftMostByte();
 
    TR_ASSERT(bump >= 0,"leftAlignmentBump %d should not be negative\n",bump);
    return bump;
@@ -2681,12 +2681,12 @@ OMR::Z::MemoryReference::getLeftAlignmentBump(TR::Instruction * instr, TR::CodeG
 int32_t
 OMR::Z::MemoryReference::getSizeIncreaseBump(TR::Instruction * instr, TR::CodeGenerator * cg)
    {
-   if ((self()->getSymbolReference() == NULL) || !self()->getSymbolReference()->isTempVariableSizeSymRef())
+   if ((getSymbolReference() == NULL) || !getSymbolReference()->isTempVariableSizeSymRef())
       return 0;
-   TR_ASSERT(self()->getTotalSizeForAlignment() > 0,"getTotalSizeForAlignment() %d not initialized in getSizeIncreaseBump()\n",self()->getTotalSizeForAlignment());
-   TR_ASSERT( self()->getSymbolReference()->getSymbol()->getSize() > 0,"symbol size not initialized in getSizeIncreaseBump()\n");
+   TR_ASSERT(getTotalSizeForAlignment() > 0,"getTotalSizeForAlignment() %d not initialized in getSizeIncreaseBump()\n",getTotalSizeForAlignment());
+   TR_ASSERT( getSymbolReference()->getSymbol()->getSize() > 0,"symbol size not initialized in getSizeIncreaseBump()\n");
 
-   int32_t bump = self()->getSymbolReference()->getSymbol()->getSize() - self()->getTotalSizeForAlignment();
+   int32_t bump = getSymbolReference()->getSymbol()->getSize() - getTotalSizeForAlignment();
 
    TR_ASSERT(bump >=0,"symbol size bump %d should not be negative\n",bump);
    return bump;
@@ -2695,58 +2695,58 @@ OMR::Z::MemoryReference::getSizeIncreaseBump(TR::Instruction * instr, TR::CodeGe
 int32_t
 OMR::Z::MemoryReference::calcDisplacement(uint8_t * cursor, TR::Instruction * instr, TR::CodeGenerator * cg)
    {
-   TR::Snippet * snippet = self()->getSnippet();
-   TR::Symbol * symbol = self()->getSymbolReference()->getSymbol();
+   TR::Snippet * snippet = getSnippet();
+   TR::Symbol * symbol = getSymbolReference()->getSymbol();
    int32_t disp = _offset;
    TR::Compilation *comp = cg->comp();
 
-   if (self()->rightAlignMemRef())
+   if (rightAlignMemRef())
       {
-      TR_ASSERT( !self()->leftAlignMemRef(),"A memory reference should not be marked as both right and left aligned\n");
+      TR_ASSERT( !leftAlignMemRef(),"A memory reference should not be marked as both right and left aligned\n");
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"instr %p : right aligning memRef with symRef #%d (%s, isTemp %s) _offset %d, totalSize %d : bump = ",
             instr,
-            self()->getSymbolReference()->getReferenceNumber(),
-            cg->getDebug()->getName(self()->getSymbolReference()->getSymbol()),
-            self()->getSymbolReference()->isTempVariableSizeSymRef() ? "yes":"no",
+            getSymbolReference()->getReferenceNumber(),
+            cg->getDebug()->getName(getSymbolReference()->getSymbol()),
+            getSymbolReference()->isTempVariableSizeSymRef() ? "yes":"no",
             _offset,
-            self()->getTotalSizeForAlignment());
+            getTotalSizeForAlignment());
       int32_t oldDisp = disp;
-      disp += self()->getRightAlignmentBump(instr, cg);
+      disp += getRightAlignmentBump(instr, cg);
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"%d (disp = %d)\n",disp-oldDisp,disp);
       }
 
-   if (self()->leftAlignMemRef())
+   if (leftAlignMemRef())
       {
-      TR_ASSERT( !self()->rightAlignMemRef(),"A memory reference should not be marked as both left and right aligned\n");
+      TR_ASSERT( !rightAlignMemRef(),"A memory reference should not be marked as both left and right aligned\n");
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"instr %p : left aligning memRef with symRef #%d (%s, isTemp %s), _offset %d : bump = totalSize - leftMostByte = %d - %d = ",
             instr,
-            self()->getSymbolReference()->getReferenceNumber(),
-            cg->getDebug()->getName(self()->getSymbolReference()->getSymbol()),
-            self()->getSymbolReference()->isTempVariableSizeSymRef() ? "yes":"no",
+            getSymbolReference()->getReferenceNumber(),
+            cg->getDebug()->getName(getSymbolReference()->getSymbol()),
+            getSymbolReference()->isTempVariableSizeSymRef() ? "yes":"no",
             _offset,
-            self()->getTotalSizeForAlignment(),
-            self()->getLeftMostByte());
+            getTotalSizeForAlignment(),
+            getLeftMostByte());
       int32_t oldDisp = disp;
-      disp += self()->getLeftAlignmentBump(instr, cg);
+      disp += getLeftAlignmentBump(instr, cg);
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"%d (disp = %d)\n",disp-oldDisp,disp);
       }
 
-   if (self()->getSymbolReference()->isTempVariableSizeSymRef())
+   if (getSymbolReference()->isTempVariableSizeSymRef())
       {
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"instr %p : bumping tempVariableSizeSymRef memRef with symRef #%d (%s), _offset %d : bump = symSize - totalSize = %d - %d = ",
             instr,
-            self()->getSymbolReference()->getReferenceNumber(),
-            cg->getDebug()->getName(self()->getSymbolReference()->getSymbol()),
+            getSymbolReference()->getReferenceNumber(),
+            cg->getDebug()->getName(getSymbolReference()->getSymbol()),
             _offset,
-            self()->getSymbolReference()->getSymbol()->getSize(),
-            self()->getTotalSizeForAlignment());
+            getSymbolReference()->getSymbol()->getSize(),
+            getTotalSizeForAlignment());
       int32_t oldDisp = disp;
-      disp += self()->getSizeIncreaseBump(instr, cg);
+      disp += getSizeIncreaseBump(instr, cg);
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"%d (disp = %d)\n",disp-oldDisp,disp);
       }
@@ -2757,7 +2757,7 @@ OMR::Z::MemoryReference::calcDisplacement(uint8_t * cursor, TR::Instruction * in
          // Displacement of literals in the lit pool are all known
          // a priori.
          //
-         disp = snippet->getCodeBaseOffset() + self()->getOffset();
+         disp = snippet->getCodeBaseOffset() + getOffset();
 
          // We use the 12bitRelloc code to double check that all disp's
          // are indeed equal pre-bin and post-bin encoding.
@@ -2773,11 +2773,11 @@ OMR::Z::MemoryReference::calcDisplacement(uint8_t * cursor, TR::Instruction * in
       if (symbol->isRegisterMappedSymbol())
          {
          disp += symbol->castToRegisterMappedSymbol()->getOffset();
-         if (TR::Compiler->target.is64Bit() && TR::MemoryReference::needsAdjustDisp(instr, this, cg) && !self()->getDispAdjusted())
+         if (TR::Compiler->target.is64Bit() && TR::MemoryReference::needsAdjustDisp(instr, this, cg) && !getDispAdjusted())
             {
             disp += 4;
             }
-         self()->setDispAdjusted();
+         setDispAdjusted();
          }
       }
 
@@ -2911,13 +2911,13 @@ generateImmToRegister(TR::CodeGenerator * cg, TR::Node * node, TR::Register * ta
 int32_t
 OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenerator * cg, TR::Instruction * instr)
    {
-   if (self()->wasCreatedDuringInstructionSelection())
+   if (wasCreatedDuringInstructionSelection())
       {
-      self()->setOffset(cg->getFrameSizeInBytes());
+      setOffset(cg->getFrameSizeInBytes());
       }
    uint8_t * instructionStart = cursor;
-   TR::RealRegister * base  = (self()->getBaseRegister() ? toRealRegister(self()->getBaseRegister()) : 0);
-   TR::RealRegister * index = (self()->getIndexRegister() ? toRealRegister(self()->getIndexRegister()) : 0);
+   TR::RealRegister * base  = (getBaseRegister() ? toRealRegister(self()->getBaseRegister()) : 0);
+   TR::RealRegister * index = (getIndexRegister() ? toRealRegister(self()->getIndexRegister()) : 0);
 
    int32_t nbytes     = 0;
    bool largeDisp     = false;
@@ -2934,9 +2934,9 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
    TR::Instruction * currInstr = prevInstr;
    TR::Node * node = instr->getNode();
 
-   bool is2ndSSMemRef=self()->is2ndMemRef();
+   bool is2ndSSMemRef=is2ndMemRef();
 
-   int32_t displacement = self()->calcDisplacement(cursor, instr, cg);
+   int32_t displacement = calcDisplacement(cursor, instr, cg);
 
    //add project specific relocations for specific instructions
    addInstrSpecificRelocation(cg, instr, displacement, cursor);
@@ -3052,7 +3052,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
             prevInstr = currInstr;
 
             base = scratchReg;
-            self()->setBaseRegister(base, cg);
+            setBaseRegister(base, cg);
             }
          else if (index!=NULL && base!=NULL) // Neither is NULL, pick one
             {
@@ -3068,7 +3068,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
             prevInstr = currInstr;
 
             index = scratchReg;
-            self()->setIndexRegister(index);
+            setIndexRegister(index);
             }
          else if (index==NULL)                                      // Since index reg is free, use it directly
             {
@@ -3085,7 +3085,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
             //    A GPRt, 0(Rscrtch,base)
 
             index = scratchReg;
-            self()->setIndexRegister(index);
+            setIndexRegister(index);
             }
          else // base is NULL                                       // Since base reg is free, use it directly
             {
@@ -3101,7 +3101,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
             //    A GPRt, 0(index,Rscrtch)
 
             base = scratchReg;
-            self()->setBaseRegister(base, cg);
+            setBaseRegister(base, cg);
             }
 
          if (nbytes == 0)
@@ -3186,7 +3186,7 @@ OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp(uint8_t *curso
    int32_t nbytes    = 0;
    TR::Compilation *comp = cg->comp();
    uint8_t * instructionStart = cursor;
-   bool is2ndSSMemRef = self()->is2ndMemRef();
+   bool is2ndSSMemRef = is2ndMemRef();
    bool largeDisp = (is2ndSSMemRef && instr->isExtDisp2()) ||
                     (!is2ndSSMemRef && instr->isExtDisp());
    int32_t offsetToLongDispSlot = (cg->getLinkage())->getOffsetToLongDispSlot();
@@ -3205,7 +3205,7 @@ OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp(uint8_t *curso
       }
    else
       {
-      TR_ASSERT( !self()->isMemRefMustNotSpill(),"OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp -- This memoryReference must not spill");
+      TR_ASSERT( !isMemRefMustNotSpill(),"OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp -- This memoryReference must not spill");
       if (!is2ndSSMemRef)
          {
          scratchReg = instr->getLocalLocalSpillReg1();
@@ -3248,25 +3248,25 @@ OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp(uint8_t *curso
 bool
 OMR::Z::MemoryReference::doEvaluate(TR::Node * subTree, TR::CodeGenerator * cg)
    {
-   if (self()->forceEvaluation())
+   if (forceEvaluation())
       return true;
 
    // do not recurse down if _this_ node has a register
    if (subTree->getRegister() != NULL)
       return true;
 
-   if (self()->forceFolding())
+   if (forceFolding())
       return false;
 
    TR::Compilation *comp = cg->comp();
 
-   if (self()->forceFirstTimeFolding())
+   if (forceFirstTimeFolding())
       {
       if (cg->traceBCDCodeGen())
          traceMsg(comp,"\tforceFirstTimeFolding=true for subTree %s (%p) refCount %d, reg %s (reset firstTimeFlag for next doEvaluate)\n",
             subTree->getOpCode().getName(),subTree,subTree->getReferenceCount(),subTree->getRegister()?cg->getDebug()->getName(subTree->getRegister()):"NULL");
-      self()->resetForceFirstTimeFolding();
-      self()->setForceEvaluation();
+      resetForceFirstTimeFolding();
+      setForceEvaluation();
       return false;
       }
 

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -90,7 +90,7 @@ namespace OMR
 namespace Z
 {
 
-class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
+class /*OMR_EXTENSIBLE*/ MemoryReference : public OMR::MemoryReference
 {
 TR::Register              *_baseRegister;
 

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -156,7 +156,7 @@ MemoryReference(MemoryReference& mr, int32_t n, TR::CodeGenerator *cg);
 /** @return true if instr needs to be adjusted for long displacement */
 static bool needsAdjustDisp(TR::Instruction * instr, MemoryReference * mRef, TR::CodeGenerator * cg);
 static bool canUseTargetRegAsScratchReg (TR::Instruction * instr);
-virtual static bool typeNeedsAlignment(TR::Node *node);
+static bool typeNeedsAlignment(TR::Node *node);
 static bool shouldLabelForRAS(TR::SymbolReference * symRef,  TR::CodeGenerator * cg);
 int32_t calcDisplacement(uint8_t * cursor, TR::Instruction * instr, TR::CodeGenerator * cg);
 int32_t getRightAlignmentBump(TR::Instruction * instr, TR::CodeGenerator * cg);

--- a/compiler/z/codegen/OMRMemoryReference.hpp
+++ b/compiler/z/codegen/OMRMemoryReference.hpp
@@ -156,7 +156,7 @@ MemoryReference(MemoryReference& mr, int32_t n, TR::CodeGenerator *cg);
 /** @return true if instr needs to be adjusted for long displacement */
 static bool needsAdjustDisp(TR::Instruction * instr, MemoryReference * mRef, TR::CodeGenerator * cg);
 static bool canUseTargetRegAsScratchReg (TR::Instruction * instr);
-static bool typeNeedsAlignment(TR::Node *node);
+virtual static bool typeNeedsAlignment(TR::Node *node);
 static bool shouldLabelForRAS(TR::SymbolReference * symRef,  TR::CodeGenerator * cg);
 int32_t calcDisplacement(uint8_t * cursor, TR::Instruction * instr, TR::CodeGenerator * cg);
 int32_t getRightAlignmentBump(TR::Instruction * instr, TR::CodeGenerator * cg);
@@ -164,7 +164,7 @@ int32_t getLeftAlignmentBump(TR::Instruction * instr, TR::CodeGenerator * cg);
 int32_t getSizeIncreaseBump(TR::Instruction * instr, TR::CodeGenerator * cg);
 
 /** Project specific relocations for specific instructions */
-void addInstrSpecificRelocation(TR::CodeGenerator* cg, TR::Instruction* instr, int32_t disp, uint8_t * cursor) {} //J9 AOT only for now
+virtual void addInstrSpecificRelocation(TR::CodeGenerator* cg, TR::Instruction* instr, int32_t disp, uint8_t * cursor) {} //J9 AOT only for now
 
 bool setForceFoldingIfAdvantageous(TR::CodeGenerator * cg, TR::Node * addressChild);
 bool tryBaseIndexDispl(TR::CodeGenerator* cg, TR::Node* loadStore, TR::Node* addressChild);
@@ -417,15 +417,15 @@ const char *getName()              {return _name; }
 void tryForceFolding(TR::Node * rootLoadOrStore, TR::CodeGenerator * cg, TR_StorageReference *storageReference, TR::SymbolReference *& symRef, TR::Symbol *& symbol,
                      List<TR::Node>& nodesAlreadyEvaluatedBeforeFoldingList) {}
 
-TR::UnresolvedDataSnippet * createUnresolvedDataSnippet(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool isStore) {return NULL;}
-TR::UnresolvedDataSnippet * createUnresolvedDataSnippetForiaload(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore) {return NULL;}
-void createUnresolvedSnippetWithNodeRegister(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register *& writableLiteralPoolRegister) {}
-void createUnresolvedDataSnippetForBaseNode(TR::CodeGenerator * cg, TR::Register * writableLiteralPoolRegister) {}
+virtual TR::UnresolvedDataSnippet * createUnresolvedDataSnippet(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool isStore) {return NULL;}
+virtual TR::UnresolvedDataSnippet * createUnresolvedDataSnippetForiaload(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore) {return NULL;}
+virtual void createUnresolvedSnippetWithNodeRegister(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register *& writableLiteralPoolRegister) {}
+virtual void createUnresolvedDataSnippetForBaseNode(TR::CodeGenerator * cg, TR::Register * writableLiteralPoolRegister) {}
 
-void createPatchableDataInLitpool(TR::Node * node, TR::CodeGenerator * cg, TR::Register * tempReg, TR::UnresolvedDataSnippet * uds) {}
+virtual void createPatchableDataInLitpool(TR::Node * node, TR::CodeGenerator * cg, TR::Register * tempReg, TR::UnresolvedDataSnippet * uds) {}
 
-bool symRefHasTemporaryNegativeOffset() {return false;}
-void setMemRefAndGetUnresolvedData(TR::Snippet *& snippet) {}
+virtual bool symRefHasTemporaryNegativeOffset() {return false;}
+virtual void setMemRefAndGetUnresolvedData(TR::Snippet *& snippet) {}
 };
 }
 }


### PR DESCRIPTION
* Defined OMR_API in compiler/infra/annotations.hpp
* Commented out `OMR_EXTENSIBLE` from MemoryReference class declarations
* Removed `self()` from function calls of MemoryReference
* Functions virtualized can be found [here](https://github.com/samasri/omr/blob/master/tools/compiler/OMRStatistics/doc/virtualization/MemoryReference.md)

Since virtualizing the MemoryReference hierarchy requires changes from both, the OMR and OpenJ9, projects this PR is linked to [a related one in openJ9](https://github.com/eclipse/openj9/pull/3606) achieving the same purpose.

Signed-off-by: Samer AL Masri <almasri@ualberta.ca>