### PR TITLE
Support Symbol Validation Manager on Z

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -9396,7 +9396,7 @@ static TR::Node *constrainIfcmpeqne(OMR::ValuePropagation *vp, TR::Node *node, b
 
 #ifdef J9_PROJECT_SPECIFIC
 
-   if ((!vp->comp()->compileRelocatableCode() || vp->comp()->getOption(TR_UseSymbolValidationManager)) &&
+   if (!vp->comp()->compileRelocatableCode() &&
        vp->lastTimeThrough() &&
        vp->comp()->performVirtualGuardNOPing() &&
        !vp->_curBlock->isCold() &&

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2287,11 +2287,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
       }
 
    TR_VirtualGuardSite *site = NULL;
-   if (node->isSideEffectGuard())
-      {
-      site = comp->addSideEffectNOPSite();
-      }
-   else if (cg->needClassAndMethodPointerRelocations())
+   if (cg->needClassAndMethodPointerRelocations())
       {
       site = (TR_VirtualGuardSite *)comp->addAOTNOPSite();
       TR_AOTGuardSite *aotSite = (TR_AOTGuardSite *)site;
@@ -2304,10 +2300,9 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          case TR_DirectMethodGuard:
          case TR_NonoverriddenGuard:
          case TR_InterfaceGuard:
-         case TR_AbstractGuard:
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
-         //case TR_AbstractGuard:
+         case TR_AbstractGuard:
             aotSite->setGuard(virtualGuard);
             break;
 
@@ -2315,13 +2310,17 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
             break;
 
          default:
-            TR_ASSERT(0, "AOT guard in node but not one of known guards supported for AOT. Guard: %d", reloKind);
+            TR_ASSERT_FATAL(0, "AOT guard in node but not one of known guards supported for AOT. Guard: %d", reloKind);
             break;
          }
       }
-   else
+   else if (!node->isSideEffectGuard())
       {
       site = virtualGuard->addNOPSite();
+      }
+   else 
+      {
+      site = comp->addSideEffectNOPSite();
       }
 
    List<TR::Register> popRegisters(cg->trMemory());

--- a/compiler/z/codegen/CallSnippet.cpp
+++ b/compiler/z/codegen/CallSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -381,7 +381,7 @@ TR_RuntimeHelper TR::S390CallSnippet::getInterpretedDispatchHelper(
       isJitInduceOSRCall = true;
       }
 
-   if (methodSymRef->isUnresolved() || comp->compileRelocatableCode())
+   if (methodSymRef->isUnresolved() || (comp->compileRelocatableCode() && !comp->getOption(TR_UseSymbolValidationManager)))
       {
       TR_ASSERT(!isJitInduceOSRCall || !comp->compileRelocatableCode(), "calling jitInduceOSR is not supported yet under AOT\n");
       if (methodSymbol->isSpecial())
@@ -440,7 +440,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390CallSnippet * snippet)
 
    bufferPos = printS390ArgumentsFlush(pOutFile, callNode, bufferPos, snippet->getSizeOfArguments());
 
-   if (methodSymRef->isUnresolved() || _comp->compileRelocatableCode())
+   if (methodSymRef->isUnresolved() || (_comp->compileRelocatableCode() && !_comp->getOption(TR_UseSymbolValidationManager)))
       {
       if (methodSymbol->isSpecial())
          {

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
    TR::Compilation *comp = cg()->comp();
 
    uint32_t reloType = getReloType();
-
+   TR::SymbolType symbolKind = TR::SymbolType::typeClass;
    switch (reloType)
       {
       case 0:
@@ -92,6 +92,33 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_ClassAddress:
       case TR_ClassObject:
+         {
+         AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
+         TR::SymbolReference *reloSymRef= (reloType==TR_ClassAddress)?getNode()->getSymbolReference():getSymbolReference();
+         if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
+            {
+            TR_ASSERT_FATAL(getDataAs8Bytes(), "Static Sym can not be NULL");
+
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                                       (uint8_t *) getDataAs8Bytes(),
+                                                                                       (uint8_t *) TR::SymbolType::typeClass,
+                                                                                       TR_SymbolFromManager,
+                                                                                       cg()),
+                                                                                       __FILE__, __LINE__, getNode());
+
+            }
+         else
+            {
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) reloSymRef,
+                                                                                 getNode() ? (uint8_t *)(intptr_t)getNode()->getInlinedSiteIndex() : (uint8_t *)-1,
+                                                                                 (TR_ExternalRelocationTargetKind) reloType, cg()),
+                                                                                 __FILE__, __LINE__, getNode());
+
+            }
+
+
+         }
+         break;
       case TR_MethodObject:
          {
          AOTcgDiag3(comp, "add relocation (%d) cursor=%x symbolReference=%x\n", reloType, cursor, getSymbolReference());
@@ -170,24 +197,38 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_RamMethod:
       case TR_MethodPointer:
+         symbolKind = TR::SymbolType::typeMethod;
+         // intentional fall through
       case TR_ClassPointer:
-         {
          AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
-         TR::Relocation *relo;
-         //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
-         //so we need to pass it to relocation in targetaddress2 for now
-         //two instances where use this relotype in such way are: profile checkcast and arraystore check object check optimiztaions
-         uint8_t * targetAdress2 = NULL;
-         if (getNode()->getOpCodeValue() != TR::aconst)
+         if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
-            if (TR::Compiler->target.is64Bit())
-               targetAdress2 = (uint8_t *) *((uint64_t*) cursor);
-            else
-               targetAdress2 = (uint8_t *) *((uintptrj_t*) cursor);
+            TR_ASSERT_FATAL(getDataAs8Bytes(), "Static Sym can not be NULL");
+            cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                                 (uint8_t *) getDataAs8Bytes(),
+                                                                                 (uint8_t *)symbolKind,
+                                                                                 TR_SymbolFromManager,
+                                                                                 cg()),
+                                                                              __FILE__, __LINE__,
+                                                                              getNode());
             }
-         relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode(), targetAdress2, (TR_ExternalRelocationTargetKind) reloType, cg());
-         cg()->addExternalRelocation(relo, __FILE__, __LINE__, getNode());
-         }
+         else
+            {
+            TR::Relocation *relo;
+            //for optimizations where we are trying to relocate either profiled j9class or getfrom signature we can't use node to get the target address
+            //so we need to pass it to relocation in targetaddress2 for now
+            //two instances where use this relotype in such way are: profile checkcast and arraystore check object check optimiztaions
+            uint8_t * targetAdress2 = NULL;
+            if (getNode()->getOpCodeValue() != TR::aconst)
+               {
+               if (TR::Compiler->target.is64Bit())
+                  targetAdress2 = (uint8_t *) *((uint64_t*) cursor);
+               else
+                  targetAdress2 = (uint8_t *) *((uintptrj_t*) cursor);
+               }
+            relo = new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) getNode(), targetAdress2, (TR_ExternalRelocationTargetKind) reloType, cg());
+            cg()->addExternalRelocation(relo, __FILE__, __LINE__, getNode());
+            }
          break;
 
       case TR_DebugCounter:

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -169,10 +169,9 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
          case TR_DirectMethodGuard:
          case TR_NonoverriddenGuard:
          case TR_InterfaceGuard:
-         case TR_AbstractGuard:
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
-         //case TR_AbstractGuard:
+         case TR_AbstractGuard:
             aotSite->setGuard(virtualGuard);
             break;
 
@@ -180,7 +179,7 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
             break;
 
          default:
-            TR_ASSERT(0, "got AOT guard in node but virtual guard not one of known guards supported for AOT. Guard: %d", virtualGuard->getKind());
+            TR_ASSERT_FATAL(0, "got AOT guard in node but virtual guard not one of known guards supported for AOT. Guard: %d", virtualGuard->getKind());
             break;
          }
       }

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -169,6 +169,7 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
          case TR_DirectMethodGuard:
          case TR_NonoverriddenGuard:
          case TR_InterfaceGuard:
+         case TR_AbstractGuard:
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
          //case TR_AbstractGuard:
@@ -188,7 +189,7 @@ virtualGuardHelper(TR::Node * node, TR::CodeGenerator * cg)
       TR_VirtualGuard * virtualGuard = comp->findVirtualGuardInfo(node);
       site = virtualGuard->addNOPSite();
       }
-   else
+   else 
       {
       site = comp->addSideEffectNOPSite();
       }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -293,6 +293,11 @@ genLoadLongConstant(TR::CodeGenerator * cg, TR::Node * node, int64_t value, TR::
       {
       TR::Instruction * temp = cursor;
       cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::LG, node, targetRegister, value, TR_GlobalValue, cond, cursor, base);
+      }
+   else if (comp->compileRelocatableCode() && sym && (sym->isRecompilationCounter()))
+      {
+      TR::Instruction * temp = cursor;
+      cursor = generateRegLitRefInstruction(cg, TR::InstOpCode::LG, node, targetRegister, value, TR_BodyInfoAddress, cond, cursor, base);
       }
    else if (comp->compileRelocatableCode() && sym && sym->isStatic() && !sym->isClassObject() && !sym->isNotDataAddress())
       {


### PR DESCRIPTION
This pull request contains three main changes. 
1. Update relocation on Z codegen to support Symbol Validation Manager on Z if it is enabled. 
2. SideEffect guard is not supported in AOT yet though it was generated if Symbol Validation Manager, this caused a potential bug where we are left with Sife Effect guard node in AOT compiled body with no relocations. 
3. Fix x86 Codegen to check if it is compiling relocatable method first so that we do not miss assert in case we encounter a virtual guard that is not supported under AOT. 

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>