### PR TITLE
 Read barrier verification

### DIFF
--- a/example/glue/GlobalCollectorDelegate.hpp
+++ b/example/glue/GlobalCollectorDelegate.hpp
@@ -136,7 +136,13 @@ public:
 	 * @param env environment for calling thread
 	 */
 	void prepareHeapForWalk(MM_EnvironmentBase *env) {}
-	
+
+	/* Read Barrier Verifier specific methods */
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	void poisonSlots(MM_EnvironmentBase *env) {}
+	void healSlots(MM_EnvironmentBase *env) {}
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+
 	/**
 	 * In order to allow the heap to remain walkable for diagnostics some fixup is required
 	 * after global collection. This method is called to allow the delegate to suppress fixup

--- a/gc/base/CollectorLanguageInterface.hpp
+++ b/gc/base/CollectorLanguageInterface.hpp
@@ -58,6 +58,12 @@ public:
 
 	virtual void kill(MM_EnvironmentBase *env) = 0;
 
+	/* Read Barrier Verifier specific methods */
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	virtual void scavenger_poisonSlots(MM_EnvironmentBase *env) {}
+	virtual void scavenger_healSlots(MM_EnvironmentBase *env) {}
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/**
 	 * This method will be called on the master GC thread after each scavenger cycle, successful or

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -38,6 +38,7 @@
 #include "GlobalGCStats.hpp"
 #include "GlobalVLHGCStats.hpp"
 #include "LargeObjectAllocateStats.hpp"
+#include "MemoryHandle.hpp"
 #include "MixedObjectModel.hpp"
 #include "NUMAManager.hpp"
 #include "OMRVMThreadListIterator.hpp"
@@ -262,6 +263,12 @@ public:
 	void* heapBaseForBarrierRange0;
 	uintptr_t heapSizeForBarrierRange0;
 
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	void* shadowHeapBase; 	/* Read Barrier Verifier shadow heap base address */
+	void* shadowHeapTop;	/* Read Barrier Verifier shadow heap base address */
+	MM_MemoryHandle shadowHeapHandle; /* Read Barrier Verifier shadow heap Virtual Memory handle (descriptor) */
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+
 	bool doOutOfLineAllocationTrace;
 	bool doFrequentObjectAllocationSampling; /**< Whether to track object allocations*/
 	uintptr_t oolObjectSamplingBytesGranularity; /**< How often (in bytes) we do an ool allocation trace */
@@ -376,6 +383,13 @@ public:
 
 	uintptr_t fvtest_forceSweepChunkArrayCommitFailure; /**< Force failure at Sweep Chunk Array commit operation */
 	uintptr_t fvtest_forceSweepChunkArrayCommitFailureCounter; /**< Force failure at Sweep Chunk Array commit operation counter */
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	uintptr_t fvtest_enableReadBarrierVerification; /**< Forces failure at all direct memory read sites */
+	uintptr_t fvtest_enableMonitorObjectsReadBarrierVerification; /**< Forces failure at all direct memory read sites for monitor slot objects */
+	uintptr_t fvtest_enableClassStaticsReadBarrierVerification; /**< Forces failure at all direct memory read sites for class statics */
+	uintptr_t fvtest_enableJNIGlobalWeakReadBarrierVerification; /**< Forces failure at all direct memory read sites for JNI Global weak references */
+	uintptr_t fvtest_enableHeapReadBarrierVerification; /**< Forces failure at all direct memory read sites for heap references */
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
 
 	uintptr_t fvtest_forceMarkMapCommitFailure; /**< Force failure at Mark Map commit operation */
 	uintptr_t fvtest_forceMarkMapCommitFailureCounter; /**< Force failure at Mark Map commit operation counter */
@@ -1264,6 +1278,11 @@ public:
 #endif /* OMR_GC_STACCATO */
 		, heapBaseForBarrierRange0(NULL)
 		, heapSizeForBarrierRange0(0)
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+		, shadowHeapBase(0)
+		, shadowHeapTop(0)
+		, shadowHeapHandle()
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
 		, doOutOfLineAllocationTrace(true) /* Tracing after ever x bytes allocated per thread. Enabled by default. */
 		, doFrequentObjectAllocationSampling(false) /* Finds most frequently allocated classes. Disabled by default. */
 		, oolObjectSamplingBytesGranularity(16*1024*1024) /* Default granularity set to 16M (shows <1% perf loss). */
@@ -1355,6 +1374,13 @@ public:
 		, fvtest_disableInlineAllocation(0)
 		, fvtest_forceSweepChunkArrayCommitFailure(0)
 		, fvtest_forceSweepChunkArrayCommitFailureCounter(0)
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+		, fvtest_enableReadBarrierVerification(0)
+		, fvtest_enableMonitorObjectsReadBarrierVerification(0)
+		, fvtest_enableClassStaticsReadBarrierVerification(0)
+		, fvtest_enableJNIGlobalWeakReadBarrierVerification(0)
+		, fvtest_enableHeapReadBarrierVerification(0)
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
 		, fvtest_forceMarkMapCommitFailure(0)
 		, fvtest_forceMarkMapCommitFailureCounter(0)
 		, fvtest_forceMarkMapDecommitFailure(0)

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -140,7 +140,7 @@ MM_HeapVirtualMemory::tearDown(MM_EnvironmentBase* env)
 		manager->destroyRegionTable(env);
 	}
 
-	memoryManager->destroyVirtualMemory(env, &_vmemHandle);
+	memoryManager->destroyVirtualMemoryForHeap(env, &_vmemHandle);
 
 	MM_Heap::tearDown(env);
 }

--- a/gc/base/MemoryManager.hpp
+++ b/gc/base/MemoryManager.hpp
@@ -167,6 +167,15 @@ public:
 	 * @param[in/out] handle pointer to memory handle
 	 */
 	void destroyVirtualMemory(MM_EnvironmentBase* env, MM_MemoryHandle* handle);
+	
+	/**
+	 * Destroy virtual memory instance, plus everything that is heap specific (for example, shadow heap)
+	 *
+	 * @param env environment
+	 * @param[in/out] handle pointer to memory handle
+	 */
+	void destroyVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryHandle* handle);
+	
 
 	/**
 	 * Commit memory for range for specified virtual memory instance

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -39,6 +39,13 @@
 #include "ParallelHeapWalker.hpp"
 #include "ParallelSweepScheme.hpp"
 
+/* Declaration of "C" style Read Barrier Verifier specific methods */
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+void poisonReferenceSlots(OMR_VMThread *omrVMThread, MM_HeapRegionDescriptor *region, omrobjectptr_t object, void *userData);
+void poisonReferenceSlot(MM_EnvironmentBase *env, GC_SlotObject *slotObject);
+void healReferenceSlot(MM_EnvironmentBase *env, GC_SlotObject *slotObject);
+void healReferenceSlots(OMR_VMThread *omrVMThread, MM_HeapRegionDescriptor *region, omrobjectptr_t object, void *userData);
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
 
 class MM_CollectionStatisticsStandard;
 class MM_CompactScheme;
@@ -260,6 +267,11 @@ public:
 
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
 	virtual void collectorShutdown(MM_GCExtensionsBase *extensions);
+
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	void poisonHeap(MM_EnvironmentBase *env);
+	void healHeap(MM_EnvironmentBase *env);
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
 
 	/**
 	 *  Fixes up all unloaded objects so that the heap can be walked and only live objects returned

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4025,6 +4025,12 @@ MM_Scavenger::getCollectorExpandSize(MM_EnvironmentBase *env)
 void
 MM_Scavenger::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	if (1 == _extensions->fvtest_enableReadBarrierVerification) {
+		scavenger_healSlots(env);
+	}
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+
 	env->_cycleState = &_cycleState;
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
@@ -4063,6 +4069,12 @@ MM_Scavenger::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *su
 	calcGCStats((MM_EnvironmentStandard*)env);
 
 	Assert_MM_true(env->_cycleState == &_cycleState);
+
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	if (1 == _extensions->fvtest_enableReadBarrierVerification) {
+		scavenger_poisonSlots(env);
+	}
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
 }
 
 /**
@@ -5081,3 +5093,18 @@ MM_Scavenger::completeConcurrentCycle(MM_EnvironmentBase *env)
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 #endif /* OMR_GC_MODRON_SCAVENGER */
+
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+void
+MM_Scavenger::scavenger_poisonSlots(MM_EnvironmentBase *env)
+{
+	/* This will poison only the root slots */
+	_cli->scavenger_poisonSlots(env);
+}
+void
+MM_Scavenger::scavenger_healSlots(MM_EnvironmentBase *env)
+{
+	/* This will heal only the root slots */
+	_cli->scavenger_healSlots(env);
+}
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -589,7 +589,13 @@ public:
 
 	static MM_Scavenger *newInstance(MM_EnvironmentStandard *env, MM_HeapRegionManager *regionManager);
 	virtual void kill(MM_EnvironmentBase *env);
-	
+
+	/* Read Barrier Verifier specific methods */
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	virtual void scavenger_poisonSlots(MM_EnvironmentBase *env);
+	virtual void scavenger_healSlots(MM_EnvironmentBase *env);
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
 	virtual void collectorShutdown(MM_GCExtensionsBase* extensions);
 

--- a/glue/CollectorLanguageInterfaceImpl.hpp
+++ b/glue/CollectorLanguageInterfaceImpl.hpp
@@ -64,6 +64,12 @@ public:
 	static MM_CollectorLanguageInterfaceImpl *newInstance(MM_EnvironmentBase *env);
 	virtual void kill(MM_EnvironmentBase *env);
 
+	/* Read Barrier Verifier specific methods */
+#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+	virtual void scavenger_poisonSlots(MM_EnvironmentBase *env);
+	virtual void scavenger_healSlots(MM_EnvironmentBase *env);
+#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+
 #if defined(OMR_GC_MODRON_COMPACTION)
 	virtual CompactPreventedReason parallelGlobalGC_checkIfCompactionShouldBePrevented(MM_EnvironmentBase *env) {return COMPACT_PREVENTED_NONE;}
 #endif /* OMR_GC_MODRON_COMPACTION */


### PR DESCRIPTION
Language independent infrastructure needed by
ReadBarierVerifier to catch direct memory reads. Along with creation and
destruction of shadow heap it includes healing and poisoning of memory
addresses before and after GC, respectively.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>