### PR TITLE
Tril tests: Use floating-point abs function in filters

### DIFF
--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,8 @@
 
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
+
+#include <cmath>
 
 int32_t iadd(int32_t l, int32_t r) {
     return l+r;
@@ -174,7 +176,7 @@ bool smallFp_filter(std::tuple<T, T> a)
    // workaround: avoid failure caused by snprintf("%f")
    auto a0 = std::get<0>(a);
    auto a1 = std::get<1>(a);
-   return ((abs(a0) < 0.01 && a0 != 0.0) || (abs(a1) < 0.01 && a1 != 0.0));
+   return ((std::abs(a0) < 0.01 && a0 != 0.0) || (std::abs(a1) < 0.01 && a1 != 0.0));
    }
 
 float fadd(float l, float r) {

--- a/fvtest/compilertriltest/CompareTest.cpp
+++ b/fvtest/compilertriltest/CompareTest.cpp
@@ -22,7 +22,7 @@
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
 
-#include <math.h>
+#include <cmath>
 
 int32_t icmpeq(int32_t l, int32_t r) {
     return (l == r) ? 1 : 0;
@@ -388,7 +388,7 @@ bool smallFp_filter(std::tuple<T, T> a)
    // workaround: avoid failure caused by snprintf("%f")
    auto a0 = std::get<0>(a);
    auto a1 = std::get<1>(a);
-   return ((abs(a0) < 0.01 && a0 != 0.0) || (abs(a1) < 0.01 && a1 != 0.0));
+   return ((std::abs(a0) < 0.01 && a0 != 0.0) || (std::abs(a1) < 0.01 && a1 != 0.0));
    }
 
 int32_t fcmpeq(float l, float r) {

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,8 @@
 
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
+
+#include <cmath>
 
 int32_t b2i(int8_t x) {
     return static_cast<int32_t>(x);
@@ -913,7 +915,7 @@ template <typename F, typename I>
 bool fp_filter(F a)
    {
    // workaround: avoid failure caused by snprintf("%f") or potential undefined behaviour
-   return (abs(a) < 0.01 && a != 0.0) ||
+   return (std::abs(a) < 0.01 && a != 0.0) ||
       (a > static_cast<F>(std::numeric_limits<I>::max())) ||
       (a < static_cast<F>(std::numeric_limits<I>::min())) ;
    }
@@ -1162,7 +1164,7 @@ template <typename T>
 bool smallFp_filter(T a)
    {
    // workaround: avoid failure caused by snprintf("%f")
-   return (abs(a) < 0.01 && a != 0.0);
+   return (std::abs(a) < 0.01 && a != 0.0);
    }
 
 double f2d(float x) {


### PR DESCRIPTION
I have used the abs() function in some test case filters for
floating-point workaround, but that is an integer function.
This commit corrects it by replacing with std::abs().

Signed-off-by: knn-k <konno@jp.ibm.com>