### PR TITLE
Recover x86 jit builder testing

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -62,6 +62,13 @@ endif()
 ## Do NOT force it since it is explicitly disabled on Windows for now.
 if(OMR_JITBUILDER)
 	set(OMR_JITBUILDER_TEST ON CACHE BOOL "")
+
+	## Enable additional JitBuilder tests if running on a supported platform
+        #  (which currently means 64-bit x86 platforms except for Windows)
+	if((OMR_HOST_ARCH STREQUAL "x86" AND NOT OMR_OS_WINDOWS) AND OMR_TEMP_DATA_SIZE STREQUAL "64")
+    		set(OMR_JITBUILDER_TEST_EXTENDED ON)
+	endif()
+
 else()
     # if JitBuilder isn't enabled, the tests can't be built
     set(OMR_JITBUILDER_TEST OFF CACHE BOOL "" FORCE)

--- a/compiler/codegen/OMRInstruction.cpp
+++ b/compiler/codegen/OMRInstruction.cpp
@@ -244,15 +244,15 @@ Instruction::useRegister(TR::Register *reg)
    {
 
    if (reg->getStartOfRange() == 0 ||
-       (reg->getStartOfRange()->getIndex() > self()->getIndex()) &&
-       !self()->cg()->getIsInOOLSection())
+       ((reg->getStartOfRange()->getIndex() > self()->getIndex()) &&
+        !self()->cg()->getIsInOOLSection()))
       {
       reg->setStartOfRange(self());
       }
 
    if (reg->getEndOfRange() == 0 ||
-       (reg->getEndOfRange()->getIndex() < self()->getIndex()) &&
-       !self()->cg()->getIsInOOLSection())
+       ((reg->getEndOfRange()->getIndex() < self()->getIndex()) &&
+        !self()->cg()->getIsInOOLSection()))
       {
       reg->setEndOfRange(self());
       }

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -1433,7 +1433,7 @@ TR_GlobalRegisterAllocator::transformNode(
          // internal pointer must always be present on the stack.
          //
          //
-         if (!fpStore && !symRef->storeCanBeRemoved()
+         if ((!fpStore && !symRef->storeCanBeRemoved())
              || (comp()->getOption(TR_MimicInterpreterFrameShape) && comp()->getOption(TR_FSDGRA)))
             {
             gr->setValue(0);
@@ -3961,9 +3961,9 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
          }
 
       if (!canSkip &&
-          ((node->getOpCodeValue() == TR::iadd) || (node->getOpCodeValue() == TR::isub) ||
-           (node->getOpCodeValue() == TR::iand) || (node->getOpCodeValue() == TR::iloadi) || (node->getOpCodeValue() == TR::ixor)) ||
-          ((node->getOpCodeValue() == TR::iload) /* && !node->getSymbolReference()->getSymbol()->isAutoOrParm() */))
+          (((node->getOpCodeValue() == TR::iadd) || (node->getOpCodeValue() == TR::isub) ||
+            (node->getOpCodeValue() == TR::iand) || (node->getOpCodeValue() == TR::iloadi) || (node->getOpCodeValue() == TR::ixor)) ||
+           ((node->getOpCodeValue() == TR::iload) /* && !node->getSymbolReference()->getSymbol()->isAutoOrParm() */)))
          {
          TR::Node *storeNode = NULL;
          TR::Node *loadNode = NULL;
@@ -4290,9 +4290,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
       TR::CFG *cfg = comp()->getFlowGraph();
 
       TR::SymbolReference *symRef = node->getSymbolReference();
-      if ((symRef->getSymbol()->isAutoOrParm() ||
-           (0) && symRef->getSymbol()->getDataType() != TR::NoType)
-          && isSymRefAvailable(symRef, blocksInLoop))
+      if (symRef->getSymbol()->isAutoOrParm() && isSymRefAvailable(symRef, blocksInLoop))
          {
          TR_RegisterCandidate *rc = registerCandidates[symRef->getReferenceNumber()];
          if (!rc)

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -3889,7 +3889,6 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
    bool                   hasCatchBlock)
    {
    bool enableSignExtGRA = false; // enable for other platforms later
-   bool enableNewSignExtGRA = false;
 
    static char *doit = feGetEnv("TR_SIGNEXTGRA");
    if (NULL != doit)
@@ -3901,323 +3900,17 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
       static char *doit2 = feGetEnv("TR_NSIGNEXTGRA");
       if (NULL != doit2)
          enableSignExtGRA = false;
-
-      static char *doit3 = feGetEnv("TR_NEWSIGNEXTGRA");
-      if (NULL != doit3)
-         enableNewSignExtGRA = true;
       }
 
    TR::Node *origNode = NULL;
    TR::Node *prevArrayAccess = NULL;
-   if (enableNewSignExtGRA)
-      {
-      prevArrayAccess = *currentArrayAccess;
-
-      if (node->getOpCode().hasSymbolReference() &&
-          (node->getSymbolReference()->getSymbol()->isArrayShadowSymbol()))
-         {
-         TR::Node *child = node->getFirstChild();
-         if (child->getOpCodeValue() == TR::aladd)
-            {
-            TR::Node *offsetChild = child->getSecondChild();
-            if (((offsetChild->getOpCodeValue() == TR::ladd) || (offsetChild->getOpCodeValue() == TR::lsub)) &&
-                (offsetChild->getSecondChild()->getOpCodeValue() == TR::lconst))
-               offsetChild = offsetChild->getFirstChild();
-
-            int32_t sizeOfElem;
-            if (node->getDataType() == TR::Address)
-               sizeOfElem = TR::Compiler->om.sizeofReferenceField();
-            else
-               sizeOfElem = node->getOpCode().getSize();
-
-            if ((offsetChild->getOpCodeValue() == TR::lmul) &&
-                (offsetChild->getSecondChild()->getOpCodeValue() == TR::lconst) &&
-                (sizeOfElem == offsetChild->getSecondChild()->getLongInt()))
-               {
-               TR::Node *longIndexNode = offsetChild->getFirstChild();
-               if (longIndexNode->getOpCodeValue() == TR::i2l)
-                  {
-                  *currentArrayAccess = longIndexNode;
-                  }
-               }
-            else if ((offsetChild->getOpCodeValue() == TR::i2l) &&
-                     (sizeOfElem == 1))
-               {
-               *currentArrayAccess = offsetChild;
-               }
-            }
-         }
-
-      bool canSkip = false;
-      if (0 && ((node->getOpCode().isLoadVarDirect() && node->getSymbolReference()->getSymbol()->isAuto()) ||
-          (((node->getOpCodeValue() == TR::iadd) || (node->getOpCodeValue() == TR::isub)) &&
-            node->getFirstChild()->getOpCode().isLoadVarDirect() &&
-            node->getFirstChild()->getSymbolReference()->getSymbol()->isAuto() &&
-            node->getSecondChild()->getOpCode().isLoadConst() /* &&
-                                                                 ((node->getSecondChild()->getInt() <= 32767) && (node->getSecondChild()->getInt() >= -32767)) */ )))
-         {
-         if (!_rejectedSignExtNodes.find(node))
-            canSkip = true;
-         }
-
-      if (!canSkip &&
-          (((node->getOpCodeValue() == TR::iadd) || (node->getOpCodeValue() == TR::isub) ||
-            (node->getOpCodeValue() == TR::iand) || (node->getOpCodeValue() == TR::iloadi) || (node->getOpCodeValue() == TR::ixor)) ||
-           ((node->getOpCodeValue() == TR::iload) /* && !node->getSymbolReference()->getSymbol()->isAutoOrParm() */)))
-         {
-         TR::Node *storeNode = NULL;
-         TR::Node *loadNode = NULL;
-         if (*currentArrayAccess)
-            {
-            if (TR::Compiler->target.is64Bit() &&
-                !_rejectedSignExtNodes.find(node))
-               {
-               if ((node->getOpCodeValue() == TR::iload) &&
-                   (node->getSymbolReference()->getSymbol()->isAutoOrParm()
-                   ))
-                  {
-                  loadNode = node;
-                  canSkip = true;
-                  }
-               else if (false)
-                  {
-                  TR_ASSERT(comp()->getOptimizer()->cachedExtendedBBInfoValid(), "Incorrect value in _startOfExtendedBBForBB");
-                  TR::TreeTop *cursorTree = _candidates->_startOfExtendedBBForBB[block->getNumber()]->getEntry()->getNextTreeTop();
-                  while (cursorTree)
-                     {
-                     TR::Node *cursorNode = cursorTree->getNode();
-                     if (cursorNode->getOpCode().isStoreDirect() &&
-                         cursorNode->getSymbolReference()->getSymbol()->isAuto() &&
-                         (cursorNode->getFirstChild() == node))
-                        {
-                        storeNode = cursorNode;
-                        canSkip = true;
-                        break;
-                        }
-
-                      if (cursorNode->getOpCodeValue() == TR::BBStart)
-                         {
-                         if (!cursorNode->getBlock()->isExtensionOfPreviousBlock())
-                            break;
-                         }
-
-                      cursorTree = cursorTree->getNextTreeTop();
-                     }
-                  }
-               }
-            }
-
-         if (canSkip)
-            {
-            TR_BlockStructure *blockStructure = block->getStructureOf();
-            if (comp()->getFlowGraph()->getStructure() &&
-                blockStructure)
-               {
-               TR_Structure *containingLoop = blockStructure->getContainingLoop();
-
-               if (containingLoop)
-                  {
-                  TR::Block *loopInvariantBlock = NULL;
-                  TR_RegionStructure *parentStructure = containingLoop->getParent()->asRegion();
-                  TR_StructureSubGraphNode *subNode = NULL;
-                  TR_RegionStructure::Cursor si(*parentStructure);
-                  for (subNode = si.getCurrent(); subNode != NULL; subNode = si.getNext())
-                     {
-                     if (subNode->getNumber() == containingLoop->getNumber())
-                        break;
-                     }
-
-                  if ((subNode->getPredecessors().size() == 1))
-                     {
-                     TR_StructureSubGraphNode *loopInvariantNode = toStructureSubGraphNode(subNode->getPredecessors().front()->getFrom());
-                     if (loopInvariantNode->getStructure()->asBlock() &&
-                         loopInvariantNode->getStructure()->asBlock()->isLoopInvariantBlock())
-                        loopInvariantBlock = loopInvariantNode->getStructure()->asBlock()->getBlock();
-                     }
-
-                  if (loopInvariantBlock)
-                     {
-                     TR::SymbolReference *storeSymRef = NULL;
-                     if (loadNode)
-                        storeSymRef = loadNode->getSymbolReference();
-                     else
-                        storeSymRef = storeNode->getSymbolReference();
-
-                     TR::Node *signExtStore = NULL;
-
-                     if (_candidatesSignExtendedInThisLoop->get(storeSymRef->getReferenceNumber()))
-                        {
-                        TR::TreeTop *cursorTree = loopInvariantBlock->getExit();
-                        while (cursorTree)
-                           {
-                           TR::Node *cursorNode = cursorTree->getNode();
-                           if ((cursorNode->getOpCodeValue() == comp()->il.opCodeForDirectStore(node->getDataType())) &&
-                               (cursorNode->getSymbolReference() == storeSymRef))
-                              {
-                              if (cursorNode->getFirstChild()->getOpCode().isLoadVar() &&
-                                  (cursorNode->getFirstChild()->getSymbolReference() == cursorNode->getSymbolReference()) &&
-                                  cursorNode->needsSignExtension())
-                                 {
-                                 signExtStore = cursorNode;
-                                 break;
-                                 }
-                              }
-
-                           if (cursorNode->getOpCodeValue() == TR::BBStart)
-                              break;
-
-                           cursorTree = cursorTree->getPrevTreeTop();
-                           }
-                        }
-                     else
-                        {
-                        signExtStore = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(node->getDataType()), 1, 1,
-                                                             TR::Node::createWithSymRef(node, comp()->il.opCodeForDirectLoad(storeSymRef->getSymbol()->getDataType()), 0, storeSymRef),
-                                                             storeSymRef);
-
-                        TR::TreeTop *initTree = TR::TreeTop::create(comp(), signExtStore, 0, 0);
-
-                        TR::TreeTop *placeHolderTree = loopInvariantBlock->getLastRealTreeTop();
-                        TR::Node *placeHolderNode = placeHolderTree->getNode();
-                        if (placeHolderNode->getOpCode().isResolveOrNullCheck() ||
-                           (placeHolderNode->getOpCodeValue() == TR::treetop))
-                           placeHolderNode = placeHolderNode->getFirstChild();
-
-                        TR::ILOpCode &placeHolderOpCode = placeHolderNode->getOpCode();
-
-                        if (!placeHolderOpCode.isBranch() &&
-                            !placeHolderOpCode.isJumpWithMultipleTargets() &&
-                            !placeHolderOpCode.isReturn() &&
-                            (placeHolderOpCode.getOpCodeValue() != TR::athrow))
-                            placeHolderTree = loopInvariantBlock->getExit();
-
-                        TR::TreeTop *prevTree = placeHolderTree->getPrevTreeTop();
-                        prevTree->join(initTree);
-                        initTree->join(placeHolderTree);
-                        signExtStore->setNeedsSignExtension(true);
-                        }
-
-                     TR_ASSERT(signExtStore, "Store for sign extension must be found or created in loop pre-header\n");
-
-                     if (trace())
-                        {
-                        traceMsg(comp(), "Skip %p sign ext store %p load %p store %p\n", node, signExtStore, loadNode, storeNode);
-                        traceMsg(comp(), "loop invariant block_%d loop %p\n", loopInvariantBlock->getNumber(), containingLoop);
-                        }
-
-                     node->setSkipSignExtension(true);
-                     int32_t childNum = -1;
-                     if (parent)
-                        {
-                        int32_t i = 0;
-                        while (i < parent->getNumChildren())
-                           {
-                           if (parent->getChild(i) == node)
-                              {
-                              childNum = i;
-                              break;
-                              }
-                           i++;
-                           }
-                        }
-
-                     TR_NodeTriple *nodeTriple = new (comp()->trHeapMemory()) TR_NodeTriple(parent, signExtStore, (loadNode ? parent : storeNode), childNum);                                    _nodeTriplesToBeChecked.add(nodeTriple);
-                     _candidatesNeedingSignExtension->set(storeSymRef->getReferenceNumber());
-                     _candidatesSignExtendedInThisLoop->set(storeSymRef->getReferenceNumber());
-                     }
-                  }
-               }
-
-            canSkip = false;
-            }
-         }
-
-      origNode = node;
-      if (0 && *currentArrayAccess &&
-          canSkip)
-         {
-         TR_UseDefInfo *info = optimizer()->getUseDefInfo();
-         if (TR::Compiler->target.is64Bit() && info &&
-             (parent->getOpCodeValue() == TR::i2l) /* && node->isNonNegative() */ &&
-             (*currentArrayAccess == parent) &&
-             enableSignExtGRA)
-            {
-             TR_BlockStructure *blockStructure = block->getStructureOf();
-            node->setSkipSignExtension(true);
-            if (!node->getOpCode().isLoadVarDirect())
-               node = node->getFirstChild();
-
-            _nodesToBeChecked.add(origNode);
-
-            _candidatesNeedingSignExtension->set(node->getSymbolReference()->getReferenceNumber());
-            //_candidatesSignExtendedInThisLoop->set(node->getSymbolReference()->getReferenceNumber());
-
-            int32_t useIndex = node->getUseDefIndex();
-            TR_UseDefInfo::BitVector defs(comp()->allocator());
-            if (info->getUseDef(defs, useIndex))
-               {
-               TR_UseDefInfo::BitVector::Cursor cursor(defs);
-               for (cursor.SetToFirstOne(); cursor.Valid(); cursor.SetToNextOne())
-                  {
-                  int32_t defIndex = info->getFirstDefIndex() + (int32_t) cursor;
-                  if (defIndex < info->getFirstRealDefIndex()) // def is  unseen--can't mark this node as skippable
-                     {
-                     origNode->setSkipSignExtension(false);
-                     break;
-                     }
-                  TR::Node *defNode = info->getNode(defIndex);
-                  if (defNode->getOpCode().isStore())
-                     {
-                     TR::Symbol *sym = defNode->getSymbolReference()->getSymbol();
-                     TR_ASSERT((sym == node->getSymbolReference()->getSymbol()), "Symbols must match between a use and a def\n");
-
-                     if (sym->isAuto())
-                        {
-                        bool seenLoad = false;
-                        bool dependentStore = isDependentStore(defNode, defs, node->getSymbolReference(), &seenLoad);
-                        if (dependentStore &&
-                            defNode->getFirstChild()->isNonNegative() &&
-                            seenLoad)
-                           {
-                           //printf("Skip sign extension at def node %p in %s\n", defNode, comp->getCurrentMethod()->signature());
-                           TR::TreeTop *defTree = info->getTreeTop(defIndex);
-                           TR::Block *defBlock = defTree->getEnclosingBlock();
-                           TR_BlockStructure *defBlockStructure = defBlock->getStructureOf();
-                           if (comp()->getFlowGraph()->getStructure() &&
-                               blockStructure && defBlockStructure &&
-                               (blockStructure->getContainingLoop() == defBlockStructure->getContainingLoop()))
-                              continue;
-                           }
-                           defNode->setNeedsSignExtension(true);
-                        }
-                      }
-                  }
-               }
-            }
-         }
-
-      if (TR::Compiler->target.is64Bit() &&
-          parent &&
-          (parent->getOpCodeValue() == TR::i2l) &&
-          ((*currentArrayAccess != parent) &&
-           (grandParent->getOpCodeValue() != TR::l2i)) &&
-          node->skipSignExtension())
-         {
-         _rejectedSignExtNodes.add(node);
-         node->setSkipSignExtension(false);
-         }
-      }
 
    if (node->getVisitCount() == visitCount)
       return;
 
    node->setVisitCount(visitCount);
 
-   if (enableNewSignExtGRA)
-      node = origNode;
-
-   if (!enableNewSignExtGRA && /* !hasCatchBlock && */ node->getOpCode().isLoadVarDirect() &&
-         (node->getSymbolReference()->getSymbol()->isAuto() ))
+   if (node->getOpCode().isLoadVarDirect() && node->getSymbolReference()->getSymbol()->isAuto())
       {
       TR_UseDefInfo *info = optimizer()->getUseDefInfo();
       if (TR::Compiler->target.is64Bit() && info &&
@@ -4401,11 +4094,6 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
         !(opCode.isAdd() || opCode.isSub() || opCode.isMul() ||
           opCode.isBooleanCompare() || opCode.isNullCheck() || opCode.isBndCheck())))
       findSymsUsedInIndirectAccesses(node, symsThatShouldNotBeAssignedInCurrentLoop, assignedAutosInCurrentLoop, true);
-
-   if (enableNewSignExtGRA && node->getOpCode().hasSymbolReference() &&
-       (node->getSymbolReference()->getSymbol()->isArrayShadowSymbol()))
-      *currentArrayAccess = prevArrayAccess;
-
    }
 
 
@@ -4634,7 +4322,6 @@ TR_GlobalRegisterAllocator::createStoresForSignExt(
    LexicalTimer t("TR_GlobalRegisterAllocator::createStoresForSignExt", comp()->phaseTimer());
 
    bool enableSignExtGRA = false; // enable for other platforms later
-   bool enableNewSignExtGRA = false;
 
    static char *doit = feGetEnv("TR_SIGNEXTGRA");
    if (NULL != doit)
@@ -4646,148 +4333,9 @@ TR_GlobalRegisterAllocator::createStoresForSignExt(
       static char *doit2 = feGetEnv("TR_NSIGNEXTGRA");
       if (NULL != doit2)
          enableSignExtGRA = false;
-
-      static char *doit3 = feGetEnv("TR_NEWSIGNEXTGRA");
-      if (NULL != doit3)
-         enableNewSignExtGRA = true;
       }
 
    TR::Node *prevArrayAccess = NULL;
-   if (enableNewSignExtGRA)
-      {
-      prevArrayAccess = *currentArrayAccess;
-
-      if (node->getOpCode().hasSymbolReference() &&
-          (node->getSymbolReference()->getSymbol()->isArrayShadowSymbol()))
-         {
-         TR::Node *child = node->getFirstChild();
-         if (child->getOpCodeValue() == TR::aladd)
-            {
-            TR::Node *offsetChild = child->getSecondChild();
-            if (((offsetChild->getOpCodeValue() == TR::ladd) || (offsetChild->getOpCodeValue() == TR::lsub)) &&
-                (offsetChild->getSecondChild()->getOpCodeValue() == TR::lconst))
-               offsetChild = offsetChild->getFirstChild();
-
-            int32_t sizeOfElem;
-            if (node->getDataType() == TR::Address)
-               sizeOfElem = TR::Compiler->om.sizeofReferenceField();
-            else
-               sizeOfElem = node->getOpCode().getSize();
-
-            if ((offsetChild->getOpCodeValue() == TR::lmul) &&
-                (offsetChild->getSecondChild()->getOpCodeValue() == TR::lconst) &&
-                (sizeOfElem == offsetChild->getSecondChild()->getLongInt()))
-               {
-               TR::Node *longIndexNode = offsetChild->getFirstChild();
-               if (longIndexNode->getOpCodeValue() == TR::i2l)
-                  *currentArrayAccess = longIndexNode;
-               }
-            else if ((offsetChild->getOpCodeValue() == TR::i2l) &&
-                     (node->getOpCode().getSize() == 1))
-               {
-               *currentArrayAccess = offsetChild;
-               }
-            }
-         }
-
-      bool needStoreAndItExists = false;
-
-      if (!needStoreAndItExists &&
-          ((node->getOpCodeValue() == TR::iadd) || (node->getOpCodeValue() == TR::isub) ||
-           (node->getOpCodeValue() == TR::iand) || (node->getOpCodeValue() == TR::iloadi) || (node->getOpCodeValue() == TR::ixor) ||
-           ((node->getOpCodeValue() == TR::iload) && !node->getSymbolReference()->getSymbol()->isAutoOrParm())
-           ))
-         {
-         TR::Node *storeNode = NULL;
-         if (*currentArrayAccess)
-            {
-            if (TR::Compiler->target.is64Bit() &&
-                (parent->getOpCodeValue() == TR::i2l) /* && node->isNonNegative() */ &&
-                (*currentArrayAccess == parent) &&
-                !_rejectedSignExtNodes.find(node))
-               {
-               TR_ASSERT(comp()->getOptimizer()->cachedExtendedBBInfoValid(), "Incorrect value in _startOfExtendedBBForBB");
-               TR::TreeTop *cursorTree = _candidates->_startOfExtendedBBForBB[block->getNumber()]->getEntry()->getNextTreeTop();
-               while (cursorTree)
-                  {
-                  TR::Node *cursorNode = cursorTree->getNode();
-                  if (cursorNode->getOpCode().isStoreDirect() &&
-                      cursorNode->getSymbolReference()->getSymbol()->isAuto() &&
-                      (cursorNode->getFirstChild() == node))
-                     {
-                     storeNode = cursorNode;
-                     needStoreAndItExists = true;
-                     break;
-                     }
-
-                   if (cursorNode->getOpCodeValue() == TR::BBStart)
-                      {
-                      if (!cursorNode->getBlock()->isExtensionOfPreviousBlock())
-                         break;
-                      }
-
-                   cursorTree = cursorTree->getNextTreeTop();
-                   }
-
-               if (!needStoreAndItExists)
-                  {
-                  TR_BlockStructure *blockStructure = block->getStructureOf();
-                  if (comp()->getFlowGraph()->getStructure() &&
-                      blockStructure)
-                     {
-                     TR_Structure *containingLoop = blockStructure->getContainingLoop();
-
-                     if (containingLoop)
-                        {
-                        TR::Block *loopInvariantBlock = NULL;
-                        TR_RegionStructure *parentStructure = containingLoop->getParent()->asRegion();
-                        TR_StructureSubGraphNode *subNode = NULL;
-                        TR_RegionStructure::Cursor si(*parentStructure);
-                        for (subNode = si.getCurrent(); subNode != NULL; subNode = si.getNext())
-                           {
-                           if (subNode->getNumber() == containingLoop->getNumber())
-                              break;
-                           }
-
-                        if ((subNode->getPredecessors().size() == 1))
-                           {
-                           TR_StructureSubGraphNode *loopInvariantNode = toStructureSubGraphNode(subNode->getPredecessors().front()->getFrom());
-                           if (loopInvariantNode->getStructure()->asBlock() &&
-                               loopInvariantNode->getStructure()->asBlock()->isLoopInvariantBlock())
-                              loopInvariantBlock = loopInvariantNode->getStructure()->asBlock()->getBlock();
-                           }
-
-                        if (loopInvariantBlock)
-                           {
-                           if (!_storeSymRef)
-                              _storeSymRef = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), node->getDataType());
-                           TR::Node *signExtStore = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(node->getDataType()), 1, 1,
-                                                                   node,
-                                                                   _storeSymRef);
-
-                           TR::TreeTop *initTree = TR::TreeTop::create(comp(), signExtStore, 0, 0);
-                           TR::TreeTop *prevTree = treetop->getPrevTreeTop();
-                           prevTree->join(initTree);
-                           initTree->join(treetop);
-                           cg()->setLiveLocals(NULL);
-                           }
-                        }
-                     }
-                  }
-               }
-            }
-         }
-
-      if (TR::Compiler->target.is64Bit() &&
-          parent &&
-          (parent->getOpCodeValue() == TR::i2l) &&
-          ((*currentArrayAccess != parent) &&
-           (grandParent->getOpCodeValue() != TR::l2i)) &&
-          node->skipSignExtension())
-         {
-         _rejectedSignExtNodes.add(node);
-         }
-      }
 
    if (node->getVisitCount() == visitCount)
       return;
@@ -4797,10 +4345,6 @@ TR_GlobalRegisterAllocator::createStoresForSignExt(
    int32_t childNum;
    for (childNum=0;childNum<node->getNumChildren();childNum++)
       createStoresForSignExt(node->getChild(childNum), node, parent, treetop, currentArrayAccess, block, blocksInLoop, visitCount, hasCatchBlock);
-
-   if (enableNewSignExtGRA && node->getOpCode().hasSymbolReference() &&
-       (node->getSymbolReference()->getSymbol()->isArrayShadowSymbol()))
-      *currentArrayAccess = prevArrayAccess;
    }
 
 const char *

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -2015,12 +2015,37 @@
                 { "name": ""
                 , "overloadsuffix": ""
                 , "flags": []
-                , "return": "VirtualMachineOperandArray"
+                , "return": "none"
                 , "parms": [
                     {"name":"mb","type":"MethodBuilder"},
-                    {"name":"numOfElements","type":"int32"},
+                    {"name":"sizeHint","type":"int32"},
                     {"name":"elementType","type":"IlType"},
-                    {"name":"arrayBase","type":"VirtualMachineRegister"}
+                    {"name":"stackTopRegister","type":"VirtualMachineRegister"}
+                    ]
+                },
+                { "name": ""
+                , "overloadsuffix": ""
+                , "flags": []
+                , "return": "none"
+                , "parms": [
+                    {"name":"mb","type":"MethodBuilder"},
+                    {"name":"sizeHint","type":"int32"},
+                    {"name":"elementType","type":"IlType"},
+                    {"name":"stackTopRegister","type":"VirtualMachineRegister"},
+                    {"name":"growsUp","type":"boolean"}
+                    ]
+                },
+                { "name": ""
+                , "overloadsuffix": ""
+                , "flags": []
+                , "return": "none"
+                , "parms": [
+                    {"name":"mb","type":"MethodBuilder"},
+                    {"name":"sizeHint","type":"int32"},
+                    {"name":"elementType","type":"IlType"},
+                    {"name":"stackTopRegister","type":"VirtualMachineRegister"},
+                    {"name":"growsUp","type":"boolean"},
+                    {"name":"stackInitialOffset","type":"int32"}
                     ]
                 }
                 ],

--- a/jitbuilder/release/CMakeLists.txt
+++ b/jitbuilder/release/CMakeLists.txt
@@ -43,9 +43,9 @@ create_jitbuilder_test(pow2            cpp/samples/Pow2.cpp)
 create_jitbuilder_test(simple          cpp/samples/Simple.cpp)
 create_jitbuilder_test(worklist        cpp/samples/Worklist.cpp)
 
-# Additional Tests: These may not run properly on all platforms
-# Opt in by setting OMR_JITBUILDER_ADDITIONAL
-if(OMR_JITBUILDER_ADDITIONAL)
+# Extended JitBuilder Tests: These may not run properly on all platforms
+# Opt in by setting OMR_JITBUILDER_TEST_EXTENDED
+if(OMR_JITBUILDER_TEST_EXTENDED)
 	create_jitbuilder_test(call              cpp/samples/Call.cpp)
 	create_jitbuilder_test(conststring       cpp/samples/ConstString.cpp)
 	create_jitbuilder_test(dotproduct        cpp/samples/DotProduct.cpp)

--- a/jitbuilder/release/cpp/samples/OperandStackTests.cpp
+++ b/jitbuilder/release/cpp/samples/OperandStackTests.cpp
@@ -585,7 +585,7 @@ OperandStackTestUsingStructMethod::OperandStackTestUsingStructMethod(OMR::JitBui
    : OperandStackTestMethod(d)
    {
    d->DefineStruct("Thread");
-   d->DefineField("Thread", "sp", d->PointerTo(d->PointerTo(STACKVALUEILTYPE)), offsetof(Thread, sp));
+   d->DefineField("Thread", "sp", d->PointerTo(STACKVALUEILTYPE), offsetof(Thread, sp));
    d->CloseStruct("Thread");
 
    DefineParameter("thread", d->PointerTo("Thread"));


### PR DESCRIPTION
I recently discovered that many of our extended JitBuilder sample tests (which cannot be run safely on all platforms) are not being run on the x86 platforms where they can run safely. On top of that, one of the samples (OperandStackTests) was broken.

I also found that the JitBuilder API description for VirtualMachineOperandStack constructors was not quite right (and we probably didn't discover that because the tests weren't being run).

This PR includes a fix for the OperandStackTests failure, a fix for the API description, and the extended JitBuilder testing is enabled for X86 platforms so hopefully we won't end up in this state again.

Finally, I also fixed a couple more compiler warnings (one in the optimizer, which I *believe* is the last exposed warning in the entire optimizer, which is nice, and one of many more to be fixed in the code generator).