### PR TITLE
GC: Relax Scavenger's Aliasing Inhibiting Condition

### DIFF
--- a/gc/base/Dispatcher.cpp
+++ b/gc/base/Dispatcher.cpp
@@ -89,8 +89,9 @@ MM_Dispatcher::cleanupAfterTask(MM_EnvironmentBase *env)
 void
 MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
 {
+	uintptr_t activeThreads = recomputeActiveThreadCount(env, task, newThreadCount);
 	task->masterSetup(env);
-	prepareThreadsForTask(env, task, newThreadCount);
+	prepareThreadsForTask(env, task, activeThreads);
 	acceptTask(env);
 	task->run(env);
 	completeTask(env);
@@ -107,4 +108,10 @@ MM_Dispatcher::startUpThreads()
 void 
 MM_Dispatcher::shutDownThreads() 
 {
+}
+
+uintptr_t
+MM_Dispatcher::recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
+{
+	return 1;
 }

--- a/gc/base/Dispatcher.hpp
+++ b/gc/base/Dispatcher.hpp
@@ -60,6 +60,8 @@ protected:
 	virtual void completeTask(MM_EnvironmentBase *env);
 	virtual void cleanupAfterTask(MM_EnvironmentBase *env);
 
+	virtual uintptr_t recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount);
+
 public:
 	static MM_Dispatcher *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -452,6 +452,7 @@ public:
 	double dnssMinimumExpansion;
 	double dnssMinimumContraction;
 	bool enableSplitHeap; /**< true if we are using gencon with -Xgc:splitheap (we will fail to boostrap if we can't allocate both ranges) */
+	double aliasInhibitingThresholdPercentage; /**< percentage of threads that can be blocked before copy cache aliasing is inhibited (set through aliasInhibitingThresholdPercentage=) */
 
 	enum HeapInitializationSplitHeapSection {
 		HEAP_INITIALIZATION_SPLIT_HEAP_UNKNOWN = 0,
@@ -1399,6 +1400,7 @@ public:
 		, dnssMinimumExpansion(0.0)
 		, dnssMinimumContraction(0.0)
 		, enableSplitHeap(false)
+		, aliasInhibitingThresholdPercentage(0.20)
 		, splitHeapSection(HEAP_INITIALIZATION_SPLIT_HEAP_UNKNOWN)
 #endif /* OMR_GC_MODRON_SCAVENGER */
 		, globalMaximumContraction(0.05) /* by default, contract must be at most 5% of the committed heap */

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -107,9 +107,9 @@ protected:
 	virtual void acceptTask(MM_EnvironmentBase *env);
 	virtual void completeTask(MM_EnvironmentBase *env);
 	virtual void wakeUpThreads(uintptr_t count);
-
-	virtual void recomputeActiveThreadCount(MM_EnvironmentBase *env);
 	
+	virtual uintptr_t recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount);
+
 	virtual void setThreadInitializationComplete(MM_EnvironmentBase *env);
 	
 	uintptr_t adjustThreadCount(uintptr_t maxThreadCount);

--- a/gc/base/standard/ConcurrentScavengeTask.hpp
+++ b/gc/base/standard/ConcurrentScavengeTask.hpp
@@ -63,15 +63,7 @@ public:
 	{
 		return _bytesScanned;
 	}
-	virtual void setup(MM_EnvironmentBase *env)
-	{
-		MM_ParallelScavengeTask::setup(env);
-	}
 	virtual void run(MM_EnvironmentBase *env);
-	virtual void cleanup(MM_EnvironmentBase *env)
-	{
-		MM_ParallelScavengeTask::cleanup(env);
-	}
 
 	MM_ConcurrentScavengeTask(MM_EnvironmentBase *env,
 			MM_Dispatcher *dispatcher,

--- a/gc/base/standard/ParallelScavengeTask.cpp
+++ b/gc/base/standard/ParallelScavengeTask.cpp
@@ -39,6 +39,13 @@ MM_ParallelScavengeTask::run(MM_EnvironmentBase *envBase)
 }
 
 void
+MM_ParallelScavengeTask::masterSetup(MM_EnvironmentBase *env)
+{
+	uintptr_t calculatedAliasThreshold = (uintptr_t)(getThreadCount() * env->getExtensions()->aliasInhibitingThresholdPercentage);
+	_collector->setAliasThreshold(calculatedAliasThreshold);
+}
+
+void
 MM_ParallelScavengeTask::setup(MM_EnvironmentBase *env)
 {
 	if (env->isMasterThread()) {

--- a/gc/base/standard/ParallelScavengeTask.hpp
+++ b/gc/base/standard/ParallelScavengeTask.hpp
@@ -57,6 +57,7 @@ public:
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);
 	virtual void cleanup(MM_EnvironmentBase *env);
+	virtual void masterSetup(MM_EnvironmentBase *env);
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	/**

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3133,7 +3133,7 @@ MM_Scavenger::aliasToCopyCache(MM_EnvironmentStandard *env, GC_SlotObject *scann
 	 *
 	 * @NOTE this is likely too aggressive and should be relaxed.
 	 */
-	if (0 == _waitingCount) {
+	if (_waitingCount <= _waitingCountAliasThreshold) {
 		/* Only alias if the scanCache != copyCache. IF the caches are the same there is no benefit
 		 * to aliasing. The checks afterwards will ensure that a very similar copy order will happen
 		 * if the copyCache changes from the currently aliased scan cache

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -105,6 +105,7 @@ private:
 	uintptr_t _cachesPerThread; /**< maximum number of copy and scan caches required per thread at any one time */
 	omrthread_monitor_t _scanCacheMonitor; /**< monitor to synchronize threads on scan lists */
 	omrthread_monitor_t _freeCacheMonitor; /**< monitor to synchronize threads on free list */
+	uintptr_t _waitingCountAliasThreshold; /**< Only alias a copy cache IF the number of threads waiting hasn't reached the threshold*/
 	volatile uintptr_t _waitingCount; /**< count of threads waiting  on scan cache queues (blocked via _scanCacheMonitor); threads never wait on _freeCacheMonitor */
 	uintptr_t _cacheLineAlignment; /**< The number of bytes per cache line which is used to determine which boundaries in memory represent the beginning of a cache line */
 	volatile bool _rescanThreadsForRememberedObjects; /**< Indicates that thread-referenced objects were tenured and threads must be rescanned */
@@ -545,6 +546,9 @@ public:
 	 */
 	void resetTenureLargeAllocateStats(MM_EnvironmentBase *env);
 
+	/* API used by ParallelScavengeTask to set _waitingCountAliasThreshold. */
+	void setAliasThreshold(uintptr_t waitingCountAliasThreshold) { _waitingCountAliasThreshold = waitingCountAliasThreshold; }
+
 protected:
 	virtual void setupForGC(MM_EnvironmentBase *env);
 	virtual void masterSetupForGC(MM_EnvironmentStandard *env);
@@ -794,6 +798,7 @@ public:
 		, _cachesPerThread(0)
 		, _scanCacheMonitor(NULL)
 		, _freeCacheMonitor(NULL)
+		, _waitingCountAliasThreshold(0)
 		, _waitingCount(0)
 		, _cacheLineAlignment(0)
 #if !defined(OMR_GC_CONCURRENT_SCAVENGER)


### PR DESCRIPTION
waitingCountAliasThreshold introduced to relax copy cache alias inhibiting - relaxed to 20% from 0% threads that are allowed to be stalled.

See https://github.com/eclipse/omr/issues/3089

Signed-off-by: Salman Rana <salman.rana@ibm.com>