### PR TITLE
Store barrier in co-operative copy setup

### DIFF
--- a/gc/structs/ForwardedHeader.cpp
+++ b/gc/structs/ForwardedHeader.cpp
@@ -174,7 +174,11 @@ MM_ForwardedHeader::copySetup(omrobjectptr_t destinationObjectPtr, uintptr_t *re
 
 	/* set the remaining length to copy */
 	objectHeader->slot = (fomrobject_t)(*remainingSizeToCopy | (0 << OUTSTANDING_COPIES_SHIFT)) | _beingCopiedTag;
-	/* write sync not necessary (atomic in follow-up set forward is an implicit barrier) */
+	/* Make sure that destination object header is visible to other potential participating threads.
+	 * About to be executed atomic as part of forwarding operation is executed on source object header,
+	 * hence it will not synchronize memory in the destination object header.
+	 */
+	MM_AtomicOperations::storeSync();
 
 	return sizeToCopy;
 #else


### PR DESCRIPTION
This barrier is at the beginning of co-operative copy, before a thread
tries to win it, to ensure that other participating threads (that lost
the race) see the valid control info (like remaining bytes left).

Contrary to initial belief, the atomic operation (on source object
header) following the setup step (which mutates the destination object
header) is not an implicit store barrier for the setup. Hence, an
explicit one is introduced.

Closely related to https://github.com/eclipse/omr/pull/3262, which makes
sure that barrier is also executed at the end of co-operative copy.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>