### PR TITLE
AArch64: Call generateCatchBlockBBStartPrologue in BBStartEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -448,6 +448,11 @@ OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *c
    TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
    TR::Instruction *fence = generateAdminInstruction(cg, TR::InstOpCode::fence, node, fenceNode);
 
+   if (block->isCatchBlock())
+      {
+      cg->generateCatchBlockBBStartPrologue(node, fence);
+      }
+
    return NULL;
    }
 


### PR DESCRIPTION
This commit adds a call to generateCatchBlockBBStartPrologue() in
BBStartEvaluator() for aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>