### PR TITLE
Add C++ wrappers for OMR global singletons

### DIFF
--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -39,3 +39,7 @@ function(omr_add_gc_test testname)
 		COMMAND "${testname}"
 	)
 endfunction(omr_add_gc_test)
+
+omr_add_gc_test(TestPlatformInterface)
+omr_add_gc_test(TestRuntime)
+omr_add_gc_test(TestThreadingInterface)

--- a/fvtest/gc_api_test/TestPlatformInterface.cpp
+++ b/fvtest/gc_api_test/TestPlatformInterface.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/PlatformInterface.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+
+TEST(TestPlatformInterface, StartupPlatformInterface)
+{
+	PlatformInterface platform;
+	EXPECT_EQ(OMR_ERROR_NONE, platform.initialize());
+	EXPECT_TRUE(platform.initialized());
+	platform.tearDown();
+	EXPECT_FALSE(platform.initialized());
+}
+
+} // namespace OMR

--- a/fvtest/gc_api_test/TestRuntime.cpp
+++ b/fvtest/gc_api_test/TestRuntime.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/Runtime.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+
+TEST(TestRuntime, StartupAndShutdown)
+{
+	Runtime runtime;
+	EXPECT_FALSE(runtime.initialized());
+	EXPECT_EQ(OMR_ERROR_NONE, runtime.initialize());
+	EXPECT_TRUE(runtime.initialized());
+	runtime.tearDown();
+	EXPECT_FALSE(runtime.initialized());
+}
+
+}  // namespace OMR

--- a/fvtest/gc_api_test/TestThreadingInterface.cpp
+++ b/fvtest/gc_api_test/TestThreadingInterface.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/Thread.hpp>
+#include <OMR/ThreadingInterface.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+
+TEST(TestThreadingInterface, StartupAndAttachThread)
+{
+	ThreadingInterface threading;
+	EXPECT_EQ(OMR_ERROR_NONE, threading.initialize());
+	EXPECT_TRUE(threading.initialized());
+
+	{
+		Thread self;
+		EXPECT_EQ(OMR_ERROR_NONE, self.attach(threading));
+		EXPECT_TRUE(self.attached());
+		self.detach();
+		EXPECT_FALSE(self.attached());
+	}
+
+	threading.tearDown();
+	EXPECT_FALSE(threading.initialized());
+}
+
+} // namespace OMR

--- a/gc/api/include/OMR/PlatformInterface.hpp
+++ b/gc/api/include/OMR/PlatformInterface.hpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_PLATFORMINTERFACE_HPP_)
+#define OMR_PLATFORMINTERFACE_HPP_
+
+#include <OMR/Thread.hpp>
+#include <OMR/ThreadingInterface.hpp>
+#include <assert.h>
+#include <omr.h>
+#include <omrcfg.h>
+#include <stdlib.h>
+
+namespace OMR
+{
+
+/// OMR Thread and Port Library Wrapper
+class PlatformInterface
+{
+public:
+	PlatformInterface() : _initialized(false) {}
+
+	~PlatformInterface() { assert(!_initialized); }
+
+	omr_error_t initialize()
+	{
+		assert(!_initialized);
+
+		// Threading
+
+		omr_error_t error = _threading.initialize();
+		if (error == OMR_ERROR_NONE) {
+			Thread self;
+			error = self.attach(_threading);
+			if (error == OMR_ERROR_NONE) {
+				error = (omr_error_t)omrport_init_library(&library(), sizeof(OMRPortLibrary));
+				self.detach();
+				if (error == OMR_ERROR_NONE) {
+					_initialized = true;
+				} else {
+					_threading.tearDown();
+				}
+			} else {
+				_threading.tearDown();
+			}
+		}
+		return error;
+	}
+
+	void tearDown()
+	{
+		if (_initialized) {
+			Thread self;
+			self.attach(_threading);
+			library().port_shutdown_library(&library());
+			self.detach();
+			_threading.tearDown();
+			_initialized = false;
+		}
+	}
+
+	bool initialized() const { return _initialized; }
+
+	OMRPortLibrary& library() { return _library; }
+
+	const OMRPortLibrary& library() const { return _library; }
+
+	const ThreadingInterface& threading() const { return _threading; }
+
+private:
+	ThreadingInterface _threading;
+	OMRPortLibrary _library;
+	bool _initialized;
+};
+
+} // namespace OMR
+
+#endif // OMR_PLATFORMINTERFACE_HPP_

--- a/gc/api/include/OMR/Runtime.hpp
+++ b/gc/api/include/OMR/Runtime.hpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_RUNTIME_HPP_)
+#define OMR_RUNTIME_HPP_
+
+#include <OMR/PlatformInterface.hpp>
+#include <omr.h>
+#include <omrcfg.h>
+#include <string.h>
+
+namespace OMR
+{
+
+/// The runtime is for initializing OMR globals.
+/// Users may only create a single runtime in each process. The runtime must be initalized and torn down manually.
+class Runtime
+{
+public:
+	Runtime() : _platform(), _data(), _initialized(false) {}
+
+	~Runtime() { assert(!initialized()); }
+
+	/// Initialize the process runtime.
+	omr_error_t initialize()
+	{
+		assert(!_initialized);
+		omr_error_t error = OMR_ERROR_NONE;
+		error = _platform.initialize();
+		if (error == OMR_ERROR_NONE) {
+			memset(&_data, 0, sizeof(OMR_Runtime));
+			_data._configuration._maximum_vm_count = 0;
+			_data._vmCount = 0;
+			_data._vmList = nullptr;
+			_data._portLibrary = &platform().library();
+			error = omr_initialize_runtime(&_data);
+			if (error == OMR_ERROR_NONE) {
+				_initialized = true;
+			} else {
+				_platform.tearDown();
+			}
+		}
+		return error;
+	}
+
+	void tearDown()
+	{
+		if (_initialized) {
+			omr_destroy_runtime(&_data);
+			_platform.tearDown();
+			_initialized = false;
+		}
+	}
+
+	bool initialized() const { return _initialized; }
+
+	PlatformInterface& platform() { return _platform; }
+
+	const PlatformInterface& platform() const { return _platform; }
+
+	OMR_Runtime& data() { return _data; }
+
+	const OMR_Runtime& data() const { return _data; }
+
+private:
+	PlatformInterface _platform;
+	OMR_Runtime _data;
+	bool _initialized;
+};
+
+} // namespace OMR
+
+#endif // OMR_RUNTIME_HPP_

--- a/gc/api/include/OMR/Thread.hpp
+++ b/gc/api/include/OMR/Thread.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_THREAD_HPP_)
+#define OMR_THREAD_HPP_
+
+#include <OMR/ThreadingInterface.hpp>
+#include <omrcfg.h>
+
+namespace OMR
+{
+
+class Thread
+{
+public:
+	Thread() : _attached(false) {}
+
+	~Thread() { assert(!_attached); }
+
+	omr_error_t attach(const ThreadingInterface& threading)
+	{
+		assert(threading.initialized());
+		omr_error_t error = (omr_error_t)omrthread_attach_ex(&_self, J9THREAD_ATTR_DEFAULT);
+		if (error == OMR_ERROR_NONE) {
+			_attached = true;
+		}
+		return error;
+	}
+
+	void detach()
+	{
+		if (_attached) {
+			omrthread_detach(_self);
+			_attached = false;
+		}
+	}
+
+	bool attached() const { return _attached; }
+
+	omrthread_t data() { return _self; }
+
+	const omrthread_t data() const { return _self; }
+
+private:
+	omrthread_t _self;
+	bool _attached;
+};
+
+} // namespace OMR
+
+#endif // OMR_THREAD_HPP_

--- a/gc/api/include/OMR/ThreadingInterface.hpp
+++ b/gc/api/include/OMR/ThreadingInterface.hpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_THREADINGINTERFACE_HPP_)
+#define OMR_THREADINGINTERFACE_HPP_
+
+#include <assert.h>
+#include <omr.h>
+#include <omrcfg.h>
+#include <thread_api.h>
+
+namespace OMR
+{
+
+/// OMR Thread library wrapper.
+class ThreadingInterface
+{
+public:
+	ThreadingInterface() : _initialized(false) {}
+
+	~ThreadingInterface() { assert(!_initialized); }
+
+	omr_error_t initialize()
+	{
+		assert(!_initialized);
+		omr_error_t error = (omr_error_t)omrthread_init_library();
+		if (error == OMR_ERROR_NONE) {
+			_initialized = true;
+		}
+		return error;
+	}
+
+	void tearDown()
+	{
+		if (_initialized) {
+			omrthread_shutdown_library();
+			_initialized = false;
+		}
+	}
+
+	bool initialized() const { return _initialized; }
+
+private:
+	bool _initialized;
+};
+
+} // namespace OMR
+
+#endif // OMR_THREADINGINTERFACE_HPP_


### PR DESCRIPTION
This PR adds three utilities:
1. Runtime: Wraps up the Platform interface and the OMR_Runtime.
2. PlatformInterface: Wrapper for the port library and the threading interface
3. ThreadingInterface / Thread: Wrapper for the thread library.

OMR::Runtime bundles together the global singletons which every VM-level class (GC, JIT, RAS, etc) would depend on.

Signed-off-by: Robert Young <rwy0717@gmail.com>