### PR TITLE
AArch64: Call decFutureUseCount() in Machine::assignOneRegister()

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -471,6 +471,12 @@ TR::RealRegister *OMR::ARM64::Machine::assignOneRegister(TR::Instruction *curren
       self()->cg()->traceRegAssigned(virtualRegister, assignedRegister);
       }
 
+   if (virtualRegister->decFutureUseCount() == 0)
+      {
+      virtualRegister->setAssignedRegister(NULL);
+      assignedRegister->setState(TR::RealRegister::Unlatched);
+      }
+
    return assignedRegister;
    }
 


### PR DESCRIPTION
decFutureUseCount() has not been called upon register assignment for
aarch64 instructions. This commit adds a call to decFutureUseCount()
in OMR::ARM64::Machine::assignOneRegister().

Signed-off-by: knn-k <konno@jp.ibm.com>