### PR TITLE
Rename OMR::Power::Machine::getPPCRealRegister()

### DIFF
--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2534,7 +2534,7 @@ TR::Register *OMR::Power::TreeEvaluator::getstackEvaluator(TR::Node *node, TR::C
    {
    const TR::PPCLinkageProperties &properties = cg->getProperties();
 
-   TR::Register *spReg = cg->machine()->getPPCRealRegister(properties.getNormalStackPointerRegister());
+   TR::Register *spReg = cg->machine()->getRealRegister(properties.getNormalStackPointerRegister());
    TR::Register *trgReg = cg->allocateRegister();
 
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, trgReg, spReg);
@@ -2550,7 +2550,7 @@ TR::Register *OMR::Power::TreeEvaluator::deallocaEvaluator(TR::Node *node, TR::C
    const TR::PPCLinkageProperties &properties = cg->getProperties();
 
    // TODO: restore stack chain
-   TR::Register *spReg = cg->machine()->getPPCRealRegister(properties.getNormalStackPointerRegister());
+   TR::Register *spReg = cg->machine()->getRealRegister(properties.getNormalStackPointerRegister());
 
    generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, spReg, srcReg);
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -144,9 +144,9 @@ OMR::Power::CodeGenerator::CodeGenerator() :
       self()->setTrackItems(NULL);
       }
 
-   self()->setStackPointerRegister(self()->machine()->getPPCRealRegister(_linkageProperties->getNormalStackPointerRegister()));
-   self()->setMethodMetaDataRegister(self()->machine()->getPPCRealRegister(_linkageProperties->getMethodMetaDataRegister()));
-   self()->setTOCBaseRegister(self()->machine()->getPPCRealRegister(_linkageProperties->getTOCBaseRegister()));
+   self()->setStackPointerRegister(self()->machine()->getRealRegister(_linkageProperties->getNormalStackPointerRegister()));
+   self()->setMethodMetaDataRegister(self()->machine()->getRealRegister(_linkageProperties->getMethodMetaDataRegister()));
+   self()->setTOCBaseRegister(self()->machine()->getRealRegister(_linkageProperties->getTOCBaseRegister()));
    self()->getLinkage()->initPPCRealRegisterLinkage();
    self()->getLinkage()->setParameterLinkageRegisterIndex(self()->comp()->getJittedMethodSymbol());
    self()->machine()->initREGAssociations();
@@ -398,7 +398,7 @@ OMR::Power::CodeGenerator::generateSwitchToInterpreterPrePrologue(
       TR::Instruction *cursor,
       TR::Node *node)
    {
-   TR::Register   *gr0 = self()->machine()->getPPCRealRegister(TR::RealRegister::gr0);
+   TR::Register   *gr0 = self()->machine()->getRealRegister(TR::RealRegister::gr0);
    TR::ResolvedMethodSymbol *methodSymbol = self()->comp()->getJittedMethodSymbol();
    TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_PPCrevertToInterpreterGlue, false, false, false);
    uintptrj_t             ramMethod = (uintptrj_t)methodSymbol->getResolvedMethod()->resolvedMethodAddress();
@@ -1712,6 +1712,8 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
    self()->setBinaryBufferCursor(temp);
    self()->alignBinaryBufferCursor();
 
+   TR::Instruction *nop;
+   TR::Register *gr1 = self()->machine()->getRealRegister(TR::RealRegister::gr1);
    bool skipLabel = false;
 
    bool  isPrivateLinkage = (self()->comp()->getJittedMethodSymbol()->getLinkageConvention() == TR_Private);
@@ -1944,7 +1946,7 @@ void OMR::Power::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *ma
    for (int i=TR::RealRegister::FirstGPR;
             i<=TR::RealRegister::LastGPR; i++)
       {
-      TR::RealRegister *realReg = self()->machine()->getPPCRealRegister(
+      TR::RealRegister *realReg = self()->machine()->getRealRegister(
               (TR::RealRegister::RegNum)i);
 
       if (realReg->getHasBeenAssignedInMethod())
@@ -2529,7 +2531,7 @@ void OMR::Power::CodeGenerator::setRealRegisterAssociation(TR::Register     *reg
    {
    if (!reg->isLive() || realNum == TR::RealRegister::NoReg)
       return;
-   TR::RealRegister *realReg = self()->machine()->getPPCRealRegister(realNum);
+   TR::RealRegister *realReg = self()->machine()->getRealRegister(realNum);
    self()->getLiveRegisters(reg->getKind())->setAssociation(reg, realReg);
    }
 
@@ -2539,7 +2541,7 @@ void OMR::Power::CodeGenerator::addRealRegisterInterference(TR::Register    *reg
    {
    if (!reg->isLive() || realNum == TR::RealRegister::NoReg)
       return;
-   TR::RealRegister *realReg = self()->machine()->getPPCRealRegister(realNum);
+   TR::RealRegister *realReg = self()->machine()->getRealRegister(realNum);
    reg->getLiveRegisterInfo()->addInterference(realReg->getRealRegisterMask());
    }
 
@@ -3033,7 +3035,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
 
 bool OMR::Power::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
-   return self()->machine()->getPPCRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
+   return self()->machine()->getRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
    }
 
 
@@ -3675,4 +3677,3 @@ OMR::Power::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
 
    return result;
    }
-

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,7 +81,7 @@ TR::MemoryReference *OMR::Power::Linkage::getOutgoingArgumentMemRef(int32_t argS
    TR::Machine *machine = self()->cg()->machine();
    const TR::PPCLinkageProperties& properties = self()->getProperties();
 
-   TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(machine->getPPCRealRegister(properties.getNormalStackPointerRegister()),
+   TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
                                                                               argSize+properties.getOffsetToFirstParm(), length, self()->cg());
    memArg.argRegister = argReg;
    memArg.argMemory = result;
@@ -101,7 +101,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
 TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, bool fsd, bool saveOnly,
                                              List<TR::ParameterSymbol> &parmList)
    {
-   #define  REAL_REGISTER(ri)  machine->getPPCRealRegister(ri)
+   #define  REAL_REGISTER(ri)  machine->getRealRegister(ri)
    #define  REGNUM(ri)         ((TR::RealRegister::RegNum)(ri))
    const TR::PPCLinkageProperties& properties = self()->getProperties();
    TR::Machine *machine = self()->cg()->machine();
@@ -509,7 +509,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
             if (hasToLoadFromStack &&
                   numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, argRegister,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
                }
@@ -518,7 +518,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
          case TR::Address:
             if (numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateTrg1MemInstruction(self()->cg(),TR::InstOpCode::Op_load, firstNode, argRegister,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress(), self()->cg()), cursor);
                }
@@ -528,7 +528,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
             if (hasToLoadFromStack &&
                   numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                if (TR::Compiler->target.is64Bit())
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::ld, firstNode, argRegister,
                         new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()), cursor);
@@ -538,7 +538,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                         new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
-                     argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
+                     argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, argRegister,
                            new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, 4, self()->cg()), cursor);
                      }
@@ -553,7 +553,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
             if (hasToLoadFromStack &&
                   numFloatArgs<properties.getNumFloatArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
+               argRegister = machine->getRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
                cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lfs, firstNode, argRegister,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()), cursor);
                }
@@ -563,7 +563,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
             if (hasToLoadFromStack &&
                   numFloatArgs<properties.getNumFloatArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
+               argRegister = machine->getRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
                cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lfd, firstNode, argRegister,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()), cursor);
                }
@@ -604,7 +604,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
             if (hasToStoreToStack &&
                   numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stw, firstNode,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()),
                      argRegister, cursor);
@@ -614,7 +614,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
          case TR::Address:
             if (numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateMemSrc1Instruction(self()->cg(),TR::InstOpCode::Op_st, firstNode,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, TR::Compiler->om.sizeofReferenceAddress(), self()->cg()),
                      argRegister, cursor);
@@ -625,7 +625,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
             if (hasToStoreToStack &&
                   numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                if (TR::Compiler->target.is64Bit())
                   cursor = generateMemSrc1Instruction(self()->cg(),TR::InstOpCode::Op_st, firstNode,
                         new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()),
@@ -637,7 +637,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                         argRegister, cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
-                     argRegister = machine->getPPCRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
+                     argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                      cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stw, firstNode,
                            new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, 4, self()->cg()),
                            argRegister, cursor);
@@ -653,7 +653,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
             if (hasToStoreToStack &&
                   numFloatArgs<properties.getNumFloatArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
+               argRegister = machine->getRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
                cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stfs, firstNode,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 4, self()->cg()),
                      argRegister, cursor);
@@ -664,7 +664,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
             if (hasToStoreToStack &&
                   numFloatArgs<properties.getNumFloatArgRegs())
                {
-               argRegister = machine->getPPCRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
+               argRegister = machine->getRealRegister(properties.getFloatArgumentRegister(numFloatArgs));
                cursor = generateMemSrc1Instruction(self()->cg(), TR::InstOpCode::stfd, firstNode,
                      new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()),
                      argRegister, cursor);

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -512,7 +512,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
       for (int i  = first; i <= last; i++)
          {
          uint64_t iInterfere = interference & (1<<(i-maskI));
-         TR::RealRegister *realReg = machine->getPPCRealRegister((TR::RealRegister::RegNum)i);
+         TR::RealRegister *realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             TR::Register *associatedVirtual = realReg->getAssignedRegister();
@@ -895,7 +895,7 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction      *c
    TR_Debug          *debugObj = self()->cg()->getDebug();
    if (targetRegister == NULL)
       {
-      if ((rk == TR_CCR) && (!self()->cg()->isOutOfLineColdPath() && !self()->cg()->isOutOfLineHotPath()) && ((sameReg=self()->cg()->machine()->getPPCRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::FirstCCR+toPPCCRBackingStore(location)->getCcrFieldIndex())))->getState() == TR::RealRegister::Free))
+      if ((rk == TR_CCR) && (!self()->cg()->isOutOfLineColdPath() && !self()->cg()->isOutOfLineHotPath()) && ((sameReg=self()->cg()->machine()->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::FirstCCR+toPPCCRBackingStore(location)->getCcrFieldIndex())))->getState() == TR::RealRegister::Free))
          {
          targetRegister = sameReg;
          }
@@ -1864,7 +1864,7 @@ OMR::Power::Machine::createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::lis
 
    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg; i++)
       {
-      TR::RealRegister *realReg = self()->getPPCRealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
       TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned ||
               realReg->getState() == TR::RealRegister::Free ||
               realReg->getState() == TR::RealRegister::Locked,
@@ -1882,7 +1882,7 @@ OMR::Power::Machine::createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::lis
       deps = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, self()->cg()->trMemory());
       for (int32_t j = TR::RealRegister::FirstGPR; j <= endReg; j++)
          {
-         TR::RealRegister *realReg = self()->getPPCRealRegister((TR::RealRegister::RegNum)j);
+         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)j);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             TR::Register *virtReg = realReg->getAssignedRegister();

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -91,7 +91,12 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::Register *setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, TR::Register * virtReg);
    TR::Register *getVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum);
 
-   TR::RealRegister *getPPCRealRegister(TR::RealRegister::RegNum regNum)
+   /**
+    * @brief Converts RegNum to RealRegister
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum)
       {
       return _registerFile[regNum];
       }

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -92,6 +92,16 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::Register *getVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum);
 
    /**
+    * @brief This method is the wrapper for \code getRealRegister.
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getPPCRealRegister(TR::RealRegister::RegNum regNum)
+      {
+      return _registerFile[regNum];
+      }
+
+   /**
     * @brief Converts RegNum to RealRegister
     * @param[in] regNum : register number
     * @return RealRegister for specified register number

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1078,7 +1078,7 @@ uint8_t *OMR::Power::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
    if (self()->getStaticRelocation() != NULL)
       self()->getStaticRelocation()->setSource2Instruction(currentInstruction);
 
-   base = (self()->getBaseRegister()==NULL)?cg->machine()->getPPCRealRegister(TR::RealRegister::gr0):toRealRegister(self()->getBaseRegister());
+   base = (self()->getBaseRegister()==NULL)?cg->machine()->getRealRegister(TR::RealRegister::gr0):toRealRegister(self()->getBaseRegister());
    index=(self()->getIndexRegister()==NULL)?NULL:toRealRegister(self()->getIndexRegister());
 
    if (TR::Compiler->target.is64Bit() && self()->isTOCAccess())
@@ -1384,7 +1384,7 @@ uint8_t *OMR::Power::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
          else
             {
             TR::RealRegister   *stackPtr = cg->getStackPointerRegister();
-            TR::RealRegister *rX = cg->machine()->getPPCRealRegister(choose_rX(currentInstruction, base));
+            TR::RealRegister *rX = cg->machine()->getRealRegister(choose_rX(currentInstruction, base));
             *wcursor = (TR::Compiler->target.is64Bit())?0xf800fff8:0x9000fffc;
             rX->setRegisterFieldRS(wcursor);
             stackPtr->setRegisterFieldRA(wcursor);

--- a/compiler/p/codegen/OMRRealRegister.cpp
+++ b/compiler/p/codegen/OMRRealRegister.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,7 @@ OMR::Power::RealRegister::regMaskToRealRegister(TR_RegisterMask mask, TR_Registe
       rr = FirstCCR;
    else if (rk == TR_VRF)
       rr = FirstVRF;
-   return cg->machine()->getPPCRealRegister(RegNum(rr+bitPos));
+   return cg->machine()->getRealRegister(RegNum(rr+bitPos));
    }
 
 TR_RegisterMask

--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -644,7 +644,7 @@ static void assignFreeRegisters(TR::Instruction              *currentInstruction
    // Assign a chain of dependencies where the head of the chain depends on a free reg
    while (dep)
       {
-      TR_ASSERT(machine->getPPCRealRegister(dep->getRealRegister())->getState() == TR::RealRegister::Free, "Expecting free target register");
+      TR_ASSERT(machine->getRealRegister(dep->getRealRegister())->getState() == TR::RealRegister::Free, "Expecting free target register");
       TR::RealRegister *assignedReg = dep->getRegister()->getAssignedRealRegister() ?
          toRealRegister(dep->getRegister()->getAssignedRealRegister()) : NULL;
       machine->coerceRegisterAssignment(currentInstruction, dep->getRegister(), dep->getRealRegister());
@@ -666,7 +666,7 @@ static void assignContendedRegisters(TR::Instruction              *currentInstru
 
    TR::Register *virtReg = dep->getRegister();
    TR::RealRegister::RegNum targetRegNum = dep->getRealRegister();
-   TR::RealRegister *targetReg = machine->getPPCRealRegister(targetRegNum);
+   TR::RealRegister *targetReg = machine->getRealRegister(targetRegNum);
    TR::RealRegister *assignedReg = virtReg->getAssignedRealRegister() ?
       toRealRegister(virtReg->getAssignedRealRegister()) :  NULL;
 
@@ -739,7 +739,7 @@ static void assignContendedRegisters(TR::Instruction              *currentInstru
       {
       virtReg = dep->getRegister();
       targetRegNum = dep->getRealRegister();
-      targetReg = machine->getPPCRealRegister(targetRegNum);
+      targetReg = machine->getRealRegister(targetRegNum);
       assignedReg = virtReg->getAssignedRealRegister() ?
          toRealRegister(virtReg->getAssignedRealRegister()) : NULL;
 
@@ -863,19 +863,19 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
    // count up how many registers are locked for each type
    for(i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR; i++)
       {
-        realReg = machine->getPPCRealRegister((TR::RealRegister::RegNum)i);
+        realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
         if (realReg->getState() == TR::RealRegister::Locked)
            lockedGPRs++;
       }
    for(i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; i++)
       {
-        realReg = machine->getPPCRealRegister((TR::RealRegister::RegNum)i);
+        realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
         if (realReg->getState() == TR::RealRegister::Locked)
            lockedFPRs++;
       }
    for(i = TR::RealRegister::FirstVRF; i <= TR::RealRegister::LastVRF; i++)
       {
-        realReg = machine->getPPCRealRegister((TR::RealRegister::RegNum)i);
+        realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
         if (realReg->getState() == TR::RealRegister::Locked)
            lockedVRFs++;
       }
@@ -949,7 +949,7 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          if (virtReg->getKind() != TR_CCR)
             continue;
          dependentRegNum = _dependencies[i].getRealRegister();
-         dependentRealReg = machine->getPPCRealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
 
          if (dependentRegNum != TR::RealRegister::NoReg &&
              dependentRegNum != TR::RealRegister::SpilledReg &&
@@ -965,7 +965,7 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
       {
       virtReg = _dependencies[i].getRegister();
       dependentRegNum = _dependencies[i].getRealRegister();
-      dependentRealReg = machine->getPPCRealRegister(dependentRegNum);
+      dependentRealReg = machine->getRealRegister(dependentRegNum);
 
       if (dependentRegNum != TR::RealRegister::NoReg &&
           dependentRegNum != TR::RealRegister::SpilledReg &&
@@ -985,7 +985,7 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          assignedRegister = toRealRegister(virtReg->getAssignedRealRegister());
          }
       dependentRegNum  = _dependencies[i].getRealRegister();
-      dependentRealReg = machine->getPPCRealRegister(dependentRegNum);
+      dependentRealReg = machine->getRealRegister(dependentRegNum);
       if (dependentRegNum != TR::RealRegister::NoReg &&
           dependentRegNum != TR::RealRegister::SpilledReg &&
           dependentRealReg != assignedRegister)

--- a/compiler/p/codegen/OMRRegisterIterator.cpp
+++ b/compiler/p/codegen/OMRRegisterIterator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,17 +50,17 @@ OMR::Power::RegisterIterator::RegisterIterator(TR::Machine *machine, TR_Register
 TR::Register *
 OMR::Power::RegisterIterator::getFirst()
    {
-   return _machine->getPPCRealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
+   return _machine->getRealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
    }
 
 TR::Register *
 OMR::Power::RegisterIterator::getCurrent()
    {
-   return _machine->getPPCRealRegister((TR::RealRegister::RegNum)_cursor);
+   return _machine->getRealRegister((TR::RealRegister::RegNum)_cursor);
    }
 
 TR::Register *
 OMR::Power::RegisterIterator::getNext()
    {
-   return _cursor == _lastRegIndex ? NULL : _machine->getPPCRealRegister((TR::RealRegister::RegNum)(++_cursor));
+   return _cursor == _lastRegIndex ? NULL : _machine->getRealRegister((TR::RealRegister::RegNum)(++_cursor));
    }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6133,8 +6133,8 @@ void OMR::Power::TreeEvaluator::preserveTOCRegister(TR::Node *node, TR::CodeGene
    TR::Compilation* comp = cg->comp();
 
    //We need to preserve the JIT TOC whenever we call out. We're saving this on the caller TOC slot as defined by the ABI.
-   TR::Register * grTOCReg       = cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
-   TR::Register * grSysStackReg   = cg->machine()->getPPCRealRegister(TR::RealRegister::gr1);
+   TR::Register * grTOCReg       = cg->machine()->getRealRegister(TR::RealRegister::gr2);
+   TR::Register * grSysStackReg   = cg->machine()->getRealRegister(TR::RealRegister::gr1);
 
    int32_t callerSaveTOCOffset = (TR::Compiler->target.cpu.isBigEndian() ? 5 : 3) *  TR::Compiler->om.sizeofReferenceAddress();
 
@@ -6146,8 +6146,8 @@ void OMR::Power::TreeEvaluator::preserveTOCRegister(TR::Node *node, TR::CodeGene
 void OMR::Power::TreeEvaluator::restoreTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
 {
    //Here we restore the JIT TOC after returning from a call out. We're restoring from the caller TOC slot as defined by the ABI.
-   TR::Register * grTOCReg       = cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
-   TR::Register * grSysStackReg   = cg->machine()->getPPCRealRegister(TR::RealRegister::gr1);
+   TR::Register * grTOCReg       = cg->machine()->getRealRegister(TR::RealRegister::gr2);
+   TR::Register * grSysStackReg   = cg->machine()->getRealRegister(TR::RealRegister::gr1);
    TR::Compilation* comp = cg->comp();
 
    int32_t callerSaveTOCOffset = (TR::Compiler->target.cpu.isBigEndian() ? 5 : 3) *  TR::Compiler->om.sizeofReferenceAddress();
@@ -6157,7 +6157,7 @@ void OMR::Power::TreeEvaluator::restoreTOCRegister(TR::Node *node, TR::CodeGener
 
 TR::Register *OMR::Power::TreeEvaluator::retrieveTOCRegister(TR::Node *node, TR::CodeGenerator *cg, TR::RegisterDependencyConditions *dependencies)
 {
-   return cg->machine()->getPPCRealRegister(TR::RealRegister::gr2);
+   return cg->machine()->getRealRegister(TR::RealRegister::gr2);
 }
 
 TR::Register * OMR::Power::TreeEvaluator::ibyteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,7 +70,7 @@ OMR::Power::Instruction::generateBinaryEncoding()
       if (self()->getOpCodeValue() == TR::InstOpCode::genop)
          {
          TR::RealRegister::RegNum nopreg = TR::Compiler->target.cpu.id() > TR_PPCp6 ? TR::RealRegister::gr2 : TR::RealRegister::gr1;
-         TR::RealRegister *r = self()->cg()->machine()->getPPCRealRegister(nopreg);
+         TR::RealRegister *r = self()->cg()->machine()->getRealRegister(nopreg);
          r->setRegisterFieldRS((uint32_t *) cursor);
          r->setRegisterFieldRA((uint32_t *) cursor);
          }

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -778,7 +778,7 @@ TR_Debug::printPPCGCRegisterMap(TR::FILE *pOutFile, TR::GCRegisterMap * map)
    for (int i = 31; i>=0; i--)
       {
       if (map->getMap() & (1 << i))
-         trfprintf(pOutFile, "%s ", getName(machine->getPPCRealRegister((TR::RealRegister::RegNum)(31 - i + TR::RealRegister::FirstGPR))));
+         trfprintf(pOutFile, "%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum)(31 - i + TR::RealRegister::FirstGPR))));
       }
 
    trfprintf(pOutFile,"}\n");

--- a/compiler/p/codegen/PPCHelperCallSnippet.cpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -144,7 +144,7 @@ uint8_t *TR::PPCArrayCopyCallSnippet::emitSnippetBody()
 
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    getSnippetLabel()->setCodeLocation(buffer);
-   TR::RealRegister *lengthReg = cg()->machine()->getPPCRealRegister(_lengthRegNum);
+   TR::RealRegister *lengthReg = cg()->machine()->getRealRegister(_lengthRegNum);
    TR::Node *lengthNode = node->getChild(2);
    int64_t byteLen = (lengthNode->getType().isInt32() ?
                       lengthNode->getInt() : lengthNode->getLongInt());
@@ -166,7 +166,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCArrayCopyCallSnippet *snippet, uint8_
    {
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "ArrayCopy Helper Call Snippet");
 
-   TR::RealRegister *lengthReg = _cg->machine()->getPPCRealRegister(snippet->getLengthRegNum());
+   TR::RealRegister *lengthReg = _cg->machine()->getRealRegister(snippet->getLengthRegNum());
 
    printPrefix(pOutFile, NULL, cursor, 4);
    trfprintf(pOutFile, "li \t%s, %d", getName(lengthReg), *((int32_t *) cursor) & 0x0000ffff);

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -440,7 +440,7 @@ void TR::PPCTrg1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned, 
    TR::Instruction::assignRegisters( kindToBeAssigned );
 
    if (excludeGPR0 && (assignedRegister != NULL) &&
-       (toRealRegister(assignedRegister) == machine->getPPCRealRegister(TR::RealRegister::gr0)))
+       (toRealRegister(assignedRegister) == machine->getRealRegister(TR::RealRegister::gr0)))
       {
       TR::RealRegister    *alternativeRegister;
 
@@ -552,7 +552,7 @@ void TR::PPCTrg1Src1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssign
    targetVirtual->block();
    assignedRegister = sourceVirtual->getAssignedRealRegister();
    if (excludeGPR0 && (assignedRegister != NULL) &&
-       (toRealRegister(assignedRegister) == machine->getPPCRealRegister(TR::RealRegister::gr0)))
+       (toRealRegister(assignedRegister) == machine->getRealRegister(TR::RealRegister::gr0)))
       {
       TR::RealRegister    *alternativeRegister;
 
@@ -908,7 +908,7 @@ void TR::PPCMemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigne
    mref->blockRegisters();
    assignedRegister = sourceVirtual->getAssignedRealRegister();
    if (excludeGPR0 && (assignedRegister != NULL) &&
-       (toRealRegister(assignedRegister) == machine->getPPCRealRegister(TR::RealRegister::gr0)))
+       (toRealRegister(assignedRegister) == machine->getRealRegister(TR::RealRegister::gr0)))
       {
       TR::RealRegister    *alternativeRegister;
 
@@ -953,7 +953,7 @@ TR::Register *TR::PPCMemSrc1Instruction::getSourceRegisterForStmw(uint32_t i)
    if (rrWant <= TR::RealRegister::LastGPR)
        {
       TR::Machine *machine = cg()->machine();
-       return machine->getPPCRealRegister(rrWant);
+       return machine->getRealRegister(rrWant);
        }
    return NULL;
    }
@@ -1066,7 +1066,7 @@ TR::Register *TR::PPCTrg1MemInstruction::getTargetRegisterForLmw(uint32_t i)
    if (rrWant <= TR::RealRegister::LastGPR)
        {
       TR::Machine *machine = cg()->machine();
-       return machine->getPPCRealRegister(rrWant);
+       return machine->getRealRegister(rrWant);
        }
    return NULL;
    }

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -372,46 +372,46 @@ TR::PPCSystemLinkage::initPPCRealRegisterLinkage()
    int icount;
 
    icount = TR::RealRegister::gr1;
-   machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
-   machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getPPCRealRegister((TR::RealRegister::RegNum)icount));
+   machine->getRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
+   machine->getRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getRealRegister((TR::RealRegister::RegNum)icount));
 
    icount = TR::RealRegister::gr2;
-   machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
-   machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getPPCRealRegister((TR::RealRegister::RegNum)icount));
+   machine->getRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
+   machine->getRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getRealRegister((TR::RealRegister::RegNum)icount));
 
    icount = TR::RealRegister::gr13;
-   machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
-   machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getPPCRealRegister((TR::RealRegister::RegNum)icount));
+   machine->getRealRegister((TR::RealRegister::RegNum)icount)->setState(TR::RealRegister::Locked);
+   machine->getRealRegister((TR::RealRegister::RegNum)icount)->setAssignedRegister(machine->getRealRegister((TR::RealRegister::RegNum)icount));
 
    for (icount=TR::RealRegister::gr3; icount<=TR::RealRegister::gr12;
         icount++)
-      machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
 
    for (icount=TR::RealRegister::LastGPR;
         icount>=TR::RealRegister::gr14; icount--)
-      machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
 
    for (icount=TR::RealRegister::FirstFPR;
         icount<=TR::RealRegister::fp13; icount++)
-      machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
 
    for (icount=TR::RealRegister::LastFPR;
         icount>=TR::RealRegister::fp14; icount--)
-      machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
 
    for (icount=TR::RealRegister::FirstVRF;
         icount<=TR::RealRegister::LastVRF; icount++)
-      machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
 
    for (icount=TR::RealRegister::FirstCCR;
         icount<=TR::RealRegister::LastCCR; icount++)
       if (icount>=TR::RealRegister::cr2 && icount<=TR::RealRegister::cr4)
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000-icount);
          }
       else
          {
-         machine->getPPCRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
+         machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(icount);
          }
 
    machine->setNumberOfLockedRegisters(TR_GPR, 3);
@@ -561,7 +561,7 @@ TR::PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    TR::RealRegister::RegNum regIndex = TR::RealRegister::gr13;
    if (!method->isEHAware())
       {
-      while (regIndex<=TR::RealRegister::LastGPR && !machine->getPPCRealRegister(regIndex)->getHasBeenAssignedInMethod())
+      while (regIndex<=TR::RealRegister::LastGPR && !machine->getRealRegister(regIndex)->getHasBeenAssignedInMethod())
          regIndex = (TR::RealRegister::RegNum)((uint32_t)regIndex+1);
       }
 
@@ -575,7 +575,7 @@ TR::PPCSystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    regIndex = TR::RealRegister::fp14;
    if (!method->isEHAware())
       {
-      while (regIndex<=TR::RealRegister::LastFPR && !machine->getPPCRealRegister(regIndex)->getHasBeenAssignedInMethod())
+      while (regIndex<=TR::RealRegister::LastFPR && !machine->getRealRegister(regIndex)->getHasBeenAssignedInMethod())
          regIndex = (TR::RealRegister::RegNum)((uint32_t)regIndex + 1);
       }
 
@@ -636,13 +636,13 @@ TR::PPCSystemLinkage::createPrologue(
    const TR::PPCLinkageProperties &properties = getProperties();
    TR::ResolvedMethodSymbol        *bodySymbol = comp()->getJittedMethodSymbol();
    // Stack Pointer Register may currently be set to "alternate"
-   cg()->setStackPointerRegister(machine->getPPCRealRegister(properties.getNormalStackPointerRegister()));
+   cg()->setStackPointerRegister(machine->getRealRegister(properties.getNormalStackPointerRegister()));
    TR::RealRegister        *sp = cg()->getStackPointerRegister();
    TR::RealRegister        *metaBase = cg()->getMethodMetaDataRegister();
-   TR::RealRegister        *gr2 = machine->getPPCRealRegister(TR::RealRegister::gr2);
-   TR::RealRegister        *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
-   TR::RealRegister        *gr11 = machine->getPPCRealRegister(TR::RealRegister::gr11);
-   TR::RealRegister        *cr0 = machine->getPPCRealRegister(TR::RealRegister::cr0);
+   TR::RealRegister        *gr2 = machine->getRealRegister(TR::RealRegister::gr2);
+   TR::RealRegister        *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
+   TR::RealRegister        *gr11 = machine->getRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister        *cr0 = machine->getRealRegister(TR::RealRegister::cr0);
    TR::Node                   *firstNode = comp()->getStartTree()->getNode();
    TR::RealRegister::RegNum regIndex;
    int32_t                    size = bodySymbol->getLocalMappingCursor();
@@ -671,19 +671,19 @@ TR::PPCSystemLinkage::createPrologue(
    TR::RealRegister::RegNum savedFirst=TR::RealRegister::fp14;
    if (!bodySymbol->isEHAware())
       {
-      while (savedFirst<=TR::RealRegister::LastFPR && !machine->getPPCRealRegister(savedFirst)->getHasBeenAssignedInMethod())
+      while (savedFirst<=TR::RealRegister::LastFPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
          savedFirst=(TR::RealRegister::RegNum)((uint32_t)savedFirst+1);
       }
    for (regIndex=TR::RealRegister::LastFPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
       {
       argSize = argSize - 8;
-      cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, 8, cg()), machine->getPPCRealRegister(regIndex), cursor);
+      cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, 8, cg()), machine->getRealRegister(regIndex), cursor);
       }
 
    savedFirst = TR::RealRegister::gr13;
    if (!bodySymbol->isEHAware())
       {
-      while (savedFirst<=TR::RealRegister::LastGPR && !machine->getPPCRealRegister(savedFirst)->getHasBeenAssignedInMethod())
+      while (savedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
          savedFirst=(TR::RealRegister::RegNum)((uint32_t)savedFirst+1);
       }
 
@@ -695,19 +695,19 @@ TR::PPCSystemLinkage::createPrologue(
          for (regIndex=TR::RealRegister::LastGPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
             {
             argSize = argSize - TR::Compiler->om.sizeofReferenceAddress();
-            cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), machine->getPPCRealRegister(regIndex), cursor);
+            cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), machine->getRealRegister(regIndex), cursor);
             }
       else
          {
          argSize = argSize - (TR::RealRegister::LastGPR - savedFirst + 1) * 4;
-         cursor = generateMemSrc1Instruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), machine->getPPCRealRegister(savedFirst), cursor);
+         cursor = generateMemSrc1Instruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::stw:TR::InstOpCode::stmw, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, argSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), machine->getRealRegister(savedFirst), cursor);
          }
       }
 
    if ( bodySymbol->isEHAware() ||
-        machine->getPPCRealRegister(TR::RealRegister::cr2)->getHasBeenAssignedInMethod() ||
-        machine->getPPCRealRegister(TR::RealRegister::cr3)->getHasBeenAssignedInMethod() ||
-        machine->getPPCRealRegister(TR::RealRegister::cr4)->getHasBeenAssignedInMethod() )
+        machine->getRealRegister(TR::RealRegister::cr2)->getHasBeenAssignedInMethod() ||
+        machine->getRealRegister(TR::RealRegister::cr3)->getHasBeenAssignedInMethod() ||
+        machine->getRealRegister(TR::RealRegister::cr4)->getHasBeenAssignedInMethod() )
       {
       cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::mfcr, firstNode, gr0, 0xff, cursor);
       cursor = generateMemSrc1Instruction(cg(),TR::InstOpCode::Op_st, firstNode, new (trHeapMemory()) TR::MemoryReference(sp, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()), gr0, cursor);
@@ -763,8 +763,8 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    TR::RealRegister *sp = cg()->getStackPointerRegister();
    TR::RealRegister *sp2 = sp;
-   TR::RealRegister *gr0 = machine->getPPCRealRegister(TR::RealRegister::gr0);
-   TR::RealRegister *gr11 = machine->getPPCRealRegister(TR::RealRegister::gr11);
+   TR::RealRegister *gr0 = machine->getRealRegister(TR::RealRegister::gr0);
+   TR::RealRegister *gr11 = machine->getRealRegister(TR::RealRegister::gr11);
    TR::Node *currentNode = cursor->getNode();
    int32_t size = bodySymbol->getLocalMappingCursor();
    int32_t saveSize = 0;
@@ -774,19 +774,19 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    if (!bodySymbol->isEHAware())
       {
-      while (savedFirst<=TR::RealRegister::LastFPR && !machine->getPPCRealRegister(savedFirst)->getHasBeenAssignedInMethod())
+      while (savedFirst<=TR::RealRegister::LastFPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
          savedFirst=(TR::RealRegister::RegNum)((uint32_t)savedFirst+1);
       }
    for (regIndex=TR::RealRegister::LastFPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
       {
       saveSize = saveSize - 8;
-      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lfd, currentNode, machine->getPPCRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, 8, cg()), cursor);
+      cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lfd, currentNode, machine->getRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, 8, cg()), cursor);
       }
 
    savedFirst = TR::RealRegister::gr13;
    if (!bodySymbol->isEHAware())
       {
-      while (savedFirst<=TR::RealRegister::LastGPR && !machine->getPPCRealRegister(savedFirst)->getHasBeenAssignedInMethod())
+      while (savedFirst<=TR::RealRegister::LastGPR && !machine->getRealRegister(savedFirst)->getHasBeenAssignedInMethod())
          savedFirst=(TR::RealRegister::RegNum)((uint32_t)savedFirst+1);
       }
 
@@ -798,12 +798,12 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
          for (regIndex=TR::RealRegister::LastGPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
             {
             saveSize = saveSize - TR::Compiler->om.sizeofReferenceAddress();
-            cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getPPCRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
+            cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, machine->getRealRegister(regIndex), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
             }
       else
          {
          saveSize = saveSize - (TR::RealRegister::LastGPR - savedFirst + 1) * 4;
-         cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getPPCRealRegister(savedFirst), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), cursor);
+         cursor = generateTrg1MemInstruction(cg(), (savedFirst==TR::RealRegister::LastGPR)?TR::InstOpCode::lwz:TR::InstOpCode::lmw, currentNode, machine->getRealRegister(savedFirst), new (trHeapMemory()) TR::MemoryReference(sp, saveSize, 4*(TR::RealRegister::LastGPR-savedFirst+1), cg()), cursor);
          }
       }
 
@@ -833,9 +833,9 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    if ( bodySymbol->isEHAware() ||
-        machine->getPPCRealRegister(TR::RealRegister::cr2)->getHasBeenAssignedInMethod() ||
-        machine->getPPCRealRegister(TR::RealRegister::cr3)->getHasBeenAssignedInMethod() ||
-        machine->getPPCRealRegister(TR::RealRegister::cr4)->getHasBeenAssignedInMethod() )
+        machine->getRealRegister(TR::RealRegister::cr2)->getHasBeenAssignedInMethod() ||
+        machine->getRealRegister(TR::RealRegister::cr3)->getHasBeenAssignedInMethod() ||
+        machine->getRealRegister(TR::RealRegister::cr4)->getHasBeenAssignedInMethod() )
       {
       cursor = generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, currentNode, gr0, new (trHeapMemory()) TR::MemoryReference(sp, TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()), cursor);
       cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::mtcrf, currentNode, gr0, 0xff, cursor);
@@ -1566,7 +1566,7 @@ void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                        
    //Library TOC Register
    TR::Register        *grTOCReg=TR::TreeEvaluator::retrieveTOCRegister(callNode, cg(), dependencies);
    //Native Stack Pointer (C Stack)
-   TR::RealRegister *grSysStackReg=cg()->machine()->getPPCRealRegister(properties.getNormalStackPointerRegister());
+   TR::RealRegister *grSysStackReg=cg()->machine()->getRealRegister(properties.getNormalStackPointerRegister());
 
    TR_ASSERT((gr0 != NULL),            "TR::PPCSystemLinkage::buildVirtualDispatch no dependence set on scratch register gr0.");
    TR_ASSERT((grTOCReg != NULL),       "TR::PPCSystemLinkage::buildVirtualDispatch no dependence set on Library TOC register gr2.");


### PR DESCRIPTION
Rename the `OMR::Power::Machine::getPPCRealRegister()` method to
`OMR::Power::Machine::getRealRegister()` in order to get the strength
of polymorphism.

P.S. The method `getPPCRealRegister()` is still declared for backward compatibility.

Issue: #2645