### PR TITLE
 Correctly fill 64-bit registers on 31-bit in OOL

### DIFF
--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -959,6 +959,11 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
                      break;
                   case TR_GPR:
                      opCode = TR::InstOpCode::getLoadOpCode();
+                     
+                     if (virtReg->is64BitReg())
+                        {
+                        opCode = TR::InstOpCode::LG;
+                        }
                      break;
                   case TR_FPR:
                      opCode = TR::InstOpCode::LD;
@@ -970,12 +975,10 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
                      TR_ASSERT( 0, "\nRegister kind not supported in OOL spill\n");
                      break;
                   }
-
+               
                if (cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA) &&
                    rk != TR_FPR && rk != TR_VRF)
                   {
-                  opCode = virtReg->is64BitReg()? TR::InstOpCode::LG : TR::InstOpCode::L;
-
                   if (assignedReg->isHighWordRegister())
                      {
                      // virtReg was spilled to an HPR and now we need it spilled to stack

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -13907,10 +13907,7 @@ OMR::Z::TreeEvaluator::lRegLoadEvaluator(TR::Node * node, TR::CodeGenerator * cg
       }
 
    // GRA needs to tell LRA about the register type
-   if (cg->supportsHighWordFacility() && !comp->getOption(TR_DisableHighWordRA))
-      {
-      globalReg->setIs64BitReg(true);
-      }
+   globalReg->setIs64BitReg(true);
 
    return globalReg;
    }


### PR DESCRIPTION
When a register is spilled in the mainline but used in the out of line
(OOL) code section we are forced to perform a spill and a fill in the
OOL such that the register state remains the same on both paths of
execution.

The way this is handled on Z is that `SpilledReg` register dependencies
are added to the OOL entry label which represent the state of the
machine at the branch to the OOL entry label in the mainline.

Because a register may have been spilled in the mainline and used in
the OOL we must perform a fill (generate a load). When 64-bit registers
are available for use in 31-bit targets the register kind will be a
`TR_GPR64`, however currently the `is64BitReg` flags are not properly
set for these register kinds and as such we cannot use this flag as an
"end-all" answer to whether we should generate a 32-bit fill or a
64-bit fill (decision to use `L` vs. `LG` instructions).

Until this is resolved so that we use the `is64BitReg` flag on both
31-bit and 64-bit we must honor the decision made by the register kind
when doing a fill for an OOL section.

See OutOfLineCodeSection.hpp for more details on how local RA handles
OOL code sections.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>