### PR TITLE
Free the code cache repository segment in the Test Compiler and JitBuilder on JIT shutdown

### DIFF
--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -237,6 +237,7 @@ OMR::CodeCacheManager::destroy()
       self()->freeMemory(codeCache);
       codeCache = nextCache;
       }
+   self()->freeCodeCacheSegment(_codeCacheRepositorySegment);
    _initialized = false;
    }
 

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -233,6 +233,21 @@ public:
    void repositoryCodeCacheCreated();
    void registerCompiledMethod(const char *sig, uint8_t *startPC, uint32_t codeSize);
    void registerStaticRelocation(const TR::StaticRelocation &relocation);
+
+   /**
+    * @brief Hint to free a given code cache segment.
+    *
+    * This function is intended to allow code cache segments allocated by
+    * `allocateCodeCacheSegment()` to be freed. Because it may not always
+    * be safe to actually free code cache memory, callers should treat
+    * this function as a hint. It is up to downstream projects to decide
+    * how to handle these requests. By default, if no overrides are
+    * provided, no memory is ever freed.
+    *
+    * @param memSegment is a pointer to the TR::CodeCacheMemorySegment instance
+    *        that handles the segment memory to be freed.
+    */
+   void freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment) {}
 
 protected:
 

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -79,4 +79,14 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) ((size_t)memorySlab + codeCacheSizeToAllocate - sizeof(TR::CodeCacheMemorySegment));
    new (memSegment) TR::CodeCacheMemorySegment(memorySlab, reinterpret_cast<uint8_t *>(memSegment));
    return memSegment;
+   }
+
+void
+TestCompiler::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment)
+   {
+#if defined(OMR_OS_WINDOWS)
+   VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
+#else
+   munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));
+#endif
    }

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.hpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,6 +56,11 @@ public:
    TR::CodeCacheMemorySegment *allocateCodeCacheSegment(size_t segmentSize,
                                                         size_t &codeCacheSizeToAllocate,
                                                         void *preferredStartAddress);
+
+   /**
+    * @brief Override of OMR::freeCodeCacheSegment that actually frees memory.
+    */
+   void freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment);
 
 private :
    static TR::CodeCacheManager *_codeCacheManager;

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -103,4 +103,14 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) ((size_t)memorySlab + codeCacheSizeToAllocate - sizeof(TR::CodeCacheMemorySegment));
    new (memSegment) TR::CodeCacheMemorySegment(memorySlab, reinterpret_cast<uint8_t *>(memSegment));
    return memSegment;
+   }
+
+void
+JitBuilder::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment)
+   {
+#if defined(OMR_OS_WINDOWS)
+   VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
+#else
+   munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));
+#endif
    }

--- a/jitbuilder/runtime/JBCodeCacheManager.hpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -65,6 +65,11 @@ public:
    TR::CodeCacheMemorySegment *allocateCodeCacheSegment(size_t segmentSize,
                                                         size_t &codeCacheSizeToAllocate,
                                                         void *preferredStartAddress);
+
+   /**
+    * @brief Override of OMR::freeCodeCacheSegment that actually frees memory.
+    */
+   void freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment);
 
 private :
    static TR::CodeCacheManager *_codeCacheManager;


### PR DESCRIPTION
This change adds the ability to free the code cache memory segments to the compiler. In the Test Compiler and JitBuilder, the code cache repository segment is now freed when the JIT shuts down.

This should resolve the test failure seen in  #3388.