### PR TITLE
Fix IlBuilder::NotEqualTo for floating-point NaNs

### DIFF
--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -257,7 +257,7 @@ OMR::ILOpCode::compareOpCode(TR::DataType dt,
             switch(ct)
                {
                case TR_cmpEQ: return TR::fcmpeq;
-               case TR_cmpNE: return TR::fcmpne;
+               case TR_cmpNE: return TR::fcmpneu;
                case TR_cmpLT: return TR::fcmplt;
                case TR_cmpLE: return TR::fcmple;
                case TR_cmpGT: return TR::fcmpgt;
@@ -271,7 +271,7 @@ OMR::ILOpCode::compareOpCode(TR::DataType dt,
             switch(ct)
                {
                case TR_cmpEQ: return TR::dcmpeq;
-               case TR_cmpNE: return TR::dcmpne;
+               case TR_cmpNE: return TR::dcmpneu;
                case TR_cmpLT: return TR::dcmplt;
                case TR_cmpLE: return TR::dcmple;
                case TR_cmpGT: return TR::dcmpgt;


### PR DESCRIPTION
Previously, the IlBuilder::NotEqualTo service was generating fcmpne and
dcmpne opcodes when comparing floating-point values. However, these
opcodes return false when their operands are unordered with respect to
each other (i.e. when one or both are NaN). This result is unexpected
and is almost never what a JitBuilder user wants to generate, as the
IEEE 754 standard (whose behaviour is mandated by many languages) says
that non-equality should return true for unordered operands.

The fcmpneu and dcmpneu opcodes do exhibit the expected behaviour with
regards to unordered operands. Thus, in order to better conform to user
expectations, IlBuilder::NotEqualTo will now emit those opcodes instead
when comparing floating-point values.

Fixes: #3206
Signed-off-by: Ben Thomas <ben@benthomas.ca>