### PR TITLE
WIP: Virtualized Symbol Hierarchy

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -946,7 +946,7 @@ OMR::SymbolReferenceTable::methodSymRefFromName(TR::ResolvedMethodSymbol * ownin
       {
       // fullSignature will be kept as a key by _methodsBySignature, so it needs heapAlloc
       //
-      key = OwningMethodAndString(owningMethodSymbol->getResolvedMethodIndex(), self()->strdup(fullSignature));
+      key = OwningMethodAndString(owningMethodSymbol->getResolvedMethodIndex(), strdup(fullSignature));
       if (comp()->getOption(TR_TraceMethodIndex))
          traceMsg(comp(), "-- MBS cache miss (1) owning method #%d, signature %s\n", owningMethodSymbol->getResolvedMethodIndex().value(), fullSignature);
       }
@@ -1054,7 +1054,7 @@ TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateAsyncCheckSymbolRef(TR::ResolvedMethodSymbol *)
    {
 #ifdef RUBY_PROJECT_SPECIFIC
-   return self()->findOrCreateRubyHelperSymbolRef(RubyHelper_rb_threadptr_execute_interrupts,
+   return findOrCreateRubyHelperSymbolRef(RubyHelper_rb_threadptr_execute_interrupts,
                                           true,    /*canGCandReturn*/
                                           true,    /*canGCandExcept*/
                                           false);  /*preservesAllRegisters*/
@@ -1908,14 +1908,14 @@ void OMR::SymbolReferenceTable::makeSharedAliases(TR::SymbolReference *sr1, TR::
 
     if (aliases1 == NULL)
        {
-       aliases1 = new (comp()->trHeapMemory()) TR_BitVector(self()->getNumSymRefs(), comp()->trMemory(), heapAlloc);
+       aliases1 = new (comp()->trHeapMemory()) TR_BitVector(getNumSymRefs(), comp()->trMemory(), heapAlloc);
        aliases1->empty();
        _sharedAliasMap->insert(std::make_pair(symRefNum1, aliases1));
        }
 
     if (aliases2 == NULL)
        {
-       aliases2 = new (comp()->trHeapMemory()) TR_BitVector(self()->getNumSymRefs(), comp()->trMemory(), heapAlloc);
+       aliases2 = new (comp()->trHeapMemory()) TR_BitVector(getNumSymRefs(), comp()->trMemory(), heapAlloc);
        aliases2->empty();
        _sharedAliasMap->insert(std::make_pair(symRefNum2, aliases2));
        }

--- a/compiler/il/OMRSymbolReference.cpp
+++ b/compiler/il/OMRSymbolReference.cpp
@@ -82,19 +82,19 @@ OMR::SymbolReference::init(TR::SymbolReferenceTable * symRefTab,
    _extraInfo = NULL;
    _knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
    symRefTab->aliasBuilder.updateSubSets(self());
-   self()->setHasBeenAccessedAtRuntime(TR_maybe);
+   setHasBeenAccessedAtRuntime(TR_maybe);
    }
 
 OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable * symRefTab)
    {
-   self()->init(symRefTab, symRefTab->assignSymRefNumber(self()));
+   init(symRefTab, symRefTab->assignSymRefNumber(self()));
    }
 
 OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable * symRefTab,
                    TR::Symbol * symbol,
                    intptrj_t offset)
    {
-   self()->init(symRefTab, symRefTab->assignSymRefNumber(self()), symbol, offset);
+   init(symRefTab, symRefTab->assignSymRefNumber(self()), symbol, offset);
    }
 
 OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable * symRefTab,
@@ -102,7 +102,7 @@ OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable * symRefTab,
                    TR::Symbol *ps,
                    intptrj_t offset)
    {
-   self()->init(symRefTab, refNumber, ps, offset);
+   init(symRefTab, refNumber, ps, offset);
    }
 
 OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable *symRefTab,
@@ -110,7 +110,7 @@ OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable *symRefTab,
                    TR::Symbol *ps,
                    intptrj_t offset)
    {
-   self()->init(symRefTab, symRefTab->getNonhelperIndex(number), ps, offset);
+   init(symRefTab, symRefTab->getNonhelperIndex(number), ps, offset);
    }
 
 
@@ -119,7 +119,7 @@ OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable *symRefTab,
  */
 OMR::SymbolReference::SymbolReference(TR::SymbolReferenceTable * symRefTab, TR::Symbol * symbol, intptrj_t offset, const char *name)
    {
-   self()->init(symRefTab,
+   init(symRefTab,
         symRefTab->assignSymRefNumber(self()),
         symbol,
         offset,
@@ -139,7 +139,7 @@ OMR::SymbolReference::SymbolReference(
       int32_t unresolvedIndex,
       TR::KnownObjectTable::Index knownObjectIndex)
    {
-   self()->init(symRefTab,
+   init(symRefTab,
         symRefTab->assignSymRefNumber(self()),
         sym,
         0,  // Offset 0
@@ -163,7 +163,7 @@ OMR::SymbolReference::SymbolReference(
 void *
 OMR::SymbolReference::getMethodAddress()
    {
-   return (void *)self()->getSymbol()->castToMethodSymbol()->getMethodAddress();
+   return (void *)getSymbol()->castToMethodSymbol()->getMethodAddress();
    }
 
 /**
@@ -172,7 +172,7 @@ OMR::SymbolReference::getMethodAddress()
 TR::ResolvedMethodSymbol *
 OMR::SymbolReference::getOwningMethodSymbol(TR::Compilation *c)
    {
-   return c->getOwningMethodSymbol(self()->getOwningMethodIndex());
+   return c->getOwningMethodSymbol(getOwningMethodIndex());
    }
 
 /**
@@ -181,7 +181,7 @@ OMR::SymbolReference::getOwningMethodSymbol(TR::Compilation *c)
 TR_ResolvedMethod *
 OMR::SymbolReference::getOwningMethod(TR::Compilation * c)
    {
-   return self()->getOwningMethodSymbol(c)->getResolvedMethod();
+   return getOwningMethodSymbol(c)->getResolvedMethod();
    }
 
 bool
@@ -190,7 +190,7 @@ OMR::SymbolReference::maybeVolatile()
    if (_symbol->isVolatile())
       return true;
 
-   if (self()->isUnresolved()
+   if (isUnresolved()
        && !_symbol->isConstObjectRef()
        && (_symbol->isShadow() || _symbol->isStatic()))
       return true;
@@ -203,33 +203,33 @@ OMR::SymbolReference::isUnresolvedFieldInCP(TR::Compilation *c)
    {
    TR_ASSERT(c->compileRelocatableCode(),"isUnresolvedFieldInCP only callable in AOT compiles");
 
-   if (!self()->isUnresolved())
+   if (!isUnresolved())
       return false;
 
    if (c->getOption(TR_DisablePeekAOTResolutions))
       return true;
 
-   return self()->getOwningMethod(c)->getUnresolvedFieldInCP(self()->getCPIndex());
+   return getOwningMethod(c)->getUnresolvedFieldInCP(getCPIndex());
    }
 
 bool
 OMR::SymbolReference::isUnresolvedMethodInCP(TR::Compilation *c)
    {
-   TR_ASSERT(c->compileRelocatableCode() && self()->getSymbol()->isMethod(), "isUnresolvedMethodInCP only callable in AOT compiles on method symbols");
+   TR_ASSERT(c->compileRelocatableCode() && getSymbol()->isMethod(), "isUnresolvedMethodInCP only callable in AOT compiles on method symbols");
 
-   if (!self()->isUnresolved())
+   if (!isUnresolved())
       return false;
 
    if (c->getOption(TR_DisablePeekAOTResolutions))
       return true;
 
-   TR::MethodSymbol *sym = self()->getSymbol()->getMethodSymbol();
+   TR::MethodSymbol *sym = getSymbol()->getMethodSymbol();
    if (sym->isStatic())
-      return self()->getOwningMethod(c)->getUnresolvedStaticMethodInCP(self()->getCPIndex());
+      return getOwningMethod(c)->getUnresolvedStaticMethodInCP(getCPIndex());
    else if (sym->isSpecial())
-      return self()->getOwningMethod(c)->getUnresolvedSpecialMethodInCP(self()->getCPIndex());
+      return getOwningMethod(c)->getUnresolvedSpecialMethodInCP(getCPIndex());
    else if (sym->isVirtual())
-      return self()->getOwningMethod(c)->getUnresolvedVirtualMethodInCP(self()->getCPIndex());
+      return getOwningMethod(c)->getUnresolvedVirtualMethodInCP(getCPIndex());
    else
       return true;
    }
@@ -262,15 +262,15 @@ OMR::SymbolReference::isThisPointer()
    TR::Compilation *c = TR::comp();
    TR::ParameterSymbol* p = _symbol->getParmSymbol();
    return p && p->getSlot() == 0
-      && !self()->getOwningMethod(c)->isStatic();
+      && !getOwningMethod(c)->isStatic();
    }
 
 bool
 OMR::SymbolReference::isTemporary(TR::Compilation *c)
    {
-   return self()->getSymbol()->isAuto()
-      && (self()->getCPIndex() >= self()->getOwningMethodSymbol(c)->getFirstJitTempIndex()
-          || self()->getCPIndex() < 0);
+   return getSymbol()->isAuto()
+      && (getCPIndex() >= getOwningMethodSymbol(c)->getFirstJitTempIndex()
+          || getCPIndex() < 0);
    }
 
 const char *
@@ -293,13 +293,13 @@ OMR::SymbolReference::create(TR::SymbolReferenceTable *symRefTab, TR::Symbol *sy
 TR::KnownObjectTable::Index
 OMR::SymbolReference::getKnownObjectIndex()
    {
-   if (self()->getSymbol())
+   if (getSymbol())
       {
-      TR::ParameterSymbol *parm = self()->getSymbol()->getParmSymbol();
+      TR::ParameterSymbol *parm = getSymbol()->getParmSymbol();
       if (parm && parm->hasKnownObjectIndex())
          {
          if (_knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
-            TR_ASSERT(self()->getKnownObjectIndex() == parm->getKnownObjectIndex(), "Parm symbol and symref known-object indexes must match (%d != %d)", self()->getKnownObjectIndex(), parm->getKnownObjectIndex());
+            TR_ASSERT(getKnownObjectIndex() == parm->getKnownObjectIndex(), "Parm symbol and symref known-object indexes must match (%d != %d)", getKnownObjectIndex(), parm->getKnownObjectIndex());
          return parm->getKnownObjectIndex();
          }
       }
@@ -309,14 +309,14 @@ OMR::SymbolReference::getKnownObjectIndex()
 bool
 OMR::SymbolReference::hasKnownObjectIndex()
    {
-   return self()->getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN;
+   return getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN;
    }
 
 uintptrj_t*
 OMR::SymbolReference::getKnownObjectReferenceLocation(TR::Compilation *comp)
    {
-   return self()->hasKnownObjectIndex() ?
-      comp->getKnownObjectTable()->getPointerLocation(self()->getKnownObjectIndex()) :
+   return hasKnownObjectIndex() ?
+      comp->getKnownObjectTable()->getPointerLocation(getKnownObjectIndex()) :
       NULL;
    }
 
@@ -341,20 +341,20 @@ void
 OMR::SymbolReference::setUseDefAliases(TR_BitVector * bv)
    {
    _useDefAliases = bv;
-   TR_ASSERT((!_symbol || !_symbol->isArrayShadowSymbol()) && !self()->isTempVariableSizeSymRef(),
+   TR_ASSERT((!_symbol || !_symbol->isArrayShadowSymbol()) && !isTempVariableSizeSymRef(),
              "should never call with an array shadow or a tempMemSlot");
    }
 
 bool
 OMR::SymbolReference::canCauseGC()
    {
-   return self()->canGCandReturn() || self()->canGCandExcept();
+   return canGCandReturn() || canGCandExcept();
    }
 
 bool
 OMR::SymbolReference::isLitPoolReference()
    {
-   return self()->isLiteralPoolAddress() || self()->isFromLiteralPool();
+   return isLiteralPoolAddress() || isFromLiteralPool();
    }
 
 void

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -80,7 +80,7 @@ namespace OMR
  *
  * \see Symbol
  */
-class OMR_EXTENSIBLE SymbolReference
+class /*OMR_EXTENSIBLE*/ SymbolReference
    {
 
 public:

--- a/compiler/il/Symbol.hpp
+++ b/compiler/il/Symbol.hpp
@@ -55,7 +55,7 @@
 namespace TR
 {
 
-class OMR_EXTENSIBLE Symbol : public OMR::SymbolConnector
+class /*OMR_EXTENSIBLE*/ Symbol : public OMR::SymbolConnector
    {
 
 public:

--- a/compiler/il/SymbolReference.hpp
+++ b/compiler/il/SymbolReference.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,7 +36,7 @@ namespace TR { class Symbol; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE SymbolReference : public OMR::SymbolReferenceConnector
+class /*OMR_EXTENSIBLE*/ SymbolReference : public OMR::SymbolReferenceConnector
    {
 
 public:

--- a/compiler/il/symbol/AutomaticSymbol.hpp
+++ b/compiler/il/symbol/AutomaticSymbol.hpp
@@ -32,7 +32,7 @@ namespace TR { class Compilation; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE AutomaticSymbol : public OMR::AutomaticSymbolConnector
+class /*OMR_EXTENSIBLE*/ AutomaticSymbol : public OMR::AutomaticSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/LabelSymbol.hpp
+++ b/compiler/il/symbol/LabelSymbol.hpp
@@ -29,7 +29,7 @@ namespace TR { class CodeGenerator; }
 
 namespace TR {
 
-class OMR_EXTENSIBLE LabelSymbol : public OMR::LabelSymbolConnector
+class /*OMR_EXTENSIBLE*/ LabelSymbol : public OMR::LabelSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/MethodSymbol.hpp
+++ b/compiler/il/symbol/MethodSymbol.hpp
@@ -32,7 +32,7 @@ class TR_Method;
 namespace TR
 {
 
-class OMR_EXTENSIBLE MethodSymbol : public OMR::MethodSymbolConnector
+class /*OMR_EXTENSIBLE*/ MethodSymbol : public OMR::MethodSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ OMR::AutomaticSymbol::init()
    }
 
 TR::ILOpCodes
-OMR::AutomaticSymbol::getKind()
+OMR::AutomaticSymbol::getOpCodeKind()
   {
   TR_ASSERT(self()->isLocalObject(), "Should be local object");
   return _kind;

--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -40,25 +40,25 @@ namespace TR { class SymbolReference; }
 OMR::AutomaticSymbol::AutomaticSymbol() :
    TR::RegisterMappedSymbol()
    {
-   self()->init();
+   init();
    }
 
 OMR::AutomaticSymbol::AutomaticSymbol(TR::DataType d) :
    TR::RegisterMappedSymbol(d)
    {
-   self()->init();
+   init();
    }
 
 OMR::AutomaticSymbol::AutomaticSymbol(TR::DataType d, uint32_t s) :
    TR::RegisterMappedSymbol(d, s)
    {
-   self()->init();
+   init();
    }
 
 OMR::AutomaticSymbol::AutomaticSymbol(TR::DataType d, uint32_t s, const char *name) :
    TR::RegisterMappedSymbol(d, s)
    {
-   self()->init(); _name = name;
+   init(); _name = name;
    }
 
 TR::AutomaticSymbol *
@@ -70,16 +70,16 @@ OMR::AutomaticSymbol::self()
 rcount_t
 OMR::AutomaticSymbol::setReferenceCount(rcount_t i)
    {
-   if (self()->isVariableSizeSymbol() && i > 0)
-      self()->castToVariableSizeSymbol()->setIsReferenced();
+   if (isVariableSizeSymbol() && i > 0)
+      castToVariableSizeSymbol()->setIsReferenced();
    return (_referenceCount = i);
    }
 
 rcount_t
 OMR::AutomaticSymbol::incReferenceCount()
    {
-   if (self()->isVariableSizeSymbol())
-      self()->castToVariableSizeSymbol()->setIsReferenced();
+   if (isVariableSizeSymbol())
+      castToVariableSizeSymbol()->setIsReferenced();
    return ++_referenceCount;
    }
 
@@ -94,112 +94,112 @@ OMR::AutomaticSymbol::init()
 TR::ILOpCodes
 OMR::AutomaticSymbol::getOpCodeKind()
   {
-  TR_ASSERT(self()->isLocalObject(), "Should be local object");
+  TR_ASSERT(isLocalObject(), "Should be local object");
   return _kind;
   }
 
 TR::SymbolReference *
 OMR::AutomaticSymbol::getClassSymbolReference()
    {
-   TR_ASSERT(self()->isLocalObject(), "Should be tagged as local object");
+   TR_ASSERT(isLocalObject(), "Should be tagged as local object");
    return _kind != TR::newarray ? _classSymRef : 0;
    }
 
 TR::SymbolReference *
 OMR::AutomaticSymbol::setClassSymbolReference(TR::SymbolReference *s)
    {
-   TR_ASSERT(self()->isLocalObject(), "Should be tagged as local object");
+   TR_ASSERT(isLocalObject(), "Should be tagged as local object");
    return (_classSymRef = s);
    }
 
 int32_t
 OMR::AutomaticSymbol::getArrayType()
    {
-   TR_ASSERT(self()->isLocalObject(), "Should be tagged as local object");
+   TR_ASSERT(isLocalObject(), "Should be tagged as local object");
    return _kind == TR::newarray ? _arrayType : 0;
    }
 
 TR::AutomaticSymbol *
 OMR::AutomaticSymbol::getPinningArrayPointer()
    {
-   TR_ASSERT(self()->isInternalPointer(), "Should be internal pointer");
+   TR_ASSERT(isInternalPointer(), "Should be internal pointer");
    return _pinningArrayPointer;
    }
 
 TR::AutomaticSymbol *
 OMR::AutomaticSymbol::setPinningArrayPointer(TR::AutomaticSymbol *s)
    {
-   TR_ASSERT(self()->isInternalPointer(), "Should be internal pointer");
+   TR_ASSERT(isInternalPointer(), "Should be internal pointer");
    return (_pinningArrayPointer = s);
    }
 
 uint32_t
 OMR::AutomaticSymbol::getActiveSize()
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return _activeSize;
    }
 
 uint32_t
 OMR::AutomaticSymbol::setActiveSize(uint32_t s)
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return (_activeSize = s);
    }
 
 bool
 OMR::AutomaticSymbol::isReferenced()
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return _variableSizeSymbolFlags.testAny(IsReferenced);
    }
 
 void
 OMR::AutomaticSymbol::setIsReferenced(bool b)
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    _variableSizeSymbolFlags.set(IsReferenced, b);
    }
 
 bool
 OMR::AutomaticSymbol::isAddressTaken()
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return _variableSizeSymbolFlags.testAny(IsAddressTaken);
    }
 
 void
 OMR::AutomaticSymbol::setIsAddressTaken(bool b)
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    _variableSizeSymbolFlags.set(IsAddressTaken, b);
    }
 
 bool
 OMR::AutomaticSymbol::isSingleUse()
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return _variableSizeSymbolFlags.testAny(IsSingleUse);
    }
 
 void
 OMR::AutomaticSymbol::setIsSingleUse(bool b)
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    _variableSizeSymbolFlags.set(IsSingleUse, b);
    }
 
 TR::Node *
 OMR::AutomaticSymbol::getNodeToFreeAfter()
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return _nodeToFreeAfter;
    }
 
 TR::Node *
 OMR::AutomaticSymbol::setNodeToFreeAfter(TR::Node *n)
    {
-   TR_ASSERT(self()->isVariableSizeSymbol(), "Should be variable sized symbol");
+   TR_ASSERT(isVariableSizeSymbol(), "Should be variable sized symbol");
    return _nodeToFreeAfter = n;
    }
 

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,7 +134,7 @@ public:
                                                    uint32_t               s,
                                                    TR_FrontEnd *          fe);
 
-   TR::ILOpCodes getKind();
+   TR::ILOpCodes getOpCodeKind();
 
    TR::SymbolReference *getClassSymbolReference();
    TR::SymbolReference *setClassSymbolReference(TR::SymbolReference *s);

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -49,7 +49,7 @@ namespace TR { class SymbolReference; }
 namespace OMR
 {
 
-class OMR_EXTENSIBLE AutomaticSymbol : public TR::RegisterMappedSymbol
+class /*OMR_EXTENSIBLE*/ AutomaticSymbol : public TR::RegisterMappedSymbol
    {
 
 public:

--- a/compiler/il/symbol/OMRLabelSymbol.cpp
+++ b/compiler/il/symbol/OMRLabelSymbol.cpp
@@ -74,7 +74,7 @@ OMR::LabelSymbol::LabelSymbol() :
    _snippet(NULL),
    _directlyTargeted(false)
    {
-   self()->setIsLabel();
+   setIsLabel();
 
    TR::Compilation *comp = TR::comp();
    if (comp && comp->getDebug())
@@ -88,7 +88,7 @@ OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen) :
    _estimatedCodeLocation(0),
    _snippet(NULL)
    {
-   self()->setIsLabel();
+   setIsLabel();
 
    TR::Compilation *comp = TR::comp();
    if (comp && comp->getDebug())
@@ -102,7 +102,7 @@ OMR::LabelSymbol::LabelSymbol(TR::CodeGenerator *codeGen, TR::Block *labb) :
    _estimatedCodeLocation(0),
    _snippet(NULL)
    {
-   self()->setIsLabel();
+   setIsLabel();
 
    TR::Compilation *comp = TR::comp();
    if (comp && comp->getDebug())
@@ -132,17 +132,17 @@ OMR::LabelSymbol::makeRelativeLabelSymbol(intptr_t offset)
    // Is this assert here purely to ensure that the label size doesn't blow the buffer?
    TR_ASSERT(offset*2 > -9999999 && offset*2 < +9999999, "assertion failure");
 
-   self()->setRelativeLabel();
+   setRelativeLabel();
    _offset = offset;
    char * name = (char*)calloc(10,sizeof(char));  // FIXME: Leaked.
    sprintf(name, "%d", (int)(offset*2));
-   self()->setName(name);
+   setName(name);
    }
 
 intptr_t
 OMR::LabelSymbol::getDistance()
    {
-   TR_ASSERT(self()->isRelativeLabel(), "Must be a relative label to have a valid offset!");
+   TR_ASSERT(isRelativeLabel(), "Must be a relative label to have a valid offset!");
    return _offset;
    }
 

--- a/compiler/il/symbol/OMRLabelSymbol.hpp
+++ b/compiler/il/symbol/OMRLabelSymbol.hpp
@@ -61,7 +61,7 @@ namespace OMR
  *
  * A label has an instruction, a code location...
  */
-class OMR_EXTENSIBLE LabelSymbol : public TR::Symbol
+class /*OMR_EXTENSIBLE*/ LabelSymbol : public TR::Symbol
    {
 public:
    TR::LabelSymbol * self();

--- a/compiler/il/symbol/OMRMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRMethodSymbol.cpp
@@ -38,7 +38,7 @@ OMR::MethodSymbol::MethodSymbol(TR_LinkageConventions lc, TR_Method * m) :
 bool
 OMR::MethodSymbol::firstArgumentIsReceiver()
    {
-   if (self()->isSpecial() || self()->isVirtual() || self()->isInterface() || self()->isComputedVirtual())
+   if (isSpecial() || isVirtual() || isInterface() || isComputedVirtual())
       return true;
 
    return false;
@@ -54,7 +54,7 @@ OMR::MethodSymbol::self()
 bool
 OMR::MethodSymbol::isComputed()
    {
-   return self()->isComputedStatic() || self()->isComputedVirtual();
+   return isComputedStatic() || isComputedVirtual();
    }
 
 /**

--- a/compiler/il/symbol/OMRMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRMethodSymbol.hpp
@@ -186,15 +186,15 @@ public:
    void setTreatAsAlwaysExpandBIF(bool b=true) { _methodFlags.set(TreatAsAlwaysExpandBIF, b);}
    bool treatAsAlwaysExpandBIF()               { return _methodFlags.testAny(TreatAsAlwaysExpandBIF);}
 
-   bool safeToSkipNullChecks() { return false; }
-   bool safeToSkipBoundChecks() { return false; }
-   bool safeToSkipDivChecks() { return false; }
-   bool safeToSkipCheckCasts() { return false; }
-   bool safeToSkipArrayStoreChecks() { return false; }
-   bool safeToSkipZeroInitializationOnNewarrays() { return false; }
-   bool safeToSkipChecksOnArrayCopies() { return false; }
+   virtual bool safeToSkipNullChecks() { return false; }
+   virtual bool safeToSkipBoundChecks() { return false; }
+   virtual bool safeToSkipDivChecks() { return false; }
+   virtual bool safeToSkipCheckCasts() { return false; }
+   virtual bool safeToSkipArrayStoreChecks() { return false; }
+   virtual bool safeToSkipZeroInitializationOnNewarrays() { return false; }
+   virtual bool safeToSkipChecksOnArrayCopies() { return false; }
 
-   bool isPureFunction() { return false; }
+   virtual bool isPureFunction() { return false; }
 
 protected:
 

--- a/compiler/il/symbol/OMRMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRMethodSymbol.hpp
@@ -48,7 +48,7 @@ namespace OMR
 /**
  * Symbol for methods, along with information about the method
  */
-class OMR_EXTENSIBLE MethodSymbol : public TR::Symbol
+class /*OMR_EXTENSIBLE*/ MethodSymbol : public TR::Symbol
    {
 
 protected:

--- a/compiler/il/symbol/OMRParameterSymbol.cpp
+++ b/compiler/il/symbol/OMRParameterSymbol.cpp
@@ -48,7 +48,7 @@ OMR::ParameterSymbol::ParameterSymbol(TR::DataType d, int32_t slot) :
    {
    _flags.setValue(KindMask, IsParameter);
    _addressSize = TR::ParameterSymbol::convertTypeToSize(TR::Address);
-   self()->setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
+   setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
    }
 
 OMR::ParameterSymbol::ParameterSymbol(TR::DataType d, int32_t slot, size_t size) :
@@ -62,19 +62,19 @@ OMR::ParameterSymbol::ParameterSymbol(TR::DataType d, int32_t slot, size_t size)
    {
    _flags.setValue(KindMask, IsParameter);
    _addressSize = TR::ParameterSymbol::convertTypeToSize(TR::Address);
-   self()->setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
+   setOffset(slot * TR::ParameterSymbol::convertTypeToSize(TR::Address));
    }
 
 void
 OMR::ParameterSymbol::setParameterOffset(int32_t o)
    {
-   self()->setOffset(o);
+   setOffset(o);
    }
 
 int32_t
 OMR::ParameterSymbol::getSlot()
    {
-   return self()->getParameterOffset() / (uint32_t)_addressSize; // cast _addressSize explicity
+   return getParameterOffset() / (uint32_t)_addressSize; // cast _addressSize explicity
    }
 
 template <typename AllocatorType>

--- a/compiler/il/symbol/OMRParameterSymbol.hpp
+++ b/compiler/il/symbol/OMRParameterSymbol.hpp
@@ -43,7 +43,7 @@ namespace TR { class ParameterSymbol; }
 namespace OMR
 {
 
-class OMR_EXTENSIBLE ParameterSymbol : public TR::RegisterMappedSymbol
+class /*OMR_EXTENSIBLE*/ ParameterSymbol : public TR::RegisterMappedSymbol
    {
 
 protected:

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.cpp
@@ -55,7 +55,7 @@ OMR::RegisterMappedSymbol::RegisterMappedSymbol(int32_t o) :
    _mappedOffset(o),
    _GCMapIndex(-1)
    {
-   self()->setLiveLocalIndexUninitialized();
+   setLiveLocalIndexUninitialized();
    }
 
 OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataType d) :
@@ -63,7 +63,7 @@ OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataType d) :
    _mappedOffset(0),
    _GCMapIndex(-1)
    {
-   self()->setLiveLocalIndexUninitialized();
+   setLiveLocalIndexUninitialized();
    }
 
 OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataType d, uint32_t s) :
@@ -71,7 +71,7 @@ OMR::RegisterMappedSymbol::RegisterMappedSymbol(TR::DataType d, uint32_t s) :
    _mappedOffset(0),
    _GCMapIndex(-1)
    {
-   self()->setLiveLocalIndexUninitialized();
+   setLiveLocalIndexUninitialized();
    }
 
 TR::RegisterMappedSymbol *
@@ -84,7 +84,7 @@ void
 OMR::RegisterMappedSymbol::setLiveLocalIndex(uint16_t i, TR_FrontEnd * fe)
    {
    _liveLocalIndex = i;
-   if (self()->isLiveLocalIndexUninitialized())
+   if (isLiveLocalIndexUninitialized())
       {
       TR_ASSERT(0, "OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
       TR::comp()->failCompilation<TR::CompilationException>("OMR::RegisterMappedSymbol::_liveLocalIndex == USHRT_MAX");
@@ -106,14 +106,14 @@ OMR::RegisterMappedSymbol::setLiveLocalIndexUninitialized()
 TR_MethodMetaDataType
 OMR::RegisterMappedSymbol::getMethodMetaDataType()
    {
-   TR_ASSERT(self()->isMethodMetaData(), "should be method metadata!");
+   TR_ASSERT(isMethodMetaData(), "should be method metadata!");
    return _type;
    }
 
 void
 OMR::RegisterMappedSymbol::setMethodMetaDataType(TR_MethodMetaDataType type)
    {
-   TR_ASSERT(self()->isMethodMetaData(), "should be method metadata!");
+   TR_ASSERT(isMethodMetaData(), "should be method metadata!");
    _type = type;
 }
 

--- a/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/OMRRegisterMappedSymbol.hpp
@@ -62,7 +62,7 @@ namespace OMR
  *
  * \todo Concept doesn't have the best name, and should likely be renamed
  */
-class OMR_EXTENSIBLE RegisterMappedSymbol : public TR::Symbol
+class /*OMR_EXTENSIBLE*/ RegisterMappedSymbol : public TR::Symbol
    {
 
 protected:

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -100,11 +100,11 @@ void
 OMR::ResolvedMethodSymbol::initForCompilation(TR::Compilation *comp)
    {
    TR::Region &heapRegion = comp->trMemory()->heapMemoryRegion();
-   self()->getParameterList().setRegion(heapRegion);
-   self()->getAutomaticList().setRegion(heapRegion);
+   getParameterList().setRegion(heapRegion);
+   getAutomaticList().setRegion(heapRegion);
 
-   self()->getVariableSizeSymbolList().setRegion(heapRegion);
-   self()->getTrivialDeadTreeBlocksList().setRegion(heapRegion);
+   getVariableSizeSymbolList().setRegion(heapRegion);
+   getTrivialDeadTreeBlocksList().setRegion(heapRegion);
    }
 
 
@@ -141,13 +141,13 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 
    if (comp->isGPUCompileCPUCode())
       {
-      self()->setLinkage(TR_System);
+      setLinkage(TR_System);
       }
 
     _methodIndex = comp->addOwningMethod(self());
    if (comp->getOption(TR_TraceMethodIndex))
       traceMsg(comp, "-- New symbol for method: M%p index: %d owningMethod: M%p sig: %s\n",
-         method, (int)_methodIndex.value(), method->owningMethod(), self()->signature(comp->trMemory()));
+         method, (int)_methodIndex.value(), method->owningMethod(), signature(comp->trMemory()));
 
    if (_methodIndex >= MAX_CALLER_INDEX)
       {
@@ -155,7 +155,7 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
       }
 
    if (_resolvedMethod->isSynchronized())
-      self()->setSynchronised();
+      setSynchronised();
 
    // Set the interpreted flag for an interpreted method unless we're calling
    // the method that's being jitted
@@ -166,11 +166,11 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
       {
       if (_resolvedMethod->isInterpreted())
          {
-         self()->setInterpreted();
-         self()->setMethodAddress(_resolvedMethod->resolvedMethodAddress());
+         setInterpreted();
+         setMethodAddress(_resolvedMethod->resolvedMethodAddress());
          }
       else
-         self()->setMethodAddress(_resolvedMethod->startAddressForJittedMethod());
+         setMethodAddress(_resolvedMethod->startAddressForJittedMethod());
       }
 
 #ifdef J9_PROJECT_SPECIFIC
@@ -186,12 +186,12 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
         ((_resolvedMethod->getRecognizedMethod() == TR::java_lang_Math_copySign_F) ||
          (_resolvedMethod->getRecognizedMethod() == TR::java_lang_Math_copySign_D))))
       {
-      self()->setCanReplaceWithHWInstr(true);
+      setCanReplaceWithHWInstr(true);
       }
 
    if (_resolvedMethod->isJNINative())
       {
-      self()->setJNI();
+      setJNI();
 #if defined(TR_TARGET_POWER)
       switch(_resolvedMethod->getRecognizedMethod())
          {
@@ -276,32 +276,32 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
 #endif // J9_PROJECT_SPECIFIC
       if (_resolvedMethod->isNative())
       {
-      if (!self()->isInterpreted() && _resolvedMethod->isJITInternalNative())
+      if (!isInterpreted() && _resolvedMethod->isJITInternalNative())
          {
-         self()->setMethodAddress(_resolvedMethod->startAddressForJITInternalNativeMethod());
-         self()->setJITInternalNative();
+         setMethodAddress(_resolvedMethod->startAddressForJITInternalNativeMethod());
+         setJITInternalNative();
          }
       else
          {
-         self()->setVMInternalNative();
+         setVMInternalNative();
          }
       }
 
    if (_resolvedMethod->isFinal())
-      self()->setFinal();
+      setFinal();
 
    if (_resolvedMethod->isStatic())
-      self()->setStatic();
+      setStatic();
 
-   self()->setParameterList();
+   setParameterList();
 
-   _properties.set(CanSkipNullChecks                   , self()->safeToSkipNullChecks());
-   _properties.set(CanSkipBoundChecks                  , self()->safeToSkipBoundChecks());
-   _properties.set(CanSkipCheckCasts                   , self()->safeToSkipCheckCasts());
-   _properties.set(CanSkipDivChecks                    , self()->safeToSkipDivChecks());
-   _properties.set(CanSkipArrayStoreChecks             , self()->safeToSkipArrayStoreChecks());
-   _properties.set(CanSkipChecksOnArrayCopies          , self()->safeToSkipChecksOnArrayCopies());
-   _properties.set(CanSkipZeroInitializationOnNewarrays, self()->safeToSkipZeroInitializationOnNewarrays());
+   _properties.set(CanSkipNullChecks                   , safeToSkipNullChecks());
+   _properties.set(CanSkipBoundChecks                  , safeToSkipBoundChecks());
+   _properties.set(CanSkipCheckCasts                   , safeToSkipCheckCasts());
+   _properties.set(CanSkipDivChecks                    , safeToSkipDivChecks());
+   _properties.set(CanSkipArrayStoreChecks             , safeToSkipArrayStoreChecks());
+   _properties.set(CanSkipChecksOnArrayCopies          , safeToSkipChecksOnArrayCopies());
+   _properties.set(CanSkipZeroInitializationOnNewarrays, safeToSkipZeroInitializationOnNewarrays());
    }
 
 
@@ -309,30 +309,30 @@ int32_t
 OMR::ResolvedMethodSymbol::getSyncObjectTempIndex()
    {
    int32_t delta = 0;
-   if (self()->comp()->getOption(TR_MimicInterpreterFrameShape))
+   if (comp()->getOption(TR_MimicInterpreterFrameShape))
       {
       delta++;
       }
 
-   return self()->getFirstJitTempIndex() - delta;
+   return getFirstJitTempIndex() - delta;
    }
 
 int32_t
 OMR::ResolvedMethodSymbol::getThisTempForObjectCtorIndex()
    {
    int32_t delta = 0;
-   if (self()->comp()->getOption(TR_MimicInterpreterFrameShape))
+   if (comp()->getOption(TR_MimicInterpreterFrameShape))
       {
       delta++;
       }
 
-   return self()->getFirstJitTempIndex() - delta;
+   return getFirstJitTempIndex() - delta;
    }
 
 List<TR::ParameterSymbol>&
 OMR::ResolvedMethodSymbol::getLogicalParameterList(TR::Compilation *comp)
    {
-      return self()->getParameterList();
+      return getParameterList();
    }
 
 template <typename AllocatorType>
@@ -421,47 +421,47 @@ bcIndexForFakeInduce(TR::Compilation* comp, int16_t* callSiteInsertionPoint,
 bool
 OMR::ResolvedMethodSymbol::canInjectInduceOSR(TR::Node* node)
    {
-   bool trace = self()->comp()->getOption(TR_TraceOSR);
+   bool trace = comp()->getOption(TR_TraceOSR);
    if (node->getOpCodeValue() != TR::treetop
        && node->getOpCodeValue() != TR::NULLCHK
        && node->getOpCodeValue() != TR::ResolveAndNULLCHK)
       {
       if (trace)
-         traceMsg(self()->comp(), "node doesn't have a treetop, NULLCHK, or ResolveAndNULLCHK root\n");
+         traceMsg(comp(), "node doesn't have a treetop, NULLCHK, or ResolveAndNULLCHK root\n");
       return false;
       }
    if (node->getNumChildren() != 1
        || !node->getChild(0)->getOpCode().isCall())
       {
       if (trace)
-         traceMsg(self()->comp(), "there is no call under the treetop\n");
+         traceMsg(comp(), "there is no call under the treetop\n");
       return false;
       }
    TR::Node* callNode = node->getChild(0);
    if (callNode->getReferenceCount() != 1 && node->getOpCodeValue() == TR::treetop)
       {
       if (trace)
-         traceMsg(self()->comp(), "call node has a refcount larger than 1 and is under a treetop\n");
+         traceMsg(comp(), "call node has a refcount larger than 1 and is under a treetop\n");
       return false;
       }
-   const char* rootSignature = self()->comp()->signature();
+   const char* rootSignature = comp()->signature();
    if (!strncmp(rootSignature, "java/lang/Object.newInstancePrototype", 37))
       {
       if (trace)
-         traceMsg(self()->comp(), "root method is a java/lang/Object.newInstancePrototype method\n");
+         traceMsg(comp(), "root method is a java/lang/Object.newInstancePrototype method\n");
       return false;
       }
    if (!strncmp(rootSignature, "java/lang/Class.newInstancePrototype", 36))
       {
       if (trace)
-         traceMsg(self()->comp(), "root method is a java/lang/Class.newInstancePrototype method\n");
+         traceMsg(comp(), "root method is a java/lang/Class.newInstancePrototype method\n");
       return false;
       }
-   const char* currentSignature = self()->signature(self()->comp()->trMemory());
+   const char* currentSignature = signature(comp()->trMemory());
    if (!strncmp(currentSignature, "com/ibm/jit/JITHelpers", 22))
       {
       if (trace)
-         traceMsg(self()->comp(), "node is a com/ibm/jit/jit helper method\n");
+         traceMsg(comp(), "node is a com/ibm/jit/jit helper method\n");
       return false;
       }
 
@@ -474,18 +474,18 @@ OMR::ResolvedMethodSymbol::canInjectInduceOSR(TR::Node* node)
           methSym->getMethodKind() == TR::MethodSymbol::Special)
          {
          if (trace)
-            traceMsg(self()->comp(), "node is a helper, native, or a special call\n");
+            traceMsg(comp(), "node is a helper, native, or a special call\n");
          return false;
          }
       }
    if (sym->isResolvedMethod())
       {
       auto * methSym = sym->castToResolvedMethodSymbol();
-      const char* signature = methSym->signature(self()->comp()->trMemory());
+      const char* signature = methSym->signature(comp()->trMemory());
       if (!strncmp(signature, "com/ibm/jit/JITHelpers", 22))
          {
          if (trace)
-            traceMsg(self()->comp(), "node is a com/ibm/jit/jit helper method\n");
+            traceMsg(comp(), "node is a com/ibm/jit/jit helper method\n");
          return false;
          }
       }
@@ -510,19 +510,19 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
    {
    // If not specified use the outermost CFG
    if (!cfg)
-      cfg = self()->comp()->getFlowGraph();
+      cfg = comp()->getFlowGraph();
 
    //Now we need to put the induceOSR call as the first treetop of its block.
    //Because if we don't do that and if there is a method call before induceOSR in induceOSR's block
    //and that method gets inlined
    //there is no guarantee that the future block containing the induceOSR call still will have an exception
    //edge to the OSR catch block.
-   TR::SymbolReferenceTable* symRefTab = self()->comp()->getSymRefTab();
+   TR::SymbolReferenceTable* symRefTab = comp()->getSymRefTab();
    TR::SymbolReference *induceOSRSymRef = symRefTab->findOrCreateInduceOSRSymbolRef(TR_induceOSRAtCurrentPC);
    TR::Node *refNode = insertionPoint->getNode();
 
-   if (self()->comp()->getOption(TR_TraceOSR))
-     traceMsg(self()->comp(), "O^O OSR: Inject induceOSR call for [%p] at %3d:%d\n", refNode, refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex());
+   if (comp()->getOption(TR_TraceOSR))
+     traceMsg(comp(), "O^O OSR: Inject induceOSR call for [%p] at %3d:%d\n", refNode, refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex());
 
    TR::Block * firstHalfBlock = insertionPoint->getEnclosingBlock();
    if (shouldSplitBlock)
@@ -531,7 +531,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
 
    // The arguments for a transition to this bytecode index may have already been stashed.
    // If they have, use these directly rather than copying the reference node.
-   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(
+   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(
       refNode->getByteCodeInfo().getCallerIndex(), self());
    TR_Array<int32_t> *stashedArgs = osrMethodData->getArgInfo(refNode->getByteCodeIndex());
    int32_t firstArgIndex = 0;
@@ -549,7 +549,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
       }
 
    TR::Node *induceOSRCallNode = TR::Node::createWithSymRef(refNode, TR::call, numChildren - firstArgIndex, induceOSRSymRef);
-   TR_OSRPoint *point = self()->findOSRPoint(refNode->getByteCodeInfo());
+   TR_OSRPoint *point = findOSRPoint(refNode->getByteCodeInfo());
    TR_ASSERT(point, "Could not find osr point for bytecode %d:%d!", refNode->getByteCodeInfo().getCallerIndex(), refNode->getByteCodeInfo().getByteCodeIndex());
 
    // If arguments have been stashed against this BCI, copy them now, ignoring the copyChildren flag
@@ -557,7 +557,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
       {
       for (int32_t i = 0; i < numChildren; ++i)
          induceOSRCallNode->setAndIncChild(i,
-            TR::Node::createLoad(induceOSRCallNode, self()->comp()->getSymRefTab()->getSymRef((*stashedArgs)[i])));
+            TR::Node::createLoad(induceOSRCallNode, comp()->getSymRefTab()->getSymRef((*stashedArgs)[i])));
       }
    else if (copyChildren)
       {
@@ -569,11 +569,11 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
       induceOSRCallNode->setNumChildren(0);
       }
 
-   if (self()->comp()->getOptions()->getVerboseOption(TR_VerboseOSRDetails))
-      TR_VerboseLog::writeLineLocked(TR_Vlog_OSRD, "Injected induceOSR call at %3d:%d in %s", refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex(), self()->comp()->signature());
+   if (comp()->getOptions()->getVerboseOption(TR_VerboseOSRDetails))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_OSRD, "Injected induceOSR call at %3d:%d in %s", refNode->getInlinedSiteIndex(), refNode->getByteCodeIndex(), comp()->signature());
 
    TR::Node *induceOSRTreeTopNode = TR::Node::create(TR::treetop, 1, induceOSRCallNode);
-   insertionPoint->insertBefore(TR::TreeTop::create(self()->comp(), induceOSRTreeTopNode));
+   insertionPoint->insertBefore(TR::TreeTop::create(comp(), induceOSRTreeTopNode));
    return insertionPoint->getPrevTreeTop();
    }
 
@@ -625,9 +625,9 @@ OMR::ResolvedMethodSymbol::induceOSRAfterImpl(TR::TreeTop *insertionPoint, TR_By
    {
    TR::Block *block = insertionPoint->getEnclosingBlock();
 
-   if (self()->supportsInduceOSR(induceBCI, block, self()->comp()))
+   if (supportsInduceOSR(induceBCI, block, comp()))
       {
-      TR::CFG *cfg = self()->comp()->getFlowGraph();
+      TR::CFG *cfg = comp()->getFlowGraph();
       cfg->setStructure(NULL);
       TR::TreeTop *remainderTree = insertionPoint->getNextTreeTop();
       if (remainderTree->getNode()->getOpCodeValue() != TR::BBEnd)
@@ -636,21 +636,21 @@ OMR::ResolvedMethodSymbol::induceOSRAfterImpl(TR::TreeTop *insertionPoint, TR_By
             {
             TR::Block *remainderBlock = block->split(remainderTree, cfg, false, true);
             remainderBlock->setIsExtensionOfPreviousBlock(true);
-            if (self()->comp()->getOption(TR_TraceOSR))
-               traceMsg(self()->comp(), "  Split of block_%d at n%dn produced block_%d which is an extension\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
+            if (comp()->getOption(TR_TraceOSR))
+               traceMsg(comp(), "  Split of block_%d at n%dn produced block_%d which is an extension\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
             }
          else
             {
             TR::Block *remainderBlock = block->split(remainderTree, cfg, true, true);
-            if (self()->comp()->getOption(TR_TraceOSR))
-               traceMsg(self()->comp(), "  Split of block_%d at n%dn produced block_%d\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
+            if (comp()->getOption(TR_TraceOSR))
+               traceMsg(comp(), "  Split of block_%d at n%dn produced block_%d\n", block->getNumber(), remainderTree->getNode()->getGlobalIndex(), remainderBlock->getNumber());
             }
          }
 
       induceBCI.setByteCodeIndex(induceBCI.getByteCodeIndex() + offset);
 
       // create a block that will be the target of the branch with BCI for the induceOSR
-      TR::Block *osrBlock = TR::Block::createEmptyBlock(self()->comp(), MAX_COLD_BLOCK_COUNT);
+      TR::Block *osrBlock = TR::Block::createEmptyBlock(comp(), MAX_COLD_BLOCK_COUNT);
       osrBlock->setIsCold();
       osrBlock->getEntry()->getNode()->setByteCodeInfo(induceBCI);
       osrBlock->getExit()->getNode()->setByteCodeInfo(induceBCI);
@@ -665,15 +665,15 @@ OMR::ResolvedMethodSymbol::induceOSRAfterImpl(TR::TreeTop *insertionPoint, TR_By
       cfg->addNode(osrBlock);
       cfg->addEdge(block, osrBlock);
 
-      if (self()->comp()->getOption(TR_TraceOSR))
-         traceMsg(self()->comp(), "  Created OSR block_%d and inserting it at the end of the method\n", osrBlock->getNumber());
+      if (comp()->getOption(TR_TraceOSR))
+         traceMsg(comp(), "  Created OSR block_%d and inserting it at the end of the method\n", osrBlock->getNumber());
 
       branch->getNode()->setBranchDestination(osrBlock->getEntry());
       block->append(branch);
       cfg->copyExceptionSuccessors(block, osrBlock);
 
       // induce OSR in the new block
-      return self()->genInduceOSRCallAndCleanUpFollowingTreesImmediately(osrBlock->getExit(), induceBCI, false, self()->comp());
+      return genInduceOSRCallAndCleanUpFollowingTreesImmediately(osrBlock->getExit(), induceBCI, false, comp());
       }
    return NULL;
    }
@@ -681,17 +681,17 @@ OMR::ResolvedMethodSymbol::induceOSRAfterImpl(TR::TreeTop *insertionPoint, TR_By
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::induceImmediateOSRWithoutChecksBefore(TR::TreeTop *insertionPoint)
    {
-   if (self()->supportsInduceOSR(insertionPoint->getNode()->getByteCodeInfo(), insertionPoint->getEnclosingBlock(), self()->comp()))
-      return self()->genInduceOSRCallAndCleanUpFollowingTreesImmediately(insertionPoint, insertionPoint->getNode()->getByteCodeInfo(), false, self()->comp());
-   if (self()->comp()->getOption(TR_TraceOSR))
-      traceMsg(self()->comp(), "induceImmediateOSRWithoutChecksBefore n%dn failed - supportsInduceOSR returned false\n", insertionPoint->getNode()->getGlobalIndex());
+   if (supportsInduceOSR(insertionPoint->getNode()->getByteCodeInfo(), insertionPoint->getEnclosingBlock(), comp()))
+      return genInduceOSRCallAndCleanUpFollowingTreesImmediately(insertionPoint, insertionPoint->getNode()->getByteCodeInfo(), false, comp());
+   if (comp()->getOption(TR_TraceOSR))
+      traceMsg(comp(), "induceImmediateOSRWithoutChecksBefore n%dn failed - supportsInduceOSR returned false\n", insertionPoint->getNode()->getGlobalIndex());
    return NULL;
    }
 
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::genInduceOSRCallAndCleanUpFollowingTreesImmediately(TR::TreeTop *insertionPoint, TR_ByteCodeInfo induceBCI, bool shouldSplitBlock, TR::Compilation *comp)
    {
-   TR::TreeTop *induceOSRCallTree = self()->genInduceOSRCall(insertionPoint, induceBCI.getCallerIndex(), 0, false, shouldSplitBlock);
+   TR::TreeTop *induceOSRCallTree = genInduceOSRCall(insertionPoint, induceBCI.getCallerIndex(), 0, false, shouldSplitBlock);
 
    if (induceOSRCallTree)
       {
@@ -733,8 +733,8 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
                                           bool shouldSplitBlock,
                                           TR::CFG *cfg)
    {
-   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, self());
-   return self()->genInduceOSRCall(insertionPoint, inlinedSiteIndex, osrMethodData, numChildren, copyChildren, shouldSplitBlock, cfg);
+   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(inlinedSiteIndex, self());
+   return genInduceOSRCall(insertionPoint, inlinedSiteIndex, osrMethodData, numChildren, copyChildren, shouldSplitBlock, cfg);
    }
 
 TR::TreeTop *
@@ -748,16 +748,16 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
    {
    // If not specified use the outermost CFG
    if (!callerCFG)
-      callerCFG = self()->comp()->getFlowGraph();
+      callerCFG = comp()->getFlowGraph();
 
    TR::Node *insertionPointNode = insertionPoint->getNode();
-   if (self()->comp()->getOption(TR_TraceOSR))
-      traceMsg(self()->comp(), "Osr point added for %p, callerIndex=%d, bcindex=%d\n",
+   if (comp()->getOption(TR_TraceOSR))
+      traceMsg(comp(), "Osr point added for %p, callerIndex=%d, bcindex=%d\n",
               insertionPointNode, insertionPointNode->getByteCodeInfo().getCallerIndex(),
               insertionPointNode->getByteCodeInfo().getByteCodeIndex());
 
    TR::Block * OSRCatchBlock = osrMethodData->getOSRCatchBlock();
-   TR::TreeTop *induceOSRCallTree = self()->genInduceOSRCallNode(insertionPoint, numChildren, copyChildren, shouldSplitBlock, callerCFG);
+   TR::TreeTop *induceOSRCallTree = genInduceOSRCallNode(insertionPoint, numChildren, copyChildren, shouldSplitBlock, callerCFG);
 
    TR::Block *enclosingBlock = insertionPoint->getEnclosingBlock();
    if (!enclosingBlock->getLastRealTreeTop()->getNode()->getOpCode().isReturn())
@@ -783,7 +783,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
       }
 
    TR::SymbolReference * tempSymRef = 0;
-   TR::Node * loadExcpSymbol = TR::Node::createWithSymRef(insertionPointNode, TR::aload, 0, self()->comp()->getSymRefTab()->findOrCreateExcpSymbolRef());
+   TR::Node * loadExcpSymbol = TR::Node::createWithSymRef(insertionPointNode, TR::aload, 0, comp()->getSymRefTab()->findOrCreateExcpSymbolRef());
 
    TR::TreeTop *lastTreeInEnclosingBlock = enclosingBlock->getLastRealTreeTop();
    if (lastTreeInEnclosingBlock != enclosingBlock->getLastNonControlFlowTreeTop())
@@ -794,11 +794,11 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
       lastTreeInEnclosingBlock->getNode()->recursivelyDecReferenceCount();
       }
 
-   enclosingBlock->append(TR::TreeTop::create(self()->comp(), TR::Node::createWithSymRef(TR::athrow, 1, 1, loadExcpSymbol, self()->comp()->getSymRefTab()->findOrCreateAThrowSymbolRef(self()))));
+   enclosingBlock->append(TR::TreeTop::create(comp(), TR::Node::createWithSymRef(TR::athrow, 1, 1, loadExcpSymbol, comp()->getSymRefTab()->findOrCreateAThrowSymbolRef(self()))));
    enclosingBlock->getLastRealTreeTop()->getNode()->setThrowInsertedByOSR(true);
 
    bool firstOSRPoint = false;
-   if (self()->getOSRPoints().isEmpty())
+   if (getOSRPoints().isEmpty())
       firstOSRPoint = true;
 
    // TODO: The late addition of OSR infrastructure based on the lack of OSR points should not be possible, as we shouldn't have been able to induce without
@@ -808,18 +808,18 @@ OMR::ResolvedMethodSymbol::genInduceOSRCall(TR::TreeTop* insertionPoint,
       TR::Block *OSRCodeBlock = osrMethodData->getOSRCodeBlock();
       TR::Block *OSRCatchBlock = osrMethodData->getOSRCatchBlock();
 
-      if (self()->comp()->getOption(TR_TraceOSR))
-         traceMsg(self()->comp(), "code %p %d catch %p %d\n", OSRCodeBlock, OSRCodeBlock->getNumber(), OSRCatchBlock, OSRCatchBlock->getNumber());
+      if (comp()->getOption(TR_TraceOSR))
+         traceMsg(comp(), "code %p %d catch %p %d\n", OSRCodeBlock, OSRCodeBlock->getNumber(), OSRCatchBlock, OSRCatchBlock->getNumber());
 
-      self()->getLastTreeTop()->insertTreeTopsAfterMe(OSRCatchBlock->getEntry(), OSRCodeBlock->getExit());
-      self()->genOSRHelperCall(inlinedSiteIndex, self()->comp()->getSymRefTab(), callerCFG);
+      getLastTreeTop()->insertTreeTopsAfterMe(OSRCatchBlock->getEntry(), OSRCodeBlock->getExit());
+      genOSRHelperCall(inlinedSiteIndex, comp()->getSymRefTab(), callerCFG);
       }
 
-   self()->insertRematableStoresFromCallSites(self()->comp(), inlinedSiteIndex, induceOSRCallTree);
-   self()->insertStoresForDeadStackSlotsBeforeInducingOSR(self()->comp(), inlinedSiteIndex, insertionPoint->getNode()->getByteCodeInfo(), induceOSRCallTree);
+   insertRematableStoresFromCallSites(comp(), inlinedSiteIndex, induceOSRCallTree);
+   insertStoresForDeadStackSlotsBeforeInducingOSR(comp(), inlinedSiteIndex, insertionPoint->getNode()->getByteCodeInfo(), induceOSRCallTree);
 
-   if (self()->comp()->getOption(TR_TraceOSR))
-      traceMsg(self()->comp(), "last real tree n%dn\n", enclosingBlock->getLastRealTreeTop()->getNode()->getGlobalIndex());
+   if (comp()->getOption(TR_TraceOSR))
+      traceMsg(comp(), "last real tree n%dn\n", enclosingBlock->getLastRealTreeTop()->getNode()->getGlobalIndex());
    return induceOSRCallTree;
    }
 
@@ -852,7 +852,7 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
       if ((callerIndex != -3 && refNode->getInlinedSiteIndex() != callerIndex) ||
           (byteCodeIndex != -3 && refNode->getByteCodeIndex() != byteCodeIndex))
          return 0;
-      if (self()->canInjectInduceOSR(refNode))
+      if (canInjectInduceOSR(refNode))
          return 1;
       else
          {
@@ -865,11 +865,11 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
    else if (childPath[0] == 'r')
       {
       if (callerIndex == -2) return 0;
-      if (!self()->canInjectInduceOSR(refNode)) return 0;
-      int32_t random = self()->comp()->adhocRandom().getRandom();
-      if (self()->comp()->getOption(TR_TraceOSR))
-         traceMsg(self()->comp(), "Random fake induceOSR injection: caller=%d bc=%x random=%d\n", callerIndex, byteCodeIndex, random);
-      if (self()->comp()->adhocRandom().getRandom() % recipProb != 0) return 0;
+      if (!canInjectInduceOSR(refNode)) return 0;
+      int32_t random = comp()->adhocRandom().getRandom();
+      if (comp()->getOption(TR_TraceOSR))
+         traceMsg(comp(), "Random fake induceOSR injection: caller=%d bc=%x random=%d\n", callerIndex, byteCodeIndex, random);
+      if (comp()->adhocRandom().getRandom() % recipProb != 0) return 0;
       return 1;
       }
    else if (childPath[0] == 'g')
@@ -877,7 +877,7 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
       if ((callerIndex != -3 && refNode->getInlinedSiteIndex() != callerIndex) ||
           (byteCodeIndex != -3 && refNode->getByteCodeIndex() < byteCodeIndex))
          return 0;
-      if (self()->canInjectInduceOSR(refNode))
+      if (canInjectInduceOSR(refNode))
          return 1;
       else
          return 0;
@@ -890,16 +890,16 @@ OMR::ResolvedMethodSymbol::matchInduceOSRCall(TR::TreeTop* insertionPoint,
 void
 OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteIndex)
    {
-   bool trace = self()->comp()->getOption(TR_TraceOSR);
-   TR_ASSERT(self()->getFirstTreeTop(), "the method doesn't have any trees\n");
+   bool trace = comp()->getOption(TR_TraceOSR);
+   TR_ASSERT(getFirstTreeTop(), "the method doesn't have any trees\n");
    int16_t callSiteInsertionPoint, bcIndexInsertionPoint;
    char childPath[10];
    childPath[0] = '\0';
-   bcIndexForFakeInduce(self()->comp(), &callSiteInsertionPoint, &bcIndexInsertionPoint, childPath);
-   const char * mSignature = self()->signature(self()->comp()->trMemory());
+   bcIndexForFakeInduce(comp(), &callSiteInsertionPoint, &bcIndexInsertionPoint, childPath);
+   const char * mSignature = signature(comp()->trMemory());
 
    TR::TreeTop *lastTreeTop = NULL;
-   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
+   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
 
    // Under NextGenHCR, the method entry for the outermost method is an implicit OSR point
    // To ensure a transition from this point is possible, it is necessary to generate and attach
@@ -907,41 +907,41 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
    // This exception edge should remain until OSR guards have been inserted, at which point it is no
    // longer needed
    //
-   if (self()->comp()->isOutermostMethod() && self()->comp()->getHCRMode() == TR::osr)
+   if (comp()->isOutermostMethod() && comp()->getHCRMode() == TR::osr)
       {
       // Add an exception edge to the OSR catch block from the first block
-      TR::Block *OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(self()->getFirstTreeTop()->getNode());
-      TR::Block *firstBlock = self()->getFirstTreeTop()->getEnclosingBlock();
+      TR::Block *OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(getFirstTreeTop()->getNode());
+      TR::Block *firstBlock = getFirstTreeTop()->getEnclosingBlock();
       if (!firstBlock->hasExceptionSuccessor(OSRCatchBlock))
-         self()->comp()->getFlowGraph()->addEdge(TR::CFGEdge::createExceptionEdge(firstBlock, OSRCatchBlock, self()->comp()->trMemory()));
+         comp()->getFlowGraph()->addEdge(TR::CFGEdge::createExceptionEdge(firstBlock, OSRCatchBlock, comp()->trMemory()));
 
       // Create an OSR point with bytecode index 0
-      TR_ByteCodeInfo firstBCI = self()->getFirstTreeTop()->getNode()->getByteCodeInfo();
+      TR_ByteCodeInfo firstBCI = getFirstTreeTop()->getNode()->getByteCodeInfo();
       firstBCI.setByteCodeIndex(0);
-      TR_OSRPoint *osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(firstBCI, osrMethodData, self()->comp()->trMemory());
-      osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
+      TR_OSRPoint *osrPoint = new (comp()->trHeapMemory()) TR_OSRPoint(firstBCI, osrMethodData, comp()->trMemory());
+      osrPoint->setOSRIndex(addOSRPoint(osrPoint));
       }
 
    //Using this flag we avoid processing twice a call before which we are injecting an induceOSR
    bool skipNextTT = false;
-   for (TR::TreeTop* tt = self()->getFirstTreeTop(); tt; tt = tt->getNextTreeTop())
+   for (TR::TreeTop* tt = getFirstTreeTop(); tt; tt = tt->getNextTreeTop())
       {
       TR::Node* ttnode = tt->getNode();
       if (!skipNextTT)
          {
-         int matchCode = self()->matchInduceOSRCall(tt, callSiteInsertionPoint, bcIndexInsertionPoint, childPath);
+         int matchCode = matchInduceOSRCall(tt, callSiteInsertionPoint, bcIndexInsertionPoint, childPath);
          if (matchCode > 0)
             {
             TR::Node *refNode = tt->getNode()->getFirstChild();
             int32_t numChildren   = refNode->getNumChildren();
             int32_t firstArgIndex = refNode->getFirstArgumentIndex();
-            self()->genInduceOSRCallNode(tt, (numChildren - firstArgIndex), matchCode == 1);
+            genInduceOSRCallNode(tt, (numChildren - firstArgIndex), matchCode == 1);
             tt = tt->getPrevTreeTop();
             ttnode = tt->getNode();
             if (trace)
                {
-               const char * mSignature = self()->signature(self()->comp()->trMemory());
-               traceMsg(self()->comp(), "fake induce %p generated for %s at callsite %d bytecode %x\n",
+               const char * mSignature = signature(comp()->trMemory());
+               traceMsg(comp(), "fake induce %p generated for %s at callsite %d bytecode %x\n",
                        ttnode, mSignature, callSiteInsertionPoint, bcIndexInsertionPoint);
                }
             skipNextTT = true;
@@ -951,31 +951,31 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
          skipNextTT = false;
       // check potential OSR point using a node to avoid a check for the exception successor
       // which we are responsible for creating if we decide to continue with this OSR point
-      if (self()->comp()->isPotentialOSRPoint(tt->getNode()))
+      if (comp()->isPotentialOSRPoint(tt->getNode()))
          {
          TR::Block * block = tt->getEnclosingBlock();
          // Add the OSR point to the list
          TR::Block * OSRCatchBlock = osrMethodData->findOrCreateOSRCatchBlock(ttnode);
          TR_OSRPoint *osrPoint = NULL;
 
-         if (self()->comp()->isOSRTransitionTarget(TR::preExecutionOSR) || self()->comp()->requiresAnalysisOSRPoint(ttnode))
+         if (comp()->isOSRTransitionTarget(TR::preExecutionOSR) || comp()->requiresAnalysisOSRPoint(ttnode))
             {
-            osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(ttnode->getByteCodeInfo(), osrMethodData, self()->comp()->trMemory());
-            osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
-            if (self()->comp()->getOption(TR_TraceOSR))
-               traceMsg(self()->comp(), "pre osr point added for [%p] for bci %d:%d\n",
+            osrPoint = new (comp()->trHeapMemory()) TR_OSRPoint(ttnode->getByteCodeInfo(), osrMethodData, comp()->trMemory());
+            osrPoint->setOSRIndex(addOSRPoint(osrPoint));
+            if (comp()->getOption(TR_TraceOSR))
+               traceMsg(comp(), "pre osr point added for [%p] for bci %d:%d\n",
                   ttnode, ttnode->getByteCodeInfo().getCallerIndex(),
                   ttnode->getByteCodeInfo().getByteCodeIndex());
             }
 
-         if (self()->comp()->isOSRTransitionTarget(TR::postExecutionOSR))
+         if (comp()->isOSRTransitionTarget(TR::postExecutionOSR))
             {
             TR_ByteCodeInfo offsetBCI = ttnode->getByteCodeInfo();
-            offsetBCI.setByteCodeIndex(offsetBCI.getByteCodeIndex() + self()->comp()->getOSRInductionOffset(ttnode));
-            osrPoint = new (self()->comp()->trHeapMemory()) TR_OSRPoint(offsetBCI, osrMethodData, self()->comp()->trMemory());
-            osrPoint->setOSRIndex(self()->addOSRPoint(osrPoint));
-            if (self()->comp()->getOption(TR_TraceOSR))
-               traceMsg(self()->comp(), "post osr point added for [%p] for bci %d:%d\n",
+            offsetBCI.setByteCodeIndex(offsetBCI.getByteCodeIndex() + comp()->getOSRInductionOffset(ttnode));
+            osrPoint = new (comp()->trHeapMemory()) TR_OSRPoint(offsetBCI, osrMethodData, comp()->trMemory());
+            osrPoint->setOSRIndex(addOSRPoint(osrPoint));
+            if (comp()->getOption(TR_TraceOSR))
+               traceMsg(comp(), "post osr point added for [%p] for bci %d:%d\n",
                   ttnode, offsetBCI.getCallerIndex(), offsetBCI.getByteCodeIndex());
             }
 
@@ -989,7 +989,7 @@ OMR::ResolvedMethodSymbol::genAndAttachOSRCodeBlocks(int32_t currentInlinedSiteI
             }
 
          if (edge == block->getExceptionSuccessors().end())
-            self()->comp()->getFlowGraph()->addEdge( TR::CFGEdge::createExceptionEdge(block, OSRCatchBlock, self()->comp()->trMemory()));
+            comp()->getFlowGraph()->addEdge( TR::CFGEdge::createExceptionEdge(block, OSRCatchBlock, comp()->trMemory()));
          }
       if (tt->getNextTreeTop() == NULL)
          lastTreeTop = tt;
@@ -1050,16 +1050,16 @@ OMR::ResolvedMethodSymbol::sharesStackSlot(TR::SymbolReference *symRef)
    {
    TR_ASSERT(symRef->getSymbol()->isAutoOrParm(), "sharesStackSlot requires #%d to be on the stack", symRef->getReferenceNumber());
    int32_t slot = symRef->getCPIndex();
-   if (slot >= self()->getFirstJitTempIndex())
+   if (slot >= getFirstJitTempIndex())
       return false; // Jit temps don't share slots
    TR::DataType dt = symRef->getSymbol()->getDataType();
    bool takesTwoSlots = dt == TR::Int64 || dt == TR::Double;
 
    List<TR::SymbolReference> *listForPrevSlot, *list, *listForNextSlot;
    if (slot < 0)
-      getNeighboringSymRefLists(-slot - 1, self()->getPendingPushSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
+      getNeighboringSymRefLists(-slot - 1, getPendingPushSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
    else
-      getNeighboringSymRefLists(slot, self()->getAutoSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
+      getNeighboringSymRefLists(slot, getAutoSymRefs(), &listForPrevSlot, &list, &listForNextSlot);
 
    if (list->isMultipleEntry())
       return true;
@@ -1076,15 +1076,15 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    {
    // If not specified use the outermost CFG
    if (!cfg)
-      cfg = self()->comp()->getFlowGraph();
+      cfg = comp()->getFlowGraph();
 
-   bool trace = self()->comp()->getOption(TR_TraceOSR);
+   bool trace = comp()->getOption(TR_TraceOSR);
    // Use first node of the method for bytecode info
-   TR_ASSERT(self()->getFirstTreeTop(), "first tree top is NULL in %s", self()->signature(self()->comp()->trMemory()));
-   TR::Node *firstNode = self()->getFirstTreeTop()->getNode();
+   TR_ASSERT(getFirstTreeTop(), "first tree top is NULL in %s", signature(comp()->trMemory()));
+   TR::Node *firstNode = getFirstTreeTop()->getNode();
 
    // Create the OSR helper symbol reference
-   TR::Node *vmThread = TR::Node::createWithSymRef(firstNode, TR::loadaddr, 0, new (self()->comp()->trHeapMemory()) TR::SymbolReference(symRefTab, TR::RegisterMappedSymbol::createMethodMetaDataSymbol(self()->comp()->trHeapMemory(), "vmThread")));
+   TR::Node *vmThread = TR::Node::createWithSymRef(firstNode, TR::loadaddr, 0, new (comp()->trHeapMemory()) TR::SymbolReference(symRefTab, TR::RegisterMappedSymbol::createMethodMetaDataSymbol(comp()->trHeapMemory(), "vmThread")));
    TR::SymbolReference *osrHelper = symRefTab->findOrCreateRuntimeHelper(TR_prepareForOSR, false, false, true);
 #if defined(TR_TARGET_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM)
    osrHelper->getSymbol()->castToMethodSymbol()->setLinkage(TR_System);
@@ -1093,10 +1093,10 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    osrHelper->getSymbol()->castToMethodSymbol()->setSystemLinkageDispatch();
 #endif
 
-   TR_OSRMethodData *osrMethodData = self()->comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
+   TR_OSRMethodData *osrMethodData = comp()->getOSRCompilationData()->findOrCreateOSRMethodData(currentInlinedSiteIndex, self());
 
    // Create children to the OSR helper call node and save them to a list
-   TR_Array<TR::Node*> loadNodes(self()->comp()->trMemory());
+   TR_Array<TR::Node*> loadNodes(comp()->trMemory());
    loadNodes.add(vmThread);
    loadNodes.add(TR::Node::iconst(firstNode, osrMethodData->getInlinedSiteIndex()));
    TR::Node *loadNode = NULL;
@@ -1106,7 +1106,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    bool alreadyLoadedThisTempForObjectCtor = false;
 
    // Pending push temporaries
-   TR_Array<List<TR::SymbolReference> > *ppsListArray = self()->getPendingPushSymRefs();
+   TR_Array<List<TR::SymbolReference> > *ppsListArray = getPendingPushSymRefs();
    for (i = 0; ppsListArray && i < ppsListArray->size(); ++i)
       {
       List<TR::SymbolReference> ppsList = (*ppsListArray)[i];
@@ -1114,20 +1114,20 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       int symRefOrder = 0;
       for (TR::SymbolReference* symRef = ppsIt.getFirst(); symRef; symRef = ppsIt.getNext(), symRefOrder++)
          {
-         bool sharesSlot = self()->sharesStackSlot(symRef);
+         bool sharesSlot = sharesStackSlot(symRef);
          if (sharesSlot)
             {
             if (trace)
-               traceMsg(self()->comp(), "#%d shares pending push slot\n", symRef->getReferenceNumber());
-            if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
+               traceMsg(comp(), "#%d shares pending push slot\n", symRef->getReferenceNumber());
+            if (comp()->getOption(TR_DisableOSRSharedSlots))
                {
-               self()->comp()->failCompilation<TR::ILGenFailure>("Pending push slot sharing detected");
+               comp()->failCompilation<TR::ILGenFailure>("Pending push slot sharing detected");
                }
             }
 
-         if (self()->getSyncObjectTemp() == symRef)
+         if (getSyncObjectTemp() == symRef)
             alreadyLoadedSyncObjectTemp = true;
-         else if (self()->getThisTempForObjectCtor() == symRef)
+         else if (getThisTempForObjectCtor() == symRef)
             alreadyLoadedThisTempForObjectCtor = true;
 
          loadNodes.add(TR::Node::createLoad(firstNode, symRef));
@@ -1137,7 +1137,7 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       }
 
    //  parameters and autos
-   TR_Array<List<TR::SymbolReference> > *autosListArray = self()->getAutoSymRefs();
+   TR_Array<List<TR::SymbolReference> > *autosListArray = getAutoSymRefs();
    for (i = 0; autosListArray && i < autosListArray->size(); ++i)
       {
       List<TR::SymbolReference> autosList = (*autosListArray)[i];
@@ -1145,27 +1145,27 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
       int symRefOrder = 0;
       for (TR::SymbolReference* symRef = autosIt.getFirst(); symRef; symRef = autosIt.getNext(), symRefOrder++)
          {
-         bool sharesSlot = self()->sharesStackSlot(symRef);
+         bool sharesSlot = sharesStackSlot(symRef);
          if (sharesSlot)
             {
             if (trace)
-               traceMsg(self()->comp(), "#%d shares auto slot\n", symRef->getReferenceNumber());
-            if (self()->comp()->getOption(TR_DisableOSRSharedSlots))
+               traceMsg(comp(), "#%d shares auto slot\n", symRef->getReferenceNumber());
+            if (comp()->getOption(TR_DisableOSRSharedSlots))
                {
-               self()->comp()->failCompilation<TR::ILGenFailure>("Auto/parm slot sharing detected");
+               comp()->failCompilation<TR::ILGenFailure>("Auto/parm slot sharing detected");
                }
             }
          // Certain special temps go into the OSR buffer, but most don't
          //
-         if (self()->getSyncObjectTemp() == symRef)
+         if (getSyncObjectTemp() == symRef)
             alreadyLoadedSyncObjectTemp = true;
-         else if (self()->getThisTempForObjectCtor() == symRef)
+         else if (getThisTempForObjectCtor() == symRef)
             alreadyLoadedThisTempForObjectCtor = true;
-         else if (symRef->getCPIndex() >= self()->getFirstJitTempIndex())
+         else if (symRef->getCPIndex() >= getFirstJitTempIndex())
             continue;
          TR::Symbol *sym = symRef->getSymbol();
          if (trace)
-            traceMsg(self()->comp(), "symref # %d is %s\n", symRef->getReferenceNumber(), (sym->isAuto()?"auto":(sym->isParm()?"parm":"not auto or parm")));
+            traceMsg(comp(), "symref # %d is %s\n", symRef->getReferenceNumber(), (sym->isAuto()?"auto":(sym->isParm()?"parm":"not auto or parm")));
 
          loadNodes.add(TR::Node::createLoad(firstNode, symRef));
          loadNodes.add(TR::Node::iconst(firstNode, symRef->getReferenceNumber()));
@@ -1174,17 +1174,17 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
 
       }
 
-   if (!alreadyLoadedSyncObjectTemp && (self()->getSyncObjectTemp() != NULL))
+   if (!alreadyLoadedSyncObjectTemp && (getSyncObjectTemp() != NULL))
       {
-      loadNodes.add(TR::Node::createLoad(firstNode, self()->getSyncObjectTemp()));
-      loadNodes.add(TR::Node::iconst(firstNode, self()->getSyncObjectTemp()->getReferenceNumber()));
+      loadNodes.add(TR::Node::createLoad(firstNode, getSyncObjectTemp()));
+      loadNodes.add(TR::Node::iconst(firstNode, getSyncObjectTemp()->getReferenceNumber()));
       loadNodes.add(TR::Node::iconst(firstNode, -1));
       }
 
-   if (!alreadyLoadedThisTempForObjectCtor && (self()->getThisTempForObjectCtor() != NULL))
+   if (!alreadyLoadedThisTempForObjectCtor && (getThisTempForObjectCtor() != NULL))
       {
-      loadNodes.add(TR::Node::createLoad(firstNode, self()->getThisTempForObjectCtor()));
-      loadNodes.add(TR::Node::iconst(firstNode, self()->getThisTempForObjectCtor()->getReferenceNumber()));
+      loadNodes.add(TR::Node::createLoad(firstNode, getThisTempForObjectCtor()));
+      loadNodes.add(TR::Node::iconst(firstNode, getThisTempForObjectCtor()->getReferenceNumber()));
       loadNodes.add(TR::Node::iconst(firstNode, -1));
       }
 
@@ -1203,51 +1203,51 @@ OMR::ResolvedMethodSymbol::genOSRHelperCall(int32_t currentInlinedSiteIndex, TR:
    // Add the call to the OSR Block
    TR::Node *osrNode = TR::Node::create(TR::treetop, 1, osrCall);
    TR::Block *OSRCodeBlock = osrMethodData->getOSRCodeBlock();
-   TR::TreeTop *osrTT = TR::TreeTop::create(self()->comp(), osrNode);
+   TR::TreeTop *osrTT = TR::TreeTop::create(comp(), osrNode);
    OSRCodeBlock->append(osrTT);
 
    static bool disableOSRwithTM = feGetEnv("TR_disableOSRwithTM") ? true: false;
-   if (self()->comp()->cg()->getSupportsTM() && !self()->comp()->getOption(TR_DisableTLE) && !disableOSRwithTM)
+   if (comp()->cg()->getSupportsTM() && !comp()->getOption(TR_DisableTLE) && !disableOSRwithTM)
       {
       TR::Node *tabortNode = TR::Node::create(osrNode, TR::tabort, 0, 0);
-      TR::TreeTop *tabortTT = TR::TreeTop::create(self()->comp(),tabortNode, NULL,NULL);
-      tabortNode->setSymbolReference(self()->comp()->getSymRefTab()->findOrCreateTransactionAbortSymbolRef(self()->comp()->getMethodSymbol()));
+      TR::TreeTop *tabortTT = TR::TreeTop::create(comp(),tabortNode, NULL,NULL);
+      tabortNode->setSymbolReference(comp()->getSymRefTab()->findOrCreateTransactionAbortSymbolRef(comp()->getMethodSymbol()));
       if (trace)
-         traceMsg(self()->comp(), "adding tabortNode %p, tabortTT %p, osrNode %p\n", tabortNode, tabortTT, osrNode);
+         traceMsg(comp(), "adding tabortNode %p, tabortTT %p, osrNode %p\n", tabortNode, tabortTT, osrNode);
       osrTT->insertBefore(tabortTT);
       if (trace)
-         traceMsg(self()->comp(), "osrNode->getPrevTreeTop()->getNode() %p\n", osrTT->getPrevTreeTop()->getNode());
+         traceMsg(comp(), "osrNode->getPrevTreeTop()->getNode() %p\n", osrTT->getPrevTreeTop()->getNode());
       }
 
-   if (self()->comp()->getCurrentInlinedSiteIndex() == -1)
+   if (comp()->getCurrentInlinedSiteIndex() == -1)
       {
       //I'm compiling the top-level caller, so put a TR::igoto to vmThread->osrReturnAddress
       //to get the control back to the VM after we fill the OSR buffer
-      TR::Node* osrReturnAddress = TR::Node::createLoad(firstNode , self()->comp()->getSymRefTab()->findOrCreateOSRReturnAddressSymbolRef());
+      TR::Node* osrReturnAddress = TR::Node::createLoad(firstNode , comp()->getSymRefTab()->findOrCreateOSRReturnAddressSymbolRef());
       TR::Node* igotoNode = TR::Node::create(firstNode, TR::igoto, 1);
       igotoNode->setChild(0, osrReturnAddress);
       osrReturnAddress->incReferenceCount();
-      OSRCodeBlock->append(TR::TreeTop::create(self()->comp(), igotoNode));
+      OSRCodeBlock->append(TR::TreeTop::create(comp(), igotoNode));
       }
    else
       {
       // Add the dead stores for this call site
-      TR_OSRMethodData* callerOSRData = self()->comp()->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
-      TR_InlinedCallSite &callSiteInfo = self()->comp()->getInlinedCallSite(currentInlinedSiteIndex);
-      callerOSRData->getMethodSymbol()->insertStoresForDeadStackSlots(self()->comp(), callSiteInfo._byteCodeInfo,
+      TR_OSRMethodData* callerOSRData = comp()->getOSRCompilationData()->findCallerOSRMethodData(osrMethodData);
+      TR_InlinedCallSite &callSiteInfo = comp()->getInlinedCallSite(currentInlinedSiteIndex);
+      callerOSRData->getMethodSymbol()->insertStoresForDeadStackSlots(comp(), callSiteInfo._byteCodeInfo,
          OSRCodeBlock->getExit(), false);
 
       //create an appropritely-typed return node and append it to the OSR code block and add
       //the corresponding cfg edge
-      bool voidReturn = self()->getResolvedMethod()->returnOpCode() == TR::Return;
-      TR::Node *retNode = TR::Node::create(firstNode, self()->getResolvedMethod()->returnOpCode(), voidReturn?0:1);
+      bool voidReturn = getResolvedMethod()->returnOpCode() == TR::Return;
+      TR::Node *retNode = TR::Node::create(firstNode, getResolvedMethod()->returnOpCode(), voidReturn?0:1);
       if (!voidReturn)
          {
-         TR::Node *retValNode = TR::Node::create(firstNode, self()->comp()->il.opCodeForConst(self()->getResolvedMethod()->returnType()), 0);
+         TR::Node *retValNode = TR::Node::create(firstNode, comp()->il.opCodeForConst(getResolvedMethod()->returnType()), 0);
          retValNode->setLongInt(0);
          retNode->setAndIncChild(0, retValNode);
          }
-      OSRCodeBlock->append(TR::TreeTop::create(self()->comp(), retNode));
+      OSRCodeBlock->append(TR::TreeTop::create(comp(), retNode));
       }
 
    cfg->addEdge(OSRCodeBlock, cfg->getEnd());
@@ -1269,11 +1269,11 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
       if (comp->isPeekingMethod())
          traceMsg(comp, "<peeking ilgen\n"
                  "\tmethod=\"%s\">\n",
-                 self()->signature(comp->trMemory()));
+                 signature(comp->trMemory()));
       else
          traceMsg(comp, "<ilgen\n"
                  "\tmethod=\"%s\">\n",
-                 self()->signature(comp->trMemory()));
+                 signature(comp->trMemory()));
       if (comp->getDebug())
          {
          traceMsg(comp, "   <request> ");
@@ -1306,7 +1306,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             }
 
          if (_tempIndex == -1)
-            self()->setParameterList();
+            setParameterList();
          _tempIndex = _firstJitTempIndex;
          //_automaticList.setListHead(0); // what's the point ? sym ref tab can use the sym refs anyway by using methodSymbol's auto sym refs and pending push sym refs list; this only confuses analyses into thinking these autos cannot be used when they actually can be
 
@@ -1317,14 +1317,14 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
 
          if (comp->getOutFile() != NULL && comp->getOption(TR_TraceBC))
             {
-            traceMsg(self()->comp(), "genIL() returned %d\n", genIL_rc);
+            traceMsg(comp(), "genIL() returned %d\n", genIL_rc);
             }
 
          if (_methodFlags.testAny(IlGenSuccess))
             {
             if (!comp->isPeekingMethod())
                {
-               if (self()->catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
+               if (catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
                   {
                   comp->failCompilation<TR::CompilationException>("Catch blocks have real predecessors");
                   }
@@ -1339,20 +1339,20 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
                && !comp->isPeekingMethod()
                && !(comp->getOption(TR_DisableNextGenHCR) && comp->getOption(TR_EnableHCR))
                && comp->supportsInduceOSR()
-               && !self()->cannotAttemptOSRDuring(siteIndex, comp);
+               && !cannotAttemptOSRDuring(siteIndex, comp);
 
             optimizer = TR::Optimizer::createOptimizer(comp, self(), true);
             previousOptimizer = comp->getOptimizer();
             comp->setOptimizer(optimizer);
 
-            self()->detectInternalCycles(comp->getFlowGraph(), comp);
+            detectInternalCycles(comp->getFlowGraph(), comp);
 
             if (doOSR)
                {
                TR_OSRCompilationData *osrCompData = comp->getOSRCompilationData();
                TR_ASSERT(osrCompData != NULL, "OSR compilation data is NULL\n");
 
-               self()->genAndAttachOSRCodeBlocks(siteIndex);
+               genAndAttachOSRCodeBlocks(siteIndex);
 
                // Check for the OSR blocks directly, since they're specific
                // to the current inlined call site, unlike getOSRPoints().
@@ -1361,13 +1361,13 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
 
                if (osrMethodData->getOSRCodeBlock() != NULL)
                   {
-                  self()->genOSRHelperCall(siteIndex, symRefTab);
+                  genOSRHelperCall(siteIndex, symRefTab);
                   if (comp->getOption(TR_TraceOSR))
                      comp->dumpMethodTrees("Trees after OSR in genIL", self());
                   }
 
                if (!comp->isOutermostMethod())
-                  self()->cleanupUnreachableOSRBlocks(siteIndex, comp);
+                  cleanupUnreachableOSRBlocks(siteIndex, comp);
                }
 
             if (optimizer)
@@ -1385,7 +1385,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
       }
    catch (const TR::RecoverableILGenException &e)
       {
-      if (self()->comp()->isOutermostMethod())
+      if (comp()->isOutermostMethod())
          throw;
       _methodFlags.set(IlGenSuccess, false);
       if (optimizer) //if the exception is from ilgen opts we need to restore previous optimizer
@@ -1498,7 +1498,7 @@ OMR::ResolvedMethodSymbol::getNumberOfBackEdges()
    {
    int32_t numBackEdges = 0;
    bool inColdBlock = false;
-   for (TR::TreeTop *tt = self()->getFirstTreeTop();
+   for (TR::TreeTop *tt = getFirstTreeTop();
         tt;
         tt = tt->getNextTreeTop())
       {
@@ -1520,12 +1520,12 @@ void
 OMR::ResolvedMethodSymbol::resetLiveLocalIndices()
    {
    TR::ParameterSymbol *p1;
-   ListIterator<TR::ParameterSymbol> parms(&self()->getParameterList());
+   ListIterator<TR::ParameterSymbol> parms(&getParameterList());
    for (p1 = parms.getFirst(); p1 != NULL; p1 = parms.getNext())
       p1->setLiveLocalIndexUninitialized();
 
    TR::AutomaticSymbol *p2;
-   ListIterator<TR::AutomaticSymbol> locals(&self()->getAutomaticList());
+   ListIterator<TR::AutomaticSymbol> locals(&getAutomaticList());
    for (p2 = locals.getFirst(); p2 != NULL; p2 = locals.getNext())
       p2->setLiveLocalIndexUninitialized();
    }
@@ -1540,11 +1540,11 @@ OMR::ResolvedMethodSymbol::supportsInduceOSR(TR_ByteCodeInfo &bci,
       return false;
 
    // Check it is possible to transition within this call site
-   if (self()->cannotAttemptOSRDuring(bci.getCallerIndex(), comp, runCleanup))
+   if (cannotAttemptOSRDuring(bci.getCallerIndex(), comp, runCleanup))
       return false;
 
    // Check it is possible to transition at this BCI
-   if (self()->cannotAttemptOSRAt(bci, blockToOSRAt, comp))
+   if (cannotAttemptOSRAt(bci, blockToOSRAt, comp))
       return false;
 
    return true;
@@ -1621,7 +1621,7 @@ OMR::ResolvedMethodSymbol::cannotAttemptOSRDuring(int32_t callSite, TR::Compilat
                traceMsg(comp, "Cannot attempt OSR as OSR code block for site index %d is absent\n",
                   osrMethodData->getInlinedSiteIndex());
             if (runCleanup)
-               self()->cleanupUnreachableOSRBlocks(origCallSite, comp);
+               cleanupUnreachableOSRBlocks(origCallSite, comp);
             cannotAttemptOSR = true;
             break;
             }
@@ -1678,7 +1678,7 @@ OMR::ResolvedMethodSymbol::cannotAttemptOSRAt(TR_ByteCodeInfo &bci,
          callSite, byteCodeIndex);
 
    // Check it is possible to transition at this index
-   if (self()->_cannotAttemptOSR->get(byteCodeIndex))
+   if (_cannotAttemptOSR->get(byteCodeIndex))
       {
       if (comp->getOption(TR_TraceOSR))
          traceMsg(comp, "Cannot attempt OSR at bytecode index %d:%d\n",
@@ -1763,7 +1763,7 @@ OMR::ResolvedMethodSymbol::cleanupUnreachableOSRBlocks(int32_t inlinedSiteIndex,
 
             while (!CallerOSRCatchBlock->getExceptionPredecessors().empty())
                {
-               self()->getFlowGraph()->removeEdge(CallerOSRCatchBlock->getExceptionPredecessors().front());
+               getFlowGraph()->removeEdge(CallerOSRCatchBlock->getExceptionPredecessors().front());
                }
             }
          else
@@ -1851,7 +1851,7 @@ OMR::ResolvedMethodSymbol::isOSRRelatedNode(TR::Node *node, TR_ByteCodeInfo &osr
    TR_ByteCodeInfo &bci = node->getByteCodeInfo();
    bool byteCodeIndex = osrBCI.getCallerIndex() == bci.getCallerIndex()
       && osrBCI.getByteCodeIndex() == bci.getByteCodeIndex();
-   return byteCodeIndex && self()->isOSRRelatedNode(node);
+   return byteCodeIndex && isOSRRelatedNode(node);
    }
 
 /*
@@ -1861,11 +1861,11 @@ OMR::ResolvedMethodSymbol::isOSRRelatedNode(TR::Node *node, TR_ByteCodeInfo &osr
 TR::TreeTop *
 OMR::ResolvedMethodSymbol::getOSRTransitionTreeTop(TR::TreeTop *tt)
    {
-   if (self()->comp()->isOSRTransitionTarget(TR::postExecutionOSR))
+   if (comp()->isOSRTransitionTarget(TR::postExecutionOSR))
       {
-      TR_ByteCodeInfo bci = self()->getOSRByteCodeInfo(tt->getNode());
+      TR_ByteCodeInfo bci = getOSRByteCodeInfo(tt->getNode());
       TR::TreeTop *cursor = tt->getNextTreeTop();
-      while (cursor && self()->isOSRRelatedNode(cursor->getNode(), bci))
+      while (cursor && isOSRRelatedNode(cursor->getNode(), bci))
          {
          tt = cursor;
          cursor = cursor->getNextTreeTop();
@@ -1990,7 +1990,7 @@ OMR::ResolvedMethodSymbol::insertStoresForDeadStackSlotsBeforeInducingOSR(TR::Co
       return;
       }
 
-   self()->insertStoresForDeadStackSlots(comp, byteCodeInfo, induceOSRTree);
+   insertStoresForDeadStackSlots(comp, byteCodeInfo, induceOSRTree);
    }
 
 TR_OSRPoint *
@@ -2013,11 +2013,11 @@ OMR::ResolvedMethodSymbol::addAutomatic(TR::AutomaticSymbol *p)
    {
    if (!_automaticList.find(p))
       {
-      bool compiledMethod = self()->comp()->getJittedMethodSymbol() == self();
+      bool compiledMethod = comp()->getJittedMethodSymbol() == self();
 
-      TR::CodeGenerator *cg = self()->comp()->cg();
+      TR::CodeGenerator *cg = comp()->cg();
       if (cg->getMappingAutomatics() && compiledMethod)
-         cg->getLinkage()->mapSingleAutomatic(p, self()->getLocalMappingCursor());
+         cg->getLinkage()->mapSingleAutomatic(p, getLocalMappingCursor());
 
       _automaticList.add(p);
       }
@@ -2053,7 +2053,7 @@ OMR::ResolvedMethodSymbol::setTempIndex(int32_t index, TR_FrontEnd * fe)
    {
    if ((_tempIndex = index) < 0)
       {
-      self()->comp()->failCompilation<TR::CompilationException>("TR::ResolvedMethodSymbol::_tempIndex overflow");
+      comp()->failCompilation<TR::CompilationException>("TR::ResolvedMethodSymbol::_tempIndex overflow");
       }
    return index;
    }
@@ -2061,16 +2061,16 @@ OMR::ResolvedMethodSymbol::setTempIndex(int32_t index, TR_FrontEnd * fe)
 ncount_t
 OMR::ResolvedMethodSymbol::generateAccurateNodeCount()
    {
-   TR::TreeTop *tt = self()->getFirstTreeTop();
+   TR::TreeTop *tt = getFirstTreeTop();
 
-   self()->comp()->incOrResetVisitCount();
+   comp()->incOrResetVisitCount();
 
    ncount_t count=0;
 
    for (; tt; tt = tt->getNextTreeTop())
       {
       TR::Node *node = tt->getNode();
-      count += self()->recursivelyCountChildren(node);
+      count += recursivelyCountChildren(node);
       }
    return count;
    }
@@ -2080,15 +2080,15 @@ OMR::ResolvedMethodSymbol::recursivelyCountChildren(TR::Node *node)
    {
    ncount_t count=1;
 
-   if( node->getVisitCount() >= self()->comp()->getVisitCount() )
+   if( node->getVisitCount() >= comp()->getVisitCount() )
       return 0;
 
-   node->setVisitCount(self()->comp()->getVisitCount());
+   node->setVisitCount(comp()->getVisitCount());
 
    for(int32_t i=0 ; i < node->getNumChildren(); i++)
       {
       if( node->getChild(i) )
-         count += self()->recursivelyCountChildren(node->getChild(i));
+         count += recursivelyCountChildren(node->getChild(i));
       }
 
    return count;
@@ -2097,10 +2097,10 @@ OMR::ResolvedMethodSymbol::recursivelyCountChildren(TR::Node *node)
 List<TR::SymbolReference> &
 OMR::ResolvedMethodSymbol::getAutoSymRefs(int32_t slot)
    {
-   TR_Memory * m = self()->comp()->trMemory();
+   TR_Memory * m = comp()->trMemory();
    if (!_autoSymRefs)
       {
-      if (self()->comp()->getJittedMethodSymbol() == self())
+      if (comp()->getJittedMethodSymbol() == self())
          _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, 100, true);
       else
          _autoSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, _resolvedMethod->numberOfParameterSlots() + _resolvedMethod->numberOfTemps() + 5, true);
@@ -2122,14 +2122,14 @@ void
 OMR::ResolvedMethodSymbol::setParmSymRef(int32_t slot, TR::SymbolReference *symRef)
    {
    if (!_parmSymRefs)
-      _parmSymRefs = new (self()->comp()->trHeapMemory()) TR_Array<TR::SymbolReference*>(self()->comp()->trMemory(), self()->getNumParameterSlots());
+      _parmSymRefs = new (comp()->trHeapMemory()) TR_Array<TR::SymbolReference*>(comp()->trMemory(), getNumParameterSlots());
    (*_parmSymRefs)[slot] = symRef;
    }
 
 List<TR::SymbolReference> &
 OMR::ResolvedMethodSymbol::getPendingPushSymRefs(int32_t slot)
    {
-   TR_Memory * m = self()->comp()->trMemory();
+   TR_Memory * m = comp()->trMemory();
    if (!_pendingPushSymRefs)
       {
       _pendingPushSymRefs = new (m->trHeapMemory()) TR_Array<List<TR::SymbolReference> >(m, 10, true);
@@ -2147,8 +2147,8 @@ OMR::ResolvedMethodSymbol::removeTree(TR::TreeTop *tt)
    if (node != NULL)
       {
       node->recursivelyDecReferenceCount();
-      if (self()->comp()->getOption(TR_TraceAddAndRemoveEdge))
-         traceMsg(self()->comp(), "remove [%s]\n", node->getName(self()->comp()->getDebug()));
+      if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+         traceMsg(comp(), "remove [%s]\n", node->getName(comp()->getDebug()));
       }
 
    TR::TreeTop *prev = tt->getPrevTreeTop();
@@ -2178,11 +2178,11 @@ OMR::ResolvedMethodSymbol::getLastTreeTop(TR::Block * b)
 TR::Block *
 OMR::ResolvedMethodSymbol::prependEmptyFirstBlock()
    {
-   TR::Node * firstNode = self()->getFirstTreeTop()->getNode();
+   TR::Node * firstNode = getFirstTreeTop()->getNode();
    TR::Block * firstBlock = firstNode->getBlock();
 
    TR::Block * newBlock = TR::Block::createEmptyBlock(firstNode, _flowGraph->comp(), firstBlock->getFrequency());
-   self()->setFirstTreeTop(newBlock->getEntry());
+   setFirstTreeTop(newBlock->getEntry());
 
    _flowGraph->insertBefore(newBlock, firstBlock);
    _flowGraph->addEdge(_flowGraph->getStart(), newBlock);
@@ -2252,7 +2252,7 @@ OMR::ResolvedMethodSymbol::detectInternalCycles(TR::CFG *cfg, TR::Compilation *c
                         {
                         TR::TreeTop *next = retain->getNextTreeTop();
                         if (next && next->getNode()->getOpCodeValue() == TR::asynccheck)
-                           retain = self()->getOSRTransitionTreeTop(next);
+                           retain = getOSRTransitionTreeTop(next);
                         }
 
                      retain->join(clonedCatch->getExit());
@@ -2347,9 +2347,9 @@ OMR::ResolvedMethodSymbol::removeUnusedLocals()
    uint32_t removedSize = 0;
 #endif
 
-   bool compiledMethod = (self()->comp()->getMethodSymbol() == self());
+   bool compiledMethod = (comp()->getMethodSymbol() == self());
 
-   TR_BitVector *liveButMaybeUnreferencedLocals = self()->comp()->cg()->getLiveButMaybeUnreferencedLocals();
+   TR_BitVector *liveButMaybeUnreferencedLocals = comp()->cg()->getLiveButMaybeUnreferencedLocals();
 
    while (cursor)
       {
@@ -2394,7 +2394,7 @@ OMR::ResolvedMethodSymbol::removeUnusedLocals()
                   afterTotalSize,
                   removedSize,
                   removedTotalSize,
-                  self()->comp()->signature());
+                  comp()->signature());
       }
 #endif
    }
@@ -2402,13 +2402,13 @@ OMR::ResolvedMethodSymbol::removeUnusedLocals()
 int32_t
 OMR::ResolvedMethodSymbol::incTempIndex(TR_FrontEnd * fe)
    {
-   return self()->setTempIndex(_tempIndex+1, fe);
+   return setTempIndex(_tempIndex+1, fe);
    }
 
 bool
 OMR::ResolvedMethodSymbol::hasEscapeAnalysisOpportunities()
    {
-   return self()->hasNews() || self()->hasDememoizationOpportunities();
+   return hasNews() || hasDememoizationOpportunities();
    }
 
 bool
@@ -2421,7 +2421,7 @@ int32_t
 OMR::ResolvedMethodSymbol::getArrayCopyTempSlot(TR_FrontEnd * fe)
    {
    if (_arrayCopyTempSlot == -1)
-      _arrayCopyTempSlot = self()->incTempIndex(fe);
+      _arrayCopyTempSlot = incTempIndex(fe);
    return _arrayCopyTempSlot;
    }
 
@@ -2430,91 +2430,91 @@ OMR::ResolvedMethodSymbol::getArrayCopyTempSlot(TR_FrontEnd * fe)
 uint32_t&
 OMR::ResolvedMethodSymbol::getLocalMappingCursor()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _localMappingCursor;
    }
 void
 OMR::ResolvedMethodSymbol::setLocalMappingCursor(uint32_t i)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    _localMappingCursor = i;
    }
 
 uint32_t
 OMR::ResolvedMethodSymbol::getProloguePushSlots()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _prologuePushSlots;
    }
 uint32_t
 OMR::ResolvedMethodSymbol::setProloguePushSlots(uint32_t s)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return (_prologuePushSlots = s);
    }
 
 uint32_t
 OMR::ResolvedMethodSymbol::getScalarTempSlots()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _scalarTempSlots;
    }
 uint32_t
 OMR::ResolvedMethodSymbol::setScalarTempSlots(uint32_t s)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return (_scalarTempSlots = s);
    }
 
 uint32_t
 OMR::ResolvedMethodSymbol::getObjectTempSlots()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _objectTempSlots;
    }
 uint32_t
 OMR::ResolvedMethodSymbol::setObjectTempSlots(uint32_t s)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return (_objectTempSlots = s);
    }
 
 bool
 OMR::ResolvedMethodSymbol::containsOnlySinglePrecision()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _methodFlags.testAny(OnlySinglePrecision);
    }
 void
 OMR::ResolvedMethodSymbol::setContainsOnlySinglePrecision(bool b)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    _methodFlags.set(OnlySinglePrecision, b);
    }
 
 bool
 OMR::ResolvedMethodSymbol::usesSinglePrecisionMode()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _methodFlags.testAny(SinglePrecisionMode);
    }
 void
 OMR::ResolvedMethodSymbol::setUsesSinglePrecisionMode(bool b)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    _methodFlags.set(SinglePrecisionMode, b);
    }
 
 bool
 OMR::ResolvedMethodSymbol::isNoTemps()
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    return _methodFlags.testAny(NoTempsSet);
    }
 void
 OMR::ResolvedMethodSymbol::setNoTemps(bool b)
    {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
+   TR_ASSERT(isJittedMethod(), "Should have been created as a jitted method.");
    _methodFlags.set(NoTempsSet, b);
    }
 

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -71,7 +71,7 @@ namespace OMR
 /**
  * Class for resolved method symbols
  */
-class OMR_EXTENSIBLE ResolvedMethodSymbol : public TR::MethodSymbol
+class /*OMR_EXTENSIBLE*/ ResolvedMethodSymbol : public TR::MethodSymbol
    {
 
 protected:

--- a/compiler/il/symbol/OMRStaticSymbol.cpp
+++ b/compiler/il/symbol/OMRStaticSymbol.cpp
@@ -73,7 +73,7 @@ TR::StaticSymbol * OMR::StaticSymbol::createNamed(AllocatorType m, TR::DataType 
 const char *
 OMR::StaticSymbol::getName()
    {
-   TR_ASSERT(self()->isNamed(),"Must have called makeNamed() to get a valid name");
+   TR_ASSERT(isNamed(),"Must have called makeNamed() to get a valid name");
    return _name;
    }
 

--- a/compiler/il/symbol/OMRStaticSymbol.hpp
+++ b/compiler/il/symbol/OMRStaticSymbol.hpp
@@ -47,7 +47,7 @@ namespace OMR
 /**
  * A symbol with an adress
  */
-class OMR_EXTENSIBLE StaticSymbol : public TR::Symbol
+class /*OMR_EXTENSIBLE*/ StaticSymbol : public TR::Symbol
    {
 protected:
    TR::StaticSymbol* self();

--- a/compiler/il/symbol/OMRSymbol.cpp
+++ b/compiler/il/symbol/OMRSymbol.cpp
@@ -66,7 +66,7 @@ OMR::Symbol::Symbol(TR::DataType d) :
    _flags2(0),
    _localIndex(0)
    {
-   self()->setDataType(d);
+   setDataType(d);
    }
 
 OMR::Symbol::Symbol(TR::DataType d, uint32_t size) :
@@ -75,7 +75,7 @@ OMR::Symbol::Symbol(TR::DataType d, uint32_t size) :
    _flags2(0),
    _localIndex(0)
    {
-   self()->setDataType(d);
+   setDataType(d);
    _size = size;
    }
 

--- a/compiler/il/symbol/OMRSymbol.cpp
+++ b/compiler/il/symbol/OMRSymbol.cpp
@@ -82,14 +82,14 @@ OMR::Symbol::Symbol(TR::DataType d, uint32_t size) :
 bool
 OMR::Symbol::isReferenced()
    {
-   return self()->isVariableSizeSymbol() && self()->castToVariableSizeSymbol()->isReferenced();
+   return isVariableSizeSymbol() && castToVariableSizeSymbol()->isReferenced();
    }
 
 bool
 OMR::Symbol::dontEliminateStores(TR::Compilation *comp, bool isForLocalDeadStore)
    {
-   return (self()->isAuto() && _flags.testAny(PinningArrayPointer)) ||
-          (self()->isParm() && _flags.testAny(ReinstatedReceiver)) ||
+   return (isAuto() && _flags.testAny(PinningArrayPointer)) ||
+          (isParm() && _flags.testAny(ReinstatedReceiver)) ||
           _flags.testAny(HoldsMonitoredObject) ||
           (comp->getSymRefTab()->findThisRangeExtensionSymRef() && (self() == comp->getSymRefTab()->findThisRangeExtensionSymRef()->getSymbol()));
    }
@@ -97,7 +97,7 @@ OMR::Symbol::dontEliminateStores(TR::Compilation *comp, bool isForLocalDeadStore
 uint32_t
 OMR::Symbol::getNumberOfSlots()
    {
-   uint32_t numSlots = self()->getRoundedSize()/self()->convertTypeToSize(TR::Address);
+   uint32_t numSlots = getRoundedSize()/convertTypeToSize(TR::Address);
 
    // We should always give at least 1 slot.
    //  This is specifically for the case of an int type on 64bit pltfrms
@@ -142,14 +142,14 @@ OMR::Symbol::setDataType(TR::DataType dt)
 uint32_t
 OMR::Symbol::getRoundedSize()
    {
-   int32_t roundedSize = (int32_t)((self()->getSize()+3)&(~3)); // cast explicitly
+   int32_t roundedSize = (int32_t)((getSize()+3)&(~3)); // cast explicitly
    return roundedSize ? roundedSize : 4;
    }
 
 int32_t
 OMR::Symbol::getOffset()
    {
-   TR::RegisterMappedSymbol * r = self()->getRegisterMappedSymbol();
+   TR::RegisterMappedSymbol * r = getRegisterMappedSymbol();
    return r ? r->getOffset() : 0;
    }
 

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -215,7 +215,7 @@ public:
    bool isMethodMetaData()       { return _flags.testValue(KindMask, IsMethodMetaData); }
    bool isResolvedMethod()       { return _flags.testValue(KindMask, IsResolvedMethod); }
    inline bool isMethod();
-   bool isStatic()               { return _flags.testValue(KindMask, IsStatic); }
+   virtual bool isStatic()               { return _flags.testValue(KindMask, IsStatic); }
    bool isShadow()               { return _flags.testValue(KindMask, IsShadow); }
    bool isLabel()                { return _flags.testValue(KindMask, IsLabel); }
    void setIsLabel()             { _flags.setValue(KindMask, IsLabel);}

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -168,7 +168,7 @@ public:
    inline TR::StaticSymbol                    *castToCallSiteTableEntrySymbol();
    inline TR::StaticSymbol                    *castToMethodTypeTableEntrySymbol();
 
-   int32_t getOffset();
+   virtual int32_t getOffset();
 
    uint32_t getNumberOfSlots();
 

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -190,7 +190,7 @@ public:
    void     setSize(size_t s)               { _size = s; }
    uint32_t getRoundedSize();
 
-   const char * getName()                   { return _name; }
+   virtual const char * getName()                   { return _name; }
    void         setName(const char * name)  { _name = name; }
 
    uint32_t getFlags()                      { return _flags.getValue(); }

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -204,7 +204,7 @@ public:
     * Flag functions
     */
 
-   void          setDataType(TR::DataType dt);
+   virtual void          setDataType(TR::DataType dt);
    TR::DataType  getDataType() { return (TR::DataTypes)_flags.getValue(DataTypeMask);}
    inline TR::DataType  getType();
 

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -73,7 +73,7 @@ namespace OMR {
  * A Symbol object contains data type, size and attribute
  * information for a symbol.
  */
-class OMR_EXTENSIBLE Symbol
+class /*OMR_EXTENSIBLE*/ Symbol
    {
 
 public:

--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -74,13 +74,13 @@ TR::AutomaticSymbol * OMR::Symbol::castToLocalObjectSymbol()
 
 TR::StaticSymbol * OMR::Symbol::castToStaticSymbol()
    {
-   TR_ASSERT(self()->isStatic(), "OMR::Symbol::castToStaticSymbol, symbol is not a static symbol");
+   TR_ASSERT(isStatic(), "OMR::Symbol::castToStaticSymbol, symbol is not a static symbol");
    return (TR::StaticSymbol *)this;
    }
 
 TR::StaticSymbol * OMR::Symbol::castToNamedStaticSymbol()
    {
-   TR_ASSERT(self()->isNamed() && self()->isStatic(), "OMR::Symbol::castToNamedStaticSymbol, symbol is not a named static symbol");
+   TR_ASSERT(self()->isNamed() && isStatic(), "OMR::Symbol::castToNamedStaticSymbol, symbol is not a named static symbol");
    return (TR::StaticSymbol *)this;
    }
 
@@ -158,7 +158,7 @@ OMR::Symbol::isInternalPointerAuto()
 bool
 OMR::Symbol::isNamed()
    {
-   return self()->isStatic() && _flags.testAny(IsNamed);
+   return isStatic() && _flags.testAny(IsNamed);
    }
 
 void
@@ -314,111 +314,111 @@ OMR::Symbol::isReinstatedReceiver()
 void
 OMR::Symbol::setConstString()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(ConstString);
    }
 
 bool
 OMR::Symbol::isConstString()
    {
-   return self()->isStatic() && _flags.testAny(ConstString);
+   return isStatic() && _flags.testAny(ConstString);
    }
 
 void
 OMR::Symbol::setConstantDynamic()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags2.set(ConstantDynamic);
    }
 
 bool
 OMR::Symbol::isConstantDynamic()
    {
-   return self()->isStatic() && _flags2.testAny(ConstantDynamic);
+   return isStatic() && _flags2.testAny(ConstantDynamic);
    }
 
 void
 OMR::Symbol::setAddressIsCPIndexOfStatic(bool b)
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(AddressIsCPIndexOfStatic, b);
    }
 
 bool
 OMR::Symbol::addressIsCPIndexOfStatic()
    {
-   return self()->isStatic() && _flags.testAny(AddressIsCPIndexOfStatic);
+   return isStatic() && _flags.testAny(AddressIsCPIndexOfStatic);
    }
 
 bool
 OMR::Symbol::isRecognizedStatic()
    {
-   return self()->isStatic() && _flags.testAny(RecognizedStatic);
+   return isStatic() && _flags.testAny(RecognizedStatic);
    }
 
 void
 OMR::Symbol::setCompiledMethod()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(CompiledMethod);
    }
 
 bool
 OMR::Symbol::isCompiledMethod()
    {
-   return self()->isStatic() && _flags.testAny(CompiledMethod);
+   return isStatic() && _flags.testAny(CompiledMethod);
    }
 
 void
 OMR::Symbol::setStartPC()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(StartPC);
    }
 
 bool
 OMR::Symbol::isStartPC()
    {
-   return self()->isStatic() && _flags.testAny(StartPC);
+   return isStatic() && _flags.testAny(StartPC);
    }
 
 void
 OMR::Symbol::setCountForRecompile()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(CountForRecompile);
    }
 
 bool
 OMR::Symbol::isCountForRecompile()
    {
-   return self()->isStatic() && _flags.testAny(CountForRecompile);
+   return isStatic() && _flags.testAny(CountForRecompile);
    }
 
 void
 OMR::Symbol::setRecompilationCounter()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(RecompilationCounter);
    }
 
 bool
 OMR::Symbol::isRecompilationCounter()
    {
-   return self()->isStatic() && _flags.testAny(RecompilationCounter);
+   return isStatic() && _flags.testAny(RecompilationCounter);
    }
 
 void
 OMR::Symbol::setGCRPatchPoint()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags.set(GCRPatchPoint);
    }
 
 bool
 OMR::Symbol::isGCRPatchPoint()
    {
-   return self()->isStatic() && _flags.testAny(GCRPatchPoint);
+   return isStatic() && _flags.testAny(GCRPatchPoint);
    }
 
 bool
@@ -623,39 +623,39 @@ OMR::Symbol::isRelativeLabel()
 void
 OMR::Symbol::setConstMethodType()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags2.set(ConstMethodType);
    }
 
 bool
 OMR::Symbol::isConstMethodType()
    {
-   return self()->isStatic() && _flags2.testAny(ConstMethodType);
+   return isStatic() && _flags2.testAny(ConstMethodType);
    }
 
 void
 OMR::Symbol::setConstMethodHandle()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags2.set(ConstMethodHandle);
    }
 
 bool
 OMR::Symbol::isConstMethodHandle()
    {
-   return self()->isStatic() && _flags2.testAny(ConstMethodHandle);
+   return isStatic() && _flags2.testAny(ConstMethodHandle);
    }
 
 bool
 OMR::Symbol::isConstObjectRef()
    {
-   return self()->isStatic() && (_flags.testAny(ConstString) || _flags2.testAny(ConstMethodType|ConstMethodHandle|ConstantDynamic));
+   return isStatic() && (_flags.testAny(ConstString) || _flags2.testAny(ConstMethodType|ConstMethodHandle|ConstantDynamic));
    }
 
 bool
 OMR::Symbol::isStaticField()
    {
-   return self()->isStatic() && !(self()->isConstObjectRef() || self()->isClassObject() || self()->isAddressOfClassObject() || self()->isConst());
+   return isStatic() && !(self()->isConstObjectRef() || self()->isClassObject() || self()->isAddressOfClassObject() || self()->isConst());
    }
 
 bool
@@ -667,40 +667,40 @@ OMR::Symbol::isFixedObjectRef()
 void
 OMR::Symbol::setCallSiteTableEntry()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags2.set(CallSiteTableEntry);
    }
 
 bool
 OMR::Symbol::isCallSiteTableEntry()
    {
-   return self()->isStatic() && _flags2.testAny(CallSiteTableEntry);
+   return isStatic() && _flags2.testAny(CallSiteTableEntry);
    }
 
 void
 OMR::Symbol::setMethodTypeTableEntry()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags2.set(MethodTypeTableEntry);
    }
 
 bool
 OMR::Symbol::isMethodTypeTableEntry()
    {
-   return self()->isStatic() && _flags2.testAny(MethodTypeTableEntry);
+   return isStatic() && _flags2.testAny(MethodTypeTableEntry);
    }
 
 void
 OMR::Symbol::setNotDataAddress()
    {
-   TR_ASSERT(self()->isStatic(), "assertion failure");
+   TR_ASSERT(isStatic(), "assertion failure");
    _flags2.set(NotDataAddress);
    }
 
 bool
 OMR::Symbol::isNotDataAddress()
    {
-   return self()->isStatic() && _flags2.testAny(NotDataAddress);
+   return isStatic() && _flags2.testAny(NotDataAddress);
    }
 
 void
@@ -796,7 +796,7 @@ OMR::Symbol::getLocalObjectSymbol()
 TR::StaticSymbol *
 OMR::Symbol::getStaticSymbol()
    {
-   return self()->isStatic() ? (TR::StaticSymbol *)this : 0;
+   return isStatic() ? (TR::StaticSymbol *)this : 0;
    }
 
 TR::MethodSymbol *

--- a/compiler/il/symbol/ParameterSymbol.hpp
+++ b/compiler/il/symbol/ParameterSymbol.hpp
@@ -31,7 +31,7 @@
 namespace TR
 {
 
-class OMR_EXTENSIBLE ParameterSymbol : public OMR::ParameterSymbolConnector
+class /*OMR_EXTENSIBLE*/ ParameterSymbol : public OMR::ParameterSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/RegisterMappedSymbol.hpp
+++ b/compiler/il/symbol/RegisterMappedSymbol.hpp
@@ -30,7 +30,7 @@
 namespace TR
 {
 
-class OMR_EXTENSIBLE RegisterMappedSymbol : public OMR::RegisterMappedSymbolConnector
+class /*OMR_EXTENSIBLE*/ RegisterMappedSymbol : public OMR::RegisterMappedSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/ResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/ResolvedMethodSymbol.hpp
@@ -30,7 +30,7 @@ namespace TR { class Compilation; }
 namespace TR
 {
 
-class OMR_EXTENSIBLE ResolvedMethodSymbol : public OMR::ResolvedMethodSymbolConnector
+class /*OMR_EXTENSIBLE*/ ResolvedMethodSymbol : public OMR::ResolvedMethodSymbolConnector
    {
 
 protected:

--- a/compiler/il/symbol/StaticSymbol.hpp
+++ b/compiler/il/symbol/StaticSymbol.hpp
@@ -33,7 +33,7 @@
 namespace TR
 {
 
-class OMR_EXTENSIBLE StaticSymbol : public OMR::StaticSymbolConnector
+class /*OMR_EXTENSIBLE*/ StaticSymbol : public OMR::StaticSymbolConnector
    {
 
 protected:

--- a/compiler/optimizer/LocalDeadStoreElimination.cpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -868,7 +868,7 @@ void TR::LocalDeadStoreElimination::eliminateDeadObjectInitializations()
          if (sym)
             {
             if (sym->isLocalObject() &&
-                sym->getLocalObjectSymbol()->getKind() == TR::New)
+                sym->getLocalObjectSymbol()->getOpCodeKind() == TR::New)
                sym->setLocalIndex(numSymbols++);
             else
                sym->setLocalIndex(0);
@@ -906,7 +906,7 @@ void TR::LocalDeadStoreElimination::eliminateDeadObjectInitializations()
          {
          if (storeNode->getFirstChild()->getOpCode().hasSymbolReference() &&
              storeNode->getFirstChild()->getSymbolReference()->getSymbol()->isLocalObject() &&
-             (storeNode->getFirstChild()->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getKind() == TR::New) &&
+             (storeNode->getFirstChild()->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getOpCodeKind() == TR::New) &&
              !usedLocalObjectSymbols.get(storeNode->getFirstChild()->getSymbolReference()->getSymbol()->getLocalIndex()))
             removableLocalObjectStore = true;
          else if (currentNews.find(storeNode->getFirstChild()) ||
@@ -1013,7 +1013,7 @@ void TR::LocalDeadStoreElimination::findLocallyAllocatedObjectUses(LDSBitVector 
    {
    if (node->getOpCode().hasSymbolReference() &&
        (node->getSymbolReference()->getSymbol()->isLocalObject() &&
-        node->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getKind() == TR::New) &&
+        node->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getOpCodeKind() == TR::New) &&
        !(parent->getOpCode().isStoreIndirect() && childNum == 0 &&
          ( (uint32_t) parent->getSymbolReference()->getOffset() < fe()->getObjectHeaderSizeInBytes())))
        usedLocalObjectSymbols.set(node->getSymbolReference()->getSymbol()->getLocalIndex());

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -11250,12 +11250,12 @@ TR::Node *constrainLoadaddr(OMR::ValuePropagation *vp, TR::Node *node)
       TR::VPClassType *typeConstraint = 0;
       TR::AutomaticSymbol *localObj = symbol->castToLocalObjectSymbol();
       symRef                       = localObj->getClassSymbolReference();
-      if (localObj->getKind() == TR::New)
+      if (localObj->getOpCodeKind() == TR::New)
          {
          if (symRef)
             typeConstraint = TR::VPClassType::create(vp, symRef, true);
          }
-      else if (localObj->getKind() == TR::anewarray)
+      else if (localObj->getOpCodeKind() == TR::anewarray)
          {
          typeConstraint = TR::VPClassType::create(vp, symRef, true);
          typeConstraint = typeConstraint->getClassType()->getArrayClass(vp);


### PR DESCRIPTION
* Commented out OMR_EXTENSIBLE from `Symbol` class declarations
* Removed self() from function calls of `Symbol`

Since virtualizing the `Symbol` hierarchy requires changes from both, the OMR and OpenJ9, projects this PR is linked to [a related one in openJ9](https://github.com/eclipse/openj9/pull/3741) achieving the same purpose.


Signed-off-by: Samer AL Masri <almasri@ualberta.ca>