### PR TITLE
Remove unused debug register spill stats

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -81,16 +81,6 @@
 
 namespace TR { class RealRegister; }
 
-#ifdef DEBUG
-int OMR::CodeGenerator::_totalNumSpilledRegisters = 0;
-int OMR::CodeGenerator::_totalNumRematerializedConstants = 0;
-int OMR::CodeGenerator::_totalNumRematerializedLocals = 0;
-int OMR::CodeGenerator::_totalNumRematerializedStatics = 0;
-int OMR::CodeGenerator::_totalNumRematerializedIndirects = 0;
-int OMR::CodeGenerator::_totalNumRematerializedAddresses = 0;
-int OMR::CodeGenerator::_totalNumRematerializedXMMRs = 0;
-#endif
-
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 void
 OMR::CodeGenerator::checkForLiveRegisters(TR_LiveRegisters *liveRegisters)

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2574,23 +2574,6 @@ OMR::CodeGenerator::sizeOfInstructionToBePatchedHCRGuard(TR::Instruction *vgdnop
    }
 
 #ifdef DEBUG
-
-void
-OMR::CodeGenerator::dumpSpillStats(TR_FrontEnd *fe)
-   {
-   if (debug("spillStats"))
-      {
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"Register Spilling/Rematerialization:");
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d registers spilled", _totalNumSpilledRegisters);
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d constants rematerialized", _totalNumRematerializedConstants);
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d locals rematerialized", _totalNumRematerializedLocals);
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d statics rematerialized", _totalNumRematerializedStatics);
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d indirect accesses rematerialized", _totalNumRematerializedIndirects);
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d addresses rematerialized", _totalNumRematerializedAddresses);
-      TR_VerboseLog::writeLine(TR_Vlog_INFO,"%8d XMMRs rematerialized", _totalNumRematerializedXMMRs);
-      }
-   }
-
 void
 OMR::CodeGenerator::shutdown(TR_FrontEnd *fe, TR::FILE *logFile)
    {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -974,14 +974,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
 #ifdef DEBUG
    static void shutdown(TR_FrontEnd *fe, TR::FILE *logFile);
-   static void dumpSpillStats(TR_FrontEnd *fe);
-   static void incNumSpilledRegisters()        {_totalNumSpilledRegisters++;}
-   static void incNumRematerializedConstants() {_totalNumRematerializedConstants++;}
-   static void incNumRematerializedLocals()    {_totalNumRematerializedLocals++;}
-   static void incNumRematerializedStatics()   {_totalNumRematerializedStatics++;}
-   static void incNumRematerializedIndirects() {_totalNumRematerializedIndirects++;}
-   static void incNumRematerializedAddresses() {_totalNumRematerializedAddresses++;}
-   static void incNumRematerializedXMMRs()     {_totalNumRematerializedXMMRs++;}
 #endif
 
    void dumpDataSnippets(TR::FILE *outFile) {}
@@ -1900,16 +1892,6 @@ class OMR_EXTENSIBLE CodeGenerator
    static TR_TreeEvaluatorFunctionPointer _nodeToInstrEvaluators[];
 
    protected:
-
-#ifdef DEBUG
-   static int _totalNumSpilledRegisters;         // For collecting statistics on spilling
-   static int _totalNumRematerializedConstants;
-   static int _totalNumRematerializedLocals;
-   static int _totalNumRematerializedStatics;
-   static int _totalNumRematerializedIndirects;
-   static int _totalNumRematerializedAddresses;
-   static int _totalNumRematerializedXMMRs;
-#endif
 
    bool _disableInternalPointers;
 

--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -775,23 +775,11 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
                    self()->getDebug()->getName(bestDiscardableRegister));
 
             tempMR->setBaseRegister(info->getBaseRegister()->getAssignedRegister());
-#ifdef DEBUG
-            self()->cg()->incNumRematerializedIndirects();
-#endif
             }
-#ifdef DEBUG
-         else if (tempMR->getSymbolReference().getSymbol()->isStatic())
-            self()->cg()->incNumRematerializedStatics();
-         else
-            self()->cg()->incNumRematerializedLocals();
-#endif
 
          if (info->getDataType() == TR_RematerializableFloat)
             {
             instr = generateRegMemInstruction(currentInstruction, MOVSSRegMem, best, tempMR, self()->cg());
-#ifdef DEBUG
-            self()->cg()->incNumRematerializedXMMRs();
-#endif
             }
          else
             {
@@ -802,9 +790,6 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
          {
          TR::MemoryReference  *tempMR = generateX86MemoryReference(info->getSymbolReference(), self()->cg());
          instr = generateRegMemInstruction(currentInstruction, LEARegMem(), best, tempMR, self()->cg());
-#ifdef DEBUG
-         self()->cg()->incNumRematerializedAddresses();
-#endif
          }
       else
          {
@@ -812,17 +797,11 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
             {
             TR::MemoryReference* tempMR = generateX86MemoryReference(self()->cg()->findOrCreate4ByteConstant(currentInstruction->getNode(), info->getConstant()), self()->cg());
             instr = generateRegMemInstruction(currentInstruction, MOVSSRegMem, best, tempMR, self()->cg());
-#ifdef DEBUG
-            self()->cg()->incNumRematerializedXMMRs();
-#endif
             }
          else
             {
             instr = TR::TreeEvaluator::insertLoadConstant(0, best, info->getConstant(), info->getDataType(), self()->cg(), currentInstruction);
             }
-#ifdef DEBUG
-         self()->cg()->incNumRematerializedConstants();
-#endif
          }
 
       self()->cg()->traceRAInstruction(instr);
@@ -959,9 +938,6 @@ TR::RealRegister *OMR::X86::Machine::freeBestGPRegister(TR::Instruction         
 
       self()->cg()->traceRegFreed(bestRegister, best);
       self()->cg()->traceRAInstruction(instr);
-#ifdef DEBUG
-      self()->cg()->incNumSpilledRegisters();
-#endif
       }
 
    if (enableRematerialisation)
@@ -2846,9 +2822,6 @@ TR::Instruction *OMR::X86::Machine::fpSpillFPR(TR::Instruction *prevInstruction,
                                               isFloat ? FSTPMemReg : DSTPMemReg,
                                               tempMR,
                                               self()->fpMapToStackRelativeRegister(vreg), self()->cg());
-#ifdef DEBUG
-      self()->cg()->incNumSpilledRegisters();
-#endif
       }
 
    self()->fpStackPop();


### PR DESCRIPTION
This spill statistics gathering is a legacy implementation that is no
longer used and not available on all platforms.  No known OMR consumer
is using this.  Remove it to simplify the code.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>