### PR TITLE
AArch64: Remove unnecessary ARM64Dep*Instruction classes

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -473,20 +473,11 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsImm:
          print(pOutFile, (TR::ARM64ImmInstruction *)instr);
          break;
-      case OMR::Instruction::IsDep:
-         print(pOutFile, (TR::ARM64DepInstruction *)instr);
-         break;
       case OMR::Instruction::IsLabel:
          print(pOutFile, (TR::ARM64LabelInstruction *)instr);
          break;
-      case OMR::Instruction::IsDepLabel:
-         print(pOutFile, (TR::ARM64DepLabelInstruction *)instr);
-         break;
       case OMR::Instruction::IsConditionalBranch:
          print(pOutFile, (TR::ARM64ConditionalBranchInstruction *)instr);
-         break;
-      case OMR::Instruction::IsDepConditionalBranch:
-         print(pOutFile, (TR::ARM64DepConditionalBranchInstruction *)instr);
          break;
       case OMR::Instruction::IsCompareBranch:
          print(pOutFile, (TR::ARM64CompareBranchInstruction *)instr);
@@ -574,16 +565,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ImmInstruction *instr)
    }
 
 void
-TR_Debug::print(TR::FILE *pOutFile, TR::ARM64DepInstruction *instr)
-   {
-   printPrefix(pOutFile, instr);
-   trfprintf(pOutFile, "%s", getOpCodeName(&instr->getOpCode()));
-   if (instr->getDependencyConditions())
-      print(pOutFile, instr->getDependencyConditions());
-   trfflush(pOutFile);
-   }
-
-void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64LabelInstruction *instr)
    {
    printPrefix(pOutFile, instr);
@@ -609,13 +590,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64LabelInstruction *instr)
          }
       }
    printInstructionComment(pOutFile, 1, instr);
-   trfflush(_comp->getOutFile());
-   }
-
-void
-TR_Debug::print(TR::FILE *pOutFile, TR::ARM64DepLabelInstruction *instr)
-   {
-   print(pOutFile, (TR::ARM64LabelInstruction *)instr);
    if (instr->getDependencyConditions())
       print(pOutFile, instr->getDependencyConditions());
    trfflush(_comp->getOutFile());
@@ -627,13 +601,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ConditionalBranchInstruction *instr
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s.%s \t", getOpCodeName(&instr->getOpCode()), ARM64ConditionNames[instr->getConditionCode()]);
    print(pOutFile, instr->getLabelSymbol());
-   trfflush(_comp->getOutFile());
-   }
-
-void
-TR_Debug::print(TR::FILE *pOutFile, TR::ARM64DepConditionalBranchInstruction *instr)
-   {
-   print(pOutFile, (TR::ARM64ConditionalBranchInstruction *)instr);
    if (instr->getDependencyConditions())
       print(pOutFile, instr->getDependencyConditions());
    trfflush(_comp->getOutFile());

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -67,14 +67,6 @@ TR::Instruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::M
    return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, relocationKind, sr, cg);
    }
 
-TR::Instruction *generateDepInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-   TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
-   {
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64DepInstruction(op, node, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64DepInstruction(op, node, cond, cg);
-   }
-
 TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::LabelSymbol *sym, TR::Instruction *preced)
    {
@@ -83,12 +75,12 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
    return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cg);
    }
 
-TR::Instruction *generateDepLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
    {
    if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64DepLabelInstruction(op, node, sym, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64DepLabelInstruction(op, node, sym, cond, cg);
+      return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cond, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64LabelInstruction(op, node, sym, cond, cg);
    }
 
 TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
@@ -99,12 +91,12 @@ TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR:
    return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, cg);
    }
 
-TR::Instruction *generateDepConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::Instruction *generateConditionalBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::LabelSymbol *sym, TR::ARM64ConditionCode cc, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
    {
    if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64DepConditionalBranchInstruction(op, node, sym, cc, cond, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64DepConditionalBranchInstruction(op, node, sym, cc, cond, cg);
+      return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, cond, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64ConditionalBranchInstruction(op, node, sym, cc, cond, cg);
    }
 
 TR::Instruction *generateCompareBranchInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -110,22 +110,6 @@ TR::Instruction *generateImmInstruction(
                    TR::Instruction *preced = NULL);
 
 /*
- * @brief Generates dep instruction
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] cond : register dependency condition
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateDepInstruction(
-                   TR::CodeGenerator *cg,
-                   TR::InstOpCode::Mnemonic op,
-                   TR::Node *node,
-                   TR::RegisterDependencyConditions *cond,
-                   TR::Instruction *preced = NULL);
-
-/*
  * @brief Generates label instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode
@@ -151,7 +135,7 @@ TR::Instruction *generateLabelInstruction(
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateDepLabelInstruction(
+TR::Instruction *generateLabelInstruction(
                    TR::CodeGenerator *cg,
                    TR::InstOpCode::Mnemonic op,
                    TR::Node *node,
@@ -188,7 +172,7 @@ TR::Instruction *generateConditionalBranchInstruction(
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateDepConditionalBranchInstruction(
+TR::Instruction *generateConditionalBranchInstruction(
                    TR::CodeGenerator *cg,
                    TR::InstOpCode::Mnemonic op,
                    TR::Node *node,

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -26,11 +26,8 @@
 
    IsNotExtended,
    IsImm,
-   IsDep,
    IsLabel,
-      IsDepLabel,
       IsConditionalBranch,
-         IsDepConditionalBranch,
       IsCompareBranch,
    IsRegBranch,
    IsAdmin,

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -510,14 +510,7 @@ OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *c
 
    if (node->getLabel() != NULL)
       {
-      if (deps == NULL)
-         {
-         node->getLabel()->setInstruction(generateLabelInstruction(cg, TR::InstOpCode::label, node, node->getLabel()));
-         }
-      else
-         {
-         node->getLabel()->setInstruction(generateDepLabelInstruction(cg, TR::InstOpCode::label, node, node->getLabel(), deps));
-         }
+      node->getLabel()->setInstruction(generateLabelInstruction(cg, TR::InstOpCode::label, node, node->getLabel(), deps));
       }
 
    TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
@@ -541,14 +534,11 @@ OMR::ARM64::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    if (NULL == block->getNextBlock())
       {
       TR::Instruction *lastInstruction = cg->getAppendInstruction();
-#if 0
-      // TODO: Enable this part when TR::InstOpCode::bl becomes available
       if (lastInstruction->getOpCodeValue() == TR::InstOpCode::bl
               && lastInstruction->getNode()->getSymbolReference()->getReferenceNumber() == TR_aThrow)
          {
          lastInstruction = generateInstruction(cg, TR::InstOpCode::bad, node, lastInstruction);
          }
-#endif
       }
 
    TR::TreeTop *nextTT = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -341,11 +341,8 @@ namespace TR { class J9S390InterfaceCallDataSnippet; }
 #endif
 
 namespace TR { class ARM64ImmInstruction; }
-namespace TR { class ARM64DepInstruction; }
 namespace TR { class ARM64LabelInstruction; }
-namespace TR { class ARM64DepLabelInstruction; }
 namespace TR { class ARM64ConditionalBranchInstruction; }
-namespace TR { class ARM64DepConditionalBranchInstruction; }
 namespace TR { class ARM64CompareBranchInstruction; }
 namespace TR { class ARM64RegBranchInstruction; }
 namespace TR { class ARM64AdminInstruction; }
@@ -1085,11 +1082,8 @@ public:
    void printPrefix(TR::FILE *, TR::Instruction *);
 
    void print(TR::FILE *, TR::ARM64ImmInstruction *);
-   void print(TR::FILE *, TR::ARM64DepInstruction *);
    void print(TR::FILE *, TR::ARM64LabelInstruction *);
-   void print(TR::FILE *, TR::ARM64DepLabelInstruction *);
    void print(TR::FILE *, TR::ARM64ConditionalBranchInstruction *);
-   void print(TR::FILE *, TR::ARM64DepConditionalBranchInstruction *);
    void print(TR::FILE *, TR::ARM64CompareBranchInstruction *);
    void print(TR::FILE *, TR::ARM64RegBranchInstruction *);
    void print(TR::FILE *, TR::ARM64AdminInstruction *);


### PR DESCRIPTION
This commit removes some ARM64Dep*Instruction classes.
The base OMR::ARM64::Instruction class already has the common
RegisterDependencyConditions field in it, and you don't need to
define separate classes like ARM64DepLabelInstruction from
ARM64LabelInstruction.

Signed-off-by: knn-k <konno@jp.ibm.com>