### PR TITLE
WIP: More strict condition for isOSRInductionHelper

### DIFF
--- a/compiler/il/OMRSymbolReference.cpp
+++ b/compiler/il/OMRSymbolReference.cpp
@@ -372,5 +372,6 @@ OMR::SymbolReference::hasBeenAccessedAtRuntime()
 bool
 OMR::SymbolReference::isOSRInductionHelper()
    {
-   return _referenceNumber == TR_induceOSRAtCurrentPCAndRecompile || _referenceNumber == TR_induceOSRAtCurrentPC;
+   TR::MethodSymbol *sym = self()->getSymbol()->getMethodSymbol();
+   return sym && sym->isHelper() && (_referenceNumber == TR_induceOSRAtCurrentPCAndRecompile || _referenceNumber == TR_induceOSRAtCurrentPC);
    }


### PR DESCRIPTION
The old condition is not sufficient to tell if the method is induceOSR
helper since the reference index for normal methods and helper methods
can overlap.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>