### PR TITLE
gc clang-format: put a space after template keyword

### DIFF
--- a/gc/.clang-format
+++ b/gc/.clang-format
@@ -95,7 +95,7 @@ ReflowComments:  false
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: false
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true


### PR DESCRIPTION
Signed-off-by: Robert Young <rwy0717@gmail.com>