### PR TITLE
Add more type traits to OMR/TypeTraits.hpp to support JitBuilder and Tril

### DIFF
--- a/fvtest/coretest/TestTypeTraits.cpp
+++ b/fvtest/coretest/TestTypeTraits.cpp
@@ -172,6 +172,22 @@ TEST(TestTypeTraits, IsIntegral)
 	EXPECT_FALSE((IsIntegral<int&>::VALUE));
 }
 
+TEST(TestTypeTraits, IsFloatingPoint)
+{
+	EXPECT_TRUE((IsFloatingPoint<float>::VALUE));
+	EXPECT_TRUE((IsFloatingPoint<double>::VALUE));
+	EXPECT_TRUE((IsFloatingPoint<long double>::VALUE));
+	EXPECT_TRUE((IsFloatingPoint<const float>::VALUE));
+	EXPECT_TRUE((IsFloatingPoint<volatile float>::VALUE));
+	EXPECT_TRUE((IsFloatingPoint<const volatile float>::VALUE));
+	EXPECT_FALSE((IsFloatingPoint<int>::VALUE));
+	EXPECT_FALSE((IsFloatingPoint<long long>::VALUE));
+	EXPECT_FALSE((IsFloatingPoint<void>::VALUE));
+	EXPECT_FALSE((IsFloatingPoint<bool>::VALUE));
+	EXPECT_FALSE((IsFloatingPoint<float*>::VALUE));
+	EXPECT_FALSE((IsFloatingPoint<double&>::VALUE));
+}
+
 template <typename T>
 typename EnableIf<IsSame<T, int>::VALUE, bool>::Type sillyIsInt(T x)
 {

--- a/fvtest/coretest/TestTypeTraits.cpp
+++ b/fvtest/coretest/TestTypeTraits.cpp
@@ -23,6 +23,9 @@
 #include <OMR/TypeTraits.hpp>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <stdint.h>
+
 namespace OMR
 {
 
@@ -144,6 +147,29 @@ TEST(TestTypeTraits, IsVoid)
 	EXPECT_FALSE((IsVoid<const volatile int>::VALUE));
 
 	EXPECT_FALSE((IsVoid<void*>::VALUE));
+}
+
+TEST(TestTypeTraits, IsIntegral)
+{
+	EXPECT_TRUE((IsIntegral<bool>::VALUE));
+	EXPECT_TRUE((IsIntegral<char>::VALUE));
+	EXPECT_TRUE((IsIntegral<unsigned char>::VALUE));
+	EXPECT_TRUE((IsIntegral<signed char>::VALUE));
+	EXPECT_TRUE((IsIntegral<unsigned short>::VALUE));
+	EXPECT_TRUE((IsIntegral<long>::VALUE));
+	EXPECT_TRUE((IsIntegral<unsigned long long>::VALUE));
+	EXPECT_TRUE((IsIntegral<const int8_t>::VALUE));
+	EXPECT_TRUE((IsIntegral<volatile uint16_t>::VALUE));
+	EXPECT_TRUE((IsIntegral<const volatile size_t>::VALUE));
+	EXPECT_TRUE((IsIntegral<intmax_t>::VALUE));
+	EXPECT_TRUE((IsIntegral<intptr_t>::VALUE));
+	EXPECT_TRUE((IsIntegral<uintmax_t>::VALUE));
+	EXPECT_TRUE((IsIntegral<uintptr_t>::VALUE));
+	EXPECT_FALSE((IsIntegral<float>::VALUE));
+	EXPECT_FALSE((IsIntegral<double>::VALUE));
+	EXPECT_FALSE((IsIntegral<void>::VALUE));
+	EXPECT_FALSE((IsIntegral<int*>::VALUE));
+	EXPECT_FALSE((IsIntegral<int&>::VALUE));
 }
 
 template <typename T>

--- a/fvtest/coretest/TestTypeTraits.cpp
+++ b/fvtest/coretest/TestTypeTraits.cpp
@@ -98,6 +98,17 @@ TEST(TestTypeTraits, RemoveCvRef)
 	// TODO: EXPECT_TRUE((IsSame<int, RemoveCvRef<int&&>::Type>::VALUE));
 }
 
+TEST(TestTypeTraits, RemovePointer)
+{
+	EXPECT_TRUE((IsSame<int, RemovePointer<int>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemovePointer<int*>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemovePointer<int* const>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemovePointer<int* volatile>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int, RemovePointer<int* const volatile>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<const volatile int, RemovePointer<const volatile int * const volatile>::Type>::VALUE));
+	EXPECT_TRUE((IsSame<int*&, RemovePointer<int*&>::Type>::VALUE));
+}
+
 TEST(TestTypeTraits, IsReference)
 {
 	EXPECT_FALSE((IsReference<int>::VALUE));

--- a/fvtest/coretest/TestTypeTraits.cpp
+++ b/fvtest/coretest/TestTypeTraits.cpp
@@ -188,6 +188,20 @@ TEST(TestTypeTraits, IsFloatingPoint)
 	EXPECT_FALSE((IsFloatingPoint<double&>::VALUE));
 }
 
+TEST(TestTypeTraits, IsArithmetic)
+{
+	EXPECT_TRUE((IsArithmetic<int>::VALUE));
+	EXPECT_TRUE((IsArithmetic<unsigned long>::VALUE));
+	EXPECT_TRUE((IsArithmetic<long double>::VALUE));
+	EXPECT_TRUE((IsArithmetic<uintptr_t>::VALUE));
+	EXPECT_TRUE((IsArithmetic<const double>::VALUE));
+	EXPECT_TRUE((IsArithmetic<volatile float>::VALUE));
+	EXPECT_TRUE((IsArithmetic<const volatile bool>::VALUE));
+	EXPECT_FALSE((IsArithmetic<float *>::VALUE));
+	EXPECT_FALSE((IsArithmetic<int&>::VALUE));
+	EXPECT_FALSE((IsArithmetic<void>::VALUE));
+}
+
 template <typename T>
 typename EnableIf<IsSame<T, int>::VALUE, bool>::Type sillyIsInt(T x)
 {

--- a/fvtest/tril/tril/ast.hpp
+++ b/fvtest/tril/tril/ast.hpp
@@ -26,7 +26,6 @@
 
 #include "OMR/TypeTraits.hpp"
 
-#include <type_traits>
 #include <assert.h>
 #include <cstring>
 
@@ -41,8 +40,8 @@
  *
  * Type name     | Used for              | Compatible with (C++ types)
  * --------------|-----------------------|--------------------------------------
- * Integer       | integral values       | any type satisfying `std::is_integral`
- * FloatingPoint | floating point values | any type satisfying `std::is_floating_point`
+ * Integer       | integral values       | any type satisfying `OMR::IsIntegral`/`std::is_integral`
+ * FloatingPoint | floating point values | any type satisfying `OMR::IsFloatingPoint`/`std::is_floating_point`
  * String        | character strings     | `const char*`
  *
  * Names for these types are defined in the ASTType enum.
@@ -106,17 +105,17 @@ struct ASTValue {
      */
 
     template <typename T>
-    typename OMR::EnableIf<std::is_integral<T>::value , T>::Type get() const {
+    typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE , T>::Type get() const {
         assert(Integer == _type);
         return static_cast<T>(_value.integer);
     }
     template <typename T>
-    typename OMR::EnableIf<std::is_floating_point<T>::value, T>::Type get() const {
+    typename OMR::EnableIf<OMR::IsFloatingPoint<T>::VALUE, T>::Type get() const {
         assert(FloatingPoint == _type);
         return static_cast<T>(_value.floatingPoint);
     }
     template <typename T>
-    typename OMR::EnableIf<std::is_same<String_t, T>::value, T>::Type get() const {
+    typename OMR::EnableIf<OMR::IsSame<String_t, T>::VALUE, T>::Type get() const {
         assert(String == _type);
         return static_cast<T>(_value.str);
     }
@@ -154,15 +153,15 @@ struct ASTValue {
      */
 
     template <typename T>
-    typename OMR::EnableIf<std::is_integral<T>::value , bool>::type isCompatibleWith() const {
+    typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE , bool>::Type isCompatibleWith() const {
         return Integer == _type;
     }
     template <typename T>
-    typename OMR::EnableIf<std::is_floating_point<T>::value, bool>::type isCompatibleWith() const {
+    typename OMR::EnableIf<OMR::IsFloatingPoint<T>::VALUE, bool>::Type isCompatibleWith() const {
         return FloatingPoint == _type;
     }
     template <typename T>
-    typename OMR::EnableIf<std::is_same<String_t, T>::value, bool>::type isCompatibleWith() const {
+    typename OMR::EnableIf<OMR::IsSame<String_t, T>::VALUE, bool>::Type isCompatibleWith() const {
         return String == _type;
     }
 

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -146,6 +146,32 @@ struct IsPointer : IsPointerBase<typename RemoveCv<T>::Type> {};
 template <typename T>
 struct IsVoid : IsSame<typename RemoveCv<T>::Type, void> {};
 
+/// IsNonCvIntegral<T>::VALUE is true if T is a non-cv-qualified primitive integral type
+///
+/// Note: Unlike `std::is_integral`, any compiler-defined extended integer types are not
+/// supported by IsNonCvIntegral.
+template <typename T>
+struct IsNonCvIntegral : FalseConstant {};
+
+template <> struct IsNonCvIntegral<bool> : TrueConstant {};
+template <> struct IsNonCvIntegral<char> : TrueConstant {};
+template <> struct IsNonCvIntegral<signed char> : TrueConstant {};
+template <> struct IsNonCvIntegral<unsigned char> : TrueConstant {};
+template <> struct IsNonCvIntegral<short> : TrueConstant {};
+template <> struct IsNonCvIntegral<int> : TrueConstant {};
+template <> struct IsNonCvIntegral<long> : TrueConstant {};
+template <> struct IsNonCvIntegral<long long> : TrueConstant {};
+template <> struct IsNonCvIntegral<unsigned short> : TrueConstant {};
+template <> struct IsNonCvIntegral<unsigned int> : TrueConstant {};
+template <> struct IsNonCvIntegral<unsigned long> : TrueConstant {};
+template <> struct IsNonCvIntegral<unsigned long long> : TrueConstant {};
+
+/// IsIntegral<T>::VALUE is true if T is a (possibly cv-qualified) primitive integral type.
+///
+/// (see note for IsNonCvIntegral)
+template <typename T>
+struct IsIntegral : IsNonCvIntegral<typename RemoveCv<T>::Type> {};
+
 ///
 /// Miscellaneous transformations
 ///

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -98,6 +98,17 @@ struct RemoveCvRef : RemoveCv<typename RemoveReference<T>::Type> {};
 // template <typename T>
 // struct RemoveCvRef<T&&> : RemoveCvRef<T> {};
 
+/// Remove one layer of non-cv-qualified pointers
+template <typename T>
+struct RemoveNonCvPointer : TypeAlias<T> {};
+
+template <typename T>
+struct RemoveNonCvPointer<T*> : TypeAlias<T> {};
+
+/// Remove one layer of possibly cv-qualified pointers
+template <typename T>
+struct RemovePointer : RemoveNonCvPointer<typename RemoveCv<T>::Type> {};
+
 ///
 /// Type reflection: statically query types
 ///

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -172,6 +172,18 @@ template <> struct IsNonCvIntegral<unsigned long long> : TrueConstant {};
 template <typename T>
 struct IsIntegral : IsNonCvIntegral<typename RemoveCv<T>::Type> {};
 
+/// IsNonCvFloatingPoint<T>::VALUE is true if T is a non-cv-qualified floating point type
+template <typename T>
+struct IsNonCvFloatingPoint : FalseConstant {};
+
+template <> struct IsNonCvFloatingPoint<float> : TrueConstant {};
+template <> struct IsNonCvFloatingPoint<double> : TrueConstant {};
+template <> struct IsNonCvFloatingPoint<long double> : TrueConstant {};
+
+/// IsFloatingPoint<T>::VALUE is tue if T is a (possibly cv-qualified) floating point type
+template <typename T>
+struct IsFloatingPoint : IsNonCvFloatingPoint<typename RemoveCv<T>::Type> {};
+
 ///
 /// Miscellaneous transformations
 ///

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -184,6 +184,10 @@ template <> struct IsNonCvFloatingPoint<long double> : TrueConstant {};
 template <typename T>
 struct IsFloatingPoint : IsNonCvFloatingPoint<typename RemoveCv<T>::Type> {};
 
+/// IsArithmetic<T>::VALUE is true if T is a (possibly cv-qualified) primtive integral or floating point type
+template <typename T>
+struct IsArithmetic : BoolConstant<IsIntegral<T>::VALUE || IsFloatingPoint<T>::VALUE> {};
+
 ///
 /// Miscellaneous transformations
 ///

--- a/include_core/OMR/TypeTraits.hpp
+++ b/include_core/OMR/TypeTraits.hpp
@@ -133,14 +133,14 @@ struct IsReference<T&> : TrueConstant {};
 
 /// Helper for IsPointer.
 template <typename T>
-struct IsPointerBase : FalseConstant {};
+struct IsNonCvPointer : FalseConstant {};
 
 template <typename T>
-struct IsPointerBase<T*> : TrueConstant {};
+struct IsNonCvPointer<T*> : TrueConstant {};
 
 /// IsPointer<T>::VALUE is true if T is a (possibly cv qualified) primitive pointer type.
 template <typename T>
-struct IsPointer : IsPointerBase<typename RemoveCv<T>::Type> {};
+struct IsPointer : IsNonCvPointer<typename RemoveCv<T>::Type> {};
 
 /// IsVoid<T>::VALUE is true if T is (possibly cv qualified) void.
 template <typename T>

--- a/jitbuilder/apigen/extras/cpp/TypeDictionaryExtrasInsideClass.hpp
+++ b/jitbuilder/apigen/extras/cpp/TypeDictionaryExtrasInsideClass.hpp
@@ -51,8 +51,8 @@
     */
    template <typename T>
    struct is_supported {
-      static const bool value =  std::is_arithmetic<T>::value // note: is_arithmetic = is_integral || is_floating_point
-                              || std::is_void<T>::value;
+      static const bool value =  OMR::IsArithmetic<T>::VALUE // note: IsArithmetic = IsIntegral || IsFloatingPoint
+                              || OMR::IsVoid<T>::VALUE;
    };
    template <typename T>
    struct is_supported<T*> {
@@ -104,14 +104,14 @@
     * rules that a type must follow to match a given function implementation.
     *
     * For integer and floating point types, the type traits library is used to
-    * identify the "family" of the specified type. For example, `std::is_integral<>`
+    * identify the "family" of the specified type. For example, `OMR::IsIntegral<>`
     * is used to identify all the integer types. The `sizeof` operator is then used
     * to determine the size of the specified type. The combination of the type's
     * family and size is used to select the function that gets selected.
     *
     * For types that do not belong to a family (e.g. `void`), the size is not needed.
     *
-    * For pointer types, `std::remove_pointer<>` is used to get the type being
+    * For pointer types, `OMR::RemovePointer<>` is used to get the type being
     * pointed to. Iff `is_supported<>::value` evaluates to true for this type,
     * then `toIlType<>()` is recursively called on it.
     *
@@ -121,15 +121,15 @@
     * ### Rule definition
     *
     * The rules for enable a template overload (described above) are defined
-    * using `std::enable_if<>`, where conditional enabling is achieved using
-    * SFINAE. The field `std::enable_if<>::type` is used as the type of the
+    * using `OMR::EnableIf<>`, where conditional enabling is achieved using
+    * SFINAE. The field `OMR::EnableIf<>::Type` is used as the type of the
     * anonymous argument in `toIlType<>()`.
     *
     * All definitions take the following form:
     *
     * ```c++
     * template <typename T>
-    * void toIlType(typename std::enable_if<THE CONDITION>::type* = 0) {...}
+    * void toIlType(typename OMR::EnableIf<THE CONDITION>::Type* = 0) {...}
     * ```
     *
     * and have the same signature: `void(void*)`. Calls to `toIlType<>()`
@@ -168,29 +168,29 @@
 
    // integral
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 1)>::type* = 0) { return Int8; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE && (sizeof(T) == 1)>::Type* = 0) { return Int8; }
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 2)>::type* = 0) { return Int16; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE && (sizeof(T) == 2)>::Type* = 0) { return Int16; }
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 4)>::type* = 0) { return Int32; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE && (sizeof(T) == 4)>::Type* = 0) { return Int32; }
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_integral<T>::value && (sizeof(T) == 8)>::type* = 0) { return Int64; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsIntegral<T>::VALUE && (sizeof(T) == 8)>::Type* = 0) { return Int64; }
 
    // floating point
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_floating_point<T>::value && (sizeof(T) == 4)>::type* = 0) { return Float; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsFloatingPoint<T>::VALUE && (sizeof(T) == 4)>::Type* = 0) { return Float; }
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_floating_point<T>::value && (sizeof(T) == 8)>::type* = 0) { return Double; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsFloatingPoint<T>::VALUE && (sizeof(T) == 8)>::Type* = 0) { return Double; }
 
    // void
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_void<T>::value>::type* = 0) { return NoType; }
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsVoid<T>::VALUE>::Type* = 0) { return NoType; }
 
    // pointer
    template <typename T>
-   IlType* toIlType(typename std::enable_if<std::is_pointer<T>::value && is_supported<typename std::remove_pointer<T>::type>::value>::type* = 0)
+   IlType* toIlType(typename OMR::EnableIf<OMR::IsPointer<T>::VALUE && is_supported<typename OMR::RemovePointer<T>::Type>::value>::Type* = 0)
       {
-      return PointerTo(toIlType<typename std::remove_pointer<T>::type>());
+      return PointerTo(toIlType<typename OMR::RemovePointer<T>::Type>());
       }
 
 #endif // !defined(TYPEDICTIONARY_EXTRAS_INSIDE_CLASS_INCL)

--- a/jitbuilder/apigen/extras/cpp/TypeDictionaryExtrasOutsideClass.hpp
+++ b/jitbuilder/apigen/extras/cpp/TypeDictionaryExtrasOutsideClass.hpp
@@ -22,7 +22,7 @@
 #ifndef TYPEDICTIONARY_EXTRAS_OUTSIDE_CLASS_INCL
 #define TYPEDICTIONARY_EXTRAS_OUTSIDE_CLASS_INCL
 
-#include <type_traits>
+#include <OMR/TypeTraits.hpp>
 
 /**
  * @brief Convenience API for defining JitBuilder structs from C/C++ structs (PODs)

--- a/jitbuilder/release/cpp/Makefile
+++ b/jitbuilder/release/cpp/Makefile
@@ -1,19 +1,19 @@
 ###############################################################################
 # Copyright (c) 2000, 2017 IBM Corp. and others
-#  
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#       
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#     
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
@@ -25,7 +25,7 @@
 CC?=gcc
 CXX?=g++
 # one glorious day we can remove -Wno-write-strings
-CXXFLAGS=-g -std=c++0x -O0 -c -fno-rtti -fPIC -I./include -Wno-write-strings
+CXXFLAGS=-g -std=c++0x -O0 -c -fno-rtti -fPIC -I./include -I../../../include_core -Wno-write-strings
 
 .SUFFIXES: .cpp .o
 
@@ -144,14 +144,14 @@ Call.o: $(SAMPLE_SRC)/Call.cpp $(SAMPLE_SRC)/Call.hpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
-conditionals : $(LIBJITBUILDER) Conditionals.o	
+conditionals : $(LIBJITBUILDER) Conditionals.o
 	$(CXX) -g -fno-rtti -o $@ Conditionals.o -L$(LIBJITBUILDERDIR) -ljitbuilder -ldl
 
 Conditionals.o: $(SAMPLE_SRC)/Conditionals.cpp $(SAMPLE_SRC)/Conditionals.hpp
 	$(CXX) -o $@ $(CXXFLAGS) $<
 
 
-conststring : $(LIBJITBUILDER) ConstString.o	
+conststring : $(LIBJITBUILDER) ConstString.o
 	$(CXX) -g -fno-rtti -o $@ ConstString.o -L$(LIBJITBUILDERDIR) -ljitbuilder -ldl
 
 ConstString.o: $(SAMPLE_SRC)/ConstString.cpp $(SAMPLE_SRC)/ConstString.hpp


### PR DESCRIPTION
This changeset adds the following type traits:

- IsIntegral: replaces `std::is_integral`
- IsFloatingPoint: replaces `std::is_floating_point`
- IsArithmetic: replaces `std::is_arithmetic`
- RemovePoineter: replaces `std::remove_pointer`

In addition, the JitBuilder `toIlType` and `is_supported` services and Tril implementation are refactored to make use of these newly implemented utilities, breaking their dependency on the C++11 `type_traits` standard library.

Closes #3323