### PR TITLE
Remove TR_X86FPStackIterator (X87 FP) class

### DIFF
--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4983,18 +4983,6 @@ TR_Debug::traceRegisterAssignment(TR::Instruction *instr, bool insertedByRA, boo
                   }
                trfprintf(_file, "</fprs>\n");
                }
-#if defined(TR_TARGET_X86)
-            if (_registerKindsToAssign & TR_X87_Mask)
-               {
-               trfprintf(_file, "<x87>\n");
-               TR::RegisterIterator *iter = _comp->cg()->getX87RegisterIterator();
-               for (TR::Register *reg = iter->getFirst(); reg; reg = iter->getNext())
-                  {
-                  printFullRegInfo(_file, reg);
-                  }
-               trfprintf(_file, "</x87>\n");
-               }
-#endif
             trfprintf(_file, "</regstates>\n");
             }
          if (_comp->getOptions()->getRegisterAssignmentTraceOption(TR_TraceRAPreAssignmentInstruction))

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -478,7 +478,6 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
       {
       self()->setGPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_GPR));
       self()->setFPRegisterIterator(new (self()->trHeapMemory()) TR::RegisterIterator(self()->machine(), TR_FPR));
-      self()->setX87RegisterIterator(new (self()->trHeapMemory()) TR_X86FPStackIterator(self()->machine()));
       }
 
    self()->setSupportsProfiledInlining();

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -36,7 +36,6 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include "codegen/Machine.hpp"                 // for Machine, etc
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"                // for Register
-#include "codegen/RegisterIterator.hpp"        // for RegisterIterator
 #include "codegen/ScratchRegisterManager.hpp"
 #include "compile/Compilation.hpp"             // for Compilation
 #include "env/jittypes.h"                      // for intptrj_t
@@ -332,9 +331,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
       {
       return (_assignmentDirection = d);
       }
-
-   TR::RegisterIterator *getX87RegisterIterator()                          {return _x87RegisterIterator;}
-   TR::RegisterIterator *setX87RegisterIterator(TR::RegisterIterator *iter) {return (_x87RegisterIterator = iter);}
 
    TR::RealRegister *getFrameRegister()                       {return _frameRegister;}
    TR::RealRegister *getMethodMetaDataRegister();
@@ -634,7 +630,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::list<TR_OutlinedInstructions*>    _outlinedInstructionsList;
 
    RegisterAssignmentDirection     _assignmentDirection;
-   TR::RegisterIterator            *_x87RegisterIterator;
 
    int32_t                         _instructionPatchAlignmentBoundary;
    int32_t                         _PicSlotCount;
@@ -801,28 +796,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 #endif
 
 #define IS_32BIT_RIP(x,rip)  ((intptrj_t)(x) == (intptrj_t)(rip) + (int32_t)((intptrj_t)(x) - (intptrj_t)(rip)))
-
-
-class TR_X86FPStackIterator : public TR::RegisterIterator
-   {
-   public:
-
-   TR_X86FPStackIterator(TR::Machine *machine, TR_RegisterKinds kind = TR_NoRegister):
-      TR::RegisterIterator(machine, kind)
-      {
-      _machine = machine;
-      _cursor = TR_X86FPStackRegister::fpFirstStackReg;
-      }
-
-   TR::Register *getFirst() {return _machine->getFPStackLocationPtr(_cursor = TR_X86FPStackRegister::fpFirstStackReg);}
-   TR::Register *getCurrent() {return _machine->getFPStackLocationPtr(_cursor);}
-   TR::Register *getNext() {return _cursor > TR_X86FPStackRegister::fpLastStackReg ? NULL : _machine->getFPStackLocationPtr(++_cursor);}
-
-   private:
-
-   TR::Machine *_machine;
-   int32_t _cursor;
-   };
 
 class TR_X86ScratchRegisterManager: public TR_ScratchRegisterManager
    {


### PR DESCRIPTION
As it is discussed in #2822, X87 support is deprecated, and will be
removed. This fact lets us the opportunity to remove
'TR_X86FPStackIterator' from the codebase as the first step to
consolidate implementations of RegisterIterator.

Issue: #2645
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>