### PR TITLE
AArch64: Add is64bit parameter to generateCompareInstruction()

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -283,22 +283,20 @@ static TR::Instruction *generateSrc1ImmInstruction(TR::CodeGenerator *cg, TR::In
    }
 
 TR::Instruction *generateCompareImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *sreg, int32_t imm, TR::Instruction *preced)
+   TR::Register *sreg, int32_t imm, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of SUBS instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subsimmx : TR::InstOpCode::subsimmw;
 
    return generateSrc1ImmInstruction(cg, op, node, sreg, imm, preced);
    }
 
 TR::Instruction *generateTestImmInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *sreg, int32_t imm, TR::Instruction *preced)
+   TR::Register *sreg, int32_t imm, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of ANDS instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsimmx : TR::InstOpCode::andsimmw;
 
    return generateSrc1ImmInstruction(cg, op, node, sreg, imm, preced);
@@ -318,22 +316,20 @@ static TR::Instruction *generateSrc2Instruction(TR::CodeGenerator *cg, TR::InstO
    }
 
 TR::Instruction *generateCompareInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+   TR::Register *s1reg, TR::Register *s2reg, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of SUBS instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subsx : TR::InstOpCode::subsw;
 
    return generateSrc2Instruction(cg, op, node, s1reg, s2reg, preced);
    }
 
 TR::Instruction *generateTestInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *s1reg, TR::Register *s2reg, TR::Instruction *preced)
+   TR::Register *s1reg, TR::Register *s2reg, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of ANDS instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::andsx : TR::InstOpCode::andsw;
 
    return generateSrc2Instruction(cg, op, node, s1reg, s2reg, preced);

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -507,6 +507,7 @@ TR::Instruction *generateLogicalShiftLeftImmInstruction(
  * @param[in] node : node
  * @param[in] sreg : source register
  * @param[in] imm : immediate value
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -515,6 +516,7 @@ TR::Instruction *generateCompareImmInstruction(
                   TR::Node *node,
                   TR::Register *sreg,
                   int32_t imm,
+                  bool is64bit = false,
                   TR::Instruction *preced = NULL);
 
 /*
@@ -523,6 +525,7 @@ TR::Instruction *generateCompareImmInstruction(
  * @param[in] node : node
  * @param[in] s1reg : source register 1
  * @param[in] s2reg : source register 2
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -531,6 +534,7 @@ TR::Instruction *generateCompareInstruction(
                   TR::Node *node,
                   TR::Register *s1reg,
                   TR::Register *s2reg,
+                  bool is64bit = false,
                   TR::Instruction *preced = NULL);
 
 /*
@@ -539,6 +543,7 @@ TR::Instruction *generateCompareInstruction(
  * @param[in] node : node
  * @param[in] sreg : source register
  * @param[in] imm : immediate value
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -547,6 +552,7 @@ TR::Instruction *generateTestImmInstruction(
                   TR::Node *node,
                   TR::Register *sreg,
                   int32_t imm,
+                  bool is64bit = false,
                   TR::Instruction *preced = NULL);
 
 /*
@@ -555,6 +561,7 @@ TR::Instruction *generateTestImmInstruction(
  * @param[in] node : node
  * @param[in] s1reg : source register 1
  * @param[in] s2reg : source register 2
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -563,6 +570,7 @@ TR::Instruction *generateTestInstruction(
                   TR::Node *node,
                   TR::Register *s1reg,
                   TR::Register *s2reg,
+                  bool is64bit = false,
                   TR::Instruction *preced = NULL);
 
 /*


### PR DESCRIPTION
This commit adds is64bit parameter to generateCompareInstruction(),
generateTestInstruction(), etc.
Those functions used to look at node->getDataType().isInt64() to
determine whether 64-bit or not.  It is inappropriate for lcmpeq
or other lcmp* nodes that compare 64-bit values and return 32-bit
value.

Signed-off-by: knn-k <konno@jp.ibm.com>