### PR TITLE
Add OMR_GC_TEST compile flag

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -45,6 +45,7 @@ set(OMR_JITBUILDER OFF CACHE BOOL "Enable building JitBuilder")
 set(OMR_TEST_COMPILER OFF CACHE BOOL "Enable building the test compiler")
 
 set(OMR_GC ON CACHE BOOL "Enable the GC")
+set(OMR_GC_TEST ${OMR_GC} CACHE BOOL "Enable the GC tests.")
 
 ## OMR_COMPILER is required for OMR_JITBUILDER and OMR_TEST_COMPILER
 if(NOT OMR_COMPILER)

--- a/fvtest/CMakeLists.txt
+++ b/fvtest/CMakeLists.txt
@@ -35,7 +35,7 @@ add_subdirectory(threadtest)
 add_subdirectory(utiltest)
 add_subdirectory(vmtest)
 
-if(OMR_GC)
+if(OMR_GC_TEST)
 	add_subdirectory(gctest)
 endif()
 


### PR DESCRIPTION
Allow us to enable the GC, and FV testing, while turning the xml-driven
GC heap tests off. These tests are currently incompatible with the
gc-api and om.

In the future, the tests will be made to be gc-api compatible, but it's
unclear if the tests will be based off om or continue to use the object
model from the gc example.

Signed-off-by: Robert Young <rwy0717@gmail.com>