### PR TITLE
Add ErrorCode, ErrorCategory, Unique(Singleton)

### DIFF
--- a/fvtest/coretest/CMakeLists.txt
+++ b/fvtest/coretest/CMakeLists.txt
@@ -38,5 +38,7 @@ function(omr_add_core_test testname)
 endfunction(omr_add_core_test)
 
 omr_add_core_test(TestBytes)
+omr_add_core_test(TestErrorCode)
 omr_add_core_test(TestIntrusiveList)
 omr_add_core_test(TestTypeTraits)
+omr_add_core_test(TestUnique)

--- a/fvtest/coretest/TestErrorCode.cpp
+++ b/fvtest/coretest/TestErrorCode.cpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/ErrorCode.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR {
+
+class ExampleErrorCategory : public ErrorCategory
+{
+public:
+	virtual const char* message(int code) const {
+		const char* m = NULL;
+		switch(code) {
+		case 0:
+			m = "example: success";
+			break;
+		default:
+			m = "example: failure";
+			break;
+		}
+		return m;
+	}
+};
+
+static const ExampleErrorCategory EXAMPLE_ERROR_CATEGORY;
+
+TEST(TestErrorCategory, CompareCategories)
+{
+	const ExampleErrorCategory a;
+	const ExampleErrorCategory b;
+	EXPECT_EQ(a, a);
+	EXPECT_EQ(b, b);
+	EXPECT_NE(a, b);
+}
+
+TEST(TestErrorCategory, CheckGenericCategoryMessages)
+{
+	EXPECT_STREQ(GENERIC_ERROR_CATEGORY.message(0), "success (generic)");
+	EXPECT_STREQ(GENERIC_ERROR_CATEGORY.message(1), "failure (generic)");
+	EXPECT_STREQ(GENERIC_ERROR_CATEGORY.message(-1), "failure (generic)");
+}
+
+TEST(TestErrorCategory, CheckExampleCategoryMessages)
+{
+	EXPECT_STREQ(EXAMPLE_ERROR_CATEGORY.message(0), "example: success");
+	EXPECT_STREQ(EXAMPLE_ERROR_CATEGORY.message(1), "example: failure");
+	EXPECT_STREQ(EXAMPLE_ERROR_CATEGORY.message(-1), "example: failure");
+}
+
+TEST(TestErrorCode, NoError)
+{
+	const ErrorCode error(0);
+
+	EXPECT_EQ(error.value(), 0);
+	EXPECT_EQ(error.category(), GENERIC_ERROR_CATEGORY);
+	EXPECT_TRUE(error.ok());
+	EXPECT_FALSE(error.bad());
+}
+
+TEST(TestErrorCode, DefaultError)
+{
+	const ErrorCode error(1);
+	EXPECT_TRUE(error.bad());
+	EXPECT_FALSE(error.ok());
+	EXPECT_EQ(error.category(), GENERIC_ERROR_CATEGORY);
+}
+
+TEST(TestErrorCode, Copyable)
+{
+	const ErrorCode a(EXAMPLE_ERROR_CATEGORY, 42);
+	const ErrorCode b = a;
+
+	EXPECT_EQ(a, b);
+	EXPECT_EQ(a.value(), b.value());
+	EXPECT_EQ(a.category(), b.category());
+
+	EXPECT_TRUE(a.bad());
+	EXPECT_TRUE(b.bad());
+}
+
+TEST(TestErrorCode, Assignable)
+{
+	const ErrorCode a(EXAMPLE_ERROR_CATEGORY, 42);
+	ErrorCode b;
+	b = a;
+	EXPECT_EQ(a, b);
+	EXPECT_EQ(a.value(), b.value());
+	EXPECT_EQ(a.category(), b.category());
+}
+
+TEST(TestErrorCode, AssignValueOnly)
+{
+	ErrorCode error(EXAMPLE_ERROR_CATEGORY);
+	error = 1;
+	EXPECT_EQ(error.category(), EXAMPLE_ERROR_CATEGORY);
+	EXPECT_EQ(error.value(), 1);
+}
+
+TEST(TestErrorCode, Categorize)
+{
+	ErrorCode e;
+	e.categorize(EXAMPLE_ERROR_CATEGORY);
+	EXPECT_EQ(e.category(), EXAMPLE_ERROR_CATEGORY);
+}
+
+TEST(TestErrorCode, Message)
+{
+	EXPECT_STREQ(ErrorCode(EXAMPLE_ERROR_CATEGORY, 0).message(), "example: success");
+	EXPECT_STREQ(ErrorCode(EXAMPLE_ERROR_CATEGORY, 1).message(), "example: failure");
+	EXPECT_STREQ(ErrorCode(EXAMPLE_ERROR_CATEGORY, -1).message(), "example: failure");
+}
+
+}  // namespace OMR

--- a/fvtest/coretest/TestUnique.cpp
+++ b/fvtest/coretest/TestUnique.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/Unique.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+
+TEST(TestUnique, Compare)
+{
+	Unique a;
+	Unique b;
+
+	EXPECT_EQ(a, a);
+	EXPECT_EQ(b, b);
+	EXPECT_NE(a, b);
+}
+
+TEST(TestUnique, CopyCompare)
+{
+	Unique a;
+	Unique b = a;
+	EXPECT_NE(a, b);
+}
+
+}  // namespace OMR

--- a/include_core/OMR/ErrorCategory.hpp
+++ b/include_core/OMR/ErrorCategory.hpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+ 
+#if !defined(OMR_ERRORCATEGORY_HPP_)
+#define OMR_ERRORCATEGORY_HPP_
+
+#include <omrcfg.h>
+#include <OMR/UniqueSingleton.hpp>
+
+namespace OMR
+{
+
+/// An ErrorCategory is used to distinguish error codes from multiple sources.
+/// Each category is able to translate error codes into string messages.
+/// The ErrorCode is responsible for pairing a category with an integer code.
+///
+/// To define a new ErrorCategory, subclass this type and implement the message
+/// virtual member function. Create a const singleton instance of that type,
+/// using that as your category when creating ErrorCodes.
+///
+/// Category equivalence is determined by address/identity, so no two different
+/// objects will ever be equal. This means it is safe to reuse a single
+/// implementation for two different categories.
+///
+/// There exists one built-in category, GENERIC_ERROR_CATEGORY, which is
+/// generally used as a default when no category is used.
+class ErrorCategory : public UniqueSingleton
+{
+public:
+	ErrorCategory() {}
+
+	/// Convert a code to a message. The string is static, unowned data.
+	/// Subclasses implement this function to translate integer codes to
+	/// string messages. No default implementation.
+	virtual const char* message(int code) const = 0;
+};
+
+}  // namespace OMR
+
+#endif  // OMR_ERRORCATEGORY_HPP_

--- a/include_core/OMR/ErrorCode.hpp
+++ b/include_core/OMR/ErrorCode.hpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_ERRORCODE_HPP_)
+#define OMR_ERRORCODE_HPP_
+
+#include <omrcfg.h>
+#include <OMR/GenericErrorCategory.hpp>
+
+namespace OMR
+{
+
+/// An integer error code with an associated category.
+/// An error code of zero is considered to be a success, or non-error. Any other
+/// value indicates an error. The default category is the OMR::GENERIC_ERROR_CATEGORY.
+///
+/// The ErrorCategories are not 
+class ErrorCode
+{
+public:
+	ErrorCode() : _value(0), _category(&GENERIC_ERROR_CATEGORY) {}
+
+	explicit ErrorCode(int value) : _value(value), _category(&GENERIC_ERROR_CATEGORY) {}
+
+	explicit ErrorCode(const ErrorCategory& category) : _value(0), _category(&category) {}
+
+	ErrorCode(const ErrorCategory& category, int value) : _value(value), _category(&category) {}
+
+	ErrorCode(const ErrorCode& other) : _value(other.value()), _category(&other.category()) {}
+
+	int value() const { return _value; }
+
+	const ErrorCategory& category() const { return *_category; }
+
+	/// Set the category
+	ErrorCode& categorize(const ErrorCategory& category)
+	{
+		_category = &category;
+		return *this;
+	}
+
+	/// Compare two ErrorCodes.
+	/// For two ErrorCodes to be equal, they must have the same code and category.
+	/// To check just the value, use one of value(), ok(), or bad().
+	bool operator==(const ErrorCode& rhs) const
+	{
+		return _value == rhs.value() && _category == &rhs.category();
+	}
+
+	bool operator!=(const ErrorCode& rhs) const
+	{
+		return _value != rhs.value() && _category != &rhs.category();
+	}
+
+	/// Assign only the value, leaving the category unchanged.
+	ErrorCode& operator=(int value)
+	{
+		_value = value;
+		return *this;
+	}
+
+	/// Assign both the category and the value.
+	ErrorCode& operator=(const ErrorCode& other)
+	{
+		_value = other.value();
+		_category = &other.category();
+		return *this;
+	}
+
+	/// Zero the error code and reset the category to default.
+	void clear()
+	{
+		_value = 0;
+		_category = &GENERIC_ERROR_CATEGORY;
+	}
+
+	/// Convert the error code to a message using the error category.
+	/// The returned string is static constant data.
+	const char* message() const { return category().message(value()); }
+
+	/// True if the error code is zero.
+	bool ok() const { return value() == 0; }
+
+	/// True if the error code is nonzero.
+	bool bad() const { return value() != 0; }
+
+private:
+	int _value;
+	const ErrorCategory* _category;
+};
+
+}  // namespace OMR
+
+#endif // OMR_ERRORCODE_HPP_

--- a/include_core/OMR/GenericErrorCategory.hpp
+++ b/include_core/OMR/GenericErrorCategory.hpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_GENERICERRORCATEGORY_HPP_)
+#define OMR_GENERICERRORCATEGORY_HPP_
+
+#include <OMR/ErrorCategory.hpp>
+
+namespace OMR
+{
+
+/// A basic error category used by default in an ErrorCode.
+class GenericErrorCategory : public ErrorCategory {
+public:
+	virtual const char* message(int code) const;
+};
+
+/// The singleton instance of the generic error category.
+extern const GenericErrorCategory GENERIC_ERROR_CATEGORY;
+
+}  // namespace OMR
+
+#endif // OMR_GENERICERRORCATEGORY_HPP_

--- a/include_core/OMR/PlatformErrorCategory.hpp
+++ b/include_core/OMR/PlatformErrorCategory.hpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_PLATFORMERRORCATEGORY_HPP_)
+#define OMR_PLATFORMERRORCATEGORY_HPP_
+
+#include <omrcfg.h>
+#include <omr.h>
+#include <OMR/ErrorCategory.hpp>
+
+namespace OMR
+{
+
+/// The port or thread library error category.
+class PlatformErrorCategory : public ErrorCategory
+{
+	virtual const char* message(int code) const;
+};
+
+/// The singleton platform ErrorCategory value.
+/// Used when an error is produced by the port or thread library.
+extern const PlatformErrorCategory PLATFORM_ERROR_CATEGORY;
+
+}  // namespace OMR
+
+#endif // OMR_PLATFORMERRORCATEGORY_HPP_

--- a/include_core/OMR/Unique.hpp
+++ b/include_core/OMR/Unique.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <omrcfg.h>
+
+#if !defined(OMR_UNIQUE_HPP_)
+#define OMR_UNIQUE_HPP_
+
+namespace OMR
+{
+
+/// Universally unique value.
+/// Unique objects are comparable to other unique values, but are equal only to
+/// themselves.
+class Unique
+{
+public:
+	Unique() {}
+
+	/// Compare if this object and the rhs are the same object, by
+	/// address/identity.
+	bool operator==(const Unique& rhs) const
+	{
+		return this == &rhs;
+	}
+
+	/// Compare if this category and the lhs are not the same object, by
+	//// address/identity.
+	bool operator!=(const Unique& rhs) const
+	{
+		return this != &rhs;
+	}
+};
+
+}  // namespace OMR
+
+#endif // OMR_UNIQUE_HPP_

--- a/include_core/OMR/UniqueSingleton.hpp
+++ b/include_core/OMR/UniqueSingleton.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_UNIQUESINGLETON_HPP_)
+#define OMR_UNIQUESINGLETON_HPP_
+
+#include <omrcfg.h>
+#include <OMR/Unique.hpp>
+
+namespace OMR
+{
+
+/// A static, globally unique constant.
+///
+/// UniqueSingletons are unique values that are not copyable, nor assignable.
+///
+/// This is a utility for creating globally unique constants. A library can
+/// extern a set of UniqueSingleton constants, which can be compared to
+/// constants in other libraries. In some ways, UniqueSingletons represent
+/// an alternative way to achieve extensible enumerations.
+class UniqueSingleton : public Unique
+{
+public:
+	UniqueSingleton() : Unique() {}
+
+private:
+	UniqueSingleton(const UniqueSingleton&);
+
+	UniqueSingleton& operator=(const UniqueSingleton&);
+};
+
+}  // namespace OMR
+
+#endif // OMR_UNIQUESINGLETON_HPP_

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -46,6 +46,8 @@ add_tracegen(utilcore.tdf j9utilcore)
 
 add_library(omrutil_obj OBJECT
 	ut_j9utilcore.c
+	omr-GenericErrorCategory.cpp
+	omr-PlatformErrorCategory.cpp
 )
 
 target_include_directories(omrutil_obj

--- a/util/omrutil/omr-GenericErrorCategory.cpp
+++ b/util/omrutil/omr-GenericErrorCategory.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <omrcfg.h>
+#include <OMR/GenericErrorCategory.hpp>
+#include <stddef.h>
+
+namespace OMR
+{
+
+const char* GenericErrorCategory::message(int code) const
+{
+	const char* msg = NULL;
+	switch (code) {
+	case 0:
+		msg = "success (generic)";
+		break;
+	default:
+		msg = "failure (generic)";
+		break;
+	}
+	return msg;
+}
+
+const GenericErrorCategory GENERIC_ERROR_CATEGORY;
+
+} // namespace OMR

--- a/util/omrutil/omr-PlatformErrorCategory.cpp
+++ b/util/omrutil/omr-PlatformErrorCategory.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2018 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <omrcfg.h> 
+#include <OMR/PlatformErrorCategory.hpp>
+#include <stddef.h>
+
+namespace OMR
+{
+
+const char *PlatformErrorCategory::message(int code) const
+{
+	const char *msg = NULL;
+	switch (code) {
+	case OMR_ERROR_NONE:
+		msg = "OMR_ERROR_NONE";
+		break;
+	case OMR_ERROR_OUT_OF_NATIVE_MEMORY:
+		msg = "OMR_ERROR_OUT_OF_NATIVE_MEMORY";
+		break;
+	case OMR_ERROR_FAILED_TO_ATTACH_NATIVE_THREAD:
+		msg = "OMR_ERROR_FAILED_TO_ATTACH_NATIVE_THREAD";
+		break;
+	case OMR_ERROR_MAXIMUM_VM_COUNT_EXCEEDED:
+		msg = "OMR_ERROR_MAXIMUM_VM_COUNT_EXCEEDED";
+		break;
+	case OMR_ERROR_MAXIMUM_THREAD_COUNT_EXCEEDED:
+		msg = "OMR_ERROR_MAXIMUM_THREAD_COUNT_EXCEEDED";
+		break;
+	case OMR_THREAD_STILL_ATTACHED:
+		msg = "OMR_THREAD_STILL_ATTACHED";
+		break;
+	case OMR_VM_STILL_ATTACHED:
+		msg = "OMR_VM_STILL_ATTACHED";
+		break;
+	case OMR_ERROR_FAILED_TO_ALLOCATE_MONITOR:
+		msg = "OMR_ERROR_FAILED_TO_ALLOCATE_MONITOR";
+		break;
+	case OMR_ERROR_INTERNAL:
+		msg = "OMR_ERROR_INTERNAL";
+		break;
+	case OMR_ERROR_ILLEGAL_ARGUMENT:
+		msg = "OMR_ERROR_ILLEGAL_ARGUMENT";
+		break;
+	case OMR_ERROR_NOT_AVAILABLE:
+		msg = "OMR_ERROR_NOT_AVAILABLE";
+		break;
+	case OMR_THREAD_NOT_ATTACHED:
+		msg = "OMR_THREAD_NOT_ATTACHED";
+		break;
+	case OMR_ERROR_FILE_UNAVAILABLE:
+		msg = "OMR_ERROR_FILE_UNAVAILABLE";
+		break;
+	case OMR_ERROR_RETRY:
+		msg = "OMR_ERROR_RETRY";
+		break;
+	default :
+		msg = "Unknown error!";
+		break;
+	}
+	return msg;
+}
+
+const PlatformErrorCategory PLATFORM_ERROR_CATEGORY;
+
+}  // namespace OMR


### PR DESCRIPTION
OMR has a lot of independent components, and a lot of sources of error.
There is no single view / enum of all possible errors across all
components. In the VM startup, this is a particular problem, because the
VM is responsible for initializing all other OMR components. The VM
needs to communicate what component failed, and how.

This PR adds a new ErrorCode and ErrorCategory utility to OMR. Each
instance of the ErrorCategory class is a static global singleton.
ErrorCategory values are comparable by identity (address), so are only
equal to themselves.  This allows each component (or even OMR consumers)
to create their own globally unique ErrorCategory values, without any
centralized coordination.

The ErrorCode class associates an integer code with an ErrorCategory,
and can be used as a more general error code. Through it's category,
it's possible to translate an ErrorCode to a string using the message()
member function.

ErrorCode and ErrorCategory's design is based off the C++11 std
error_condition and error_category. The differences are:

0. OMR-style naming.
1. No bool operator for ErrorCode. Instead, use the member functions
   ok(), bad(), or just test the error's value().
2. ErrorCategories translate error codes into static const char* data,
   rather than return a std::string, which we can not use.
3. No special support for enum classes, which our compilers don't yet
   support.

As long as OMR does not link against the standard library, we
will not be able to use std error_code.

The ErrorCategory is built off a new Unique utility, which is a general
utility class for defining globally unique values. In the future, Unique
could be used to create new kinds of extensibility in OMR.

Signed-off-by: Robert Young <rwy0717@gmail.com>