### PR TITLE
VGC: report Concurrent Scavenger phase termination

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4947,7 +4947,8 @@ MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 		_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
 
 		/* Now that we are done with concurrent scanning in this cycle (where we could possibly
-		 * be interested in its value), reset this flag */
+		 * be interested in its value), record the flag for reporting purposes and reset it. */
+		getConcurrentPhaseStats()->_terminationWasRequested = _shouldYield;
 		_shouldYield = false;
 
 		/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -454,7 +454,7 @@ public:
 	void handleConcurrentEnd(J9HookInterface** hook, UDATA eventNum, void* eventData);
 	
 	virtual	void handleConcurrentStartInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
-	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData) {}
+	virtual void handleConcurrentEndInternal(J9HookInterface** hook, UDATA eventNum, void* eventData);
 	virtual const char *getConcurrentTypeString() { return NULL; }
 	
 	virtual void handleConcurrentGCOpStart(J9HookInterface** hook, uintptr_t eventNum, void* eventData) {}

--- a/gc/verbose/schema.xsd
+++ b/gc/verbose/schema.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2010, 2016 IBM Corp. and others
+Copyright (c) 2010, 2018 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -612,6 +612,8 @@ xmlns:vgc="http://www.ibm.com/j9/verbosegc">
 	<complexType name="concurrent-end">
 		<sequence>
 			<element ref="vgc:concurrent-mark-end" maxOccurs="1" minOccurs="1" />
+			<element ref="vgc:warning" maxOccurs="unbounded" minOccurs="0" />
+			<element ref="vgc:gc-op" maxOccurs="1" minOccurs="0" />
 		</sequence>
 		<attribute name="id" type="integer" use="required" />
 		<attribute name="type" type="string" use="required" />


### PR DESCRIPTION
If concurrent phase is prematurely terminated, a warning message is
reported by verbose GC.

Distinguish (for now) between:
- externally requested termination (JVMTI and similar)
- GC requested (exhausted allocate/survivor, global STW, etc.)

Example of exhausted allocate/survivor:


```
<concurrent-end id="13810" type="scavenge" contextid="13800"
timestamp="2018-11-23T18:07:54.482">
<warning details="termination requested by GC" />  <<<<<<<<<<<<<<<<<<<<
<gc-op id="13811" type="scavenge" timems="9.128"
contextid="13800" timestamp="2018-11-23T18:07:54.482">
  <memory-copied type="nursery" objects="46034"
bytes="7511576" bytesdiscarded="142136" />
  <memory-copied type="tenure" objects="458" bytes="17376"
bytesdiscarded="496" />
  <copy-failed type="nursery" objects="49" bytes="3624" />
</gc-op>
</concurrent-end>

<exclusive-start id="13812"
timestamp="2018-11-23T18:07:54.482" intervalms="13.230">
  <response-info timems="2.577" idlems="0.784" threads="3"
lastid="000000000141C500" lastname="AbstractDriver Thread Spawner for
jobset Mauve" />
</exclusive-start>
<af-start id="13813" threadId="0000000001FFB088"
totalBytesRequested="48" timestamp="2018-11-23T18:07:54.483"
intervalms="13.249" type="nursery" />
<gc-start id="13814" type="scavenge" contextid="13800"
timestamp="2018-11-23T18:07:54.484">
  <mem-info id="13815" free="45614456" total="241762304"
percent="18">
    <mem type="nursery" free="0" total="140247040"
percent="0">
      <mem type="allocate/survivor" free="0"
total="14024704" percent="0" />      <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
      <mem type="evacuate" free="0" total="126222336"
percent="0" />
    </mem>
   
```

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>