### PR TITLE
Add basic type_traits-like utility to OMR

### DIFF
--- a/fvtest/coretest/CMakeLists.txt
+++ b/fvtest/coretest/CMakeLists.txt
@@ -39,3 +39,4 @@ endfunction(omr_add_core_test)
 
 omr_add_core_test(TestBytes)
 omr_add_core_test(TestIntrusiveList)
+omr_add_core_test(TestTypeTraits)

--- a/fvtest/coretest/TestTypeTraits.cpp
+++ b/fvtest/coretest/TestTypeTraits.cpp
@@ -1,0 +1,116 @@
+#include <OMR/TypeTraits.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+
+TEST(TestTypeTraits, IntegralConst)
+{
+	EXPECT_EQ(0, (IntegralConstant<int, 0>::VALUE));
+	EXPECT_EQ(0xdeadbeef, (IntegralConstant<unsigned int, 0xdeadbeef>::VALUE));
+}
+
+TEST(TestTypeTraits, BooleanConstant)
+{
+	EXPECT_TRUE((BoolConstant<true>::VALUE));
+	EXPECT_TRUE(TrueConstant::VALUE);
+	EXPECT_FALSE((BoolConstant<false>::VALUE));
+	EXPECT_FALSE(FalseConstant::VALUE);
+}
+
+TEST(TestTypeTraits, IsSame)
+{
+	EXPECT_TRUE((IsSame<int, int>::VALUE));
+	EXPECT_FALSE((IsSame<int, double>::VALUE));
+	EXPECT_TRUE((IsSame<void*, void*>::VALUE));
+	EXPECT_FALSE((IsSame<void* const, void*>::VALUE));
+	EXPECT_FALSE((IsSame<void*, const void*>::VALUE));
+}
+
+TEST(TestTypeTraits, TypeAlias)
+{
+	EXPECT_TRUE((IsSame<void, TypeAlias<void>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<void*, TypeAlias<void*>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<const int, TypeAlias<const int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int&, TypeAlias<int&>::Type>::VALUE));
+}
+
+TEST(TestTypeTraits, RemoveConst)
+{
+	EXPECT_TRUE((IsSame<int, RemoveConst<int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveConst<const int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<volatile int, RemoveConst<const volatile int>::Type>::VALUE));
+}
+
+TEST(TestTypeTraits, RemoveVolatile)
+{
+	EXPECT_TRUE((IsSame<int, RemoveVolatile<int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveVolatile<volatile int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<const int, RemoveVolatile<const volatile int>::Type>::VALUE));
+}
+
+TEST(TestTypeTraits, RemoveCv)
+{
+	EXPECT_TRUE((IsSame<int, RemoveCv<int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCv<const int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCv<const volatile int>::Type>::VALUE));
+}
+
+TEST(TestTypeTraits, RemoveReference)
+{
+	EXPECT_TRUE((IsSame<int, RemoveReference<int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveReference<int&>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<const int, RemoveReference<const int&>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int*, RemoveReference<int*&>::Type>::VALUE));
+	// TODO: EXPECT_TRUE((IsSame<int, RemoveReference<int&&>::Type>::VALUE));
+}
+
+TEST(TestTypeTraits, RemoveCvRef)
+{
+	EXPECT_TRUE((IsSame<int, RemoveCvRef<int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCvRef<const int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCvRef<const volatile int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCvRef<int&>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCvRef<const int&>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemoveCvRef<const volatile int&>::Type>::VALUE));
+	// TODO: EXPECT_TRUE((IsSame<int, RemoveCvRef<int&&>::Type>::VALUE));
+}
+
+TEST(TestTypeTraits, IsReference)
+{
+	EXPECT_FALSE((IsReference<int>::VALUE));
+	EXPECT_FALSE((IsReference<int*>::VALUE));
+	EXPECT_TRUE((IsReference<int&>::VALUE));
+	EXPECT_TRUE((IsReference<const int&>::VALUE));
+	// TODO: EXPECT_TRUE((IsReference<int&&>::VALUE));
+}
+
+TEST(TestTypeTraits, IsPointer)
+{
+	EXPECT_TRUE((IsPointer<int*>::VALUE));
+	EXPECT_TRUE((IsPointer<void*>::VALUE));
+	EXPECT_TRUE((IsPointer<void* const>::VALUE));
+	EXPECT_TRUE((IsPointer<void* volatile>::VALUE));
+	EXPECT_TRUE((IsPointer<void* const volatile>::VALUE));
+	EXPECT_TRUE((IsPointer<void**>::VALUE));
+	EXPECT_FALSE((IsPointer<void*&>::VALUE));
+	EXPECT_FALSE((IsPointer<int>::VALUE));
+	EXPECT_FALSE((IsPointer<void>::VALUE));
+	EXPECT_FALSE((IsPointer<int&>::VALUE));
+}
+
+TEST(TestTypeTraits, IsVoid)
+{
+	EXPECT_TRUE((IsVoid<void>::VALUE));
+	EXPECT_TRUE((IsVoid<const void>::VALUE));
+	EXPECT_TRUE((IsVoid<volatile void>::VALUE));
+	EXPECT_TRUE((IsVoid<const volatile void>::VALUE));
+	EXPECT_FALSE((IsVoid<int>::VALUE));
+	EXPECT_FALSE((IsVoid<const int>::VALUE));
+	EXPECT_FALSE((IsVoid<volatile int>::VALUE));
+	EXPECT_FALSE((IsVoid<const volatile int>::VALUE));
+
+	EXPECT_FALSE((IsVoid<void*>::VALUE));
+}
+
+}  // namespace OMR

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_TYPETRAITS_HPP_)
+#define OMR_TYPETRAITS_HPP_
+
+namespace OMR
+{
+
+///
+/// Basic constants
+///
+
+/// Define an integral constant.
+template <typename T, T value>
+struct IntegralConstant
+{
+	typedef T ValueType;
+
+	static const ValueType VALUE = value;
+
+	ValueType operator()() const { return VALUE; }
+};
+
+template <typename T, T value>
+const T IntegralConstant<T, value>::VALUE;
+
+template <bool value>
+struct BoolConstant : IntegralConstant<bool, value> {};
+
+struct FalseConstant : BoolConstant<false> {};
+
+struct TrueConstant : BoolConstant<true> {};
+
+template <typename T>
+struct TypeAlias
+{
+	typedef T Type;
+};
+
+///
+/// Type modifications: add or remove qualifiers or type modifiers
+///
+
+/// RemoveConst<T> is T without any const qualifiers.
+template <typename T>
+struct RemoveConst : TypeAlias<T> {};
+
+template <typename T>
+struct RemoveConst<const T> : TypeAlias<T> {};
+
+/// RemoveVolatile<T>::Type is T without volatile qualifiers.
+template <typename T>
+struct RemoveVolatile : TypeAlias<T> {};
+
+template <typename T>
+struct RemoveVolatile<volatile T> : TypeAlias<T> {};
+
+/// RemoveCv<T>::Type is T without const/volatile qualifiers.
+template <typename T>
+struct RemoveCv : RemoveVolatile<typename RemoveConst<T>::Type> {};
+
+/// RemoveReference<T>::Type is T as a non-reference.
+template <typename T>
+struct RemoveReference : TypeAlias<T> {};
+
+template <typename T>
+struct RemoveReference<T&> : RemoveReference<T> {};
+
+// TODO: Handle RValue references in typetraits
+// template <typename T>
+// struct RemoveReference<T&&> : RemoveReference<T> {};
+
+/// Remove cv-qualifiers and one layer of references.
+template <typename T>
+struct RemoveCvRef : RemoveCv<typename RemoveReference<T>::Type> {};
+
+// TODO: Handle rvalue references in type traits
+// template <typename T>
+// struct RemoveCvRef<T&&> : RemoveCvRef<T> {};
+
+///
+/// Type reflection: statically query types
+///
+
+/// True if T and U are the exact same type. Does not remove qualifiers.
+template <typename T, typename U>
+struct IsSame : FalseConstant {};
+
+template <typename T>
+struct IsSame<T, T> : TrueConstant {};
+
+/// true if T is a reference type.
+template <typename T>
+struct IsReference : FalseConstant {};
+
+template <typename T>
+struct IsReference<T&> : TrueConstant {};
+
+// TODO: Handle rvalue references in type traits
+// template <typename T>
+// struct IsReference<T&&> : TrueConstant {};
+
+/// Helper for IsPointer.
+template <typename T>
+struct IsPointerBase : FalseConstant {};
+
+template <typename T>
+struct IsPointerBase<T*> : TrueConstant {};
+
+/// IsPointer<T>::VALUE is true if T is a (possibly cv qualified) primitive pointer type.
+template <typename T>
+struct IsPointer : IsPointerBase<typename RemoveCv<T>::Type> {};
+
+/// IsVoid<T>::VALUE is true if T is (possibly cv qualified) void.
+template <typename T>
+struct IsVoid : IsSame<typename RemoveCv<T>::Type, void> {};
+
+}  // namespace OMR
+
+#endif // OMR_TYPETRAITS_HPP_

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -84,7 +84,7 @@ template <typename T>
 struct RemoveReference : TypeAlias<T> {};
 
 template <typename T>
-struct RemoveReference<T&> : RemoveReference<T> {};
+struct RemoveReference<T&> : TypeAlias<T> {};
 
 // TODO: Handle RValue references in typetraits
 // template <typename T>


### PR DESCRIPTION
Type traits are useful in templated code to make queries or assertions
about type parameters. For example, a container might assert that it
never contains a reference type.  A smart pointer won't define
pointer-operators when it's referent is void.

Our supported compilers don't provide the standard C++11 header
<type_traits> in OMR. Even looking at planned compiler upgrades, it's
unlikely we'll ever get a standard implementation of type_traits on XLC.

This header provides some easily implemented type traits without any
hacks or compiler support. As well, this header follows OMR coding
conventions, rather than try to simulate the standard type_traits
header.

This PR implements the following:

* Static constants:
  * `IntegralConstant<T, X>`
  * `BoolConstant<B>` / `TrueConstant` / `FalseConstant`
  * `TypeAlias<T>`
* types queries:
  * `IsSame<T, U>`
  * `IsReference<T>`
  * `IsVoid<T>`
  * `IsPointer<T>`
* type modifications:
  * `RemoveConst<T>`
  * `RemoveVolatile<T>`
  * `RemoveCv<T>`
  * `RemoveReference<T>`
  * `RemoveCvRef<T>`

There's lots of opportunities for expanding the traits provided in this
initial commit, but this is a good base for defining container types in
OMR.

Signed-off-by: Robert Young <rwy0717@gmail.com>