### PR TITLE
Disable OMR_THR_YIELD_ALG on MacOS

### DIFF
--- a/example/glue/configure_includes/configure_osx.mk
+++ b/example/glue/configure_includes/configure_osx.mk
@@ -39,7 +39,6 @@ CONFIGURE_ARGS += \
   --enable-OMR_TEST_COMPILER \
   --enable-OMR_THR_FORK_SUPPORT \
   --enable-OMR_THR_THREE_TIER_LOCKING \
-  --enable-OMR_THR_YIELD_ALG \
   --enable-OMR_GC_ARRAYLETS \
   --enable-OMR_THR_SPIN_WAKE_CONTROL
 

--- a/glue/configure_includes/configure_osx.mk
+++ b/glue/configure_includes/configure_osx.mk
@@ -32,7 +32,6 @@ CONFIGURE_ARGS += \
   --enable-OMR_PORT_CAN_RESERVE_SPECIFIC_ADDRESS \
   --enable-OMR_THR_FORK_SUPPORT \
   --enable-OMR_THR_THREE_TIER_LOCKING \
-  --enable-OMR_THR_YIELD_ALG \
   --enable-OMR_GC_ARRAYLETS
 
 CONFIGURE_ARGS += libprefix=lib exeext= solibext=.dylib arlibext=.a objext=.o


### PR DESCRIPTION
OMR_THR_YIELD_ALG should only be used with Completely Fair Scheduler
(CFS). CFS is only available on Linux.

MacOS schedulers can be classified as multilevel feedback queue
schedulers. MacOS doesn't use CFS. Thus, disabling OMR_THR_YIELD_ALG on
MacOS.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>