### PR TITLE
Add J9THREAD_LIB_FLAG_NO_DEFAULT_AFFINITY thread library flag

### DIFF
--- a/include_core/omrthread.h
+++ b/include_core/omrthread.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -102,6 +102,7 @@ or omrthread priority value.
 #define J9THREAD_LIB_FLAG_JLM_INIT_DATA_STRUCTURES  (J9THREAD_LIB_FLAG_JLM_ENABLED|J9THREAD_LIB_FLAG_JLM_INFO_SAMPLING_ENABLED|J9THREAD_LIB_FLAG_CUSTOM_ADAPTIVE_SPIN_ENABLED)
 #define J9THREAD_LIB_FLAG_DESTROY_MUTEX_ON_MONITOR_FREE  0x400000
 #define J9THREAD_LIB_FLAG_ENABLE_CPU_MONITOR  0x800000
+#define J9THREAD_LIB_FLAG_NO_DEFAULT_AFFINITY  0x1000000
 
 #define J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD  0
 #define J9THREAD_LIB_YIELD_ALGORITHM_CONSTANT_USLEEP  2

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1573,11 +1573,16 @@ thread_wrapper(WRAPPER_ARG arg)
 				affinityCount += 1;
 			}
 		}
-		/* If the affinityCount is zero, this call will have the effect of clearing any affinity that the thread may have inherited
-		 * and it assuming the initial affinity that the process had (if reverting to that affinity isn't possible on the platform,
-		 * the call is supposed to do nothing).
+		/* if J9THREAD_LIB_FLAG_NO_DEFAULT_AFFINITY is set we only want to modify the affinity if
+		 * the caller provided us with a non-zero affinity
 		 */
-		omrthread_numa_set_node_affinity_nolock(thread, affinity, affinityCount, 0);
+		if ((affinityCount != 0) || OMR_ARE_NO_BITS_SET(lib->flags, J9THREAD_LIB_FLAG_NO_DEFAULT_AFFINITY)) {
+			/* If the affinityCount is zero, this call will have the effect of clearing any affinity that the thread may have inherited
+			* and it assuming the initial affinity that the process had (if reverting to that affinity isn't possible on the platform,
+			* the call is supposed to do nothing).
+			*/
+			omrthread_numa_set_node_affinity_nolock(thread, affinity, affinityCount, 0);
+		}
 	}
 #endif /* OMR_PORT_NUMA_SUPPORT */
 	THREAD_UNLOCK(thread);


### PR DESCRIPTION
If set, forked threads will not have their affinity modified unless a
non-zero affinity mask has been specified.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>