### PR TITLE
Clarify meaning of return value in omrsysinfo_is_running_in_container

### DIFF
--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -957,7 +957,7 @@ omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
  *
  * @param[in] errorCode int32_t pointer to state error code from internal calls
  *
- * @return TRUE if Runtime is running in a container and FALSE if not
+ * @return TRUE if Runtime is running in a container and FALSE if not or if an error occurs
  */
 BOOLEAN
 omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -4203,7 +4203,8 @@ _end:
  * Checks if the process is running inside container
  *
  * @param[in] portLibrary pointer to OMRPortLibrary
- * @param[out] inContainer pointer to BOOLEAN which on successful return indicates if the process is running in container or not
+ * @param[out] inContainer pointer to BOOLEAN which on successful return indicates if
+ * 		the process is running in container or not.  On error it indicates FALSE.
  *
  * @return 0 on success, otherwise negative error code
  */
@@ -4472,7 +4473,7 @@ omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
 
 /*
  * Gets if the Runtime is running in a Container by assigning the BOOLEAN value to inContainer param
- * Returns TRUE if running inside a container and FALSE if not
+ * Returns TRUE if running inside a container and FALSE if not or if an error occurs
  */
 BOOLEAN
 omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)


### PR DESCRIPTION
Questions were raised on whether the result of the function could be
trusted when an error was encountered.  This change clarifies the
functions contract to ensure that FALSE is always returned if an
error occurs.

Checked all three places this function is defined:
* omr/port/common/omrsysinfo.c
* omr/port/win32/omrsysinfo.c (empty implemention, no comment)
* omr/port/unix/omrsysinfo.c

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>