### PR TITLE
Add RefSlotHandle types to GC

### DIFF
--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -39,3 +39,5 @@ function(omr_add_gc_test testname)
 		COMMAND "${testname}"
 	)
 endfunction(omr_add_gc_test)
+
+omr_add_gc_test(TestRefSlotHandle)

--- a/fvtest/gc_api_test/TestRefSlotHandle.cpp
+++ b/fvtest/gc_api_test/TestRefSlotHandle.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2019 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <OMR/GC/RefSlotHandle.hpp>
+#include <OMR/GC/CompressedRefSlotHandle.hpp>
+#include <gtest/gtest.h>
+
+namespace OMR
+{
+namespace GC
+{
+
+TEST(TestRefSlotHandle, ReadFromRefSlot)
+{
+	omrobjectptr_t slot = (omrobjectptr_t)42;
+	RefSlotHandle handle(&slot);
+	EXPECT_EQ(handle.toAddress(), &slot);
+	EXPECT_EQ(handle.readReference(), slot);
+}
+
+TEST(TestRefSlotHandle, WriteToRefSlot)
+{
+	const omrobjectptr_t DATA = (omrobjectptr_t)42;
+
+	omrobjectptr_t slot = (omrobjectptr_t)0;
+	RefSlotHandle handle(&slot);
+	handle.writeReference(DATA);
+	EXPECT_EQ(handle.readReference(), DATA);
+	EXPECT_EQ(slot, DATA);
+}
+
+#if defined(OMR_ENV_DATA64)
+
+TEST(TestCompressedRefSlotHandle, ReadFromCompressedRefSlot)
+{
+	const size_t SHIFT = 2;
+	const uint32_t DATA = 42 << SHIFT;
+
+	uint32_t slot = DATA >> SHIFT;
+	CompressedRefSlotHandle handle(&slot, SHIFT);
+	EXPECT_EQ(handle.toAddress(), &slot);
+	EXPECT_EQ(handle.readReference(), (omrobjectptr_t)DATA);
+}
+
+TEST(TestCompressedRefSlotHandle, WriteToCompressedRefSlot)
+{
+	const size_t SHIFT = 2;
+	const omrobjectptr_t DATA = (omrobjectptr_t)(42 << SHIFT);
+
+	uint32_t slot = 0;
+	CompressedRefSlotHandle handle(&slot, SHIFT);
+	handle.writeReference(DATA);
+	EXPECT_EQ(handle.readReference(), DATA);
+	EXPECT_EQ(slot, (uint32_t)(((uint64_t)DATA) >> SHIFT));
+}
+
+#endif  /* OMR_ENV_DATA64 */
+
+}  /* namespace GC */
+}  /* namespace OMR */

--- a/gc/api/include/OMR/GC/CompressedRefSlotHandle.hpp
+++ b/gc/api/include/OMR/GC/CompressedRefSlotHandle.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2019 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_GC_COMPRESSEDREFSLOTHANDLE_HPP_
+#define OMR_GC_COMPRESSEDREFSLOTHANDLE_HPP_
+
+#include <objectdescription.h>
+#include <omrcfg.h>
+#include <stdint.h>
+
+namespace OMR
+{
+namespace GC
+{
+
+#if defined(OMR_ENV_DATA64)
+
+class CompressedRefSlotHandle
+{
+public:
+	CompressedRefSlotHandle(uint32_t* slot, uint32_t shift) : _slot(slot), _shift(shift) {}
+
+	void* toAddress() const { return _slot; }
+
+	omrobjectptr_t readReference() const { return decode(*_slot, _shift); }
+
+	void writeReference(omrobjectptr_t value) const { *_slot = encode(value, _shift); }
+
+private:
+	static omrobjectptr_t
+	decode(uint32_t data, uint32_t shift)
+	{
+		return (omrobjectptr_t)(((uint64_t)data) << shift);
+	}
+
+	static uint32_t
+	encode(omrobjectptr_t data, uint32_t shift)
+	{
+		return (uint32_t)(((uint64_t)(data)) >> shift);
+	}
+
+	uint32_t* _slot;
+	uint32_t _shift;
+};
+
+#endif /* defined(OMR_ENV_DATA64) */
+
+} /* namespace GC */
+} /* namespace OMR */
+
+#endif /* OMR_GC_COMPRESSEDREFSLOTHANDLE_HPP_ */

--- a/gc/api/include/OMR/GC/RefSlotHandle.hpp
+++ b/gc/api/include/OMR/GC/RefSlotHandle.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *  Copyright (c) 2018, 2019 IBM and others
+ *
+ *  This program and the accompanying materials are made available under
+ *  the terms of the Eclipse Public License 2.0 which accompanies this
+ *  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ *  or the Apache License, Version 2.0 which accompanies this distribution and
+ *  is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  This Source Code may also be made available under the following
+ *  Secondary Licenses when the conditions for such availability set
+ *  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ *  General Public License, version 2 with the GNU Classpath
+ *  Exception [1] and GNU General Public License, version 2 with the
+ *  OpenJDK Assembly Exception [2].
+ *
+ *  [1] https://www.gnu.org/software/classpath/license.html
+ *  [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_GC_REFSLOTHANDLE_HPP_
+#define OMR_GC_REFSLOTHANDLE_HPP_
+
+#include "omrcfg.h"
+#include "objectdescription.h"
+
+namespace OMR
+{
+namespace GC
+{
+
+/**
+ * A handle to a reference-slot. Similar to an `Object**`.
+ */
+class RefSlotHandle
+{
+public:
+	explicit RefSlotHandle(omrobjectptr_t* slot) : _slot(slot) {}
+
+	void* toAddress() const { return _slot; }
+
+	omrobjectptr_t readReference() const { return *_slot; }
+
+	void writeReference(omrobjectptr_t value) const { *_slot = value; }
+
+private:
+	omrobjectptr_t* _slot;
+};
+
+} /* namespace GC */
+} /* namespace OMR */
+
+#endif /* OMR_GC_REFSLOTHANDLE_HPP_ */


### PR DESCRIPTION
The RefSlotHandle is "A handle to a reference-slot in an object". The
RefSlotHandle is a default implementation of a SlotHandle for bare,
unencoded gc-references.

This PR also adds a CompressedRefSlotHandle, for working with compressed
references. The reference shift is dynamic.

In the future, these classes will be used by OMR client's object
scanners to give the GC read-write capabilities on objects.

Signed-off-by: Robert Young <rwy0717@gmail.com>