### PR TITLE
Perform wrtbar versioning conservatively

### DIFF
--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -286,6 +286,7 @@ class TR_LoopVersioner : public TR_LoopTransformer
 
    TR_PostDominators *_postDominators;
    bool _loopTransferDone;
+   bool _skipWrtbarVersion;
    };
 
 


### PR DESCRIPTION
If a GC point is triggered mid-loop, destination object of
the wrtbar can move/tenure. And if it is not remembered, upon return
from GC the remaining loop iterations will not run any wrtbars
since we had versioned them out. The fix here is to be conservative
when versioning wrtbars - for correctness, if there is a GC
point in the loop, wrtbar versioning will not be performed.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>