### PR TITLE
Make x86-64 table jump position independent in AOT

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -462,12 +462,33 @@ TR::Register *OMR::X86::TreeEvaluator::tableEvaluator(TR::Node *node, TR::CodeGe
          cg->evaluate(secondChild->getFirstChild()); // evaluate the glRegDeps
       }
 
-   TR::MemoryReference *tempMR = generateX86MemoryReference((TR::Register *)NULL,
-                                                            selectorReg,
-                                                            (uint8_t)(TR::Compiler->target.is64Bit()? 3 : 2),
-                                                            (intptrj_t)branchTable, cg);
+   TR::MemoryReference *jumpMR = NULL;
+   TR::Register *branchTableReg = NULL;
+   if (TR::Compiler->target.is64Bit() && cg->comp()->compileRelocatableCode())
+      {
+      // Generate position-independent code so that no (external) relocation is
+      // necessary:
+      //
+      //    lea rBranchTable, [rip + OFFSET_TO_JUMP_TABLE]
+      //    jmp qword ptr [rBranchTable + 8*rIndex]
+      //
+      TR::LabelSymbol *label = generateLabelSymbol(cg);
+      label->setCodeLocation(reinterpret_cast<uint8_t*>(branchTable));
+      TR::MemoryReference *branchTableLeaMR = generateX86MemoryReference(label, cg);
+      branchTableReg = cg->allocateRegister();
+      generateRegMemInstruction(LEA8RegMem, node, branchTableReg, branchTableLeaMR, cg);
+      jumpMR = generateX86MemoryReference(branchTableReg, selectorReg, 3, cg);
+      }
+   else
+      {
+      jumpMR = generateX86MemoryReference(
+         (TR::Register *)NULL,
+         selectorReg,
+         (uint8_t)(TR::Compiler->target.is64Bit()? 3 : 2),
+         (intptrj_t)branchTable, cg);
 
-   tempMR->setNeedsCodeAbsoluteExternalRelocation();
+      jumpMR->setNeedsCodeAbsoluteExternalRelocation();
+      }
 
    TR::X86MemTableInstruction *jmpTableInstruction = NULL;
 
@@ -481,11 +502,11 @@ TR::Register *OMR::X86::TreeEvaluator::tableEvaluator(TR::Node *node, TR::CodeGe
          deps->stopAddingConditions();
          }
 
-      jmpTableInstruction = generateMemTableInstruction(JMPMem, node, tempMR, numBranchTableEntries, deps, cg);
+      jmpTableInstruction = generateMemTableInstruction(JMPMem, node, jumpMR, numBranchTableEntries, deps, cg);
       }
    else
       {
-      generateMemInstruction(JMPMem, node, tempMR, cg);
+      generateMemInstruction(JMPMem, node, jumpMR, cg);
       }
 
    for (i = 2; i < node->getNumChildren(); ++i)
@@ -499,6 +520,9 @@ TR::Register *OMR::X86::TreeEvaluator::tableEvaluator(TR::Node *node, TR::CodeGe
       {
       cg->decReferenceCount(node->getChild(i));
       }
+
+   if (branchTableReg != NULL)
+      cg->stopUsingRegister(branchTableReg);
 
    return NULL;
    }


### PR DESCRIPTION
The `TR_MethodAddress` relocation which has until now been generated for the displacement of the memory reference of the jump dispatching a `table` node is incorrect on 64-bit.

First, the displacement is only 32 bits, but the relocation works on a pointer-sized value (64 bits). The high half of the "address" is really the first four bytes of the next instruction. If the address adjustment changes the high half, then the next instruction will be modified.

Second, the 32-bit displacement gets sign-extended. If the code were originally compiled at a location below 2GB, and later loaded above 2GB (but below 4GB), the address adjustment will set the sign bit, so that the sign-extension is no longer the same as the zero-extension (i.e. the correct address).

To prevent these problems, the table evaluator now generates a position-independent sequence for the jump table dispatch, which requires no (external) relocation:

    lea rJumpTable, [rip + OFFSET_TO_JUMP_TABLE]
    jmp qword ptr [rJumpTable + 8*rIndex]

This sequence is only generated for 64-bit relocatable code. 32-bit code doesn't have access to `rip`-relative addressing, but it's immune to the above relocation problems anyway, since the pointer size is 32 bits, and there is no sign- nor zero-extension. For non-relocatable code, the existing lone `jmp` is preferable to a two-instruction sequence.

The addresses contained in the jump table remain position-dependent, and they continue to get relocated just as before.