### PR TITLE
Only free the code cache repository segment when it's used

### DIFF
--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -237,7 +237,12 @@ OMR::CodeCacheManager::destroy()
       self()->freeMemory(codeCache);
       codeCache = nextCache;
       }
-   self()->freeCodeCacheSegment(_codeCacheRepositorySegment);
+
+   if (self()->usingRepository())
+      {
+      self()->freeCodeCacheSegment(_codeCacheRepositorySegment);
+      }
+
    _initialized = false;
    }
 


### PR DESCRIPTION
Pull request #3463 added functionality to free the code cache repository
segment when the compiler's code cache manager is destroyed. However, it
is possible to create a code cache manager that doesn't use a
repository. This commit therefore adds to check to only free the
repository segment if it's actually being used.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>