### PR TITLE
Set induceOSR method symbol to be interpreted

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -349,6 +349,18 @@ OMR::SymbolReferenceTable::findOrCreateOSRReturnAddressSymbolRef()
    return element(osrReturnAddressSymbol);
    }
 
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induceOSRHelper)
+   {
+   TR_ASSERT(induceOSRHelper == TR_induceOSRAtCurrentPC || induceOSRHelper == TR_induceOSRAtCurrentPCAndRecompile, "unexpected helper index when creating induce OSR helper symbol reference");
+   TR::SymbolReference *induceOSRSymRef = findOrCreateRuntimeHelper(induceOSRHelper,
+                                                                    true /* canGCandReturn */,
+                                                                    true /* canGCandExcept */,
+                                                                    true /* preservesAllRegisters */);
+   // treat jitInduceOSR like an interpreted call so that each platform's codegen generate a snippet for it
+   induceOSRSymRef->getSymbol()->getMethodSymbol()->setInterpreted();
+   return induceOSRSymRef;
+   }
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateArrayletShadowSymbolRef(TR::DataType type)

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -357,7 +357,7 @@ OMR::SymbolReferenceTable::findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induc
                                                                     true /* canGCandReturn */,
                                                                     true /* canGCandExcept */,
                                                                     true /* preservesAllRegisters */);
-   // treat jitInduceOSR like an interpreted call so that each platform's codegen generate a snippet for it
+   // treat jitInduceOSR like an interpreted call so that each platform's codegen generates a snippet for it
    induceOSRSymRef->getSymbol()->getMethodSymbol()->setInterpreted();
    return induceOSRSymRef;
    }

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -360,6 +360,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbol index);
    TR::SymbolReference * findOrCreatePotentialOSRPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateOSRFearPointHelperSymbolRef();
+   TR::SymbolReference * findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induceOSRHelper);
 
    TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType);
    TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -518,12 +518,7 @@ OMR::ResolvedMethodSymbol::genInduceOSRCallNode(TR::TreeTop* insertionPoint,
    //there is no guarantee that the future block containing the induceOSR call still will have an exception
    //edge to the OSR catch block.
    TR::SymbolReferenceTable* symRefTab = self()->comp()->getSymRefTab();
-   TR::SymbolReference *induceOSRSymRef = symRefTab->findOrCreateRuntimeHelper(TR_induceOSRAtCurrentPC,
-                                                                               true /* canGCandReturn */,
-                                                                               true /* canGCandExcept */,
-                                                                               true /* preservesAllRegisters */);
-   // treat jitInduceOSR like an interpreted call so that each platform's codegen generate a snippet for it
-   induceOSRSymRef->getSymbol()->getMethodSymbol()->setInterpreted();
+   TR::SymbolReference *induceOSRSymRef = symRefTab->findOrCreateInduceOSRSymbolRef(TR_induceOSRAtCurrentPC);
    TR::Node *refNode = insertionPoint->getNode();
 
    if (self()->comp()->getOption(TR_TraceOSR))
@@ -601,10 +596,7 @@ OMR::ResolvedMethodSymbol::induceOSRAfterAndRecompile(TR::TreeTop *insertionPoin
    TR_ASSERT_FATAL(induceOSRCallNode->getOpCode().isCall() &&
                    symRef->getReferenceNumber() == TR_induceOSRAtCurrentPC,
                    "induceOSRCallNode %p (n%dn) under induceOSRCallTree %p should be a call node with TR_induceOSRAtCurrentPC helper call", induceOSRCallNode, induceOSRCallNode->getGlobalIndex(), induceOSRCallTree->getNode());
-   induceOSRCallNode->setSymbolReference(self()->comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_induceOSRAtCurrentPCAndRecompile,
-                                                                                                   true /* canGCandReturn */,
-                                                                                                   true /* canGCandExcept */,
-                                                                                                   true /* preservesAllRegisters */));
+   induceOSRCallNode->setSymbolReference(self()->comp()->getSymRefTab()->findOrCreateInduceOSRSymbolRef(TR_induceOSRAtCurrentPCAndRecompile));
    return true;
    }
 


### PR DESCRIPTION
InduceOSR helpers needs to call through snippet to pass arguments as if
calling an interpreted method. Fix and refactor APIs to set the helper
method symbol as interpreted.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>