### PR TITLE
Store barrier in co-operative copy

### DIFF
--- a/gc/structs/ForwardedHeader.cpp
+++ b/gc/structs/ForwardedHeader.cpp
@@ -281,6 +281,7 @@ MM_ForwardedHeader::copyOrWaitOutline(omrobjectptr_t destinationObjectPtr)
 
 			if (0 == remainingSizeToCopy) {
 				if (participatingInCopy) {
+					MM_AtomicOperations::storeSync();
 					fomrobject_t newValue = (fomrobject_t)(((outstandingCopies - 1) << OUTSTANDING_COPIES_SHIFT) | _beingCopiedTag);
 					if (oldValue != lockCompareExchangeObjectHeader(&objectHeader->slot, oldValue, newValue)) {
 						continue;


### PR DESCRIPTION
If a thread (GC or mutator) was participating in co-operative copying of
a large object, prior to announcing it's finished, and leaving the
'party', it will issue a store barrier (for weak memory models) that
will ensure all the copy work it has done is visible to the rest of the
world.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>