### PR TITLE
Add a direct method call relocation and clean up some related code

### DIFF
--- a/compiler/codegen/OMRAheadOfTimeCompile.cpp
+++ b/compiler/codegen/OMRAheadOfTimeCompile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,57 +113,6 @@ void OMR::AheadOfTimeCompile::traceRelocationOffsets(uint8_t *&cursor, int32_t o
          }
       cursor += offsetSize;
       }
-   }
-
-uintptr_t
-findCorrectInlinedSiteIndex(void *constantPool, TR::Compilation *comp, uintptr_t currentInlinedSiteIndex)
-   {
-   uintptr_t cp2 = 0;
-
-   uintptr_t inlinedSiteIndex = currentInlinedSiteIndex;
-   if (inlinedSiteIndex==(uintptr_t)-1)
-      {
-      cp2 = (uintptr_t) comp->getCurrentMethod()->constantPool();
-      }
-   else
-      {
-      TR_InlinedCallSite &ics2 = comp->getInlinedCallSite(inlinedSiteIndex);
-      TR_AOTMethodInfo *aotMethodInfo2 = (TR_AOTMethodInfo *)ics2._methodInfo;
-      cp2 = (uintptr_t)aotMethodInfo2->resolvedMethod->constantPool();
-      }
-
-   bool matchFound = false;
-
-   if ( (uintptr_t) constantPool == cp2)
-      {
-      matchFound = true;
-      }
-   else
-      {
-      if ((uintptr_t)constantPool == (uintptr_t)comp->getCurrentMethod()->constantPool())
-         {
-         matchFound = true;
-         inlinedSiteIndex = (uintptr_t)-1;
-         }
-      else
-         {
-         for (uintptr_t i = 0; i < comp->getNumInlinedCallSites(); i++)
-            {
-            TR_InlinedCallSite &ics = comp->getInlinedCallSite(i);
-
-            TR_AOTMethodInfo *aotMethodInfo = (TR_AOTMethodInfo *)ics._methodInfo;
-
-            if ((uintptr_t)constantPool == (uintptr_t)aotMethodInfo->resolvedMethod->constantPool())
-               {
-               matchFound = true;
-               inlinedSiteIndex = i;
-               break;
-               }
-            }
-         }
-      }
-   TR_ASSERT(matchFound, "couldn't find this CP in inlined site list");
-   return inlinedSiteIndex;
    }
 
 void createGuardSiteForRemovedGuard(TR::Compilation *comp, TR::Node *ifNode)

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2952,16 +2952,6 @@ void OMR::CodeGenerator::addRelocation(TR::Relocation *r)
       {
       _relocationList.push_front(r);
       }
-   }
-
-void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::AOTRelocationPositionRequest where)
-   {
-   self()->addExternalRelocation(r, generatingFileName, generatingLineNumber, node, static_cast<TR::ExternalRelocationPositionRequest>(where));
-   }
-
-void OMR::CodeGenerator::addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo* info, TR::AOTRelocationPositionRequest where)
-   {
-   self()->addExternalRelocation(r, info, static_cast<TR::ExternalRelocationPositionRequest>(where));
    }
 
 void OMR::CodeGenerator::addExternalRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::ExternalRelocationPositionRequest where)

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -238,11 +238,6 @@ namespace TR
       {
       ExternalRelocationAtFront,
       ExternalRelocationAtBack,
-      };
-   enum AOTRelocationPositionRequest
-      {
-      AOTRelocationAtFront = ExternalRelocationAtFront,
-      AOTRelocationAtBack = ExternalRelocationAtBack,
       };
    }
 
@@ -1067,13 +1062,10 @@ class OMR_EXTENSIBLE CodeGenerator
    // Relocations
    //
    TR::list<TR::Relocation*>& getRelocationList() {return _relocationList;}
-   TR::list<TR::Relocation*>& getAOTRelocationList() {return _externalRelocationList;}
    TR::list<TR::Relocation*>& getExternalRelocationList() {return _externalRelocationList;}
    TR::list<TR::StaticRelocation>& getStaticRelocations() { return _staticRelocationList; }
 
    void addRelocation(TR::Relocation *r);
-   void addAOTRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::AOTRelocationPositionRequest where = TR::AOTRelocationAtBack);
-   void addAOTRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info, TR::AOTRelocationPositionRequest where = TR::AOTRelocationAtBack);
    void addExternalRelocation(TR::Relocation *r, const char *generatingFileName, uintptr_t generatingLineNumber, TR::Node *node, TR::ExternalRelocationPositionRequest where = TR::ExternalRelocationAtBack);
    void addExternalRelocation(TR::Relocation *r, TR::RelocationDebugInfo *info, TR::ExternalRelocationPositionRequest where = TR::ExternalRelocationAtBack);
    void addStaticRelocation(const TR::StaticRelocation &relocation);

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -460,6 +460,7 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_ValidateMethodFromSingleAbstractImplementer (96)",
    "TR_ValidateImproperInterfaceMethodFromCP (97)",
    "TR_SymbolFromManager (98)",
+   "TR_MethodCallAddress (99)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/codegen/Relocation.hpp
+++ b/compiler/codegen/Relocation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,6 @@ class Relocation
    /**dumps a trace of the internals - override as required */
    virtual void trace(TR::Compilation* comp);
 
-   virtual void addAOTRelocation(TR::CodeGenerator *codeGen) {addExternalRelocation(codeGen);}
    virtual void addExternalRelocation(TR::CodeGenerator *codeGen) {}
 
    virtual void apply(TR::CodeGenerator *codeGen);
@@ -416,7 +415,6 @@ class ExternalRelocation : public TR::Relocation
 
    void trace(TR::Compilation* comp);
 
-   void addAOTRelocation(TR::CodeGenerator *codeGen) {addExternalRelocation(codeGen);}
    void addExternalRelocation(TR::CodeGenerator *codeGen);
    virtual uint8_t collectModifier();
    virtual uint32_t getNarrowSize() {return 2;}

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -393,7 +393,8 @@ typedef enum
    TR_ValidateMethodFromSingleAbstractImplementer = 96,
    TR_ValidateImproperInterfaceMethodFromCP=97,
    TR_SymbolFromManager                   = 98,
-   TR_NumExternalRelocationKinds          = 99,
+   TR_MethodCallAddress                   = 99,
+   TR_NumExternalRelocationKinds          = 100,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1093,6 +1093,11 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                         getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
                         (TR_ExternalRelocationTargetKind) reloTypes [rType], cg()),
                         __FILE__, __LINE__, getNode());
+                  }
+               else if (resolvedMethod)
+                  {
+                  cg()->addProjectSpecializedRelocation(cursor, (uint8_t *)getSymbolReference()->getMethodAddress(), NULL, TR_MethodCallAddress,
+                                         __FILE__, __LINE__, getNode());
                   }
                else
                   {


### PR DESCRIPTION
This PR adds a new relocation identifier, `TR_MethodCallAddress` and uses it during BinaryEncoding on x86 to create the corresponding project-specific relocation on direct call instructions. The implementation will be downstream, but the high level description is that it will be used to relocate direct calls where the call target is known at compile time but the address of the call instruction is not, thereby necessitating the use of a relocation to generate the appropriate relative offset for the call once its position is known.

Also included are some self-explanatory cleanups.

FYI @mpirvu.