### PR TITLE
Initialize Suballocator variables all platforms

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1541,9 +1541,9 @@ public:
 #endif
 		, heapInitializationFailureReason(HEAP_INITIALIZATION_FAILURE_REASON_NO_ERROR)
 		, scavengerAlignHotFields(true) /* VM Design 1774: hot field alignment is on by default */
-#if defined(OMR_GC_COMPRESSED_POINTERS)
 		, suballocatorInitialSize(SUBALLOCATOR_INITIAL_SIZE) /* default for J9Heap suballocator initial size is 200 MB */
 		, suballocatorCommitSize(SUBALLOCATOR_COMMIT_SIZE) /* default for J9Heap suballocator commit size is 50 MB */
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		, shouldAllowShiftingCompression(true) /* VM Design 1810: shifting compression enabled, by default, for compressed refs */
 		, shouldForceSpecifiedShiftingCompression(0)
 		, forcedShiftingCompressionAmount(0)

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -496,7 +496,6 @@ typedef enum {
 #define PREFERRED_HEAP_BASE 0x0
 #endif
 
-#if defined(OMR_GC_COMPRESSED_POINTERS)
 #define SUBALLOCATOR_INITIAL_SIZE (200*1024*1024)
 #define SUBALLOCATOR_COMMIT_SIZE (50*1024*1024)
 #if defined(AIXPPC)
@@ -505,7 +504,6 @@ typedef enum {
 #else /* defined(AIXPPC) */
 #define SUBALLOCATOR_ALIGNMENT (8*1024*1024)
 #endif /* defined(AIXPPC) */
-#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 #if defined(OMR_GC_REALTIME)
 #define METRONOME_DEFAULT_HRT_PERIOD_MICRO 1000 /* This gives vanilla linux a chance to use the HRT */


### PR DESCRIPTION
Suballocator related variables suballocatorInitialSize and
suballocatorCommitSize in MM_GCExtensionsBase are defined for all
platforms but initialized in class constructor only for Compressed Refs.
It cause operations with non-initialized memory might crash Memory
Check. Extending scope of initialization of these variables for all
platforms. As far as Suballocator happen to be used for Compressed Refs
platforms only it is irrelevant which values these variables are
initialized on other platforms. Set them exactly the same as in CR to
have cleaner code. Again, this would not have any impact for non-CR
platforms footprint.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>