### PR TITLE
AArch64: Remove TR::ARM64ConditionalBranchInstruction::assignRegisters()

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -23,17 +23,6 @@
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/RegisterDependency.hpp"
 
-// TR::ARM64ConditionalBranchInstruction:: member functions
-
-void TR::ARM64ConditionalBranchInstruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
-   {
-   if (getDependencyConditions())
-      {
-      getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
-      getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());
-      }
-   }
-
 // TR::ARM64Trg1Instruction:: member functions
 
 bool TR::ARM64Trg1Instruction::refsRegister(TR::Register *reg)

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -444,12 +444,6 @@ class ARM64ConditionalBranchInstruction : public ARM64LabelInstruction
       }
 
    /**
-    * @brief Assigns registers
-    * @param[in] kindToBeAssigned : register kind
-    */
-   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
-
-   /**
     * @brief Generates binary encoding of the instruction
     * @return instruction cursor
     */


### PR DESCRIPTION
This commit removes redundant assignRegisters()
from TR::ARM64ConditionalBranchInstruction, because
OMR::ARM64::Instruction::assignRegisters() does the work.

Signed-off-by: knn-k <konno@jp.ibm.com>