### PR TITLE
AArch64: Improve code generation of lcmpeq, lucmpeq, etc.

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -52,7 +52,7 @@ inline bool constantIsImm9(int32_t intValue)
  * @param[in] intValue : unsigned integer value
  * @return true if the value can be placed in 12-bit field, false otherwise
  */
-inline bool constantIsUnsignedImm12(uint32_t intValue)
+inline bool constantIsUnsignedImm12(uint64_t intValue)
    {
    return (intValue < 4096);
    }


### PR DESCRIPTION
This commit improves code generation of comparison evaluators of
64-bit integers.
Their logic is commoned with 32-bit integer comparison. As its
result, it uses subsimmx instruction when the second child is a
small constant (less than 4096), and that saves one instruction.

Signed-off-by: knn-k <konno@jp.ibm.com>