### PR TITLE
Add linkage tests for Microsoft x64 calling convention

### DIFF
--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -381,6 +381,64 @@ inline std::vector<int32_t> const_values<int32_t>()
    }
 
 /**
+ * @brief Convenience function returning possible test inputs of the specified type
+ */
+template <>
+inline std::vector<float> const_values<float>()
+   {
+   float inputArray[] = {
+      zero_value<float>(),
+      one_value<float>(),
+      negative_one_value<float>(),
+      positive_value<float>(),
+      negative_value<float>(),
+      std::numeric_limits<float>::min(),
+      std::numeric_limits<float>::max(),
+      static_cast<float>(std::numeric_limits<float>::min() + 1),
+      static_cast<float>(std::numeric_limits<float>::max() - 1),
+      0x0000005F,
+      0x00000088,
+      static_cast<float>(0x80FF0FF0),
+      static_cast<float>(0x80000000),
+      static_cast<float>(0xFF000FFF),
+      static_cast<float>(0xFFFFFF0F),
+      0.01f,
+      0.1f
+   };
+
+   return std::vector<float>(inputArray, inputArray + sizeof(inputArray) / sizeof(float));
+   }
+
+/**
+ * @brief Convenience function returning possible test inputs of the specified type
+ */
+template <>
+inline std::vector<double> const_values<double>()
+   {
+   double inputArray[] = {
+      zero_value<double>(),
+      one_value<double>(),
+      negative_one_value<double>(),
+      positive_value<double>(),
+      negative_value<double>(),
+      std::numeric_limits<double>::min(),
+      std::numeric_limits<double>::max(),
+      static_cast<double>(std::numeric_limits<double>::min() + 1),
+      static_cast<double>(std::numeric_limits<double>::max() - 1),
+      0x0000005F,
+      0x00000088,
+      static_cast<double>(0x80FF0FF0),
+      static_cast<double>(0x80000000),
+      static_cast<double>(0xFF000FFF),
+      static_cast<double>(0xFFFFFF0F),
+      0.01,
+      0.1
+   };
+
+   return std::vector<double>(inputArray, inputArray + sizeof(inputArray) / sizeof(double));
+   }
+
+/**
  * @brief Convenience function returning pairs of possible test inputs of the specified types
  */
 template <typename L, typename R>

--- a/fvtest/compilertriltest/LinkageTest.cpp
+++ b/fvtest/compilertriltest/LinkageTest.cpp
@@ -98,9 +98,11 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingSingleArg) {
 
     auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam)>();
 
-    EXPECT_EQ(static_cast<TypeParam>(0), entry_point( static_cast<TypeParam>(0)))  << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(1), entry_point( static_cast<TypeParam>(1)))  << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(-1), entry_point(static_cast<TypeParam>(-1))) << "Input Trees: " << inputTrees;
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.cbegin(); i != inputs.cend(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(*i))  << "Input Trees: " << inputTrees;
+    }
 }
 
 template <typename T>
@@ -146,9 +148,11 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFourArg) {
 
     auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>();
 
-    EXPECT_EQ(static_cast<TypeParam>(1024),    entry_point(0,0,0,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(-1),      entry_point(0,0,0,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(0xf0f0f), entry_point(0,0,0,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.cbegin(); i != inputs.cend(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0,0,0, *i))  << "Input Trees: " << inputTrees;
+    }
 }
 
 template <typename T>
@@ -228,9 +232,11 @@ TYPED_TEST(LinkageTest, SystemLinkageJitedToJitedParameterPassingFourArg) {
 
     auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam)>();
 
-    EXPECT_EQ(static_cast<TypeParam>(1024),    entry_point(0,0,0,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(-1),      entry_point(0,0,0,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(0xf0f0f), entry_point(0,0,0,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.cbegin(); i != inputs.cend(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0,0,0, *i))  << "Input Trees: " << inputTrees;
+    }
 }
 
 template <typename T>
@@ -285,9 +291,11 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArg) {
 
     auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam,TypeParam)>();
 
-    EXPECT_EQ(static_cast<TypeParam>(1024),    entry_point(0,0,0,0,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(-1),      entry_point(0,0,0,0,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
-    EXPECT_EQ(static_cast<TypeParam>(0xf0f0f), entry_point(0,0,0,0,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
+    auto inputs = TRTest::const_values<TypeParam>();
+    for (auto i = inputs.cbegin(); i != inputs.cend(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(static_cast<TypeParam>(*i), entry_point(0,0,0,0, *i))  << "Input Trees: " << inputTrees;
+    }
 }
 
 /*
@@ -357,10 +365,12 @@ TYPED_TEST(LinkageTest, SystemLinkageParameterPassingFiveArgToStackUser) {
 
     auto entry_point = compiler.getEntryPoint<TypeParam (*)(TypeParam,TypeParam,TypeParam,TypeParam,TypeParam)>();
 
+    // Check the compiled function itself
     EXPECT_EQ(static_cast<TypeParam>(2053),     stackUser<TypeParam>(1,1,1,1,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
     EXPECT_EQ(static_cast<TypeParam>(3),        stackUser<TypeParam>(1,1,1,1,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
     EXPECT_EQ(static_cast<TypeParam>(0x1e1e23), stackUser<TypeParam>(1,1,1,1,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
 
+    // Check the linkage
     EXPECT_EQ(static_cast<TypeParam>(2053),     entry_point(1,1,1,1,static_cast<TypeParam>(1024)))     << "Input Trees: " << inputTrees;
     EXPECT_EQ(static_cast<TypeParam>(3),        entry_point(1,1,1,1,static_cast<TypeParam>(-1)))       << "Input Trees: " << inputTrees;
     EXPECT_EQ(static_cast<TypeParam>(0x1e1e23), entry_point(1,1,1,1,static_cast<TypeParam>(0xf0f0f)))  << "Input Trees: " << inputTrees;
@@ -397,9 +407,11 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFourArgWithMixedT
 
     auto entry_point = compiler.getEntryPoint<FourMixedArgumentFunction>();
 
-    EXPECT_EQ(1024,    entry_point(0.0,0,0.0,1024))     << "Input Trees: " << inputTrees;
-    EXPECT_EQ(-1,      entry_point(0.0,0,0.0,-1))       << "Input Trees: " << inputTrees;
-    EXPECT_EQ(0xf0f0f, entry_point(0.0,0,0.0,0xf0f0f))  << "Input Trees: " << inputTrees;
+    auto inputs = TRTest::const_values<int32_t>();
+    for (auto i = inputs.cbegin(); i != inputs.cend(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_EQ(*i, entry_point(0.0,0,0.0, *i))  << "Input Trees: " << inputTrees;
+    }
 }
 
 double fifthArgFromMixedTypes(double a, int32_t b, double c, int32_t d, double e) { return e; }
@@ -432,7 +444,9 @@ TEST_F(LinkageWithMixedTypesTest, SystemLinkageParameterPassingFiveArgWithMixedT
 
     auto entry_point = compiler.getEntryPoint<FiveMixedArgumentFunction>();
 
-    EXPECT_DOUBLE_EQ(1024.3, entry_point(0.0,0,0.0,0,1024.3)) << "Input Trees: " << inputTrees;
-    EXPECT_DOUBLE_EQ(-1.7,   entry_point(0.0,0,0.0,0,-1.7))   << "Input Trees: " << inputTrees;
-    EXPECT_DOUBLE_EQ(0.001,  entry_point(0.0,0,0.0,0,0.001))  << "Input Trees: " << inputTrees;
+    auto inputs = TRTest::const_values<double>();
+    for (auto i = inputs.cbegin(); i != inputs.cend(); ++i) {
+        SCOPED_TRACE(*i);
+        EXPECT_DOUBLE_EQ(*i, entry_point(0.0,0,0.0,0, *i))  << "Input Trees: " << inputTrees;
+    }
 }

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -972,6 +972,11 @@ class FloatToInt32 : public TRTest::UnaryOpTest<int32_t,float> {};
 
 TEST_P(FloatToInt32, UsingConst) {
     auto param = TRTest::to_struct(GetParam());
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.value <= static_cast<float>(std::numeric_limits<int32_t>::min())
+            || param.value >= static_cast<float>(std::numeric_limits<int32_t>::max()))
+        && (OMRPORT_ARCH_HAMMER == arch), KnownBug)
+        << "f2i test behaves unexpectedly on x86-64 with certain high input values (see issue #3602)";
 
     char inputTrees[160] = {0};
     std::snprintf(inputTrees, 160,
@@ -997,6 +1002,11 @@ TEST_P(FloatToInt32, UsingConst) {
 
 TEST_P(FloatToInt32, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF((param.value <= static_cast<float>(std::numeric_limits<int32_t>::min())
+            || param.value >= static_cast<float>(std::numeric_limits<int32_t>::max()))
+        && (OMRPORT_ARCH_HAMMER == arch), KnownBug)
+        << "f2i test behaves unexpectedly on x86-64 with certain high input values (see issue #3602)";
 
     char *inputTrees =
         "(method return=Int32 args=[Float]"


### PR DESCRIPTION
Microsoft x64 calling convention brings addition limitations for x86-64:
only four registers are available for arguments (not four for integer
and four for float but four for both). Also the caller has
responsibility to allocate 32 bytes of "shadow space" on the stack right
before calling the function (regardless of the actual parameters used).

Two tests are added to check these circumstances: the first just
demonstrates how to invoke a method with five arguments while the second
one invokes a method who is actively using the stack and can corrupts
the return address if no "shadow space" has been allocated.

Issue: #3366
Signed-off-by: Pavel Samolysov <samolisov@gmail.com>