### PR TITLE
Check register properties for generating load

### DIFF
--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -424,7 +424,7 @@ void OMR::Z::RegisterDependencyConditions::resolveSplitDependencies(
          case TR_GPR:
             opCode = TR::InstOpCode::getLoadRegOpCode();
             if (cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) &&
-                  (child->getDataType() == TR::Int32 ||
+                  (!reg->is64BitReg() ||
                   child->getOpCodeValue() == TR::icall ||
                   child->getOpCodeValue() == TR::icalli ||
                   TR::RealRegister::isHPR(regNum)))


### PR DESCRIPTION
While resolving register dependencies at split point (GlRegDeps) we check type of the node to decide whether if we need 32 Bit or 64 Bit load instruction. If we have evaluated this node to use 64 Bit register it should use 64 Bit load instruction to generate necessary instruction to satisfy register dependencies at split point.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>