### PR TITLE
Simplify instanceof/guard type constraint creation

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -8998,169 +8998,67 @@ static void removeConditionalBranch(OMR::ValuePropagation *vp, TR::Node *node, T
       vp->_edgesToBeRemoved->add(branchEdge);
    }
 
-// check for compatibility between types
-//
+// Constrain objects that pass a type test, given a constraint on the class
+// against which the object is to be tested.
 static TR::VPConstraint*
-genTypeResult(OMR::ValuePropagation *vp, TR::VPConstraint *objectRefConstraint,
-               TR::VPConstraint *classConstraint, bool &applyType, bool isInstanceOf)
+passingTypeTestObjectConstraint(
+   OMR::ValuePropagation *vp,
+   TR::VPConstraint *classConstraint,
+   bool testingForFixedType)
    {
-   TR::VPConstraint *newConstraint = NULL;
-   if (objectRefConstraint)
+   TR_ASSERT_FATAL(
+      classConstraint->isClassObject() == TR_yes,
+      "expected a instanceof classConstraint to be a 'ClassObject'");
+
+   TR::VPClassType *type = classConstraint->getClassType();
+   TR_ASSERT_FATAL(
+      type != NULL,
+      "expected instanceof classConstraint to have a type");
+
+   // Even if we know the exact type tested against, objects passing the type
+   // test may be instances of derived classes, so relax to a bound.
+   if (!testingForFixedType && type->isFixedClass())
       {
-      if (vp->trace())
-            traceMsg(vp->comp(), "Preempting type intersection..\n");
-      TR::VPClass *instanceClass = classConstraint->asClass();
-      TR::VPClassPresence *presence = classConstraint->getClassPresence();
-      TR::VPClassType *type = classConstraint->getClassType();
-      if (instanceClass)
-         {
-         TR::VPClassType *newType;
-         // dilute the type because don't want to get the 'fixed' property
-         if (type && type->asFixedClass())
-            newType = TR::VPResolvedClass::create(vp, type->getClass());
-         else
-            newType = type;
-         bool castIsClassObject = false;
-         bool castIsInterfaceImplementedByClass = false;
-
-         // determine if the instanceClass is a java/lang/Class
-         // if so, then the result constraint can only claim to
-         // be a classObject
-         //
-         if (type && type->asResolvedClass())
-            {
-            TR::VPResolvedClass *rc = type->asResolvedClass();
-            TR_OpaqueClassBlock *jlClass = vp->fe()->getClassClassPointer(rc->getClass());
-            if (jlClass)
-               {
-               applyType = true;
-               if (rc->getClass() == jlClass)
-                  castIsClassObject = true;
-               else if (rc->isClassObject() == TR_maybe)
-                  castIsInterfaceImplementedByClass = true;
-               }
-            else
-               applyType = false;
-            }
-
-         // check if the two types are compatible
-         //
-         instanceClass->typeIntersect(presence, newType, objectRefConstraint, vp);
-
-         // intersections failed?
-         //
-         if (!presence && objectRefConstraint->getClassPresence() && instanceClass->getClassPresence())
-            newConstraint = NULL;
-         else if (!newType && objectRefConstraint->getClassType() && instanceClass->getClassType())
-            {
-            if (applyType)
-               newConstraint = NULL;
-            }
-
-         // one of the types could be null
-         else if (presence && presence->isNullObject())
-            newConstraint = presence;
-         else if (isInstanceOf &&
-                  !objectRefConstraint->getClassType() &&
-                  !castIsClassObject && !castIsInterfaceImplementedByClass &&
-                  objectRefConstraint->isNonNullObject() &&
-                     (objectRefConstraint->isClassObject() == TR_yes))
-            {
-            // objectRefconstraint does not have a type and only
-            // has a classObject property i.e.
-            // <classObject> intersecting with
-            // <classObject, type, non-null>
-            //
-            // if the castClass type is not java/lang/Class (or one of the interfaces
-            // implemented by it) and VP is analyzing an instanceof, then the types cannot
-            // possibly be related - so the result should indicate incompatibility.
-            // in other cases (equality or inequality) the result is not known.
-            //
-            newConstraint = NULL;
-            }
-         else
-            {
-            TR::VPObjectLocation *loc = NULL;
-            if (castIsClassObject)
-               {
-               // the object could have no type to begin with,
-               // if so, do *not* create the specialClass constraint
-               //
-               if (objectRefConstraint->getClassType())
-                  newType = TR::VPResolvedClass::create(vp, (TR_OpaqueClassBlock *)VP_SPECIALKLASS);
-               else
-                  newType = NULL;
-               }
-            else if (castIsInterfaceImplementedByClass)
-               {
-               // dont want to propagate the interface implemented by Class
-               // as the type if the object is a classobject
-               if (objectRefConstraint->isClassObject() == TR_yes)
-                  newType = NULL;
-               }
-
-            // inject a classObject property on the constraint
-            if ((objectRefConstraint && (objectRefConstraint->isClassObject() == TR_yes)) ||
-                  castIsClassObject)
-               loc = TR::VPObjectLocation::create(vp, TR::VPObjectLocation::ClassObject);
-
-            // final construction
-            newConstraint = TR::VPClass::create(vp, newType, presence, NULL, NULL, loc);
-            }
-         }
+      // Note: if type->getClass() is final, this will still result in a
+      // fixed-class constraint, but that's fine.
+      type = TR::VPResolvedClass::create(vp, type->getClass());
       }
-   else
+
+   // Use the signature to check whether type is java/lang/Class exactly. We
+   // can't rely on isJavaLangClassObject() because it returns TR_maybe in this
+   // case. (If it were to return TR_yes, it would mean the referent is a
+   // java/lang/Class representing java/lang/Class, i.e. Class.class, which
+   // would be incorrect in this case.)
+   TR::VPObjectLocation *loc = NULL;
+   int sigLen;
+   const char *sig = type->getClassSignature(sigLen);
+   if (sig != NULL && sigLen == 17 && !strncmp(sig, "Ljava/lang/Class;", sigLen))
       {
-      if (vp->trace())
-         traceMsg(vp->comp(), "ObjectRef has no constraint, so applying cast class properties...\n");
-
-      TR::VPClassType *newType = NULL;
-      bool castIsClassObject = false;
-      if (classConstraint->getClassType()->asResolvedClass())
-         {
-         // check if cast class is a java/lang/Class type
-         //
-         TR_OpaqueClassBlock *klass = classConstraint->getClassType()->getClass();
-         TR_OpaqueClassBlock *jlClass = vp->fe()->getClassClassPointer(klass);
-         if (jlClass)
-            {
-            applyType = true;
-            if (klass == jlClass)
-               {
-               newType = NULL;
-               castIsClassObject = true;
-               }
-            else
-               newType = TR::VPResolvedClass::create(vp, classConstraint->getClass());
-            }
-         else
-            applyType = false;
-         }
-      else
-         {
-         newType = classConstraint->getClassType();
-         applyType = true;
-         }
-      if (applyType)
-         {
-         TR::VPObjectLocation *loc = NULL;
-         if (castIsClassObject)
-            loc = TR::VPObjectLocation::create(vp, TR::VPObjectLocation::JavaLangClassObject);
-
-         newConstraint = TR::VPClass::create(vp, newType,
-                                          classConstraint->getClassPresence(), NULL, NULL, loc);
-         TR_ASSERT(newConstraint, "newConstraint cannot be NULL\n");
-         }
+      // Just say that it's a java/lang/Class, with no information about the
+      // class that it represents.
+      type = NULL;
+      loc = TR::VPObjectLocation::create(
+         vp,
+         TR::VPObjectLocation::JavaLangClassObject);
       }
+
+   // Objects passing any kind of instanceof are non-null:
+   // - instanceof itself is only true for non-null objects.
+   // - In a more direct type test that unconditionally loads the VFT
+   //   pointer, the object must be non-null even if it's a different type.
+   TR::VPNonNullObject *nonnull = TR::VPNonNullObject::create(vp);
+   TR::VPConstraint *newConstraint =
+      TR::VPClass::create(vp, type, nonnull, NULL, NULL, loc);
+
+   TR_ASSERT_FATAL(newConstraint != NULL, "failed to create constraint");
+
    if (vp->trace())
       {
-      traceMsg(vp->comp(), "genTypeResult returning constraint: ");
-      if (newConstraint == NULL)
-         traceMsg(vp->comp(), "none (generalized?)");
-      else
-         newConstraint->print(vp->comp(), vp->comp()->getOutFile());
+      traceMsg(vp->comp(), "passingTypeTestObjectConstraint returning constraint: ");
+      newConstraint->print(vp->comp(), vp->comp()->getOutFile());
       traceMsg(vp->comp(), "\n");
       }
+
    return newConstraint;
    }
 
@@ -9610,7 +9508,6 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
    TR::VPConstraint *instanceofConstraint = NULL;
    TR::Node         *instanceofObjectRef = NULL;
    bool             instanceofOnBranch = false;
-   bool instanceofDetected = false;
    bool instanceofDetectedAndFixedType = false;
    bool isInstanceOf = false;
 
@@ -9626,7 +9523,6 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
          if (classConstraint && classConstraint->getClassType())
             {
             instanceofConstraint = classConstraint;
-            instanceofDetected = true;
             isInstanceOf = true;
             if (value ^ (int32_t)branchOnEqual)
                instanceofOnBranch = false;
@@ -9688,7 +9584,6 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
                      {
                      instanceofConstraint = classConstraint;
                      instanceofDetectedAndFixedType = true;
-                     instanceofDetected = true;
                      //printf("Reached here in %s\n", signature(vp->comp()->getCurrentMethod()));
                      if (node->getOpCodeValue() == TR::ifacmpne)
                         instanceofOnBranch = false;
@@ -9866,90 +9761,17 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
 
    if (instanceofConstraint && instanceofOnBranch)
       {
-      if (instanceofDetected)
+      TR::VPConstraint *newConstraint = passingTypeTestObjectConstraint(
+         vp,
+         instanceofConstraint,
+         instanceofDetectedAndFixedType);
+
+      if (!isVirtualGuardNopable
+          && !vp->addEdgeConstraint(instanceofObjectRef, newConstraint, edgeConstraints))
          {
-         bool isGlobal;
-         TR::VPConstraint *newConstraint = NULL;
-         TR::VPConstraint *objectRefConstraint = vp->getConstraint(instanceofObjectRef, isGlobal);
-         if (objectRefConstraint)
-            {
-            TR::VPClass *instanceClass = instanceofConstraint->asClass();
-            TR_ASSERT(instanceClass, "Cast class must be a VPClass wrapper\n");
-            if (instanceClass)
-               {
-               // AOT returns NULL for getClassClass currently,
-               // so don't propagate type
-               bool applyType = true;
-               bool removeBranch = false;
-               newConstraint = genTypeResult(vp, objectRefConstraint, instanceClass, applyType, isInstanceOf);
-
-               TR::VPConstraint *newTypeConstraint = newConstraint;
-               if (newTypeConstraint && !newTypeConstraint->asClassType() && newTypeConstraint->asClass())
-                  newTypeConstraint = newTypeConstraint->asClass()->getClassType();
-               else if (newTypeConstraint && !newTypeConstraint->asClassType())
-                  newTypeConstraint = NULL;
-
-               if (newTypeConstraint && instanceofDetectedAndFixedType &&
-                   newTypeConstraint->asResolvedClass() && !newTypeConstraint->asFixedClass())
-                  {
-                  TR_OpaqueClassBlock *clazz = newTypeConstraint->asResolvedClass()->getClass();
-                  if (clazz)
-                     {
-                     TR::VPFixedClass *newFixedConstraint = TR::VPFixedClass::create(vp, clazz);
-                     newConstraint = newConstraint->intersect(newFixedConstraint, vp);
-                     }
-                  }
-
-               if (!newConstraint && applyType)
-                  removeBranch = true;
-               else if (newConstraint && !isVirtualGuardNopable &&
-                           !vp->addEdgeConstraint(instanceofObjectRef, newConstraint, edgeConstraints))
-                  removeBranch = true;
-
-               if (removeBranch)
-                  {
-                  if (!vp->intersectionFailed())
-                     cannotBranch = true;
-                  else
-                     vp->setIntersectionFailed(false);
-                  }
-               }
-            }
-         else
-            {
-            bool applyType = true;
-            newConstraint = genTypeResult(vp, objectRefConstraint, instanceofConstraint, applyType, isInstanceOf);
-
-            TR::VPConstraint *newTypeConstraint = newConstraint;
-            if (newTypeConstraint && !newTypeConstraint->asClassType() && newTypeConstraint->asClass())
-                newTypeConstraint = newTypeConstraint->asClass()->getClassType();
-            else if (newTypeConstraint && !newTypeConstraint->asClassType())
-               newTypeConstraint = NULL;
-
-            if (newTypeConstraint && instanceofDetectedAndFixedType &&
-                newTypeConstraint->asResolvedClass() && !newTypeConstraint->asFixedClass())
-               {
-               TR_OpaqueClassBlock *clazz = newTypeConstraint->asResolvedClass()->getClass();
-               if (clazz)
-                  {
-                  TR::VPFixedClass *newFixedConstraint = TR::VPFixedClass::create(vp, clazz);
-                  newConstraint = newConstraint->intersect(newFixedConstraint, vp);
-                  }
-               }
-
-            if (applyType && !isVirtualGuardNopable &&
-                  !vp->addEdgeConstraint(instanceofObjectRef, newConstraint, edgeConstraints))
-               {
-               if (!vp->intersectionFailed())
-                  cannotBranch = true;
-               else
-                  vp->setIntersectionFailed(false);
-               }
-            }
-         }
-      ///if (!vp->addEdgeConstraint(instanceofObjectRef, instanceofConstraint, edgeConstraints))
-      else if (!vp->addEdgeConstraint(instanceofObjectRef, instanceofConstraint, edgeConstraints))
+         TR_ASSERT_FATAL(!vp->intersectionFailed(), "VP intersection error");
          cannotBranch = true;
+         }
       }
 
 
@@ -10057,87 +9879,17 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
 
    if (instanceofConstraint && !instanceofOnBranch)
       {
-      if (instanceofDetected)
+      TR::VPConstraint *newConstraint = passingTypeTestObjectConstraint(
+         vp,
+         instanceofConstraint,
+         instanceofDetectedAndFixedType);
+
+      if (!isVirtualGuardNopable
+          && !vp->addBlockConstraint(instanceofObjectRef, newConstraint, NULL, false))
          {
-         bool isGlobal;
-         TR::VPConstraint *newConstraint = NULL;
-         TR::VPConstraint *objectRefConstraint = vp->getConstraint(instanceofObjectRef, isGlobal);
-         if (objectRefConstraint)
-            {
-            TR::VPClass *instanceClass = instanceofConstraint->asClass();
-            TR_ASSERT(instanceClass, "Cast class must be a VPClass wrapper\n");
-            if (instanceClass)
-               {
-               // AOT returns NULL for getClassClass currently,
-               // so don't propagate type
-               bool applyType = true;
-               bool removeBranch = false;
-               newConstraint = genTypeResult(vp, objectRefConstraint, instanceClass, applyType, isInstanceOf);
-
-               TR::VPConstraint *newTypeConstraint = newConstraint;
-               if (newTypeConstraint && !newTypeConstraint->asClassType() && newTypeConstraint->asClass())
-                  newTypeConstraint = newTypeConstraint->asClass()->getClassType();
-               else if (newTypeConstraint && !newTypeConstraint->asClassType())
-                  newTypeConstraint = NULL;
-
-               if (newTypeConstraint && instanceofDetectedAndFixedType &&
-                   newTypeConstraint->asResolvedClass() && !newTypeConstraint->asFixedClass())
-                  {
-                  TR_OpaqueClassBlock *clazz = newTypeConstraint->asResolvedClass()->getClass();
-                  if (clazz)
-                     {
-                     TR::VPFixedClass *newFixedConstraint = TR::VPFixedClass::create(vp, clazz);
-                     newConstraint = newConstraint->intersect(newFixedConstraint, vp);
-                     }
-                  }
-
-               if (!newConstraint && applyType)
-                  removeBranch = true;
-               else if (newConstraint && !isVirtualGuardNopable &&
-                           !vp->addBlockConstraint(instanceofObjectRef, newConstraint, NULL, false))
-                  removeBranch = true;
-               if (removeBranch)
-                  {
-                  if (!vp->intersectionFailed())
-                     cannotFallThrough = true;
-                  else
-                     vp->setIntersectionFailed(false);
-                  }
-               }
-            }
-         else
-            {
-            bool applyType = true;
-            newConstraint = genTypeResult(vp, objectRefConstraint, instanceofConstraint, applyType, isInstanceOf);
-            TR::VPConstraint *newTypeConstraint = newConstraint;
-            if (newTypeConstraint && !newTypeConstraint->asClassType() && newTypeConstraint->asClass())
-               newTypeConstraint = newTypeConstraint->asClass()->getClassType();
-            else if (newTypeConstraint && !newTypeConstraint->asClassType())
-               newTypeConstraint = NULL;
-
-            if (newTypeConstraint && instanceofDetectedAndFixedType &&
-                newTypeConstraint->asResolvedClass() && !newTypeConstraint->asFixedClass())
-               {
-               TR_OpaqueClassBlock *clazz = newTypeConstraint->asResolvedClass()->getClass();
-               if (clazz)
-                  {
-                  TR::VPFixedClass *newFixedConstraint = TR::VPFixedClass::create(vp, clazz);
-                  newConstraint = newConstraint->intersect(newFixedConstraint, vp);
-                  }
-               }
-
-            if (applyType && !isVirtualGuardNopable &&
-                  !vp->addBlockConstraint(instanceofObjectRef, newConstraint, NULL, false))
-               {
-               if (!vp->intersectionFailed())
-                  cannotFallThrough = true;
-               else
-                  vp->setIntersectionFailed(false);
-               }
-            }
-         }
-      else if (!vp->addBlockConstraint(instanceofObjectRef, instanceofConstraint, NULL, false))
+         TR_ASSERT_FATAL(!vp->intersectionFailed(), "VP intersection error");
          cannotFallThrough = true;
+         }
       }
 
    if (virtualGuardConstraint && virtualGuardWillBeEliminated)


### PR DESCRIPTION
...where genTypeResult() was used.

Rather than attempt not to intersect constraints, this logic now simply
generates the constraint for objects that pass the type test, and tries
to add that constraint on the appropriate path, implicitly intersecting
it with any pre-existing constraint. The branch can be folded away if
one of the paths is found to be unreachable due to an empty constraint
intersection.

The previous logic could sometimes fold away a profiled guard against
java/lang/Class even in the absence of any other type information,
generating an unconditional goto to the taken side (fall-back path),
which is functionally correct but undesirable. This now only happens
when an existing type constraint precludes the object from being an
instance of java/lang/Class.