### PR TITLE
Enable copy leaf object first by default

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1597,7 +1597,7 @@ public:
 		, tarokEnableIncrementalClassGC(true)
 		, tarokEnableCompressedCardTable(true)
 		, compressedCardTable(NULL)
-		, tarokEnableLeafFirstCopying(false)
+		, tarokEnableLeafFirstCopying(true)
 		, tarokMaximumAgeInBytes(0)
 		, tarokMaximumNurseryAgeInBytes(0)
 		, tarokAllocationAgeEnabled(false)


### PR DESCRIPTION
	- Enable copy leaf object first for Copyforward scheme

Signed-off-by: Lin Hu <linhu@ca.ibm.com>