### PR TITLE
 TGC root scan time

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -350,6 +350,7 @@ public:
 	uintptr_t markingArraySplitMinimumAmount; /**< minimum number of elements to split array scanning work in marking scheme */
 
 	bool rootScannerStatsEnabled; /**< Enable/disable recording of performance statistics for the root scanner.  Defaults to false. */
+	bool rootScannerStatsUsed; /**< Flag that indicates if rootScannerStats are used for in the last increment (by any thread, for any of its roots) */
 
 	/* bools and counters for -Xgc:fvtest options */
 	bool fvtest_forceOldResize;
@@ -1331,6 +1332,7 @@ public:
 		, markingArraySplitMaximumAmount(DEFAULT_ARRAY_SPLIT_MAXIMUM_SIZE)
 		, markingArraySplitMinimumAmount(DEFAULT_ARRAY_SPLIT_MINIMUM_SIZE)
 		, rootScannerStatsEnabled(false)
+		, rootScannerStatsUsed(false)
 		, fvtest_forceOldResize(0)
 		, fvtest_oldResizeCounter(0)
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)

--- a/gc/stats/RootScannerStats.cpp
+++ b/gc/stats/RootScannerStats.cpp
@@ -36,6 +36,9 @@ MM_RootScannerStats::clear()
 	for (uintptr_t i = 0; i < RootScannerEntity_Count; i++) {
 		_entityScanTime[i] = 0;
 	}
+	_statsUsed = false;
+	_maxIncrementTime = 0;
+	_maxIncrementEntity = RootScannerEntity_None;
 }
 
 void

--- a/gc/stats/RootScannerStats.hpp
+++ b/gc/stats/RootScannerStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,7 +38,10 @@ class MM_RootScannerStats : public MM_Base
 {
 /* Data Members */
 public:
+	bool _statsUsed; /**< Flag that indicates if the owner thread used the stats for last increment (for any of its roots) */
 	uint64_t _entityScanTime[RootScannerEntity_Count]; /**< Time spent scanning each root scanner entity per thread.  Values of 0 indicate no time (regardless of clock resolution) spent scanning. */
+	uint64_t _maxIncrementTime;  /**< Longest increment */
+	RootScannerEntity _maxIncrementEntity; /**< Entity of the longest increment */
 	
 /* Function Members */
 public:


### PR DESCRIPTION
1) Flags for reducing  printing

Introduce two flags (global and per thread) that will assist in reducing
the amount of prints for TGC root scan time. They will be printed only
if any thread worked on any of roots for a given increment. This will be
particularly useful for Metronome (in OpenJ9) since stats are reported
for each GC increment, and most of increments do not deal with roots.

2) Max Increment time

Introduce fields root scan stats for max increment time and entity that
that owns that max increment. This values will be reported by
incremental GCs, like Metronome GC, where scan time spent for one entity
could span over several increments.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>