### PR TITLE
Guarantee functional correctness of rdbar/wrtbar

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2734,3 +2734,8 @@ void OMR::Compilation::invalidateAliasRegion()
       new (&self()->_aliasRegion) TR::Region(_heapMemoryRegion);
       }
    }
+
+bool OMR::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
+   {
+   return false;
+   }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -544,6 +544,19 @@ public:
    bool hasNativeCall()                         { return _flags.testAny(HasNativeCall); }
    void setHasNativeCall()                      { _flags.set(HasNativeCall); }
 
+   /*
+   * \brief
+   *    This query tells whether the trees might contain rdbar/wrtbar opcodes
+   *    that are not fully supported by optimizer yet
+   *
+   * \note
+   *    This query is for temporarily disable opts not supporting
+   *    the newly added rdbar/wrtbar opcodes. Subprojects can overrite
+   *    the answer. This query should be deleted eventually if
+   *    all the optimizations support the opcodes.
+   */
+   bool incompleteOptimizerSupportForReadWriteBarriers();
+
    // P codegen
    TR::list<TR_PrefetchInfo*> &getExtraPrefetchInfo() { return _extraPrefetchInfo; }
    TR_PrefetchInfo *findExtraPrefetchInfo(TR::Node * node, bool use = true);

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -600,13 +600,17 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::iuload: return TR::iustore;
       case TR::iuloadi: return TR::iustorei;
       case TR::luloadi: return TR::lustorei;
-      case TR::brdbari: return TR::bwrtbari;
-      case TR::srdbari: return TR::swrtbari;
-      case TR::irdbari: return TR::iwrtbari;
-      case TR::lrdbari: return TR::lwrtbari;
-      case TR::frdbari: return TR::fwrtbari;
-      case TR::drdbari: return TR::dwrtbari;
-      case TR::ardbari: return TR::awrtbari;
+      case TR::brdbari:
+      case TR::srdbari:
+      case TR::irdbari:
+      case TR::lrdbari:
+      case TR::frdbari:
+      case TR::drdbari:
+      case TR::ardbari:
+         //There is not necessarily a guaranteed symmetry about whether an indirect rdbar should be mapped to
+         //an indirect wrtbar or a normal indirect store. The mapping of rdbar/ wrtbar totally depends on the
+         //actual use in subprojects and should be undefined in OMR level.
+         TR_ASSERT_FATAL(0, "xrdbari can't be used with global opcode mapping API at OMR level\n");
       default: break;
       }
 
@@ -628,13 +632,23 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::fstorei:  return TR::floadi;
       case TR::dstorei:  return TR::dloadi;
       case TR::astorei:  return TR::aloadi;
-      case TR::awrtbari:  return TR::aloadi;
+      case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
-      case TR::cstorei: return TR::cloadi;
+      case TR::cstorei:  return TR::cloadi;
       case TR::bustorei: return TR::buloadi;
-      case TR::iustore: return TR::iuload;
+      case TR::iustore:  return TR::iuload;
       case TR::iustorei: return TR::iuloadi;
       case TR::lustorei: return TR::luloadi;
+      case TR::bwrtbari:
+      case TR::swrtbari:
+      case TR::iwrtbari:
+      case TR::lwrtbari:
+      case TR::fwrtbari:
+      case TR::dwrtbari:
+         //There is not necessarily a guaranteed symmetry about whether an indirect wrtbar should be mapped to
+         //an indirect rdbar or a normal indirect load. The mapping of rdbar/wrtbar totally depends on the
+         //actual use in subprojects and should be undefined in OMR level.
+         TR_ASSERT_FATAL(0, "xwrtbari can't be used with global opcode mapping API at OMR level\n");
 
       default: break;
       }

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -85,6 +85,15 @@ TR_FieldPrivatizer::TR_FieldPrivatizer(TR::OptimizationManager *manager)
 
 int32_t TR_FieldPrivatizer::perform()
    {
+
+   // Need to confirm places calling opCodeFor* APIs are doing the right
+   // thing for readbar and wrtbar. All the transformations applied to normal
+   // load/store s should be applied to rd/wrtbar s. However, we need to be
+   // careful about the difference in the shape of the trees and the
+   // mapping relationship between different loads and stores
+   if (comp()->incompleteOptimizerSupportForReadWriteBarriers())
+      return 0;
+
    TR::StackMemoryRegion stackMemoryRegion(*trMemory());
 
    _postDominators = NULL;

--- a/compiler/optimizer/PartialRedundancy.cpp
+++ b/compiler/optimizer/PartialRedundancy.cpp
@@ -230,6 +230,14 @@ int32_t TR_PartialRedundancy::perform()
    if (comp()->getProfilingMode() == JitProfiling && comp()->getHCRMode() != TR::none && _numProfilingsAllowed == 0)
       return 0;
 
+   // Need to confirm places calling opCodeFor* APIs are doing the right
+   // thing for readbar and wrtbar. All the transformations applied to normal
+   // load/store s should be applied to rd/wrtbar s. However, we need to be
+   // careful about the difference in the shape of the trees and the
+   // mapping relationship between different loads and stores.
+   if (comp()->incompleteOptimizerSupportForReadWriteBarriers())
+      return 0;
+
    TR::StackMemoryRegion stackMemoryRegion(*trMemory());
 
    // setAlteredCode(false);


### PR DESCRIPTION
Map rdbar/wrtbars to corresponding opcode to normal opcode to keep
consistency with the existing wrtbar opcode. Subprojects can overwrite
the mapping decisions.

PRE and FieldPrivatizer are disabled for now if the trees might contain
newly added rdbar/wrtbar. All the transformations applied to normal
load/write s should be applied to rd/wrtbar s. However, we need to
be careful about the difference in the shape of the trees and the
mapping relationship between different loads and writes. More
investigation is needed to make sure those 2 opts would do the right
thing for rdbar/wrtbars.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>