### PR TITLE
DDR: allow ddr-scanner to handle exe/dll files

### DIFF
--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -83,7 +83,7 @@ private:
 	DDR_RC createClassUDT(IDiaSymbol *symbol, ClassUDT **newClass, NamespaceUDT *outerUDT);
 	DDR_RC createEnumUDT(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
 	DDR_RC createTypedef(IDiaSymbol *symbol, NamespaceUDT *outerUDT);
-	DDR_RC loadDataFromPdb(const wchar_t *filename, IDiaDataSource **diaDataSource, IDiaSession **diaSession, IDiaSymbol **diaSymbol);
+	DDR_RC loadDataFromBinary(const wchar_t *filename, IDiaDataSource **diaDataSource, IDiaSession **diaSession, IDiaSymbol **diaSymbol);
 	DDR_RC setSuperClassName(IDiaSymbol *symbol, ClassUDT *newUDT);
 	void getNamespaceFromName(const string &name, NamespaceUDT **outerUDT);
 	static DDR_RC getName(IDiaSymbol *symbol, string *name);


### PR DESCRIPTION
If filename does not end with '.pdb', assume the file is an exe/dll file

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>