### PR TITLE
Fix invalid option definitions causing crashes in the JIT

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -114,7 +114,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"alwaysSafeFatalAssert", "I\tAlways issue a safe fatal assertion for testing purposes",      SET_OPTION_BIT(TR_AlwaysSafeFatal), "F"},
    {"alwaysWorthInliningThreshold=", "O<nnn>\t", TR::Options::set32BitNumeric, offsetof(OMR::Options, _alwaysWorthInliningThreshold), 0, " %d" },
    {"aot",                "O\tahead-of-time compilation",
-        SET_OPTION_BIT(TR_AOT), NULL, NOT_IN_SUBSET},
+        SET_OPTION_BIT(TR_AOT), "F", NOT_IN_SUBSET},
    {"aotOnlyFromBootstrap", "O\tahead-of-time compilation allowed only for methods from bootstrap classes",
         SET_OPTION_BIT(TR_AOTCompileOnlyFromBootstrap), "F", NOT_IN_SUBSET },
    {"aotrtDebugLevel=", "R<nnn>\tprint aotrt debug output according to level", TR::Options::set32BitNumeric, offsetof(OMR::Options,_newAotrtDebugLevel), 0, " %d"},


### PR DESCRIPTION
The `TR::OptionTable::msg` field must be non-null, otherwise when
printing the options via the `verbose` command we run into null pointer
dereferences which causes the JIT to crash.

Issue: eclipse/openj9#3955

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>