### PR TITLE
Rename OMR::X86::Machine::getX86RealRegister()

### DIFF
--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -616,7 +616,7 @@ int32_t TR::AMD64SystemLinkage::buildArgs(
    TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
    TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
    TR::RealRegister::RegNum noReg = TR::RealRegister::NoReg;
-   TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
    int32_t firstNodeArgument = callNode->getFirstArgumentIndex();
    int32_t lastNodeArgument = callNode->getNumChildren() - 1;
    int32_t offset = 0;
@@ -849,7 +849,7 @@ TR::Register *TR::AMD64SystemLinkage::buildDirectDispatch(
          generateX86MemoryReference(frameObjectSymRef, cg()),
          cg());
 
-   TR::RealRegister *espReal = cg()->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = cg()->machine()->getRealRegister(TR::RealRegister::esp);
    TR::Register *gcMapPCRegister = cg()->allocateRegister();
 
    generateRegMemInstruction(

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -57,7 +57,7 @@ class AMD64SystemLinkage : public TR::X86SystemLinkage
 
    TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
 
-   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() { return machine()->getX86RealRegister(TR::RealRegister::r11); }
+   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() { return machine()->getRealRegister(TR::RealRegister::r11); }
 
    private:
    bool layoutTypeInRegs(TR::DataType type, uint16_t &intReg, uint16_t &floatReg, TR::parmLayoutResult&);

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
 
    self()->initLinkageToGlobalRegisterMap();
 
-   self()->setRealVMThreadRegister(self()->machine()->getX86RealRegister(TR::RealRegister::ebp));
+   self()->setRealVMThreadRegister(self()->machine()->getRealRegister(TR::RealRegister::ebp));
 
    // GRA-related initialization is done after calling initialize() so we can
    // use such things as getNumberOfGlobal[FG]PRs().

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -1193,7 +1193,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbo
       TR::Register        *doubleReg = cg->evaluate(child);
       TR::Register        *lowReg    = cg->allocateRegister(TR_GPR);
       TR::Register        *highReg   = cg->allocateRegister(TR_GPR);
-      TR::RealRegister *espReal   = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+      TR::RealRegister *espReal   = cg->machine()->getRealRegister(TR::RealRegister::esp);
 
       deps = generateRegisterDependencyConditions((uint8_t) 0, 3, cg);
       deps->addPostCondition(lowReg, TR::RealRegister::NoReg, cg);

--- a/compiler/x/codegen/HelperCallSnippet.cpp
+++ b/compiler/x/codegen/HelperCallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -257,7 +257,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
 
          *buffer = 0x50;
          TR_ASSERT(deps, "null dependencies on restart label of helper call snippet with register args");
-         cg()->machine()->getX86RealRegister(deps->getPostConditions()->getRegisterDependency(registerArgs++)->getRealRegister())->setRegisterFieldInOpcode(buffer++);
+         cg()->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(registerArgs++)->getRealRegister())->setRegisterFieldInOpcode(buffer++);
          }
       }
 
@@ -397,7 +397,7 @@ TR_Debug::printBody(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet, uin
             printPrefix(pOutFile, NULL, bufferPos, 1);
             trfprintf(pOutFile, "push\t");
             TR_ASSERT( deps, "null dependencies on restart label of helper call snippet with register args");
-            print(pOutFile, _cg->machine()->getX86RealRegister(deps->getPostConditions()->getRegisterDependency(registerArgs++)->getRealRegister()), TR_WordReg);
+            print(pOutFile, _cg->machine()->getRealRegister(deps->getPostConditions()->getRegisterDependency(registerArgs++)->getRealRegister()), TR_WordReg);
             bufferPos++;
             }
          }

--- a/compiler/x/codegen/IA32LinkageUtils.cpp
+++ b/compiler/x/codegen/IA32LinkageUtils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -214,7 +214,7 @@ TR::Register *IA32LinkageUtils::pushFloatArg(
    }
 
    pushRegister = cg->evaluate(child);
-   TR::RealRegister *espReal = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    generateRegImmInstruction(SUB4RegImms, child, espReal, 4, cg);
 
    if (cg->useSSEForSinglePrecision() && pushRegister->getKind() == TR_FPR)
@@ -283,7 +283,7 @@ TR::Register *IA32LinkageUtils::pushDoubleArg(
       }
 
    pushRegister = cg->evaluate(child);
-   TR::RealRegister *espReal = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
    generateRegImmInstruction(SUB4RegImms, child, espReal, 8, cg);
 
    if (cg->useSSEForSinglePrecision() && pushRegister->getKind() == TR_FPR)

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -333,13 +333,13 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    // Use a virtual frame pointer register.  The real frame pointer register to be used
    // will be substituted based on _vfpState during size estimation.
    //
-   _frameRegister = self()->machine()->getX86RealRegister(TR::RealRegister::vfp);
+   _frameRegister = self()->machine()->getRealRegister(TR::RealRegister::vfp);
 
    TR::Register            *vmThreadRegister = self()->setVMThreadRegister(self()->allocateRegister());
    TR::RealRegister::RegNum vmThreadIndex    = _linkageProperties->getMethodMetaDataRegister();
    if (vmThreadIndex != TR::RealRegister::NoReg)
       {
-      TR::RealRegister *vmThreadReal = self()->machine()->getX86RealRegister(vmThreadIndex);
+      TR::RealRegister *vmThreadReal = self()->machine()->getRealRegister(vmThreadIndex);
       vmThreadRegister->setAssignedRegister(vmThreadReal);
       vmThreadRegister->setAssociation(vmThreadIndex);
       vmThreadReal->setAssignedRegister(vmThreadRegister);
@@ -1129,7 +1129,7 @@ void OMR::X86::CodeGenerator::saveBetterSpillPlacements(TR::Instruction * branch
 
    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++)
       {
-      realReg = self()->machine()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      realReg = self()->machine()->getRealRegister((TR::RealRegister::RegNum)i);
 
       // Skip non-assignable registers
       //
@@ -2222,7 +2222,7 @@ void OMR::X86::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map
    //
    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i)
       {
-      TR::RealRegister * reg = self()->machine()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister * reg = self()->machine()->getRealRegister((TR::RealRegister::RegNum)i);
       if (reg->getHasBeenAssignedInMethod())
          {
          TR::Register *virtReg = reg->getAssignedRegister();
@@ -2353,9 +2353,9 @@ TR::RealRegister::RegNum OMR::X86::CodeGenerator::pickNOPRegister(TR::Instructio
    // We don't do ebp or esp (or r11 or r12 for that matter) because their
    // binary encodings are not always idential to those of the other registers.
 
-   TR::RealRegister * ebx = self()->machine()->getX86RealRegister(TR::RealRegister::ebx);
-   TR::RealRegister * esi = self()->machine()->getX86RealRegister(TR::RealRegister::esi);
-   TR::RealRegister * edi = self()->machine()->getX86RealRegister(TR::RealRegister::edi);
+   TR::RealRegister * ebx = self()->machine()->getRealRegister(TR::RealRegister::ebx);
+   TR::RealRegister * esi = self()->machine()->getRealRegister(TR::RealRegister::esi);
+   TR::RealRegister * edi = self()->machine()->getRealRegister(TR::RealRegister::edi);
 
    int8_t ebxLastDef = 0;
    int8_t esiLastDef = 0;
@@ -2695,8 +2695,8 @@ uint8_t *OMR::X86::CodeGenerator::generatePadding(uint8_t              *cursor,
       if (_paddingTable->_flags.testAny(TR_X86PaddingTable::registerMatters))
          {
          TR::RealRegister::RegNum  regIndex  = self()->pickNOPRegister(neighborhood);
-         TR::RealRegister      *reg       = self()->machine()->getX86RealRegister(regIndex);
-         int32_t                  prefixLen = (_paddingTable->_prefixMask & (1<<length))? 1 : 0;
+         TR::RealRegister         *reg       = self()->machine()->getRealRegister(regIndex);
+         int32_t                   prefixLen = (_paddingTable->_prefixMask & (1<<length))? 1 : 0;
 
          // Target reg
          //

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -156,7 +156,7 @@ void OMR::X86::Instruction::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
             {
             // Skip non-assignable registers
             //
-            if (machine->getX86RealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
+            if (machine->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
                continue;
 
             TR::Register *virtReg = machine->getVirtualAssociatedWithReal((TR::RealRegister::RegNum)i);

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -569,7 +569,7 @@ void OMR::X86::Linkage::associatePreservedRegisters(TR::RegisterDependencyCondit
          {
          // Can't use locked regs
          //
-         if (self()->machine()->getX86RealRegister((TR::RealRegister::RegNum)realReg)->getState() == TR::RealRegister::Locked)
+         if (self()->machine()->getRealRegister((TR::RealRegister::RegNum)realReg)->getState() == TR::RealRegister::Locked)
             continue;
 
          // Volatile regs are no good for virtuals that live across a call

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -505,7 +505,7 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
          continue;
          }
 
-      realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
 
       if (realReg->getState() == TR::RealRegister::Assigned)
          {
@@ -1434,8 +1434,8 @@ void OMR::X86::Machine::swapGPRegisters(TR::Instruction          *currentInstruc
                                     TR::RealRegister::RegNum  regNum1,
                                     TR::RealRegister::RegNum  regNum2)
    {
-   TR::RealRegister *realReg1 = self()->getX86RealRegister(regNum1);
-   TR::RealRegister *realReg2 = self()->getX86RealRegister(regNum2);
+   TR::RealRegister *realReg1 = self()->getRealRegister(regNum1);
+   TR::RealRegister *realReg2 = self()->getRealRegister(regNum2);
    TR::Instruction *instr = new (self()->cg()->trHeapMemory()) TR::X86RegRegInstruction(currentInstruction, XCHGRegReg(), realReg1, realReg2, self()->cg());
 
    TR::Register *virtReg1 = realReg1->getAssignedRegister();
@@ -1490,7 +1490,7 @@ void OMR::X86::Machine::setGPRWeightsFromAssociations()
       {
       // Skip non-assignable registers
       //
-      if (self()->getX86RealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
+      if (self()->getRealRegister((TR::RealRegister::RegNum)i)->getState() == TR::RealRegister::Locked)
          continue;
 
       TR::Register *assocReg = _registerAssociations[i];
@@ -1543,7 +1543,7 @@ OMR::X86::Machine::createRegisterAssociationDirective(TR::Instruction *cursor)
 
       // Skip non-assignable registers
       //
-      if (self()->getX86RealRegister(regNum)->getState() == TR::RealRegister::Locked)
+      if (self()->getRealRegister(regNum)->getState() == TR::RealRegister::Locked)
          continue;
 
       associations->addPostCondition(self()->getVirtualAssociatedWithReal(regNum),
@@ -1737,7 +1737,7 @@ OMR::X86::Machine::cloneRegisterFile(TR::RealRegister **registerFile, TR_Allocat
       }
 
    // the vfp entry is a real register and it must always point to the same _frameRegister pointer so the memRef assignRegisters check
-   // if (_baseRegister == cg()->machine()->getX86RealRegister(TR::RealRegister::vfp)
+   // if (_baseRegister == cg()->machine()->getRealRegister(TR::RealRegister::vfp)
    // works correctly
    registerFileClone[TR::RealRegister::vfp] = self()->cg()->getFrameRegister();
 
@@ -1762,7 +1762,7 @@ TR::RegisterDependencyConditions * OMR::X86::Machine::createDepCondForLiveGPRs()
    //
    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR; i = ((i==TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i+1))
       {
-      TR::RealRegister *realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Assigned ||
           realReg->getState() == TR::RealRegister::Free ||
           realReg->getState() == TR::RealRegister::Blocked)
@@ -1776,7 +1776,7 @@ TR::RegisterDependencyConditions * OMR::X86::Machine::createDepCondForLiveGPRs()
       deps = generateRegisterDependencyConditions(0, c, self()->cg());
       for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastXMMR; i = ((i==TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i+1))
          {
-         TR::RealRegister *realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
+         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
          if (realReg->getState() == TR::RealRegister::Assigned ||
              realReg->getState() == TR::RealRegister::Free ||
              realReg->getState() == TR::RealRegister::Blocked)
@@ -1819,7 +1819,7 @@ TR::RegisterDependencyConditions * OMR::X86::Machine::createCondForLiveAndSpille
       endReg = TR::RealRegister::LastXMMR;
    for (i = TR::RealRegister::FirstGPR; i <= endReg; i = ((i==TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i+1))
       {
-      TR::RealRegister *realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
       TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned ||
               realReg->getState() == TR::RealRegister::Free ||
               realReg->getState() == TR::RealRegister::Locked,
@@ -1837,7 +1837,7 @@ TR::RegisterDependencyConditions * OMR::X86::Machine::createCondForLiveAndSpille
       deps = generateRegisterDependencyConditions(0, c, self()->cg());
       for (i = TR::RealRegister::FirstGPR; i <= endReg; i = ((i==TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i+1))
          {
-         TR::RealRegister *realReg = self()->getX86RealRegister((TR::RealRegister::RegNum)i);
+         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             TR::Register *virtReg = realReg->getAssignedRegister();

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -138,7 +138,12 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    uint8_t getNumberOfGPRs() { return _numGPRs; }
 
-   TR::RealRegister *getX86RealRegister(TR::RealRegister::RegNum regNum)
+   /**
+    * @brief Converts RegNum to RealRegister
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum)
       {
       return _registerFile[regNum];
       }

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -139,6 +139,16 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    uint8_t getNumberOfGPRs() { return _numGPRs; }
 
    /**
+    * @brief This method is the wrapper for \code getRealRegister.
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getX86RealRegister(TR::RealRegister::RegNum regNum)
+      {
+      return _registerFile[regNum];
+      }
+
+   /**
     * @brief Converts RegNum to RealRegister
     * @param[in] regNum : register number
     * @return RealRegister for specified register number

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -860,9 +860,9 @@ OMR::X86::MemoryReference::assignRegisters(
 
    if (_baseRegister != NULL)
       {
-      if (_baseRegister == cg->machine()->getX86RealRegister(TR::RealRegister::vfp))
+      if (_baseRegister == cg->machine()->getRealRegister(TR::RealRegister::vfp))
          {
-         assignedBaseRegister = cg->machine()->getX86RealRegister(TR::RealRegister::vfp);
+         assignedBaseRegister = cg->machine()->getRealRegister(TR::RealRegister::vfp);
          }
       else
          {
@@ -935,7 +935,7 @@ OMR::X86::MemoryReference::estimateBinaryLength(TR::CodeGenerator *cg)
       {
       // Rewrite VFP-relative memref in terms of an actual register
       //
-      _baseRegister = cg->machine()->getX86RealRegister(cg->vfpState()._register);
+      _baseRegister = cg->machine()->getRealRegister(cg->vfpState()._register);
       self()->getSymbolReference().setOffset(self()->getSymbolReference().getOffset() + cg->vfpState()._displacement);
       }
 
@@ -1055,14 +1055,14 @@ OMR::X86::MemoryReference::getBinaryLengthLowerBound(TR::CodeGenerator *cg)
 
       if (registerNumber == TR::RealRegister::vfp)
          {
-         TR_ASSERT(cg->machine()->getX86RealRegister(registerNumber)->getAssignedRealRegister(),
+         TR_ASSERT(cg->machine()->getRealRegister(registerNumber)->getAssignedRealRegister(),
                 "virtual frame pointer must be assigned before estimating instruction length lower bound!\n");
-         registerNumber = toRealRegister(cg->machine()->getX86RealRegister(registerNumber)->
+         registerNumber = toRealRegister(cg->machine()->getRealRegister(registerNumber)->
                              getAssignedRealRegister())->getRegisterNumber();
          }
       }
 
-   TR::RealRegister *base = cg->machine()->getX86RealRegister(registerNumber);
+   TR::RealRegister *base = cg->machine()->getRealRegister(registerNumber);
    switch (addressTypes)
       {
       case 1:
@@ -1420,11 +1420,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
             {
-            TR_ASSERT(cg->machine()->getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister(),
+            TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
                    "virtual frame pointer must be assigned before binary encoding!\n");
 
             base = toRealRegister(cg->machine()->
-               getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
+               getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
             self()->setBaseRegister(base);
             }
@@ -1483,11 +1483,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
             {
-            TR_ASSERT(cg->machine()->getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister(),
+            TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
                    "virtual frame pointer must be assigned before binary encoding!\n");
 
             base = toRealRegister(cg->machine()->
-                   getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
+                   getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
             self()->setBaseRegister(base);
             }
@@ -1605,11 +1605,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
             {
-            TR_ASSERT(cg->machine()->getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister(),
+            TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
                    "virtual frame pointer must be assigned before binary encoding!\n");
 
             base = toRealRegister(cg->machine()->
-                   getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
+                   getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
             self()->setBaseRegister(base);
             }
@@ -1665,11 +1665,11 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
          if (baseRegisterNumber == TR::RealRegister::vfp)
             {
-            TR_ASSERT(cg->machine()->getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister(),
+            TR_ASSERT(cg->machine()->getRealRegister(baseRegisterNumber)->getAssignedRealRegister(),
                    "virtual frame pointer must be assigned before binary encoding!\n");
 
             base = toRealRegister(cg->machine()->
-                      getX86RealRegister(baseRegisterNumber)->getAssignedRealRegister());
+                      getRealRegister(baseRegisterNumber)->getAssignedRealRegister());
             baseRegisterNumber = base->getRegisterNumber();
             self()->setBaseRegister(base);
             }

--- a/compiler/x/codegen/OMRRealRegister.cpp
+++ b/compiler/x/codegen/OMRRealRegister.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ OMR::X86::RealRegister::regMaskToRealRegister(TR_RegisterMask mask, TR_RegisterK
    else
       TR_ASSERT(false, "Invalid TR_RegisterKinds value passed to OMR::X86::RealRegister::regMaskToRealRegister()");
 
-   return cg->machine()->getX86RealRegister(TR::RealRegister::RegNum(rr+bitPos));
+   return cg->machine()->getRealRegister(TR::RealRegister::RegNum(rr+bitPos));
    }
 
 TR_RegisterMask

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -508,13 +508,13 @@ TR_X86RegisterDependencyIndex OMR::X86::RegisterDependencyConditions::unionRealD
             if (dep->getRegister() == vmThreadRegister)
                {
                //diagnostic("\nEnvicting virt reg %s dep for %s replaced with virt reg %s\n      {\"%s\"}",
-               //   getDebug()->getName(dep->getRegister()),getDebug()->getName(machine->getX86RealRegister(rr)),getDebug()->getName(vr), cg->comp()->getCurrentMethod()->signature());
+               //   getDebug()->getName(dep->getRegister()),getDebug()->getName(machine->getRealRegister(rr)),getDebug()->getName(vr), cg->comp()->getCurrentMethod()->signature());
                deps->setDependencyInfo(candidate, vr, rr, cg, flag, isAssocRegDependency);
                }
             else
                {
                //diagnostic("\nSkipping virt reg %s dep for %s in favour of %s\n     {%s}}\n",
-               //   getDebug()->getName(vr),getDebug()->getName(machine->getX86RealRegister(rr)),getDebug()->getName(dep->getRegister()), cg->comp()->getCurrentMethod()->signature());
+               //   getDebug()->getName(vr),getDebug()->getName(machine->getRealRegister(rr)),getDebug()->getName(dep->getRegister()), cg->comp()->getCurrentMethod()->signature());
                TR_ASSERT(vr == vmThreadRegister, "Conflicting EBP register dependencies.\n");
                }
             return cursor;
@@ -659,7 +659,7 @@ void TR_X86RegisterDependencyGroup::blockRealDependencyRegisters(TR_X86RegisterD
       {
       if (_dependencies[i].getRealRegister() != TR::RealRegister::NoReg)
          {
-         machine->getX86RealRegister(_dependencies[i].getRealRegister())->block();
+         machine->getRealRegister(_dependencies[i].getRealRegister())->block();
          }
       }
    }
@@ -672,7 +672,7 @@ void TR_X86RegisterDependencyGroup::unblockRealDependencyRegisters(TR_X86Registe
       {
       if (_dependencies[i].getRealRegister() != TR::RealRegister::NoReg)
          {
-         machine->getX86RealRegister(_dependencies[i].getRealRegister())->unblock();
+         machine->getRealRegister(_dependencies[i].getRealRegister())->unblock();
          }
       }
    }
@@ -849,7 +849,7 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          if (virtReg->getKind() == TR_GPR)
             {
             dependentRegNum  = dependencies[i]->getRealRegister();
-            dependentRealReg = machine->getX86RealRegister(dependentRegNum);
+            dependentRealReg = machine->getRealRegister(dependentRegNum);
             assignedReg      = NULL;
             TR::RealRegister::RegNum assignedRegNum = TR::RealRegister::NoReg;
             if (virtReg->getAssignedRegister())
@@ -897,7 +897,7 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          {
          virtReg = dependencies[i]->getRegister();
          dependentRegNum = dependencies[i]->getRealRegister();
-         dependentRealReg = machine->getX86RealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
          if (dependentRealReg->getState() == TR::RealRegister::Free)
             {
             if (virtReg->getKind() == TR_FPR || virtReg->getKind() == TR_VRF)
@@ -923,7 +923,7 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          virtReg = dependencies[i]->getRegister();
          assignedReg = toRealRegister(virtReg->getAssignedRealRegister());
          dependentRegNum = dependencies[i]->getRealRegister();
-         dependentRealReg = machine->getX86RealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
          if (dependentRealReg != assignedReg)
             {
             if (virtReg->getKind() == TR_FPR || virtReg->getKind() == TR_VRF)
@@ -1072,7 +1072,7 @@ void TR_X86RegisterDependencyGroup::setDependencyInfo(
       rr != TR::RealRegister::NoReg &&
       rr != TR::RealRegister::ByteReg)
       {
-      TR::RealRegister *realReg = cg->machine()->getX86RealRegister(rr);
+      TR::RealRegister *realReg = cg->machine()->getRealRegister(rr);
       if ((vr->getKind() == TR_GPR) && !isAssocRegDependency)
          {
          // Remember this association so that we can build interference info for
@@ -1124,7 +1124,7 @@ TR::RealRegister *OMR::X86::RegisterDependencyConditions::getRealRegisterFromVir
 
       if (dependency->getRegister() == virtReg)
          {
-         return machine->getX86RealRegister(dependency->getRealRegister());
+         return machine->getRealRegister(dependency->getRealRegister());
          }
       }
 
@@ -1135,7 +1135,7 @@ TR::RealRegister *OMR::X86::RegisterDependencyConditions::getRealRegisterFromVir
 
       if (dependency->getRegister() == virtReg)
          {
-         return machine->getX86RealRegister(dependency->getRealRegister());
+         return machine->getRealRegister(dependency->getRealRegister());
          }
       }
 

--- a/compiler/x/codegen/OMRRegisterIterator.cpp
+++ b/compiler/x/codegen/OMRRegisterIterator.cpp
@@ -50,17 +50,17 @@ OMR::X86::RegisterIterator::RegisterIterator(TR::Machine *machine, TR_RegisterKi
 TR::Register *
 OMR::X86::RegisterIterator::getFirst()
    {
-   return _machine->getX86RealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
+   return _machine->getRealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
    }
 
 TR::Register *
 OMR::X86::RegisterIterator::getCurrent()
    {
-   return _machine->getX86RealRegister((TR::RealRegister::RegNum)_cursor);
+   return _machine->getRealRegister((TR::RealRegister::RegNum)_cursor);
    }
 
 TR::Register *
 OMR::X86::RegisterIterator::getNext()
    {
-   return _cursor == _lastRegIndex ? NULL : _machine->getX86RealRegister((TR::RealRegister::RegNum)(++_cursor));
+   return _cursor == _lastRegIndex ? NULL : _machine->getRealRegister((TR::RealRegister::RegNum)(++_cursor));
    }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3470,7 +3470,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
    if (comp->getOption(TR_BreakBBStart))
       {
       TR::Machine *machine = cg->machine();
-      generateRegImmInstruction(TEST4RegImm4, node, machine->getX86RealRegister(TR::RealRegister::esp), block->getNumber(), cg);
+      generateRegImmInstruction(TEST4RegImm4, node, machine->getRealRegister(TR::RealRegister::esp), block->getNumber(), cg);
       generateInstruction(BADIA32Op, node, cg);
       }
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1502,7 +1502,7 @@ void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, in
          {
          //generate LOCK OR dword ptr [esp], 0
          padInst = generateAlignmentInstruction(inst, 8, cg);
-         TR::RealRegister *espReal = cg->machine()->getX86RealRegister(TR::RealRegister::esp);
+         TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
          TR::MemoryReference *espMemRef = generateX86MemoryReference(espReal, 0, cg);
          fenceInst = new (cg->trHeapMemory()) TR::X86MemImmInstruction(padInst, fenceOp.getOpCodeValue(), espMemRef, 0, cg);
          }
@@ -1998,8 +1998,8 @@ void TR::X86MemRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
              (getMemoryReference()->getIndexRegister() == cg()->getVMThreadRegister()))
             {
             blockedEbp = true;
-            oldState = cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->getState();
-            cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->setState(TR::RealRegister::Locked); //(TR::RealRegister::Locked);
+            oldState = cg()->machine()->getRealRegister(TR::RealRegister::ebp)->getState();
+            cg()->machine()->getRealRegister(TR::RealRegister::ebp)->setState(TR::RealRegister::Locked); //(TR::RealRegister::Locked);
             }
          getMemoryReference()->blockRegisters();
          if (getDependencyConditions())
@@ -2058,15 +2058,15 @@ void TR::X86MemRegInstruction::assignRegisters(TR_RegisterKinds kindsToBeAssigne
             switch (oldState)
                {
                case TR::RealRegister::Free :
-                  cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Free); break;
+                  cg()->machine()->getRealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Free); break;
                case TR::RealRegister::Unlatched :
-                  cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Unlatched); break;
+                  cg()->machine()->getRealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Unlatched); break;
                case TR::RealRegister::Assigned :
-                  cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Assigned); break;
+                  cg()->machine()->getRealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Assigned); break;
                case TR::RealRegister::Blocked :
-                  cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Blocked); break;
+                  cg()->machine()->getRealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Blocked); break;
                case TR::RealRegister::Locked :
-                  cg()->machine()->getX86RealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Locked); break;
+                  cg()->machine()->getRealRegister(TR::RealRegister::ebp)->resetState(TR::RealRegister::Locked); break;
                }
             }
 
@@ -4337,7 +4337,7 @@ generateVirtualGuardNOPInstruction(TR::Instruction *i, TR::Node * node, TR_Virtu
 
 bool TR::X86VirtualGuardNOPInstruction::usesRegister(TR::Register *reg)
    {
-   if (_nopSize > 0 && cg()->machine()->getX86RealRegister(_register) == reg)
+   if (_nopSize > 0 && cg()->machine()->getRealRegister(_register) == reg)
       return true;
    if (getDependencyConditions())
       return getDependencyConditions()->usesRegister(reg);

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -2842,7 +2842,7 @@ class X86VFPDedicateInstruction : public TR::X86RegMemInstruction
       // returns [vfp+0].
       //
       TR::Machine *machine = cg->machine();
-      return generateX86MemoryReference(machine->getX86RealRegister(TR::RealRegister::vfp), 0, cg);
+      return generateX86MemoryReference(machine->getRealRegister(TR::RealRegister::vfp), 0, cg);
       }
 
    public:

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -261,7 +261,7 @@ TR_Debug::printDependencyConditions(
          }
       else
          {
-         len = sprintf(cursor, "%s", getName(_cg->machine()->getX86RealRegister(r)));
+         len = sprintf(cursor, "%s", getName(_cg->machine()->getRealRegister(r)));
         }
 
       *(cursor+len)=')';
@@ -335,7 +335,7 @@ TR_Debug::dumpDependencyGroup(TR::FILE *                         pOutFile,
         else if (r == TR::RealRegister::SpilledReg)
            trfprintf(pOutFile, "SpilledReg]");
         else
-           trfprintf(pOutFile, "%s]", getName(_cg->machine()->getX86RealRegister(r)));
+           trfprintf(pOutFile, "%s]", getName(_cg->machine()->getRealRegister(r)));
         }
 
       foundDep = true;
@@ -1782,7 +1782,7 @@ TR_Debug::printX86GCRegisterMap(TR::FILE *pOutFile, TR::GCRegisterMap * map)
    for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i)
       {
       if (map->getMap() & (1 << (i-1))) // TODO:AMD64: Use the proper mask value
-         trfprintf(pOutFile,"%s ", getName(machine->getX86RealRegister((TR::RealRegister::RegNum)i)));
+         trfprintf(pOutFile,"%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum)i)));
       }
 
    trfprintf(pOutFile,"}\n");
@@ -2305,7 +2305,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
                opCodeName = "mov";
                modrmOffset = 1;
                TR::RealRegister::RegNum reg = linkageProperties.getIntegerArgumentRegister(numGPArgs);
-               regName = getName(_cg->machine()->getX86RealRegister(reg));
+               regName = getName(_cg->machine()->getRealRegister(reg));
                }
             numGPArgs++;
             break;
@@ -2316,7 +2316,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
                opCodeName = "mov";
                modrmOffset = 2;
                TR::RealRegister::RegNum reg = linkageProperties.getIntegerArgumentRegister(numGPArgs);
-               regName = getName(_cg->machine()->getX86RealRegister(reg), TR_DoubleWordReg);
+               regName = getName(_cg->machine()->getRealRegister(reg), TR_DoubleWordReg);
                }
             numGPArgs++;
             break;
@@ -2326,7 +2326,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
                opCodeName = "movss";
                modrmOffset = 3;
                TR::RealRegister::RegNum reg = linkageProperties.getFloatArgumentRegister(numFPArgs);
-               regName = getName(_cg->machine()->getX86RealRegister(reg), TR_QuadWordReg);
+               regName = getName(_cg->machine()->getRealRegister(reg), TR_QuadWordReg);
                }
             numFPArgs++;
             break;
@@ -2336,7 +2336,7 @@ TR_Debug::printArgumentFlush(TR::FILE *              pOutFile,
                opCodeName = "movsd";
                modrmOffset = 3;
                TR::RealRegister::RegNum reg = linkageProperties.getFloatArgumentRegister(numFPArgs);
-               regName = getName(_cg->machine()->getX86RealRegister(reg), TR_QuadWordReg);
+               regName = getName(_cg->machine()->getRealRegister(reg), TR_QuadWordReg);
                }
             numFPArgs++;
             break;

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -93,7 +93,7 @@ TR::Instruction *
 TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
    {
    TR::Machine *machine = cg()->machine();
-   TR::RealRegister *framePointer = machine->getX86RealRegister(TR::RealRegister::vfp);
+   TR::RealRegister *framePointer = machine->getRealRegister(TR::RealRegister::vfp);
 
    TR::ResolvedMethodSymbol             *bodySymbol = comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>  paramIterator(&(bodySymbol->getParameterList()));
@@ -148,7 +148,7 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
             loadCursor = generateRegMemInstruction(
                loadCursor,
                TR::Linkage::movOpcodes(RegMem, movDataType),
-               machine->getX86RealRegister(ai),
+               machine->getRealRegister(ai),
                generateX86MemoryReference(framePointer, offset, cg()),
                cg()
                );
@@ -171,7 +171,7 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
                cursor,
                TR::Linkage::movOpcodes(MemReg, movDataType),
                generateX86MemoryReference(framePointer, offset, cg()),
-               machine->getX86RealRegister(sourceIndex),
+               machine->getRealRegister(sourceIndex),
                cg()
                );
             }
@@ -261,8 +261,8 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
             cursor = generateRegRegInstruction(
                cursor,
                TR::Linkage::movOpcodes(RegReg, movStatus[source].outgoingDataType),
-               machine->getX86RealRegister(regCursor),
-               machine->getX86RealRegister(source),
+               machine->getRealRegister(regCursor),
+               machine->getRealRegister(source),
                cg()
                );
             // Update movStatus as we go so we don't generate redundant movs
@@ -298,7 +298,7 @@ TR::X86SystemLinkage::savePreservedRegisters(TR::Instruction *cursor)
            pindex--)
          {
          TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-         TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+         TR::RealRegister *reg = machine()->getRealRegister(idx);
          if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked)
             {
             cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, PUSHReg, reg, cg());
@@ -312,13 +312,13 @@ TR::X86SystemLinkage::savePreservedRegisters(TR::Instruction *cursor)
            pindex--)
          {
          TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-         TR::RealRegister *reg = machine()->getX86RealRegister(getProperties().getPreservedRegister((uint32_t)pindex));
+         TR::RealRegister *reg = machine()->getRealRegister(getProperties().getPreservedRegister((uint32_t)pindex));
          if(reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked)
             {
             cursor = generateMemRegInstruction(
                cursor,
                TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(reg)),
-               generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
+               generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
                reg,
                cg()
                );
@@ -421,7 +421,7 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
    TR_DebugFrameSegmentInfo *debugFrameSlotInfo=NULL;
 #endif
 
-   TR::RealRegister *espReal = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
 
@@ -437,7 +437,7 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
    int32_t pindex; // Preserved register index
    for (pindex = 0; pindex < properties.getMaxRegistersPreservedInPrologue(); pindex++)
       {
-      TR::RealRegister *reg = machine()->getX86RealRegister(properties.getPreservedRegister((uint32_t)pindex));
+      TR::RealRegister *reg = machine()->getRealRegister(properties.getPreservedRegister((uint32_t)pindex));
       if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked)
          {
          preservedRegsSize += properties.getPointerSize();
@@ -487,14 +487,14 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
       cursor = new (trHeapMemory()) TR::X86RegInstruction(
          cursor,
          PUSHReg,
-         machine()->getX86RealRegister(properties.getFramePointerRegister()),
+         machine()->getRealRegister(properties.getFramePointerRegister()),
          cg());
 
-      TR::RealRegister *stackPointerReg = machine()->getX86RealRegister(TR::RealRegister::esp);
+      TR::RealRegister *stackPointerReg = machine()->getRealRegister(TR::RealRegister::esp);
       cursor = new (trHeapMemory()) TR::X86RegRegInstruction(
          cursor,
          MOVRegReg(),
-         machine()->getX86RealRegister(properties.getFramePointerRegister()),
+         machine()->getRealRegister(properties.getFramePointerRegister()),
          stackPointerReg,
          cg());
 
@@ -564,7 +564,7 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
       debugFrameSlotInfo = new (trHeapMemory()) TR_DebugFrameSegmentInfo(comp(),
          paramCursor->getOffset(), paramCursor->getSize(), "Parameter",
          debugFrameSlotInfo,
-         (ai==NOT_ASSIGNED)? NULL : machine()->getX86RealRegister(ai)
+         (ai==NOT_ASSIGNED)? NULL : machine()->getRealRegister(ai)
          );
       }
 
@@ -634,7 +634,7 @@ TR::X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
            pindex++)
          {
          TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-         TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+         TR::RealRegister *reg = machine()->getRealRegister(idx);
          if (reg->getHasBeenAssignedInMethod())
             {
             cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, POPReg, reg, cg());
@@ -649,7 +649,7 @@ TR::X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
            pindex--)
          {
          TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
-         TR::RealRegister *reg = machine()->getX86RealRegister(idx);
+         TR::RealRegister *reg = machine()->getRealRegister(idx);
 
          if (comp()->getOption(TR_TraceCG))
             {
@@ -662,7 +662,7 @@ TR::X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
                cursor,
                TR::Linkage::movOpcodes(RegMem, fullRegisterMovType(reg)),
                reg,
-               generateX86MemoryReference(machine()->getX86RealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
+               generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
                cg()
                );
             offsetCursor -= pointerSize;
@@ -677,7 +677,7 @@ TR::X86SystemLinkage::restorePreservedRegisters(TR::Instruction *cursor)
 void
 TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   TR::RealRegister    *espReal      = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister    *espReal      = machine()->getRealRegister(TR::RealRegister::esp);
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
 
    const int32_t localSize = _properties.getOffsetToFirstLocal() - bodySymbol->getLocalMappingCursor();
@@ -709,8 +709,8 @@ TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
       {
       // Restore stack pointer from frame pointer
       //
-      cursor = new (trHeapMemory()) TR::X86RegRegInstruction(cursor, MOVRegReg(), espReal, machine()->getX86RealRegister(_properties.getFramePointerRegister()), cg());
-      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, POPReg, machine()->getX86RealRegister(_properties.getFramePointerRegister()), cg());
+      cursor = new (trHeapMemory()) TR::X86RegRegInstruction(cursor, MOVRegReg(), espReal, machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
+      cursor = new (trHeapMemory()) TR::X86RegInstruction(cursor, POPReg, machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
       }
    else if (allocSize == 0)
       {

--- a/compiler/x/i386/codegen/IA32SystemLinkage.cpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.cpp
@@ -361,7 +361,7 @@ int32_t TR::IA32SystemLinkage::buildArgs(
 
 TR::Register *TR::IA32SystemLinkage::buildDirectDispatch(TR::Node *callNode, bool spillFPRegs)
    {
-   TR::RealRegister    *stackPointerReg = machine()->getX86RealRegister(TR::RealRegister::esp);
+   TR::RealRegister    *stackPointerReg = machine()->getRealRegister(TR::RealRegister::esp);
    TR::SymbolReference *methodSymRef    = callNode->getSymbolReference();
    TR::MethodSymbol    *methodSymbol    = callNode->getSymbol()->castToMethodSymbol();
    TR::ILOpCodes        callOpCodeValue = callNode->getOpCodeValue();

--- a/compiler/x/i386/codegen/IA32SystemLinkage.hpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,7 +48,7 @@ class IA32SystemLinkage : public TR::X86SystemLinkage
    int32_t layoutParm(TR::Node*, int32_t&, uint16_t&, uint16_t&, TR::parmLayoutResult&);
    int32_t layoutParm(TR::ParameterSymbol*, int32_t&, uint16_t&, uint16_t&, TR::parmLayoutResult&);
    virtual TR::Register *buildVolatileAndReturnDependencies(TR::Node *callNode, TR::RegisterDependencyConditions *deps);
-   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() { return machine()->getX86RealRegister(TR::RealRegister::ecx); }
+   virtual TR::RealRegister* getSingleWordFrameAllocationRegister() { return machine()->getRealRegister(TR::RealRegister::ecx); }
    private:
    virtual uint32_t getAlignment(TR::DataType);
    };

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -90,7 +90,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
          }
       self()->setSupportsDivCheck();
       self()->setJNILinkageCalleeCleanup();
-      self()->setRealVMThreadRegister(self()->machine()->getX86RealRegister(TR::RealRegister::ebp));
+      self()->setRealVMThreadRegister(self()->machine()->getRealRegister(TR::RealRegister::ebp));
       }
    else if (TR::Compiler->target.isLinux())
       {
@@ -106,7 +106,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
          self()->setHasResumableTrapHandler();
          self()->setEnableImplicitDivideCheck();
          }
-      self()->setRealVMThreadRegister(self()->machine()->getX86RealRegister(TR::RealRegister::ebp));
+      self()->setRealVMThreadRegister(self()->machine()->getRealRegister(TR::RealRegister::ebp));
       self()->setSupportsDivCheck();
       }
    else


### PR DESCRIPTION
Rename the `OMR::X86::Machine::getX86RealRegister()` method to
`OMR::X86::Machine::getRealRegister()` in order to get the strength of
polymorphism.

P.S. The method `getX86RealRegister()` is still declared for backward compatibility.

Issue: #2645