### PR TITLE
AArch64: Implement icmpeqEvaluator(), etc.

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -148,6 +148,20 @@ uint8_t *TR::ARM64Trg1Instruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64Trg1CondInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
+   insertConditionCodeField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 uint8_t *TR::ARM64Trg1ImmInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/aarch64/codegen/ARM64ConditionCode.hpp
+++ b/compiler/aarch64/codegen/ARM64ConditionCode.hpp
@@ -48,4 +48,11 @@ typedef enum {
 
 } // TR
 
+/**
+ * @brief Returns inverted condition code
+ * @param[in] cc : condition code
+ * @return inverted condition code
+ */
+inline TR::ARM64ConditionCode cc_invert(TR::ARM64ConditionCode cc) { return (TR::ARM64ConditionCode)(cc ^ 1); }
+
 #endif

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -24,6 +24,7 @@
 
 #include "ras/Debug.hpp"
 
+#include "codegen/ARM64ConditionCode.hpp"
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/InstOpCode.hpp"
@@ -499,6 +500,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsTrg1:
          print(pOutFile, (TR::ARM64Trg1Instruction *)instr);
          break;
+      case OMR::Instruction::IsTrg1Cond:
+         print(pOutFile, (TR::ARM64Trg1CondInstruction *)instr);
+         break;
       case OMR::Instruction::IsTrg1Imm:
          print(pOutFile, (TR::ARM64Trg1ImmInstruction *)instr);
          break;
@@ -679,6 +683,26 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Instruction *instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getTargetRegister(), TR_WordReg);
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1CondInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   if (instr->getOpCodeValue() == TR::InstOpCode::csincx)
+      {
+      // cset alias
+      trfprintf(pOutFile, "cset \t");
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg);
+      trfprintf(pOutFile, ", %s", ARM64ConditionNames[cc_invert(instr->getConditionCode())]);
+      }
+   else
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg);
+      trfprintf(pOutFile, ", xzr, xzr, %s", ARM64ConditionNames[instr->getConditionCode()]);
+      }
    trfflush(_comp->getOutFile());
    }
 

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -22,6 +22,7 @@
 #include "aarch64/codegen/GenerateInstructions.hpp"
 
 #include <stdint.h>
+#include "codegen/ARM64ConditionCode.hpp"
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/InstOpCode.hpp"
@@ -386,4 +387,15 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node,
    if (preced)
       return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, preced, cg);
    return new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, cg);
+   }
+
+TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node,
+   TR::Register *treg, TR::ARM64ConditionCode cc, TR::Instruction *preced)
+   {
+   /* Alias of CSINC instruction with inverted condition code */
+   TR::InstOpCode::Mnemonic op = TR::InstOpCode::csincx;
+
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), cg);
    }

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -623,4 +623,20 @@ TR::Instruction *generateMulInstruction(
                   TR::Register *s2reg,
                   TR::Instruction *preced = NULL);
 
+/*
+ * @brief Generates CSET instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] cc : branch condition code
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateCSetInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::Node *node,
+                  TR::Register *treg,
+                  TR::ARM64ConditionCode cc,
+                  TR::Instruction *preced = NULL);
+
 #endif

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -35,6 +35,7 @@
    IsRegBranch,
    IsAdmin,
    IsTrg1,
+      IsTrg1Cond,
       IsTrg1Imm,
       IsTrg1Src1,
          IsTrg1Src1Imm,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -347,6 +347,7 @@ namespace TR { class ARM64CompareBranchInstruction; }
 namespace TR { class ARM64RegBranchInstruction; }
 namespace TR { class ARM64AdminInstruction; }
 namespace TR { class ARM64Trg1Instruction; }
+namespace TR { class ARM64Trg1CondInstruction; }
 namespace TR { class ARM64Trg1ImmInstruction; }
 namespace TR { class ARM64Trg1Src1Instruction; }
 namespace TR { class ARM64Trg1Src1ImmInstruction; }
@@ -1101,6 +1102,7 @@ public:
    void print(TR::FILE *, TR::ARM64RegBranchInstruction *);
    void print(TR::FILE *, TR::ARM64AdminInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Instruction *);
+   void print(TR::FILE *, TR::ARM64Trg1CondInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src1Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src1ImmInstruction *);


### PR DESCRIPTION
This commit implements icmpeqEvaluator() and similar evaluators for
aarch64.

Signed-off-by: knn-k <konno@jp.ibm.com>