### PR TITLE
Fix for incorrect FP/Vector arithmetic evaluator on X86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -4233,7 +4233,8 @@ TR::Register* OMR::X86::TreeEvaluator::FloatingPointAndVectorBinaryArithmeticEva
 
    if (useRegMemForm)
       {
-      if (operandNode1->getReferenceCount() != 1 ||
+      if (operandNode1->getRegister()                               ||
+          operandNode1->getReferenceCount() != 1                    ||
           operandNode1->getOpCodeValue() != MemoryLoadOpCodes[type] ||
           BinaryArithmeticOpCodesForMem[type][arithmetic] == BADIA32Op)
          {


### PR DESCRIPTION
FloatingPointAndVectorBinaryArithmeticEvaluator should have checked if a
xload node has been evaluated before optimizing the instruction using
RegMem form instructions. Fixing.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>