### PR TITLE
Changing the name of OMR::AutomaticSymbol::getKind() to getOpCodeKind()

### DIFF
--- a/compiler/il/symbol/OMRAutomaticSymbol.cpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ OMR::AutomaticSymbol::init()
    }
 
 TR::ILOpCodes
-OMR::AutomaticSymbol::getKind()
+OMR::AutomaticSymbol::getOpCodeKind()
   {
   TR_ASSERT(self()->isLocalObject(), "Should be local object");
   return _kind;

--- a/compiler/il/symbol/OMRAutomaticSymbol.hpp
+++ b/compiler/il/symbol/OMRAutomaticSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -134,7 +134,7 @@ public:
                                                    uint32_t               s,
                                                    TR_FrontEnd *          fe);
 
-   TR::ILOpCodes getKind();
+   TR::ILOpCodes getOpCodeKind();
 
    TR::SymbolReference *getClassSymbolReference();
    TR::SymbolReference *setClassSymbolReference(TR::SymbolReference *s);

--- a/compiler/optimizer/LocalDeadStoreElimination.cpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -868,7 +868,7 @@ void TR::LocalDeadStoreElimination::eliminateDeadObjectInitializations()
          if (sym)
             {
             if (sym->isLocalObject() &&
-                sym->getLocalObjectSymbol()->getKind() == TR::New)
+                sym->getLocalObjectSymbol()->getOpCodeKind() == TR::New)
                sym->setLocalIndex(numSymbols++);
             else
                sym->setLocalIndex(0);
@@ -906,7 +906,7 @@ void TR::LocalDeadStoreElimination::eliminateDeadObjectInitializations()
          {
          if (storeNode->getFirstChild()->getOpCode().hasSymbolReference() &&
              storeNode->getFirstChild()->getSymbolReference()->getSymbol()->isLocalObject() &&
-             (storeNode->getFirstChild()->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getKind() == TR::New) &&
+             (storeNode->getFirstChild()->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getOpCodeKind() == TR::New) &&
              !usedLocalObjectSymbols.get(storeNode->getFirstChild()->getSymbolReference()->getSymbol()->getLocalIndex()))
             removableLocalObjectStore = true;
          else if (currentNews.find(storeNode->getFirstChild()) ||
@@ -1013,7 +1013,7 @@ void TR::LocalDeadStoreElimination::findLocallyAllocatedObjectUses(LDSBitVector 
    {
    if (node->getOpCode().hasSymbolReference() &&
        (node->getSymbolReference()->getSymbol()->isLocalObject() &&
-        node->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getKind() == TR::New) &&
+        node->getSymbolReference()->getSymbol()->getLocalObjectSymbol()->getOpCodeKind() == TR::New) &&
        !(parent->getOpCode().isStoreIndirect() && childNum == 0 &&
          ( (uint32_t) parent->getSymbolReference()->getOffset() < fe()->getObjectHeaderSizeInBytes())))
        usedLocalObjectSymbols.set(node->getSymbolReference()->getSymbol()->getLocalIndex());

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -11490,12 +11490,12 @@ TR::Node *constrainLoadaddr(OMR::ValuePropagation *vp, TR::Node *node)
       TR::VPClassType *typeConstraint = 0;
       TR::AutomaticSymbol *localObj = symbol->castToLocalObjectSymbol();
       symRef                       = localObj->getClassSymbolReference();
-      if (localObj->getKind() == TR::New)
+      if (localObj->getOpCodeKind() == TR::New)
          {
          if (symRef)
             typeConstraint = TR::VPClassType::create(vp, symRef, true);
          }
-      else if (localObj->getKind() == TR::anewarray)
+      else if (localObj->getOpCodeKind() == TR::anewarray)
          {
          typeConstraint = TR::VPClassType::create(vp, symRef, true);
          typeConstraint = typeConstraint->getClassType()->getArrayClass(vp);


### PR DESCRIPTION
Changed the name of `getKind` in `OMR::AutomaticSymbol` to have less ambiguity in function names.

`getKind()` function is being defined in two classes of the same hierarchy, but with different return types:
* `OMR::Symbol::getKind()` returns an `int32_t`
* `OMR::AutomaticSymbol::getKind()` returns an `TR::ILOpCodes` object
* `OMR::AutomaticSymbol` indirectly inherits from `OMR::Symbol`

As part of our work to virtualize the class hierarchies of Eclipse OMR (see motivation of #3235 for more info), we stumbled upon this case. Virtualizing `getKind()` here is not possible due to the different return type. In order to move on with our process and help OMR have a clearer design (less ambiguity in function names), we suggest changing the `getKind()` function in `OMR::AutomaticSymbol` to `getOpCodeKind()`, which describes the functionality of this method more clearly.

Signed-off-by: Samer AL Masri <almasri@ualberta.ca>