### PR TITLE
Rename OMR::Z::Machine::getS390RealRegister()

### DIFF
--- a/compiler/z/codegen/CallSnippet.cpp
+++ b/compiler/z/codegen/CallSnippet.cpp
@@ -100,7 +100,7 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
             if (intArgNum < linkage->getNumIntegerArgumentRegisters())
                {
                buffer = storeArgumentItem(TR::InstOpCode::ST, buffer,
-                           machine->getS390RealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
+                           machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
 
@@ -117,7 +117,7 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
             if (intArgNum < linkage->getNumIntegerArgumentRegisters())
                {
                buffer = storeArgumentItem(TR::InstOpCode::getStoreOpCode(), buffer,
-                           machine->getS390RealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
+                           machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
                }
             intArgNum++;
 
@@ -137,16 +137,16 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
                if (TR::Compiler->target.is64Bit())
                   {
                   buffer = storeArgumentItem(TR::InstOpCode::STG, buffer,
-                              machine->getS390RealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
+                              machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
                   }
                else
                   {
                   buffer = storeArgumentItem(TR::InstOpCode::ST, buffer,
-                              machine->getS390RealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
+                              machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
                   if (intArgNum < linkage->getNumIntegerArgumentRegisters() - 1)
                      {
                      buffer = storeArgumentItem(TR::InstOpCode::ST, buffer,
-                                 machine->getS390RealRegister(linkage->getIntegerArgumentRegister(intArgNum + 1)), offset + 4, cg);
+                                 machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum + 1)), offset + 4, cg);
                      }
                   }
                }
@@ -165,7 +165,7 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
             if (floatArgNum < linkage->getNumFloatArgumentRegisters())
                {
                buffer = storeArgumentItem(TR::InstOpCode::STE, buffer,
-                           machine->getS390RealRegister(linkage->getFloatArgumentRegister(floatArgNum)), offset, cg);
+                           machine->getRealRegister(linkage->getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
             if (rightToLeft)
@@ -182,7 +182,7 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
             if (floatArgNum < linkage->getNumFloatArgumentRegisters())
                {
                buffer = storeArgumentItem(TR::InstOpCode::STD, buffer,
-                           machine->getS390RealRegister(linkage->getFloatArgumentRegister(floatArgNum)), offset, cg);
+                           machine->getRealRegister(linkage->getFloatArgumentRegister(floatArgNum)), offset, cg);
                }
             floatArgNum++;
             if (rightToLeft)

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -111,7 +111,7 @@ TR::Instruction * generateS390CompareOps(TR::Node * node, TR::CodeGenerator * cg
 void killRegisterIfNotLocked(TR::CodeGenerator * cg, TR::RealRegister::RegNum reg, TR::Instruction * instr , TR::RegisterDependencyConditions * deps = NULL)
    {
          TR::Register *dummy = NULL;
-         if (cg->machine()->getS390RealRegister(reg)->getState() != TR::RealRegister::Locked)
+         if (cg->machine()->getRealRegister(reg)->getState() != TR::RealRegister::Locked)
             {
             if (deps == NULL)
                deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 1, cg);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1508,7 +1508,7 @@ OMR::Z::CodeGenerator::insertInstructionPrefetches()
          _hottestReturn._returnLabel = generateLabelSymbol(self());
 
          TR::Register * tempReg = self()->allocateRegister();
-         TR::RealRegister * spReg =  self()->getS390Linkage()->getS390RealRegister(self()->getS390Linkage()->getStackPointerRegister());
+         TR::RealRegister * spReg =  self()->getS390Linkage()->getRealRegister(self()->getS390Linkage()->getStackPointerRegister());
          int32_t frameSize = self()->getFrameSizeInBytes();
 
          TR::MemoryReference * tempMR = generateS390MemoryReference(spReg, frameSize, self());
@@ -2524,28 +2524,28 @@ OMR::Z::CodeGenerator::prepareRegistersForAssignment()
    // count up how many registers are locked for each type
    for (int32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedGPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedHPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedFPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstVRF; i <= TR::RealRegister::LastVRF; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedVRFs;
       }
@@ -2787,8 +2787,8 @@ OMR::Z::CodeGenerator::doRegisterAssignment(TR_RegisterKinds kindsToAssign)
       {
       for (uint32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR; ++i)
          {
-         TR_ASSERT(self()->machine()->getS390RealRegister(i)->getState() != TR::RealRegister::Assigned,
-                    "ASSERTION: GPR registers are still assigned at end of first RA pass! %s regNum=%s\n", self()->comp()->signature(), self()->getDebug()->getName(self()->machine()->getS390RealRegister(i)));
+         TR_ASSERT(self()->machine()->getRealRegister(i)->getState() != TR::RealRegister::Assigned,
+                    "ASSERTION: GPR registers are still assigned at end of first RA pass! %s regNum=%s\n", self()->comp()->signature(), self()->getDebug()->getName(self()->machine()->getRealRegister(i)));
          }
 
       if (self()->getDebug())
@@ -3137,7 +3137,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
                   {
                   for (uint8_t i=highReg->getRegisterNumber()+1; i++; i<= numRegs)
                      {
-                     self()->getS390Linkage()->getS390RealRegister(REGNUM(i))->setModified(true);
+                     self()->getS390Linkage()->getRealRegister(REGNUM(i))->setModified(true);
                      }
                   }
                }
@@ -3861,7 +3861,7 @@ OMR::Z::CodeGenerator::setRealRegisterAssociation(TR::Register * reg, TR::RealRe
       return;
       }
 
-   TR::RealRegister * realReg = self()->machine()->getS390RealRegister(realNum);
+   TR::RealRegister * realReg = self()->machine()->getRealRegister(realNum);
    self()->getLiveRegisters(reg->getKind())->setAssociation(reg, realReg);
    }
 
@@ -3906,7 +3906,7 @@ void OMR::Z::CodeGenerator::startInternalControlFlow(TR::Instruction *instr)
           {
           TR::RealRegister::RegNum rr = postConds->getRegisterDependency(i)->getRealRegister();
           if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
-            r = mach->getS390RealRegister(rr);
+            r = mach->getRealRegister(rr);
           }
         if(r) _internalControlFlowRegisters.push_back(r);
         }
@@ -5190,7 +5190,7 @@ OMR::Z::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map)
       {
       for (int32_t i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; i++)
          {
-         TR::RealRegister * realReg = self()->machine()->getS390RealRegister((TR::RealRegister::RegNum) i);
+         TR::RealRegister * realReg = self()->machine()->getRealRegister((TR::RealRegister::RegNum) i);
          if (realReg->getHasBeenAssignedInMethod())
             {
             TR::Register * virtReg = realReg->getAssignedRegister();
@@ -5205,7 +5205,7 @@ OMR::Z::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap * map)
       }
    for (int32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; i++)
       {
-      TR::RealRegister * realReg = self()->machine()->getS390RealRegister((TR::RealRegister::RegNum) i);
+      TR::RealRegister * realReg = self()->machine()->getRealRegister((TR::RealRegister::RegNum) i);
       if (realReg->getHasBeenAssignedInMethod())
          {
          TR::Register * virtReg = realReg->getAssignedRegister();
@@ -6408,7 +6408,7 @@ void handleLoadWithRegRanges(TR::Instruction *inst, TR::CodeGenerator *cg)
                  i != highRegNum ;
                  i  = ((i == (isVector ? numVRFs - 1 : 15)) ? 0 : i+1))
       {
-      TR::RealRegister *reg = cg->machine()->getS390RealRegister(i + TR::RealRegister::GPR0);
+      TR::RealRegister *reg = cg->machine()->getRealRegister(i + TR::RealRegister::GPR0);
 
       // Registers that are assigned need to be checked whether they have a matching STM--otherwise we spill.
       // Since we are called post RA for the LM, we check if assigned registers are last used on the LM so we can

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -775,7 +775,7 @@ bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
   TR::MemoryReference **_targetMem = self()->targetMemBase();
   TR::Register *baseReg, *indexReg;
 
-  if(self()->getOpCodeValue() == TR::InstOpCode::BCR && _sourceRegSize == 1 && _sourceReg[0]->getRealRegister() == machine->getS390RealRegister(TR::RealRegister::GPR0))
+  if(self()->getOpCodeValue() == TR::InstOpCode::BCR && _sourceRegSize == 1 && _sourceReg[0]->getRealRegister() == machine->getRealRegister(TR::RealRegister::GPR0))
     return false;
 
   if((self()->getOpCodeValue() == TR::InstOpCode::XGR || self()->getOpCodeValue() == TR::InstOpCode::XR) && _sourceReg[0] == _targetReg[0])
@@ -898,7 +898,7 @@ bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
               TR::RealRegister::RegNum rr = dep->getRealRegister();
               if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
-                usedRegs.push_back(machine->getS390RealRegister(rr));
+                usedRegs.push_back(machine->getRealRegister(rr));
                 }
               }
             }
@@ -931,7 +931,7 @@ bool OMR::Z::Instruction::getUsedRegisters(TR::list<TR::Register *> &usedRegs)
               TR::RealRegister::RegNum rr = dep->getRealRegister();
               if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
-                usedRegs.push_back(machine->getS390RealRegister(rr));
+                usedRegs.push_back(machine->getRealRegister(rr));
                 }
               }
             }
@@ -1019,7 +1019,7 @@ bool OMR::Z::Instruction::getDefinedRegisters(TR::list<TR::Register *> &defedReg
               TR::RealRegister::RegNum rr = dep->getRealRegister();
               if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
-                defedRegs.push_back(machine->getS390RealRegister(rr));
+                defedRegs.push_back(machine->getRealRegister(rr));
                 }
               }
             }
@@ -1052,7 +1052,7 @@ bool OMR::Z::Instruction::getDefinedRegisters(TR::list<TR::Register *> &defedReg
               TR::RealRegister::RegNum rr = dep->getRealRegister();
               if(rr>TR::RealRegister::NoReg && rr<=TR::RealRegister::LastHPR)
                 {
-                defedRegs.push_back(machine->getS390RealRegister(rr));
+                defedRegs.push_back(machine->getRealRegister(rr));
                 }
               }
             }
@@ -1104,14 +1104,14 @@ bool OMR::Z::Instruction::getKilledRegisters(TR::list<TR::Register *> &killedReg
         TR::RegisterDependency* dep=postConds->getRegisterDependency(i);
         TR::Register *r=dep->getRegister();
         if(r && r->isPlaceholderReg())
-          killedRegs.push_back(machine->getS390RealRegister(dep->getRealRegister()));
+          killedRegs.push_back(machine->getRealRegister(dep->getRealRegister()));
         }
       }
     }
 
   // A function call via address in a register uses register r1 to hold the target address but this register is also killed.
   if(self()->getOpCodeValue() == TR::InstOpCode::BASR)
-    killedRegs.push_back(machine->getS390RealRegister(TR::RealRegister::GPR1));
+    killedRegs.push_back(machine->getRealRegister(TR::RealRegister::GPR1));
 
   // We might have an out of line EX instruction.  If so, we
   // need to check whether either the EX instruction OR the instruction
@@ -2519,7 +2519,7 @@ OMR::Z::Instruction::assignRegistersAndDependencies(TR_RegisterKinds kindToBeAss
           {
           if (linkage->getPreserved(REGNUM(i)))
             {
-            TR::RealRegister * targetRegister = machine->getS390RealRegister(REGNUM(i));
+            TR::RealRegister * targetRegister = machine->getRealRegister(REGNUM(i));
             TR::Register * assignedReg = targetRegister->getAssignedRegister();
             if(assignedReg && assignedReg->getKind() != TR_FPR)
               {
@@ -2976,7 +2976,7 @@ OMR::Z::Instruction::setUseDefRegisters(bool updateDependencies)
          lowRegNum = (lowRegNum == 15) ? 0 : lowRegNum + 1;
          for (uint32_t i = lowRegNum; i != highRegNum; i = ((i == 15) ? 0 : i + 1))  // wrap around to 0 at 15
             {
-            TR::RealRegister *reg = self()->cg()->machine()->getS390RealRegister(i + TR::RealRegister::GPR0);
+            TR::RealRegister *reg = self()->cg()->machine()->getRealRegister(i + TR::RealRegister::GPR0);
             if (loadOrStoreMultiple == 0) // load
                (*_defRegs)[indexTarget++] = reg;
             else if (loadOrStoreMultiple == 1) // store
@@ -3143,7 +3143,7 @@ OMR::Z::Instruction::getOneLocalLocalAllocFreeReg(TR::RealRegister ** reg)
      {
      if ( (_binFreeRegs>>cnt)&0x1 )
         {
-        *reg = self()->cg()->machine()->getS390RealRegister(cnt+1);
+        *reg = self()->cg()->machine()->getRealRegister(cnt+1);
         return true;
         }
      cnt++;
@@ -3169,11 +3169,11 @@ OMR::Z::Instruction::getTwoLocalLocalAllocFreeReg(TR::RealRegister ** reg1, TR::
         {
         if (*reg1 == NULL)
            {
-           *reg1 = self()->cg()->machine()->getS390RealRegister(cnt+1);
+           *reg1 = self()->cg()->machine()->getRealRegister(cnt+1);
            }
         else
            {
-           *reg2 = self()->cg()->machine()->getS390RealRegister(cnt+1);
+           *reg2 = self()->cg()->machine()->getRealRegister(cnt+1);
            return true;
            }
         }

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -3441,6 +3441,12 @@ OMR::Z::Linkage::trStackMemory()
    }
 
 TR::RealRegister *
+OMR::Z::Linkage::getS390RealRegister(TR::RealRegister::RegNum rNum)
+   {
+   return self()->cg()->machine()->getRealRegister(rNum);
+   }
+
+TR::RealRegister *
 OMR::Z::Linkage::getRealRegister(TR::RealRegister::RegNum rNum)
    {
    return self()->cg()->machine()->getRealRegister(rNum);

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -147,14 +147,14 @@ OMR::Z::Linkage::markPreservedRegsInDep(TR::RegisterDependencyConditions * deps)
       if (self()->getPreserved(REGNUM(curReg)) &&
           deps->searchPostConditionRegister(REGNUM(curReg)))
          {
-         self()->getS390RealRegister(REGNUM(curReg))->setModified(true);
+         self()->getRealRegister(REGNUM(curReg))->setModified(true);
          }
       }
 
   // and the RAReg
   if (deps && deps->searchPostConditionRegister(self()->cg()->getReturnAddressRegister()))
      {
-     self()->getS390RealRegister(self()->getReturnAddressRegister())->setModified(true);
+     self()->getRealRegister(self()->getReturnAddressRegister())->setModified(true);
      }
   }
 
@@ -162,14 +162,14 @@ void
 OMR::Z::Linkage::markPreservedRegsInBlock(int32_t blockNum)
    {
    // kill RAReg
-   self()->getS390RealRegister(self()->getReturnAddressRegister())->setModified(true);
+   self()->getRealRegister(self()->getReturnAddressRegister())->setModified(true);
 
    // catch blocks kill all preserved regs
    for (int32_t curReg = TR::RealRegister::FirstGPR; curReg <= TR::RealRegister::LastFPR; curReg++)
       {
       if (self()->getPreserved(REGNUM(curReg)))
          {
-         self()->getS390RealRegister(REGNUM(curReg))->setModified(true);
+         self()->getRealRegister(REGNUM(curReg))->setModified(true);
          }
       }
    }
@@ -577,7 +577,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
          }
 
       if (ai >= 0 &&
-         loadOpCode == TR::InstOpCode::L && enableHighWordRA && self()->getS390RealRegister(REGNUM(ai))->isHighWordRegister())
+         loadOpCode == TR::InstOpCode::L && enableHighWordRA && self()->getRealRegister(REGNUM(ai))->isHighWordRegister())
          loadOpCode = TR::InstOpCode::LFH;
 
       if (((self()->isSmallIntParmsAlignedRight() && paramCursor->getType().isIntegral()) ||
@@ -699,25 +699,25 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   if (genBinary)
                      {
                      cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(storeOpCode, (uint8_t *) cursor,
-                                          self()->getS390RealRegister(regNum), offset, self()->cg());
+                                          self()->getRealRegister(regNum), offset, self()->cg());
                      }
                   else
                      {
                      TR::MemoryReference* mr = generateS390MemoryReference(stackPtr, offset, self()->cg(), param_name);
 
                      if (storeOpCode == TR::InstOpCode::STCM)
-                        cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::STCM, firstNode, self()->getS390RealRegister(regNum),
+                        cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::STCM, firstNode, self()->getRealRegister(regNum),
                                     opcodeMask, mr, (TR::Instruction *) cursor);
 
                      else
-                        cursor = generateRXInstruction(self()->cg(), storeOpCode, firstNode, self()->getS390RealRegister(regNum),
+                        cursor = generateRXInstruction(self()->cg(), storeOpCode, firstNode, self()->getRealRegister(regNum),
                                              mr, (TR::Instruction *) cursor);
 
 
 
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      if (!InPreProlog && !globalAllocatedRegisters.isSet(regNum))
-                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(regNum), offset);
+                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(regNum), offset);
                      }
                   }
 
@@ -727,17 +727,17 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                      {
                      if (genBinary)
                         {
-                        cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::ST, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                        cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::ST, (uint8_t *) cursor, self()->getRealRegister(regNum),
                                              offset, self()->cg());
                         }
                      else
                         {
                         TR::MemoryReference* mr = generateS390MemoryReference(stackPtr, offset + 4, self()->cg(), param_name);
-                        cursor =  generateRXInstruction(self()->cg(), TR::InstOpCode::ST, firstNode, self()->getS390RealRegister(REGNUM(regNum + 1)),
+                        cursor =  generateRXInstruction(self()->cg(), TR::InstOpCode::ST, firstNode, self()->getRealRegister(REGNUM(regNum + 1)),
                                              mr, (TR::Instruction *) cursor);
                         ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                         if (!InPreProlog && !globalAllocatedRegisters.isSet(regNum))
-                           self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(regNum), offset);
+                           self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(regNum), offset);
                         }
 
                      // argument stored, so regnum is free to be used as a scratch reg
@@ -754,17 +754,17 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                   if (genBinary)
                      {
-                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STE, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STE, (uint8_t *) cursor, self()->getRealRegister(regNum),
                                           offset, self()->cg());
                      }
                   else
                      {
                      TR::MemoryReference* mr = generateS390MemoryReference(stackPtr, offset, self()->cg(), param_name);
-                     cursor =  generateRXInstruction(self()->cg(), TR::InstOpCode::STE, firstNode, self()->getS390RealRegister(regNum),
+                     cursor =  generateRXInstruction(self()->cg(), TR::InstOpCode::STE, firstNode, self()->getRealRegister(regNum),
                                           mr, (TR::Instruction *) cursor);
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      if (!InPreProlog && !globalAllocatedRegisters.isSet(regNum))
-                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(regNum), offset);
+                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(regNum), offset);
                      }
                   break;
                case TR::Double:
@@ -773,26 +773,26 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                   if (genBinary)
                      {
-                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getRealRegister(regNum),
                                           offset, self()->cg());
                      }
                   else
                      {
                      TR::MemoryReference* mr = generateS390MemoryReference(stackPtr, offset, self()->cg(), param_name);
-                     cursor = (void *) generateRXInstruction(self()->cg(), TR::InstOpCode::STD, firstNode, self()->getS390RealRegister(regNum),
+                     cursor = (void *) generateRXInstruction(self()->cg(), TR::InstOpCode::STD, firstNode, self()->getRealRegister(regNum),
                                           mr, (TR::Instruction *) cursor);
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      if (!InPreProlog && !globalAllocatedRegisters.isSet(regNum))
-                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(regNum), offset);
+                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(regNum), offset);
                      }
                   break;
 #ifdef J9_PROJECT_SPECIFIC
                case TR::DecimalLongDouble:
                   if (genBinary)
                      {
-                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getRealRegister(regNum),
                                           offset, self()->cg());
-                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getS390RealRegister(REGNUM(regNum+2)),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::STD, (uint8_t *) cursor, self()->getRealRegister(REGNUM(regNum+2)),
                                           offset+8, self()->cg());
                      }
                   else
@@ -800,16 +800,16 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                      TR::MemoryReference* mr = generateS390MemoryReference(stackPtr, offset, self()->cg(), param_name);
                      TR::MemoryReference * hiMR = generateS390MemoryReference(*mr, 8, self()->cg());
 
-                     cursor = (void *) generateRXInstruction(self()->cg(), TR::InstOpCode::STD, firstNode, self()->getS390RealRegister(regNum),
+                     cursor = (void *) generateRXInstruction(self()->cg(), TR::InstOpCode::STD, firstNode, self()->getRealRegister(regNum),
                                           mr, (TR::Instruction *) cursor);
-                     cursor = (void *) generateRXInstruction(self()->cg(), TR::InstOpCode::STD, firstNode, self()->getS390RealRegister(REGNUM(regNum+2)),
+                     cursor = (void *) generateRXInstruction(self()->cg(), TR::InstOpCode::STD, firstNode, self()->getRealRegister(REGNUM(regNum+2)),
                                           hiMR, (TR::Instruction *) cursor);
 
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      if (!InPreProlog && !globalAllocatedRegisters.isSet(regNum))
-                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(regNum), offset);
+                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(regNum), offset);
                      if (!InPreProlog && !globalAllocatedRegisters.isSet(REGNUM(regNum+2)))
-                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(REGNUM(regNum+2)), offset+8);
+                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(REGNUM(regNum+2)), offset+8);
                      }
                   break;
 #endif
@@ -820,17 +820,17 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                case TR::VectorDouble:
                   if (genBinary)
                      {
-                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::VST, (uint8_t *) cursor, self()->getS390RealRegister(regNum),
+                     cursor =  (void *) TR::S390CallSnippet::storeArgumentItem(TR::InstOpCode::VST, (uint8_t *) cursor, self()->getRealRegister(regNum),
                                           offset, self()->cg());
                      }
                   else
                      {
                      TR::MemoryReference* mr = generateS390MemoryReference(stackPtr, offset, self()->cg(), param_name);
-                     cursor =  generateRXInstruction(self()->cg(), TR::InstOpCode::VST, firstNode, self()->getS390RealRegister(regNum),
+                     cursor =  generateRXInstruction(self()->cg(), TR::InstOpCode::VST, firstNode, self()->getRealRegister(regNum),
                                           mr, (TR::Instruction *) cursor);
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      if (!InPreProlog && !globalAllocatedRegisters.isSet(regNum))
-                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getS390RealRegister(regNum), offset);
+                        self()->removeOSCOnSavedArgument((TR::Instruction *)cursor, self()->getRealRegister(regNum), offset);
                      }
                   break;
 
@@ -871,8 +871,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                       )
                      {
-                     cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LDR, firstNode, self()->getS390RealRegister(REGNUM(ai)),
-                                    self()->getS390RealRegister(regNum), (TR::Instruction *) cursor);
+                     cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LDR, firstNode, self()->getRealRegister(REGNUM(ai)),
+                                    self()->getRealRegister(regNum), (TR::Instruction *) cursor);
 
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      freeScratchable.reset(ai);
@@ -883,8 +883,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                      {
                      int32_t ai_l = paramCursor->getAllocatedLow();  //  low reg of a pair
                      TR_ASSERT( (ai_l == (ai+2)),"global RA incorrect for long double params");
-                     cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LXR, firstNode, self()->cg()->allocateFPRegisterPair(self()->getS390RealRegister(REGNUM(ai_l)), self()->getS390RealRegister(REGNUM(ai))),
-                        self()->cg()->allocateFPRegisterPair(self()->getS390RealRegister(REGNUM(regNum+2)),self()->getS390RealRegister(REGNUM(regNum))), (TR::Instruction *) cursor);
+                     cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LXR, firstNode, self()->cg()->allocateFPRegisterPair(self()->getRealRegister(REGNUM(ai_l)), self()->getRealRegister(REGNUM(ai))),
+                        self()->cg()->allocateFPRegisterPair(self()->getRealRegister(REGNUM(regNum+2)),self()->getRealRegister(REGNUM(regNum))), (TR::Instruction *) cursor);
 
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                      freeScratchable.reset(ai);
@@ -897,8 +897,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                      {
                      if ((dtype == TR::Int64) && self()->cg()->use64BitRegsOn32Bit())
                         {
-                        cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getS390RealRegister(REGNUM(ai)),
-                                    self()->getS390RealRegister(regNum), 32, (TR::Instruction *) cursor);
+                        cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getRealRegister(REGNUM(ai)),
+                                    self()->getRealRegister(regNum), 32, (TR::Instruction *) cursor);
 
                         if (regNum != ai)
                            {
@@ -909,14 +909,14 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                         // Figure out if the low word is passed in a reg or in memory
                         if (fullLong)
                            {
-                           cursor = generateRRInstruction(self()->cg(), TR::InstOpCode::LR, firstNode, self()->getS390RealRegister(REGNUM(ai)),
-                                    self()->getS390RealRegister(REGNUM(regNum + 1)), (TR::Instruction *) cursor);
+                           cursor = generateRRInstruction(self()->cg(), TR::InstOpCode::LR, firstNode, self()->getRealRegister(REGNUM(ai)),
+                                    self()->getRealRegister(REGNUM(regNum + 1)), (TR::Instruction *) cursor);
 
                            freeScratchable.set(regNum + 1);
                            }
                         else
                            {
-                           cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, self()->getS390RealRegister(REGNUM(ai)),
+                           cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, self()->getRealRegister(REGNUM(ai)),
                                     generateS390MemoryReference(stackPtr, offset + 4, self()->cg()), (TR::Instruction *) cursor);
                            }
 
@@ -926,15 +926,15 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                         }
                      else
                         {
-                        if (enableHighWordRA && self()->getS390RealRegister(REGNUM(ai))->isHighWordRegister())
+                        if (enableHighWordRA && self()->getRealRegister(REGNUM(ai))->isHighWordRegister())
                            {
-                           cursor = generateExtendedHighWordInstruction(firstNode, self()->cg(), TR::InstOpCode::LHLR, self()->getS390RealRegister(REGNUM(ai)),
-                                                          self()->getS390RealRegister(regNum), 0, (TR::Instruction *) cursor);
+                           cursor = generateExtendedHighWordInstruction(firstNode, self()->cg(), TR::InstOpCode::LHLR, self()->getRealRegister(REGNUM(ai)),
+                                                          self()->getRealRegister(regNum), 0, (TR::Instruction *) cursor);
                            }
                         else
                            {
-                           cursor = generateRRInstruction(self()->cg(), TR::InstOpCode::getLoadRegOpCode(), firstNode, self()->getS390RealRegister(REGNUM(ai)),
-                                                          self()->getS390RealRegister(regNum), (TR::Instruction *) cursor);
+                           cursor = generateRRInstruction(self()->cg(), TR::InstOpCode::getLoadRegOpCode(), firstNode, self()->getRealRegister(REGNUM(ai)),
+                                                          self()->getRealRegister(regNum), (TR::Instruction *) cursor);
                            }
 
                         freeScratchable.reset(ai);
@@ -1029,7 +1029,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                {
                if (freeScratchable.isSet(ai_l))
                   {
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode, self()->getS390RealRegister(REGNUM(ai_l)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode, self()->getRealRegister(REGNUM(ai_l)),
                              generateS390MemoryReference(stackPtr, offset + 4, self()->cg()), (TR::Instruction *) cursor);
 
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
@@ -1059,8 +1059,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                if (freeScratchable.isSet(ai_l))
                   {
                   cursor = generateRRInstruction(self()->cg(), TR::InstOpCode::getLoadRegOpCode(), firstNode,
-                                   self()->getS390RealRegister(REGNUM(ai_l)),
-                                   self()->getS390RealRegister(REGNUM(regNum + 1)), (TR::Instruction *) cursor);
+                                   self()->getRealRegister(REGNUM(ai_l)),
+                                   self()->getRealRegister(REGNUM(regNum + 1)), (TR::Instruction *) cursor);
 
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   freeScratchable.reset(ai_l);
@@ -1097,9 +1097,9 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   TR::MemoryReference * mr = generateS390MemoryReference(stackPtr, offset, self()->cg());
 
                   if (loadOpCode == TR::InstOpCode::ICM)
-                     cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::ICM, firstNode, self()->getS390RealRegister(REGNUM(ai)), opcodeMask, mr, (TR::Instruction *) cursor);
+                     cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::ICM, firstNode, self()->getRealRegister(REGNUM(ai)), opcodeMask, mr, (TR::Instruction *) cursor);
                   else
-                     cursor = generateRXInstruction(self()->cg(), loadOpCode, firstNode, self()->getS390RealRegister(REGNUM(ai)),
+                     cursor = generateRXInstruction(self()->cg(), loadOpCode, firstNode, self()->getRealRegister(REGNUM(ai)),
                              mr, (TR::Instruction *) cursor);
 
 
@@ -1121,7 +1121,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   if (freeScratchable.isSet(ai_l))
                      {
                      cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(), firstNode,
-                                  self()->getS390RealRegister(REGNUM(ai_l)),
+                                  self()->getRealRegister(REGNUM(ai_l)),
                                   generateS390MemoryReference(stackPtr, offset + 4, self()->cg()), (TR::Instruction *) cursor);
                      ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
 
@@ -1144,7 +1144,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                if (freeScratchable.isSet(ai))
                   {
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, self()->getS390RealRegister(REGNUM(ai)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, self()->getRealRegister(REGNUM(ai)),
                               generateS390MemoryReference(stackPtr, offset, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
 
@@ -1164,7 +1164,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                if (freeScratchable.isSet(ai))
                   {
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getS390RealRegister(REGNUM(ai)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getRealRegister(REGNUM(ai)),
                               generateS390MemoryReference(stackPtr, offset, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
 
@@ -1183,10 +1183,10 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                TR_ASSERT( (ai_l == (ai+2) ),"global RA incorrect for long double param");
                if (freeScratchable.isSet(ai))
                   {
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getS390RealRegister(REGNUM(ai)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getRealRegister(REGNUM(ai)),
                               generateS390MemoryReference(stackPtr, offset, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getS390RealRegister(REGNUM(ai_l)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getRealRegister(REGNUM(ai_l)),
                               generateS390MemoryReference(stackPtr, offset+8, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
 
@@ -1241,15 +1241,15 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
             switch(busyMoves[2][i1])
                {
                case 0: // Reg 2 Reg
-                  if (enableHighWordRA && self()->getS390RealRegister(REGNUM(target))->isHighWordRegister())
+                  if (enableHighWordRA && self()->getRealRegister(REGNUM(target))->isHighWordRegister())
                      {
-                     cursor = generateExtendedHighWordInstruction(firstNode, self()->cg(), TR::InstOpCode::LHLR, self()->getS390RealRegister(REGNUM(target)),
-                                                                  self()->getS390RealRegister(REGNUM(source)), 0, (TR::Instruction *) cursor);
+                     cursor = generateExtendedHighWordInstruction(firstNode, self()->cg(), TR::InstOpCode::LHLR, self()->getRealRegister(REGNUM(target)),
+                                                                  self()->getRealRegister(REGNUM(source)), 0, (TR::Instruction *) cursor);
                      }
                   else
                      {
-                     cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::getLoadRegOpCode(), firstNode, self()->getS390RealRegister(REGNUM(target)),
-                                                    self()->getS390RealRegister(REGNUM(source)), (TR::Instruction *) cursor);
+                     cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::getLoadRegOpCode(), firstNode, self()->getRealRegister(REGNUM(target)),
+                                                    self()->getRealRegister(REGNUM(source)), (TR::Instruction *) cursor);
 
                      }
                   freeScratchable.set(source);
@@ -1259,35 +1259,35 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   TR::MemoryReference *mr = generateS390MemoryReference(stackPtr, source, self()->cg());
 
                   if ((TR::InstOpCode::Mnemonic) busyMoves[3][i1] == TR::InstOpCode::ICM)
-                     cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::ICM, firstNode, self()->getS390RealRegister(REGNUM(target)), busyMoves[4][i1], mr, (TR::Instruction *) cursor);
+                     cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::ICM, firstNode, self()->getRealRegister(REGNUM(target)), busyMoves[4][i1], mr, (TR::Instruction *) cursor);
 
                   else if ((TR::InstOpCode::Mnemonic) busyMoves[3][i1] == TR::InstOpCode::LFH)
-                     cursor = generateRXYInstruction(self()->cg(), TR::InstOpCode::LFH, firstNode, self()->getS390RealRegister(REGNUM(target)), mr, (TR::Instruction *) cursor);
+                     cursor = generateRXYInstruction(self()->cg(), TR::InstOpCode::LFH, firstNode, self()->getRealRegister(REGNUM(target)), mr, (TR::Instruction *) cursor);
 
                   else
-                     cursor = generateRXInstruction(self()->cg(), (TR::InstOpCode::Mnemonic) busyMoves[3][i1], firstNode, self()->getS390RealRegister(REGNUM(target)), mr, (TR::Instruction *) cursor);
+                     cursor = generateRXInstruction(self()->cg(), (TR::InstOpCode::Mnemonic) busyMoves[3][i1], firstNode, self()->getRealRegister(REGNUM(target)), mr, (TR::Instruction *) cursor);
 
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   break;
                   }
                case 3: // Floats
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, self()->getS390RealRegister(REGNUM(target)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LE, firstNode, self()->getRealRegister(REGNUM(target)),
                               generateS390MemoryReference(stackPtr, source, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   break;
                case 4:  // Doubles
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getS390RealRegister(REGNUM(target)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getRealRegister(REGNUM(target)),
                               generateS390MemoryReference(stackPtr, source, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   break;
                case 5:  // Floats and Doubles
-                  cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LDR, firstNode, self()->getS390RealRegister(REGNUM(target)),
-                              self()->getS390RealRegister(REGNUM(source)), (TR::Instruction *) cursor);
+                  cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LDR, firstNode, self()->getRealRegister(REGNUM(target)),
+                              self()->getRealRegister(REGNUM(source)), (TR::Instruction *) cursor);
                   freeScratchable.set(source);
                   break;
                case 6: // 64bit reg on 31bit
-                  cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getS390RealRegister(REGNUM(target)),
-                                    self()->getS390RealRegister(REGNUM(source)), 32, (TR::Instruction *) cursor);
+                  cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getRealRegister(REGNUM(target)),
+                                    self()->getRealRegister(REGNUM(source)), 32, (TR::Instruction *) cursor);
                   busyMoves[0][i1] = busyMoves[1][i1] = -1;
                   numMoves--;
                   if (source != target)
@@ -1298,13 +1298,13 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   i1++;
                   source = busyMoves[0][i1];
                   target = busyMoves[1][i1];
-                  cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LR, firstNode, self()->getS390RealRegister(REGNUM(target)),
-                              self()->getS390RealRegister(REGNUM(source)), (TR::Instruction *) cursor);
+                  cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LR, firstNode, self()->getRealRegister(REGNUM(target)),
+                              self()->getRealRegister(REGNUM(source)), (TR::Instruction *) cursor);
                   freeScratchable.set(source);
                   break;
                case 7: // 64bit reg on 31bit
-                  cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getS390RealRegister(REGNUM(target)),
-                                    self()->getS390RealRegister(REGNUM(source)), 32, (TR::Instruction *) cursor);
+                  cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getRealRegister(REGNUM(target)),
+                                    self()->getRealRegister(REGNUM(source)), 32, (TR::Instruction *) cursor);
                   busyMoves[0][i1] = busyMoves[1][i1] = -1;
                   numMoves--;
                   if (source != target)
@@ -1315,15 +1315,15 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   i1++;
                   source = busyMoves[0][i1];
                   target = busyMoves[1][i1];
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, self()->getS390RealRegister(REGNUM(target)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::L, firstNode, self()->getRealRegister(REGNUM(target)),
                               generateS390MemoryReference(stackPtr, source, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   break;
                case 9:  // LongDouble
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getS390RealRegister(REGNUM(target)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getRealRegister(REGNUM(target)),
                               generateS390MemoryReference(stackPtr, source, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
-                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getS390RealRegister(REGNUM(target+2)),
+                  cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::LD, firstNode, self()->getRealRegister(REGNUM(target+2)),
                               generateS390MemoryReference(stackPtr, source+8, self()->cg()), (TR::Instruction *) cursor);
                   ((TR::Instruction*)cursor)->setBinLocalFreeRegs(binLocalRegs);
                   freeScratchable.reset(target+2);
@@ -1332,8 +1332,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   break;
                case 10:  // LongDouble
                   cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LXR, firstNode,
-                              self()->cg()->allocateFPRegisterPair(self()->getS390RealRegister(REGNUM(target+2)),self()->getS390RealRegister(REGNUM(target))),
-                              self()->cg()->allocateFPRegisterPair(self()->getS390RealRegister(REGNUM(source+2)),self()->getS390RealRegister(REGNUM(source))),
+                              self()->cg()->allocateFPRegisterPair(self()->getRealRegister(REGNUM(target+2)),self()->getRealRegister(REGNUM(target))),
+                              self()->cg()->allocateFPRegisterPair(self()->getRealRegister(REGNUM(source+2)),self()->getRealRegister(REGNUM(source))),
                               (TR::Instruction *) cursor);
                   freeScratchable.set(source);
                   freeScratchable.set(source+2);
@@ -3005,12 +3005,12 @@ OMR::Z::Linkage::getFirstSavedRegister(int32_t fromreg, int32_t toreg)
    // if the first saved reg is an HPR, we will return the corresponding GPR
    bool checkHPR = (self()->cg()->supportsHighWordFacility() &&
                     !self()->comp()->getOption(TR_DisableHighWordRA) &&
-                    (self()->getS390RealRegister(REGNUM(fromreg)))->isLowWordRegister() &&
-                    (self()->getS390RealRegister(REGNUM(toreg)))->isLowWordRegister());
+                    (self()->getRealRegister(REGNUM(fromreg)))->isLowWordRegister() &&
+                    (self()->getRealRegister(REGNUM(toreg)))->isLowWordRegister());
    for (int32_t i = fromreg; i <= toreg; ++i)
       {
-      if ((self()->getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() ||
-          (checkHPR && (self()->getS390RealRegister(REGNUM(i)))->getHighWordRegister()->getHasBeenAssignedInMethod()))
+      if ((self()->getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() ||
+          (checkHPR && (self()->getRealRegister(REGNUM(i)))->getHighWordRegister()->getHasBeenAssignedInMethod()))
          {
          firstUsedReg = REGNUM(i);
          return firstUsedReg;
@@ -3031,13 +3031,13 @@ OMR::Z::Linkage::getLastSavedRegister(int32_t fromreg, int32_t toreg)
    // if the last saved reg is an HPR, we will return the corresponding GPR
    bool checkHPR = (self()->cg()->supportsHighWordFacility() &&
                     !self()->comp()->getOption(TR_DisableHighWordRA) &&
-                    (self()->getS390RealRegister(REGNUM(fromreg)))->isLowWordRegister() &&
-                    (self()->getS390RealRegister(REGNUM(toreg)))->isLowWordRegister());
+                    (self()->getRealRegister(REGNUM(fromreg)))->isLowWordRegister() &&
+                    (self()->getRealRegister(REGNUM(toreg)))->isLowWordRegister());
 
    for (int32_t i = fromreg; i <= toreg; ++i)
       {
-      if ((self()->getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() ||
-          (checkHPR && (self()->getS390RealRegister(REGNUM(i)))->getHighWordRegister()->getHasBeenAssignedInMethod()))
+      if ((self()->getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() ||
+          (checkHPR && (self()->getRealRegister(REGNUM(i)))->getHighWordRegister()->getHasBeenAssignedInMethod()))
          {
          lastUsedReg = REGNUM(i);
          }
@@ -3112,7 +3112,7 @@ OMR::Z::Linkage::restorePreservedRegs(TR::RealRegister::RegNum firstUsedReg,
       for (uint8_t i = 0; i < newNumUsedRegs; i++)
          {
          cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(),
-                   nextNode, self()->getS390RealRegister(REGNUM(curReg)), rsa, cursor);
+                   nextNode, self()->getRealRegister(REGNUM(curReg)), rsa, cursor);
 
          curDisp += self()->cg()->machine()->getGPRSize();
          curReg++;
@@ -3131,19 +3131,19 @@ OMR::Z::Linkage::restorePreservedRegs(TR::RealRegister::RegNum firstUsedReg,
             ((newFirstUsedReg+1) %2 == 0))
       {
       cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::getLoadMultipleOpCode(), nextNode,
-                 self()->getS390RealRegister(REGNUM(newFirstUsedReg)),
-                 self()->getS390RealRegister(REGNUM(newLastUsedReg)), rsa, cursor);
+                 self()->getRealRegister(REGNUM(newFirstUsedReg)),
+                 self()->getRealRegister(REGNUM(newLastUsedReg)), rsa, cursor);
       }
    else //32-bit (try to use bumps)
       {
       //Load Single + Load Multiple
       cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(),
-                nextNode, self()->getS390RealRegister(REGNUM(newFirstUsedReg)), rsa, cursor);
+                nextNode, self()->getRealRegister(REGNUM(newFirstUsedReg)), rsa, cursor);
 
       rsa = generateS390MemoryReference(spReg, rsa->getOffset()+self()->cg()->machine()->getGPRSize(), self()->cg());
       cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::getLoadMultipleOpCode(), nextNode,
-                    self()->getS390RealRegister(REGNUM(newFirstUsedReg+1)),
-                    self()->getS390RealRegister(REGNUM(newLastUsedReg)), rsa, cursor);
+                    self()->getRealRegister(REGNUM(newFirstUsedReg+1)),
+                    self()->getRealRegister(REGNUM(newLastUsedReg)), rsa, cursor);
       }
    return cursor;
    }
@@ -3347,13 +3347,13 @@ OMR::Z::Linkage::setVectorReturnRegister(TR::RealRegister::RegNum r)
 TR::RealRegister *
 OMR::Z::Linkage::getStackPointerRealRegister()
    {
-   return self()->getS390RealRegister(_stackPointerRegister);
+   return self()->getRealRegister(_stackPointerRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getStackPointerRealRegister(uint32_t num)
    {
-   return self()->getS390RealRegister(_stackPointerRegister);
+   return self()->getRealRegister(_stackPointerRegister);
    }
 
 TR::RealRegister::RegNum
@@ -3371,43 +3371,43 @@ OMR::Z::Linkage::getNormalStackPointerRealRegister()
 TR::RealRegister *
 OMR::Z::Linkage::getEntryPointRealRegister()
    {
-   return self()->getS390RealRegister(_entryPointRegister);
+   return self()->getRealRegister(_entryPointRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getLitPoolRealRegister()
    {
-   return self()->getS390RealRegister(_litPoolRegister);
+   return self()->getRealRegister(_litPoolRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getStaticBaseRealRegister()
    {
-   return self()->getS390RealRegister(_staticBaseRegister);
+   return self()->getRealRegister(_staticBaseRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getPrivateStaticBaseRealRegister()
    {
-   return self()->getS390RealRegister(_privateStaticBaseRegister);
+   return self()->getRealRegister(_privateStaticBaseRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getReturnAddressRealRegister()
    {
-   return self()->getS390RealRegister(_returnAddrRegister);
+   return self()->getRealRegister(_returnAddrRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getVTableIndexArgumentRegisterRealRegister()
    {
-   return self()->getS390RealRegister(_vtableIndexArgumentRegister);
+   return self()->getRealRegister(_vtableIndexArgumentRegister);
    }
 
 TR::RealRegister *
 OMR::Z::Linkage::getJ9MethodArgumentRegisterRealRegister()
    {
-   return self()->getS390RealRegister(_j9methodArgumentRegister);
+   return self()->getRealRegister(_j9methodArgumentRegister);
    }
 
 TR::Compilation *
@@ -3441,7 +3441,7 @@ OMR::Z::Linkage::trStackMemory()
    }
 
 TR::RealRegister *
-OMR::Z::Linkage::getS390RealRegister(TR::RealRegister::RegNum rNum)
+OMR::Z::Linkage::getRealRegister(TR::RealRegister::RegNum rNum)
    {
-   return self()->cg()->machine()->getS390RealRegister(rNum);
+   return self()->cg()->machine()->getRealRegister(rNum);
    }

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -612,6 +612,7 @@ enum TR_DispatchType
    TR_HeapMemory        trHeapMemory();
    TR_StackMemory       trStackMemory();
 
+   TR::RealRegister *  getS390RealRegister(TR::RealRegister::RegNum rNum);
    TR::RealRegister *  getRealRegister(TR::RealRegister::RegNum rNum);
 
    TR::RealRegister::RegNum getFirstSavedRegister(int32_t fromreg, int32_t toreg);

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -612,7 +612,7 @@ enum TR_DispatchType
    TR_HeapMemory        trHeapMemory();
    TR_StackMemory       trStackMemory();
 
-   TR::RealRegister *  getS390RealRegister(TR::RealRegister::RegNum rNum);
+   TR::RealRegister *  getRealRegister(TR::RealRegister::RegNum rNum);
 
    TR::RealRegister::RegNum getFirstSavedRegister(int32_t fromreg, int32_t toreg);
    TR::RealRegister::RegNum getLastSavedRegister(int32_t fromreg, int32_t toreg);

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -1789,7 +1789,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
 
          self()->coerceRegisterAssignment(currInst, firstReg,
             (TR::RealRegister::RegNum) (toRealRegister(freeRegisterLow)->getRegisterNumber() - 1), PAIRREG);
-         freeRegisterHigh = self()->getS390RealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
+         freeRegisterHigh = self()->getRealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
          }
       else if (!self()->isLegalOddRegister(freeRegisterLow, DISALLOWBLOCKED, availRegMask))
          {
@@ -1803,7 +1803,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
 
          self()->coerceRegisterAssignment(currInst, lastReg,
             (TR::RealRegister::RegNum) (toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1), PAIRREG);
-         freeRegisterLow = self()->getS390RealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
+         freeRegisterLow = self()->getRealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
          }
       else if (!self()->isLegalEvenOddPair(freeRegisterHigh, freeRegisterLow, availRegMask))
          {
@@ -1822,7 +1822,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
 
             self()->coerceRegisterAssignment(currInst, lastReg,
                                      (TR::RealRegister::RegNum) (toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1), PAIRREG);
-            freeRegisterLow = self()->getS390RealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
+            freeRegisterLow = self()->getRealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterHigh)->getRegisterNumber() + 1));
             }
          else if (self()->isLegalOddRegister(freeRegisterLow, DISALLOWBLOCKED, availRegMask))
             {
@@ -1833,7 +1833,7 @@ OMR::Z::Machine::assignBestRegisterPair(TR::Register    *regPair,
 
             self()->coerceRegisterAssignment(currInst, firstReg,
                                      (TR::RealRegister::RegNum) (toRealRegister(freeRegisterLow)->getRegisterNumber() - 1), PAIRREG);
-            freeRegisterHigh = self()->getS390RealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
+            freeRegisterHigh = self()->getRealRegister((TR::RealRegister::RegNum) (toRealRegister(freeRegisterLow)->getRegisterNumber() - 1));
             }
          else
             {
@@ -3351,7 +3351,7 @@ OMR::Z::Machine::constructFreeRegBitVector(TR::Instruction  *currentInstruction)
 
    for (int32_t i=first; i<=last; i++)
       {
-      TR::RealRegister * realReg = self()->getS390RealRegister(cnt+1);
+      TR::RealRegister * realReg = self()->getRealRegister(cnt+1);
 
       if ( realReg->getState() == TR::RealRegister::Free &&
            !currentInstruction->usesRegister(realReg)   &&
@@ -3379,7 +3379,7 @@ OMR::Z::Machine::findRegNotUsedInInstruction(TR::Instruction  *currentInstructio
 
    for (int32_t i = first; i <= last, spill==NULL; i++)
       {
-      TR::RealRegister * realReg = self()->getS390RealRegister((TR::RealRegister::RegNum) i);
+      TR::RealRegister * realReg = self()->getRealRegister((TR::RealRegister::RegNum) i);
       if ( realReg->getState() != TR::RealRegister::Locked && !currentInstruction->usesRegister(realReg))
          {
          spill = realReg;
@@ -3406,7 +3406,7 @@ OMR::Z::Machine::findVirtRegInHighWordRegister(TR::Register *virtReg)
    for (int32_t i = first; i <= last; i++)
       {
       TR::RealRegister * realReg =
-         machine->getS390RealRegister((TR::RealRegister::RegNum) i);
+         machine->getRealRegister((TR::RealRegister::RegNum) i);
 
       if (realReg->getAssignedRegister() && virtReg == realReg->getAssignedRegister() )
          {
@@ -3463,7 +3463,7 @@ OMR::Z::Machine::spillAllVolatileHighRegisters(TR::Instruction *currentInstructi
       {
       TR::Register * virtReg = NULL;
       TR::RealRegister * realReg =
-         machine->getS390RealRegister((TR::RealRegister::RegNum) i);
+         machine->getRealRegister((TR::RealRegister::RegNum) i);
       bool volatileReg = true;     // All high regs are volatile
                                    // !linkage->getPreserved((TR::RealRegister::RegNum) i);
 
@@ -3539,7 +3539,7 @@ OMR::Z::Machine::freeBestRegister(TR::Instruction * currentInstruction, TR::Regi
    for (int32_t i = first; i <= last; i++)
       {
       int32_t iInterfere = interference & (1 << (i - maskI));
-      TR::RealRegister * realReg = machine->getS390RealRegister((TR::RealRegister::RegNum) i);
+      TR::RealRegister * realReg = machine->getRealRegister((TR::RealRegister::RegNum) i);
 
       if (!enableHighWordRA)
          {
@@ -5944,7 +5944,7 @@ int32_t OMR::Z::Machine::addGlobalReg(TR::RealRegister::RegNum reg, int32_t tabl
    {
    if (reg == TR::RealRegister::NoReg)
       return tableIndex;
-   if (self()->getS390RealRegister(reg)->getState() == TR::RealRegister::Locked)
+   if (self()->getRealRegister(reg)->getState() == TR::RealRegister::Locked)
       return tableIndex;
    for (int32_t i = 0; i < tableIndex; i++)
       if (_globalRegisterNumberToRealRegisterMap[i] == reg)
@@ -5967,7 +5967,7 @@ int32_t OMR::Z::Machine::addGlobalRegLater(TR::RealRegister::RegNum reg, int32_t
    {
    if (reg == TR::RealRegister::NoReg)
       return tableIndex;
-   if (self()->getS390RealRegister(reg)->getState() == TR::RealRegister::Locked)
+   if (self()->getRealRegister(reg)->getState() == TR::RealRegister::Locked)
       return tableIndex;
    for (int32_t i = 0; i < tableIndex; i++)
       if (_globalRegisterNumberToRealRegisterMap[i] == reg)
@@ -6663,7 +6663,7 @@ TR::RegisterDependencyConditions * OMR::Z::Machine::createDepCondForLiveGPRs(TR:
    TR::Compilation *comp = self()->cg()->comp();
    for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF; i = ((i == TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstVRF : i+1) )
       {
-      TR::RealRegister *realReg = self()->getS390RealRegister(i);
+      TR::RealRegister *realReg = self()->getRealRegister(i);
 
       TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned ||
               realReg->getState() == TR::RealRegister::Free ||
@@ -6680,12 +6680,12 @@ TR::RegisterDependencyConditions * OMR::Z::Machine::createDepCondForLiveGPRs(TR:
       {
       for (i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; i++)
          {
-         if (self()->getS390RealRegister(i)->getState() == TR::RealRegister::Assigned && self()->getS390RealRegister(i)->getAssignedRegister())
+         if (self()->getRealRegister(i)->getState() == TR::RealRegister::Assigned && self()->getRealRegister(i)->getAssignedRegister())
             {
-            if (self()->getS390RealRegister(i)->getAssignedRegister() != self()->getS390RealRegister(i)->getLowWordRegister()->getAssignedRegister())
+            if (self()->getRealRegister(i)->getAssignedRegister() != self()->getRealRegister(i)->getLowWordRegister()->getAssignedRegister())
                c++;
             // if a HPR is assigned to a virtReg but a virtReg is not assigned to HPR, we must have spilled the virtReg to HPR
-            if (!self()->getS390RealRegister(i)->getAssignedRegister()->getAssignedRegister())
+            if (!self()->getRealRegister(i)->getAssignedRegister()->getAssignedRegister())
                c++;
             }
          }
@@ -6698,7 +6698,7 @@ TR::RegisterDependencyConditions * OMR::Z::Machine::createDepCondForLiveGPRs(TR:
       deps = new (self()->cg()->trHeapMemory(), TR_MemoryBase::RegisterDependencyConditions) TR::RegisterDependencyConditions(0, c, self()->cg());
       for (i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastVRF; i = ((i==TR::RealRegister::LastAssignableGPR)? TR::RealRegister::FirstVRF : i+1))
          {
-         TR::RealRegister *realReg = self()->getS390RealRegister(i);
+         TR::RealRegister *realReg = self()->getRealRegister(i);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             TR::Register *virtReg = realReg->getAssignedRegister();
@@ -6717,18 +6717,18 @@ TR::RegisterDependencyConditions * OMR::Z::Machine::createDepCondForLiveGPRs(TR:
          {
          for (i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; i++)
             {
-            if (self()->getS390RealRegister(i)->getState() == TR::RealRegister::Assigned && self()->getS390RealRegister(i)->getAssignedRegister())
+            if (self()->getRealRegister(i)->getState() == TR::RealRegister::Assigned && self()->getRealRegister(i)->getAssignedRegister())
                {
-               if(self()->getS390RealRegister(i)->getAssignedRegister() != self()->getS390RealRegister(i)->getLowWordRegister()->getAssignedRegister())
+               if(self()->getRealRegister(i)->getAssignedRegister() != self()->getRealRegister(i)->getLowWordRegister()->getAssignedRegister())
                   {
-                  deps->addPostCondition(self()->getS390RealRegister(i)->getAssignedRegister(),self()->getS390RealRegister(i)->getRegisterNumber());
-                  self()->getS390RealRegister(i)->getAssignedRegister()->incFutureUseCount();
+                  deps->addPostCondition(self()->getRealRegister(i)->getAssignedRegister(),self()->getRealRegister(i)->getRegisterNumber());
+                  self()->getRealRegister(i)->getAssignedRegister()->incFutureUseCount();
                   }
                // if a HPR is assigned to a virtReg but a virtReg is not assigned to HPR, we must have spilled the virtReg to HPR
-               if(!self()->getS390RealRegister(i)->getAssignedRegister()->getAssignedRegister())
+               if(!self()->getRealRegister(i)->getAssignedRegister()->getAssignedRegister())
                   {
                   // this is not a conflicting dependency rather a directive to tell RA to mark the virt reg as a HPR spill
-                  deps->addPostCondition(self()->getS390RealRegister(i), TR::RealRegister::SpilledReg);
+                  deps->addPostCondition(self()->getRealRegister(i), TR::RealRegister::SpilledReg);
                   }
                }
             }

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -101,7 +101,7 @@ template <typename ListKind> class List;
 #define ALLOWLOCKED      true
 #define DISALLOWBLOCKED  false
 
-#define  REAL_REGISTER(ri)  machine->getS390RealRegister(ri)
+#define  REAL_REGISTER(ri)  machine->getRealRegister(ri)
 
 #define GLOBAL_REG_FOR_LITPOOL     3    // GPR6
 
@@ -229,12 +229,22 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    Machine(TR::CodeGenerator *cg);
 
-   TR::RealRegister *getS390RealRegister(TR::RealRegister::RegNum regNum)
+   /**
+    * @brief Converts RegNum to RealRegister
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum)
       {
       return _registerFile[regNum];
       }
 
-   TR::RealRegister *getS390RealRegister(int32_t regNum)
+   /**
+    * @brief Converts RegNum to RealRegister
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getRealRegister(int32_t regNum)
       {
       return _registerFile[regNum];
       }

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -101,8 +101,6 @@ template <typename ListKind> class List;
 #define ALLOWLOCKED      true
 #define DISALLOWBLOCKED  false
 
-#define  REAL_REGISTER(ri)  machine->getRealRegister(ri)
-
 #define GLOBAL_REG_FOR_LITPOOL     3    // GPR6
 
 #define TR_LONG_TO_PACKED_SIZE            16    ///< The result byte size in memory for a long to packed conversion (i.e. with CVDG)

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -228,11 +228,31 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    Machine(TR::CodeGenerator *cg);
 
    /**
+    * @brief This method is the wrapper for \code getRealRegister.
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getS390RealRegister(TR::RealRegister::RegNum regNum)
+      {
+      return _registerFile[regNum];
+      }
+
+   /**
     * @brief Converts RegNum to RealRegister
     * @param[in] regNum : register number
     * @return RealRegister for specified register number
     */
    TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum)
+      {
+      return _registerFile[regNum];
+      }
+
+   /**
+    * @brief This method is the wrapper for \code getRealRegister.
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getS390RealRegister(int32_t regNum)
       {
       return _registerFile[regNum];
       }

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -669,7 +669,7 @@ TR_S390RegisterDependencyGroup::genBitMapOfAssignableGPRs(TR::CodeGenerator * cg
       TR::RealRegister::RegNum realReg = _dependencies[i].getRealRegister();
       if (TR::RealRegister::isGPR(realReg))
          {
-         availRegMap &= ~machine->getS390RealRegister(realReg)->getRealRegisterMask();
+         availRegMap &= ~machine->getRealRegister(realReg)->getRealRegisterMask();
          }
       }
 
@@ -740,11 +740,11 @@ TR_S390RegisterDependencyGroup::checkRegisterPairSufficiencyAndHPRAssignment(TR:
             if (TR::RealRegister::isHPR(realRegI))
                {
                virtRegI->setAssignToHPR(true);
-               cg->maskAvailableHPRSpillMask(~(machine->getS390RealRegister(realRegI)->getRealRegisterMask()));
+               cg->maskAvailableHPRSpillMask(~(machine->getRealRegister(realRegI)->getRealRegisterMask()));
                }
             else if (TR::RealRegister::isGPR(realRegI) && virtRegI->is64BitReg())
                {
-               cg->maskAvailableHPRSpillMask(~(machine->getS390RealRegister(realRegI)->getRealRegisterMask() << 16));
+               cg->maskAvailableHPRSpillMask(~(machine->getRealRegister(realRegI)->getRealRegisterMask() << 16));
                }
             }
          }
@@ -1102,28 +1102,28 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
    // count up how many registers are locked for each type
    for (int32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedGPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstHPR; i <= TR::RealRegister::LastHPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedHPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedFPRs;
       }
 
    for (int32_t i = TR::RealRegister::FirstVRF; i <= TR::RealRegister::LastVRF; ++i)
       {
-      TR::RealRegister* realReg = machine->getS390RealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister* realReg = machine->getRealRegister((TR::RealRegister::RegNum)i);
       if (realReg->getState() == TR::RealRegister::Locked)
          ++lockedVRFs;
       }
@@ -1451,7 +1451,7 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
          TR_ASSERT( virtReg != NULL, "null virtual register during coercion");
          dependentRegNum = _dependencies[i].getRealRegister();
 
-         dependentRealReg = machine->getS390RealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
 
          // If dep requires a specific real reg, and the real reg is free
          if (dependentRegNum != TR::RealRegister::NoReg     &&
@@ -1468,7 +1468,7 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
             if(comp->getOption(TR_EnableTrueRegisterModel) && _dependencies[i].getDefsRegister() &&
                 virtReg->isPendingSpillOnDef())
               {
-              TR::RealRegister * realReg = machine->getS390RealRegister(dependentRegNum);
+              TR::RealRegister * realReg = machine->getRealRegister(dependentRegNum);
               if(cg->insideInternalControlFlow())
                 machine->reverseSpillState(cg->getInstructionAtEndInternalControlFlow(), virtReg, toRealRegister(realReg));
               else
@@ -1498,7 +1498,7 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
             }
 
          dependentRegNum = _dependencies[i].getRealRegister();
-         dependentRealReg = machine->getS390RealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
 
          // If the dependency requires a real reg
          // and the assigned real reg is not equal to the required one
@@ -1529,7 +1529,7 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
                    if (aRealNum != TR::RealRegister::NoReg     &&
                        aRealNum != TR::RealRegister::AssignAny &&
                        aRealNum != TR::RealRegister::SpilledReg &&
-                       assignedRegister == machine->getS390RealRegister(aRealNum))
+                       assignedRegister == machine->getRealRegister(aRealNum))
                      {
                        #if 0
                         fprintf(stdout, "COERCE3 %i (%s, %d)\n", i, cg->getDebug()->getName(virtReg), aRealNum-1);
@@ -1542,7 +1542,7 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
                         if(comp->getOption(TR_EnableTrueRegisterModel) && _dependencies[lcount].getDefsRegister() &&
                             depReg->isPendingSpillOnDef())
                           {
-                          TR::RealRegister * realReg = machine->getS390RealRegister(aRealNum);
+                          TR::RealRegister * realReg = machine->getRealRegister(aRealNum);
                           if(cg->insideInternalControlFlow())
                             machine->reverseSpillState(cg->getInstructionAtEndInternalControlFlow(), depReg, toRealRegister(realReg));
                           else
@@ -1556,7 +1556,7 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
             if(comp->getOption(TR_EnableTrueRegisterModel) && _dependencies[i].getDefsRegister() &&
                 virtReg->isPendingSpillOnDef())
               {
-              TR::RealRegister * realReg = machine->getS390RealRegister(dependentRegNum);
+              TR::RealRegister * realReg = machine->getRealRegister(dependentRegNum);
               if(cg->insideInternalControlFlow())
                 machine->reverseSpillState(cg->getInstructionAtEndInternalControlFlow(), virtReg, toRealRegister(realReg));
               else

--- a/compiler/z/codegen/OMRRegisterIterator.cpp
+++ b/compiler/z/codegen/OMRRegisterIterator.cpp
@@ -57,17 +57,17 @@ OMR::Z::RegisterIterator::RegisterIterator ( TR::Machine * machine, TR_RegisterK
 TR::Register *
 OMR::Z::RegisterIterator::getFirst()
    {
-   return _machine->getS390RealRegister(_cursor = _firstRegIndex);
+   return _machine->getRealRegister(_cursor = _firstRegIndex);
    }
 
 TR::Register *
 OMR::Z::RegisterIterator::getCurrent()
    {
-   return _machine->getS390RealRegister(_cursor);
+   return _machine->getRealRegister(_cursor);
    }
 
 TR::Register *
 OMR::Z::RegisterIterator::getNext()
    {
-   return _cursor == _lastRegIndex ? NULL : _machine->getS390RealRegister(++_cursor);
+   return _cursor == _lastRegIndex ? NULL : _machine->getRealRegister(++_cursor);
    }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -14888,7 +14888,7 @@ TR_S390ComputeCC::saveHostCC(TR::Node *node, TR::Register *ccReg, TR::CodeGenera
 TR::Register *OMR::Z::TreeEvaluator::loadAutoOffsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *reg = cg->allocateRegister();
-   TR::MemoryReference *mr = generateS390MemoryReference(cg->machine()->getS390RealRegister(TR::RealRegister::GPR0), 0, cg);
+   TR::MemoryReference *mr = generateS390MemoryReference(cg->machine()->getRealRegister(TR::RealRegister::GPR0), 0, cg);
    mr->setSymbolReference(node->getSymbolReference());
    generateRXInstruction(cg, TR::InstOpCode::LA, node, reg, mr);
    cg->stopUsingRegister(reg);

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -2198,7 +2198,7 @@ TR_Debug::printS390GCRegisterMap(TR::FILE *pOutFile, TR::GCRegisterMap * map)
       {
       if (map->getMap() & (1 << (i - 1)))
          {
-         trfprintf(pOutFile, "%s ", getName(machine->getS390RealRegister((TR::RealRegister::RegNum) i)));
+         trfprintf(pOutFile, "%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum) i)));
          }
       }
    trfprintf(pOutFile, "}\n");
@@ -2211,12 +2211,12 @@ TR_Debug::printS390GCRegisterMap(TR::FILE *pOutFile, TR::GCRegisterMap * map)
          // 2 bits per register, '10' means HPR has collectible, '11' means both HPR and GPR have collectibles
          if (map->getHPRMap() & (1 << (i - TR::RealRegister::FirstHPR)*2 + 1))
             {
-            trfprintf(pOutFile, "%s ", getName(machine->getS390RealRegister((TR::RealRegister::RegNum) i)));
+            trfprintf(pOutFile, "%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum) i)));
             }
          // Compressed collectible in lower GPR.
          if (map->getHPRMap() & (1 << (i - TR::RealRegister::FirstHPR)*2))
             {
-            trfprintf(pOutFile, "%s ", getName(machine->getS390RealRegister((TR::RealRegister::RegNum) (i - TR::RealRegister::FirstHPR + TR::RealRegister::FirstGPR))));
+            trfprintf(pOutFile, "%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum) (i - TR::RealRegister::FirstHPR + TR::RealRegister::FirstGPR))));
             }
          }
       trfprintf(pOutFile, "}\n");
@@ -2459,7 +2459,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                   trfprintf(pOutFile, "ST   \t");
                   }
 
-               print(pOutFile, machine->getS390RealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)));
+               print(pOutFile, machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)));
                trfprintf(pOutFile, ",%d(,", offset);
                print(pOutFile, stackPtr);
                trfprintf(pOutFile, ")");
@@ -2491,7 +2491,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                   {
                   printPrefix(pOutFile, NULL, bufferPos, 6);
                   trfprintf(pOutFile, "STG  \t");
-                  print(pOutFile, machine->getS390RealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)));
+                  print(pOutFile, machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)));
                   trfprintf(pOutFile, ",%d(,", offset);
                   print(pOutFile, stackPtr);
                   trfprintf(pOutFile, ")");
@@ -2501,7 +2501,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                   {
                   printPrefix(pOutFile, NULL, bufferPos, 4);
                   trfprintf(pOutFile, "ST   \t");
-                  print(pOutFile, machine->getS390RealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)));
+                  print(pOutFile, machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum)));
                   trfprintf(pOutFile, ", %d(,", offset);
                   print(pOutFile, stackPtr);
                   trfprintf(pOutFile, ")");
@@ -2512,7 +2512,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                      printPrefix(pOutFile, NULL, bufferPos, 4);
                      trfprintf(pOutFile, "ST   \t");
 
-                     print(pOutFile, machine->getS390RealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum + 1)));
+                     print(pOutFile, machine->getRealRegister(privateLinkage->getIntegerArgumentRegister(intArgNum + 1)));
                      trfprintf(pOutFile, ",%d(,", offset + 4);
                      print(pOutFile, stackPtr);
                      trfprintf(pOutFile, ")");
@@ -2536,7 +2536,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "STD   \t");
-               print(pOutFile, machine->getS390RealRegister(privateLinkage->getFloatArgumentRegister(floatArgNum)));
+               print(pOutFile, machine->getRealRegister(privateLinkage->getFloatArgumentRegister(floatArgNum)));
                trfprintf(pOutFile, ",%d(,", offset);
                print(pOutFile, stackPtr);
                trfprintf(pOutFile, ")");
@@ -2558,7 +2558,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "STE  \t");
-               print(pOutFile, machine->getS390RealRegister(privateLinkage->getFloatArgumentRegister(floatArgNum)));
+               print(pOutFile, machine->getRealRegister(privateLinkage->getFloatArgumentRegister(floatArgNum)));
                trfprintf(pOutFile, ",%d(,", offset);
                print(pOutFile, stackPtr);
                trfprintf(pOutFile, ")");

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -3152,7 +3152,7 @@ generateSerializationInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Inst
 
    // We needed some special handling in TR::Instruction::assignRegisterNoDependencies
    // to recognize real register GPR0 being passed in.
-   TR::RealRegister *gpr0 = cg->machine()->getS390RealRegister(TR::RealRegister::GPR0);
+   TR::RealRegister *gpr0 = cg->machine()->getRealRegister(TR::RealRegister::GPR0);
 
    TR::Instruction * instr = NULL;
    if (preced)

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -89,8 +89,8 @@ TR::S390RSInstruction::generateAdditionalSourceRegisters(TR::Register * fReg, TR
       int8_t curReg = firstRegNum+1;
       for (int8_t i=0; i < numRegsToAdd; i++)
          {
-         // (*_additionalRegisters)[i] = machine->getS390RealRegister(((TR::RealRegister::RegNum)curReg));
-         TR::Register *temp = machine->getS390RealRegister(((TR::RealRegister::RegNum)curReg));
+         // (*_additionalRegisters)[i] = machine->getRealRegister(((TR::RealRegister::RegNum)curReg));
+         TR::Register *temp = machine->getRealRegister(((TR::RealRegister::RegNum)curReg));
          useSourceRegister(temp);
         curReg++;
          }

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -310,7 +310,7 @@ TR_S390PostRAPeephole::AGIReduction()
    TR::Register *lgrTargetReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(1);
    TR::Register *lgrSourceReg = ((TR::S390RRInstruction*)_cursor)->getRegisterOperand(2);
 
-   TR::RealRegister *gpr0 = _cg->machine()->getS390RealRegister(TR::RealRegister::GPR0);
+   TR::RealRegister *gpr0 = _cg->machine()->getRealRegister(TR::RealRegister::GPR0);
 
    // no renaming possible if both target and source are the same
    // this can happend with LTR and LTGR
@@ -505,7 +505,7 @@ TR_S390PostRAPeephole::replaceGuardedLoadWithSoftwareReadBarrier()
    TR::MemoryReference *loadMemRef = generateS390MemoryReference(*load->getMemoryReference(), 0, _cg);
    TR::Register *loadTargetReg = _cursor->getRegisterOperand(1);
    TR::Register *vmReg = _cg->getLinkage()->getMethodMetaDataRealRegister();
-   TR::Register *raReg = _cg->machine()->getS390RealRegister(_cg->getReturnAddressRegister());
+   TR::Register *raReg = _cg->machine()->getRealRegister(_cg->getReturnAddressRegister());
    TR::Instruction* prev = load->getPrev();
 
    // If guarded load target and mem ref registers are the same,
@@ -1894,11 +1894,11 @@ TR_S390PostRAPeephole::trueCompEliminationForLoadComp()
    TR::RealRegister *tempReg = NULL;
    if((toRealRegister(srcReg))->getRegisterNumber() == TR::RealRegister::GPR1)
       {
-      tempReg = _cg->machine()->getS390RealRegister(TR::RealRegister::GPR2);
+      tempReg = _cg->machine()->getRealRegister(TR::RealRegister::GPR2);
       }
    else
       {
-      tempReg = _cg->machine()->getS390RealRegister(TR::RealRegister::GPR1);
+      tempReg = _cg->machine()->getRealRegister(TR::RealRegister::GPR1);
       }
 
    if (prev && prev->defsRegister(srcReg))
@@ -2649,7 +2649,7 @@ TR_S390PostRAPeephole::markBlockThatModifiesRegister(TR::Instruction * cursor,
                {
                for (uint8_t i=highReg->getRegisterNumber()+1; i++; i<= numRegs)
                   {
-                  _cg->getS390Linkage()->getS390RealRegister(REGNUM(i))->setModified(true);
+                  _cg->getS390Linkage()->getRealRegister(REGNUM(i))->setModified(true);
                   }
                }
             }

--- a/compiler/z/codegen/S390SystemLinkage.hpp
+++ b/compiler/z/codegen/S390SystemLinkage.hpp
@@ -213,17 +213,17 @@ public:
 
    virtual TR::RealRegister::RegNum setNormalStackPointerRegister  (TR::RealRegister::RegNum r) { return _normalStackPointerRegister = r; }
    virtual TR::RealRegister::RegNum getNormalStackPointerRegister()   { return _normalStackPointerRegister; }
-   virtual TR::RealRegister *getNormalStackPointerRealRegister() {return getS390RealRegister(_normalStackPointerRegister);}
+   virtual TR::RealRegister *getNormalStackPointerRealRegister() {return getRealRegister(_normalStackPointerRegister);}
 
    virtual TR::RealRegister::RegNum setAlternateStackPointerRegister  (TR::RealRegister::RegNum r) { return _alternateStackPointerRegister = r; }
    virtual TR::RealRegister::RegNum getAlternateStackPointerRegister()   { return _alternateStackPointerRegister; }
-   virtual TR::RealRegister *getAlternateStackPointerRealRegister() {return getS390RealRegister(_alternateStackPointerRegister);}
+   virtual TR::RealRegister *getAlternateStackPointerRealRegister() {return getRealRegister(_alternateStackPointerRegister);}
    virtual void initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList=0);
 
    // Register used for EX instructions for debug hooks - set by notifyHasHooks
    virtual TR::RealRegister::RegNum setDebugHooksRegister(TR::RealRegister::RegNum r) { return _debugHooksRegister = r; }
    virtual TR::RealRegister::RegNum getDebugHooksRegister()   { return _debugHooksRegister; }
-   virtual TR::RealRegister *getDebugHooksRealRegister() {return getS390RealRegister(_debugHooksRegister);}
+   virtual TR::RealRegister *getDebugHooksRealRegister() {return getRealRegister(_debugHooksRegister);}
 
    // == General utilities (linkage independent)
    virtual TR::Instruction *addImmediateToRealRegister(TR::RealRegister * targetReg, int32_t immediate, TR::RealRegister *tempReg, TR::Node *node, TR::Instruction *cursor, bool *checkTempNeeded=NULL);

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -106,7 +106,7 @@ TR::S390SystemLinkage::initS390RealRegisterLinkage()
       }
 
 #if 0
-   TR::RealRegister * gpr0Real  = machine()->getS390RealRegister(TR::RealRegister::GPR0);
+   TR::RealRegister * gpr0Real  = machine()->getRealRegister(TR::RealRegister::GPR0);
    gpr0Real->setState(TR::RealRegister::Locked);
    gpr0Real->setAssignedRegister(gpr0Real);
    gpr0Real->setHasBeenAssignedInMethod(true);
@@ -114,7 +114,7 @@ TR::S390SystemLinkage::initS390RealRegisterLinkage()
 
 #if 0
 // May lock this if GOT needed
-   TR::RealRegister * gpr12Real  = cg()->machine()->getS390RealRegister(TR::RealRegister::GPR12);
+   TR::RealRegister * gpr12Real  = cg()->machine()->getRealRegister(TR::RealRegister::GPR12);
    gpr12Real->setState(TR::RealRegister::Locked);
    gpr12Real->setAssignedRegister(gpr12Real);
    gpr12Real->setHasBeenAssignedInMethod(true);
@@ -136,7 +136,7 @@ TR::S390SystemLinkage::initS390RealRegisterLinkage()
          {
          weight = icount;
          }
-      cg()->machine()->getS390RealRegister((TR::RealRegister::RegNum) icount)->setWeight(weight);
+      cg()->machine()->getRealRegister((TR::RealRegister::RegNum) icount)->setWeight(weight);
       }
    }
 
@@ -218,7 +218,7 @@ TR::S390SystemLinkage::getputFPRs(TR::InstOpCode::Mnemonic opcode, TR::Instructi
          offset = beginSaveOffset + (j*fprSize);
          rsa = generateS390MemoryReference(spReg, offset, cg());
          cursor = generateRXInstruction(cg(), opcode,
-               node, getS390RealRegister(REGNUM(i+TR::RealRegister::FirstFPR)), rsa, cursor);
+               node, getRealRegister(REGNUM(i+TR::RealRegister::FirstFPR)), rsa, cursor);
          j++;
          }
       }
@@ -266,8 +266,8 @@ TR::S390SystemLinkage::getputHPRs(TR::InstOpCode::Mnemonic opcode, TR::Instructi
          rsa = generateS390MemoryReference(spReg, offset, cg());
          int shift = (i == lastSaved) && (HPRSaveMask & (1 << i)) ? 0 : 1;
          cursor = generateRSInstruction(cg(), opcode,
-               node, getS390RealRegister(REGNUM(k+TR::RealRegister::FirstGPR)),
-               getS390RealRegister(REGNUM(i-shift+TR::RealRegister::FirstGPR)), rsa, cursor);
+               node, getRealRegister(REGNUM(k+TR::RealRegister::FirstGPR)),
+               getRealRegister(REGNUM(i-shift+TR::RealRegister::FirstGPR)), rsa, cursor);
          }
       previousWasOne = HPRSaveMask & (1 << i);
       }
@@ -1434,7 +1434,7 @@ TR::S390SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method, uint32_t stac
       int16_t FPRSaveMask = 0;
       for (i = TR::RealRegister::FirstFPR; i <= TR::RealRegister::LastFPR; ++i)
          {
-         if (getPreserved(REGNUM(i)) && ((getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod()))
+         if (getPreserved(REGNUM(i)) && ((getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod()))
             {
             FPRSaveMask |= 1 << (i - TR::RealRegister::FirstFPR);
             stackIndex -= cg()->machine()->getFPRSize();
@@ -1534,7 +1534,7 @@ TR::S390SystemLinkage::saveGPRsInPrologue2(TR::Instruction * cursor)
             firstReg = static_cast<TR::RealRegister::RegNum>(i);
             }
 
-         if ((getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+         if ((getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
             {
             traceMsg(comp(), "\t It is Assigned. Putting in to GPRSaveMask\n");
             GPRSaveMask |= 1 << (i - TR::RealRegister::FirstGPR);
@@ -1542,7 +1542,7 @@ TR::S390SystemLinkage::saveGPRsInPrologue2(TR::Instruction * cursor)
             lastReg = static_cast<TR::RealRegister::RegNum>(i);
             }
 
-         if ((getS390RealRegister(REGNUM(i)))->getModified())
+         if ((getRealRegister(REGNUM(i)))->getModified())
             {
             traceMsg(comp(), "\tIt is also Modified\n");
             }
@@ -1559,29 +1559,29 @@ TR::S390SystemLinkage::saveGPRsInPrologue2(TR::Instruction * cursor)
    TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
 
    if (lastReg - firstReg == 0)
-      cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getS390RealRegister(REGNUM(firstReg )), retAddrMemRef, cursor);
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getRealRegister(REGNUM(firstReg )), retAddrMemRef, cursor);
    else if (lastReg > firstReg)
-      cursor = generateRSInstruction(cg(),  TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getS390RealRegister(REGNUM(firstReg)),  getS390RealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
+      cursor = generateRSInstruction(cg(),  TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getRealRegister(REGNUM(firstReg)),  getRealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
 
 
    //r14 is a special case.  It is the return value register.  Since we will have to save/restore it often, we will try to reduce the range above by just emiting its own save/restore
    // should also experiment with changing preferred ordering in pickregister.
    traceMsg(comp(), "Considering Register %d:\n",i- TR::RealRegister::FirstGPR);
 
-   if(getPreserved(REGNUM(i)) && (getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+   if(getPreserved(REGNUM(i)) && (getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
       {
       traceMsg(comp(), "\t It is Assigned. Putting in to GPRSaveMask\n");
       GPRSaveMask |= 1 << (i - TR::RealRegister::FirstGPR);
       offset =  getRegisterSaveOffset(REGNUM(i));
       TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
-      cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getS390RealRegister(REGNUM(i)), retAddrMemRef, cursor);
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getRealRegister(REGNUM(i)), retAddrMemRef, cursor);
       }
 
    //r15 (stack pointer) might need to be put in to the register mask as well.  Other code will deal with how we save/restore it.
 
    ++i;
    traceMsg(comp(), "Considering Register %d:\n",i- TR::RealRegister::FirstGPR);
-   if(getPreserved(REGNUM(i)) && (getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+   if(getPreserved(REGNUM(i)) && (getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
       {
       traceMsg(comp(), "\t It is Assigned. Putting in to GPRSaveMask\n");
       GPRSaveMask |= 1 << (i - TR::RealRegister::FirstGPR);
@@ -1619,7 +1619,7 @@ TR::S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
             firstReg = static_cast<TR::RealRegister::RegNum>(i);
             }
 
-         if ((getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+         if ((getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
             {
             if (comp()->getOption(TR_TraceCG))
                traceMsg(comp(), "\t It is Assigned. Putting in to GPRSaveMask\n");
@@ -1627,7 +1627,7 @@ TR::S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
             findStartReg = false;
             }
 
-         if (!findStartReg && ( !(getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() || (i == TR::RealRegister::LastGPR && firstReg != TR::RealRegister::LastGPR)) )
+         if (!findStartReg && ( !(getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() || (i == TR::RealRegister::LastGPR && firstReg != TR::RealRegister::LastGPR)) )
             {
             // LastGPR is the stack pointer on zLinux which always be saved and restored
             if (i == TR::RealRegister::LastGPR && !getIsLeafRoutine())
@@ -1647,9 +1647,9 @@ TR::S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
             TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
 
             if (lastReg - firstReg == 0)
-               cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getS390RealRegister(REGNUM(firstReg)), retAddrMemRef, cursor);
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getRealRegister(REGNUM(firstReg)), retAddrMemRef, cursor);
             else
-               cursor = generateRSInstruction(cg(),  TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getS390RealRegister(REGNUM(firstReg)),  getS390RealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
+               cursor = generateRSInstruction(cg(),  TR::InstOpCode::getStoreMultipleOpCode(), firstNode, getRealRegister(REGNUM(firstReg)),  getRealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
 
 
             findStartReg = true;
@@ -1666,7 +1666,7 @@ TR::S390SystemLinkage::saveGPRsInPrologue(TR::Instruction * cursor)
        lastReg = static_cast<TR::RealRegister::RegNum>(TR::RealRegister::LastGPR);
        offset =  getRegisterSaveOffset(REGNUM(lastReg));
        TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
-       cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getS390RealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
+       cursor = generateRXInstruction(cg(), TR::InstOpCode::getStoreOpCode(), firstNode, getRealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
       }
 
    setGPRSaveMask(GPRSaveMask);
@@ -1775,11 +1775,11 @@ bool OMR::Z::Linkage::checkPreservedRegisterUsage(bool *regs, int32_t regsSize)
 
    for( i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastGPR-2; ++i )      //special case for r14, the return value
       {
-      //TR_ASSERT(regs[i] == (getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod(), "Mismatch between register assigned information!!\n");
+      //TR_ASSERT(regs[i] == (getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod(), "Mismatch between register assigned information!!\n");
 
-      //traceMsg(comp(), "regs[%d] = %d getHasBeenAssignedInMethod = %d\n",i,regs[i],(getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod());
+      //traceMsg(comp(), "regs[%d] = %d getHasBeenAssignedInMethod = %d\n",i,regs[i],(getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod());
 
-      if (self()->getPreserved(REGNUM(i)) && (self()->getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+      if (self()->getPreserved(REGNUM(i)) && (self()->getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
          {
          if(self()->comp()->getOption(TR_TraceCG))
             traceMsg(self()->comp(), "\t%d",i-TR::RealRegister::FirstGPR);
@@ -1893,8 +1893,8 @@ void TR::S390SystemLinkage::createPrologue(TR::Instruction * cursor)
       // Check for large stack
       bool largeStack = (stackFrameSize < MIN_IMMEDIATE_VAL || stackFrameSize > MAX_IMMEDIATE_VAL);
 
-      TR::RealRegister * tempReg = getS390RealRegister(TR::RealRegister::GPR0);
-      TR::RealRegister * backChainReg = getS390RealRegister(TR::RealRegister::GPR1);
+      TR::RealRegister * tempReg = getRealRegister(TR::RealRegister::GPR0);
+      TR::RealRegister * backChainReg = getRealRegister(TR::RealRegister::GPR1);
 
 
       if (!largeStack)
@@ -1941,7 +1941,7 @@ void TR::S390SystemLinkage::createPrologue(TR::Instruction * cursor)
          retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
          offset += cg()->machine()->getFPRSize();
          cursor = generateRXInstruction(cg(), TR::InstOpCode::STD,
-               firstNode, getS390RealRegister(REGNUM(i+TR::RealRegister::FirstFPR)), retAddrMemRef, cursor);
+               firstNode, getRealRegister(REGNUM(i+TR::RealRegister::FirstFPR)), retAddrMemRef, cursor);
          }
       }
 
@@ -1974,7 +1974,7 @@ TR::S390SystemLinkage::restoreGPRsInEpilogue2(TR::Instruction *cursor)
          if (findStartReg)
             firstReg = static_cast<TR::RealRegister::RegNum>(i);
 
-         if ((getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+         if ((getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
             {
             traceMsg(comp(), "\tand Assigned. ");
             findStartReg = false;
@@ -1993,21 +1993,21 @@ TR::S390SystemLinkage::restoreGPRsInEpilogue2(TR::Instruction *cursor)
    TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset + stackFrameSize, cg());
 
    if (lastReg - firstReg == 0)
-      cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getS390RealRegister(REGNUM(firstReg)), retAddrMemRef, cursor);
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getRealRegister(REGNUM(firstReg)), retAddrMemRef, cursor);
    else if (lastReg > firstReg)
-      cursor = generateRSInstruction(cg(),  TR::InstOpCode::getLoadMultipleOpCode(), nextNode, getS390RealRegister(REGNUM(firstReg)),  getS390RealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
+      cursor = generateRSInstruction(cg(),  TR::InstOpCode::getLoadMultipleOpCode(), nextNode, getRealRegister(REGNUM(firstReg)),  getRealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
 
 
    //r14 is a special case.  It is the return value register.  Since we will have to save/restore it often, we will try to reduce the range above by just emiting its own save/restore
    // should also experiment with changing preferred ordering in pickregister.
    traceMsg(comp(), "Considering Register %d:\n",i- TR::RealRegister::FirstGPR);
 
-   if(getPreserved(REGNUM(i)) && (getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+   if(getPreserved(REGNUM(i)) && (getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
       {
       traceMsg(comp(), "\t It is Assigned.\n");
       offset =  getRegisterSaveOffset(REGNUM(i));
       TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset + stackFrameSize, cg());
-      cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getS390RealRegister(REGNUM(i)), retAddrMemRef, cursor);
+      cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getRealRegister(REGNUM(i)), retAddrMemRef, cursor);
       }
 
    return cursor;
@@ -2041,14 +2041,14 @@ TR::S390SystemLinkage::restoreGPRsInEpilogue(TR::Instruction *cursor)
          if (findStartReg)
             firstReg = static_cast<TR::RealRegister::RegNum>(i);
 
-         if ((getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
+         if ((getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod())
             {
             if (comp()->getOption(TR_TraceCG))
                traceMsg(comp(), "\tand Assigned. ");
             findStartReg = false;
             }
 
-         if (!findStartReg && ( !(getS390RealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() || (i == TR::RealRegister::LastGPR && firstReg != TR::RealRegister::LastGPR)) )
+         if (!findStartReg && ( !(getRealRegister(REGNUM(i)))->getHasBeenAssignedInMethod() || (i == TR::RealRegister::LastGPR && firstReg != TR::RealRegister::LastGPR)) )
             {
             // LastGPR is the stack pointer on zLinux which always be saved and restored
             if (i == TR::RealRegister::LastGPR && !getIsLeafRoutine())
@@ -2066,9 +2066,9 @@ TR::S390SystemLinkage::restoreGPRsInEpilogue(TR::Instruction *cursor)
             TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset + stackFrameSize, cg());
 
             if (lastReg - firstReg == 0)
-               cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getS390RealRegister(REGNUM(firstReg )), retAddrMemRef, cursor);
+               cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getRealRegister(REGNUM(firstReg )), retAddrMemRef, cursor);
             else
-               cursor = generateRSInstruction(cg(),  TR::InstOpCode::getLoadMultipleOpCode(), nextNode, getS390RealRegister(REGNUM(firstReg)),  getS390RealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
+               cursor = generateRSInstruction(cg(),  TR::InstOpCode::getLoadMultipleOpCode(), nextNode, getRealRegister(REGNUM(firstReg)),  getRealRegister(REGNUM(lastReg)), retAddrMemRef, cursor);
 
 
             findStartReg = true;
@@ -2085,7 +2085,7 @@ TR::S390SystemLinkage::restoreGPRsInEpilogue(TR::Instruction *cursor)
        lastReg = static_cast<TR::RealRegister::RegNum>(TR::RealRegister::LastGPR);
        offset =  getRegisterSaveOffset(REGNUM(lastReg));
        TR::MemoryReference *retAddrMemRef = generateS390MemoryReference(spReg, offset + stackFrameSize, cg());
-       cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getS390RealRegister(REGNUM(lastReg )), retAddrMemRef, cursor);
+       cursor = generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), nextNode, getRealRegister(REGNUM(lastReg )), retAddrMemRef, cursor);
        }
    return cursor;
    }
@@ -2127,7 +2127,7 @@ void TR::S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
         retAddrMemRef = generateS390MemoryReference(spReg, offset, cg());
 
         cursor = generateRXInstruction(cg(), TR::InstOpCode::LD,
-           nextNode, getS390RealRegister(REGNUM(i+TR::RealRegister::FirstFPR)), retAddrMemRef, cursor);
+           nextNode, getRealRegister(REGNUM(i+TR::RealRegister::FirstFPR)), retAddrMemRef, cursor);
 
         offset +=  cg()->machine()->getFPRSize();
         }
@@ -2138,7 +2138,7 @@ void TR::S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
       // Check for large stack
       bool largeStack = (stackFrameSize < MIN_IMMEDIATE_VAL || stackFrameSize > MAX_IMMEDIATE_VAL);
 
-      TR::RealRegister * tempReg = getS390RealRegister(TR::RealRegister::GPR0);
+      TR::RealRegister * tempReg = getRealRegister(TR::RealRegister::GPR0);
 
       if (comp()->getOption(TR_TraceCG))
          traceMsg(comp(), "GPRSaveMask: Register context %x\n", GPRSaveMask&0xffff);
@@ -2152,7 +2152,7 @@ void TR::S390SystemLinkage::createEpilogue(TR::Instruction * cursor)
       }
 
    cursor = generateS390RegInstruction(cg(), TR::InstOpCode::BCR, nextNode,
-          getS390RealRegister(REGNUM(TR::RealRegister::GPR14)), cursor);
+          getRealRegister(REGNUM(TR::RealRegister::GPR14)), cursor);
    ((TR::S390RegInstruction *)cursor)->setBranchCondition(TR::InstOpCode::COND_BCR);
    }
 

--- a/compiler/z/codegen/TRSystemLinkage.hpp
+++ b/compiler/z/codegen/TRSystemLinkage.hpp
@@ -98,7 +98,7 @@ public:
 
    virtual TR::RealRegister::RegNum setEnvironmentPointerRegister (TR::RealRegister::RegNum r) { return _environmentPointerRegister = r; }
    virtual TR::RealRegister::RegNum getEnvironmentPointerRegister() { return _environmentPointerRegister; }
-   virtual TR::RealRegister *getEnvironmentPointerRealRegister() {return getS390RealRegister(_environmentPointerRegister);}
+   virtual TR::RealRegister *getEnvironmentPointerRealRegister() {return getRealRegister(_environmentPointerRegister);}
 
    virtual int32_t getRegisterSaveOffset(TR::RealRegister::RegNum);
 
@@ -146,7 +146,7 @@ public:
 
    virtual void setGOTPointerRegister (TR::RealRegister::RegNum r)         { _GOTPointerRegister = r; }
    virtual TR::RealRegister::RegNum getGOTPointerRegister()         { return _GOTPointerRegister; }
-   virtual TR::RealRegister *getGOTPointerRealRegister() {return getS390RealRegister(_GOTPointerRegister);}
+   virtual TR::RealRegister *getGOTPointerRealRegister() {return getRealRegister(_GOTPointerRegister);}
    virtual int32_t getRegisterSaveOffset(TR::RealRegister::RegNum);
    virtual void initParamOffset(TR::ResolvedMethodSymbol * method, int32_t stackIndex, List<TR::ParameterSymbol> *parameterList=0);
 

--- a/compiler/z/codegen/TRzOSSystemLinkageBase.hpp
+++ b/compiler/z/codegen/TRzOSSystemLinkageBase.hpp
@@ -78,11 +78,11 @@ public:
 
    virtual TR::RealRegister::RegNum setCAAPointerRegister (TR::RealRegister::RegNum r)         { return _CAAPointerRegister = r; }
    virtual TR::RealRegister::RegNum getCAAPointerRegister()         { return _CAAPointerRegister; }
-   virtual TR::RealRegister *getCAAPointerRealRegister() {return getS390RealRegister(_CAAPointerRegister);}
+   virtual TR::RealRegister *getCAAPointerRealRegister() {return getRealRegister(_CAAPointerRegister);}
 
    virtual TR::RealRegister::RegNum setParentDSAPointerRegister (TR::RealRegister::RegNum r)         { return _parentDSAPointerRegister = r; }
    virtual TR::RealRegister::RegNum getParentDSAPointerRegister()         { return _parentDSAPointerRegister; }
-   virtual TR::RealRegister *getParentDSAPointerRealRegister() {return getS390RealRegister(_parentDSAPointerRegister);}
+   virtual TR::RealRegister *getParentDSAPointerRealRegister() {return getRealRegister(_parentDSAPointerRegister);}
 
    // === Fastlink specific
    virtual bool isAggregateReturnedInIntRegisters(int32_t aggregateLenth)   { return isFastLinkLinkageType(); }


### PR DESCRIPTION
Rename the `OMR::Z::Machine::getS390RealRegister()` method to
`OMR::Z::Machine::getRealRegister()` in order to get the strength
of polymorphism.

P.S. The method `geS390RealRegister()` is still remaining for backward compatibility.

Issue: #2645