### PR TITLE
compiler: build: Allow dollars in identifiers

### DIFF
--- a/fvtest/compilertest/build/toolcfg/gnu/common.mk
+++ b/fvtest/compilertest/build/toolcfg/gnu/common.mk
@@ -95,8 +95,7 @@ CX_FLAGS+=\
     -pthread \
     -fomit-frame-pointer \
     -fasynchronous-unwind-tables \
-    -Wreturn-type \
-    -fno-dollars-in-identifiers
+    -Wreturn-type
 
 CXX_FLAGS+=\
     -std=c++0x \

--- a/jitbuilder/build/toolcfg/gnu/common.mk
+++ b/jitbuilder/build/toolcfg/gnu/common.mk
@@ -95,8 +95,7 @@ CX_FLAGS+=\
     -pthread \
     -fomit-frame-pointer \
     -fasynchronous-unwind-tables \
-    -Wreturn-type \
-    -fno-dollars-in-identifiers
+    -Wreturn-type
 
 CXX_FLAGS+=\
     -std=c++0x \


### PR DESCRIPTION
Apple patches libstdc++v3 with additional support for dtrace. These
dtrace symbols use dollar sign identifiers, and are incompatible with
the compile option -fno-dollars-in-identifiers. This commit removes the
option.

Signed-off-by: Robert Young <rwy0717@gmail.com>