### PR TITLE
AArch64: Change the operand order of store instructions in trace file

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -831,8 +831,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64MemSrc1Instruction *instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
-   print(pOutFile, instr->getMemoryReference()); trfprintf(pOutFile, ", ");
-   print(pOutFile, instr->getSource1Register(), TR_WordReg);
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getMemoryReference());
 
    printMemoryReferenceComment(pOutFile, instr->getMemoryReference());
    trfflush(_comp->getOutFile());


### PR DESCRIPTION
This commit changes the order of operands of store instructions
from "str [sp, 0], lr" to "str lr, [sp, 0]", which is the same order
as that in AArch64 assembler syntax.

Signed-off-by: knn-k <konno@jp.ibm.com>