### PR TITLE
AArch64: Remove redundant call to decFutureUseCount()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -296,12 +296,6 @@ void TR::ARM64MemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssig
       }
    mref->unblockRegisters();
 
-   if (sourceVirtual->decFutureUseCount() == 0)
-      {
-      sourceVirtual->setAssignedRegister(NULL);
-      assignedRegister->setState(TR::RealRegister::Unlatched);
-      }
-
    setSource1Register(assignedRegister);
 
    if (getDependencyConditions())


### PR DESCRIPTION
This commit fixes TR::ARM64MemSrc1Instruction::assignRegisters().
It calls decFutureUseCount() on sourceVirtual, but that is not
needed because assignOneRegister() has already done it.

Signed-off-by: knn-k <konno@jp.ibm.com>