### PR TITLE
Fix bad code - dereferencing a null pointer

### DIFF
--- a/port/osx/omrintrospect.c
+++ b/port/osx/omrintrospect.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -260,7 +260,7 @@ setupNativeThread(J9ThreadWalkState *state, thread_context *sigContext)
 			CLEAR_ERROR(state);
 		}
 
-		if (NULL == state->current_thread->callstack && state->current_thread->callstack->symbol) {
+		if ((NULL != state->current_thread->callstack) && (NULL == state->current_thread->callstack->symbol)) {
 			SPECULATE_ERROR(state, FAULT_DURING_BACKTRACE, 3);
 			state->portLibrary->introspect_backtrace_symbols(state->portLibrary, state->current_thread, state->heap);
 			CLEAR_ERROR(state);


### PR DESCRIPTION
Currently, the code dereferences a `null` pointer by accessing
`callstack->symbol` when `callstack` is `null`.

`introspect_backtrace_symbols` should be invoked when a `callstack` exists
and `callstack->symbol` is `null`.

The code has been fixed to avoid dereferencing a `null` pointer, and
invoke `introspect_backtrace_symbols` under the correct conditions.

Issue: #3507.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>