### PR TITLE
[WIP]Delete unused OMR functions

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -244,7 +244,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _accumulatorNodeUsage(0),
      _nodesUnderComputeCCList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _nodesToUncommonList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
-     _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _collectedSpillList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
      _allSpillList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
      _relocationList(getTypedAllocator<TR::Relocation*>(TR::comp()->allocator())),

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -223,7 +223,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _codeCache(0),
      _committedToCodeCache(false),
      _codeCacheSwitched(false),
-     _dummyTempStorageRefNode(NULL),
      _blockRegisterPressureCache(NULL),
      _simulatedNodeStates(NULL),
      _availableSpillTemps(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -250,7 +250,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _externalRelocationList(getTypedAllocator<TR::Relocation*>(TR::comp()->allocator())),
      _staticRelocationList(_compilation->allocator()),
      _breakPointList(getTypedAllocator<uint8_t*>(TR::comp()->allocator())),
-     _jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(TR::comp()->allocator())),
      _preJitMethodEntrySize(0),
      _jitMethodEntryPaddingSize(0),
      _lastInstructionBeforeCurrentEvaluationTreeTop(NULL),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1851,8 +1851,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR::Node*> _nodesUnderComputeCCList;
    TR::list<TR::Node*> _nodesToUncommonList;
 
-   TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> _jniCallSites; // list of instrutions representing direct jni call sites
-
    TR_Array<void *> _monitorMapping;
 
    TR::list<TR::Node*> _compressedRefs;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1901,9 +1901,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    bool _afterRA;
 
-   // MOVE TO J9 Z CodeGenerator
-   // isTemporaryBased storageReferences just have a symRef but some other routines expect a node so use the below to fill in this symRef on this node
-   TR::Node *_dummyTempStorageRefNode;
 
    public:
    static TR_TreeEvaluatorFunctionPointer _nodeToInstrEvaluators[];

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1850,7 +1850,6 @@ class OMR_EXTENSIBLE CodeGenerator
    int32_t _currentPathDepth;
    TR::list<TR::Node*> _nodesUnderComputeCCList;
    TR::list<TR::Node*> _nodesToUncommonList;
-   TR::list<TR::Node*> _nodesSpineCheckedList;
 
    TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> _jniCallSites; // list of instrutions representing direct jni call sites
 


### PR DESCRIPTION
This is a work in progress to delete unused functions that I have moved to openj9 in this [PR](https://github.com/eclipse/openj9/pull/4160).

Ensure openj9 PR is merged before this one.