### PR TITLE
Revert back to not setting skip zero init on anewarray node

### DIFF
--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -3603,7 +3603,6 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, OMR::
          }
       TR::SymbolReference *symRef = comp()->getSymRefTab()->findOrCreateANewArraySymbolRef(objNode->getSymbolReference()->getOwningMethodSymbol(comp()));
       TR::Node::recreateWithoutProperties(callNode, TR::anewarray, 2, lenNode, classNode, symRef);
-      callNode->setCanSkipZeroInitialization(true);
       }
    TR::Node *newArray = callNode;
    newArray->setIsNonNull(true);


### PR DESCRIPTION
On Power, setting skip zero init caused assertion in GC. Revert
back the logic for now.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>