### PR TITLE
Concurrent Scavenger yield

### DIFF
--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -239,6 +239,8 @@ public:
 	 * Fixup should update slots to point to the forwarded version of the object and/or remove self forwarded bit in the object itself.
 	 */
 	virtual void scavenger_fixupIndirectObjectSlots(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr) = 0;
+	
+	virtual bool scavenger_shouldYield() { return false; }
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 

--- a/gc/base/standard/ConcurrentScavengeTask.hpp
+++ b/gc/base/standard/ConcurrentScavengeTask.hpp
@@ -35,9 +35,8 @@ class MM_ConcurrentScavengeTask : public MM_ParallelScavengeTask
 {
 	/* Data Members */
 private:
-	UDATA const _bytesToScan;	/**< The number of bytes that this must scan before it will stop trying to do more work */
-	UDATA volatile _bytesScanned;	/**< The number of bytes scanned by this */
-	volatile bool * const _forceExit;	/**< Shared state concurrently updated by an external thread to force the receiver to cause all threads to yield (by setting the destination of the pointer to true) */
+	uintptr_t const _bytesToScan;	/**< The number of bytes that this must scan before it will stop trying to do more work */
+	volatile uintptr_t _bytesScanned;	/**< The number of bytes scanned by this */
 protected:
 public:
 
@@ -55,12 +54,12 @@ public:
 private:
 protected:
 public:
-	virtual UDATA getVMStateID()
+	virtual uintptr_t getVMStateID()
 	{
 		return OMRVMSTATE_GC_CONCURRENT_SCAVENGER;
 	}
 
-	UDATA getBytesScanned()
+	uintptr_t getBytesScanned()
 	{
 		return _bytesScanned;
 	}
@@ -73,22 +72,16 @@ public:
 	{
 		MM_ParallelScavengeTask::cleanup(env);
 	}
-	virtual bool shouldYieldFromTask(MM_EnvironmentBase *env)
-	{
-		return false;
-	}
 
 	MM_ConcurrentScavengeTask(MM_EnvironmentBase *env,
 			MM_Dispatcher *dispatcher,
 			MM_Scavenger *scavenger,
 			ConcurrentAction action,
 			uintptr_t bytesToScan,
-			volatile bool *forceExit,
 			MM_CycleState *cycleState) :
 		MM_ParallelScavengeTask(env, dispatcher, scavenger, cycleState)
 		, _bytesToScan(bytesToScan)
 		, _bytesScanned(0)
-		, _forceExit(forceExit)
 		, _action(action)
 	{
 		_typeId = __FUNCTION__;

--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -99,7 +99,7 @@ MM_EnvironmentStandard::flushGCCaches()
 	if (getExtensions()->concurrentScavenger) {
 		if (MUTATOR_THREAD == getThreadType()) {
 			if (NULL != getExtensions()->scavenger) {
-				getExtensions()->scavenger->threadFinalReleaseCopyCaches(this, this);
+				getExtensions()->scavenger->threadFinalReleaseCaches(this);
 			}
 		}
 	}

--- a/gc/base/standard/EnvironmentStandard.hpp
+++ b/gc/base/standard/EnvironmentStandard.hpp
@@ -48,7 +48,6 @@ class MM_EnvironmentStandard : public MM_EnvironmentBase
 /* Data Section */
 public:
 	MM_CopyScanCacheStandard *_survivorCopyScanCache; /**< the current copy cache for flipping */
-	MM_CopyScanCacheStandard *_scanCache; /**< the current scan cache */
 	MM_CopyScanCacheStandard *_deferredScanCache; /**< a copy cache about to be pushed to scan queue, but before that may be merged with some other caches that collectively form contiguous memory */
 	MM_CopyScanCacheStandard *_deferredCopyCache; /**< a copy cache about to be pushed to scan queue, but before that may be merged with some other caches that collectively form contiguous memory */
 	MM_CopyScanCacheStandard *_tenureCopyScanCache; /**< the current copy cache for tenuring */
@@ -85,7 +84,6 @@ public:
 	MM_EnvironmentStandard(OMR_VMThread *omrVMThread) :
 		MM_EnvironmentBase(omrVMThread)
 		,_survivorCopyScanCache(NULL)
-		,_scanCache(NULL)
 		,_deferredScanCache(NULL)
 		,_deferredCopyCache(NULL)
 		,_tenureCopyScanCache(NULL)

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1344,7 +1344,7 @@ MM_Scavenger::copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHea
 		/* raise the alert and return (with NULL) */
 		setBackOutFlag(env, backOutFlagRaised);
 		omrthread_monitor_enter(_scanCacheMonitor);
-		if(_waitingCount) {
+		if (0 != _waitingCount) {
 			omrthread_monitor_notify_all(_scanCacheMonitor);
 		}
 		omrthread_monitor_exit(_scanCacheMonitor);
@@ -1804,6 +1804,16 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 	bool doneFlag = false;
 	volatile uintptr_t doneIndex = _doneIndex;
 
+	if (checkAndSetShouldYieldFlag()) {
+		flushBuffersForGetNextScanCache(env);
+		omrthread_monitor_enter(_scanCacheMonitor);
+		if (0 != _waitingCount) {
+			omrthread_monitor_notify_all(_scanCacheMonitor);
+		}
+		omrthread_monitor_exit(_scanCacheMonitor);
+		return NULL;
+    }
+
 	/* Preference is to use survivor copy cache */
 	cache = env->_survivorCopyScanCache;
 	if (isWorkAvailableInCacheWithCheck(cache)) {
@@ -1842,7 +1852,7 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 #endif /* OMR_SCAVENGER_TRACE || J9MODRON_TGC_PARALLEL_STATISTICS */
 
- 	while (!doneFlag && !shouldAbortScanLoop()) {
+ 	while (!doneFlag && !shouldAbortScanLoop(env)) {
  		while (_cachedEntryCount > 0) {
  			cache = getNextScanCacheFromList(env);
 
@@ -1876,7 +1886,7 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 				_extensions->copyScanRatio.reset(env, false);
 				omrthread_monitor_notify_all(_scanCacheMonitor);
 			} else {
-				while((0 == _cachedEntryCount) && (doneIndex == _doneIndex) && !shouldAbortScanLoop()) {
+				while((0 == _cachedEntryCount) && (doneIndex == _doneIndex) && !shouldAbortScanLoop(env)) {
 					flushBuffersForGetNextScanCache(env);
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 					uint64_t waitEndTime, waitStartTime;
@@ -2039,7 +2049,7 @@ MM_Scavenger::completeScan(MM_EnvironmentStandard *env)
 			omrtty_printf("Forcing backout at workUnitIndex: %zu lastSyncPointReached: %s\n", env->getWorkUnitIndex(), env->_lastSyncPointReached);
 			setBackOutFlag(env, backOutFlagRaised);
 			omrthread_monitor_enter(_scanCacheMonitor);
-			if(_waitingCount) {
+			if (0 != _waitingCount) {
 				omrthread_monitor_notify_all(_scanCacheMonitor);
 			}
 			omrthread_monitor_exit(_scanCacheMonitor);
@@ -3207,6 +3217,23 @@ MM_Scavenger::restoreMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env
 		_extensions->_masterThreadTenureTLHRemainderTop = NULL;
 		_extensions->_masterThreadTenureTLHRemainderBase = NULL;
 	}
+}
+
+MMINLINE bool
+MM_Scavenger::checkAndSetShouldYieldFlag() {
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	/* Don't rely on fact that scavenger_shouldYield() would return the same value during one concurrent phase.
+	 * If one GC thread saw that we need to yield, we must yield, there is no way back. Hence, we store the result in _shouldYield,
+	 * and rely on it for the rest of concurrent phase.
+	 */
+	if (!_shouldYield) {
+		 _shouldYield = _cli->scavenger_shouldYield();
+	}
+	return _shouldYield;
+#else
+	return false;
+#endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
+
 }
 
 /****************************************
@@ -4627,7 +4654,7 @@ MM_Scavenger::scavengeRoots(MM_EnvironmentBase *env)
 {
 	Assert_MM_true(concurrent_state_roots == _concurrentState);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_ROOTS, UDATA_MAX, NULL, env->_cycleState);
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_ROOTS, UDATA_MAX, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
 	return false;
@@ -4642,7 +4669,7 @@ MM_Scavenger::scavengeScan(MM_EnvironmentBase *envBase)
 
 	restoreMasterThreadTenureTLHRemainders(env);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, NULL, env->_cycleState);
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
 	return false;
@@ -4657,7 +4684,7 @@ MM_Scavenger::scavengeComplete(MM_EnvironmentBase *envBase)
 
 	restoreMasterThreadTenureTLHRemainders(env);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_COMPLETE, UDATA_MAX, NULL, env->_cycleState);
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_COMPLETE, UDATA_MAX, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
 	Assert_MM_true(_scavengeCacheFreeList.areAllCachesReturned());
@@ -4683,51 +4710,53 @@ MM_Scavenger::mutatorSetupForGC(MM_EnvironmentBase *envBase)
 }
 
 void
-MM_Scavenger::threadFinalReleaseCopyCaches(MM_EnvironmentBase *envBase, MM_EnvironmentBase *threadEnvironmentBase)
+MM_Scavenger::threadFinalReleaseCaches(MM_EnvironmentBase *envBase)
 {
 	MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(envBase);
-	MM_EnvironmentStandard *threadEnvironment = MM_EnvironmentStandard::getEnvironment(threadEnvironmentBase);
 
 	if (isConcurrentInProgress()) {
-		/* In a case of scavenge complete phase, master thread will act on behalf (use its own environment) of mutator threads
-		 * In a case of thread teardown or flushing caches for walk, caller ensures that own environment is used.
-		 */
-
-		Assert_MM_true(NULL == threadEnvironment->_deferredScanCache);
-
-		if (threadEnvironment->_survivorCopyScanCache) {
-			Assert_MM_true(threadEnvironment->_survivorCopyScanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
-			threadEnvironment->_survivorCopyScanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+		if (NULL != env->_deferredScanCache) {
+			Assert_MM_true(MUTATOR_THREAD != env->getThreadType());
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 			env->_scavengerStats._releaseScanListCount += 1;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			clearCache(env, threadEnvironment->_survivorCopyScanCache);
-			addCacheEntryToScanListAndNotify(env, threadEnvironment->_survivorCopyScanCache);
-			threadEnvironment->_survivorCopyScanCache = NULL;
-		}
-		if (threadEnvironment->_deferredCopyCache) {
-			Assert_MM_true(threadEnvironment->_deferredCopyCache->flags & OMR_SCAVENGER_CACHE_TYPE_CLEARED);
-			Assert_MM_true(threadEnvironment->_deferredCopyCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
-			threadEnvironment->_deferredCopyCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
-#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			env->_scavengerStats._releaseScanListCount += 1;
-#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			addCacheEntryToScanListAndNotify(env, threadEnvironment->_deferredCopyCache);
-			threadEnvironment->_deferredCopyCache = NULL;
-		}
-		if (threadEnvironment->_tenureCopyScanCache) {
-			Assert_MM_true(threadEnvironment->_tenureCopyScanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
-			threadEnvironment->_tenureCopyScanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
-#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			env->_scavengerStats._releaseScanListCount += 1;
-#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
-			clearCache(env, threadEnvironment->_tenureCopyScanCache);
-			addCacheEntryToScanListAndNotify(env, threadEnvironment->_tenureCopyScanCache);
-			threadEnvironment->_tenureCopyScanCache = NULL;
+			_scavengeCacheScanList.pushCache(env, env->_deferredScanCache);
+			env->_deferredScanCache = NULL;
 		}
 
-		abandonSurvivorTLHRemainder(threadEnvironment);
-		abandonTenureTLHRemainder(threadEnvironment, true);
+		if (NULL != env->_survivorCopyScanCache) {
+			Assert_MM_true(env->_survivorCopyScanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+			env->_survivorCopyScanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+			env->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+			clearCache(env, env->_survivorCopyScanCache);
+			_scavengeCacheScanList.pushCache(env, env->_survivorCopyScanCache);
+			env->_survivorCopyScanCache = NULL;
+		}
+		if (NULL != env->_deferredCopyCache) {
+			Assert_MM_true(env->_deferredCopyCache->flags & OMR_SCAVENGER_CACHE_TYPE_CLEARED);
+			Assert_MM_true(env->_deferredCopyCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+			env->_deferredCopyCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+			env->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+			_scavengeCacheScanList.pushCache(env, env->_deferredCopyCache);
+			env->_deferredCopyCache = NULL;
+		}
+		if (NULL != env->_tenureCopyScanCache) {
+			Assert_MM_true(env->_tenureCopyScanCache->flags & OMR_SCAVENGER_CACHE_TYPE_COPY);
+			env->_tenureCopyScanCache->flags &= ~OMR_SCAVENGER_CACHE_TYPE_COPY;
+#if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
+			env->_scavengerStats._releaseScanListCount += 1;
+#endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
+			clearCache(env, env->_tenureCopyScanCache);
+			_scavengeCacheScanList.pushCache(env, env->_tenureCopyScanCache);
+			env->_tenureCopyScanCache = NULL;
+		}
+
+		abandonSurvivorTLHRemainder(env);
+		abandonTenureTLHRemainder(env, true);
 	}
 }
 
@@ -4744,7 +4773,6 @@ MM_Scavenger::scavengeIncremental(MM_EnvironmentBase *env)
 		case concurrent_state_idle:
 		{
 			_concurrentState = concurrent_state_init;
-			_forceConcurrentTermination = false;
 			continue;
 		}
 		case concurrent_state_init:
@@ -4827,7 +4855,7 @@ MM_Scavenger::workThreadProcessRoots(MM_EnvironmentStandard *env)
 	 * This is important to do only for GC threads that will not be used in concurrent phase, but at this point
 	 * we don't know which threads Scheduler will not use, so we do it for every thread.
 	 */
-	threadFinalReleaseCopyCaches(env, env);
+	threadFinalReleaseCaches(env);
 
 	mergeThreadGCStats(env);
 }
@@ -4843,12 +4871,12 @@ MM_Scavenger::workThreadScan(MM_EnvironmentStandard *env)
 	rootScanner.scavengeRememberedSet(env);
 
 	completeScan(env);
-	// todo: are these two steps really necessary?
-	// we probably have to clear all things for master since it'll be doing final release/clear on behalf of mutator threads
-	// but is it really needed for slaves as well?
-	addCopyCachesToFreeList(env);
-	abandonSurvivorTLHRemainder(env);
-	abandonTenureTLHRemainder(env, true);
+
+	/* We might have yielded without exausting scan work. Push any open caches to the scan queue, so that GC threads from final STW phase pick them up.
+	 * Most of the time, STW phase will have a superset of GC threads, so they could just resume the work on their own caches,
+	 * but this is not 100% guarantied (the control of what threads are inolved is in Dispatcher's domain).
+	 */
+	threadFinalReleaseCaches(env);
 
 	mergeThreadGCStats(env);
 }
@@ -4914,9 +4942,13 @@ MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 
 		clearIncrementGCStats(env, false);
 
-		MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, &_forceConcurrentTermination, env->_cycleState);
+		MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, env->_cycleState);
 		/* Concurrent background task will run with different (typically lower) number of threads. */
 		_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
+
+		/* Now that we are done with concurrent scanning in this cycle (where we could possibly
+		 * be interested in its value), reset this flag */
+		_shouldYield = false;
 
 		/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */
 		_concurrentState = concurrent_state_complete;
@@ -4955,8 +4987,6 @@ void MM_Scavenger::preConcurrentInitializeStatsAndReport(MM_EnvironmentBase *env
 void MM_Scavenger::postConcurrentUpdateStatsAndReport(MM_EnvironmentBase *env, MM_ConcurrentPhaseStatsBase *stats, UDATA bytesConcurrentlyScanned)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
-
-	stats->_terminationWasRequested = _forceConcurrentTermination;
 
 	_extensions->incrementScavengerStats._endTime = omrtime_hires_clock();
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -127,10 +127,8 @@ private:
 	} _concurrentState;
 	
 	uint64_t _concurrentScavengerSwitchCount; /**< global counter of cycle start and cycle end transitions */
-	
-	/* TODO: put it parent Collector class and share with Balanced? */ 
-	volatile bool _forceConcurrentTermination;
-	
+	volatile bool _shouldYield; /**< Set by the first GC thread that observes that a criteria for yielding is met. Reset only when the concurrent phase is finished. */
+
 	MM_ConcurrentPhaseStatsBase _concurrentPhaseStats;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
@@ -145,17 +143,57 @@ public:
 	 * Function members
 	 */
 private:
+	/**
+	 * Flush the threads reference and remembered set caches before waiting in getNextScanCache.
+	 * This removes the requirement of a synchronization point after calls to completeScan when
+	 * it is followed by reference or remembered set processing.
+	 * @param env - current thread environment
+	 */
+	void flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env);
+	
 	void saveMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
 	void restoreMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env);
+	
 	void setBackOutFlag(MM_EnvironmentBase *env, BackOutState value);
 	MMINLINE bool isBackOutFlagRaised() { return _extensions->isScavengerBackOutFlagRaised(); }
-	MMINLINE bool shouldAbortScanLoop() {
+	
+	/**
+	 * Check if concurrent phase of the cycle should yield to an external activity. If so, set the flag so that other GC threads react appropriately
+	 */ 
+	bool checkAndSetShouldYieldFlag();
+	
+	/**
+	 * Check if top level scan loop should be aborted before the work is done
+	 */
+	MMINLINE bool shouldAbortScanLoop(MM_EnvironmentStandard *env) {
+		bool shouldAbort = false;
+
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-		/* Concurrent Scavenger needs to drain the scan queue, even if Scavenge aborted */
-		return false;
-#else		
-		return isBackOutFlagRaised();
-#endif /* OMR_GC_CONCURRENT_SCAVENGER */		
+		if (IS_CONCURRENT_ENABLED) {
+			/* Concurrent Scavenger needs to drain the scan queue in last scan loop before aborted handling starts.
+			 * It is however fine to leave it populated, if we want to yield in a middle of concurrent phase which aborted,
+			 * since there will be at least one scan loop afterwards in complete phase that will drain it. Bottom line,
+			 * we don't care about isBackOutFlagRaised when deciding whether to yield.
+			 */
+					 
+			shouldAbort = _shouldYield;
+			if (shouldAbort) {
+				Assert_MM_true(concurrent_state_scan == _concurrentState);
+				/* Since we are aborting the scan loop without synchornizing with other GC threads (before which we flush buffers),
+				 * we have to do it now. 
+				 * There should be no danger in not synchonizing with other threads, since we can only abort/yield in main scan loop
+				 * and not during clearable STW phase, where is a potential danger of entering a scan loop without ensuring all
+				 * threads flushed buffers from previous scan loop.
+				 */
+				flushBuffersForGetNextScanCache(env);
+			}
+		} else
+#endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
+		{		
+			shouldAbort = isBackOutFlagRaised();
+		}
+		
+		return shouldAbort;
 	}
 
 public:
@@ -196,14 +234,6 @@ public:
 	MMINLINE uintptr_t calculateOptimumCopyScanCacheSize(MM_EnvironmentStandard *env);
 	MMINLINE MM_CopyScanCacheStandard *reserveMemoryForAllocateInSemiSpace(MM_EnvironmentStandard *env, omrobjectptr_t objectToEvacuate, uintptr_t objectReserveSizeInBytes);
 	MM_CopyScanCacheStandard *reserveMemoryForAllocateInTenureSpace(MM_EnvironmentStandard *env, omrobjectptr_t objectToEvacuate, uintptr_t objectReserveSizeInBytes);
-
-	/**
-	 * Flush the threads reference and remembered set caches before waiting in getNextScanCache.
-	 * This removes the requirement of a synchronization point after calls to completeScan when
-	 * it is followed by reference or remembered set processing.
-	 * @param env - current thread environment
-	 */
-	MMINLINE void flushBuffersForGetNextScanCache(MM_EnvironmentStandard *env);
 
 	MM_CopyScanCacheStandard *getNextScanCache(MM_EnvironmentStandard *env);
 
@@ -582,7 +612,7 @@ public:
 	 * @param env Invoking thread. Could be master thread on behalf on mutator threads (threadEnvironment) for which copy caches are to be released, or could be mutator or GC thread itself.
 	 * @param threadEnvironment Thread for which copy caches are to be released. Could be either GC or mutator thread.
 	 */
-	void threadFinalReleaseCopyCaches(MM_EnvironmentBase *env, MM_EnvironmentBase *threadEnvironment);
+	void threadFinalReleaseCaches(MM_EnvironmentBase *env);
 	
 	/**
 	 * trigger STW phase (either start or end) of a Concurrent Scavenger Cycle 
@@ -598,10 +628,6 @@ public:
 	void workThreadScan(MM_EnvironmentStandard *env);
 	void workThreadComplete(MM_EnvironmentStandard *env);
 
-	
-	virtual void forceConcurrentFinish() {
-		_forceConcurrentTermination = true;
-	}
 	bool isConcurrentInProgress() {
 		return concurrent_state_idle != _concurrentState;
 	}
@@ -781,8 +807,9 @@ public:
 		, _masterGCThread(env)
 		, _concurrentState(concurrent_state_idle)
 		, _concurrentScavengerSwitchCount(0)
-		, _forceConcurrentTermination(false)
-#endif		
+		, _shouldYield(false)
+#endif /* #if defined(OMR_GC_CONCURRENT_SCAVENGER) */
+
 		, _omrVM(env->getOmrVM())
 	{
 		_typeId = __FUNCTION__;

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -877,7 +877,7 @@ MM_VerboseHandlerOutput::handleConcurrentEnd(J9HookInterface** hook, UDATA event
 	writer->formatAndOutput(env, 0, "<concurrent-end %s>", tagTemplate);
 	handleConcurrentEndInternal(hook, eventNum, eventData);
 	handleConcurrentGCOpEnd(hook, eventNum, eventData);
-	writer->formatAndOutput(env, 0, "</concurrent-end>");
+	writer->formatAndOutput(env, 0, "</concurrent-end>\n");
 	writer->flush(env);
 	exitAtomicReportingBlock();
 }


### PR DESCRIPTION
If there is a request to yield, abort the concurrent scan phase. The
rest of the work will be done in final STW phase.

There could be an arbitrary criteria, which this change does not impose;
it just provides API to check if yield is necessary.

An example of a criteria is raised exclusive VM access request (which
could be language specific). In such a case it is fair to yield and
don't have a third party to wait 100s of milisec before the concurrent
phase completes.

Another example would be exhausted hybrid survivor/allocate space.
Application cannot make progress anyway, so it's better to complete the
cycle in the final STW phase with all GC threads available (by default
4x more than number of threads in concurrent phase).

Yield checks are still relatively coarse - they are done before fetching
next work unit (scan cash), which in a bad case may still take a few
milisec to respond to yield request.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>