### PR TITLE
AArch64: Fix code generation of isub

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -56,7 +56,7 @@ static TR::Register *addOrSubInteger(TR::Node *node, TR::CodeGenerator *cg)
    else
       {
       TR::Register *src2Reg = cg->evaluate(secondChild);
-      generateTrg1Src2Instruction(cg, TR::InstOpCode::addw, node, trgReg, src1Reg, src2Reg);
+      generateTrg1Src2Instruction(cg, isAdd ? TR::InstOpCode::addw : TR::InstOpCode::subw, node, trgReg, src1Reg, src2Reg);
       }
 
    node->setRegister(trgReg);


### PR DESCRIPTION
There is a case where isubEvaluator() for aarch64 generates wrong
"addw" instruction.  This commit fixes it.

Signed-off-by: knn-k <konno@jp.ibm.com>