### PR TITLE
GC: Mac clang fix - hidden overloaded virtual function

### DIFF
--- a/gc/base/Dispatcher.cpp
+++ b/gc/base/Dispatcher.cpp
@@ -89,7 +89,7 @@ MM_Dispatcher::cleanupAfterTask(MM_EnvironmentBase *env)
 void
 MM_Dispatcher::run(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
 {
-	uintptr_t activeThreads = recomputeActiveThreadCount(env, task, newThreadCount);
+	uintptr_t activeThreads = recomputeActiveThreadCountForTask(env, task, newThreadCount);
 	task->masterSetup(env);
 	prepareThreadsForTask(env, task, activeThreads);
 	acceptTask(env);
@@ -111,7 +111,7 @@ MM_Dispatcher::shutDownThreads()
 }
 
 uintptr_t
-MM_Dispatcher::recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
+MM_Dispatcher::recomputeActiveThreadCountForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount)
 {
 	return 1;
 }

--- a/gc/base/Dispatcher.hpp
+++ b/gc/base/Dispatcher.hpp
@@ -60,7 +60,7 @@ protected:
 	virtual void completeTask(MM_EnvironmentBase *env);
 	virtual void cleanupAfterTask(MM_EnvironmentBase *env);
 
-	virtual uintptr_t recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount);
+	virtual uintptr_t recomputeActiveThreadCountForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount);
 
 public:
 	static MM_Dispatcher *newInstance(MM_EnvironmentBase *env);

--- a/gc/base/ParallelDispatcher.cpp
+++ b/gc/base/ParallelDispatcher.cpp
@@ -407,7 +407,7 @@ MM_ParallelDispatcher::setThreadCount(uintptr_t threadCount)
  * Decide how many threads should be active for a given task.
  */
 uintptr_t
-MM_ParallelDispatcher::recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount)
+MM_ParallelDispatcher::recomputeActiveThreadCountForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t threadCount)
 {
 	/* Metronome recomputes the number of GC threads at the beginning of
 	 * a GC cycle. It may not be safe to do so at the beginning of a task

--- a/gc/base/ParallelDispatcher.hpp
+++ b/gc/base/ParallelDispatcher.hpp
@@ -108,7 +108,7 @@ protected:
 	virtual void completeTask(MM_EnvironmentBase *env);
 	virtual void wakeUpThreads(uintptr_t count);
 	
-	virtual uintptr_t recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount);
+	virtual uintptr_t recomputeActiveThreadCountForTask(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount); 
 
 	virtual void setThreadInitializationComplete(MM_EnvironmentBase *env);
 	


### PR DESCRIPTION
Mac compile fail fix - hidden overloaded virtual function:

**Rename `recomputeActiveThreadCount` to `recomputeActiveThreadCountForTask`**

```
../gc_realtime/Scheduler.hpp:233:15: error: 'MM_Scheduler::recomputeActiveThreadCount' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
        virtual void recomputeActiveThreadCount(MM_EnvironmentBase *env);
                     ^
../omr/gc/base/ParallelDispatcher.hpp:111:20: note: hidden overloaded virtual function 'MM_ParallelDispatcher::recomputeActiveThreadCount' declared here: different number of parameters (3 vs 1)
        virtual uintptr_t recomputeActiveThreadCount(MM_EnvironmentBase *env, MM_Task *task, uintptr_t newThreadCount);
                          ^