### PR TITLE
AArch64: Implement fconst/dconstEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -435,6 +435,8 @@ static const char *opCodeToNameMap[] =
    "rev16w",
    "rev16x",
    "rev32",
+   "fmov_wtos",
+   "fmov_xtod",
    "proc",
    "fence",
    "return",

--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -57,17 +57,41 @@ OMR::ARM64::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::CodeGenerator *c
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::fconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   TR::Register *trgReg = cg->allocateSinglePrecisionRegister();
+   TR::Register *tmpReg = cg->allocateRegister();
+
+   union {
+      float f;
+      int32_t i;
+   } fvalue;
+
+   fvalue.f = node->getFloat();
+   loadConstant32(cg, node, fvalue.i, tmpReg);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_wtos, node, trgReg, tmpReg);
+   cg->stopUsingRegister(tmpReg);
+
+   return trgReg;
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dconstEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   TR::Register *trgReg = cg->allocateRegister(TR_FPR);
+   TR::Register *tmpReg = cg->allocateRegister();
+
+   union {
+      double d;
+      int64_t l;
+   } dvalue;
+
+   dvalue.d = node->getDouble();
+   loadConstant64(cg, node, dvalue.l, tmpReg);
+   generateTrg1Src1Instruction(cg, TR::InstOpCode::fmov_xtod, node, trgReg, tmpReg);
+   cg->stopUsingRegister(tmpReg);
+
+   return trgReg;
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -421,8 +421,11 @@
 		rev16w,                                                 	/* 0xDAC00400	REV16     	 */
 		rev16x,                                                 	/* 0x5AC00400	REV16     	 */
 		rev32,                                                  	/* 0xDAC00800	REV32     	 */
+/* VFP instructions */
+		fmov_wtos,                                              	/* 0x1E270000	FMOV      	 */
+		fmov_xtod,                                              	/* 0x9E670000	FMOV      	 */
 
-	/* Last VFP instructions */
+/* Internal OpCodes */
 		proc,  // Entry to the method
 		fence, // Fence
 		retn,  // Return

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -53,7 +53,7 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
    else if ((value & 0xFFFF) == 0)
       {
       op = TR::InstOpCode::movzw;
-      imm = (value >> 16) | TR::MOV_LSL16;
+      imm = ((value >> 16) & 0xFFFF) | TR::MOV_LSL16;
       }
    else if ((value & 0xFFFF) == 0xFFFF)
       {
@@ -71,7 +71,7 @@ TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t v
       cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movzw, node, trgReg,
                                           (value & 0xFFFF), cursor);
       cursor = generateTrg1ImmInstruction(cg, TR::InstOpCode::movkw, node, trgReg,
-                                          ((value >> 16) | TR::MOV_LSL16), cursor);
+                                          (((value >> 16) & 0xFFFF) | TR::MOV_LSL16), cursor);
       }
 
    if (!insertingInstructions)

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -420,4 +420,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xDAC00400,	/* REV16     	rev16w	 */
 		0x5AC00400,	/* REV16     	rev16x	 */
 		0xDAC00800,	/* REV32     	rev32	 */
+/* VFP instructions */
+		0x1E270000,	/* FMOV      	fmov_wtos	 */
+		0x9E670000,	/* FMOV      	fmov_xtod	 */
 };

--- a/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
@@ -27,8 +27,8 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::aconstEvaluator ,	// TR::aconst		// load address constant (zero value means NULL)
     TR::TreeEvaluator::iconstEvaluator, // TR::iconst		// load integer constant (32-bit signed 2's complement)
     TR::TreeEvaluator::lconstEvaluator, // TR::lconst		// load long integer constant (64-bit signed 2's complement)
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fconstEvaluator ,	// TR::fconst		// load float constant (32-bit ieee fp)
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dconstEvaluator ,	// TR::dconst		// load double constant (64-bit ieee fp)
+    TR::TreeEvaluator::fconstEvaluator, // TR::fconst		// load float constant (32-bit ieee fp)
+    TR::TreeEvaluator::dconstEvaluator, // TR::dconst		// load double constant (64-bit ieee fp)
     TR::TreeEvaluator::bconstEvaluator, // TR::bconst		// load byte integer constant (8-bit signed 2's complement)
     TR::TreeEvaluator::sconstEvaluator, // TR::sconst		// load short integer constant (16-bit signed 2's complement)
     TR::TreeEvaluator::iloadEvaluator, // TR::iload		// load integer


### PR DESCRIPTION
This commit adds ConstantDataSnippet for aarch64, and implements
fconst/dconstEvaluator().

Signed-off-by: knn-k <konno@jp.ibm.com>