### PR TITLE
Fix build break

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13483,7 +13483,7 @@ OMR::Z::TreeEvaluator::forwardArrayCopySequenceGenerator(TR::Node *node, TR::Cod
       // 2. byteLength > 256 && byteLength is not multiple of 256
       uint8_t residueLength = static_cast<uint8_t>(byteLen & 0xFF);
       if (byteLen <= 256 || residueLength != 0)
-         generateSS1Instruction(cg, TR::InstOpCode::MVC, node, residueLength-1, 
+         generateSS1Instruction(cg, TR::InstOpCode::MVC, node, static_cast<uint8_t>(residueLength-1), 
             generateS390MemoryReference(byteDstReg, 0, cg),
             generateS390MemoryReference(byteSrcReg, 0, cg)); 
       }
@@ -13656,6 +13656,8 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
       }
    else if (node->isBackwardArrayCopy())
       {
+      if (byteLenReg == NULL)
+         byteLenReg = cg->gprClobberEvaluate(byteLenNode);
       deps = TR::TreeEvaluator::backwardArrayCopySequenceGenerator(node, cg, byteSrcReg, byteDstReg, byteLenReg, byteLenNode, srm, mergeLabel);
       }
    else
@@ -13695,7 +13697,7 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
       deps = TR::TreeEvaluator::backwardArrayCopySequenceGenerator(node, cg, byteSrcReg, byteDstReg, byteLenReg, byteLenNode, srm, mergeLabel);
       }
    cursor = generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, mergeLabel);
-   if (!(isConstantByteLen && node->isForwardArrayCopy() && byteLenNode->getConst<int64_t>() < 256))
+   if (!(isConstantByteLen && node->isForwardArrayCopy() && byteLenNode->getConst<int64_t>() <= 256))
       {
       deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(deps, 0, 3+srm->numAvailableRegisters(), cg);
       deps->addPostCondition(byteSrcReg, TR::RealRegister::AssignAny);


### PR DESCRIPTION
When node is set to be backwardArrayCopy node, we generate backward array copy sequence only. When this is combined with constant length bytelength we end up with NULL byteLenReg which causes segmentation fault.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>