### PR TITLE
AArch64: Fix createPrologue()

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -392,6 +392,8 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
         parameter = parameterIterator.getNext())
       {
       TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, parameter->getParameterOffset(), codeGen);
+      TR::InstOpCode::Mnemonic op;
+
       switch (parameter->getDataType())
          {
          case TR::Int8:
@@ -401,7 +403,8 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
          case TR::Address:
             if (nextIntArgReg < getProperties().getNumIntArgRegs())
                {
-               cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getARM64RealRegister((TR::RealRegister::RegNum)(TR::RealRegister::x0 + nextIntArgReg)), cursor);
+               op = (parameter->getSize() == 8) ? TR::InstOpCode::strimmx : TR::InstOpCode::strimmw;
+               cursor = generateMemSrc1Instruction(cg(), op, firstNode, stackSlot, machine->getARM64RealRegister((TR::RealRegister::RegNum)(TR::RealRegister::x0 + nextIntArgReg)), cursor);
                nextIntArgReg++;
                }
             else
@@ -413,7 +416,8 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
          case TR::Double:
             if (nextFltArgReg < getProperties().getNumFloatArgRegs())
                {
-               cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::vstrimmd, firstNode, stackSlot, machine->getARM64RealRegister((TR::RealRegister::RegNum)(TR::RealRegister::v0 + nextFltArgReg)), cursor);
+               op = (parameter->getSize() == 8) ? TR::InstOpCode::vstrimmd : TR::InstOpCode::vstrimms;
+               cursor = generateMemSrc1Instruction(cg(), op, firstNode, stackSlot, machine->getARM64RealRegister((TR::RealRegister::RegNum)(TR::RealRegister::v0 + nextFltArgReg)), cursor);
                nextFltArgReg++;
                }
             else


### PR DESCRIPTION
createPrologue() has saved the argument registers using strimmx
or vstrimmd instructions, regardless of the data size.  On the other
hand, the stack offset for the argument registers takes the data
size into consideration.
This commit changes the createPrologue() instruction generation, so
that 32-bit and smaller arguments are saved by strimmw or vstrimms
instructions.

Signed-off-by: knn-k <konno@jp.ibm.com>