### PR TITLE
cmake: add omr_base: a library defining basic configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,16 +70,32 @@ include(cmake/config.cmake)
 
 enable_testing()
 
-include_directories(
-	${PROJECT_BINARY_DIR}
-	./include/
-	./include_core/
-	./third_party/
+###
+### omr_base: basic includes and definitions needed everywhere
+###
+
+add_library(omr_base INTERFACE)
+
+target_include_directories(omr_base
+	INTERFACE
+		$<BUILD_INTERFACE:${omr_SOURCE_DIR}/include_core>
+		$<BUILD_INTERFACE:${omr_BINARY_DIR}>
+		$<INSTALL_INTERFACE:${OMR_INSTALL_INC_DIR}>
 )
 
-add_definitions(
-	-DUT_DIRECT_TRACE_REGISTRATION # TODO:  Deal with that stupid jni issue in tracegen
+target_compile_definitions(omr_base
+	INTERFACE
+		-DUT_DIRECT_TRACE_REGISTRATION # TODO:  Deal with that stupid jni issue in tracegen
 )
+
+install(
+	TARGETS omr_base
+	EXPORT OmrTargets
+)
+
+###
+### Source tree checks
+###
 
 # Check for existing omrcfg in the source tree since this can cause alot of headaches
 # Also check if we are building in tree while we are at it

--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -370,6 +370,11 @@ function(create_omr_compiler_library)
 		${COMPILER_OBJECTS}
 	)
 
+	target_link_libraries(${COMPILER_NAME}
+		PUBLIC
+			omr_base
+	)
+
 	# Grab the list of core compiler objects from the global property.
 	# Note: the property is initialized by compiler/CMakeLists.txt
 	get_property(core_compiler_objects GLOBAL PROPERTY OMR_CORE_COMPILER_OBJECTS)

--- a/ddr/CMakeLists.txt
+++ b/ddr/CMakeLists.txt
@@ -25,6 +25,11 @@ endif(NOT OMR_DDR)
 
 add_library(omr_ddr_base INTERFACE)
 
+target_link_libraries(omr_ddr_base
+	INTERFACE
+		omr_base
+)
+
 target_include_directories(omr_ddr_base
 	INTERFACE
 		include/

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -30,6 +30,11 @@ target_include_directories(omr_example_base
 		glue
 )
 
+target_link_libraries(omr_example_base
+	INTERFACE
+		omr_base
+)
+
 # The GC example shows how to use OMR's GC component
 if(OMR_GC)
 	add_executable(gcexample

--- a/fvtest/rastest/CMakeLists.txt
+++ b/fvtest/rastest/CMakeLists.txt
@@ -59,19 +59,28 @@ add_library(invalidAgentMissingOnLoad SHARED
 	invalidAgentMissingOnLoad.def
 )
 
+target_link_libraries(invalidAgentMissingOnLoad PUBLIC omr_base)
+
 add_library(invalidAgentMissingOnUnload SHARED
 	invalidAgentMissingOnUnload.c
 	invalidAgentMissingOnUnload.def
 )
+
+target_link_libraries(invalidAgentMissingOnUnload PUBLIC omr_base)
+
 add_library(invalidAgentReturnError SHARED
 	invalidAgentReturnError.c
 	omragent.def
 )
 
+target_link_libraries(invalidAgentReturnError PUBLIC omr_base)
+
 add_library(sampleSubscriber SHARED
 	sampleSubscriber.c
 	omragent.def
 )
+
+target_link_libraries(sampleSubscriber PUBLIC omr_base)
 
 add_library(subscriberAgent SHARED
 	subscriberAgent.c
@@ -90,6 +99,10 @@ add_library(traceOptionAgent SHARED
 	omragent.def
 )
 
+target_link_libraries(traceOptionAgent
+	PUBLIC
+		omr_base
+)
 
 add_executable(omrrastest
 	agentNegativeTest.cpp

--- a/fvtest/util/CMakeLists.txt
+++ b/fvtest/util/CMakeLists.txt
@@ -23,6 +23,12 @@ add_library(omrtestutil STATIC
 	printerrorhelper.cpp
 	testvmhelper.cpp
 )
+
+target_link_libraries(omrtestutil
+	PUBLIC
+		omr_base
+)
+
 if(OMR_WARNINGS_AS_ERRORS)
 	target_compile_options(omrtestutil PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -56,6 +56,16 @@ add_library(omrgc_tracegen OBJECT
 	${CMAKE_CURRENT_BINARY_DIR}/ut_j9vgc.c
 )
 
+target_include_directories(omrgc_tracegen
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_compile_definitions(omrgc_tracegen
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
+)
+
 add_library(omrgc STATIC
 	base/AddressOrderedListPopulator.cpp
 	base/AllocationContext.cpp
@@ -346,6 +356,8 @@ target_include_directories(omrgc
 )
 
 target_link_libraries(omrgc
+	PUBLIC
+		omr_base
 	PRIVATE
 		${OMR_GC_GLUE_TARGET}
 		omrutil

--- a/jitbuilder/CMakeLists.txt
+++ b/jitbuilder/CMakeLists.txt
@@ -123,7 +123,8 @@ target_include_directories(jitbuilder
 )
 
 target_link_libraries(jitbuilder
-	${OMR_PORT_LIB}
+	PUBLIC
+		${OMR_PORT_LIB}
 )
 
 ## JitBuilder examples only work on 64 bit currently.

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -64,6 +64,8 @@ target_include_directories(omrcore
 )
 
 target_link_libraries(omrcore
+	PUBLIC
+		omr_base
 	PRIVATE
 		${OMR_CORE_GLUE_TARGET}
 		${OMR_RAS_GLUE_TARGET}

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -94,6 +94,7 @@ endif()
 
 target_link_libraries(omrsig
 	PRIVATE
+		omr_base
 		omrutil
 )
 

--- a/omrtrace/CMakeLists.txt
+++ b/omrtrace/CMakeLists.txt
@@ -42,8 +42,9 @@ endif()
 
 target_link_libraries(omrtrace
 	PUBLIC
-	${OMR_THREAD_LIB}
-	omrutil
+		omr_base
+		${OMR_THREAD_LIB}
+		omrutil
 )
 #TODO: check if following makefile fragment still required:
 #ifeq (gcc,$(OMR_TOOLCHAIN))

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -35,6 +35,15 @@ add_library(omrport_obj OBJECT
 	ut_omrport.c
 )
 
+target_include_directories(omrport_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_compile_definitions(omrport_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
+)
 
 if(OMR_HOST_OS STREQUAL "aix")
 	list(APPEND OBJECTS omrgetsp.s)
@@ -351,11 +360,13 @@ if(OMR_ENHANCED_WARNINGS)
 endif()
 
 target_link_libraries(omrport
+	PUBLIC
+		omr_base
 	PRIVATE
-	j9avl
-	j9hashtable
-	j9pool
-	${OMR_THREAD_LIB}
+		j9avl
+		j9hashtable
+		j9pool
+		${OMR_THREAD_LIB}
 )
 
 target_include_directories(omrport_obj PRIVATE

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -287,10 +287,22 @@ omr_find_files(resolvedPaths
 )
 
 include_directories(common)
+
 #TODO also should be able to build dynamic lib
+
 add_library(j9thr_obj OBJECT
 	${resolvedPaths}
 	ut_j9thr.c
+)
+
+target_include_directories(j9thr_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_compile_definitions(j9thr_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
 add_library(j9thrstatic STATIC
@@ -311,8 +323,10 @@ target_include_directories(j9thrstatic
 )
 
 target_link_libraries(j9thrstatic
-	j9pool
-	omrutil
+	PUBLIC
+		omr_base
+		j9pool
+		omrutil
+		${OMR_PLATFORM_THREAD_LIBRARY}
 )
 
-target_link_libraries(j9thrstatic ${OMR_PLATFORM_THREAD_LIBRARY})

--- a/util/a2e/CMakeLists.txt
+++ b/util/a2e/CMakeLists.txt
@@ -31,6 +31,11 @@ target_compile_options(j9a2e
 		${OMR_PLATFORM_SHARED_COMPILE_OPTIONS}
 )
 
+target_link_libraries(j9a2e
+	PUBLIC
+		omr_base
+)
+
 if(OMR_WARNINGS_AS_ERRORS)
 	target_compile_options(j9a2e PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()

--- a/util/avl/CMakeLists.txt
+++ b/util/avl/CMakeLists.txt
@@ -31,6 +31,11 @@ add_library(j9avl STATIC
 	ut_avl.c
 )
 
+target_link_libraries(j9avl
+	PUBLIC
+		omr_base
+)
+
 target_include_directories(j9avl
 	PUBLIC
 		$<BUILD_INTERFACE:${OMR_SOURCE_DIR}/include_core>

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -34,6 +34,16 @@ target_include_directories(j9hook_obj
 		.
 )
 
+target_include_directories(j9hook_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_compile_definitions(j9hook_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
+)
+
 add_library(j9hookstatic STATIC
 	$<TARGET_OBJECTS:j9hook_obj>
 )
@@ -52,9 +62,11 @@ target_include_directories(j9hookstatic
 	PUBLIC
 	$<TARGET_PROPERTY:j9hook_obj,INTERFACE_INCLUDE_DIRECTORIES>
 )
-target_link_libraries(j9hookstatic PUBLIC
-	${OMR_PORT_LIB}
-	j9pool
+target_link_libraries(j9hookstatic
+	PUBLIC
+		omr_base
+		${OMR_PORT_LIB}
+		j9pool
 )
 add_tracegen(j9hook.tdf)
 

--- a/util/main_function/CMakeLists.txt
+++ b/util/main_function/CMakeLists.txt
@@ -26,3 +26,8 @@ target_sources(omr_main_function
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}/main_function.cpp
 )
+
+target_link_libraries(omr_main_function
+	INTERFACE
+		omr_base
+)

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -48,6 +48,16 @@ add_library(omrutil_obj OBJECT
 	ut_j9utilcore.c
 )
 
+target_include_directories(omrutil_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_compile_definitions(omrutil_obj
+	PUBLIC
+		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
+)
+
 list(APPEND VPATH .)
 
 if(OMR_ARCH_S390)
@@ -169,8 +179,10 @@ if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(omrutil_obj PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-target_link_libraries(omrutil PUBLIC
-	j9hashtable
+target_link_libraries(omrutil
+	PUBLIC
+		omr_base
+		j9hashtable
 )
 
 set_target_properties(omrutil_obj omrutil PROPERTIES FOLDER util)

--- a/util/pool/CMakeLists.txt
+++ b/util/pool/CMakeLists.txt
@@ -30,6 +30,11 @@ add_library(j9pool STATIC
 	ut_pool.c
 )
 
+target_link_libraries(j9pool
+	PUBLIC
+		omr_base
+)
+
 if(OMR_WARNINGS_AS_ERRORS)
 	target_compile_options(j9pool PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()


### PR DESCRIPTION
OMR uses include_directories and compile_definitions to set up some
basic, universal compile options. The problem is, these only apply to
targets defined in OMR, and will not propagate out to consuming
projects. This patch is a step towards making every OMR component export
all its needed options.

omr_base is an interface library that exports all the core configuration
that most OMR components need. This gives us a centralized location to
configure basic properties of the omr project. omr_base replaces any
usage of include_directories or compile_definitions.

Virtually every library in OMR should link (directly or indirectly)
against omr_base publicly. By doing so, we can count on these properties
correctly propagating out to consuming projects through linking, without
any additional boilerplate on the consumer's end.

Signed-off-by: Robert Young <rwy0717@gmail.com>