### PR TITLE
Fix logic error in #3337

### DIFF
--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -958,11 +958,13 @@ TR_S390RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstru
                      opCode = TR::InstOpCode::LG;
                      break;
                   case TR_GPR:
-                     opCode = TR::InstOpCode::getLoadOpCode();
-                     
                      if (virtReg->is64BitReg())
                         {
                         opCode = TR::InstOpCode::LG;
+                        }
+                     else
+                        {
+                        opCode = TR::InstOpCode::L;
                         }
                      break;
                   case TR_FPR:


### PR DESCRIPTION
On 64-bit platforms #3337 unintentionally changed the semantics of OOL
spill reload logic. The `TR::InstOpCode::getLoadOpCode()` API returns a
64-bit load on 64-bit targets, which means if the spilled register was
32-bit the logic in #3337 made it so that we would never use a 32-bit
load to fill the register.

We correct this by avoiding the use of the aforementioned API and
instead simplify the logic to use a 32-bit load unless the register is
marked as a 64-bit register. This will be correct on both 31-bit and
64-bit targets.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>