### PR TITLE
Combine enter/exit tracing queries into one method

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -126,6 +126,12 @@ TR_FrontEnd::allocateRelocationData(TR::Compilation * comp, uint32_t numBytes)
    {
    notImplemented("allocateRelocationData");
    return 0;
+   }
+
+bool
+TR_FrontEnd::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
+   {
+   return false;
    }
 
 bool

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -150,6 +150,11 @@ public:
    virtual uint32_t offsetOfIsOverriddenBit();
 
    // Needs VMThread
+
+   // In practice we never enable methodEnterTracing without methodExitTracing.
+   // Combine them into one method: isMethodTracingEnabled() which should be used
+   // to replace all usages of isMethodEnterTracingEnabled() and isMethodExitTracingEnabled().
+   virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
    virtual bool isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method);
 


### PR DESCRIPTION
In practice we never enable methodEnterTracing without methodExitTracing.
isMethodEnterTracingEnabled() and isMethodExitTracingEnabled() are
implemented as the same. As proposed in issue eclipse/openj9#3585,
combine them into one method - isMethodTracingEnabled(), which should
be used to replace all usages of isMethodEnterTracingEnabled() and
isMethodExitTracingEnabled().

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>