### PR TITLE
Move Metronome Reference Stats from OpenJ9 to OMR

### DIFF
--- a/gc/stats/MetronomeStats.cpp
+++ b/gc/stats/MetronomeStats.cpp
@@ -25,4 +25,7 @@
 void
 MM_MetronomeStats::merge(MM_MetronomeStats* statsToMerge)
 {
+	_weakReferenceStats.merge(&statsToMerge->_weakReferenceStats);
+	_softReferenceStats.merge(&statsToMerge->_softReferenceStats);
+	_phantomReferenceStats.merge(&statsToMerge->_phantomReferenceStats);
 }

--- a/gc/stats/MetronomeStats.hpp
+++ b/gc/stats/MetronomeStats.hpp
@@ -25,6 +25,7 @@
 
 #include "Base.hpp"
 #include "AtomicOperations.hpp"
+#include "ReferenceStats.hpp"
 
 /**
  * @todo Provide class documentation
@@ -47,6 +48,13 @@ public:
 	uint64_t nonDeterministicSweepDelay;
 
 	uint64_t _microsToStopMutators; /**< The number of microseconds the master thread had to wait for the mutator threads to stop, at the beginning of this increment */
+
+	UDATA _unfinalizedCandidates; /**< unfinalized objects that are candidates to be finalized visited this cycle */
+	UDATA _unfinalizedEnqueued; /**< unfinalized objects that are enqueued during this cycle (MUST be less than or equal _unfinalizedCandidates) */
+
+	MM_ReferenceStats _weakReferenceStats; /**< Weak reference stats for the cycle */
+	MM_ReferenceStats _softReferenceStats; /**< Soft reference stats for the cycle */
+	MM_ReferenceStats _phantomReferenceStats; /**< Phantom reference stats for the cycle */
 protected:
 private:
 public:
@@ -72,6 +80,9 @@ public:
 		_workPacketOverflowCount = 0;
 		_objectOverflowCount = 0;
 		_microsToStopMutators = 0;
+		_weakReferenceStats.clear();
+		_softReferenceStats.clear();
+		_phantomReferenceStats.clear();
 	}
 
 	MMINLINE void incrementWorkPacketOverflowCount()


### PR DESCRIPTION
Move the reference stats from MM_MarkJavaStats to MM_MetronomeStats as these fields are only used by metronome. After adding them to MetronomeStats, the usage is to be changed in OpenJ9.

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>