### PR TITLE
Multiple ddrgen fixes

### DIFF
--- a/ddr/include/ddr/blobgen/java/genSuperset.hpp
+++ b/ddr/include/ddr/blobgen/java/genSuperset.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -23,11 +23,6 @@
 #define GENSUPERSET_HPP
 
 #include "ddr/blobgen/genBlob.hpp"
-#include "ddr/std/unordered_map.hpp"
-
-#include <set>
-
-using std::set;
 
 class Field;
 class SupersetFieldVisitor;
@@ -37,15 +32,11 @@ class Symbol_IR;
 class JavaSupersetGenerator : public SupersetGenerator
 {
 private:
-	set<string> _baseTypedefSet; /* Set of types renamed to "[U/I][SIZE]" */
-	unordered_map<string, string> _baseTypedefMap; /* Types remapped for assembled type names. */
-	unordered_map<string, string> _baseTypedefReplace; /* Type names which are replaced everywhere. */
 	intptr_t _file;
 	OMRPortLibrary *_portLibrary;
 	bool _printEmptyTypes;
 	string _pendingTypeHeading;
 
-	void initBaseTypedefSet();
 	void convertJ9BaseTypedef(Type *type, string *name);
 	void replaceBaseTypedef(Type *type, string *name);
 	DDR_RC getFieldType(Field *field, string *assembledTypeName, string *simpleTypeName);

--- a/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBinaryBlob.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -797,7 +797,20 @@ public:
 DDR_RC
 BlobFieldVisitor::visitType(Type *type) const
 {
-	*_typePrefix += type->_name;
+	const string & typeName = type->_name;
+	bool isSigned = false;
+	size_t bitWidth = 0;
+
+	if (Type::isStandardType(typeName.c_str(), (size_t)typeName.length(), &isSigned, &bitWidth)) {
+		stringstream newType;
+
+		newType << (isSigned ? "I" : "U") << bitWidth;
+
+		*_typePrefix += newType.str();
+	} else {
+		*_typePrefix += typeName;
+	}
+
 	return DDR_RC_OK;
 }
 

--- a/ddr/lib/ddr-blobgen/java/genSuperset.cpp
+++ b/ddr/lib/ddr-blobgen/java/genSuperset.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,73 +51,11 @@ replaceAll(string str, const string &subStr, const string &newStr)
 }
 
 JavaSupersetGenerator::JavaSupersetGenerator(bool printEmptyTypes)
-	: _baseTypedefSet()
-	, _baseTypedefMap()
-	, _baseTypedefReplace()
-	, _file(0)
+	: _file(0)
 	, _portLibrary(NULL)
 	, _printEmptyTypes(printEmptyTypes)
 	, _pendingTypeHeading()
 {
-	initBaseTypedefSet();
-}
-
-void
-JavaSupersetGenerator::initBaseTypedefSet()
-{
-	_baseTypedefSet.insert("unsigned char");
-	_baseTypedefSet.insert("uint8_t");
-	_baseTypedefSet.insert("__uint8_t");
-	_baseTypedefSet.insert("signed char");
-	_baseTypedefSet.insert("char");
-	_baseTypedefSet.insert("int8_t");
-	_baseTypedefSet.insert("__int8_t");
-
-	_baseTypedefSet.insert("unsigned short int");
-	_baseTypedefSet.insert("short unsigned int");
-	_baseTypedefSet.insert("uint16_t");
-	_baseTypedefSet.insert("__uint16_t");
-	_baseTypedefSet.insert("signed short int");
-	_baseTypedefSet.insert("short signed int");
-	_baseTypedefSet.insert("short int");
-	_baseTypedefSet.insert("int16_t");
-	_baseTypedefSet.insert("__int16_t");
-
-	_baseTypedefSet.insert("unsigned int");
-	_baseTypedefSet.insert("uint32_t");
-	_baseTypedefSet.insert("__uint32_t");
-	_baseTypedefSet.insert("signed int");
-	_baseTypedefSet.insert("int");
-	_baseTypedefSet.insert("int32_t");
-	_baseTypedefSet.insert("__int32_t");
-
-	_baseTypedefSet.insert("long unsigned int");
-	_baseTypedefSet.insert("unsigned long int");
-	_baseTypedefSet.insert("long long unsigned int");
-	_baseTypedefSet.insert("unsigned long long int");
-	_baseTypedefSet.insert("uint64_t");
-	_baseTypedefSet.insert("long signed int");
-	_baseTypedefSet.insert("signed long int");
-	_baseTypedefSet.insert("long long signed int");
-	_baseTypedefSet.insert("signed long long int");
-	_baseTypedefSet.insert("long int");
-	_baseTypedefSet.insert("long long int");
-	_baseTypedefSet.insert("int64_t");
-
-	_baseTypedefMap["intptr_t"] = "IDATA";
-	_baseTypedefMap["uintptr_t"] = "UDATA";
-	_baseTypedefMap["char"] = "U8";
-
-	_baseTypedefReplace["U_8"] = "U8";
-	_baseTypedefReplace["U_16"] = "U16";
-	_baseTypedefReplace["U_32"] = "U32";
-	_baseTypedefReplace["U_64"] = "U64";
-	_baseTypedefReplace["U_128"] = "U128";
-	_baseTypedefReplace["I_8"] = "I8";
-	_baseTypedefReplace["I_16"] = "I16";
-	_baseTypedefReplace["I_32"] = "I32";
-	_baseTypedefReplace["I_64"] = "I64";
-	_baseTypedefReplace["I_128"] = "I128";
 }
 
 void
@@ -125,37 +63,42 @@ JavaSupersetGenerator::convertJ9BaseTypedef(Type *type, string *typeName)
 {
 	string name = type->getFullName();
 
-	/* Convert int types to J9 base typedefs. */
-	if (_baseTypedefMap.find(name) != _baseTypedefMap.end()) {
-		name = _baseTypedefMap[name];
-	} else if (_baseTypedefSet.find(name) != _baseTypedefSet.end()) {
-		stringstream ss;
-		ss << ((string::npos == name.find_first_of('u')) ? "I" : "U")
-		   << (type->_sizeOf * 8);
-		name = ss.str();
-	} else {
-		replaceBaseTypedef(type, &name);
-	}
+	replaceBaseTypedef(type, &name);
+
 	*typeName = name;
 }
 
 void
 JavaSupersetGenerator::replaceBaseTypedef(Type *type, string *name)
 {
-	/* In both the first and second printed type name in the superset,
-	 * types such as "U_32" are replaced with "U32" and function pointers
-	 * are replaced with "void*".
-	 */
-	unordered_map<string, string>::const_iterator it = _baseTypedefReplace.find(*name);
-	if (it != _baseTypedefReplace.end()) {
-		*name = it->second;
+	string::size_type start = name->rfind('(');
+
+	if (string::npos == start) {
+		start = 0;
 	} else {
-		for (it = _baseTypedefReplace.begin(); it != _baseTypedefReplace.end(); ++it) {
-			size_t index = name->find(it->first);
-			if (string::npos != index) {
-				name->replace(index, it->first.length(), it->second);
-			}
-		}
+		start += 1;
+	}
+
+	string::size_type end = name->find_first_of("*[)", start);
+
+	if (string::npos == end) {
+		end = name->length();
+	}
+
+	string::size_type length = end - start;
+	bool isSigned = false;
+	size_t bitWidth = 0;
+
+	/*
+	 * In both the first and second printed type names in the superset,
+	 * types such as "U_32" are replaced with "U32".
+	 */
+	if (Type::isStandardType(name->c_str() + start, (size_t)length, &isSigned, &bitWidth)) {
+		stringstream ss;
+
+		ss << (isSigned ? "I" : "U") << bitWidth;
+
+		name->replace(start, length, ss.str());
 	}
 }
 

--- a/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -390,6 +390,7 @@ static const pair<const char *, Dwarf_Half> tagStrings[] = {
 	make_pair("member", DW_TAG_member),
 	make_pair("namespace", DW_TAG_namespace),
 	make_pair("pointer_type", DW_TAG_pointer_type),
+	make_pair("ptr_to_member_type", DW_TAG_ptr_to_member_type),
 	make_pair("restrict_type", DW_TAG_restrict_type),
 	make_pair("shared_type", DW_TAG_shared_type),
 	make_pair("structure_type", DW_TAG_structure_type),

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,7 +133,8 @@ main(int argc, char *argv[])
 		rc = scanner.startScan(&portLibrary, &ir, &options.debugFiles, options.blacklistFile);
 
 #if defined(DEBUG_PRINT_TYPES)
-		printf("== scan results ==\n");
+		OMRPORT_ACCESS_FROM_OMRPORT(&portLibrary);
+		omrtty_printf("== scan results ==\n");
 		for (vector<Type *>::const_iterator type = ir._types.begin(); type != ir._types.end(); ++type) {
 			(*type)->acceptVisitor(printer);
 		}
@@ -145,7 +146,8 @@ main(int argc, char *argv[])
 		ir.removeDuplicates();
 
 #if defined(DEBUG_PRINT_TYPES)
-		printf("== after removing duplicates ==\n");
+		OMRPORT_ACCESS_FROM_OMRPORT(&portLibrary);
+		omrtty_printf("== after removing duplicates ==\n");
 		for (vector<Type *>::const_iterator type = ir._types.begin(); type != ir._types.end(); ++type) {
 			(*type)->acceptVisitor(printer);
 		}


### PR DESCRIPTION
This replays #3355:

* add OSX support for DW_TAG_ptr_to_member_type
* use port library consistently if DEBUG_PRINT_TYPES is defined
* add missing use of Type::isStandardType() in blob generator
* recognize more known types and handle them consistently
-- fix bug in Type::isStandardType()
-- e.g. 'unsigned short int' was handled, but not 'unsigned short'
-- treat char as unsigned unless explicitly 'signed'
-- handle SRP types; e.g. 'J9SRP(U_32)' -> 'J9SRP(U32)'

Changes to openj9 (e.g. https://github.com/eclipse/openj9/pull/4191) should tolerate this better this time.