### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,8 @@
 /compiler/ @0xdaryl @mstoodle
 /compiler/optimizer/ @vijaysun-omr
 /compiler/il/ @vijaysun-omr @Leonardo2718
+/compiler/arm/ @0xdaryl
+/compiler/aarch64/ @0xdaryl
 /compiler/z/ @fjeremic
 
 # JitBuilder
@@ -52,7 +54,10 @@
 # Thread Library
 /thread/ @charliegracie
 
+# OMR Core Utilities
+/include_core/OMR/ @youngar @charliegracie @Leonardo2718
+
 # Tril and Testing
-/test/tril/ @Leonardo2718 @fjeremic @0xdaryl
-/test/compilertriltest/ @Leonardo2718 @fjeremic @0xdaryl
-/test/jitbuildertest/ @mstoodle @charliegracie @Leonardo2718
+/fvtest/tril/ @Leonardo2718 @fjeremic @0xdaryl
+/fvtest/compilertriltest/ @Leonardo2718 @fjeremic @0xdaryl
+/fvtest/jitbuildertest/ @mstoodle @charliegracie @Leonardo2718


### PR DESCRIPTION
- Made @0xdaryl an owner of the `compiler/arm` and `compiler/aarch64`
  directories
- Made @youngar @charliegracie @Leonardo2718 owners of the new
  `include_core/OMR` utilities direcotry
- Corrected root path to tests directory: `/test/ -> /fvtest/`

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>