### PR TITLE
GC Fix: Corrupted Remembered Set Count On Backout

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3568,8 +3568,8 @@ MM_Scavenger::completeBackOut(MM_EnvironmentStandard *env)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 #endif /* OMR_SCAVENGER_TRACE_BACKOUT */
 
-	/* Ensure we've pushed all references from buffers out to the lists */
-	_cli->scavenger_flushReferenceObjects(env);
+	/* Ensure we've pushed all references from buffers out to the lists and flushed RS fragments*/
+	flushBuffersForGetNextScanCache(env);
 
 	/* Must synchronize to be sure all private caches have been flushed */
 	if (env->_currentTask->synchronizeGCThreadsAndReleaseMaster(env, UNIQUE_ID)) {


### PR DESCRIPTION
Fix for https://github.com/eclipse/omr/issues/3211

Flush RS fragment upon backout.

Signed-off-by: Salman Rana <salman.rana@ibm.com>