### PR TITLE
Implement dynamic array clone in value propagation

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1414,6 +1414,9 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsPrimitiveArrayCopy() {return _flags2.testAny(SupportsPrimitiveArrayCopy);}
    void setSupportsPrimitiveArrayCopy() {_flags2.set(SupportsPrimitiveArrayCopy);}
 
+   bool getSupportsDynamicANewArray() {return _flags2.testAny(SupportsDynamicANewArray);}
+   void setSupportsDynamicANewArray() {_flags2.set(SupportsDynamicANewArray);}
+
    bool getSupportsReferenceArrayCopy() {return _flags1.testAny(SupportsReferenceArrayCopy);}
    void setSupportsReferenceArrayCopy() {_flags1.set(SupportsReferenceArrayCopy);}
 
@@ -1686,7 +1689,7 @@ class OMR_EXTENSIBLE CodeGenerator
       HasDoubleWordAlignedStack                           = 0x00000200,
       SupportsReadOnlyLocks                               = 0x00000400,
       SupportsArrayTranslateAndTest                       = 0x00000800,
-      // AVAILABLE                                        = 0x00001000,
+      SupportsDynamicANewArray                            = 0x00001000,
       // AVAILABLE                                        = 0x00002000,
       // AVAILABLE                                        = 0x00004000,
       SupportsPostProcessArrayCopy                        = 0x00008000,

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -7294,15 +7294,15 @@ void OMR::ValuePropagation::doDelayedTransformations()
    _objectCloneTypes.deleteAll();
 
    ListIterator<TR::TreeTop> arrayCloneIt(&_arrayCloneCalls);
-   ListIterator<TR_OpaqueClassBlock> arrayCloneTypeIt(&_arrayCloneTypes);
+   ListIterator<ArrayCloneInfo> arrayCloneTypeIt(&_arrayCloneTypes);
       {
       TR::TreeTop *callTree = arrayCloneIt.getFirst();
-      TR_OpaqueClassBlock *clazz = arrayCloneTypeIt.getFirst();
-      while (callTree && clazz)
+      ArrayCloneInfo *cloneInfo = arrayCloneTypeIt.getFirst();
+      while (callTree && cloneInfo)
          {
-         transformArrayCloneCall(callTree, clazz);
+         transformArrayCloneCall(callTree, cloneInfo);
          callTree = arrayCloneIt.getNext();
-         clazz = arrayCloneTypeIt.getNext();
+         cloneInfo = arrayCloneTypeIt.getNext();
          }
       }
    _arrayCloneCalls.deleteAll();

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -600,10 +600,19 @@ class ValuePropagation : public TR::Optimization
          : _clazz(clazz), _isFixed(isFixed)  { }
    };
 
+   struct ArrayCloneInfo {
+      TR_ALLOC(TR_Memory::ValuePropagation)
+
+      TR_OpaqueClassBlock *_clazz;
+      bool _isFixed;
+      ArrayCloneInfo(TR_OpaqueClassBlock *clazz, bool isFixed)
+         : _clazz(clazz), _isFixed(isFixed)  { }
+   };
+
 #ifdef J9_PROJECT_SPECIFIC
    void transformConverterCall(TR::TreeTop *);
    void transformObjectCloneCall(TR::TreeTop *, ObjCloneInfo *cloneInfo);
-   void transformArrayCloneCall(TR::TreeTop *, TR_OpaqueClassBlock *j9class);
+   void transformArrayCloneCall(TR::TreeTop *, ArrayCloneInfo *cloneInfo);
 #endif
 
 
@@ -905,7 +914,7 @@ class ValuePropagation : public TR::Optimization
    List<TR::TreeTop> _objectCloneCalls;
    List<TR::TreeTop> _arrayCloneCalls;
    List<ObjCloneInfo> _objectCloneTypes;
-   List<TR_OpaqueClassBlock> _arrayCloneTypes;
+   List<ArrayCloneInfo> _arrayCloneTypes;
 
    int32_t    *_parmInfo;
    bool       *_parmTypeValid;

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -3530,7 +3530,7 @@ void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR:
    return;
    }
 
-void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_OpaqueClassBlock *j9arrayClass)
+void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, OMR::ValuePropagation::ArrayCloneInfo *cloneInfo)
    {
    static char *disableArrayCloneOpt = feGetEnv("TR_disableFastArrayClone");
    if (disableArrayCloneOpt || TR::Compiler->om.canGenerateArraylets())
@@ -3547,6 +3547,9 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_Op
 
    if (!performTransformation(comp(), "%sInlining array clone call [%p] as new array and arraycopy\n", OPT_DETAILS, callNode))
       return;
+
+   TR_OpaqueClassBlock *j9arrayClass = cloneInfo->_clazz;
+   bool isFixedClass = cloneInfo->_isFixed;
 
    TR_OpaqueClassBlock *j9class = comp()->fe()->getComponentClassFromArrayClass(j9arrayClass);
 
@@ -3587,9 +3590,20 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, TR_Op
       }
    else
       {
-      TR::Node *loadaddr = TR::Node::createWithSymRef(callNode, TR::loadaddr, 0, comp()->getSymRefTab()->findOrCreateClassSymbol(callNode->getSymbolReference()->getOwningMethodSymbol(comp()), 0, j9class));
+      TR::Node *classNode;
+      if (isFixedClass)
+         {
+         classNode = TR::Node::createWithSymRef(callNode, TR::loadaddr, 0, comp()->getSymRefTab()->findOrCreateClassSymbol(callNode->getSymbolReference()->getOwningMethodSymbol(comp()), 0, j9class));
+         }
+      else
+         {
+         // Load the component class of the cloned array as 2nd child of anewarray as expected by the opcode.
+         TR::Node * arrayClassNode = TR::Node::createWithSymRef(callNode, TR::aloadi, 1, objNode, comp()->getSymRefTab()->findOrCreateVftSymbolRef());
+         classNode = TR::Node::createWithSymRef(callNode, TR::aloadi, 1, arrayClassNode, comp()->getSymRefTab()->findOrCreateArrayComponentTypeSymbolRef());
+         }
       TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateANewArraySymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
-      TR::Node::recreateWithoutProperties(callNode, TR::anewarray, 2, lenNode, loadaddr, symRef);
+      TR::Node::recreateWithoutProperties(callNode, TR::anewarray, 2, lenNode, classNode, symRef);
+      callNode->setCanSkipZeroInitialization(true);
       }
    TR::Node *newArray = callNode;
    newArray->setIsNonNull(true);

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -406,6 +406,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setSupportsEfficientNarrowIntComputation();
    self()->setSupportsEfficientNarrowUnsignedIntComputation();
    self()->setSupportsVirtualGuardNOPing();
+   self()->setSupportsDynamicANewArray();
 
    // allows [i/l]div to decompose to [i/l]mulh in TreeSimplifier
    //


### PR DESCRIPTION
Dynamic array cloning transforms refArrayObject.clone()
into anewarray followed by arraycopy, where refArrayObject
is a resolved, not fixed array class. This is safe as cloning
of an array object can safely be devirtualized and replaced with
a new array allocation followed by an array copy. The caveat is
that since the array class is not fixed, the actual class type of the
cloned array cannot be known at compile time, hence the class
child of the anewarray opcode needs to be dynamically evaluated
at runtime, instead of being represented as a runtime constant under
normal, statically allocated anewarray cases.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>