### PR TITLE
Introduce trimCodeMemoryAllocation CodeCache API

### DIFF
--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -118,6 +118,20 @@ public:
                                bool isMethodHeaderNeeded=true);
    bool resizeCodeMemory(void *memoryBlock, size_t newSize);
 
+   /**
+    * @brief Trims the size of the previously allocated code memory in this
+    *        CodeCache to the specified length.  Any leftover bytes are reclaimed.
+    *
+    * @param[in] codeMemoryStart : void* address of the start of the code memory
+    *               to trim
+    * @param[in] actualSizeInBytes : size_t describing the actual number of code
+    *               memory bytes to allocate.  A specified size of 0 will return
+    *               without any adjustment.
+    *
+    * @return true if the code memory was successfully reduced; false otherwise.
+    */
+   bool trimCodeMemoryAllocation(void *codeMemoryStart, size_t actualSizeInBytes);
+
    CodeCacheMethodHeader *addFreeBlock(void *metaData);
 
    uint8_t *findFreeBlock(size_t size, bool isCold, bool isMethodHeaderNeeded);


### PR DESCRIPTION
Essentially rename the existing CodeCache `resizeCodeMemory` function
to `trimCodeMemoryAllocation` to more accurately reflect what the
function does.  Add a Doxygen header.

The existing function `resizeCodeMemory` will remain in the code
until all known downstream projects can be modified to use the new API.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>