### PR TITLE
Provide a consistent interface for asking if trampolines are required

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -413,13 +413,21 @@ void OMR::ARM64::CodeGenerator::apply32BitLabelRelativeRelocation(int32_t *curso
    }
 
 int64_t OMR::ARM64::CodeGenerator::getLargestNegConstThatMustBeMaterialized()
-   { 
-   TR_ASSERT(0, "Not Implemented on AArch64"); 
-   return 0; 
+   {
+   TR_ASSERT(0, "Not Implemented on AArch64");
+   return 0;
    }
 
 int64_t OMR::ARM64::CodeGenerator::getSmallestPosConstThatMustBeMaterialized()
-   { 
-   TR_ASSERT(0, "Not Implemented on AArch64"); 
-   return 0; 
+   {
+   TR_ASSERT(0, "Not Implemented on AArch64");
+   return 0;
+   }
+
+bool
+OMR::ARM64::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   return
+      !TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange(targetAddress, sourceAddress) ||
+      self()->comp()->getOption(TR_StressTrampolines);
    }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -286,6 +286,17 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
    TR_GlobalRegisterNumber _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
 
+   /**
+    * @brief Answers whether a trampoline is required for a direct call instruction to
+    *           reach a target address.
+    *
+    * @param[in] targetAddress : the absolute address of the call target
+    * @param[in] sourceAddress : the absolute address of the call instruction
+    *
+    * @return : true if a trampoline is required; false otherwise.
+    */
+   bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
+
    private:
 
    enum // flags

--- a/compiler/aarch64/env/OMRCPU.cpp
+++ b/compiler/aarch64/env/OMRCPU.cpp
@@ -20,3 +20,12 @@
  *******************************************************************************/
 
 #include "env/CPU.hpp"
+#include "env/jittypes.h"
+
+bool
+OMR::ARM64::CPU::isTargetWithinUnconditionalBranchImmediateRange(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   intptrj_t range = targetAddress - sourceAddress;
+   return range <= self()->maxUnconditionalBranchImmediateForwardOffset() &&
+          range >= self()->maxUnconditionalBranchImmediateBackwardOffset();
+   }

--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -33,7 +33,9 @@ namespace OMR { typedef OMR::ARM64::CPU CPUConnector; }
 #error OMR::ARM64::CPU expected to be a primary connector, but an OMR connector is already defined
 #endif
 
+#include <stdint.h>
 #include "compiler/env/OMRCPU.hpp"
+#include "env/jittypes.h"
 
 
 namespace OMR
@@ -47,6 +49,39 @@ class CPU : public OMR::CPU
 protected:
 
    CPU() : OMR::CPU() {}
+
+public:
+
+   /**
+    * @brief Provides the maximum forward branch displacement in bytes reachable
+    *        with a relative unconditional branch with immediate (B or BL) instruction.
+    *
+    * @return Maximum forward branch displacement in bytes.
+    */
+   int32_t maxUnconditionalBranchImmediateForwardOffset() { return 0x07fffffc; }
+
+   /**
+    * @brief Provides the maximum backward branch displacement in bytes reachable
+    *        with a relative unconditional branch with immediate (B or BL) instruction.
+    *
+    * @return Maximum backward branch displacement in bytes.
+    */
+   int32_t maxUnconditionalBranchImmediateBackwardOffset() { return 0xf8000000; }
+
+   /**
+    * @brief Answers whether the distance between a target and source address
+    *        is within the reachable displacement range for a relative unconditional
+    *        branch with immediate (B or BL) instruction.
+    *
+    * @param[in] : targetAddress : the address of the target
+    *
+    * @param[in] : sourceAddress : the address of the relative unconditional branch
+    *                 with immediate (B or BL) instruction from which the
+    *                 displacement range is measured.
+    *
+    * @return true if the target is within range; false otherwise.
+    */
+   bool isTargetWithinUnconditionalBranchImmediateRange(intptrj_t targetAddress, intptrj_t sourceAddress);
 
    };
 

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -414,7 +414,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMImmSymInstruction * instr)
    {
    uint8_t *bufferPos = instr->getBinaryEncoding();
    int32_t  imm       = instr->getSourceImmediate();
-   int32_t  distance  = imm - (intptr_t)bufferPos;
 
    TR::SymbolReference      *symRef    = instr->getSymbolReference();
    TR::Symbol                *sym       = symRef->getSymbol();
@@ -422,7 +421,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMImmSymInstruction * instr)
    TR_ResolvedMethod     *callee    = calleeSym ? calleeSym->getResolvedMethod() : NULL;
 
    bool longJump = imm &&
-                   (distance > BRANCH_FORWARD_LIMIT || distance < BRANCH_BACKWARD_LIMIT) &&
+                   _cg->directCallRequiresTrampoline((intptrj_t)imm, (intptrj_t)bufferPos) &&
                    (!callee || !callee->isSameMethod(_comp->getCurrentMethod()));
 
    if (bufferPos != NULL && longJump)
@@ -823,11 +822,10 @@ void
 TR_Debug::printARMHelperBranch(TR::SymbolReference *symRef, uint8_t *bufferPos, TR::FILE *pOutFile, const char * opcodeName)
    {
    TR::MethodSymbol *methodSym = symRef->getSymbol()->castToMethodSymbol();
-   uintptr_t        target    = (uintptr_t)methodSym->getMethodAddress();
-   int32_t          distance  = target - (uintptr_t)bufferPos;
-   char            *info      = "";
+   intptrj_t         target    = (intptrj_t)methodSym->getMethodAddress();
+   char             *info      = "";
 
-   if ((distance > BRANCH_FORWARD_LIMIT || distance < BRANCH_BACKWARD_LIMIT))
+   if (_cg->directCallRequiresTrampoline(target, (intptrj_t)bufferPos))
       {
       int32_t refNum = symRef->getReferenceNumber();
       if (refNum < TR_ARMnumRuntimeHelpers)
@@ -837,7 +835,7 @@ TR_Debug::printARMHelperBranch(TR::SymbolReference *symRef, uint8_t *bufferPos, 
          }
       else if (*((uintptr_t*)bufferPos) == 0xe28fe004)  // This is a JNI method
          {
-         target = *((uintptr_t*)(bufferPos+8));
+         target = *((intptrj_t*)(bufferPos+8));
          info   = " long jump";
          }
       else
@@ -1505,31 +1503,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMRecompilationSnippet * snippet)
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), cursor, "Counting Recompilation Snippet");
 
-   char     *info = "";
-   int32_t   distance;
-   uintptr_t target;
    TR::SymbolReference *symRef = _cg->getSymRef(TR_ARMcountingRecompileMethod);
-   int32_t refNum = symRef->getReferenceNumber();
-   if ((distance > BRANCH_FORWARD_LIMIT || distance < BRANCH_BACKWARD_LIMIT))
-      {
-      target = _comp->fe()->indexedTrampolineLookup(refNum, (void *)cursor);
-      info = " Through trampoline";
-      }
+   printARMHelperBranch(symRef, cursor, pOutFile);
+   cursor += 4;
 
-   const char *name = getName(symRef);
-   printPrefix(pOutFile, NULL, cursor, 4);
-   if (name)
-      trfprintf(pOutFile, "bl\t%s\t;%s (" POINTER_PRINTF_FORMAT ")", name, info, target);
-   else
-      trfprintf(pOutFile, "bl\t" POINTER_PRINTF_FORMAT "\t\t;%s", target, info);
-   printPrefix(pOutFile, NULL, cursor, 4);
-
-#ifdef J9_PROJECT_SPECIFIC
    // methodInfo
    printPrefix(pOutFile, NULL, cursor, 4);
    trfprintf(pOutFile, "dd \t0x%08x\t\t;%s", _comp->getRecompilationInfo()->getMethodInfo(), "methodInfo");
    cursor += 4;
-#endif
 
    // startPC
    printPrefix(pOutFile, NULL, cursor, 4);

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -822,4 +822,12 @@ bool OMR::ARM::CodeGenerator::shouldValueBeInACommonedNode(int64_t value)
 bool OMR::ARM::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumber i, TR::DataType dt)
    {
    return self()->machine()->getRealRegister((TR::RealRegister::RegNum)self()->getGlobalRegister(i))->getState() == TR::RealRegister::Free;
+   }
+
+bool
+OMR::ARM::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   return
+      !TR::Compiler->target.cpu.isTargetWithinBranchImmediateRange(targetAddress, sourceAddress) ||
+      self()->comp()->getOption(TR_StressTrampolines);
    }

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -202,6 +202,16 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget) { return 8; } //FIXME
    int32_t arrayTranslateAndTestMinimumNumberOfIterations() { return 8; } //FIXME
 
+   /**
+    * @brief Answers whether a trampoline is required for a direct call instruction to
+    *           reach a target address.
+    *
+    * @param[in] targetAddress : the absolute address of the call target
+    * @param[in] sourceAddress : the absolute address of the call instruction
+    *
+    * @return : true if a trampoline is required; false otherwise.
+    */
+   bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
 
    private:
 

--- a/compiler/arm/env/OMRCPU.cpp
+++ b/compiler/arm/env/OMRCPU.cpp
@@ -20,3 +20,12 @@
  *******************************************************************************/
 
 #include "env/CPU.hpp"
+#include "env/jittypes.h"
+
+bool
+OMR::ARM::CPU::isTargetWithinBranchImmediateRange(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   intptrj_t range = targetAddress - sourceAddress;
+   return range <= self()->maxBranchImmediateForwardOffset() &&
+          range >= self()->maxBranchImmediateBackwardOffset();
+   }

--- a/compiler/arm/env/OMRCPU.hpp
+++ b/compiler/arm/env/OMRCPU.hpp
@@ -33,7 +33,9 @@ namespace OMR { typedef OMR::ARM::CPU CPUConnector; }
 #error OMR::ARM::CPU expected to be a primary connector, but an OMR connector is already defined
 #endif
 
+#include <stdint.h>
 #include "compiler/env/OMRCPU.hpp"
+#include "env/jittypes.h"
 
 
 namespace OMR
@@ -47,6 +49,39 @@ class CPU : public OMR::CPU
 protected:
 
    CPU() : OMR::CPU() {}
+
+public:
+
+   /**
+    * @brief Provides the maximum forward branch displacement in bytes reachable
+    *        with a relative branch with immediate (B or BL) instruction.
+    *
+    * @return Maximum forward branch displacement in bytes.
+    */
+   int32_t maxBranchImmediateForwardOffset() { return 0x01fffffc; }
+
+   /**
+    * @brief Provides the maximum backward branch displacement in bytes reachable
+    *        with a relative branch with immediate (B or BL) instruction.
+    *
+    * @return Maximum backward branch displacement in bytes.
+    */
+   int32_t maxBranchImmediateBackwardOffset() { return 0xfe000000; }
+
+   /**
+    * @brief Answers whether the distance between a target and source address
+    *        is within the reachable displacement range for a relative branch
+    *        with immediate (B or BL) instruction.
+    *
+    * @param[in] : targetAddress : the address of the target
+    *
+    * @param[in] : sourceAddress : the address of the relative branch with
+    *                 immediate (B or BL) instruction from which the displacement
+    *                 range is measured.
+    *
+    * @return true if the target is within range; false otherwise.
+    */
+   bool isTargetWithinBranchImmediateRange(intptrj_t targetAddress, intptrj_t sourceAddress);
 
    };
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1338,9 +1338,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR::RealRegister **_unlatchedRegisterList; // dynamically allocated
 
-   bool alwaysUseTrampolines() { return _enabledFlags.testAny(AlwaysUseTrampolines); }
-   void setAlwaysUseTrampolines() {_enabledFlags.set(AlwaysUseTrampolines);}
-
    bool shouldBuildStructure() { return _enabledFlags.testAny(ShouldBuildStructure); }
    void setShouldBuildStructure() {_enabledFlags.set(ShouldBuildStructure);}
 
@@ -1788,7 +1785,7 @@ class OMR_EXTENSIBLE CodeGenerator
       // AVAILABLE                     = 0x0002,
       // AVAILABLE                     = 0x0004,
       EnableRefinedAliasSets           = 0x0008,
-      AlwaysUseTrampolines             = 0x0010,
+      // AVAILABLE                     = 0x0010,
       ShouldBuildStructure             = 0x0020,
       LockFreeSpillList                = 0x0040,  // TAROK only (until it matures)
       UseNonLinearRegisterAssigner     = 0x0080,  // TAROK only (until it matures)

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1345,6 +1345,22 @@ class OMR_EXTENSIBLE CodeGenerator
    bool enableRefinedAliasSets();
    void setEnableRefinedAliasSets() {_enabledFlags.set(EnableRefinedAliasSets);}
 
+   /**
+    * @brief Answers whether a trampoline is required for a direct call instruction to
+    *           reach a target address.  This function should be overridden by an
+    *           architecture-specific implementation.
+    *
+    * @param[in] targetAddress : the absolute address of the call target
+    * @param[in] sourceAddress : the absolute address of the call instruction
+    *
+    * @return : true, but will assert fatally before returning.
+    */
+   bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
+      {
+      TR_ASSERT_FATAL(0, "An architecture specialization of this function must be provided.");
+      return true;
+      }
+
    // --------------------------------------------------------------------------
 
    TR::Node *createOrFindClonedNode(TR::Node *node, int32_t numChildren);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -3704,3 +3704,12 @@ OMR::Power::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
 
    return result;
    }
+
+bool
+OMR::Power::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   return
+      !TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(targetAddress, sourceAddress) ||
+      self()->comp()->getOption(TR_StressTrampolines);
+   }
+

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -497,6 +497,17 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
       TR::Register *tempReg,
       TR::Instruction **q);
 
+   /**
+    * @brief Answers whether a trampoline is required for a direct call instruction to
+    *           reach a target address.
+    *
+    * @param[in] targetAddress : the absolute address of the call target
+    * @param[in] sourceAddress : the absolute address of the call instruction
+    *
+    * @return : true if a trampoline is required; false otherwise.
+    */
+   bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
+
    private:
 
    enum // flags

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -32,3 +32,11 @@ OMR::Power::CPU::getPPCis64bit()
 
    return (p >= TR_FirstPPC64BitProcessor)? true : false;
    }
+
+bool
+OMR::Power::CPU::isTargetWithinIFormBranchRange(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   intptrj_t range = targetAddress - sourceAddress;
+   return range <= self()->maxIFormBranchForwardOffset() &&
+          range >= self()->maxIFormBranchBackwardOffset();
+   }

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -35,6 +35,7 @@ namespace OMR { typedef OMR::Power::CPU CPUConnector; }
 
 #include "compiler/env/OMRCPU.hpp"
 
+#include "env/jittypes.h"
 #include "infra/Assert.hpp"
 
 #define VALID_PROCESSOR TR_ASSERT(id() >= TR_FirstPPCProcessor && id() <= TR_LastPPCProcessor, "Not a valid PPC Processor Type")
@@ -63,6 +64,37 @@ public:
    bool getPPCSupportsAES() { return false; }
    bool getPPCSupportsTM()  { return false; }
    bool getPPCSupportsLM()  { return false; }
+
+   /**
+    * @brief Provides the maximum forward branch displacement in bytes reachable
+    *        with an I-Form branch instruction.
+    *
+    * @return Maximum forward branch displacement in bytes.
+    */
+   int32_t maxIFormBranchForwardOffset() { return 0x01fffffc; }
+
+   /**
+    * @brief Provides the maximum backward branch displacement in bytes reachable
+    *        with an I-Form branch instruction.
+    *
+    * @return Maximum backward branch displacement in bytes.
+    */
+   int32_t maxIFormBranchBackwardOffset() { return 0xfe000000; }
+
+   /**
+    * @brief Answers whether the distance between a target and source address
+    *        is within the reachable displacement range of an I-form branch
+    *        instruction.
+    *
+    * @param[in] : targetAddress : the address of the target
+    *
+    * @param[in] : sourceAddress : the address of the I-form branch instruction
+    *                 from which the displacement range is measured.
+    *
+    * @return true if the target is within range; false otherwise.
+    */
+   bool isTargetWithinIFormBranchRange(intptrj_t targetAddress, intptrj_t sourceAddress);
+
    };
 
 }

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -71,10 +71,6 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
    if (accessStaticsIndirectly)
       self()->setAccessStaticsIndirectly(true);
 
-   static char *alwaysUseTrampolines = feGetEnv("TR_AlwaysUseTrampolines");
-   if (alwaysUseTrampolines)
-      self()->setAlwaysUseTrampolines();
-
    self()->setSupportsDoubleWordCAS();
    self()->setSupportsDoubleWordSet();
 

--- a/compiler/x/codegen/HelperCallSnippet.hpp
+++ b/compiler/x/codegen/HelperCallSnippet.hpp
@@ -66,7 +66,7 @@ class X86HelperCallSnippet : public TR::X86RestartSnippet
    TR::SymbolReference *setDestination(TR::SymbolReference *s) {return (_destination = s);}
    int32_t             getStackPointerAdjustment()           {return _stackPointerAdjustment;}
 
-   static int32_t branchDisplacementToHelper(uint8_t *nextInstructionAddress, TR::SymbolReference *helper, TR::CodeGenerator *cg);
+   static int32_t branchDisplacementToHelper(uint8_t *callInstructionAddress, TR::SymbolReference *helper, TR::CodeGenerator *cg);
 
    int32_t getOffset() {return _offset;}
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3120,4 +3120,13 @@ OMR::X86::CodeGenerator::switchCodeCacheTo(TR::CodeCache *newCodeCache)
    {
    self()->setNumReservedIPICTrampolines(0);
    OMR::CodeGenerator::switchCodeCacheTo(newCodeCache);
+   }
+
+
+bool
+OMR::X86::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   return
+      !TR::Compiler->target.cpu.isTargetWithinRIPRange(targetAddress, sourceAddress) ||
+      self()->comp()->getOption(TR_StressTrampolines);
    }

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -824,7 +824,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 //
 
 #if defined(TR_TARGET_64BIT)
-#define NEEDS_TRAMPOLINE(target, rip, cg) (!IS_32BIT_RIP((target), (rip)))
+#define NEEDS_TRAMPOLINE(target, rip, cg) (cg->directCallRequiresTrampoline((intptrj_t)target, (intptrj_t)rip))
 #else
 // Give the C++ compiler a hand
 #define NEEDS_TRAMPOLINE(target, rip, cg) (0)

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -813,7 +813,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 //
 
 #if defined(TR_TARGET_64BIT)
-#define NEEDS_TRAMPOLINE(target, rip, cg) (cg->alwaysUseTrampolines() || !IS_32BIT_RIP((target), (rip)))
+#define NEEDS_TRAMPOLINE(target, rip, cg) (!IS_32BIT_RIP((target), (rip)))
 #else
 // Give the C++ compiler a hand
 #define NEEDS_TRAMPOLINE(target, rip, cg) (0)

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -604,6 +604,17 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    virtual void simulateNodeEvaluation (TR::Node *node, TR_RegisterPressureState *state, TR_RegisterPressureSummary *summary);
 
+   /**
+    * @brief Answers whether a trampoline is required for a direct call instruction to
+    *           reach a target address.
+    *
+    * @param[in] targetAddress : the absolute address of the call target
+    * @param[in] sourceAddress : the absolute address of the call instruction
+    *
+    * @return : true if a trampoline is required; false otherwise.
+    */
+   bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
+
    protected:
 
    CodeGenerator();

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,6 +35,7 @@ namespace OMR { typedef OMR::X86::CPU CPUConnector; }
 
 #include <stdint.h>
 #include "compiler/env/OMRCPU.hpp"
+#include "env/jittypes.h"
 
 struct TR_X86CPUIDBuffer;
 namespace TR { class Compilation; }
@@ -62,6 +63,22 @@ public:
    uint32_t getX86ProcessorFeatureFlags8(TR::Compilation *comp);
 
    bool testOSForSSESupport(TR::Compilation *comp);
+
+   /**
+    * @brief Answers whether the distance between a target and source address
+    *        is within the reachable RIP displacement range.
+    *
+    * @param[in] : targetAddress : the address of the target
+    *
+    * @param[in] : sourceAddress : the address of the instruction following the
+    *                 branch instruction.
+    *
+    * @return true if the target is within range; false otherwise.
+    */
+   bool isTargetWithinRIPRange(intptrj_t targetAddress, intptrj_t sourceAddress)
+      {
+      return targetAddress == sourceAddress + (int32_t)(targetAddress - sourceAddress);
+      }
 
    };
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -6924,3 +6924,11 @@ OMR::Z::CodeGenerator::findOrCreateLiteral(void *value, size_t len)
    return 0;
    }
 
+
+bool
+OMR::Z::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
+   {
+   return
+      !TR::Compiler->target.cpu.isTargetWithinBranchRelativeRILRange(targetAddress, sourceAddress) ||
+      self()->comp()->getOption(TR_StressTrampolines);
+   }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -127,7 +127,7 @@ extern int64_t getIntegralValue(TR::Node* node);
 #endif
 
 // Multi Code Cache Routines for checking whether an entry point is within reach of a BASRL.
-#define NEEDS_TRAMPOLINE(target, rip, cg) (cg->alwaysUseTrampolines() || !CHECK_32BIT_TRAMPOLINE_RANGE(target,rip))
+#define NEEDS_TRAMPOLINE(target, rip, cg) (!CHECK_32BIT_TRAMPOLINE_RANGE(target,rip))
 
 #define TR_MAX_MVC_SIZE 256
 #define TR_MAX_CLC_SIZE 256

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -127,7 +127,7 @@ extern int64_t getIntegralValue(TR::Node* node);
 #endif
 
 // Multi Code Cache Routines for checking whether an entry point is within reach of a BASRL.
-#define NEEDS_TRAMPOLINE(target, rip, cg) (!CHECK_32BIT_TRAMPOLINE_RANGE(target,rip))
+#define NEEDS_TRAMPOLINE(target, rip, cg) (cg->directCallRequiresTrampoline((intptrj_t)target, (intptrj_t)rip))
 
 #define TR_MAX_MVC_SIZE 256
 #define TR_MAX_CLC_SIZE 256

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -213,6 +213,17 @@ public:
    bool hasWarmCallsBeforeReturn();
 
    /**
+    * @brief Answers whether a trampoline is required for a direct call instruction to
+    *           reach a target address.
+    *
+    * @param[in] targetAddress : the absolute address of the call target
+    * @param[in] sourceAddress : the absolute address of the call instruction
+    *
+    * @return : true if a trampoline is required; false otherwise.
+    */
+   bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
+
+   /**
     * \brief Tells the optimzers and codegen whether a load constant node should be rematerialized.
     *
     * \details Large constants should be materialized (constant node should be commoned up)

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@ namespace OMR { typedef OMR::Z::CPU CPUConnector; }
 #endif
 
 #include "compiler/env/OMRCPU.hpp"
+#include "env/jittypes.h"
 #include "env/ProcessorInfo.hpp"
 
 namespace OMR
@@ -83,11 +84,29 @@ public:
    bool getS390SupportsRI() { return false; }
 
    bool getS390SupportsVectorFacility() { return false; }
-   
+
    bool getS390SupportsGuardedStorageFacility() { return false; }
 
    TR_S390MachineType getS390MachineType() const { return _s390MachineType; }
    void setS390MachineType(TR_S390MachineType t) { _s390MachineType = t; }
+
+   /**
+    * @brief Answers whether the distance between a target and source address
+    *        is within the reachable displacement range for a branch relative
+    *        RIL-format instruction.
+    *
+    * @param[in] : targetAddress : the address of the target
+    *
+    * @param[in] : sourceAddress : the address of the branch relative RIL-format
+    *                 instruction from which the displacement range is measured.
+    *
+    * @return true if the target is within range; false otherwise.
+    */
+   bool isTargetWithinBranchRelativeRILRange(intptrj_t targetAddress, intptrj_t sourceAddress)
+      {
+      return (targetAddress == sourceAddress + ((intptrj_t)((int32_t)((targetAddress - sourceAddress)/2)))*2) &&
+             (targetAddress % 2 == 0);
+      }
 
 private:
 


### PR DESCRIPTION
* Add CPU-specific tests for relative branch reachability
* Remove unused AlwaysUseTrampoline CodeGenerator option
* Add directCallRequiresTrampoline CodeGenerator query
* Use directCallRequiresTrampoline CodeGenerator query