### PR TITLE
AArch64: Call incRegisterTotalUseCounts() for MemoryReference

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1839,6 +1839,7 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
                             TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
       : ARM64Trg1Instruction(op, node, treg, precedingInstruction, cg), _memoryReference(mr)
       {
+      mr->incRegisterTotalUseCounts(cg);
       }
 
    /**
@@ -2030,6 +2031,7 @@ class ARM64MemSrc1Instruction : public ARM64MemInstruction
       : ARM64MemInstruction(op, node, mr, cg), _source1Register(sreg)
       {
       useRegister(sreg);
+      mr->incRegisterTotalUseCounts(cg);
       }
 
    /*

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -480,6 +480,19 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR:
    }
 
 
+void OMR::ARM64::MemoryReference::incRegisterTotalUseCounts(TR::CodeGenerator * cg)
+   {
+   if (_baseRegister != NULL)
+      {
+      _baseRegister->incTotalUseCount();
+      }
+   if (_indexRegister != NULL)
+      {
+      _indexRegister->incTotalUseCount();
+      }
+   }
+
+
 void OMR::ARM64::MemoryReference::assignRegisters(TR::Instruction *currentInstruction, TR::CodeGenerator *cg)
    {
    TR::Machine *machine = cg->machine();

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -379,6 +379,12 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    void consolidateRegisters(TR::Register *srcReg, TR::Node *srcTree, bool srcModifiable, TR::CodeGenerator *cg);
 
    /**
+    * @brief Increment totalUseCounts of registers in MemoryReference
+    * @param[in] cg : CodeGenerator
+    */
+   void incRegisterTotalUseCounts(TR::CodeGenerator *cg);
+
+   /**
     * @brief Assigns registers
     * @param[in] currentInstruction : current instruction
     * @param[in] cg : CodeGenerator


### PR DESCRIPTION
This commit adds incRegisterTotalUseCounts() in OMRMemoryReference,
and calls to it in ARM64Instruction.hpp.

Signed-off-by: knn-k <konno@jp.ibm.com>