### PR TITLE
Revert "Multiple ddrgen fixes"

### DIFF
--- a/ddr/include/ddr/blobgen/java/genSuperset.hpp
+++ b/ddr/include/ddr/blobgen/java/genSuperset.hpp
@@ -23,6 +23,11 @@
 #define GENSUPERSET_HPP
 
 #include "ddr/blobgen/genBlob.hpp"
+#include "ddr/std/unordered_map.hpp"
+
+#include <set>
+
+using std::set;
 
 class Field;
 class SupersetFieldVisitor;
@@ -32,11 +37,15 @@ class Symbol_IR;
 class JavaSupersetGenerator : public SupersetGenerator
 {
 private:
+	set<string> _baseTypedefSet; /* Set of types renamed to "[U/I][SIZE]" */
+	unordered_map<string, string> _baseTypedefMap; /* Types remapped for assembled type names. */
+	unordered_map<string, string> _baseTypedefReplace; /* Type names which are replaced everywhere. */
 	intptr_t _file;
 	OMRPortLibrary *_portLibrary;
 	bool _printEmptyTypes;
 	string _pendingTypeHeading;
 
+	void initBaseTypedefSet();
 	void convertJ9BaseTypedef(Type *type, string *name);
 	void replaceBaseTypedef(Type *type, string *name);
 	DDR_RC getFieldType(Field *field, string *assembledTypeName, string *simpleTypeName);

--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -797,20 +797,7 @@ public:
 DDR_RC
 BlobFieldVisitor::visitType(Type *type) const
 {
-	const string & typeName = type->_name;
-	bool isSigned = false;
-	size_t bitWidth = 0;
-
-	if (Type::isStandardType(typeName.c_str(), (size_t)typeName.length(), &isSigned, &bitWidth)) {
-		stringstream newType;
-
-		newType << (isSigned ? "I" : "U") << bitWidth;
-
-		*_typePrefix += newType.str();
-	} else {
-		*_typePrefix += typeName;
-	}
-
+	*_typePrefix += type->_name;
 	return DDR_RC_OK;
 }
 

--- a/ddr/lib/ddr-ir/Type.cpp
+++ b/ddr/lib/ddr-ir/Type.cpp
@@ -229,9 +229,6 @@ struct TypeWord
 	TypeKind typeKind;
 };
 
-#define TYPE_ENTRY(name, type, typeKind) \
-	{ (name), sizeof(name) - 1, 8 * sizeof(type), (typeKind) }
-
 #define TYPE_QUAL(type, typeKind) \
 	{ #type, sizeof(#type) - 1, 0, (typeKind) }
 
@@ -265,33 +262,10 @@ static const TypeWord typeWords[] = {
 	TYPE_WORD(intptr_t,  TK_std_signed),
 	TYPE_WORD(uintptr_t, TK_std_unsigned),
 
-	/* other known signed types */
-	TYPE_ENTRY("__int8_t",  int8_t,   TK_std_signed),
-	TYPE_ENTRY("__int16_t", int16_t,  TK_std_signed),
-	TYPE_ENTRY("__int32_t", int32_t,  TK_std_signed),
-	TYPE_ENTRY("__int64_t", int64_t,  TK_std_signed),
-	TYPE_ENTRY("I_8",       int8_t,   TK_std_signed),
-	TYPE_ENTRY("I_16",      int16_t,  TK_std_signed),
-	TYPE_ENTRY("I_32",      int32_t,  TK_std_signed),
-	TYPE_ENTRY("I_64",      int64_t,  TK_std_signed),
-/*  TYPE_ENTRY("I_128",     int128_t, TK_std_signed), */
-
-	/* other known unsigned types */
-	TYPE_ENTRY("__uint8_t",  uint8_t,   TK_std_unsigned),
-	TYPE_ENTRY("__uint16_t", uint16_t,  TK_std_unsigned),
-	TYPE_ENTRY("__uint32_t", uint32_t,  TK_std_unsigned),
-	TYPE_ENTRY("__uint64_t", uint64_t,  TK_std_unsigned),
-	TYPE_ENTRY("U_8",        uint8_t,   TK_std_unsigned),
-	TYPE_ENTRY("U_16",       uint16_t,  TK_std_unsigned),
-	TYPE_ENTRY("U_32",       uint32_t,  TK_std_unsigned),
-	TYPE_ENTRY("U_64",       uint64_t,  TK_std_unsigned),
-/*  TYPE_ENTRY("U_128",      uint128_t, TK_std_unsigned), */
-
 	/* terminator */
 	{ NULL, 0, false }
 };
 
-#undef TYPE_ENTRY
 #undef TYPE_QUAL
 #undef TYPE_WORD
 
@@ -309,9 +283,8 @@ Type::isStandardType(const char *type, size_t typeLen, bool *isSigned, size_t *b
 	 * occurrences of each word to verify the combination is reasonable.
 	 */
 	for (const char * cursor = type; cursor < typeEnd;) {
-		if (isspace(*cursor)) {
+		while ((cursor < typeEnd) && isspace(*cursor)) {
 			cursor += 1;
-			continue;
 		}
 
 		const char * const word = cursor;
@@ -361,8 +334,6 @@ Type::isStandardType(const char *type, size_t typeLen, bool *isSigned, size_t *b
 				bits = typeWord->bitWidth;
 				num[TK_unsigned] += 1;
 			}
-
-			break;
 		}
 	}
 
@@ -383,10 +354,6 @@ Type::isStandardType(const char *type, size_t typeLen, bool *isSigned, size_t *b
 			goto pass;
 		}
 	} else if ((1 == num[TK_char]) && (0 == num[TK_short]) && (0 == num[TK_int]) && (0 == num[TK_long])) {
-		/* char is unsigned unless explicitly 'signed' */
-		if (0 == num[TK_signed]) {
-			num[TK_unsigned] = 1;
-		}
 		bits = 8 * sizeof(char);
 		goto pass;
 	} else if ((0 == num[TK_char]) && (1 == num[TK_short]) && (1 >= num[TK_int]) && (0 == num[TK_long])) {

--- a/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
@@ -390,7 +390,6 @@ static const pair<const char *, Dwarf_Half> tagStrings[] = {
 	make_pair("member", DW_TAG_member),
 	make_pair("namespace", DW_TAG_namespace),
 	make_pair("pointer_type", DW_TAG_pointer_type),
-	make_pair("ptr_to_member_type", DW_TAG_ptr_to_member_type),
 	make_pair("restrict_type", DW_TAG_restrict_type),
 	make_pair("shared_type", DW_TAG_shared_type),
 	make_pair("structure_type", DW_TAG_structure_type),

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -133,8 +133,7 @@ main(int argc, char *argv[])
 		rc = scanner.startScan(&portLibrary, &ir, &options.debugFiles, options.blacklistFile);
 
 #if defined(DEBUG_PRINT_TYPES)
-		OMRPORT_ACCESS_FROM_OMRPORT(&portLibrary);
-		omrtty_printf("== scan results ==\n");
+		printf("== scan results ==\n");
 		for (vector<Type *>::const_iterator type = ir._types.begin(); type != ir._types.end(); ++type) {
 			(*type)->acceptVisitor(printer);
 		}
@@ -146,8 +145,7 @@ main(int argc, char *argv[])
 		ir.removeDuplicates();
 
 #if defined(DEBUG_PRINT_TYPES)
-		OMRPORT_ACCESS_FROM_OMRPORT(&portLibrary);
-		omrtty_printf("== after removing duplicates ==\n");
+		printf("== after removing duplicates ==\n");
 		for (vector<Type *>::const_iterator type = ir._types.begin(); type != ir._types.end(); ++type) {
 			(*type)->acceptVisitor(printer);
 		}


### PR DESCRIPTION
Reverts eclipse/omr#3355

An OpenJ9 contributor created the initial PR to address some issues with how ddrgen understands types.  Unfortunately, the changes introduced some issues in our builds when OpenJ9 upgraded to the  OMR version with the changes.

We haven't gotten to the bottom of the why the changes are incorrect yet but they seem to trigger a corner case resulting in incorrect behaviour.  See example below.

I'm requesting that these changes be reverted as they've introduced functional issues that affect OpenJ9's ability to take new OMR levels and may cause issues for any other ddrgen users.

We'll follow up on getting the changes fixed and re-delivered in the new year.

Example problem:
```
 [OUT] > Problem running command:
 [OUT] U64 contains value larger than Long.MAX_VALUE
 [OUT] > 
```
https://ci.eclipse.org/openj9/job/Test-sanity.functional-JDK8-linux_390-64_cmprssptrs/527/