### PR TITLE
Add omrthread_numa_get_current_node()

### DIFF
--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -1411,6 +1411,14 @@ omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintp
 void
 omrthread_numa_set_enabled(BOOLEAN enabled);
 
+
+/**
+ * Gets the NUMA node the caller is being executed on
+ * @return uintptr_t
+ */
+uintptr_t
+omrthread_numa_get_current_node();
+
 /* -------------- rasthrsup.c ------------------- */
 /**
  * @brief

--- a/thread/aix/omrthreadnuma.c
+++ b/thread/aix/omrthreadnuma.c
@@ -337,3 +337,18 @@ bindThreadToNode(omrthread_t thread, uintptr_t nodeNumber)
 	}
 	return result;
 }
+
+uintptr_t
+omrthread_numa_get_current_node(){
+	sradid_t sradid = SRADID_ANY;
+	if (NULL != PTR_rs_get_homesrad) {
+		sradid = PTR_rs_get_homesrad();
+	}
+
+	/* if we couldn't find the home SRADID return 0, meaning no affinity */
+	if (sradid == SRADID_ANY) {
+		return 0;
+	} else {
+		return sradid + 1;
+	}
+}

--- a/thread/common/omrthreadnuma.c
+++ b/thread/common/omrthreadnuma.c
@@ -138,3 +138,9 @@ omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintp
 	*nodeCount = 0;
 	return 0;
 }
+
+
+uintptr_t
+omrthread_numa_get_current_node(){
+	return 0;
+}

--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -35,6 +35,7 @@
 #include <inttypes.h>
 #include <sched.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <stdio.h>
 
 #include "omrcfg.h"
@@ -546,3 +547,17 @@ dumpNumaInfo() {
 
 }
 #endif
+
+
+uintptr_t
+omrthread_numa_get_current_node(){
+    unsigned node = 0;
+#if OMR_PORT_NUMA_SUPPORT
+    if (0 == syscall(SYS_getcpu, NULL, &node, NULL)) {
+        ++node;
+    } else {
+        node = 0;
+    }
+#endif
+    return node;
+}

--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -548,9 +548,9 @@ dumpNumaInfo() {
 }
 #endif
 
-
 uintptr_t
-omrthread_numa_get_current_node(){
+omrthread_numa_get_current_node()
+{
     unsigned node = 0;
 #if OMR_PORT_NUMA_SUPPORT
     if (0 == syscall(SYS_getcpu, NULL, &node, NULL)) {

--- a/thread/win32/omrthreadnuma.c
+++ b/thread/win32/omrthreadnuma.c
@@ -148,3 +148,17 @@ omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintp
 	*nodeCount = 0;
 	return J9THREAD_NUMA_ERR_AFFINITY_NOT_SUPPORTED;
 }
+
+uintptr_t
+omrthread_numa_get_current_node(){
+	USHORT node = 0;
+
+	PROCESSOR_NUMBER processorNumber;
+	GetCurrentProcessorNumberEx(&processorNumber);
+	if (GetNumaProcessorNodeEx(&processorNumber, &node)) {
+		node += 1;
+	}  else {
+		node = 0;
+	}
+	return node;
+}

--- a/thread/win32/omrthreadnuma.c
+++ b/thread/win32/omrthreadnuma.c
@@ -150,14 +150,15 @@ omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintp
 }
 
 uintptr_t
-omrthread_numa_get_current_node(){
+omrthread_numa_get_current_node()
+{
 	USHORT node = 0;
 
 	PROCESSOR_NUMBER processorNumber;
 	GetCurrentProcessorNumberEx(&processorNumber);
 	if (GetNumaProcessorNodeEx(&processorNumber, &node)) {
 		node += 1;
-	}  else {
+	} else {
 		node = 0;
 	}
 	return node;


### PR DESCRIPTION
Function returns the numa node number the thread is currently executing
on

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>