### PR TITLE
AArch64: Add ARM64ImmSymInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -56,6 +56,37 @@ uint8_t *TR::ARM64ImmInstruction::generateBinaryEncoding()
    return cursor;
    }
 
+uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+
+   if (getOpCodeValue() == TR::InstOpCode::bl)
+      {
+      uintptrj_t destination = getAddrImmediate();
+      intptrj_t distance = destination - (uintptrj_t)cursor;
+
+      if (constantIsSignedImm28(distance))
+         {
+         insertImmediateField(toARM64Cursor(cursor), distance);
+         }
+      else
+         {
+         TR_ASSERT(false, "Branch destination is too far away. Not implemented yet.");
+         }
+      }
+   else
+      {
+      TR_ASSERT(false, "Unsupported opcode in ImmSymInstruction.");
+      }
+
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
 uint8_t *TR::ARM64LabelInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -479,6 +479,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsImm:
          print(pOutFile, (TR::ARM64ImmInstruction *)instr);
          break;
+      case OMR::Instruction::IsImmSym:
+         print(pOutFile, (TR::ARM64ImmSymInstruction *)instr);
+         break;
       case OMR::Instruction::IsLabel:
          print(pOutFile, (TR::ARM64LabelInstruction *)instr);
          break;
@@ -567,6 +570,23 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ImmInstruction *instr)
    {
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t0x%08x", getOpCodeName(&instr->getOpCode()), instr->getSourceImmediate());
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ImmSymInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+
+   TR::Symbol *target = instr->getSymbolReference()->getSymbol();
+   const char *name = target ? getName(instr->getSymbolReference()) : 0;
+   if (name)
+      trfprintf(pOutFile, "%s \t" POINTER_PRINTF_FORMAT "\t\t; Direct Call \"%s\"", getOpCodeName(&instr->getOpCode()), instr->getAddrImmediate(), name);
+   else
+      trfprintf(pOutFile, "%s \t" POINTER_PRINTF_FORMAT, getOpCodeName(&instr->getOpCode()), instr->getAddrImmediate());
+
+   if (instr->getDependencyConditions())
+      print(pOutFile, instr->getDependencyConditions());
    trfflush(_comp->getOutFile());
    }
 

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -67,6 +67,15 @@ TR::Instruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::M
    return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, relocationKind, sr, cg);
    }
 
+TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   uintptr_t imm, TR::RegisterDependencyConditions *cond, TR::SymbolReference *sr, TR::Snippet *s,
+   TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64ImmSymInstruction(op, node, imm, cond, sr, s, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64ImmSymInstruction(op, node, imm, cond, sr, s, cg);
+   }
+
 TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::LabelSymbol *sym, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -110,6 +110,28 @@ TR::Instruction *generateImmInstruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates imm sym instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] imm : immediate value
+ * @param[in] cond : register dependency condition
+ * @param[in] sr : symbol reference
+ * @param[in] s : call snippet
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateImmSymInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   uintptr_t imm,
+                   TR::RegisterDependencyConditions *cond,
+                   TR::SymbolReference *sr,
+                   TR::Snippet *s,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates label instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -26,6 +26,7 @@
 
    IsNotExtended,
    IsImm,
+   IsImmSym,
    IsLabel,
       IsConditionalBranch,
       IsCompareBranch,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -341,6 +341,7 @@ namespace TR { class J9S390InterfaceCallDataSnippet; }
 #endif
 
 namespace TR { class ARM64ImmInstruction; }
+namespace TR { class ARM64ImmSymInstruction; }
 namespace TR { class ARM64LabelInstruction; }
 namespace TR { class ARM64ConditionalBranchInstruction; }
 namespace TR { class ARM64CompareBranchInstruction; }
@@ -1082,6 +1083,7 @@ public:
    void printPrefix(TR::FILE *, TR::Instruction *);
 
    void print(TR::FILE *, TR::ARM64ImmInstruction *);
+   void print(TR::FILE *, TR::ARM64ImmSymInstruction *);
    void print(TR::FILE *, TR::ARM64LabelInstruction *);
    void print(TR::FILE *, TR::ARM64ConditionalBranchInstruction *);
    void print(TR::FILE *, TR::ARM64CompareBranchInstruction *);


### PR DESCRIPTION
This commit implements ARM64ImmSymInstruction for method calls.

Signed-off-by: knn-k <konno@jp.ibm.com>