### PR TITLE
Enable specialized arraycopy trees for 31-Bit Z platform

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -666,6 +666,12 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setSupportsBCDToDFPReduction();
    self()->setSupportsIntDFPConversions();
 
+   // On 31-Bit zOS/zLinux We rely on optimizer to generate array copy trees specialized for direction
+   if (TR::Compiler->target.is32Bit())
+      {
+      self()->setSupportsPostProcessArrayCopy();
+      }
+
    if (_processorInfo.supportsArch(TR_S390ProcessorInfo::TR_z10))
       {
       self()->setSupportsTranslateAndTestCharString();

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13663,23 +13663,23 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
    else
       {
       // We need to decide direction of array copy at runtime.
-      TR::LabelSymbol *forwardArrayCopyLabel = generateLabelSymbol(cg);
-      cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, byteSrcReg, byteDstReg, TR::InstOpCode::COND_BNL, forwardArrayCopyLabel, false);
-      iComment("if byteSrcPointer >= byteDstPointer then GoTo forwardArrayCopy");
-      
       if (isConstantByteLen)
          {
          generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
          cFlowRegionStart->setStartInternalControlFlow();
          }
+      TR::LabelSymbol *forwardArrayCopyLabel = generateLabelSymbol(cg);
+      cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, byteSrcReg, byteDstReg, TR::InstOpCode::COND_BNL, forwardArrayCopyLabel, false);
+      iComment("if byteSrcPointer >= byteDstPointer then GoTo forwardArrayCopy");
+      
 
       TR::Register *checkBoundReg = srm->findOrCreateScratchRegister();
       if (byteLenReg == NULL)
          {
          byteLenReg = cg->gprClobberEvaluate(byteLenNode);
          }
-      cursor = generateRRRInstruction(cg, TR::InstOpCode::getAddThreeRegOpCode(), node, checkBoundReg, byteSrcReg, byteLenReg); 
-      iComment("lastElementToCopy=byteSrcPointer+lengthInBytes");
+      cursor = generateRXInstruction(cg, TR::InstOpCode::LA, node, checkBoundReg, generateS390MemoryReference(byteSrcReg, byteLenReg, 0, cg));
+      iComment("nextPointerToLastElement=byteSrcPointer+lengthInBytes");
       
       TR::LabelSymbol *backwardArrayCopyLabel = generateLabelSymbol(cg);
       cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, checkBoundReg, byteDstReg, TR::InstOpCode::COND_BH, backwardArrayCopyLabel, false);


### PR DESCRIPTION
This commit contains following changes.
1. Enable Specialized direction trees for arraycopy for 31-Bit IBM Z platform.
2. Minor changes to instruction used for array copy trees

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>