### PR TITLE
Revert "Add OMR::XXX::Machine::getXXXRealRegister()"

### DIFF
--- a/compiler/aarch64/codegen/OMRMachine.hpp
+++ b/compiler/aarch64/codegen/OMRMachine.hpp
@@ -67,16 +67,6 @@ public:
    Machine(TR::CodeGenerator *cg);
 
    /**
-    * @brief This method is the wrapper for \code getRealRegister.
-    * @param[in] regNum : register number
-    * @return RealRegister for specified register number
-    */
-   TR::RealRegister *getARM64RealRegister(TR::RealRegister::RegNum regNum)
-      {
-      return _registerFile[regNum];
-      }
-
-   /**
     * @brief Finds the best free register
     * @param[in] rk : register kind
     * @param[in] considerUnlatched : consider unlatched state or not

--- a/compiler/arm/codegen/OMRMachine.hpp
+++ b/compiler/arm/codegen/OMRMachine.hpp
@@ -79,15 +79,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    Machine(TR::CodeGenerator *cg);
 
-   /**
-    * @brief This method is the wrapper for \code getRealRegister.
-    * @param[in] regNum : register number
-    * @return RealRegister for specified register number
-    */
-   TR::RealRegister *getARMRealRegister(TR::RealRegister::RegNum regNum)
-      {
-      return _registerFile[regNum];
-      }
 
    TR::RealRegister *findBestFreeRegister(TR_RegisterKinds rk,
                                             bool excludeGPR0 = false,

--- a/compiler/p/codegen/OMRMachine.hpp
+++ b/compiler/p/codegen/OMRMachine.hpp
@@ -91,16 +91,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    TR::Register *setVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum, TR::Register * virtReg);
    TR::Register *getVirtualAssociatedWithReal(TR::RealRegister::RegNum regNum);
 
-   /**
-    * @brief This method is the wrapper for \code getRealRegister.
-    * @param[in] regNum : register number
-    * @return RealRegister for specified register number
-    */
-   TR::RealRegister *getPPCRealRegister(TR::RealRegister::RegNum regNum)
-      {
-      return _registerFile[regNum];
-      }
-
    TR::RealRegister *findBestFreeRegister(TR::Instruction *currentInstruction,
                                             TR_RegisterKinds rk,
 					    bool excludeGPR0 = false,

--- a/compiler/x/codegen/OMRMachine.hpp
+++ b/compiler/x/codegen/OMRMachine.hpp
@@ -138,16 +138,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
 
    uint8_t getNumberOfGPRs() { return _numGPRs; }
 
-   /**
-    * @brief This method is the wrapper for \code getRealRegister.
-    * @param[in] regNum : register number
-    * @return RealRegister for specified register number
-    */
-   TR::RealRegister *getX86RealRegister(TR::RealRegister::RegNum regNum)
-      {
-      return _registerFile[regNum];
-      }
-
    TR::RealRegister **cloneRegisterFile(TR::RealRegister **registerFile, TR_AllocationKind allocKind = heapAlloc);
 
    TR::RealRegister **captureRegisterFile();

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -3441,12 +3441,6 @@ OMR::Z::Linkage::trStackMemory()
    }
 
 TR::RealRegister *
-OMR::Z::Linkage::getS390RealRegister(TR::RealRegister::RegNum rNum)
-   {
-   return self()->cg()->machine()->getRealRegister(rNum);
-   }
-
-TR::RealRegister *
 OMR::Z::Linkage::getRealRegister(TR::RealRegister::RegNum rNum)
    {
    return self()->cg()->machine()->getRealRegister(rNum);

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -612,7 +612,6 @@ enum TR_DispatchType
    TR_HeapMemory        trHeapMemory();
    TR_StackMemory       trStackMemory();
 
-   TR::RealRegister *  getS390RealRegister(TR::RealRegister::RegNum rNum);
    TR::RealRegister *  getRealRegister(TR::RealRegister::RegNum rNum);
 
    TR::RealRegister::RegNum getFirstSavedRegister(int32_t fromreg, int32_t toreg);

--- a/compiler/z/codegen/OMRMachine.hpp
+++ b/compiler/z/codegen/OMRMachine.hpp
@@ -228,26 +228,6 @@ class OMR_EXTENSIBLE Machine : public OMR::Machine
    Machine(TR::CodeGenerator *cg);
 
    /**
-    * @brief This method is the wrapper for \code getRealRegister.
-    * @param[in] regNum : register number
-    * @return RealRegister for specified register number
-    */
-   TR::RealRegister *getS390RealRegister(TR::RealRegister::RegNum regNum)
-      {
-      return _registerFile[regNum];
-      }
-
-   /**
-    * @brief This method is the wrapper for \code getRealRegister.
-    * @param[in] regNum : register number
-    * @return RealRegister for specified register number
-    */
-   TR::RealRegister *getS390RealRegister(int32_t regNum)
-      {
-      return _registerFile[regNum];
-      }
-
-   /**
     * @brief Converts RegNum to RealRegister
     * @param[in] regNum : register number
     * @return RealRegister for specified register number


### PR DESCRIPTION
This reverts commits with titles such as "Add OMR::XXX::Machine::getXXXRealRegister()"

The wrapper methods 'getXXXRealRegister()' is not required since all
uses of the methods are changed to the 'getRealRegister()' one.

If the methods are still in the codebase, there forever will be a temptation for everyone to use a  platform specific method instead of the generic one.

The PR should be merged after eclipse/openj9#2936.