### PR TITLE
Heap size startup hints

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -341,6 +341,10 @@ public:
 	uintptr_t heapContractionGCTimeThreshold; /**< min percentage of time spent in gc before contraction */
 	uintptr_t heapExpansionStabilizationCount; /**< GC count required before the heap is allowed to expand due to excessvie time after last heap expansion */
 	uintptr_t heapContractionStabilizationCount; /**< GC count required before the heap is allowed to contract due to excessvie time after last heap expansion */
+	
+	float heapSizeStatupHintConservativeFactor; /**< Use only a fraction of hints stored in SC */
+	float heapSizeStatupHintWeightNewValue;		/**< Learn slowly by historic averaging of stored hints */
+	
 
 	uintptr_t workpacketCount; /**< this value is ONLY set if -Xgcworkpackets is specified - otherwise the workpacket count is determined heuristically */
 	uintptr_t packetListSplit; /**< the number of ways to split packet lists, set by -XXgc:packetListLockSplit=, or determined heuristically based on the number of GC threads */
@@ -1326,6 +1330,8 @@ public:
 		, heapContractionGCTimeThreshold(5)
 		, heapExpansionStabilizationCount(0)
 		, heapContractionStabilizationCount(3)
+		, heapSizeStatupHintConservativeFactor((float)0.7)
+		, heapSizeStatupHintWeightNewValue((float)0.0)
 		, workpacketCount(0) /* only set if -Xgcworkpackets specified */
 		, packetListSplit(0)
 		, cacheListSplit(0)

--- a/gc/base/gcutils.cpp
+++ b/gc/base/gcutils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,6 +205,8 @@ getExpandReasonAsString(ExpandReason reason)
 		return "satisfy allocation request";
 	case FORCED_NURSERY_EXPAND:
 		return "forced nursery expand";
+	case HINT_PREVIOUS_RUNS:
+		return "hint from previous runs";
 	default:
 		return "unknown";
 	}

--- a/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
+++ b/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -153,7 +153,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::inflate(MM_EnvironmentBase *env)
 		Assert_MM_true(size == (semiSpaceSize * 2));
 
 		/* Add the spaces as table-backed heap regions */
-		if(NULL == (_highSemiSpaceRegion = getHeapRegionManager()->createAuxiliaryRegionDescriptor(env, subSpaceSurvivor, semiSpaceMiddle, _highAddress))) {
+		if(NULL == (_highSemiSpaceRegion = getHeapRegionManager()->createAuxiliaryRegionDescriptor(env, subSpaceAllocate, semiSpaceMiddle, _highAddress))) {
 			return false;
 		}
 		
@@ -170,7 +170,7 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::inflate(MM_EnvironmentBase *env)
 					semiSpaceMiddle, _highAddress);
 			Assert_MM_inflateInvalidRange();
 		}
-		if(NULL == (_lowSemiSpaceRegion = getHeapRegionManager()->createAuxiliaryRegionDescriptor(env, subSpaceAllocate, _lowAddress, semiSpaceMiddle))) {
+		if(NULL == (_lowSemiSpaceRegion = getHeapRegionManager()->createAuxiliaryRegionDescriptor(env, subSpaceSurvivor, _lowAddress, semiSpaceMiddle))) {
 			return false;
 		}
 
@@ -189,9 +189,9 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::inflate(MM_EnvironmentBase *env)
 		}
 
 		/* Inform the semi spaces that they have been expanded */
-		bool result = subSpaceAllocate->expanded(env, this, _lowSemiSpaceRegion->getSize(), _lowSemiSpaceRegion->getLowAddress(), _lowSemiSpaceRegion->getHighAddress(), false);
+		bool result = subSpaceAllocate->expanded(env, this, _highSemiSpaceRegion->getSize(), _highSemiSpaceRegion->getLowAddress(), _highSemiSpaceRegion->getHighAddress(), false);
 		subSpaceAllocate->heapReconfigured(env);
-		result = result && subSpaceSurvivor->expanded(env, this, _highSemiSpaceRegion->getSize(), _highSemiSpaceRegion->getLowAddress(), _highSemiSpaceRegion->getHighAddress(), false);
+		result = result && subSpaceSurvivor->expanded(env, this, _lowSemiSpaceRegion->getSize(), _lowSemiSpaceRegion->getLowAddress(), _lowSemiSpaceRegion->getHighAddress(), false);
 		subSpaceSurvivor->heapReconfigured(env);
 		return result;
 	}

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -403,7 +403,8 @@ typedef enum {
 	SCAV_RATIO_TOO_HIGH,
 	SATISFY_COLLECTOR,
 	EXPAND_DESPERATE,
-	FORCED_NURSERY_EXPAND
+	FORCED_NURSERY_EXPAND,
+	HINT_PREVIOUS_RUNS
 } ExpandReason;
 
 typedef enum {


### PR DESCRIPTION
Some pre-req work to support Heap size startup hints feature in OpenJ9
- swapped initial order of allocate and survivor in Nursery Physical
Arena to be able to expand early
- introduce new reasons for expansion, which would be reported by
verbose GC during early startup
- introduce two tuning parameters, that will control how aggressively
the feature is used. heapSizeStatupHintWeightNewValue is for now set to
0 (which effectively means the feature is disabled), but plan is to used
more value of 0.8 or so, after some more testing is peformed

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>