### PR TITLE
Add build*/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-/build/
+/build*/
 objs/
 CMakeFiles/
 CMakeCache.txt


### PR DESCRIPTION
This lets us ignore any build directory.

Signed-off-by: Robert Young <rwy0717@gmail.com>