### PR TITLE
Add realtime gcCycleOn fields to OMR_VM from OpenJ9

### DIFF
--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -180,6 +180,13 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 		goto failed;
 	}
 
+#if defined(OMR_GC_REALTIME)
+	_omrVM->_gcCycleOn = 0;
+	if (omrthread_monitor_init_with_name(&_omrVM->_gcCycleOnMonitor, 0, "gcCycleOn")) {
+		goto failed;
+	}
+#endif /* defined(OMR_GC_REALTIME) */
+
 	return true;
 
 failed:
@@ -209,6 +216,13 @@ MM_GCExtensionsBase::tearDown(MM_EnvironmentBase* env)
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	rememberedSet.tearDown(env);
 #endif /* OMR_GC_MODRON_SCAVENGER */
+
+#if defined(OMR_GC_REALTIME)
+	if (_omrVM->_gcCycleOnMonitor) {
+		omrthread_monitor_destroy(_omrVM->_gcCycleOnMonitor);
+		_omrVM->_gcCycleOnMonitor = (omrthread_monitor_t) NULL;
+	}
+#endif /* defined(OMR_GC_REALTIME) */
 
 	objectModel.tearDown(this);
 	mixedObjectModel.tearDown(this);

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -143,6 +143,10 @@ typedef struct OMR_VM {
 	struct OMRTraceEngine *_trcEngine;
 	void *_methodDictionary;
 #endif /* OMR_RAS_TDF_TRACE */
+#if defined(OMR_GC_REALTIME)
+	omrthread_monitor_t _gcCycleOnMonitor;
+	uintptr_t _gcCycleOn;
+#endif /* defined(OMR_GC_REALTIME) */
 } OMR_VM;
 
 typedef struct OMR_VMThread {


### PR DESCRIPTION
Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>