### PR TITLE
Misc. OMR compiler flag and Option cleanup

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1349,8 +1349,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool supportVMInternalNatives();
    bool supportsNativeLongOperations();
 
-   TR::DataType IntJ() { return TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32; }
-
    // will a BCD left shift always leave the sign code unchanged and thus allow it to be propagated through and upwards
    bool propagateSignThroughBCDLeftShift(TR::DataType type) { return false; }
 
@@ -1692,7 +1690,7 @@ class OMR_EXTENSIBLE CodeGenerator
       DisableFpGRA                                        = 0x01000000,
       // AVAILABLE                                        = 0x02000000,
       MethodModifiedByRA                                  = 0x04000000,
-      SchedulingInstrCleanupNeeded                        = 0x08000000,
+      // AVAILABLE                                        = 0x08000000,
       // AVAILABLE                                        = 0x10000000,
       EnforceStoreOrder                                   = 0x20000000,
       // AVAILABLE                                        = 0x80000000,
@@ -1752,7 +1750,7 @@ class OMR_EXTENSIBLE CodeGenerator
       SupportsAtomicLoadAndAdd                            = 0x00000800,
       // AVAILABLE                                        = 0x00001000,
       // AVAILABLE                                        = 0x00002000,
-      HasSignCleans                                       = 0x00004000,
+      // AVAILABLE                                        = 0x00004000,
       SupportsArrayTranslateTRTO255                       = 0x00008000, //if (ca[i] < 256) ba[i] = (byte) ca[i]
       SupportsArrayTranslateTROTNoBreak                   = 0x00010000, //ca[i] = (char) ba[i]
       SupportsArrayTranslateTRTO                          = 0x00020000, //if (ca[i] < x) ba[i] = (byte) ca[i]; x is either 256 or 128

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -491,7 +491,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableRecompDueToInlinedMethodRedefinition", "O\tdisable recompilation for method body with patched HCR guard",  SET_OPTION_BIT(TR_DisableRecompDueToInlinedMethodRedefinition), "F"},
    {"disableReducedPriorityForCustomMethodHandleThunks",  "R\tcompile custom MethodHandle invoke exact thunks at the same priority as normal java methods", SET_OPTION_BIT(TR_DisableReducedPriorityForCustomMethodHandleThunks), "F", NOT_IN_SUBSET},
    {"disableRedundantAsyncCheckRemoval",  "O\tdisable redundant async check removal",          TR::Options::disableOptimization, redundantAsyncCheckRemoval, 0, "P"},
-   {"disableRedundantBCDSignElimination",  "I\tdisable redundant BCD sign elimination", SET_OPTION_BIT(TR_DisableRedundantBCDSignElimination),"F"},
    {"disableRedundantGotoElimination",    "O\tdisable redundant goto elimination",             TR::Options::disableOptimization, redundantGotoElimination, 0, "P"},
    {"disableRedundantMonitorElimination", "O\tdisable redundant monitor elimination",          TR::Options::disableOptimization, redundantMonitorElimination, 0, "P"},
    {"disableRefArraycopyRT",              "O\tdisable reference arraycopy for real-time gc",   SET_OPTION_BIT(TR_DisableRefArraycopyRT), "F"},
@@ -2220,7 +2219,7 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
             }
          else
             {
-            // For AOT with GCR enabled we can be more conservative with 
+            // For AOT with GCR enabled we can be more conservative with
             // upgrades through sampling because we can rely on GCR
             // In this case we'll use the same threshold value as the one
             // employed in `setGlobalAggressiveAOT` (note that larger values

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -731,7 +731,7 @@ enum TR_CompilationOptions
    // Available                                       = 0x00010000 + 21,
    TR_OldDataCacheImplementation                      = 0x00020000 + 21,
    TR_EnableDataCacheStatistics                       = 0x00040000 + 21,
-   TR_DisableRedundantBCDSignElimination              = 0x00080000 + 21,
+   // Available                                       = 0x00080000 + 21,
    // Available                                       = 0x00100000 + 21,
    TR_AllowVPRangeNarrowingBasedOnDeclaredType        = 0x00200000 + 21,
    TR_EnableScratchMemoryDebugging                    = 0x00400000 + 21,

--- a/compiler/optimizer/OMROptimizations.enum
+++ b/compiler/optimizer/OMROptimizations.enum
@@ -102,7 +102,6 @@
    OPTIMIZATION(trivialDeadTreeRemoval)
    OPTIMIZATION(osrDefAnalysis)
    OPTIMIZATION(blockShuffling)
-   OPTIMIZATION(redundantBCDSignElimination)
    OPTIMIZATION(osrLiveRangeAnalysis)
    OPTIMIZATION(osrExceptionEdgeRemoval)
    OPTIMIZATION(SPMDKernelParallelization)


### PR DESCRIPTION
Clean up deprecated flags and Options now that downstream projects have
been modified to not depend on them.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>