### PR TITLE
Optimize sequential recognized object shadow field loads in VP

### DIFF
--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -354,6 +354,8 @@ public:
 
    inline bool isRecognizedShadow();
 
+   inline bool isRecognizedKnownObjectShadow();
+
    inline void setArrayletShadowSymbol();
    inline bool isArrayletShadowSymbol();
 
@@ -512,7 +514,7 @@ public:
       ArrayShadow               = 0x80000000,
       RecognizedShadow          = 0x40000000, // recognized field
       ArrayletShadow            = 0x20000000,
-      // Available              = 0x10000000,
+      RecognizedKnownObjectShadow = 0x10000000,
       GlobalFragmentShadow      = 0x08000000,
       MemoryTypeShadow          = 0x04000000,
       Ordered                   = 0x02000000,

--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -446,6 +446,12 @@ OMR::Symbol::isRecognizedShadow()
    return self()->isShadow() && _flags.testAny(RecognizedShadow);
    }
 
+bool
+OMR::Symbol::isRecognizedKnownObjectShadow()
+   {
+   return self()->isRecognizedShadow() && _flags.testAny(RecognizedKnownObjectShadow);
+   }
+
 void
 OMR::Symbol::setArrayletShadowSymbol()
    {


### PR DESCRIPTION
Optimize the generalized pattern `Field1 f1 = o.field1; if (f1==null) initialize_f1; Field2 f2 = f1.field2; if (f2==null) initialize_f2` where `o` is a known object. If value of `f1` is null, it is initialized just once to a valid non-null value and does not change; similarly, if `f2` is null, it is also initialized to a valid non-null value and also does not change during entire run time. If `o` is a known object. VP loads `f1` at compile time and checks for null. A non-null value means it has been initialized so we treat it as a known object and attach known object, non-null, and fixed class constraints. In the loading of `f2`, the newly propagated known object constraint is attached to the base object `f1`, so again we do a compile-time load of `f2` and attach the appropriate constraints. The "initialize-just-once-and-never-change" nature of the field loads are represented as special `recognized known object` fields, with the shadow sym refs specially tagged. 

A Java example is `MyEnumClass.class.getEnumConstants()`. The method retrieves the enum constants array via 2 indirect loads: EnumVars enumVars = classObject.enumVars followed by Object[] enumConstants = enumVars.cachedEnumConstants. Both fields are initialized once and never change.