### PR TITLE
AArch64: Implement fcmpeqEvaluator, etc.

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -390,26 +390,112 @@ OMR::ARM64::TreeEvaluator::ifdcmpleEvaluator(TR::Node *node, TR::CodeGenerator *
 	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
 	}
 
+static TR::Register *fcmpHelper(TR::Node *node, TR::ARM64ConditionCode cc, bool isDouble, TR::CodeGenerator *cg)
+   {
+   TR::Register *trgReg = cg->allocateRegister();
+   TR::Node *firstChild = node->getFirstChild();
+   TR::Node *secondChild = node->getSecondChild();
+   TR::Register *src1Reg = cg->evaluate(firstChild);
+   TR::InstOpCode::Mnemonic op;
+   bool useRegCompare = true;
+
+   if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL)
+      {
+      double value = isDouble ? secondChild->getDouble() : secondChild->getFloat();
+      if (value == 0.0)
+         {
+         op = isDouble ? TR::InstOpCode::fcmpd_zero : TR::InstOpCode::fcmps_zero;
+         generateSrc1Instruction(cg, op, node, src1Reg);
+         useRegCompare = false;
+         }
+      }
+
+   if (useRegCompare)
+      {
+      TR::Register *src2Reg = cg->evaluate(secondChild);
+      op = isDouble ? TR::InstOpCode::fcmpd : TR::InstOpCode::fcmps;
+      generateSrc2Instruction(cg, op, node, src1Reg, src2Reg);
+      }
+
+   generateCSetInstruction(cg, node, trgReg, cc);
+
+   node->setRegister(trgReg);
+   firstChild->decReferenceCount();
+   secondChild->decReferenceCount();
+   return trgReg;
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::fcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_EQ, false, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::fcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_NE, false, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::fcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_LT, false, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::fcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_GE, false, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::fcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_GT, false, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::fcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_LE, false, cg);
+   }
+
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpeqEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_EQ, true, cg);
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpneEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_NE, true, cg);
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::dcmpltEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
+   {
+   return fcmpHelper(node, TR::CC_LT, true, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::dcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_GE, true, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::dcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_GT, true, cg);
+   }
+
+TR::Register *
+OMR::ARM64::TreeEvaluator::dcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   return fcmpHelper(node, TR::CC_LE, true, cg);
+   }
 
 TR::Register *
 OMR::ARM64::TreeEvaluator::dcmplEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/TreeEvaluatorTable.hpp
@@ -254,24 +254,24 @@
     TR::TreeEvaluator::lucmpgeEvaluator, // TR::lucmpge		// unsigned long compare if greater than or equal
     TR::TreeEvaluator::lucmpgtEvaluator, // TR::lucmpgt		// unsigned long compare if greater than
     TR::TreeEvaluator::lucmpleEvaluator, // TR::lucmple		// unsigned long compare if less than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpeqEvaluator ,	// TR::fcmpeq		// float compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpneEvaluator ,	// TR::fcmpne		// float compare if not equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpltEvaluator ,	// TR::fcmplt		// float compare if less than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpgeEvaluator ,	// TR::fcmpge		// float compare if greater than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpgtEvaluator ,	// TR::fcmpgt		// float compare if greater than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpleEvaluator ,	// TR::fcmple		// float compare if less than or equal
+    TR::TreeEvaluator::fcmpeqEvaluator, // TR::fcmpeq		// float compare if equal
+    TR::TreeEvaluator::fcmpneEvaluator, // TR::fcmpne		// float compare if not equal
+    TR::TreeEvaluator::fcmpltEvaluator, // TR::fcmplt		// float compare if less than
+    TR::TreeEvaluator::fcmpgeEvaluator, // TR::fcmpge		// float compare if greater than or equal
+    TR::TreeEvaluator::fcmpgtEvaluator, // TR::fcmpgt		// float compare if greater than
+    TR::TreeEvaluator::fcmpleEvaluator, // TR::fcmple		// float compare if less than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpequEvaluator ,	// TR::fcmpequ		// float compare if equal or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpneuEvaluator ,	// TR::fcmpneu		// float compare if not equal or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpltuEvaluator ,	// TR::fcmpltu		// float compare if less than or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpgeuEvaluator ,	// TR::fcmpgeu		// float compare if greater than or equal or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpgtuEvaluator ,	// TR::fcmpgtu		// float compare if greater than or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fcmpleuEvaluator ,	// TR::fcmpleu		// float compare if less than or equal or unordered
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpeqEvaluator ,	// TR::dcmpeq		// double compare if equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpneEvaluator ,	// TR::dcmpne		// double compare if not equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpltEvaluator ,	// TR::dcmplt		// double compare if less than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpgeEvaluator ,	// TR::dcmpge		// double compare if greater than or equal
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpgtEvaluator ,	// TR::dcmpgt		// double compare if greater than
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpleEvaluator ,	// TR::dcmple		// double compare if less than or equal
+    TR::TreeEvaluator::dcmpeqEvaluator, // TR::dcmpeq		// double compare if equal
+    TR::TreeEvaluator::dcmpneEvaluator, // TR::dcmpne		// double compare if not equal
+    TR::TreeEvaluator::dcmpltEvaluator, // TR::dcmplt		// double compare if less than
+    TR::TreeEvaluator::dcmpgeEvaluator, // TR::dcmpge		// double compare if greater than or equal
+    TR::TreeEvaluator::dcmpgtEvaluator, // TR::dcmpgt		// double compare if greater than
+    TR::TreeEvaluator::dcmpleEvaluator, // TR::dcmple		// double compare if less than or equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpequEvaluator ,	// TR::dcmpequ		// double compare if equal or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpneuEvaluator ,	// TR::dcmpneu		// double compare if not equal or unordered
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcmpltuEvaluator ,	// TR::dcmpltu		// double compare if less than or unordered


### PR DESCRIPTION
This commit implements fcmpeqEvaluator for aarch64 and similar
floating-point evaluators.

Signed-off-by: knn-k <konno@jp.ibm.com>