### PR TITLE
WIP - Add extra assertions for atomic non-helpers on Power

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1843,6 +1843,27 @@ bool OMR::SymbolReferenceTable::isNonHelper(int32_t ref, CommonNonhelperSymbol s
       }
    }
 
+bool OMR::SymbolReferenceTable::isNonHelper(TR::SymbolReference *symRef)
+   {
+   return isNonHelper(symRef->getReferenceNumber());
+   }
+
+bool OMR::SymbolReferenceTable::isNonHelper(int32_t ref)
+   {
+   return (ref >= _numHelperSymbols && ref < _numHelperSymbols + getLastCommonNonhelperSymbol());
+   }
+
+OMR::SymbolReferenceTable::CommonNonhelperSymbol OMR::SymbolReferenceTable::getNonHelperSymbol(TR::SymbolReference *symRef)
+   {
+   return getNonHelperSymbol(symRef->getReferenceNumber());
+   }
+
+OMR::SymbolReferenceTable::CommonNonhelperSymbol OMR::SymbolReferenceTable::getNonHelperSymbol(int32_t ref)
+   {
+   return isNonHelper(ref) ? (CommonNonhelperSymbol) (ref - _numHelperSymbols)
+                           : getLastCommonNonhelperSymbol();
+   }
+
 int32_t OMR::SymbolReferenceTable::getNonhelperIndex(CommonNonhelperSymbol s)
    {
    TR_ASSERT(s <= getLastCommonNonhelperSymbol(), "assertion failure");

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -313,6 +313,13 @@ class SymbolReferenceTable
    //
    bool isNonHelper(TR::SymbolReference *, CommonNonhelperSymbol);
    bool isNonHelper(int32_t, CommonNonhelperSymbol);
+   bool isNonHelper(TR::SymbolReference *);
+   bool isNonHelper(int32_t);
+
+   // Look up non-helper symbol reference
+   CommonNonhelperSymbol getNonHelperSymbol(TR::SymbolReference *);
+   CommonNonhelperSymbol getNonHelperSymbol(int32_t);
+
 
    // Total number of symbols (known and dynamic) in the SRT
    //

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3668,7 +3668,8 @@ OMR::Power::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
       case TR::SymbolReferenceTable::atomicFetchAndAddSymbol:
       case TR::SymbolReferenceTable::atomicSwapSymbol:
          {
-         result = true;
+         // Atomic non-helpers for Power only supported on 64-bit, for now
+         result = TR::Compiler->target.is64Bit();
          break;
          }
       }


### PR DESCRIPTION
Added assertion that we're running a 64-bit JVM when trying to inlinevone of the atomic non-helpers, as 32-bit code generation is not yet supported for it.

Also if a call to codegen inlineDirectCall from directCallEvaluator does not inline a call, added an assertion that the symbol is not one of the atomic non-helpers.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>