### PR TITLE
Remove CLQ queries as they have migrated to OpenJ9

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1486,9 +1486,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsTMDoubleWordCASORSet() { return _flags3.testAny(SupportsTMDoubleWordCASORSet);}
    void setSupportsTMDoubleWordCASORSet() { _flags3.set(SupportsTMDoubleWordCASORSet);}
 
-   bool getSupportsTMHashMapAndLinkedQueue() { return _flags4.testAny(SupportsTMHashMapAndLinkedQueue);}
-   void setSupportsTMHashMapAndLinkedQueue() { _flags4.set(SupportsTMHashMapAndLinkedQueue);}
-
    bool getSupportsAtomicLoadAndAdd() { return _flags4.testAny(SupportsAtomicLoadAndAdd);}
    void setSupportsAtomicLoadAndAdd() { _flags4.set(SupportsAtomicLoadAndAdd);}
 
@@ -1785,7 +1782,7 @@ class OMR_EXTENSIBLE CodeGenerator
       //                                                  = 0x02000000,  NOW AVAILABLE
       //                                                  = 0x04000000,  NOW AVAILABLE
       TrackingInMemoryKilledLoads                         = 0x08000000,
-      SupportsTMHashMapAndLinkedQueue                     = 0x10000000,
+      // AVAILABLE                                        = 0x10000000,
 	  SupportsLM                                          = 0x20000000,
 
       DummyLastEnum4

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -287,9 +287,6 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    if (TR::Compiler->target.cpu.getPPCSupportsLM())
       self()->setSupportsLM();
 
-   if(self()->getSupportsTM())
-      self()->setSupportsTMHashMapAndLinkedQueue();
-
    if (TR::Compiler->target.cpu.getPPCSupportsVMX() && TR::Compiler->target.cpu.getPPCSupportsVSX())
       self()->setSupportsAutoSIMD();
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -712,9 +712,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
          self()->setSupportsTM();
       }
 
-   if(self()->getSupportsTM())
-      self()->setSupportsTMHashMapAndLinkedQueue();
-
    if (_processorInfo.supportsArch(TR_S390ProcessorInfo::TR_z13) && !comp->getOption(TR_DisableArch11PackedToDFP))
       self()->setSupportsFastPackedDFPConversions();
 


### PR DESCRIPTION
As part of eclipse/openj9#3763 we have migrated the CLQ related queries
into OpenJ9 where they really belong. This commit removes the OMR
pieces of the code which were left over.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>