### PR TITLE
Get open file count at Mac OSX

### DIFF
--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1087,3 +1087,5 @@ TraceExit=Trc_PRT_signal_omrsig_is_signal_ignored_exiting Group=signal Overhead=
 TraceException=Trc_PRT_signal_unblockSignals_sigemptyset_failed Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal unblockSignals: sigemptyset failed with rc=%d and errno=%d"
 TraceException=Trc_PRT_signal_unblockSignals_sigaddset_failed Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal unblockSignals: sigaddset failed with signal=0x%X, rc=%d and errno=%d"
 TraceException=Trc_PRT_signal_unblockSignals_pthread_sigmask_failed Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal unblockSignals: pthread_sigmask failed with rc=%d and errno=%d"
+
+TraceException=Trc_PRT_sysinfo_get_open_file_count_memAllocFailed Group=sysinfo Overhead=1 Level=1 NoEnv Template="omrsysinfo_get_open_file_count: Error: memory allocation for proc_fdinfo failed."

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -34,6 +34,7 @@
 #define _GNU_SOURCE
 #elif defined(OSX)
 #define _XOPEN_SOURCE
+#include <libproc.h>
 #include <mach/mach.h>
 #include <mach/processor_info.h>
 #include <mach/mach_host.h>
@@ -3497,66 +3498,100 @@ setPortableError(OMRPortLibrary *portLibrary, const char *funcName, int32_t port
 int32_t
 omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *count)
 {
-	int32_t ret = 0;
-#if defined(LINUX) || defined(AIXPPC)
+	int32_t ret = -1;
 	uint64_t fdCount = 0;
-	char buffer[PATH_MAX] = {0};
-	const char *procDirectory = "/proc/%d/fd/";
-	struct dirent *dp = NULL;
-	DIR *dir = NULL;
 
 	Trc_PRT_sysinfo_get_open_file_count_Entry();
 	/* Check whether a valid pointee exists, to write to. */
 	if (NULL == count) {
 		portLibrary->error_set_last_error(portLibrary, EINVAL, findError(EINVAL));
 		Trc_PRT_sysinfo_get_open_file_count_invalidArgRecvd("count");
-		ret = -1;
-		goto leave_routine;
-	}
-	/* On Linux, "/proc/self" is as good as "/proc/<current-pid>/", but not on
-	 * AIX, where the current process's PID must be specified.
-	 */
-	portLibrary->str_printf(portLibrary, buffer, sizeof(buffer), procDirectory, getpid());
-	dir = opendir(buffer);
-	if (NULL == dir) {
-		int32_t rc = findError(errno);
-		portLibrary->error_set_last_error(portLibrary, errno, rc);
-		Trc_PRT_sysinfo_get_open_file_count_failedOpeningProcFS(rc);
-		ret = -1;
-		goto leave_routine;
-	}
-	/* opendir(3) was successful; look into the directory for fds. */
-	errno = 0; /* readdir(3) will set this, if an error occurs. */
-	dp = readdir(dir);
-	while (NULL != dp) {
-		/* Skip "." and ".." */
-		if (!(('.' == dp->d_name[0] && '\0' == dp->d_name[1])
-		||    ('.' == dp->d_name[0] && '.' == dp->d_name[1] && '\0' == dp->d_name[2]))
-		) {
-			fdCount++;
-		}
-		dp = readdir(dir);
-	}
-	/* readdir(3) would eventually return NULL; check whether there was an
-	 * error and readdir returned prematurely.
-	 */
-	if (0 != errno) {
-		int32_t rc = findError(errno);
-		portLibrary->error_set_last_error(portLibrary, errno, rc);
-		Trc_PRT_sysinfo_get_open_file_count_failedReadingProcFS(rc);
-		ret = -1;
 	} else {
-		/* Successfully counted up the files opened. */
-		*count = fdCount;
-		Trc_PRT_sysinfo_get_open_file_count_fileCount(fdCount);
-	}
-	closedir(dir); /* Done reading the /proc file-system. */
-leave_routine:
-	/* Clean-ups, setting-error (if any), etc, done. */
-#elif defined(OSX) || defined(J9ZOS390)
-	/* TODO: stub where z/OS || OSX code goes in. */
-	ret = OMRPORT_ERROR_SYSINFO_GET_OPEN_FILES_NOT_SUPPORTED;
+#if defined(LINUX) || defined(AIXPPC)
+		char buffer[PATH_MAX] = {0};
+		const char *procDirectory = "/proc/%d/fd/";
+		DIR *dir = NULL;
+
+		/* On Linux, "/proc/self" is as good as "/proc/<current-pid>/", but not on
+		 * AIX, where the current process's PID must be specified.
+		 */
+		portLibrary->str_printf(portLibrary, buffer, sizeof(buffer), procDirectory, getpid());
+		dir = opendir(buffer);
+		if (NULL == dir) {
+			int32_t rc = findError(errno);
+			portLibrary->error_set_last_error(portLibrary, errno, rc);
+			Trc_PRT_sysinfo_get_open_file_count_failedOpeningProcFS(rc);
+		} else {
+			struct dirent *dp = NULL;
+			/* opendir(3) was successful; look into the directory for fds. */
+			errno = 0; /* readdir(3) will set this, if an error occurs. */
+			dp = readdir(dir);
+			while (NULL != dp) {
+				/* Skip "." and ".." */
+				if (!(('.' == dp->d_name[0] && '\0' == dp->d_name[1])
+					|| ('.' == dp->d_name[0] && '.' == dp->d_name[1] && '\0' == dp->d_name[2]))
+				) {
+					fdCount++;
+				}
+				dp = readdir(dir);
+			}
+			/* readdir(3) would eventually return NULL; check whether there was an
+			 * error and readdir returned prematurely.
+			 */
+			if (0 != errno) {
+				int32_t rc = findError(errno);
+				portLibrary->error_set_last_error(portLibrary, errno, rc);
+				Trc_PRT_sysinfo_get_open_file_count_failedReadingProcFS(rc);
+			} else {
+				/* Successfully counted up the files opened. */
+				*count = fdCount;
+				Trc_PRT_sysinfo_get_open_file_count_fileCount(fdCount);
+				ret = 0;
+			}
+			closedir(dir); /* Done reading the /proc file-system. */
+		}
+#elif defined(OSX)
+		pid_t pid = getpid();
+		/* First call with null to get the size of the buffer required */
+		int32_t bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, 0, 0);
+		if (bufferSize <= 0) {
+			int32_t rc = findError(errno);
+			portLibrary->error_set_last_error(portLibrary, errno, rc);
+			Trc_PRT_sysinfo_get_open_file_count_failedReadingProcFS(rc);
+		} else {
+			struct proc_fdinfo *procFDInfo = (struct proc_fdinfo *) portLibrary->mem_allocate_memory(portLibrary, bufferSize, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+			if (NULL == procFDInfo) {
+				Trc_PRT_sysinfo_get_open_file_count_memAllocFailed();
+				portLibrary->error_set_last_error_with_message(portLibrary, OMRPORT_ERROR_SYSINFO_MEMORY_ALLOC_FAILED, "memory allocation for proc_fdinfo failed");
+			} else {
+				/* Second call with a buffer just allocated, retrieve those available proc_fdinfo instances */
+				int32_t retTmp = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, procFDInfo, bufferSize);
+				if (retTmp < 0) {
+					int32_t rc = findError(errno);
+					portLibrary->error_set_last_error(portLibrary, errno, rc);
+					Trc_PRT_sysinfo_get_open_file_count_failedReadingProcFS(rc);
+				} else {
+					int32_t i = 0;
+					int32_t numberOfProcFDs = bufferSize / PROC_PIDLISTFD_SIZE;
+					for (i = 0; i < numberOfProcFDs; i++) {
+						/* A file opened */
+						if (PROX_FDTYPE_VNODE == procFDInfo[i].proc_fdtype) {
+							fdCount++;
+						}
+					}
+					*count = fdCount;
+					Trc_PRT_sysinfo_get_open_file_count_fileCount(fdCount);
+					ret = 0;
+				}
+				portLibrary->mem_free_memory(portLibrary, procFDInfo);
+			}
+		}
+#elif defined(J9ZOS390)
+		/* TODO: stub where z/OS code goes in. */
+		ret = OMRPORT_ERROR_SYSINFO_GET_OPEN_FILES_NOT_SUPPORTED;
 #endif
+	}
+	
 	Trc_PRT_sysinfo_get_open_file_count_Exit(ret);
 	return ret;
 }


### PR DESCRIPTION
Get open file count at `Mac OSX`

Adding implementation to get open file count for `Mac OSX`;
Using `proc_pidinfo` twice to get the size of the buffer required and those available `proc_fdinfo` instances.
Note: `Mac OSX` doesn't have Linux/AIX alike `/proc/%d/fd/`
Manually verified that this PR fixes the test failure at https://github.com/eclipse/openj9/issues/3970. Also verified that this PR doesn't break other platforms (`xa/wa/mz/ap`) via a personal build.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>