### PR TITLE
Remove deprecated reg-reg mov instruction list on X86

### DIFF
--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -889,22 +889,6 @@ void TR::X86RegRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
 
       bool regRegCopy = isRegRegMove();
       TR_X86OpCodes opCode = getOpCodeValue();
-      static char* useOutOfDateRegRegMoveList = feGetEnv("TR_UseOutOfDateRegRegMoveList");
-      if (useOutOfDateRegRegMoveList)
-         {
-         if (opCode == MOVAPSRegReg ||
-             opCode == MOV8RegReg   ||
-             opCode == MOV4RegReg   ||
-             opCode == MOV2RegReg   ||
-             opCode == MOV1RegReg)
-            {
-            regRegCopy = true;
-            }
-         else
-            {
-            regRegCopy = false;
-            }
-         }
 
       if (getDependencyConditions())
          {


### PR DESCRIPTION
Out-of-dated reg-reg mov instruction list has been deprecated, removing.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>