### PR TITLE
Only devirtualize call for compatible classes

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -7281,20 +7281,6 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
          if ((receiverInfo.classIsRefined() && receiverInfo.classIsFixed()) || receiverInfo.classIsCurrentlyFinal())
             fixedOrFinalInfoExists = true;
 
-         if (!isInterface && fixedOrFinalInfoExists)
-            {
-            TR_OpaqueClassBlock *clazz = resolvedMethod->containingClass();
-            if (clazz)
-               {
-               TR_OpaqueClassBlock *thisClazz = receiverInfo.getClass();
-               if (thisClazz)
-                  {
-                  TR_YesNoMaybe isInstance = fe()->isInstanceOf(thisClazz, clazz, true);
-                  if (isInstance == TR_yes)
-                     devirtualize = true;
-                  }
-               }
-            }
          }
       }
 
@@ -7317,12 +7303,22 @@ void TR_InvariantArgumentPreexistence::processIndirectCall(TR::Node *node, TR::T
          }
 
       receiverInfo.setClassIsFixed();
+      fixedOrFinalInfoExists = true;
+      }
 
-      // If the receiver is a known object, we can always devirtualize as long
-      // as the method is resolved.
-      //
-      if (methodSymbol->isVirtual())
-         devirtualize = true;
+   if (methodSymbol->isVirtual() && fixedOrFinalInfoExists)
+      {
+      TR_OpaqueClassBlock *clazz = resolvedMethod->containingClass();
+      if (clazz)
+         {
+         TR_OpaqueClassBlock *thisClazz = receiverInfo.getClass();
+         if (thisClazz)
+            {
+            TR_YesNoMaybe isInstance = fe()->isInstanceOf(thisClazz, clazz, true);
+            if (isInstance == TR_yes)
+               devirtualize = true;
+            }
+         }
       }
 
    //


### PR DESCRIPTION
Change InvariantArgumentPreexistence to only devirtualize method if the
propagated arg info with known object index is compatible with the
method class of the callsite.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>