### PR TITLE
Adding a .gitignore entry for emacs save files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ VerboseGC_*.xml*
 # common development artifacts
 *.swp
 tags
+*~


### PR DESCRIPTION
emacs save files ending in ~ should not be tracked by git.
This commit adds them to the .gitignore file for the project.

Signed-off-by: Vijay Sundaresan <vijaysun@ca.ibm.com>