### PR TITLE
Fix cache trashing in _shouldYield

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3231,8 +3231,8 @@ MM_Scavenger::checkAndSetShouldYieldFlag() {
 	 * If one GC thread saw that we need to yield, we must yield, there is no way back. Hence, we store the result in _shouldYield,
 	 * and rely on it for the rest of concurrent phase.
 	 */
-	if (!_shouldYield) {
-		 _shouldYield = _cli->scavenger_shouldYield();
+	if (!_shouldYield && _cli->scavenger_shouldYield()) {
+		_shouldYield = true;
 	}
 	return _shouldYield;
 #else


### PR DESCRIPTION
Set the value of the flag only if it really changes (from false to
true).

The flag was being written on every check from multiple threads/CPUs,
causing cash trashing and slowing down GC with plafroms with CS enabled.
The flag (regression) was introduced here:
https://github.com/eclipse/omr/pull/3205.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>