### PR TITLE
Restrict setting TR_DisableInternalPointer to current compilation

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -371,6 +371,18 @@ OMR::Compilation::Compilation(
          );
    _isServerInlining = !options.getOption(TR_NoOptServer);
 
+   // TR_DisableInternalPointers must be set before allocateCodeGenerator(self()) is called because
+   // CodeGenerator's _disableInternalPointers member is set in its constructor and this is one of
+   // options that is checked for
+   if (_isOptServer)
+      {
+      if(self()->getMethodHotness() <= warm)
+         {
+         if (!TR::Compiler->target.cpu.isPower()) // Temporarily exclude PPC due to perf regression
+            self()->setOption(TR_DisableInternalPointers);
+         }
+      }
+
    //_methodSymbol must be done after symRefTab, but before codegen
    // _methodSymbol must be initialized here because creating a jitted method symbol
    //   actually inspects TR::comp()->_methodSymbol (to compare against the new object)
@@ -929,15 +941,7 @@ int32_t OMR::Compilation::compile()
    bool printCodegenTime = self()->getOption(TR_CummTiming);
 
    if (self()->isOptServer())
-      {
-      // Temporarily exclude PPC due to perf regression
-      if( (self()->getMethodHotness() <= warm))
-         {
-         if (!TR::Compiler->target.cpu.isPower())
-            TR::Options::getCmdLineOptions()->setOption(TR_DisableInternalPointers);
-         }
-      self()->getOptions()->setOption(TR_DisablePartialInlining);
-      }
+      self()->setOption(TR_DisablePartialInlining);
 
 #ifdef J9_PROJECT_SPECIFIC
    if (self()->getOptions()->getDelayCompile())


### PR DESCRIPTION
Previously, this option was set only when `OMR::Compilation::compile()`
was called. That resulted in the option not having an effect on
CodeGenerator's `_disableInternalPointers` member as that is
initialized much earlier in its constructor by checking a few
compilation-specific options, including `TR_DisableInternalPointers`.

For this reason, not setting `TR_DisableInternalPointer` option
globally was resulting in performance regression in some cases.
Setting this option  globally is not the correct thing to do,
as this causes the option to be applied to all subsequent
compilations regardless of whether it should be set.

By setting `TR_DisableInternalPointer` to the current
compilation-specific options in the the constructor body of
`OMR::Compilation` before `allocateCodeGenerator(TR::Compilation)`
is called, we no longer need to set this option globally.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

Fixes: #2886 