### PR TITLE
Fix warnings in multiple (mostly compiler/optimizer) files

### DIFF
--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -820,7 +820,7 @@ OMR::SymbolReference::sharesSymbol(bool includingGCSafePoint)
          if ((self()->isUnresolved() && (_symbol->isConstantDynamic() || !_symbol->isConstObjectRef())) || 
 	       _symbol->isVolatile() || self()->isLiteralPoolAddress() ||
                self()->isFromLiteralPool() || _symbol->isUnsafeShadowSymbol() ||
-               _symbol->isArrayShadowSymbol() && c->getMethodSymbol()->hasVeryRefinedAliasSets())
+               (_symbol->isArrayShadowSymbol() && c->getMethodSymbol()->hasVeryRefinedAliasSets()))
             {
             // getUseDefAliases might not return NULL
             }

--- a/compiler/optimizer/FieldPrivatizer.cpp
+++ b/compiler/optimizer/FieldPrivatizer.cpp
@@ -835,7 +835,9 @@ bool TR_FieldPrivatizer::bothSubtreesMatch(TR::Node *node1, TR::Node *node2)
       {
       if (node1->getOpCode().isLoadVar() ||
           (node1->getOpCodeValue() == TR::loadaddr && node1->getSymbolReference()->getSymbol()->isNotCollected()))
+         {
          if (node1->getSymbolReference()->getReferenceNumber() == node2->getSymbolReference()->getReferenceNumber())
+            {
             if (node1->getNumChildren() > 0)
                {
                if (bothSubtreesMatch(node1->getFirstChild(), node2->getFirstChild()))
@@ -845,7 +847,8 @@ bool TR_FieldPrivatizer::bothSubtreesMatch(TR::Node *node1, TR::Node *node2)
                {
                return true;
                }
-
+            }
+         }
       }
 
    return false;

--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -135,8 +135,8 @@ const bool TR_LoadExtensions::canSkipConversion(TR::Node* conversion, TR::Node* 
          (TR::Compiler->target.is64Bit() || comp()->cg()->use64BitRegsOn32Bit() || conversion->getSize() != 8) &&
 
          // Ensure the conversion matches our preferred extension on the load
-         (loadPrefersSignExtension && loadPrefersSignExtension == conversionOpCode.isSignExtension() ||
-          loadPrefersZeroExtension && loadPrefersZeroExtension == conversion->isZeroExtension()))
+         ((loadPrefersSignExtension && loadPrefersSignExtension == conversionOpCode.isSignExtension()) ||
+          (loadPrefersZeroExtension && loadPrefersZeroExtension == conversion->isZeroExtension())))
          {
          if (trace())
             {

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -271,7 +271,7 @@ int32_t TR_ExtendBasicBlocks::orderBlocksWithoutFrequencyInfo()
                    //(blockHotness != unknownHotness) && (bestHotness != unknownHotness))
                   {
                   //if (((bestHotness == deadCold) && (blockHotness != deadCold)) || (blockHotness > (bestHotness + 1)))
-                  if (((bestFreq == (MAX_COLD_BLOCK_COUNT+1)) && (blockFreq != (MAX_COLD_BLOCK_COUNT+1)) || (blockFreq > bestFreq + 100)))
+                  if ((((bestFreq == (MAX_COLD_BLOCK_COUNT+1)) && (blockFreq != (MAX_COLD_BLOCK_COUNT+1))) || (blockFreq > bestFreq + 100)))
                      {
                      //bestExtension = NULL;
                      continue;
@@ -3000,8 +3000,8 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                      TR::Node *treeBeforeLastRealNode = treeBefore->getNode();
                      TR::Node *firstNode = firstTree->getNode();
                      if (firstNode->getOpCode().isStoreDirect() &&
-                         (firstNode->getFirstChild()->getOpCode().isAdd() ||
-                          firstNode->getFirstChild()->getOpCode().isSub() &&
+                         ((firstNode->getFirstChild()->getOpCode().isAdd() ||
+                          firstNode->getFirstChild()->getOpCode().isSub()) &&
                           firstNode->getFirstChild()->getReferenceCount() == 1) &&
                          ((firstNode->getType().isInt32() ||
                           firstNode->getType().isInt64())
@@ -4291,8 +4291,8 @@ void TR_Rematerialization::rematerializeSSAddress(TR::Node *parent, int32_t addr
          addressNode->getSymbolReference()->getSymbol()->isAutoOrParm())
         ||
         (addressNode->getOpCode().isArrayRef() &&
-         addressNode->getSecondChild()->getOpCode().isLoadConst()) &&
-         cg()->getSupportsConstantOffsetInAddressing(addressNode->getSecondChild()->get64bitIntegralValue())))
+         addressNode->getSecondChild()->getOpCode().isLoadConst() &&
+         cg()->getSupportsConstantOffsetInAddressing(addressNode->getSecondChild()->get64bitIntegralValue()))))
 
       {
       if (performTransformation(comp(), "%sRematerializing SS address %s (%p)\n", optDetailString(),addressNode->getOpCode().getName(),addressNode))
@@ -4340,8 +4340,8 @@ void TR_Rematerialization::rematerializeAddresses(TR::Node *indirectNode, TR::Tr
                  node->getNumChildren() == 2 &&
                  (!node->getSecondChild()->getOpCode().isLoadConst() ||
                   (cg()->isMaterialized(node->getSecondChild()) ||
-                        cg()->getSupportsConstantOffsetInAddressing() &&
-                        cg()->getSupportsConstantOffsetInAddressing(node->getSecondChild()->get64bitIntegralValue())))) ||
+                        (cg()->getSupportsConstantOffsetInAddressing() &&
+                        cg()->getSupportsConstantOffsetInAddressing(node->getSecondChild()->get64bitIntegralValue()))))) ||
                 (node->getReferenceCount() == 1 &&
                  node->isInternalPointer() &&
                  node->getNumChildren() == 2 &&

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -1350,13 +1350,12 @@ bool TR_LoopVersioner::detectInvariantChecks(List<TR::Node> *nullCheckedReferenc
 
       if (!isNullCheckReferenceInvariant &&
           node->getData()->getOpCode().hasSymbolReference() &&
-          (node->getData()->getSymbolReference()->getSymbol()->isAuto() &&
-          isDependentOnInvariant(node->getData()) ||
-          node->getData()->getOpCode().isLoadIndirect() &&
-          !_seenDefinedSymbolReferences->get(node->getData()->getSymbolReference()->getReferenceNumber()) &&
-          node->getData()->getFirstChild()->getOpCode().hasSymbolReference() &&
-          node->getData()->getFirstChild()->getSymbolReference()->getSymbol()->isAuto() &&
-          isDependentOnInvariant(node->getData()->getFirstChild())))
+          ((node->getData()->getSymbolReference()->getSymbol()->isAuto() && isDependentOnInvariant(node->getData())) ||
+           (node->getData()->getOpCode().isLoadIndirect() &&
+            !_seenDefinedSymbolReferences->get(node->getData()->getSymbolReference()->getReferenceNumber()) &&
+            node->getData()->getFirstChild()->getOpCode().hasSymbolReference() &&
+            node->getData()->getFirstChild()->getSymbolReference()->getSymbol()->isAuto() &&
+            isDependentOnInvariant(node->getData()->getFirstChild()))))
          isNullCheckReferenceInvariant = true;
 
       if (!isNullCheckReferenceInvariant ||
@@ -3259,7 +3258,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
                   TR::Node *ttNode = tt->getNode();
                   TR::ILOpCode &op = ttNode->getOpCode();
                   if ( op.isCheck() || op.isCheckCast() ||
-                       op.isBranch() && ttNode->getNumChildren() >= 2 && (!tt->getNode()->getFirstChild()->getOpCode().isLoadConst() || !tt->getNode()->getSecondChild()->getOpCode().isLoadConst()))
+                       (op.isBranch() && ttNode->getNumChildren() >= 2 && (!tt->getNode()->getFirstChild()->getOpCode().isLoadConst() || !tt->getNode()->getSecondChild()->getOpCode().isLoadConst())))
                      {
                      if (!performTransformation(comp(), "%s ...disregarding %s n%dn\n", OPT_DETAILS_LOOP_VERSIONER, ttNode->getOpCode().getName(), ttNode->getGlobalIndex()))
                         isUnimportant = false;

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -3418,7 +3418,7 @@ static bool isLegalToMerge(TR::Node * node, TR::Block * block, TR::Block * nextB
       return false;
 
    blockIsEmpty = (block->getEntry() != NULL && block->getEntry()->getNextTreeTop() == block->getExit());
-   if (inEdge.empty() || !blockIsEmpty && (inEdge.front() != outEdge || (inEdge.size() > 1)))
+   if (inEdge.empty() || (!blockIsEmpty && (inEdge.front() != outEdge || (inEdge.size() > 1))))
       return false;
 
    //Can't merge block with nextBlock if block is entry point and inEdge has more than one edge

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -883,10 +883,12 @@ int32_t floatToInt(float value, bool roundUp)
    else
       {
       if (roundUp)
+         {
          if (value > 0)
             value += 0.5;
          else
             value -= 0.5;
+         }
       result = (int32_t)value;
       }
    return result;
@@ -906,10 +908,12 @@ int32_t doubleToInt(double value, bool roundUp)
    else
       {
       if (roundUp)
+         {
          if (value > 0)
             value += 0.5;
          else
             value -= 0.5;
+         }
 
       result = (int32_t)value;
       }

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -1850,8 +1850,8 @@ TR_RegisterCandidates::reprioritizeCandidates(
       if (rc->getBlocksLiveOnEntry().intersects(*successorBits))
          {
          if ((!onlyReprioritizeLongs ||
-              (rc->getType().isInt64()) &&
-               TR::Compiler->target.is32Bit()) &&
+              (rc->getType().isInt64() &&
+               TR::Compiler->target.is32Bit())) &&
              ((reprioritizeFP && isFPCandidate) ||
               (!reprioritizeFP && !isFPCandidate)))
             {
@@ -3218,9 +3218,9 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
                      maxFrequency < smallestMaxFrequency ||
                      ((maxFrequency == smallestMaxFrequency) &&
                       ((numClearStructures > maxClearStructures) ||
-                       (numClearStructures == maxClearStructures) &&
+                       ((numClearStructures == maxClearStructures) &&
                         ((numBlocksAtMaxFrequency < numberOfConflicts) ||
-                         ((numBlocksAtMaxFrequency == numberOfConflicts) && (_liveOnEntryConflicts[i].elementCount() < _liveOnEntryConflicts[conflictingRegister].elementCount()))))))
+                         ((numBlocksAtMaxFrequency == numberOfConflicts) && (_liveOnEntryConflicts[i].elementCount() < _liveOnEntryConflicts[conflictingRegister].elementCount())))))))
                     {
                     smallestMaxFrequency = maxFrequency;
                     maxClearStructures = numClearStructures;

--- a/compiler/optimizer/VirtualGuardHeadMerger.cpp
+++ b/compiler/optimizer/VirtualGuardHeadMerger.cpp
@@ -340,9 +340,9 @@ int32_t TR_VirtualGuardHeadMerger::perform() {
             {
             // TODO handle moving code earlier in the block down below the guard
             // tail split
-            if ((block->getNextBlock()->getSuccessors().size() == 1) ||
-                ((block->getNextBlock()->getSuccessors().size() == 2) &&
-                 block->getNextBlock()->getLastRealTreeTop()->getNode()->getOpCode().isBranch()) &&
+            if ((block->getNextBlock()->getSuccessors().size() == 1 ||
+                 (block->getNextBlock()->getSuccessors().size() == 2 &&
+                  block->getNextBlock()->getLastRealTreeTop()->getNode()->getOpCode().isBranch())) &&
                 performTransformation(comp(), "%sCloning block_%d and placing clone after block_%d to reduce HCR guard nops\n", OPT_DETAILS, block->getNextBlock()->getNumber(), cold1->getNumber()))
                tailSplitBlock(block, cold1);
             }

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -523,8 +523,13 @@ OMR::X86::MemoryReference::populateMemoryReference(
        subTree->getSymbolReference()->getSymbol()->isMethodMetaData())
       evalSubTree = false;
 
-   if (evalSubTree &&
-       subTree->getReferenceCount() > 1 || subTree->getRegister() != NULL || (self()->inUpcastingMode() && !subTree->cannotOverflow()))
+   // This condition was previously formatted in a misleading way given the
+   //  conditional being evaluated. I believe the condition is correct (rather,
+   //  I have no strong evidence that it is incorrect other than the formatting)
+   //  so I added parentheses to eliminate a compiler warning and reformatted
+   if ((evalSubTree && subTree->getReferenceCount() > 1)
+       || (subTree->getRegister() != NULL)
+       || (self()->inUpcastingMode() && !subTree->cannotOverflow()))
       {
       if (_baseRegister != NULL)
          {


### PR DESCRIPTION
Newer compilers complain about a few things that are not syntactically
incorrect, but might be bugs. For example, not wrapping && expressions
in parenthesis when used in || conditionals. This commit fixes a number
of such warnings found primarily in the compiler/optimizer files.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>