### PR TITLE
Added changes to resolve the balanced gc policy crash in container

### DIFF
--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -180,6 +180,7 @@ initializeNumaGlobals(struct OMRPortLibrary *portLibrary)
 	int schedReturnCode = 0;
 	int mempolicyReturnCode = 0;
 	int useAllNodes = 0;
+	PPG_numaSyscallNotAllowed = FALSE;
 
 	memset(&PPG_numa_available_node_mask, 0, sizeof(J9PortNodeMask));
 	PPG_numa_max_node_bits = 0;
@@ -192,7 +193,9 @@ initializeNumaGlobals(struct OMRPortLibrary *portLibrary)
 	PPG_numa_policy_mode = -1;
 	memset(&PPG_numa_mempolicy_node_mask, 0, sizeof(J9PortNodeMask));
 	mempolicyReturnCode = do_get_mempolicy(&PPG_numa_policy_mode, PPG_numa_mempolicy_node_mask.mask, maxNodes, (unsigned long)NULL, 0);
-
+	if ((0 != mempolicyReturnCode) && (EPERM == errno)) {
+		PPG_numaSyscallNotAllowed = TRUE;
+	}
 	if (0 == mempolicyReturnCode) {
 
 		long anySet = 0;
@@ -219,8 +222,10 @@ initializeNumaGlobals(struct OMRPortLibrary *portLibrary)
 		Trc_PRT_vmem_omrvmem_initializeNumaGlobals_get_mempolicy_failure(errno);
 	}
 
-	/* only proceed if we could successfully look up the memory policy and default affinity */
-	if ((0 == schedReturnCode) && (0 == mempolicyReturnCode)) {
+	/* Proceed if we could successfully look up the default affinity.
+	 * We proceed to get node count even if `getmempolicy` fails due to security restrictions.
+	 */
+	if ((0 == schedReturnCode) && ((0 == mempolicyReturnCode) || (PPG_numaSyscallNotAllowed))) {
 		DIR *nodes = opendir("/sys/devices/system/node/");
 		if (NULL != nodes) {
 			struct dirent *node = readdir(nodes);
@@ -569,6 +574,7 @@ omrvmem_startup(struct OMRPortLibrary *portLibrary)
 		PPG_numa_platform_supports_numa = 1;
 	} else {
 		PPG_numa_platform_supports_numa = 0;
+		omrthread_numa_set_enabled(FALSE); /* Disabling thread NUMA as well */
 	}
 #endif
 
@@ -1541,6 +1547,10 @@ omrvmem_numa_get_node_details(struct OMRPortLibrary *portLibrary, J9MemoryNodeDe
 			default:
 				/* do nothing */
 				break;
+			}
+			if (PPG_numaSyscallNotAllowed) {
+				nodeSetState = J9NUMA_DENIED;
+				nodeClearState = J9NUMA_DENIED;
 			}
 
 			/* walk through the /sys/devices/system/node/ directory to find each individual node */

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -88,6 +88,7 @@ typedef struct OMRPortPlatformGlobals {
 	uint64_t cgroupSubsystemsAvailable; /**< cgroup subsystems available for port library to use; it is valid only when cgroupEntryList is non-null */
 	uint64_t cgroupSubsystemsEnabled; /**< cgroup subsystems enabled in port library; it is valid only when cgroupEntryList is non-null */
 	OMRCgroupEntry *cgroupEntryList; /**< head of the circular linked list, each element contains information about cgroup of the process for a subsystem */
+	BOOLEAN syscallNotAllowed; /**< Assigned True if the mempolicy syscall is failed due to security opts (Can be seen in case of docker) */
 #endif /* defined(LINUX) */
 } OMRPortPlatformGlobals;
 
@@ -134,6 +135,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_cgroupSubsystemsAvailable (portLibrary->portGlobals->platformGlobals.cgroupSubsystemsAvailable)
 #define PPG_cgroupSubsystemsEnabled (portLibrary->portGlobals->platformGlobals.cgroupSubsystemsEnabled)
 #define PPG_cgroupEntryList (portLibrary->portGlobals->platformGlobals.cgroupEntryList)
+#define PPG_numaSyscallNotAllowed (portLibrary->portGlobals->platformGlobals.syscallNotAllowed)
 #endif /* defined(LINUX) */
 
 #endif /* omrportpg_h */


### PR DESCRIPTION
As mentioned in the OpenJ9 issue [#3797](https://github.com/eclipse/openj9/issues/3767) [PortLibrary](https://github.com/eclipse/omr/blob/b21d26c497f0a49736bb39897cc8e012e45df2cf/port/linux/omrvmem.c#L174) and [ThreadLibrary](https://github.com/eclipse/omr/blob/f8fc704032f95cbc0f337eb6be54f2b06e58a773/thread/linux/omrthreadnuma.c#L149) are not having a consistent view on NUMA which is making JVM to crash if its running in container (default docker or any environment where `getmempolicy` system call is restricted) with balanced gc policy. 

This Fix would allow the PortLibrary to get node count and set the memorystate to `J9NUMA_DENIED` if there is a failure in `getmempolicy` system call due to only `security restriction like EPERM - Operation Not Permitted`

FYI @LinHu2016 @ashu-mehra 

Signed-off-by: bharathappali <bharath.appali@gmail.com>