### PR TITLE
AArch64: Add is64bit parameter to generateNegInstruction()

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -353,11 +353,10 @@ TR::Instruction *generateMovInstruction(TR::CodeGenerator *cg, TR::Node *node,
    }
 
 TR::Instruction *generateNegInstruction(TR::CodeGenerator *cg, TR::Node *node,
-   TR::Register *treg, TR::Register *sreg, TR::Instruction *preced)
+   TR::Register *treg, TR::Register *sreg, bool is64bit, TR::Instruction *preced)
    {
    /* Alias of SUB instruction */
 
-   bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::subx : TR::InstOpCode::subw;
 
    return generateTrg1ZeroSrc1Instruction(cg, op, node, treg, sreg, preced);

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -579,6 +579,7 @@ TR::Instruction *generateMovInstruction(
  * @param[in] node : node
  * @param[in] treg : target register
  * @param[in] sreg : source register
+ * @param[in] is64bit : true when it is 64-bit operation
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -587,6 +588,7 @@ TR::Instruction *generateNegInstruction(
                   TR::Node *node,
                   TR::Register *treg,
                   TR::Register *sreg,
+                  bool is64bit = false,
                   TR::Instruction *preced = NULL);
 
 /*


### PR DESCRIPTION
This commit adds is64bit parameter to generateNegInstruction().
I found a case where the Node has the type Int64 while the
intended operation is 32-bit negation.

Signed-off-by: knn-k <konno@jp.ibm.com>