### PR TITLE
Use numeric_limits, not stdint.h limits

### DIFF
--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include <cstring>
+#include <limits>
 
 #include "ilgen/JitBuilderRecorderBinaryBuffer.hpp"
 #include "infra/Assert.hpp"
@@ -40,8 +41,9 @@ void
 OMR::JitBuilderRecorderBinaryBuffer::String(const char * const string)
    {
    // length(int16) characters
-   int32_t len = strlen(string);
-   TR_ASSERT(len < INT16_MAX, "JBIL: binary String format limited to %d characters", INT16_MAX);
+   const size_t len = strlen(string);
+   const int max = std::numeric_limits<int16_t>::max();
+   TR_ASSERT(len < max, "JBIL: binary String format limited to %d characters", max);
 
    Number((int16_t)len);
    for (int16_t i=0;i < len;i++)


### PR DESCRIPTION
The stdint.h limits aren't available without a macro definition on older
compilers, but this behaviour is deprecated as-of C++11. Avoid the whole
mess and stick with numeric_limits, the C++  way to get a maximum.

Signed-off-by: Robert Young <rwy0717@gmail.com>