### PR TITLE
fvtest: 'register' is deprecated and incompatible with C++17

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -1111,8 +1111,8 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 static int32_t
 onlineProcessorCount(const struct J9ProcessorInfos *procInfo)
 {
-	register int32_t cntr = 0;
-	register int32_t n_onln = 0;
+	int32_t cntr = 0;
+	int32_t n_onln = 0;
 
 	for (cntr = 1; cntr < procInfo->totalProcessorCount + 1; cntr++) {
 		if (OMRPORT_PROCINFO_PROC_ONLINE == procInfo->procInfoArray[cntr].online) {

--- a/fvtest/porttest/si_numcpusTest.cpp
+++ b/fvtest/porttest/si_numcpusTest.cpp
@@ -253,8 +253,8 @@ TEST(PortSysinfoTest, sysinfo_numcpus_runTime)
 static uint32_t
 onlineProcessorCount(const struct J9ProcessorInfos *procInfo)
 {
-	register int32_t cntr = 0;
-	register uint32_t n_onln = 0;
+	int32_t cntr = 0;
+	uint32_t n_onln = 0;
 
 	for (cntr = 1; cntr < procInfo->totalProcessorCount + 1; cntr++) {
 		if (OMRPORT_PROCINFO_PROC_ONLINE == procInfo->procInfoArray[cntr].online) {


### PR DESCRIPTION
These keywords aren't necessary and trip up some compiler configs.

Signed-off-by: Kevin Bowling <kevin.bowling@kev009.com>