### PR TITLE
WIP: Dynamically adjust TLH maximum size & support allocation sampling

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -293,7 +293,8 @@ public:
 #endif /* OMR_GC_COMBINATION_SPEC */
 
 	uintptr_t tlhMinimumSize;
-	uintptr_t tlhMaximumSize;
+	uintptr_t tlhMaximumSize; /**< Actual maximum size for TLH. */
+	uintptr_t tlhActiveMaximumSize; /**< Current maximum size for TLH allocation, could be changed as per allocationSamplingInterval, same as tlhMaximumSize by default. */
 	uintptr_t tlhInitialSize;
 	uintptr_t tlhIncrementSize;
 	uintptr_t tlhSurvivorDiscardThreshold; /**< below this size GC (Scavenger) will discard survivor copy cache TLH, if alloc not succeeded (otherwise we reuse memory for next TLH) */
@@ -609,6 +610,9 @@ public:
 	bool verboseNewFormat; /**< a flag, enabled by -XXgc:verboseNewFormat, to enable the new verbose GC format */
 	bool bufferedLogging; /**< Enabled by -Xgc:bufferedLogging.  Use buffered filestreams when writing logs (e.g. verbose:gc) to a file */
 
+	bool enableAllocationSampling; /**< a flag, true when the hook event J9HOOK_SAMPLED_OBJECT_ALLOCATE is registered, or false when unregistered */
+	uintptr_t allocationSamplingInterval; /**< the heap sampling interval */
+	uintptr_t currentAllocationRemainder; /**< the remainder of current allocation size modulo the heap sampling interval */
 	uintptr_t lowAllocationThreshold; /**< the lower bound of the allocation threshold range */
 	uintptr_t highAllocationThreshold; /**< the upper bound of the allocation threshold range */
 	bool disableInlineCacheForAllocationThreshold; /**< true if inline allocates fall within the allocation threshold*/
@@ -1275,6 +1279,7 @@ public:
 #endif /* OMR_GC_COMBINATION_SPEC */
 		, tlhMinimumSize(MINIMUM_TLH_SIZE)
 		, tlhMaximumSize(131072)
+		, tlhActiveMaximumSize(131072)
 		, tlhInitialSize(2048)
 		, tlhIncrementSize(4096)
 		, tlhSurvivorDiscardThreshold(tlhMinimumSize)
@@ -1520,6 +1525,9 @@ public:
 		, verboseExtensions(false)
 		, verboseNewFormat(true)
 		, bufferedLogging(false)
+		, enableAllocationSampling(false)
+		, allocationSamplingInterval(512 * 1024) /* 512 KB */
+		, currentAllocationRemainder(0)
 		, lowAllocationThreshold(UDATA_MAX)
 		, highAllocationThreshold(UDATA_MAX)
 		, disableInlineCacheForAllocationThreshold(false)

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -898,3 +898,9 @@ TraceEntry=Trc_MM_MSSGenerational_allocationRequestFailed_entry Overhead=1 Level
 TraceEvent=Trc_MM_MSSGenerational_allocationRequestFailed1 Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu prev != new %llx, allocate from old %llx"
 TraceEvent=Trc_MM_MSSGenerational_allocationRequestFailed Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu event %u"
 TraceExit=Trc_MM_MSSGenerational_allocationRequestFailed_exit Overhead=1 Level=1 Group=allocate Template="MSSGenerational::allocationRequestFailed size %zu exit %zu result %llx"
+
+TraceEntry=Trc_MM_AllocationSampling_setInterval_Entry Overhead=1 Level=1 Group=allocsamplinginterval Template="j9gc_set_allocation_sampling_interval: samplingInterval=%zu ext->allocationSamplingInterval=%zu"
+TraceExit=Trc_MM_AllocationSampling_setInterval_Exit Overhead=1 Level=1 Group=allocsamplinginterval Template="j9gc_set_allocation_sampling_interval"
+TraceEntry=Trc_MM_AllocationSampling_setFlag_Entry Overhead=1 Level=1 Group=allocsamplinginterval Template="j9gc_set_allocation_sampling: flag = %s"
+TraceExit=Trc_MM_AllocationSampling_setFlag_Exit Overhead=1 Level=1 Group=allocsamplinginterval Template="j9gc_set_allocation_sampling"
+


### PR DESCRIPTION
Dynamically adjust `TLH` maximum size & support allocation sampling

## Background and motivations
Application users have strong needs to understand the content of their heaps and avoid poor data allocation that can lead to problems such as heap exhaustion and GC thrashing.

There are a number of tools available to provide means to introspect into application heaps. However one piece of information missing from most of those tools is the call site for particular allocations. 

Application users need this information to debug memory issues and identify the exact location of the particular (and particularly bad) memory allocations. 

This call site information can be made available via a set of live stack traces when the allocation occurs. 

The live stack traces are language specific depending on the downstream product runtime hence such runtime implementation need to be notified when a particular allocation should be sampled while certain conditions such as sampling intervals are satisfied.

## Goals

Downstream language runtimes are to be given a chance periodically to check if a sampling should happen and ultimately notify the application user about an allocation in which the user could capture a language specific stack traces and potentially create new (language specific) objects based on the object from this allocation.

The goal of this PR is to force out-of-line allocation periodically according to sampling interval requested. During out-of-line allocation, downstream language runtime could retrieve language specific objects and provide them to the application user.
 
## High level description & design

In an ideal scenario, the user will be notified about the call site of heap allocation each time when the sampling interval threshold has been reached exactly for the allocation across threads. For illustration purpose, assuming a single thread application allocating fixed `1KB` heap memory repeatedly with a sampling interval `1MB`, the user will be notified at `1025th`, `2049th`, etc allocations, i.e., `1MB` allocation occurred between two samplings. 

There are two issues about this scenario: this sampling is biased to certain allocation though it might be what users want in some cases; other than that, multi-thread application is the majority usage, the sampling is expected to reflect the allocation across threads.

Calculating each `TLH` allocation size bears high performance hit, current proposal is to record current `TLH` allocated size before a new one is created during refresh, i.e., counting a `TLH` allocation (across threads) instead of each allocation within that `TLH`. Besides the allocations within `TLH`, there are out-of-line allocations which need to be counted as well.

The sampling is not precise. In worst scenario, a sampling doesn't happen when none of `TLH` requires refresh but the total allocation size within these `TLH` already beyond the sampling interval value. However in the long run, the total size of allocation should be statistically close to the multiplication of the sampling interval size and the number of sampling. 
Note: though current proposal already introduce randomness during sampling, there is a chance that it could be biased toward certain thread and callsite.

To summarize:
1. each out-of-line allocation will be recorded;
2. each `TLH` used space will be recorded;
3. sampling threshold is against allocations across threads.

## Details

Depending on the value of the sampling interval, different code path are going to be taken:

1. When the sampling interval specified is less than the minimum `TLH` size, inline TLH allocation will be disabled and each allocation will go through the out-of-line allocation though the allocation actually still happens on the `TLH` as long as the required size can be fit within this `TLH`. Note: the performance cost is the extra code path to the actual `TLH` allocation routine.

2. When the sampling interval is larger or equal to the minimum `TLH` size, the maximum `TLH` size is to be adjusted dynamically to match the sampling interval or usual `TLH` maximum size whichever less. When a `TLH` refresh is performed, current `TLH` usage size is recorded as part of past allocation size, and force out-of-line allocation if the sampling interval has been reached.

Notes about the the calculation of allocation size:
1. The out-of-line allocation size is recorded by downstream language runtime;
2. The `TLH` allocation size is only recorded when a new `TLH` is created which is per thread calculation;

## List of changes

Adding a new field `GCExtensionsBase.tlhActiveMaximumSize` as current maximum size for `TLH` allocation, could be changed as per `allocationSamplingInterval` (new field as well). By default, it is same as `tlhMaximumSize`. 

Also adding fields `enableAllocationSampling`, `allocationSamplingInterval` and `currentAllocationRemainder` to support allocation sampling;

`MM_TLHAllocationSupport::refresh()` is modified to record the usage size of the `TLH` being refreshed. In addition, `disableInlineTLHAllocate()` to force out-of-line for next allocation when the sampling interval has been reached;

Adding a few trace entries.

Note: forcing out-of-line allocation allows downstream project https://github.com/eclipse/openj9/pull/3754 to report sampling events according to the interval requested as per [Java 11 JEP 331](http://openjdk.java.net/jeps/331).


Signed-off-by: Jason Feng <fengj@ca.ibm.com>