### PR TITLE
Resuming externally terminated CS

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1809,7 +1809,7 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 	bool doneFlag = false;
 	volatile uintptr_t doneIndex = _doneIndex;
 
-	if (checkAndSetShouldYieldFlag()) {
+	if (checkAndSetShouldYieldFlag(env)) {
 		flushBuffersForGetNextScanCache(env);
 		omrthread_monitor_enter(_scanCacheMonitor);
 		if (0 != _waitingCount) {
@@ -1817,7 +1817,7 @@ MM_Scavenger::getNextScanCache(MM_EnvironmentStandard *env)
 		}
 		omrthread_monitor_exit(_scanCacheMonitor);
 		return NULL;
-    }
+	}
 
 	/* Preference is to use survivor copy cache */
 	cache = env->_survivorCopyScanCache;
@@ -3225,13 +3225,18 @@ MM_Scavenger::restoreMasterThreadTenureTLHRemainders(MM_EnvironmentStandard *env
 }
 
 MMINLINE bool
-MM_Scavenger::checkAndSetShouldYieldFlag() {
+MM_Scavenger::checkAndSetShouldYieldFlag(MM_EnvironmentStandard *env) {
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
-	/* Don't rely on fact that scavenger_shouldYield() would return the same value during one concurrent phase.
-	 * If one GC thread saw that we need to yield, we must yield, there is no way back. Hence, we store the result in _shouldYield,
+	/* Don't rely on various conditions being same during one concurrent phase.
+	 * If one GC thread decided that we need to yield, we must yield, there is no way back. Hence, we store the result in _shouldYield,
 	 * and rely on it for the rest of concurrent phase.
+	 * Master info if we should yield comes from exclusive VM access request being broadcasted to this thread (isExclusiveAccessRequestWaiting())
+	 * But since that request in the thread is not cleared even when implicit master GC thread enters STW phase, and since this yield check is invoked
+	 * in common code that can run both during STW and concurrent phase, we have to additionally check we are indeed in concurrent phase before deciding to yield.
+	 * Most of the time we could rely on being in 'concurrent_state_scan' but it's more reliable to actually check if exclusive access
+	 * is indeed being requested (hence scavenger_shouldYield() call too).
 	 */
-	if (!_shouldYield && _cli->scavenger_shouldYield()) {
+	if (!_shouldYield && env->isExclusiveAccessRequestWaiting() && _cli->scavenger_shouldYield()) {
 		_shouldYield = true;
 	}
 	return _shouldYield;
@@ -4943,8 +4948,6 @@ uintptr_t
 MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 {
 	if (concurrent_state_scan == _concurrentState) {
-		Assert_MM_true(concurrent_state_scan == _concurrentState || concurrent_state_idle == _concurrentState);
-
 		clearIncrementGCStats(env, false);
 
 		MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, env->_cycleState);
@@ -4952,14 +4955,27 @@ MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 		_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
 
 		/* Now that we are done with concurrent scanning in this cycle (where we could possibly
-		 * be interested in its value), record the flag for reporting purposes and reset it. */
-		getConcurrentPhaseStats()->_terminationWasRequested = _shouldYield;
-		_shouldYield = false;
+		 * be interested in its value), record shouldYield Flag for reporting purposes and reset it. */
+		if (_shouldYield) {
+			if (NULL == _extensions->gcExclusiveAccessThreadId) {
+				/* We terminated concurrent cycle due to a external request. We will not move to 'complete' phase,
+				 * but stay in concurrent scan phase and try to resume work after the external party is done 
+				 * (when we are able to regain VM access)
+				 */
+				getConcurrentPhaseStats()->_terminationRequestType = MM_ConcurrentPhaseStatsBase::terminationRequest_External;
+			} else {
+				/* Ran out of free space in allocate/survivor, or system/global GC */
+				getConcurrentPhaseStats()->_terminationRequestType = MM_ConcurrentPhaseStatsBase::terminationRequest_ByGC;
+				_concurrentState = concurrent_state_complete;
+			}
+			_shouldYield = false;
+		} else {
+			/* Exhausted scan work */
+			_concurrentState = concurrent_state_complete;
 
-		/* we can't assert the work queue is empty. some mutator threads could have just flushed their copy caches, after the task terminated */
-		_concurrentState = concurrent_state_complete;
-		/* make allocate space non-allocatable to trigger the final GC phase */
-		_activeSubSpace->flip(env, MM_MemorySubSpaceSemiSpace::disable_allocation);
+			/* make allocate space non-allocatable to trigger the next GC phase */
+			_activeSubSpace->flip(env, MM_MemorySubSpaceSemiSpace::disable_allocation);
+		}
 
 		mergeIncrementGCStats(env, false);
 

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -161,7 +161,7 @@ private:
 	/**
 	 * Check if concurrent phase of the cycle should yield to an external activity. If so, set the flag so that other GC threads react appropriately
 	 */ 
-	bool checkAndSetShouldYieldFlag();
+	MMINLINE bool checkAndSetShouldYieldFlag(MM_EnvironmentStandard *env);
 	
 	/**
 	 * Check if top level scan loop should be aborted before the work is done

--- a/gc/stats/ConcurrentPhaseStatsBase.hpp
+++ b/gc/stats/ConcurrentPhaseStatsBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -45,18 +45,41 @@ public:
 	uintptr_t _cycleID;	/**< The "_id" of the corresponding cycle */
 	uintptr_t _scanTargetInBytes;	/**< The number of bytes a given concurrent task was expected to scan before terminating */
 	uintptr_t _bytesScanned;	/**< The number of bytes a given concurrent task did scan before it terminated (can be lower than _scanTargetInBytes if the termination was asynchronously requested) */
-	bool _terminationWasRequested;	/**< True if a given concurrent task's termination was asynchronously requested (although it might have terminated due to meeting its target, anyway - there is a timing window which allows both of these reasons to be true) */
+	bool _terminationWasRequested;	/**< todo: remove after downstream projects start using _terminationRequestType */
+	enum TerminationRequestType {
+		terminationRequest_None,
+		terminationRequest_ByGC,
+		terminationRequest_External
+	};
+	TerminationRequestType _terminationRequestType; /**< Reason for concurrent task termination, asynchronous external event or itself GC (work or survivor space exhausted etc). */
 
 	/* Member Functions */
 private:
 protected:
 public:
+
+	bool isTerminationRequested() {
+		return terminationRequest_None != _terminationRequestType;
+	}
+	bool isTerminationRequestExternal() {
+		return terminationRequest_External == _terminationRequestType;
+	}
+	
+	void clear() {
+		_cycleID = 0;
+		_scanTargetInBytes = 0;
+		_bytesScanned = 0;
+		_terminationWasRequested = false;
+		_terminationRequestType = terminationRequest_None;
+	}
+	 
 	MM_ConcurrentPhaseStatsBase()
 		: MM_Base()
 		, _cycleID(0)
 		, _scanTargetInBytes(0)
 		, _bytesScanned(0)
 		, _terminationWasRequested(false)
+		, _terminationRequestType(terminationRequest_None)
 	{}
 }; 
 

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -871,18 +871,18 @@ MM_VerboseHandlerOutput::handleConcurrentEndInternal(J9HookInterface** hook, UDA
 	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(event->currentThread);
 
 	const char *reasonForTermination = NULL;
-	if (stats->_terminationWasRequested) {
-		if (NULL != _extensions->gcExclusiveAccessThreadId) {
-			/* Most interesting reason would be exhausted allocate/survior, since it could mean that
-			 * tiliting is too agressive (and survival rate is jittery), and suggest tilt tuning/limiting.
+	if (stats->isTerminationRequested()) {
+		if (stats->isTerminationRequestExternal()) {
+			/* For example, Java JVMTI and similar. Unfortunately, we could not tell what. */
+			reasonForTermination = "termination requested externally";
+		} else {
+			/* Most interesting reason would be exhausted allocate/survivor, since it could mean that
+			 * tilting is too aggressive (and survival rate is jittery), and suggest tilt tuning/limiting.
 			 * There could be various other reasons, like STW global GC (system, end of concurrent mark etc.),
 			 * or even notorious 'exclusive VM access to satisfy allocate'.
 			 * Either way, the more detailed reason could be deduced from verbose GC.
 			 */
 			reasonForTermination = "termination requested by GC";
-		} else {
-			/* JVMTI and similar. Unfortunately, we could not tell what, nor verbose GC will report it. */
-			reasonForTermination = "termination requested externally";
 		}
 		writer->formatAndOutput(env, 0, "<warning details=\"%s\" />", reasonForTermination, _extensions->gcExclusiveAccessThreadId);
 	}


### PR DESCRIPTION
If Concurrent Scavenger yielded to an external async request, after the
third party is complete (after which we are able to regain VM access),
the cycle will resume concurrently (instead of turning into the final
STW phase).

Consequently, we may have several concurrent stanzas in verbose GC
during one Concurrent Scavenge cycle (although it's still unknown what
party requested termination):

```
.... initial STW phase of a CS cycle just completed....
<exclusive-end id="16894" timestamp="2018-11-27T14:23:29.494"
durationms="7.551" />

<concurrent-start id="16895" type="scavenge" contextid="16886"
timestamp="2018-11-27T14:23:29.494">
</concurrent-start>
<concurrent-end id="16896" type="scavenge" contextid="16886"
timestamp="2018-11-27T14:23:29.502">
<warning details="termination requested externally" /> <<<<<<<<<<<<<<<<
<gc-op id="16897" type="scavenge" timems="8.391" contextid="16886"
timestamp="2018-11-27T14:23:29.502">
  <memory-copied type="nursery" objects="17881" bytes="1286648"
bytesdiscarded="23064" />
  <memory-copied type="tenure" objects="965" bytes="673672"
bytesdiscarded="6168" />
</gc-op>
</concurrent-end>

<concurrent-start id="16898" type="scavenge" contextid="16886"
timestamp="2018-11-27T14:23:29.764">
</concurrent-start>
<concurrent-end id="16899" type="scavenge" contextid="16886"
timestamp="2018-11-27T14:23:29.770">
<gc-op id="16900" type="scavenge" timems="5.922" contextid="16886"
timestamp="2018-11-27T14:23:29.770">
  <memory-copied type="nursery" objects="4571" bytes="721848"
bytesdiscarded="53656" />
  <memory-copied type="tenure" objects="28" bytes="673648"
bytesdiscarded="504" />
</gc-op>
</concurrent-end>

<exclusive-start id="16901" timestamp="2018-11-27T14:23:29.776"
intervalms="289.892">
.... final STW phase of a CS cycle about to start....
```

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>