### PR TITLE
AArch64: Implement fRegLoadEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -414,19 +414,22 @@ OMR::ARM64::TreeEvaluator::dcmplEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 	}
 
+// also handles dRegLoad
 TR::Register *
 OMR::ARM64::TreeEvaluator::fRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::fRegLoadEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   TR::Register *globalReg = node->getRegister();
 
-TR::Register *
-OMR::ARM64::TreeEvaluator::fRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::fRegStoreEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   if (globalReg == NULL)
+      {
+      if (node->getOpCodeValue() == TR::fRegLoad)
+         globalReg = cg->allocateSinglePrecisionRegister();
+      else
+         globalReg = cg->allocateRegister(TR_FPR);
+      node->setRegister(globalReg);
+      }
+   return globalReg;
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::fmaxEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
@@ -397,15 +397,15 @@
     TR::TreeEvaluator::iRegLoadEvaluator, // TR::iRegLoad		// Load integer global register
     TR::TreeEvaluator::aRegLoadEvaluator, // TR::aRegLoad		// Load address global register
     TR::TreeEvaluator::iRegLoadEvaluator, // TR::lRegLoad		// Load long integer global register
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fRegLoadEvaluator ,	// TR::fRegLoad		// Load float global register
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dRegLoadEvaluator ,	// TR::dRegLoad		// Load double global register
+    TR::TreeEvaluator::fRegLoadEvaluator, // TR::fRegLoad		// Load float global register
+    TR::TreeEvaluator::fRegLoadEvaluator, // TR::dRegLoad		// Load double global register
     TR::TreeEvaluator::iRegLoadEvaluator, // TR::sRegLoad		// Load short global register
     TR::TreeEvaluator::iRegLoadEvaluator, // TR::bRegLoad		// Load byte global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::iRegStore		// Store integer global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::aRegStore		// Store address global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::lRegStore		// Store long integer global register
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fRegStoreEvaluator ,	// TR::fRegStore		// Store float global register
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dRegStoreEvaluator ,	// TR::dRegStore		// Store double global register
+    TR::TreeEvaluator::iRegStoreEvaluator, // TR::fRegStore		// Store float global register
+    TR::TreeEvaluator::iRegStoreEvaluator, // TR::dRegStore		// Store double global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::sRegStore		// Store short global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::bRegStore		// Store byte global register
     TR::TreeEvaluator::GlRegDepsEvaluator, // TR::GlRegDeps		// Global Register Dependency List


### PR DESCRIPTION
This commmit implements fRegLoadEvaluator() for aarch64.  It is also
used for dRegLoad.  fRegStore and dRegStore are covered by iRegStore.

Signed-off-by: knn-k <konno@jp.ibm.com>