### PR TITLE
Add isPow2, aligned, and align utility to Bytes.hpp

### DIFF
--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -48,4 +48,140 @@ TEST(TestBytes, CompareOneUnitToSmallerUnit)
 	EXPECT_EQ(mebibytes(1024), gibibytes(1));
 }
 
+TEST(TestBytes, IsPow2)
+{
+	EXPECT_TRUE(isPow2(1));
+	EXPECT_TRUE(isPow2(2));
+	EXPECT_TRUE(isPow2(4));
+	EXPECT_TRUE(isPow2(8));
+	EXPECT_TRUE(isPow2(size_t(1) << ((sizeof(size_t)*8) - 1)));
+
+	EXPECT_FALSE(isPow2(0));
+	EXPECT_FALSE(isPow2(3));
+	EXPECT_FALSE(isPow2(5));
+	EXPECT_FALSE(isPow2(6));
+	EXPECT_FALSE(isPow2(7));
+	EXPECT_FALSE(isPow2(9));
+	EXPECT_FALSE(isPow2(SIZE_MAX));
+}
+
+TEST(TestBytes, AlignedUnsafe)
+{
+	EXPECT_TRUE(alignedNoCheck(0, 0));
+	EXPECT_FALSE(alignedNoCheck(1, 0));
+	EXPECT_FALSE(alignedNoCheck(2, 0));
+	EXPECT_FALSE(alignedNoCheck(gibibytes(1), 0));
+}
+
+TEST(TestBytes, Aligned)
+{
+	EXPECT_TRUE(aligned(1, 1));
+	EXPECT_TRUE(aligned(2, 1));
+
+	EXPECT_FALSE(aligned(1, 2));
+	EXPECT_TRUE(aligned(2, 2));
+	EXPECT_FALSE(aligned(3, 2));
+}
+
+TEST(TestBytes, AlignToZero)
+{
+	// Zero is considered an invalid input, since the calculation always results in zero.
+	// This test is validating that behaviour, but users should NOT be aligning to zero.
+	// the minimum valid alignment is 1.
+	EXPECT_EQ(0, alignNoCheck(0, 0));
+	EXPECT_EQ(0, alignNoCheck(1, 0));
+	EXPECT_EQ(0, alignNoCheck(2, 0));
+	EXPECT_EQ(0, alignNoCheck(3, 0));
+	EXPECT_EQ(0, alignNoCheck(gibibytes(1), 0));
+}
+
+TEST(TestBytes, AlignToOne)
+{
+	EXPECT_EQ(0, align(0, 1));
+	EXPECT_EQ(1, align(1, 1));
+	EXPECT_EQ(2, align(2, 1));
+	EXPECT_EQ(3, align(3, 1));
+	EXPECT_EQ(gibibytes(1), align(gibibytes(1), 1));
+}
+
+TEST(TestBytes, AlignToTwo)
+{
+	EXPECT_EQ(0, align(0, 2));
+	EXPECT_EQ(2, align(1, 2));
+	EXPECT_EQ(2, align(2, 2));
+	EXPECT_EQ(4, align(3, 2));
+	EXPECT_EQ(gibibytes(1), align(gibibytes(1), 2));
+}
+
+TEST(TestBytes, AlignToFour)
+{
+	EXPECT_EQ(0, align(0, 4));
+	EXPECT_EQ(4, align(1, 4));
+	EXPECT_EQ(4, align(2, 4));
+	EXPECT_EQ(4, align(3, 4));
+	EXPECT_EQ(4, align(4, 4));
+	EXPECT_EQ(8, align(5, 4));
+	EXPECT_EQ(gibibytes(1), align(gibibytes(1), 4));
+}
+
+TEST(TestBytes, AlignToEight)
+{
+	EXPECT_EQ(0, align(0, 8));
+	EXPECT_EQ(8, align(1, 8));
+	EXPECT_EQ(8, align(7, 8));
+	EXPECT_EQ(8, align(8, 8));
+	EXPECT_EQ(16, align(9, 8));
+	EXPECT_EQ(gibibytes(1), align(gibibytes(1), 4));
+}
+
+TEST(TestBytes, SaneAlignmentMaximums)
+{
+	EXPECT_NE(0, ALIGNMENT_MAX);
+	EXPECT_NE(0, UNALIGNED_SIZE_MAX);
+	EXPECT_TRUE(isPow2(ALIGNMENT_MAX));
+	EXPECT_TRUE(isPow2(UNALIGNED_SIZE_MAX));
+	EXPECT_LE(ALIGNMENT_MAX, UNALIGNED_SIZE_MAX);
+	EXPECT_TRUE(aligned(UNALIGNED_SIZE_MAX, ALIGNMENT_MAX));
+
+	// Soft requirement: we should be able to align sizes of at least 1Gib to
+	// alignments of at least 1Gib.
+	EXPECT_LE(gibibytes(1), ALIGNMENT_MAX);
+	EXPECT_LE(gibibytes(1), UNALIGNED_SIZE_MAX);
+}
+
+TEST(TestBytes, AlignToMaximumAlignment)
+{
+	EXPECT_EQ(0, align(0, ALIGNMENT_MAX));
+	EXPECT_EQ(ALIGNMENT_MAX, align(1, ALIGNMENT_MAX));
+
+	EXPECT_EQ(UNALIGNED_SIZE_MAX, align(UNALIGNED_SIZE_MAX - 1, ALIGNMENT_MAX));
+	EXPECT_EQ(UNALIGNED_SIZE_MAX, align(UNALIGNED_SIZE_MAX, ALIGNMENT_MAX));
+}
+
+TEST(TestBytes, TautologicalAlign)
+{
+	// Note: This only works because UNALIGNED_SIZE_MAX == ALIGNMENT_MAX.
+	// If ALIGNMENT_MAX is ever decreased to allow a larger UNALIGNED_SIZE_MAX,
+	// this test will fail.
+	EXPECT_EQ(ALIGNMENT_MAX, align(UNALIGNED_SIZE_MAX, ALIGNMENT_MAX));
+	EXPECT_EQ(UNALIGNED_SIZE_MAX, align(UNALIGNED_SIZE_MAX, UNALIGNED_SIZE_MAX));
+
+	EXPECT_EQ(ALIGNMENT_MAX, align(ALIGNMENT_MAX - 1, ALIGNMENT_MAX));
+	EXPECT_EQ(ALIGNMENT_MAX, align(ALIGNMENT_MAX, ALIGNMENT_MAX));
+}
+
+TEST(TestBytes, AlignAndOverflow)
+{
+	// purposefully overflow while aligning.
+	EXPECT_EQ(0, alignNoCheck(UNALIGNED_SIZE_MAX + 1, ALIGNMENT_MAX));
+	EXPECT_EQ(0, alignNoCheck(ALIGNMENT_MAX + 1, ALIGNMENT_MAX));
+}
+
+TEST(TestBytes, AlignMaximumSizeFor16byteAlignment)
+{
+	// hand crafted maximums for a 16 byte alignment
+	EXPECT_EQ(SIZE_MAX - 15, align(SIZE_MAX - 17, 16));
+	EXPECT_EQ(SIZE_MAX, align(SIZE_MAX, 1));
+}
+
 }  // namespace OMR

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -131,7 +131,7 @@ TEST(TestBytes, AlignToEight)
 	EXPECT_EQ(8, align(7, 8));
 	EXPECT_EQ(8, align(8, 8));
 	EXPECT_EQ(16, align(9, 8));
-	EXPECT_EQ(gibibytes(1), align(gibibytes(1), 4));
+	EXPECT_EQ(gibibytes(1), align(gibibytes(1), 8));
 }
 
 TEST(TestBytes, SaneAlignmentMaximums)

--- a/include_core/OMR/Bytes.hpp
+++ b/include_core/OMR/Bytes.hpp
@@ -24,7 +24,9 @@
 #define OMR_BYTES_HPP_
 
 #include <omrcfg.h>
+#include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 
 namespace OMR
 {
@@ -51,6 +53,58 @@ inline size_t
 gibibytes(size_t n)
 {
 	return n * mebibytes(1024);
+}
+
+/// True if x is a power of two.
+inline bool
+isPow2(size_t x)
+{
+	return x && ((x & (x - 1)) == 0);
+}
+
+/// The maximum safe alignment, when aligning sizes up to UNALIGNED_SIZE_MAX.
+static const size_t ALIGNMENT_MAX = (SIZE_MAX >> 1) + 1;
+
+/// The maximum safe size, when aligning up to ALIGNMENT_MAX.
+static const size_t UNALIGNED_SIZE_MAX = (SIZE_MAX >> 1) + 1;
+
+/// True if size is aligned to alignment. No safety checks.
+/// alignment must be a power of two.
+inline bool
+alignedNoCheck(size_t size, size_t alignment)
+{
+	return (size & (alignment - 1)) == 0;
+}
+
+/// True if size is aligned to alignment.
+/// alignment must be a power of two.
+inline bool
+aligned(size_t size, size_t alignment)
+{
+	assert(isPow2(alignment));
+	return alignedNoCheck(size, alignment);
+}
+
+/// Round a size up to a multiple of alignment. No safety checks.
+/// alignment must be a power of two.
+inline size_t
+alignNoCheck(size_t size, size_t alignment)
+{
+	return (size + (alignment - 1)) & ~(alignment - 1);
+}
+
+/// Round a size up to a multiple of alignment.
+/// alignment must be a power of two.
+///
+/// The maximum unaligned size is intrinsically related to the alignment.
+/// As a conservative measure, users should not align sizes greater than
+/// UNALIGNED_SIZE_MAX.
+inline size_t
+align(size_t size, size_t alignment)
+{
+	assert(isPow2(alignment));
+	assert(size <= SIZE_MAX - alignment + 1); // overflow check
+	return alignNoCheck(size, alignment);
 }
 
 } // namespace OMR


### PR DESCRIPTION
The align utility is for quickly rounding sizes up to a power of two.
Aligning is done everywhere, so it makes sense to have one common
implementation. Note that this is not a general rounding utility, as it
can only round certain specially crafted inputs.

Signed-off-by: Robert Young <rwy0717@gmail.com>