### PR TITLE
WIP: CMake target library name override

### DIFF
--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -66,7 +66,7 @@ target_compile_definitions(omrgc_tracegen
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-add_library(omrgc STATIC
+add_library(${OMR_GC_LIB} STATIC
 	base/AddressOrderedListPopulator.cpp
 	base/AllocationContext.cpp
 	base/AllocationInterfaceGeneric.cpp
@@ -203,14 +203,14 @@ add_library(omrgc STATIC
 )
 
 if(OMR_GC_OBJECT_MAP)
-	target_sources(omrgc
+	target_sources(${OMR_GC_LIB}
 		PRIVATE
 			base/ObjectMap.cpp
 	)
 endif()
 
 if(OMR_GC_MODRON_STANDARD)
-	target_sources(omrgc
+	target_sources(${OMR_GC_LIB}
 		PRIVATE
 			base/standard/ConfigurationFlat.cpp
 			base/standard/ConfigurationStandard.cpp
@@ -228,7 +228,7 @@ if(OMR_GC_MODRON_STANDARD)
 			base/standard/WorkPacketsStandard.cpp
 	)
 	if (OMR_GC_MODRON_COMPACTION)
-		target_sources(omrgc
+		target_sources(${OMR_GC_LIB}
 			PRIVATE
 				base/standard/CompactFixHeapForWalkTask.cpp
 				base/standard/CompactScheme.cpp
@@ -238,7 +238,7 @@ if(OMR_GC_MODRON_STANDARD)
 		)
 	endif()
 	if(OMR_GC_MODRON_CONCURRENT_MARK)
-		target_sources(omrgc
+		target_sources(${OMR_GC_LIB}
 			PRIVATE
 				base/standard/ConcurrentCardTable.cpp
 				base/standard/ConcurrentCardTableForWC.cpp
@@ -258,20 +258,20 @@ if(OMR_GC_MODRON_STANDARD)
 				stats/ConcurrentGCStats.cpp
 		)
 		if(OMR_GC_MODRON_SCAVENGER)
-			target_sources(omrgc
+			target_sources(${OMR_GC_LIB}
 				PRIVATE
 					base/standard/ConcurrentScanRememberedSetTask.cpp
 			)
 		endif()
 	endif()
 	if(OMR_GC_CONCURRENT_SWEEP)
-		target_sources(omrgc
+		target_sources(${OMR_GC_LIB}
 			PRIVATE
 				base/standard/ConcurrentSweepScheme.cpp
 		)
 	endif()
 	if(OMR_GC_MODRON_SCAVENGER)
-		target_sources(omrgc
+		target_sources(${OMR_GC_LIB}
 			PRIVATE
 				base/HeapSplit.cpp # TODO delete as this should not be used anymore!
 				base/MemorySubSpaceGenerational.cpp
@@ -287,7 +287,7 @@ if(OMR_GC_MODRON_STANDARD)
 				stats/ScavengerCopyScanRatio.cpp
 		)
 		if(OMR_GC_CONCURRENT_SCAVENGER)
-			ltarget_sources(omrgc
+			ltarget_sources(${OMR_GC_LIB}
 				PRIVATE
 					base/standard/ConcurrentScavengeTask.cpp
 			)
@@ -296,7 +296,7 @@ if(OMR_GC_MODRON_STANDARD)
 endif()
 
 if(OMR_GC_SEGREGATED_HEAP)
-	target_sources(omrgc
+	target_sources(${OMR_GC_LIB}
 		PRIVATE
 			base/segregated/AllocationContextSegregated.cpp
 			base/segregated/ConfigurationSegregated.cpp
@@ -322,17 +322,17 @@ if(OMR_GC_SEGREGATED_HEAP)
 	)
 endif()
 
-add_dependencies(omrgc omrgc_hookgen)
+add_dependencies(${OMR_GC_LIB} omrgc_hookgen)
 
 if(OMR_WARNINGS_AS_ERRORS)
-	target_compile_options(omrgc PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
+	target_compile_options(${OMR_GC_LIB} PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()
 
 if(OMR_ENHANCED_WARNINGS)
-	target_compile_options(omrgc PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
+	target_compile_options(${OMR_GC_LIB} PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-target_include_directories(omrgc
+target_include_directories(${OMR_GC_LIB}
 	PUBLIC
 		.
 		${CMAKE_CURRENT_BINARY_DIR}  #Ideally this should be private, but the glue pulls this in
@@ -349,7 +349,7 @@ target_include_directories(omrgc
 		$<TARGET_PROPERTY:${OMR_GC_GLUE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-target_link_libraries(omrgc
+target_link_libraries(${OMR_GC_LIB}
 	PUBLIC
 		omr_base
 	PRIVATE
@@ -361,7 +361,7 @@ target_link_libraries(omrgc
 		${OMR_HOOK_LIB}
 )
 
-set_target_properties(omrgc omrgc_hookgen omrgc_tracegen PROPERTIES FOLDER gc)
+set_target_properties(${OMR_GC_LIB} omrgc_hookgen omrgc_tracegen PROPERTIES FOLDER gc)
 
 if(OMR_GC_API)
 	add_subdirectory(api)

--- a/omrtrace/CMakeLists.txt
+++ b/omrtrace/CMakeLists.txt
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-add_library(omrtrace STATIC
+add_library(${OMR_TRACE_LIB} STATIC
 	omrtraceapi.cpp
 	omrtracecomponent.cpp
 	omrtraceformatter.cpp
@@ -33,14 +33,14 @@ add_library(omrtrace STATIC
 )
 
 if(OMR_WARNINGS_AS_ERRORS)
-	target_compile_options(omrtrace PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
+	target_compile_options(${OMR_TRACE_LIB} PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()
 
 if(OMR_ENHANCED_WARNINGS)
-	target_compile_options(omrtrace PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
+	target_compile_options(${OMR_TRACE_LIB} PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-target_link_libraries(omrtrace
+target_link_libraries(${OMR_TRACE_LIB}
 	PUBLIC
 		omr_base
 		${OMR_THREAD_LIB}

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -347,7 +347,7 @@ endif()
 
 target_sources(omrport_obj PRIVATE ${resolvedPaths})
 
-add_library(omrport STATIC
+add_library(${OMR_PORT_LIB} STATIC
 	$<TARGET_OBJECTS:omrport_obj>
 )
 
@@ -359,7 +359,7 @@ if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(omrport_obj PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-target_link_libraries(omrport
+target_link_libraries(${OMR_PORT_LIB}
 	PUBLIC
 		omr_base
 	PRIVATE
@@ -381,14 +381,14 @@ target_compile_definitions(omrport_obj PRIVATE -DOMRPORT_LIBRARY_DEFINE)
 #TODO hack to get to compile. Need platform checks
 if(NOT OMR_HOST_OS STREQUAL "win")
 	if(NOT OMR_HOST_OS STREQUAL "zos")
-		target_link_libraries(omrport PRIVATE dl)
+		target_link_libraries(${OMR_PORT_LIB} PRIVATE dl)
 	endif()
 endif()
 
 if(OMR_HOST_OS STREQUAL "osx")
-	target_link_libraries(omrport PRIVATE iconv)
+	target_link_libraries(${OMR_PORT_LIB} PRIVATE iconv)
 endif()
 
 if(OMR_HOST_OS STREQUAL "win")
-	target_link_libraries(omrport PRIVATE psapi pdh)
+	target_link_libraries(${OMR_PORT_LIB} PRIVATE psapi pdh)
 endif()

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -313,16 +313,16 @@ if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(j9thr_obj PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-add_library(j9thrstatic STATIC
+add_library(${OMR_THREAD_LIB} STATIC
 	$<TARGET_OBJECTS:j9thr_obj>
 )
 
-target_include_directories(j9thrstatic
+target_include_directories(${OMR_THREAD_LIB}
 	INTERFACE
 	.
 )
 
-target_link_libraries(j9thrstatic
+target_link_libraries(${OMR_THREAD_LIB}
 	PUBLIC
 		omr_base
 		j9pool

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -44,25 +44,25 @@ target_compile_definitions(j9hook_obj
 		$<TARGET_PROPERTY:omr_base,INTERFACE_COMPILE_DEFINITIONS>
 )
 
-add_library(j9hookstatic STATIC
+add_library(${OMR_HOOK_LIB} STATIC
 	$<TARGET_OBJECTS:j9hook_obj>
 )
 
 if(OMR_WARNINGS_AS_ERRORS)
 	target_compile_options(j9hook_obj PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
-	target_compile_options(j9hookstatic PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
+	target_compile_options(${OMR_HOOK_LIB} PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})
 endif()
 
 if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(j9hook_obj PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
-	target_compile_options(j9hookstatic PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
+	target_compile_options(${OMR_HOOK_LIB} PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-target_include_directories(j9hookstatic
+target_include_directories(${OMR_HOOK_LIB}
 	PUBLIC
 	$<TARGET_PROPERTY:j9hook_obj,INTERFACE_INCLUDE_DIRECTORIES>
 )
-target_link_libraries(j9hookstatic
+target_link_libraries(${OMR_HOOK_LIB}
 	PUBLIC
 		omr_base
 		${OMR_PORT_LIB}
@@ -70,4 +70,4 @@ target_link_libraries(j9hookstatic
 )
 add_tracegen(j9hook.tdf)
 
-set_target_properties(j9hook_obj j9hookstatic PROPERTIES FOLDER util)
+set_target_properties(j9hook_obj ${OMR_HOOK_LIB} PROPERTIES FOLDER util)


### PR DESCRIPTION
This PR will help build OpenJ9 and OMR with CMake,
OpenJ9 expect to be able to rename the target library but these were hardcoded in OMR.
This PR should fix this issue
 
Signed-off-by: jeanlego <jeanphilippe.legault@unb.ca>