### PR TITLE
Rename OMR::ARM::Machine::getARMRealRegister()

### DIFF
--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -276,7 +276,7 @@ TR_Debug::dumpDependencyGroup(TR::FILE *                        pOutFile,
       if (r == TR::RealRegister::NoReg)
          trfprintf(pOutFile, "NoReg]");
       else
-         trfprintf(pOutFile, "%s]", getName(_cg->machine()->getARMRealRegister(r)));
+         trfprintf(pOutFile, "%s]", getName(_cg->machine()->getRealRegister(r)));
 
       foundDep = true;
       }
@@ -791,7 +791,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMMultipleMoveInstruction * instr)
             {
             TR::RealRegister::RegNum r;
             r = (TR::RealRegister::RegNum)((int)TR::RealRegister::FirstGPR + i);
-            print(pOutFile, machine->getARMRealRegister(r));
+            print(pOutFile, machine->getRealRegister(r));
             regList >>= 1;
             if (regList && i != 15)
               trfprintf(pOutFile, ",");
@@ -808,7 +808,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMMultipleMoveInstruction * instr)
       for (int i = 0; i < nreg; i++)
          {
          TR::RealRegister::RegNum r = (TR::RealRegister::RegNum)((int)TR::RealRegister::FirstFPR + startReg + i);
-         print(pOutFile, machine->getARMRealRegister(r), size);
+         print(pOutFile, machine->getRealRegister(r), size);
          if (i != (nreg - 1))
             trfprintf(pOutFile, ",");
          }
@@ -928,7 +928,7 @@ TR_Debug::printARMGCRegisterMap(TR::FILE *pOutFile, TR::GCRegisterMap * map)
    for (int i = 15; i>=0; i--)
       {
       if (map->getMap() & (1 << i))
-         trfprintf(pOutFile, "%s ", getName(machine->getARMRealRegister((TR::RealRegister::RegNum)(i + TR::RealRegister::FirstGPR))));
+         trfprintf(pOutFile, "%s ", getName(machine->getRealRegister((TR::RealRegister::RegNum)(i + TR::RealRegister::FirstGPR))));
       }
 
    trfprintf(pOutFile,"}\n");
@@ -1142,7 +1142,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "str\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getARMRealRegister(linkage.getIntegerArgumentRegister(numIntArgs)));
+               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(numIntArgs)));
                bufferPos += 4;
                }
             numIntArgs++;
@@ -1156,13 +1156,13 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "str\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getARMRealRegister(linkage.getIntegerArgumentRegister(numIntArgs)));
+               print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(numIntArgs)));
                bufferPos += 4;
                if (numIntArgs < linkage.getNumIntArgRegs() - 1)
                   {
                   printPrefix(pOutFile, NULL, bufferPos, 4);
                   trfprintf(pOutFile, "str\t[gr7, %+d], ", offset + 4);
-                  print(pOutFile, machine->getARMRealRegister(linkage.getIntegerArgumentRegister(numIntArgs + 1)));
+                  print(pOutFile, machine->getRealRegister(linkage.getIntegerArgumentRegister(numIntArgs + 1)));
                   bufferPos += 4;
                   }
                }
@@ -1179,7 +1179,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "stfs\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getARMRealRegister(linkage.getFloatArgumentRegister(numFloatArgs)));
+               print(pOutFile, machine->getRealRegister(linkage.getFloatArgumentRegister(numFloatArgs)));
                bufferPos += 4;
                }
             numFloatArgs++;
@@ -1193,7 +1193,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMCallSnippet * snippet)
                {
                printPrefix(pOutFile, NULL, bufferPos, 4);
                trfprintf(pOutFile, "stfd\t[gr7, %+d], ", offset);
-               print(pOutFile, machine->getARMRealRegister(linkage.getFloatArgumentRegister(numFloatArgs)));
+               print(pOutFile, machine->getRealRegister(linkage.getFloatArgumentRegister(numFloatArgs)));
                bufferPos += 4;
                }
             numFloatArgs++;

--- a/compiler/arm/codegen/ARMInstruction.hpp
+++ b/compiler/arm/codegen/ARMInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -700,7 +700,7 @@ class ARMLoadStartPCInstruction : public TR::ARMTrg1Src2Instruction
                              TR::Register      *treg,
                              TR::SymbolReference *symRef,
                              TR::CodeGenerator *cg)
-      : TR::ARMTrg1Src2Instruction(ARMOp_sub, node, treg, cg->machine()->getARMRealRegister(TR::RealRegister::gr15),
+      : TR::ARMTrg1Src2Instruction(ARMOp_sub, node, treg, cg->machine()->getRealRegister(TR::RealRegister::gr15),
          new (cg->trHeapMemory()) TR_ARMOperand2(0xde, 24), cg), /* The value 0xde does not mean anything. It will be replaced in the binary encoding phase. */
         _symbolReference(symRef)
       {
@@ -711,7 +711,7 @@ class ARMLoadStartPCInstruction : public TR::ARMTrg1Src2Instruction
                              TR::Register      *treg,
                              TR::SymbolReference *symRef,
                              TR::CodeGenerator *cg)
-      : TR::ARMTrg1Src2Instruction(precedingInstruction, ARMOp_sub, node, treg, cg->machine()->getARMRealRegister(TR::RealRegister::gr15),
+      : TR::ARMTrg1Src2Instruction(precedingInstruction, ARMOp_sub, node, treg, cg->machine()->getRealRegister(TR::RealRegister::gr15),
          new (cg->trHeapMemory()) TR_ARMOperand2(0xde, 0), cg),  /* The value 0xde does not mean anything. It will be replaced in the binary encoding phase. */
         _symbolReference(symRef)
       {

--- a/compiler/arm/codegen/ARMOutOfLineCodeSection.cpp
+++ b/compiler/arm/codegen/ARMOutOfLineCodeSection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -97,7 +97,7 @@ void TR_ARMOutOfLineCodeSection::assignRegisters(TR_RegisterKinds kindsToBeAssig
    // it won't show up in the liveRealRegDeps. If a dead virtual occupies that real reg we need to clean it up.
    for (int32_t i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastFPR; ++i)
       {
-      TR::RealRegister *r = _cg->machine()->getARMRealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister *r = _cg->machine()->getRealRegister((TR::RealRegister::RegNum)i);
       TR::Register        *v = r->getAssignedRegister();
 
       if (v && v != r && v->getFutureUseCount() == 0)

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -178,27 +178,27 @@ void TR::ARMSystemLinkage::initARMRealRegisterLinkage()
    TR::Machine *machine = cg()->machine();
 
    // make r15 (PC) unavailable for RA
-   TR::RealRegister *reg = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *reg = machine->getRealRegister(TR::RealRegister::gr15);
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
    // make r14 (LR) unavailable for RA
-   reg = machine->getARMRealRegister(TR::RealRegister::gr14);
+   reg = machine->getRealRegister(TR::RealRegister::gr14);
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
    // make r13 (SP) unavailable for RA
-   reg = machine->getARMRealRegister(TR::RealRegister::gr13);
+   reg = machine->getRealRegister(TR::RealRegister::gr13);
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
    // make r12 (IP) unavailable for RA
-   reg = machine->getARMRealRegister(TR::RealRegister::gr12);
+   reg = machine->getRealRegister(TR::RealRegister::gr12);
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
    // make r9 unavailable for RA (just in case, because it's meaning is platform defined)
-   reg = machine->getARMRealRegister(TR::RealRegister::gr9);
+   reg = machine->getRealRegister(TR::RealRegister::gr9);
    reg->setState(TR::RealRegister::Locked);
    reg->setAssignedRegister(reg);
 
@@ -210,13 +210,13 @@ void TR::ARMSystemLinkage::initARMRealRegisterLinkage()
    // assign "maximum" weight to registers r0-r8
    for (int32_t r = TR::RealRegister::gr0; r <= TR::RealRegister::gr8; ++r)
       {
-      machine->getARMRealRegister(static_cast<TR::RealRegister::RegNum>(r))->setWeight(0xf000);
+      machine->getRealRegister(static_cast<TR::RealRegister::RegNum>(r))->setWeight(0xf000);
       }
 
    // assign "maximum" weight to registers r10-r12
    for (int32_t r = TR::RealRegister::gr10; r <= TR::RealRegister::gr12; ++r)
       {
-      machine->getARMRealRegister(static_cast<TR::RealRegister::RegNum>(r))->setWeight(0xf000);
+      machine->getRealRegister(static_cast<TR::RealRegister::RegNum>(r))->setWeight(0xf000);
       }
    }
 
@@ -453,7 +453,7 @@ void TR::ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
    TR::Machine *machine = codeGen->machine();
    TR::ResolvedMethodSymbol* bodySymbol = comp()->getJittedMethodSymbol();
    TR::Node *firstNode = comp()->getStartTree()->getNode();
-   TR::RealRegister *stackPtr = machine->getARMRealRegister(properties.getStackPointerRegister());
+   TR::RealRegister *stackPtr = machine->getRealRegister(properties.getStackPointerRegister());
 
    // Entry breakpoint
    //
@@ -483,7 +483,7 @@ void TR::ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
          case TR::Address:
             if (nextIntArgReg < getProperties().getNumIntArgRegs())
                {
-               cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getARMRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::gr0 + nextIntArgReg)), cursor);
+               cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::gr0 + nextIntArgReg)), cursor);
                nextIntArgReg++;
                }
             else
@@ -495,9 +495,9 @@ void TR::ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
             nextIntArgReg += nextIntArgReg & 0x1; // round to next even number
             if (nextIntArgReg + 1 < getProperties().getNumIntArgRegs())
                {
-               cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getARMRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::gr0 + nextIntArgReg)), cursor);
+               cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::gr0 + nextIntArgReg)), cursor);
                stackSlot = new (trHeapMemory()) TR::MemoryReference(stackPtr, parameter->getParameterOffset() + 4, codeGen);
-               cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getARMRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::gr0 + nextIntArgReg + 1)), cursor);
+               cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::gr0 + nextIntArgReg + 1)), cursor);
                nextIntArgReg += 2;
                }
             else
@@ -511,7 +511,7 @@ void TR::ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
          case TR::Double:
             if (nextFltArgReg < getProperties().getNumFloatArgRegs())
                {
-               cursor = generateMemSrc1Instruction(cg(), ARMOp_fstd, firstNode, stackSlot, machine->getARMRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::fp0 + nextFltArgReg)), cursor);
+               cursor = generateMemSrc1Instruction(cg(), ARMOp_fstd, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)(TR::RealRegister::fp0 + nextFltArgReg)), cursor);
                nextFltArgReg += 1;
                }
             else
@@ -528,12 +528,12 @@ void TR::ARMSystemLinkage::createPrologue(TR::Instruction *cursor)
    for (int r = TR::RealRegister::gr4; r <= TR::RealRegister::gr11; ++r)
       {
       auto *stackSlot = new (trHeapMemory()) TR::MemoryReference(stackPtr, (TR::RealRegister::gr11 - r + 1)*4 + bodySymbol->getLocalMappingCursor(), codeGen);
-      cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getARMRealRegister((TR::RealRegister::RegNum)r), cursor);
+      cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)r), cursor);
       }
 
    // save link register (r14)
    auto *stackSlot = new (trHeapMemory()) TR::MemoryReference(stackPtr, bodySymbol->getLocalMappingCursor(), codeGen);
-   cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getARMRealRegister(TR::RealRegister::gr14), cursor);
+   cursor = generateMemSrc1Instruction(cg(), ARMOp_str, firstNode, stackSlot, machine->getRealRegister(TR::RealRegister::gr14), cursor);
    }
 
 void TR::ARMSystemLinkage::createEpilogue(TR::Instruction *cursor)
@@ -543,17 +543,17 @@ void TR::ARMSystemLinkage::createEpilogue(TR::Instruction *cursor)
    TR::Machine *machine = codeGen->machine();
    TR::Node *lastNode = cursor->getNode();
    TR::ResolvedMethodSymbol* bodySymbol = comp()->getJittedMethodSymbol();
-   TR::RealRegister *stackPtr = machine->getARMRealRegister(properties.getStackPointerRegister());
+   TR::RealRegister *stackPtr = machine->getRealRegister(properties.getStackPointerRegister());
 
    // restore link register (r14)
    auto *stackSlot = new (trHeapMemory()) TR::MemoryReference(stackPtr, bodySymbol->getLocalMappingCursor(), codeGen);
-   cursor = generateMemSrc1Instruction(cg(), ARMOp_ldr, lastNode, stackSlot, machine->getARMRealRegister(TR::RealRegister::gr14), cursor);
+   cursor = generateMemSrc1Instruction(cg(), ARMOp_ldr, lastNode, stackSlot, machine->getRealRegister(TR::RealRegister::gr14), cursor);
 
    // restore all preserved registers
    for (int r = TR::RealRegister::gr4; r <= TR::RealRegister::gr11; ++r)
       {
       auto *stackSlot = new (trHeapMemory()) TR::MemoryReference(stackPtr, (TR::RealRegister::gr11 - r + 1)*4 + bodySymbol->getLocalMappingCursor(), codeGen);
-      cursor = generateMemSrc1Instruction(cg(), ARMOp_ldr, lastNode, stackSlot, machine->getARMRealRegister((TR::RealRegister::RegNum)r), cursor);
+      cursor = generateMemSrc1Instruction(cg(), ARMOp_ldr, lastNode, stackSlot, machine->getRealRegister((TR::RealRegister::RegNum)r), cursor);
       }
 
    // remove space for preserved registers
@@ -561,8 +561,8 @@ void TR::ARMSystemLinkage::createEpilogue(TR::Instruction *cursor)
    cursor = generateTrg1Src1ImmInstruction(codeGen, ARMOp_add, lastNode, stackPtr, stackPtr, frameSize, 0, cursor);
 
    // return using `mov r15, r14`
-   TR::RealRegister *gr14 = machine->getARMRealRegister(TR::RealRegister::gr14);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr14 = machine->getRealRegister(TR::RealRegister::gr14);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
    cursor = generateTrg1Src1Instruction(codeGen, ARMOp_mov, lastNode, gr15, gr14, cursor);
    }
 
@@ -573,7 +573,7 @@ TR::MemoryReference *TR::ARMSystemLinkage::getOutgoingArgumentMemRef(int32_t    
                                                                       TR::ARMMemoryArgument &memArg)
    {
    int32_t                spOffset = offset - (getProperties().getNumIntArgRegs() * TR::Compiler->om.sizeofReferenceAddress());
-   TR::RealRegister    *sp       = cg()->machine()->getARMRealRegister(properties.getStackPointerRegister());
+   TR::RealRegister    *sp       = cg()->machine()->getRealRegister(properties.getStackPointerRegister());
    TR::MemoryReference *result   = new (trHeapMemory()) TR::MemoryReference(sp, spOffset, cg());
 
    memArg.argRegister = argReg;

--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1414,7 +1414,7 @@ TR::Register *OMR::ARM::TreeEvaluator::tableEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      TR::RealRegister *machineIP        = cg->machine()->getARMRealRegister(TR::RealRegister::gr15);
+      TR::RealRegister *machineIP        = cg->machine()->getRealRegister(TR::RealRegister::gr15);
       uint32_t      base, rotate;
 
       if (!constantIsImmed8r(numBranchTableEntries, &base, &rotate))
@@ -1902,7 +1902,7 @@ TR::Register *OMR::ARM::TreeEvaluator::igotoEvaluator(TR::Node *node, TR::CodeGe
 
    TR::Node *labelAddr = node->getFirstChild();
    TR::Register *addrReg = cg->evaluate(labelAddr);
-   TR::RealRegister *gr15 = machine->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *gr15 = machine->getRealRegister(TR::RealRegister::gr15);
    TR::RegisterDependencyConditions *deps = NULL;
    if (node->getNumChildren() > 1)
       {

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1025,7 +1025,7 @@ TR::Register *OMR::ARM::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeG
    float value = node->getFloat();
    uint32_t i32 = *(int32_t *)(&value);
    TR::Compilation *comp = cg->comp();
-   TR::RealRegister *machineIPReg = cg->machine()->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *machineIPReg = cg->machine()->getRealRegister(TR::RealRegister::gr15);
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(2, 2, cg->trMemory());
 
    traceMsg(comp, "In fconstEvaluator %x\n", i32);
@@ -1085,7 +1085,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
    double value = node->getDouble();
    uint64_t i64 = (*(int64_t *)&value);
    TR::Compilation *comp = cg->comp();
-   TR::RealRegister *machineIPReg = cg->machine()->getARMRealRegister(TR::RealRegister::gr15);
+   TR::RealRegister *machineIPReg = cg->machine()->getRealRegister(TR::RealRegister::gr15);
    TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(2, 2, cg->trMemory());
 
    traceMsg(comp, "In dconstEvaluator %x\n", i64);

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -112,11 +112,11 @@ OMR::ARM::CodeGenerator::CodeGenerator()
       }
 
    if (!debug("hasFramePointer"))
-      self()->setFrameRegister(self()->machine()->getARMRealRegister(_linkageProperties->getStackPointerRegister()));
+      self()->setFrameRegister(self()->machine()->getRealRegister(_linkageProperties->getStackPointerRegister()));
    else
-      self()->setFrameRegister(self()->machine()->getARMRealRegister(_linkageProperties->getFramePointerRegister()));
+      self()->setFrameRegister(self()->machine()->getRealRegister(_linkageProperties->getFramePointerRegister()));
 
-   self()->setMethodMetaDataRegister(self()->machine()->getARMRealRegister(_linkageProperties->getMethodMetaDataRegister()));
+   self()->setMethodMetaDataRegister(self()->machine()->getRealRegister(_linkageProperties->getMethodMetaDataRegister()));
 
    // Tactical GRA settings
 #if 1 // PPC enables below, but seem no longer used?
@@ -280,8 +280,8 @@ directToInterpreterHelper(TR::ResolvedMethodSymbol *methodSymbol, TR::CodeGenera
 TR::Instruction *OMR::ARM::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node)
    {
    TR::Compilation *comp = self()->comp();
-   TR::Register   *gr4 = self()->machine()->getARMRealRegister(TR::RealRegister::gr4);
-   TR::Register   *lr = self()->machine()->getARMRealRegister(TR::RealRegister::gr14); // link register
+   TR::Register   *gr4 = self()->machine()->getRealRegister(TR::RealRegister::gr4);
+   TR::Register   *lr = self()->machine()->getRealRegister(TR::RealRegister::gr14); // link register
    TR::ResolvedMethodSymbol *methodSymbol = comp->getJittedMethodSymbol();
    TR::SymbolReference    *revertToInterpreterSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_ARMrevertToInterpreterGlue, false, false, false);
    uintptrj_t             ramMethod = (uintptrj_t)methodSymbol->getResolvedMethod()->resolvedMethodAddress();
@@ -325,7 +325,7 @@ static void removeGhostRegistersFromGCMaps(TR::CodeGenerator *cg, TR::Instructio
             uint32_t regMask = cg->registerBitMask(regNum);
             if (map->getRegisterMap() & regMask)
                {
-               TR::RealRegister *regInRegMap = cg->machine()->getARMRealRegister((TR::RealRegister::RegNum)regNum);
+               TR::RealRegister *regInRegMap = cg->machine()->getRealRegister((TR::RealRegister::RegNum)regNum);
                if (regInRegMap->getState() == TR::RealRegister::Free)
                   {
                   // This register is unassigned, check if it was defined before the GC point.
@@ -638,7 +638,7 @@ void OMR::ARM::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
    for (int i=TR::RealRegister::FirstGPR;
             i<=TR::RealRegister::LastGPR; i++)
       {
-      TR::RealRegister *realReg = self()->machine()->getARMRealRegister(
+      TR::RealRegister *realReg = self()->machine()->getRealRegister(
                              (TR::RealRegister::RegNum)i);
       if (realReg->getHasBeenAssignedInMethod())
          {
@@ -821,5 +821,5 @@ bool OMR::ARM::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
 
 bool OMR::ARM::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
-   return self()->machine()->getARMRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
+   return self()->machine()->getRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
    }

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -83,7 +83,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
    {
    TR::CodeGenerator     *codeGen    = self()->cg();
    TR::Machine           *machine    = codeGen->machine();
-   TR::RealRegister      *stackPtr   = machine->getARMRealRegister(self()->getProperties().getStackPointerRegister());
+   TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
    TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
 
@@ -122,7 +122,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
             case TR::Address:
                if (hasToBeOnStack)
                   {
-                  argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+                  argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                   cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
                   }
                numIntArgs++;
@@ -132,11 +132,11 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
             case TR::Int64:
             	if (hasToBeOnStack)
                   {
-                  argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+                  argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                   cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
                   if (numIntArgs < properties.getNumIntArgRegs()-1)
                      {
-                     argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
+                     argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                      cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset+4, codeGen), argRegister, cursor);
                      }
                   }
@@ -152,7 +152,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
    {
    TR::CodeGenerator     *codeGen    = self()->cg();
    TR::Machine           *machine    = codeGen->machine();
-   TR::RealRegister      *stackPtr   = machine->getARMRealRegister(self()->getProperties().getStackPointerRegister());
+   TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
    TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
@@ -176,7 +176,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
             if (hasToLoadFromStack &&
                 numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
                }
             numIntArgs++;
@@ -184,7 +184,7 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
          case TR::Address:
              if (numIntArgs<properties.getNumIntArgRegs())
                 {
-                argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                 cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
                 }
              numIntArgs++;
@@ -195,11 +195,11 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
             if (hasToLoadFromStack &&
                 numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), cursor);
                if (numIntArgs < properties.getNumIntArgRegs()-1)
                   {
-                  argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
+                  argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                   cursor = generateTrg1MemInstruction(codeGen, ARMOp_ldr, firstNode, argRegister, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, codeGen), cursor);
                   }
                }
@@ -215,7 +215,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
    {
    TR::CodeGenerator     *codeGen    = self()->cg();
    TR::Machine           *machine    = codeGen->machine();
-   TR::RealRegister      *stackPtr   = machine->getARMRealRegister(self()->getProperties().getStackPointerRegister());
+   TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
    TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
    TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
@@ -239,7 +239,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
             if (hasToSaveToStack &&
                 numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
                }
             numIntArgs++;
@@ -247,7 +247,7 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
          case TR::Address:
              if (numIntArgs<properties.getNumIntArgRegs())
                 {
-                argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                 cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
                 }
              numIntArgs++;
@@ -258,11 +258,11 @@ TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
             if (hasToSaveToStack &&
                 numIntArgs<properties.getNumIntArgRegs())
                {
-               argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
+               argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
                cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, codeGen), argRegister, cursor);
                if (numIntArgs < properties.getNumIntArgRegs()-1)
                   {
-                  argRegister = machine->getARMRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
+                  argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs+1));
                   cursor = generateMemSrc1Instruction(codeGen, ARMOp_str, firstNode, new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset + 4, codeGen), argRegister, cursor);
                   }
                }
@@ -574,7 +574,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
          {
          traceMsg(comp, "Special arg %s in %s\n",
             comp->getDebug()->getName(callNode->getChild(from)),
-            comp->getDebug()->getName(self()->cg()->machine()->getARMRealRegister(specialArgReg)));
+            comp->getDebug()->getName(self()->cg()->machine()->getRealRegister(specialArgReg)));
          }
       // Skip the special arg in the first loop
       from += step;

--- a/compiler/arm/codegen/OMRMachine.cpp
+++ b/compiler/arm/codegen/OMRMachine.cpp
@@ -147,7 +147,7 @@ TR::RealRegister *OMR::ARM::Machine::freeBestRegister(TR::Instruction     *curre
 
       for (int i  = first; i <= last; i++)
          {
-         TR::RealRegister *realReg = self()->getARMRealRegister((TR::RealRegister::RegNum)i);
+         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             candidates[numCandidates++] = realReg->getAssignedRegister();
@@ -964,7 +964,7 @@ OMR::ARM::Machine::createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::list<
 
    for (int32_t i = TR::RealRegister::FirstGPR; i <= endReg; i++)
       {
-      TR::RealRegister *realReg = self()->getARMRealRegister((TR::RealRegister::RegNum)i);
+      TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)i);
       TR_ASSERT(realReg->getState() == TR::RealRegister::Assigned ||
               realReg->getState() == TR::RealRegister::Free ||
               realReg->getState() == TR::RealRegister::Locked,
@@ -982,7 +982,7 @@ OMR::ARM::Machine::createCondForLiveAndSpilledGPRs(bool cleanRegState, TR::list<
       deps = new (self()->cg()->trHeapMemory()) TR::RegisterDependencyConditions(0, c, self()->cg()->trMemory());
       for (int32_t j = TR::RealRegister::FirstGPR; j <= endReg; j++)
          {
-         TR::RealRegister *realReg = self()->getARMRealRegister((TR::RealRegister::RegNum)j);
+         TR::RealRegister *realReg = self()->getRealRegister((TR::RealRegister::RegNum)j);
          if (realReg->getState() == TR::RealRegister::Assigned)
             {
             TR::Register *virtReg = realReg->getAssignedRegister();

--- a/compiler/arm/codegen/OMRMachine.hpp
+++ b/compiler/arm/codegen/OMRMachine.hpp
@@ -80,6 +80,16 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    Machine(TR::CodeGenerator *cg);
 
    /**
+    * @brief This method is the wrapper for \code getRealRegister.
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getARMRealRegister(TR::RealRegister::RegNum regNum)
+      {
+      return _registerFile[regNum];
+      }
+
+   /**
     * @brief Converts RegNum to RealRegister
     * @param[in] regNum : register number
     * @return RealRegister for specified register number

--- a/compiler/arm/codegen/OMRMachine.hpp
+++ b/compiler/arm/codegen/OMRMachine.hpp
@@ -79,7 +79,12 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    Machine(TR::CodeGenerator *cg);
 
-   TR::RealRegister *getARMRealRegister(TR::RealRegister::RegNum regNum)
+   /**
+    * @brief Converts RegNum to RealRegister
+    * @param[in] regNum : register number
+    * @return RealRegister for specified register number
+    */
+   TR::RealRegister *getRealRegister(TR::RealRegister::RegNum regNum)
       {
       return _registerFile[regNum];
       }

--- a/compiler/arm/codegen/OMRMemoryReference.cpp
+++ b/compiler/arm/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1194,8 +1194,8 @@ uint8_t *OMR::ARM::MemoryReference::encodeLargeARMConstant(uint32_t *wcursor, ui
       toRealRegister(currentInstruction->getMemoryDataRegister())->getRegisterNumber() == base->getRegisterNumber())
       {
       spillNeeded = true;
-      rX = cg->machine()->getARMRealRegister(choose_rX(currentInstruction, base));
-      stackPtr = cg->machine()->getARMRealRegister(cg->getLinkage()->getProperties().getStackPointerRegister());
+      rX = cg->machine()->getRealRegister(choose_rX(currentInstruction, base));
+      stackPtr = cg->machine()->getRealRegister(cg->getLinkage()->getProperties().getStackPointerRegister());
       }
    else
       {

--- a/compiler/arm/codegen/OMRRegisterDependency.cpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -430,7 +430,7 @@ void TR_ARMRegisterDependencyGroup::assignRegisters(TR::Instruction  *currentIns
          {
          virtReg = dependencies[i].getRegister();
          dependentRegNum = dependencies[i].getRealRegister();
-         dependentRealReg = machine->getARMRealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
 
          if (dependentRegNum != TR::RealRegister::NoReg &&
              dependentRegNum != TR::RealRegister::SpilledReg &&
@@ -456,7 +456,7 @@ void TR_ARMRegisterDependencyGroup::assignRegisters(TR::Instruction  *currentIns
             assignedRegister = toRealRegister(virtReg->getAssignedRealRegister());
             }
          dependentRegNum = dependencies[i].getRealRegister();
-         dependentRealReg = machine->getARMRealRegister(dependentRegNum);
+         dependentRealReg = machine->getRealRegister(dependentRegNum);
          if (dependentRegNum != TR::RealRegister::NoReg &&
              dependentRegNum != TR::RealRegister::SpilledReg &&
              dependentRealReg != assignedRegister)

--- a/compiler/arm/codegen/OMRRegisterDependency.hpp
+++ b/compiler/arm/codegen/OMRRegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,14 +92,14 @@ void print(TR::FILE *pOutFile, TR::CodeGenerator *cg)
    (void)trfflush(pOutFile);
    trfprintf(pOutFile,", Real: ");
    (void)trfflush(pOutFile);
-   if (machine->getARMRealRegister(_realRegister)==NULL)
+   if (machine->getRealRegister(_realRegister)==NULL)
       {
       trfprintf(pOutFile,"NoReg");
       (void)trfflush(pOutFile);
       }
    else
       {
-      machine->getARMRealRegister(_realRegister)->print(pOutFile, TR_WordReg);
+      machine->getRealRegister(_realRegister)->print(pOutFile, TR_WordReg);
       (void)trfflush(pOutFile);
       }
    trfprintf(pOutFile,", Flags: %x",_flags);

--- a/compiler/arm/codegen/OMRRegisterIterator.cpp
+++ b/compiler/arm/codegen/OMRRegisterIterator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,17 +50,17 @@ OMR::ARM::RegisterIterator::RegisterIterator(TR::Machine *machine, TR_RegisterKi
 TR::Register *
 OMR::ARM::RegisterIterator::getFirst()
    {
-   return _machine->getARMRealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
+   return _machine->getRealRegister((TR::RealRegister::RegNum)(_cursor = _firstRegIndex));
    }
 
 TR::Register *
 OMR::ARM::RegisterIterator::getCurrent()
    {
-   return _machine->getARMRealRegister((TR::RealRegister::RegNum)_cursor);
+   return _machine->getRealRegister((TR::RealRegister::RegNum)_cursor);
    }
 
 TR::Register *
 OMR::ARM::RegisterIterator::getNext()
    {
-   return _cursor == _lastRegIndex ? NULL : _machine->getARMRealRegister((TR::RealRegister::RegNum)(++_cursor));
+   return _cursor == _lastRegIndex ? NULL : _machine->getRealRegister((TR::RealRegister::RegNum)(++_cursor));
    }

--- a/compiler/arm/codegen/StackCheckFailureSnippet.cpp
+++ b/compiler/arm/codegen/StackCheckFailureSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@
 
 uint8_t *storeArgumentItem(TR_ARMOpCodes op, uint8_t *buffer, TR::RealRegister *reg, int32_t offset, TR::CodeGenerator *cg)
    {
-   TR::RealRegister *stackPtr = cg->machine()->getARMRealRegister(cg->getLinkage()->getProperties().getStackPointerRegister());
+   TR::RealRegister *stackPtr = cg->machine()->getRealRegister(cg->getLinkage()->getProperties().getStackPointerRegister());
    TR_ARMOpCode       opCode(op);
    opCode.copyBinaryToBuffer(buffer);
    reg->setRegisterFieldRD(toARMCursor(buffer));
@@ -47,7 +47,7 @@ uint8_t *storeArgumentItem(TR_ARMOpCodes op, uint8_t *buffer, TR::RealRegister *
 uint8_t *loadArgumentItem(TR_ARMOpCodes op, uint8_t *buffer, TR::RealRegister *reg, int32_t offset, TR::CodeGenerator *cg)
    {
    TR_ASSERT(0, "fix loadArgumentItem");
-   TR::RealRegister *stackPtr = cg->machine()->getARMRealRegister(cg->getLinkage()->getProperties().getStackPointerRegister());
+   TR::RealRegister *stackPtr = cg->machine()->getRealRegister(cg->getLinkage()->getProperties().getStackPointerRegister());
    TR_ARMOpCode       opCode(op);
    opCode.copyBinaryToBuffer(buffer);
    reg->setRegisterFieldRT(toARMCursor(buffer));


### PR DESCRIPTION
Rename the `OMR::ARM::Machine::getARMRealRegister()` method to
`OMR::ARM::Machine::getRealRegister()` in order to get the strength
of polymorphism.

P.S. The method `getARMRealRegister()` is still remaining for backward compatibility.

Issue: #2645