### PR TITLE
Add OMR::GC::Handle<T> value type

### DIFF
--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -39,3 +39,5 @@ function(omr_add_gc_test testname)
 		COMMAND "${testname}"
 	)
 endfunction(omr_add_gc_test)
+
+omr_add_gc_test(TestHandle)

--- a/fvtest/gc_api_test/TestHandle.cpp
+++ b/fvtest/gc_api_test/TestHandle.cpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2019 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/GC/Handle.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+namespace GC
+{
+
+TEST(TestHandle, HandleToVoid)
+{
+	/* Ensure these types don't cause a compilation error. */
+	Handle<void> h0;
+	Handle<volatile void> h1;
+	Handle<const void> h2;
+	Handle<const volatile void> h3;
+}
+
+TEST(TestHandle, HandleToNull)
+{
+	void* root = NULL;
+	Handle<void> handle(&root);
+	EXPECT_EQ(handle, (void*)NULL);
+	EXPECT_EQ(handle.root(), &root);
+}
+
+TEST(TestHandle, HandleToInt)
+{
+	int referent = 123;
+	int* root = &referent;
+	Handle<int> handle(&root);
+	EXPECT_EQ(*handle, referent);
+	EXPECT_EQ(handle, &referent);
+	*handle = 456;
+	EXPECT_EQ(referent, 456);
+}
+
+TEST(TestHandle, ReassignRoot)
+{
+	int a = 123;
+	int b = 456;
+	int* root = &a;
+	Handle<int> handle(&root);
+	EXPECT_EQ(a, *handle);
+	EXPECT_EQ(&a, handle);
+	root = &b;
+	EXPECT_EQ(b, *handle);
+	EXPECT_EQ(&b, handle);
+}
+
+TEST(TestHandle, Assign)
+{
+	int referent = 123;
+	int* root = &referent;
+	Handle<int> a(&root);
+	Handle<int> b;
+
+	b = a;
+	EXPECT_EQ(a, b);
+	EXPECT_EQ(a.get(), b.get());
+	EXPECT_EQ(a.root(), b.root());
+
+	*b = 456;
+	EXPECT_EQ(*a, 456);
+}
+
+TEST(TestHandle, ConvertingAssign)
+{
+	int referent = 123;
+	int* root = &referent;
+	Handle<int> a(&root);
+	Handle<const int> b;
+	b = a;
+	EXPECT_EQ(a, b);
+	EXPECT_EQ(a.get(), b.get());
+	EXPECT_EQ(a.root(), b.root());
+}
+
+struct IntPair
+{
+	int x;
+	int y;
+};
+
+TEST(TestHandle, HandleToStruct)
+{
+	IntPair referent = {1, 2};
+	IntPair* root = &referent;
+	Handle<IntPair> handle(&root);
+	EXPECT_EQ(handle->x, referent.x);
+	EXPECT_EQ(handle->y, referent.y);
+}
+
+TEST(TestHandle, ConvertingConstruct)
+{
+	int referent = 123;
+	int* root = &referent;
+	Handle<int> a(&root);
+	Handle<const int> b = a;
+	EXPECT_EQ(*a, *b);
+	EXPECT_EQ(a, b);
+	EXPECT_EQ(a.root(), b.root());
+}
+
+}  /* namespace GC */
+}  /* namespace OMR */

--- a/gc/api/include/OMR/GC/Handle.hpp
+++ b/gc/api/include/OMR/GC/Handle.hpp
@@ -169,4 +169,4 @@ operator!=(T* lhs, Handle<U> rhs)
 } /* namespace GC */
 } /* namespace OMR */
 
-#endif // OMR_GC_HANDLE_HPP_
+#endif /* OMR_GC_HANDLE_HPP_ */

--- a/gc/api/include/OMR/GC/Handle.hpp
+++ b/gc/api/include/OMR/GC/Handle.hpp
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2019 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMR_GC_HANDLE_HPP_)
+#define OMR_GC_HANDLE_HPP_
+
+#include <OMR/TypeTraits.hpp>
+#include <cstddef>
+#include <omrcfg.h>
+
+namespace OMR
+{
+namespace GC
+{
+
+template <typename T>
+class HandleBase
+{
+public:
+	HandleBase() {}
+
+	HandleBase(T* const volatile* root) : _root(root) {}
+
+	/**
+	 * Convert this Handle to a raw indirect pointer. The address of the rooting slot.
+	 */
+	T* const volatile* root() const { return this->_root; }
+
+	/**
+	 * Convert this Handle to a raw pointer.
+	 */
+	T* get() const { return *_root; }
+
+protected:
+	T* const volatile* _root;
+};
+
+template <typename T, bool DEFINE_OPERATORS = !IsVoid<T>::VALUE>
+class HandlePtrOps;
+
+template <typename T>
+class HandlePtrOps<T, true> : public HandleBase<T>
+{
+public:
+	HandlePtrOps() : HandleBase<T>() {}
+
+	HandlePtrOps(T* const volatile* root) : HandleBase<T>(root) {}
+
+	T& operator*() const { return *this->get(); }
+
+	T* operator->() const { return this->get(); }
+};
+
+template <typename T>
+class HandlePtrOps<T, false> : public HandleBase<T>
+{
+public:
+	HandlePtrOps() : HandleBase<T>() {}
+
+	HandlePtrOps(T* const volatile* root) : HandleBase<T>(root) {}
+};
+
+/**
+ * The Handle<T> provides pointer semantics by indirecting through roots.
+ *
+ * A Handle<T> is associated with a single root slot, such as an instance of StackRoot<T>. When a Handle<T> is
+ * dereferenced, it will access the target indirectly through the associated root. Because Handles always indirect
+ * through roots, they are safe to hold across a collection. A Handle is invalid when it's root is destroyed. Handles
+ * are fast and flexible to use, but care must be taken so a Handle does not outlive it's root.
+ */
+template <typename T>
+class Handle : public HandlePtrOps<T>
+{
+public:
+	/**
+	 * Uninitialized handle object. Very dangerous.
+	 */
+	Handle() : HandlePtrOps<T>() {}
+
+	template <typename U>
+	explicit Handle(U* const volatile* root) : HandlePtrOps<T>(root)
+	{}
+
+	/**
+	 * Disabled when T = U, where we rely on the implicit copy constructor.
+	 */
+	template <typename U, typename = typename EnableIf<!IsSame<T, U>::VALUE>::Type>
+	Handle(const Handle<U>& other) : HandlePtrOps<T>(other.root())
+	{}
+};
+
+/**
+ * Compare the address of the referents. Note that two Handles with different roots, but pointing at the same object,
+ * are considered equal.
+ */
+template <typename T, typename U>
+bool
+operator==(Handle<T> lhs, Handle<U> rhs)
+{
+	return lhs.get() == rhs.get();
+}
+
+/**
+ * Compare the address of the referents.
+ */
+template <typename T, typename U>
+bool
+operator!=(Handle<T> lhs, Handle<U> rhs)
+{
+	return lhs.get() != rhs.get();
+}
+
+/**
+ * Compare the address of the referent to a pointer.
+ */
+template <typename T, typename U>
+bool
+operator==(Handle<T> lhs, U* rhs)
+{
+	return lhs.get() == rhs;
+}
+
+/**
+ * Compare the address of the referent to a pointer.
+ */
+template <typename T, typename U>
+bool
+operator!=(Handle<T> lhs, U* rhs)
+{
+	return lhs.get() != rhs;
+}
+
+/**
+ * Compare the address of the referent.
+ */
+template <typename T, typename U>
+bool
+operator==(T* lhs, Handle<U> rhs)
+{
+	return lhs == rhs.get();
+}
+
+template <typename T, typename U>
+bool
+operator!=(T* lhs, Handle<U> rhs)
+{
+	return lhs != rhs.get();
+}
+
+} /* namespace GC */
+} /* namespace OMR */
+
+#endif // OMR_GC_HANDLE_HPP_


### PR DESCRIPTION
Handle<T> is a pointer-like value that indirects through an externally
rooted slot. This allows users to pass rooted gc-references through
function calls, independently of how the object is actually rooted.  The
main utility of this class is that it _signifies_ that the caller has
rooted the parameters of a function.

It is possible for Handle<T>'s to outlive their roots, which is an
extremely dangerous error. In the future, we may chose to add "handle
counting" to specialized root structures, to ensure there are no
outstanding handles when a root dies.

Another potential future enhancement would be to parameterize the root
type, to allow for different gc-reference encodings. The value of doing
this is questionable though, since the main function of the handle is to
hide the rooting mechanism, and doing this puts it right into the type.

Signed-off-by: Robert Young <rwy0717@gmail.com>