### PR TITLE
AArch64: Fix TreeEvaluatorTable.hpp for lucmpeq and lucmpne

### DIFF
--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -367,12 +367,14 @@ static TR::Register *lcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, TR::C
    return trgReg;
    }
 
+// also handles lucmpeq
 TR::Register *
 OMR::ARM64::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return lcmpHelper(node, TR::CC_EQ, cg);
    }
 
+// also handles lucmpne
 TR::Register *
 OMR::ARM64::TreeEvaluator::lcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
@@ -248,8 +248,8 @@
     TR::TreeEvaluator::lcmpgeEvaluator, // TR::lcmpge		// long compare if greater than or equal
     TR::TreeEvaluator::lcmpgtEvaluator, // TR::lcmpgt		// long compare if greater than
     TR::TreeEvaluator::lcmpleEvaluator, // TR::lcmple		// long compare if less than or equal
-    TR::TreeEvaluator::lucmpeqEvaluator, // TR::lucmpeq		// unsigned long compare if equal
-    TR::TreeEvaluator::lucmpneEvaluator, // TR::lucmpne		// unsigned long compare if not equal
+    TR::TreeEvaluator::lcmpeqEvaluator, // TR::lucmpeq		// unsigned long compare if equal
+    TR::TreeEvaluator::lcmpneEvaluator, // TR::lucmpne		// unsigned long compare if not equal
     TR::TreeEvaluator::lucmpltEvaluator, // TR::lucmplt		// unsigned long compare if less than
     TR::TreeEvaluator::lucmpgeEvaluator, // TR::lucmpge		// unsigned long compare if greater than or equal
     TR::TreeEvaluator::lucmpgtEvaluator, // TR::lucmpgt		// unsigned long compare if greater than


### PR DESCRIPTION
This commit fixes the TreeEvaluator table for aarch64.
lcmpeq/lcmpneEvaluator also handles lucmpeq and lucmpne.

Signed-off-by: knn-k <konno@jp.ibm.com>