### PR TITLE
AArch64: Add instructions for FP mov

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -435,6 +435,8 @@ static const char *opCodeToNameMap[] =
    "rev16w",
    "rev16x",
    "rev32",
+   "fmovs",
+   "fmovd",
    "fmov_wtos",
    "fmov_xtod",
    "proc",

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -422,9 +422,10 @@
 		rev16x,                                                 	/* 0x5AC00400	REV16     	 */
 		rev32,                                                  	/* 0xDAC00800	REV32     	 */
 /* VFP instructions */
+		fmovs,                                                  	/* 0x1E204000	FMOV      	 */
+		fmovd,                                                  	/* 0x1E604000	FMOV      	 */
 		fmov_wtos,                                              	/* 0x1E270000	FMOV      	 */
 		fmov_xtod,                                              	/* 0x9E670000	FMOV      	 */
-
 /* Internal OpCodes */
 		proc,  // Entry to the method
 		fence, // Fence

--- a/compiler/aarch64/codegen/OMRMachine.cpp
+++ b/compiler/aarch64/codegen/OMRMachine.cpp
@@ -496,7 +496,7 @@ static void registerCopy(TR::Instruction *precedingInstruction,
          generateTrg1Src2Instruction(cg, TR::InstOpCode::orrx, node, targetReg, zeroReg, sourceReg, precedingInstruction); /* mov (register) */
          break;
       case TR_FPR:
-         TR_ASSERT(false, "Not implemented yet.");
+         generateTrg1Src1Instruction(cg, TR::InstOpCode::fmovd, node, targetReg, sourceReg, precedingInstruction);
          break;
       default:
          TR_ASSERT(false, "Unsupported RegisterKind.");

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -421,6 +421,8 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x5AC00400,	/* REV16     	rev16x	 */
 		0xDAC00800,	/* REV32     	rev32	 */
 /* VFP instructions */
+		0x1E204000,	/* FMOV      	fmovs	 */
+		0x1E604000,	/* FMOV      	fmovd	 */
 		0x1E270000,	/* FMOV      	fmov_wtos	 */
 		0x9E670000,	/* FMOV      	fmov_xtod	 */
 };


### PR DESCRIPTION
This commit adds aarch64 instructions fmovs/fmovd to the tables,
and implements registerCopy() for TR_FPR.

Signed-off-by: knn-k <konno@jp.ibm.com>