### PR TITLE
Add Bytes utility header

### DIFF
--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(util)
 
 add_subdirectory(omrGtestGlue)
 add_subdirectory(algotest)
+add_subdirectory(coretest)
 add_subdirectory(porttest)
 add_subdirectory(rastest)
 add_subdirectory(sigtest)

--- a/fvtest/coretest/CMakeLists.txt
+++ b/fvtest/coretest/CMakeLists.txt
@@ -1,0 +1,40 @@
+###############################################################################
+# Copyright (c) 2018, 2018 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+function(omr_add_core_test testname)
+	add_executable("${testname}"
+		"${testname}.cpp"
+		main.cpp
+	)
+	target_link_libraries("${testname}"
+		PUBLIC
+			omrcore
+			omrvmstartup
+			omrGtestGlue
+	)
+	add_test(
+		NAME    "${testname}"
+		COMMAND "${testname}"
+	)
+endfunction(omr_add_core_test)
+
+omr_add_core_test(TestBytes)

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/Bytes.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+
+TEST(TestBytes, CompareZeroToZero)
+{
+	EXPECT_EQ(0, bytes(0));
+	EXPECT_EQ(0, kibibytes(0));
+	EXPECT_EQ(0, mebibytes(0));
+	EXPECT_EQ(0, gibibytes(0));
+}
+
+TEST(TestBytes, CompareOneUnitToBytes)
+{
+	EXPECT_EQ(1, bytes(1));
+	EXPECT_EQ(1024, kibibytes(1));
+	EXPECT_EQ(1024 * 1024, mebibytes(1));
+	EXPECT_EQ(1024 * 1024 * 1024, gibibytes(1));
+}
+
+TEST(TestBytes, CompareOneUnitToSmallerUnit)
+{
+	EXPECT_EQ(bytes(1024), kibibytes(1));
+	EXPECT_EQ(kibibytes(1024), mebibytes(1));
+	EXPECT_EQ(mebibytes(1024), gibibytes(1));
+}
+
+}  // namespace OMR

--- a/fvtest/coretest/main.cpp
+++ b/fvtest/coretest/main.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2018 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR
+ *LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "omrTest.h"
+
+extern "C" int omr_main_entry(int argc, char** argv, char** envp) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/include_core/OMR/Bytes.hpp
+++ b/include_core/OMR/Bytes.hpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_BYTES_HPP_)
+#define OMR_BYTES_HPP_
+
+#include <omrcfg.h>
+#include <stddef.h>
+
+namespace OMR
+{
+
+inline size_t
+bytes(size_t n)
+{
+	return n;
+}
+
+inline size_t
+kibibytes(size_t n)
+{
+	return n * bytes(1024);
+}
+
+inline size_t
+mebibytes(size_t n)
+{
+	return n * kibibytes(1024);
+}
+
+inline size_t
+gibibytes(size_t n)
+{
+	return n * mebibytes(1024);
+}
+
+} // namespace OMR
+
+#endif // OMR_BYTES_HPP_


### PR DESCRIPTION
Add a set of convenience functions for working with bytes. Useful for
specifying large sizes like heap minimum size, or maximum memory
overhead.

The kibi/mebi/gibi prefix was chosen to minimize confusion, some people
might consider a kilobyte to be 1000 or 1024 bytes, but a kibibyte is
unambiguously 1024 bytes.

Signed-off-by: Robert Young <rwy0717@gmail.com>