### PR TITLE
Supporting options and code to allow AOT at cheap warm level

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -200,7 +200,7 @@ enum TR_CompilationOptions
    TR_Timing                              = 0x00000200 + 3,
    TR_SupportSwitchToInterpreter          = 0x00000400 + 3,
    TR_DisableFPCodeGen                    = 0x00000800 + 3,
-   // Available                           = 0x00001000 + 3,
+   TR_DisableAotAtCheapWarm               = 0x00001000 + 3,
    TR_Profile                             = 0x00002000 + 3,
    TR_DisableAsyncCompilation             = 0x00004000 + 3,
    TR_DisableCompilationThread            = 0x00008000 + 3,
@@ -1691,6 +1691,7 @@ public:
    void setAggressiveQuickStart();
    void setGlobalAggressiveAOT();
    void setLocalAggressiveAOT();
+   void setInlinerOptionsForAggressiveAOT();
    void setConservativeDefaultBehavior();
 
    static bool getCountsAreProvidedByUser() { return _countsAreProvidedByUser; } // set very late in setCounts()


### PR DESCRIPTION
This commit adds a new option -Xaot:disableAOTAtCheapWarm to control the
logic that will force AOT compilations to be performed at a "cheap"
warm level. A "cheap" warm level is an optimization level where the
inliner has been subdued somewhat (the same inliner changes are applied
to the Xtune:virtualized mode in OpenJ9 JVM).
Upgrades of AOT bodies through sampling are also subdued if the
guarded counting recompilation (GCR) is enabled.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>