### PR TITLE
Rename OMR::ARM64::Machine::getARM64RealRegister()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -992,7 +992,7 @@ class ARM64Trg1CondInstruction : public ARM64Trg1Instruction
     */
    void insertZeroRegister(uint32_t *instruction)
       {
-      TR::RealRegister *zeroReg = cg()->machine()->getARM64RealRegister(TR::RealRegister::xzr);
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
       zeroReg->setRegisterFieldRM(instruction);
       zeroReg->setRegisterFieldRN(instruction);
       }

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -127,41 +127,41 @@ TR::ARM64SystemLinkage::initARM64RealRegisterLinkage()
    TR::RealRegister *reg;
    int icount;
 
-   reg = machine->getARM64RealRegister(TR::RealRegister::RegNum::x16); // IP0
+   reg = machine->getRealRegister(TR::RealRegister::RegNum::x16); // IP0
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
-   reg = machine->getARM64RealRegister(TR::RealRegister::RegNum::x17); // IP1
+   reg = machine->getRealRegister(TR::RealRegister::RegNum::x17); // IP1
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
-   reg = machine->getARM64RealRegister(TR::RealRegister::RegNum::x29); // FP
+   reg = machine->getRealRegister(TR::RealRegister::RegNum::x29); // FP
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
-   reg = machine->getARM64RealRegister(TR::RealRegister::RegNum::x30); // LR
+   reg = machine->getRealRegister(TR::RealRegister::RegNum::x30); // LR
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
-   reg = machine->getARM64RealRegister(TR::RealRegister::RegNum::sp); // SP
+   reg = machine->getRealRegister(TR::RealRegister::RegNum::sp); // SP
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
-   reg = machine->getARM64RealRegister(TR::RealRegister::RegNum::xzr); // zero
+   reg = machine->getRealRegister(TR::RealRegister::RegNum::xzr); // zero
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
    // assign "maximum" weight to registers x0-x15
    for (icount = TR::RealRegister::x0; icount <= TR::RealRegister::x15; icount++)
-      machine->getARM64RealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
 
    // assign "maximum" weight to registers x18-x28
    for (icount = TR::RealRegister::x18; icount <= TR::RealRegister::x28; icount++)
-      machine->getARM64RealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
 
    // assign "maximum" weight to registers v0-v31
    for (icount = TR::RealRegister::v0; icount <= TR::RealRegister::v31; icount++)
-      machine->getARM64RealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
+      machine->getRealRegister((TR::RealRegister::RegNum)icount)->setWeight(0xf000);
    }
 
 
@@ -223,7 +223,7 @@ TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
    // allocate space for preserved registers (x19-x28, v8-v15)
    for (int r = TR::RealRegister::x19; r <= TR::RealRegister::x28; r++)
       {
-      TR::RealRegister *rr = machine->getARM64RealRegister((TR::RealRegister::RegNum)r);
+      TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
          stackIndex += 8;
@@ -231,7 +231,7 @@ TR::ARM64SystemLinkage::mapStack(TR::ResolvedMethodSymbol *method)
       }
    for (int r = TR::RealRegister::v8; r <= TR::RealRegister::v15; r++)
       {
-      TR::RealRegister *rr = machine->getARM64RealRegister((TR::RealRegister::RegNum)r);
+      TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
          stackIndex += 8;
@@ -365,7 +365,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
    TR::Machine *machine = codeGen->machine();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
    const TR::ARM64LinkageProperties& properties = getProperties();
-   TR::RealRegister *sp = machine->getARM64RealRegister(properties.getStackPointerRegister());
+   TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
    TR::Node *firstNode = comp()->getStartTree()->getNode();
 
    // allocate stack space
@@ -381,7 +381,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
 
    // save link register (x30)
    TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, bodySymbol->getLocalMappingCursor(), codeGen);
-   cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getARM64RealRegister(TR::RealRegister::x30), cursor);
+   cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::strimmx, firstNode, stackSlot, machine->getRealRegister(TR::RealRegister::x30), cursor);
 
    // spill argument registers
    int32_t nextIntArgReg = 0;
@@ -404,7 +404,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
             if (nextIntArgReg < getProperties().getNumIntArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::strimmx : TR::InstOpCode::strimmw;
-               cursor = generateMemSrc1Instruction(cg(), op, firstNode, stackSlot, machine->getARM64RealRegister((TR::RealRegister::RegNum)(TR::RealRegister::x0 + nextIntArgReg)), cursor);
+               cursor = generateMemSrc1Instruction(cg(), op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::x0 + nextIntArgReg)), cursor);
                nextIntArgReg++;
                }
             else
@@ -417,7 +417,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
             if (nextFltArgReg < getProperties().getNumFloatArgRegs())
                {
                op = (parameter->getSize() == 8) ? TR::InstOpCode::vstrimmd : TR::InstOpCode::vstrimms;
-               cursor = generateMemSrc1Instruction(cg(), op, firstNode, stackSlot, machine->getARM64RealRegister((TR::RealRegister::RegNum)(TR::RealRegister::v0 + nextFltArgReg)), cursor);
+               cursor = generateMemSrc1Instruction(cg(), op, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::v0 + nextFltArgReg)), cursor);
                nextFltArgReg++;
                }
             else
@@ -437,7 +437,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
    uint32_t offset = bodySymbol->getLocalMappingCursor() + 8; // +8 for LR
    for (int r = TR::RealRegister::x19; r <= TR::RealRegister::x28; r++)
       {
-      TR::RealRegister *rr = machine->getARM64RealRegister((TR::RealRegister::RegNum)r);
+      TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
          TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
@@ -447,7 +447,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       }
    for (int r = TR::RealRegister::v8; r <= TR::RealRegister::v15; r++)
       {
-      TR::RealRegister *rr = machine->getARM64RealRegister((TR::RealRegister::RegNum)r);
+      TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
          TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
@@ -466,13 +466,13 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::Machine *machine = codeGen->machine();
    TR::Node *lastNode = cursor->getNode();
    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
-   TR::RealRegister *sp = machine->getARM64RealRegister(properties.getStackPointerRegister());
+   TR::RealRegister *sp = machine->getRealRegister(properties.getStackPointerRegister());
 
    // restore callee-saved registers
    uint32_t offset = bodySymbol->getLocalMappingCursor() + 8; // +8 for LR
    for (int r = TR::RealRegister::x19; r <= TR::RealRegister::x28; r++)
       {
-      TR::RealRegister *rr = machine->getARM64RealRegister((TR::RealRegister::RegNum)r);
+      TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
          TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
@@ -482,7 +482,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
    for (int r = TR::RealRegister::v8; r <= TR::RealRegister::v15; r++)
       {
-      TR::RealRegister *rr = machine->getARM64RealRegister((TR::RealRegister::RegNum)r);
+      TR::RealRegister *rr = machine->getRealRegister((TR::RealRegister::RegNum)r);
       if (rr->getHasBeenAssignedInMethod())
          {
          TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, offset, codeGen);
@@ -492,7 +492,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
 
    // restore link register (x30)
-   TR::RealRegister *lr = machine->getARM64RealRegister(TR::RealRegister::lr);
+   TR::RealRegister *lr = machine->getRealRegister(TR::RealRegister::lr);
    TR::MemoryReference *stackSlot = new (trHeapMemory()) TR::MemoryReference(sp, bodySymbol->getLocalMappingCursor(), codeGen);
    cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, lastNode, lr, stackSlot, cursor);
 

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -48,8 +48,8 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
 
    _linkageProperties = &self()->getLinkage()->getProperties();
 
-   self()->setStackPointerRegister(self()->machine()->getARM64RealRegister(_linkageProperties->getStackPointerRegister()));
-   self()->setMethodMetaDataRegister(self()->machine()->getARM64RealRegister(_linkageProperties->getMethodMetaDataRegister()));
+   self()->setStackPointerRegister(self()->machine()->getRealRegister(_linkageProperties->getStackPointerRegister()));
+   self()->setMethodMetaDataRegister(self()->machine()->getRealRegister(_linkageProperties->getMethodMetaDataRegister()));
 
    // Tactical GRA settings
    //
@@ -384,7 +384,7 @@ int32_t OMR::ARM64::CodeGenerator::getMaximumNumbersOfAssignableFPRs()
 
 bool OMR::ARM64::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
-   return self()->machine()->getARM64RealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
+   return self()->machine()->getRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
    }
 
 TR_GlobalRegisterNumber OMR::ARM64::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type)

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -120,7 +120,7 @@ TR::RealRegister *OMR::ARM64::Machine::freeBestRegister(TR::Instruction *current
 
       for (int i = first; i <= last; i++)
          {
-         TR::RealRegister *realReg = self()->getARM64RealRegister((TR::RealRegister::RegNum)i);
+         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             candidates[numCandidates++] = realReg->getAssignedRegister();
@@ -486,7 +486,7 @@ static void registerCopy(TR::Instruction *precedingInstruction,
    switch (rk)
       {
       case TR_GPR:
-         zeroReg = cg->machine()->getARM64RealRegister(TR::RealRegister::xzr);
+         zeroReg = cg->machine()->getRealRegister(TR::RealRegister::xzr);
          generateTrg1Src2Instruction(cg, TR::InstOpCode::orrx, node, targetReg, zeroReg, sourceReg, precedingInstruction); /* mov (register) */
          break;
       case TR_FPR:

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -67,6 +67,16 @@ public:
    Machine(TR::CodeGenerator *cg);
 
    /**
+    * @brief This method is the wrapper for \code getRealRegister.
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getARM64RealRegister(TR::RealRegister::RegNum regNum)
+      {
+      return _registerFile[regNum];
+      }
+
+   /**
     * @brief Converts RegNum to RealRegister
     * @param[in] regNum : register number
     * @return RealRegister for specified register number

--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -71,7 +71,7 @@ public:
     * @param[in] regNum : register number
     * @return RealRegister for specified register number
     */
-   TR::RealRegister *getARM64RealRegister(TR::RealRegister::RegNum regNum)
+   TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum)
       {
       return _registerFile[regNum];
       }

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -268,7 +268,7 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
          {
          virtReg = _dependencies[i].getRegister();
          dependentRegNum = _dependencies[i].getRealRegister();
-         dependentRealReg = machine->getARM64RealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
 
          if (dependentRegNum != TR::RealRegister::NoReg &&
              dependentRegNum != TR::RealRegister::SpilledReg &&
@@ -293,7 +293,7 @@ void TR_ARM64RegisterDependencyGroup::assignRegisters(
             assignedRegister = toRealRegister(virtReg->getAssignedRealRegister());
             }
          dependentRegNum = _dependencies[i].getRealRegister();
-         dependentRealReg = machine->getARM64RealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
          if (dependentRegNum != TR::RealRegister::NoReg &&
              dependentRegNum != TR::RealRegister::SpilledReg &&
              dependentRealReg != assignedRegister)

--- a/compiler/aarch64/codegen/OMRRegisterIterator.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterIterator.cpp
@@ -49,17 +49,17 @@ OMR::ARM64::RegisterIterator::RegisterIterator(TR::Machine *machine, TR_Register
 TR::Register *
 OMR::ARM64::RegisterIterator::getFirst()
    {
-   return _machine->getARM64RealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
+   return _machine->getRealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
    }
 
 TR::Register *
 OMR::ARM64::RegisterIterator::getCurrent()
    {
-   return _machine->getARM64RealRegister((TR::RealRegister::RegNum)_cursor);
+   return _machine->getRealRegister((TR::RealRegister::RegNum)_cursor);
    }
 
 TR::Register *
 OMR::ARM64::RegisterIterator::getNext()
    {
-   return _cursor == _lastRegIndex ? NULL : _machine->getARM64RealRegister((TR::RealRegister::RegNum)(++_cursor));
+   return _cursor == _lastRegIndex ? NULL : _machine->getRealRegister((TR::RealRegister::RegNum)(++_cursor));
    }


### PR DESCRIPTION
Rename the `OMR::ARM64::Machine::getARM64RealRegister()` method to
`OMR::ARM64::Machine::getRealRegister()` in order to get the strength
of polymorphism.

P.S. The method `getARM64RealRegister()` is still remaining for backward compatibility.

Issue: #2645