### PR TITLE
Add static symbol for constant pool address

### DIFF
--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -340,6 +340,9 @@ public:
    inline void setGCRPatchPoint();
    inline bool isGCRPatchPoint();
 
+   inline void setConstantPoolAddress();
+   inline bool isConstantPoolAddress();
+
    // flag methods specific to resolved
    //
    inline bool isJittedMethod();
@@ -507,6 +510,7 @@ public:
       StartPC                   = 0x04000000,
       CountForRecompile         = 0x02000000,
       RecompilationCounter      = 0x01000000,
+      ConstantPoolAddress       = 0x00800000,
       GCRPatchPoint             = 0x00400000,
 
       //Only Used by Symbols for which isResolvedMethod is true;

--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -641,6 +641,19 @@ OMR::Symbol::setConstMethodHandle()
    }
 
 bool
+OMR::Symbol::isConstantPoolAddress()
+   {
+   return self()->isStatic() && _flags.testAny(ConstantPoolAddress);
+   }
+
+void
+OMR::Symbol::setConstantPoolAddress()
+   {
+   TR_ASSERT(self()->isStatic(), "ConstantPoolAddress symbol has to be static");
+   _flags.set(ConstantPoolAddress);
+   }
+
+bool
 OMR::Symbol::isConstMethodHandle()
    {
    return self()->isStatic() && _flags2.testAny(ConstMethodHandle);

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1913,6 +1913,8 @@ TR_Debug::getStaticName(TR::SymbolReference * symRef)
          }
       return "unknown class object";
       }
+   else if (sym->isConstantPoolAddress())
+      return "<constant pool address>";
    else if (symRef->getCPIndex() >= 0)
       {
       if (sym->isAddressOfClassObject())


### PR DESCRIPTION
Create a static symbol to represent the constant pool address for a
resolved method so that a loadaddr node can be created when the CP
address is needed in trees and AOT can relocate the address value
correctly.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>