### PR TITLE
Introduce a CG phase to simplify instructions

### DIFF
--- a/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,7 @@
     SetupForInstructionSelectionPhase,
     RemoveUnusedLocalsPhase,
     InstructionSelectionPhase,
+    InstructionSimplificationPhase,
     CreateStackAtlasPhase,
     RegisterAssigningPhase,
     MapStackPhase,

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -312,6 +312,37 @@ OMR::CodeGenPhase::performBinaryEncodingPhase(TR::CodeGenerator * cg, TR::CodeGe
    }
 
 
+void
+OMR::CodeGenPhase::performInstructionSimplificationPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
+   {
+   TR::Compilation* comp = cg->comp();
+   bool trace = comp->getOption(TR_TraceCG);
+   phase->reportPhase(InstructionSimplificationPhase);
+
+   TR::LexicalMemProfiler mp(phase->getName(), comp->phaseMemProfiler());
+   LexicalTimer pt(phase->getName(), comp->phaseTimer());
+
+   if (comp->getOption(TR_DisableInstructionSimplification))
+      {
+      if (trace)
+         {
+         traceMsg(comp, "\n<simplification>\nInstruction Simplification is disabled\n</simplification>\n");
+         }
+      }
+   else
+      {
+      if (trace)
+         {
+         traceMsg(comp, "\n<simplification>\n");
+         }
+      cg->doInstructionSimplification();
+      if (trace)
+         {
+         traceMsg(comp, "</simplification>\n");
+         comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), "Post Simplification Instructions", false);
+         }
+      }
+   }
 
 
 void
@@ -328,9 +359,6 @@ OMR::CodeGenPhase::performPeepholePhase(TR::CodeGenerator * cg, TR::CodeGenPhase
    if (comp->getOption(TR_TraceCG))
       comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), "Post Peephole Instructions", false);
    }
-
-
-
 
 
 void
@@ -388,9 +416,6 @@ OMR::CodeGenPhase::performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::Cod
    }
 
 
-
-
-
 void
 OMR::CodeGenPhase::performCreateStackAtlasPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
    {
@@ -432,7 +457,6 @@ OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::
       comp->failCompilation<TR::CompilationInterrupted>("interrupted after instruction selection");
       }
    }
-
 
 
 void
@@ -692,6 +716,8 @@ OMR::CodeGenPhase::getName(PhaseValue phase)
          return "SetupForInstructionSelection";
       case InstructionSelectionPhase:
          return "InstructionSelection";
+      case InstructionSimplificationPhase:
+         return "InstructionSimplification";
       case CreateStackAtlasPhase:
          return "CreateStackAtlas";
       case RegisterAssigningPhase:

--- a/compiler/codegen/OMRCodeGenPhase.hpp
+++ b/compiler/codegen/OMRCodeGenPhase.hpp
@@ -85,6 +85,7 @@ class OMR_EXTENSIBLE CodeGenPhase
    static void performLowerTreesPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performSetupForInstructionSelectionPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performInstructionSelectionPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
+   static void performInstructionSimplificationPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performCreateStackAtlasPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performRegisterAssigningPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performMapStackPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);

--- a/compiler/codegen/OMRCodeGenPhaseEnum.hpp
+++ b/compiler/codegen/OMRCodeGenPhaseEnum.hpp
@@ -30,6 +30,7 @@
       UncommonCallConstNodesPhase,
       SetupForInstructionSelectionPhase,
       InstructionSelectionPhase,
+      InstructionSimplificationPhase,
       CreateStackAtlasPhase,
       RegisterAssigningPhase,
       MapStackPhase,

--- a/compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
+++ b/compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
@@ -30,6 +30,7 @@
    TR::CodeGenPhase::performUncommonCallConstNodesPhase,                                     //UncommonCallConstNodesPhase
    TR::CodeGenPhase::performSetupForInstructionSelectionPhase,                               //SetupForInstructionSelectionPhase
    TR::CodeGenPhase::performInstructionSelectionPhase,                                       //InstructionSelectionPhase
+   TR::CodeGenPhase::performInstructionSimplificationPhase,                                  //InstructionSimplificationPhase
    TR::CodeGenPhase::performCreateStackAtlasPhase,                                           //CreateStackAtlasPhase
    TR::CodeGenPhase::performRegisterAssigningPhase,                                          //RegisterAssigningPhase
    TR::CodeGenPhase::performMapStackPhase,                                                   //MapStackPhase

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -412,6 +412,7 @@ class OMR_EXTENSIBLE CodeGenerator
    void generateCode();
    void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
+   void doInstructionSimplification() { return; }
    void doPeephole() { return; }
    bool hasComplexAddressingMode() { return false; }
    void removeUnusedLocals();

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -373,6 +373,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableInliningDuringVPAtWarm",       "O\tdisable inlining during VP for warm bodies",    SET_OPTION_BIT(TR_DisableInliningDuringVPAtWarm), "F"},
    {DisableInliningOfNativesString,       "O\tdisable inlining of natives",                    SET_OPTION_BIT(TR_DisableInliningOfNatives), "F"},
    {"disableInnerPreexistence",           "O\tdisable inner preexistence",                     TR::Options::disableOptimization, innerPreexistence, 0, "P"},
+   {"disableInstructionSimplification",   "O\tdisable instruction simplification phase",       SET_OPTION_BIT(TR_DisableInstructionSimplification), "F"},
    {"disableIntegerCompareSimplification",      "O\tdisable byte/short/int/long compare simplification  ",      SET_OPTION_BIT(TR_DisableIntegerCompareSimplification), "F"},
    {"disableInterfaceCallCaching",                          "O\tdisable interfaceCall caching   ",      SET_OPTION_BIT(TR_disableInterfaceCallCaching), "F"},
    {"disableInterfaceInlining",           "O\tdisable merge new",                              SET_OPTION_BIT(TR_DisableInterfaceInlining), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -349,6 +349,7 @@ enum TR_CompilationOptions
    TR_OldJVMPI                            = 0x00000080 + 8,
    TR_EmitExecutableELFFile               = 0x00000100 + 8,
    TR_EnableJITaaSDoLocalCompilesForRemoteCompiles = 0x00000200 + 8,
+   TR_DisableInstructionSimplification    = 0x00000400 + 8,
    // Available                           = 0x00000800 + 8,
    TR_DisableLinkageRegisterAllocation    = 0x00001000 + 8,
    // Available                           = 0x00002000 + 8,


### PR DESCRIPTION
Instruction Simplification Phase provides opportunities after
Instruction Selection to simplify certain patterns that may not be
trivial in the evaluators.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>