### PR TITLE
Remove stale IVs in IVA

### DIFF
--- a/compiler/optimizer/InductionVariable.hpp
+++ b/compiler/optimizer/InductionVariable.hpp
@@ -521,6 +521,7 @@ class TR_InductionVariableAnalysis : public TR::Optimization
 
    static void appendPredecessors(WorkQueue &workList, TR::Block *block);
 
+   void removeStaleIVs(TR_RegionStructure *region);
    void gatherCandidates(TR_Structure *s, TR_BitVector *b, TR_BitVector*);
 
    void perform(TR_RegionStructure *str);


### PR DESCRIPTION
Induction variable analysis (IVA) should not leave stale induction variables (IVs) on the structure that may no longer be valid. IVA now removes all preexisting IVs from structure so that the only IVs remaining afterward are those discovered in the current pass.