### PR TITLE
Simplify child index calculation code in PRE

### DIFF
--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -3925,7 +3925,7 @@ bool TR_ExceptionCheckMotion::includeRelevantNodes(TR::Node *node, vcount_t visi
 
    int32_t rhsChild = -1;
    if (node->getOpCode().isStore())
-      rhsChild = (node->getNumChildren() - ((node->getOpCode().isWrtBar()) ? 2 : 1));
+      rhsChild = node->getOpCode().isStoreDirect() ? 0 : 1;
 
    bool childRelevant = false, containsIndirectAccess = false, containsArrayAccess = false, containsDivide = false, containsUnresolvedAccess = false;
    int32_t i;


### PR DESCRIPTION
The child index of rhsNode of a store is more relevant to whether the
store is indirect or direct rather than whether it's a wrtbar. Simplify
the calculation to make it more clear.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>