### PR TITLE
Misc startup/shutdown fixes for Concurrent Scavenger

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1234,6 +1234,15 @@ public:
 		, _masterThreadTenureTLHRemainderTop(NULL)
 #endif /* OMR_GC_MODRON_SCAVENGER */
 		, environments(NULL)
+		, excessiveGCStats()
+#if defined(OMR_GC_MODRON_STANDARD) || defined(OMR_GC_REALTIME)
+		, globalGCStats()
+#endif /* OMR_GC_MODRON_STANDARD || OMR_GC_REALTIME */
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		, incrementScavengerStats()
+		, scavengerStats()
+		, copyScanRatio()
+#endif /* OMR_GC_MODRON_SCAVENGER */		
 #if defined(OMR_GC_CONCURRENT_SWEEP)
 		, concurrentSweep(false)
 #endif /* OMR_GC_CONCURRENT_SWEEP */

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -280,6 +280,14 @@ MM_Scavenger::initialize(MM_EnvironmentBase *env)
 
 	_cacheLineAlignment = CACHE_LINE_SIZE;
 
+#if defined(OMR_GC_CONCURRENT_SCAVENGER)
+	if (_extensions->concurrentScavenger) {
+		if (!_masterGCThread.initialize(this, true, true)) {
+			return false;
+		}
+	}
+#endif /* OMR_GC_CONCURRENT_SCAVENGER */
+
 	return true;
 }
 
@@ -313,9 +321,6 @@ MM_Scavenger::collectorStartup(MM_GCExtensionsBase* extensions)
 {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavenger) {
-		if (!_masterGCThread.initialize(this, true, true)) {
-			return false;
-		}
 		if (!_masterGCThread.startup()) {
 			return false;
 		}

--- a/gc/structs/SublistPool.hpp
+++ b/gc/structs/SublistPool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,7 @@ public:
  */
 private:
 	MM_SublistPuddle *createNewPuddle(MM_EnvironmentBase *env);
+	void freePuddles(MM_EnvironmentBase *env, MM_SublistPuddle *list);
 
 protected:
 public:


### PR DESCRIPTION
- explicitly call default constructor for various stats structs in
GCExtensions 
- initialize MasterGCThread struct earlier, so that Scavenge can be
triggered on early Nursery Allocation Failure (with small Xms/Xmns),
rather then fullfilling the request from Tenure (and slowing down the
startup) 
- on shutdown free up previous RS list, too. It will be non-empty, if
shutdown is requested in a middle of CS cycle

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>