### PR TITLE
DDR: fix ddrgen bugs involving empty structs

### DIFF
--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -741,6 +741,9 @@ JavaBlobGenerator::addBlobConst(const string &name, long long value, uint32_t *c
 DDR_RC
 JavaBlobGenerator::addBlobStruct(const string &name, const string &superName, uint32_t constCount, uint32_t fieldCount, uint32_t size)
 {
+	if(!_printEmptyTypes && (0 == constCount) && (0 == fieldCount)) {
+		return DDR_RC_OK;
+	}
 	uint32_t nameOffset = UINT32_MAX;
 	uint32_t superOffset = UINT32_MAX;
 	DDR_RC rc = stringTableOffset(&_buildInfo.header, _buildInfo.stringHash, name.c_str(), &nameOffset);
@@ -917,7 +920,7 @@ JavaBlobGenerator::addFieldAndConstCount(bool addFieldsOnly, size_t fieldCount, 
 	DDR_RC rc = DDR_RC_OK;
 	size_t structDataSize = sizeof(BlobField) * fieldCount + sizeof(BlobConstant) * constCount;
 
-	if (!addFieldsOnly) {
+	if (!addFieldsOnly && (structDataSize != 0 || _printEmptyTypes)) {
 		structDataSize += sizeof(BlobStruct);
 	}
 
@@ -928,7 +931,7 @@ JavaBlobGenerator::addFieldAndConstCount(bool addFieldsOnly, size_t fieldCount, 
 
 		if (addFieldsOnly) {
 			/* just count fields and constants */
-		} else if (_printEmptyTypes || (0 != _buildInfo.constCount) || (0 != _buildInfo.fieldCount)) {
+		} else if (_printEmptyTypes || structDataSize != 0) {
 			_buildInfo.header.structureCount += 1;
 		}
 	} else {


### PR DESCRIPTION
Fix a couple of bugs with ddrgen related to empty structs

* structs are considered based on the total number of constants/fields
seen globally rather than the number of fields/constants seen in that
struct

* Empty structs are still actually output, even when -e is not specified.
This leads to an assertion failure because the number of structs output
is greater than _buildInfo.header.structureCount

* _buildInfo.header.structDataSize is incremented for empty structs which
should not be output.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>