### PR TITLE
Add awareness of Xrdbar operations for Power

### DIFF
--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -563,6 +563,20 @@ TR::Register *OMR::Power::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::Code
    {
    TR::Register *tempReg = node->setRegister(cg->allocateRegister(TR_FPR));
    return TR::TreeEvaluator::dloadHelper(node, cg, tempReg, TR::InstOpCode::lfd);
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::frdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::floadEvaluator(node, cg);
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::drdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::dloadEvaluator(node, cg);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -280,7 +280,10 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    if (TR::Compiler->vm.hasResumableTrapHandler(self()->comp()))
       self()->setHasResumableTrapHandler();
 
-   if (TR::Compiler->target.cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM))
+   /*
+    * TODO: TM is currently not compatible with read barriers. If read barriers are required, TM is disabled until the issue is fixed.
+    */
+   if (TR::Compiler->target.cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM) && !TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
       self()->setSupportsTM();
 
    // enable LM if hardware supports instructions and running the reduced-pause GC policy

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -869,6 +869,40 @@ TR::Register *OMR::Power::TreeEvaluator::cloadEvaluator(TR::Node *node, TR::Code
    return tempReg;
    }
 
+TR::Register *OMR::Power::TreeEvaluator::irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::iloadEvaluator(node, cg);
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::ardbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::aloadEvaluator(node, cg);
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::brdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::bloadEvaluator(node, cg);
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::srdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::sloadEvaluator(node, cg);
+   }
+
+TR::Register *OMR::Power::TreeEvaluator::lrdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   if (node->getSymbolReference()->getSymbol()->isStatic())
+      cg->decReferenceCount(node->getFirstChild());
+   return TR::TreeEvaluator::lloadEvaluator(node, cg);
+   }
 
 // iiload handled by iloadEvaluator
 

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,6 +75,13 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg); // ibm@59591
+   static TR::Register *irdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *frdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *drdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *ardbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *brdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *srdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *lrdbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *istoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,13 +38,13 @@
    TR::TreeEvaluator::bloadEvaluator,                   // TR::bload
    TR::TreeEvaluator::sloadEvaluator,                   // TR::sload
    TR::TreeEvaluator::lloadEvaluator,                   // TR::lload
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::irdbar
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::frdbar
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::drdbar
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::ardbar
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::brdbar
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::srdbar
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::lrdbar
+   TR::TreeEvaluator::irdbarEvaluator,                  // TR::irdbar
+   TR::TreeEvaluator::frdbarEvaluator,                  // TR::frdbar
+   TR::TreeEvaluator::drdbarEvaluator,                  // TR::drdbar
+   TR::TreeEvaluator::ardbarEvaluator,                  // TR::ardbar
+   TR::TreeEvaluator::brdbarEvaluator,                  // TR::brdbar
+   TR::TreeEvaluator::srdbarEvaluator,                  // TR::srdbar
+   TR::TreeEvaluator::lrdbarEvaluator,                  // TR::lrdbar
    TR::TreeEvaluator::iloadEvaluator,                   // TR::iloadi
    TR::TreeEvaluator::floadEvaluator,                   // TR::floadi
    TR::TreeEvaluator::dloadEvaluator,                   // TR::dloadi
@@ -52,13 +52,13 @@
    TR::TreeEvaluator::bloadEvaluator,                   // TR::bloadi
    TR::TreeEvaluator::sloadEvaluator,                   // TR::sloadi
    TR::TreeEvaluator::lloadEvaluator,                   // TR::lloadi
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::irdbari
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::frdbari
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::drdbari
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::ardbari
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::brdbari
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::srdbari
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::lrdbari
+   TR::TreeEvaluator::irdbarEvaluator,                  // TR::irdbari
+   TR::TreeEvaluator::frdbarEvaluator,                  // TR::frdbari
+   TR::TreeEvaluator::drdbarEvaluator,                  // TR::drdbari
+   TR::TreeEvaluator::ardbarEvaluator,                  // TR::ardbari
+   TR::TreeEvaluator::brdbarEvaluator,                  // TR::brdbari
+   TR::TreeEvaluator::srdbarEvaluator,                  // TR::srdbari
+   TR::TreeEvaluator::lrdbarEvaluator,                  // TR::lrdbari
    TR::TreeEvaluator::istoreEvaluator,                  // TR::istore
    TR::TreeEvaluator::lstoreEvaluator,                  // TR::lstore
    TR::TreeEvaluator::fstoreEvaluator,                  // TR::fstore


### PR DESCRIPTION
Updated evaluateNULLCHKWithPossibleResolve for Power to recognize read
barrier opcodes.

Fixed a bug in the Power version of evaluateNULLCHKWithPossibleResolve
where reference counts were not handled properly. If the child has already
been evaluated, it is not necessary to decrement the reference counts on
the reference node.

Added default xrdbarEvaluators for Power.

TM is not currently compatible with read barriers. If read barriers are
needed, TM is disabled.

Closes: #3397
Signed-off-by: jimmyk <jimmyk@ca.ibm.com>