### PR TITLE
Added portlibrary global to make isRunningInContainer called at startup

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1542,7 +1542,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsysinfo.c::omrsysinfo_get_cgroup_subsystem_list "omrsysinfo_get_cgroup_subsystem_list"*/
 	struct OMRCgroupEntry *(*sysinfo_get_cgroup_subsystem_list)(struct OMRPortLibrary *portLibrary);
 	/** see @ref omrsysinfo.c::omrsysinfo_is_running_in_container "omrsysinfo_is_running_in_container"*/
-	BOOLEAN (*sysinfo_is_running_in_container)(struct OMRPortLibrary *portLibrary, int32_t *errorCode);
+	BOOLEAN (*sysinfo_is_running_in_container)(struct OMRPortLibrary *portLibrary);
 	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_subsystem_iterator_init "omrsysinfo_cgroup_subsystem_iterator_init"*/
 	int32_t (*sysinfo_cgroup_subsystem_iterator_init)(struct OMRPortLibrary *portLibrary, uint64_t subsystem, struct OMRCgroupMetricIteratorState *state);
 	/** see @ref omrsysinfo.c::omrsysinfo_cgroup_subsystem_iterator_hasNext "omrsysinfo_cgroup_subsystem_iterator_hasNext"*/
@@ -2009,7 +2009,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_cgroup_get_memlimit(param1) privateOmrPortLibrary->sysinfo_cgroup_get_memlimit(privateOmrPortLibrary, param1)
 #define omrsysinfo_cgroup_is_memlimit_set() privateOmrPortLibrary->sysinfo_cgroup_is_memlimit_set(privateOmrPortLibrary)
 #define omrsysinfo_get_cgroup_subsystem_list() privateOmrPortLibrary->sysinfo_get_cgroup_subsystem_list(privateOmrPortLibrary)
-#define omrsysinfo_is_running_in_container(param1) privateOmrPortLibrary->sysinfo_is_running_in_container(privateOmrPortLibrary, param1)
+#define omrsysinfo_is_running_in_container() privateOmrPortLibrary->sysinfo_is_running_in_container(privateOmrPortLibrary)
 #define omrsysinfo_cgroup_subsystem_iterator_init(param1, param2) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_init(privateOmrPortLibrary, param1, param2)
 #define omrsysinfo_cgroup_subsystem_iterator_hasNext(param1) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_hasNext(privateOmrPortLibrary, param1)
 #define omrsysinfo_cgroup_subsystem_iterator_metricKey(param1, param2) privateOmrPortLibrary->sysinfo_cgroup_subsystem_iterator_metricKey(privateOmrPortLibrary, param1, param2)

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -373,6 +373,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 int32_t
 omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 {
+	PPG_isRunningInContainer = FALSE;
 	return 0;
 }
 
@@ -955,14 +956,12 @@ omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
  *
  * @param[in] portLibrary pointer to OMRPortLibrary
  *
- * @param[in] errorCode int32_t pointer to state error code from internal calls
- *
  * @return TRUE if Runtime is running in a container and FALSE if not or if an error occurs
  */
 BOOLEAN
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary)
 {
-	return FALSE;
+	return PPG_isRunningInContainer;
 }
 
 /**

--- a/port/include/omrportpg.h
+++ b/port/include/omrportpg.h
@@ -37,9 +37,11 @@ typedef struct OMRPortPlatformGlobals {
 	uintptr_t vmem_pageSize[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of supported page sizes */
 	uintptr_t vmem_pageFlags[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of flags describing type of the supported page sizes */
 	uintptr_t systemLoggingFlags;
+	BOOLEAN isRunningInContainer;
 } OMRPortPlatformGlobals;
 
 #define PPG_vmem_pageSize (portLibrary->portGlobals->platformGlobals.vmem_pageSize)
 #define PPG_vmem_pageFlags (portLibrary->portGlobals->platformGlobals.vmem_pageFlags)
 #define PPG_syslog_flags (portLibrary->portGlobals->platformGlobals.systemLoggingFlags)
+#define PPG_isRunningInContainer (portLibrary->portGlobals->platformGlobals.isRunningInContainer)
 #endif /* omrportpg_h */

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -536,7 +536,7 @@ omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC struct OMRCgroupEntry *
 omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC BOOLEAN
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode);
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC int32_t
 omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, uint64_t subsystem, struct OMRCgroupMetricIteratorState *state);
 extern J9_CFUNC BOOLEAN

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -2040,6 +2040,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 int32_t
 omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 {
+	PPG_isRunningInContainer = FALSE;
 	/* Obtain and cache executable name; if this fails, executable name remains NULL, but
 	 * shouldn't cause failure to startup port library.  Failure will be noticed only
 	 * when the omrsysinfo_get_executable_name() actually gets invoked.
@@ -2059,6 +2060,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 		}
 	}
 	attachedPortLibraries += 1;
+	isRunningInContainer(portLibrary, &PPG_isRunningInContainer);
 #endif /* defined(LINUX) */
 	return 0;
 }
@@ -4456,13 +4458,9 @@ omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
  * Returns TRUE if running inside a container and FALSE if not or if an error occurs
  */
 BOOLEAN
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary)
 {
-	BOOLEAN inContainer = FALSE;
-#if defined(LINUX) && !defined(OMRZTPF)
-	*errorCode = isRunningInContainer(portLibrary, &inContainer);
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
-	return inContainer;
+	return PPG_isRunningInContainer; 
 }
 
 int32_t

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -69,6 +69,7 @@ typedef struct OMRPortPlatformGlobals {
 	char *si_osVersion;
 	uintptr_t vmem_pageSize[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of supported page sizes */
 	uintptr_t vmem_pageFlags[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of flags describing type of the supported page sizes */
+	BOOLEAN isRunningInContainer;	
 #if defined(LINUX) && defined(S390)
 	int64_t last_clock_delta_update;  /** hw clock microsecond timestamp of last clock delta adjustment */
 	int64_t software_msec_clock_delta; /** signed difference between hw and sw clocks in milliseconds */
@@ -108,6 +109,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_si_osVersion (portLibrary->portGlobals->platformGlobals.si_osVersion)
 #define PPG_vmem_pageSize (portLibrary->portGlobals->platformGlobals.vmem_pageSize)
 #define PPG_vmem_pageFlags (portLibrary->portGlobals->platformGlobals.vmem_pageFlags)
+#define PPG_isRunningInContainer (portLibrary->portGlobals->platformGlobals.isRunningInContainer)
 #if defined(LINUX) && defined(S390)
 #define PPG_last_clock_delta_update  (portLibrary->portGlobals->platformGlobals.last_clock_delta_update)
 #define PPG_software_msec_clock_delta (portLibrary->portGlobals->platformGlobals.software_msec_clock_delta)

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -862,6 +862,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 int32_t
 omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 {
+	PPG_isRunningInContainer = FALSE;
 	/* Obtain and cache executable name; if this fails, executable name remains NULL, but
 	 * shouldn't cause failure to startup port library.  Failure will be noticed only
 	 * when the omrsysinfo_get_executable_name() actually gets invoked.
@@ -1679,9 +1680,9 @@ omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
 }
 
 BOOLEAN
-omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary, int32_t *errorCode)
+omrsysinfo_is_running_in_container(struct OMRPortLibrary *portLibrary)
 {
-	return FALSE;
+	return PPG_isRunningInContainer;
 }
 
 int32_t

--- a/port/win32_include/omrportpg.h
+++ b/port/win32_include/omrportpg.h
@@ -128,6 +128,7 @@ typedef struct OMRPortPlatformGlobals {
 	HANDLE mem_heap;
 	uintptr_t vmem_pageSize[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of supported page sizes */
 	uintptr_t vmem_pageFlags[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of flags describing type of the supported page sizes */
+	BOOLEAN isRunningInContainer;	
 	char *si_osType;
 	char *si_osTypeOnHeap;
 	char *si_osVersion;
@@ -164,6 +165,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_mem_heap (portLibrary->portGlobals->platformGlobals.mem_heap)
 #define PPG_vmem_pageSize (portLibrary->portGlobals->platformGlobals.vmem_pageSize)
 #define PPG_vmem_pageFlags (portLibrary->portGlobals->platformGlobals.vmem_pageFlags)
+#define PPG_isRunningInContainer (portLibrary->portGlobals->platformGlobals.isRunningInContainer)
 #define PPG_si_osType (portLibrary->portGlobals->platformGlobals.si_osType)
 #define PPG_si_osTypeOnHeap (portLibrary->portGlobals->platformGlobals.si_osTypeOnHeap)
 #define PPG_si_osVersion (portLibrary->portGlobals->platformGlobals.si_osVersion)

--- a/port/zos390/omrportpg.h
+++ b/port/zos390/omrportpg.h
@@ -53,6 +53,7 @@ typedef struct OMRPortPlatformGlobals {
 	char *si_osVersion;
 	uintptr_t vmem_pageSize[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of supported page sizes */
 	uintptr_t vmem_pageFlags[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of flags describing type of the supported page sizes */
+	BOOLEAN isRunningInContainer;
 #if defined(OMR_ENV_DATA64)
 	J9SubAllocateHeapMem32 subAllocHeapMem32;
 #endif
@@ -76,6 +77,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_si_osVersion (portLibrary->portGlobals->platformGlobals.si_osVersion)
 #define PPG_vmem_pageSize (portLibrary->portGlobals->platformGlobals.vmem_pageSize)
 #define PPG_vmem_pageFlags (portLibrary->portGlobals->platformGlobals.vmem_pageFlags)
+#define PPG_isRunningInContainer (portLibrary->portGlobals->platformGlobals.isRunningInContainer)
 #if defined(OMR_ENV_DATA64)
 #define PPG_mem_mem32_subAllocHeapMem32 (portLibrary->portGlobals->platformGlobals.subAllocHeapMem32)
 #endif


### PR DESCRIPTION
OMR PortLibrary Api `omrsysinfo_is_running_in_container` is required by every runtime built on top of OMR and also might be having many places where this would be called, As this api internally calls other function, its get invoked everytime we make a call to the api so i thought it would be good to have a PortLibrary global variable `PPG_isRunningInContainer` for is running in container check and also that function to be called at the portLibrary startup which assigns the value for the portlibrary global `PPG_isRunningInContainer` and would decrease the calls for `isRunningInContainer` function.

Signed-off-by: bharathappali <bharath.appali@gmail.com>