### PR TITLE
WIP: Add new RawMemory allocators but don't use them yet

### DIFF
--- a/compiler/env/newmemory/CustomAllocator.hpp
+++ b/compiler/env/newmemory/CustomAllocator.hpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_CUSTOMALLOCATOR_INCL
+#define OMR_CUSTOMALLOCATOR_INCL
+
+#pragma once
+
+#include <stddef.h>  // for size_t
+#include <cstdlib>   // for free, malloc
+#include <new>       // for bad_alloc, nothrow, nothrow_t
+#include "infra/Assert.hpp" //  for OMR_ASSERT_FATAL
+#include "env/newmemory/RawAllocator.hpp"
+
+// CustomAllocator is a more flexible implementation of TR::RawAllocator
+// but at the performance cost of an extra pointer indirection for every
+// API call. Upon construction, the functions to call to implement
+// allocate() (AllocatFunction), deallocate (DeallocateFunction), and
+// optionally noLongerUsed() (NoLongerUsedFunction) must be specified.
+
+namespace OMR
+{
+
+class CustomAllocator :  public TR::RawAllocator
+   {
+public:
+   typedef RawMemory (*AllocateFunction)(size_t, RawMemory);
+   typedef void (*DeallocateFunction)(RawMemory);
+   typedef void (*NoLongerUsedFunction)(RawMemory, size_t);
+
+   CustomAllocator(AllocateFunction allocateFunction,
+                   DeallocateFunction deallocateFunction,
+                   NoLongerUseFunction noLongerUsedFunction=0)
+      : _allocateFunction(allocateFunction)
+      , _deallocateFunction(deallocateFunction)
+      , _noLongerUsedFunction(noLongerUsedFunction)
+      {
+      OMR_ASSERT_FATAL(_allocateFunction && _deallocateFunction, "Custom allocator needs valid allocateFunction and deallocateFunction");
+      }
+
+   virtual TR::RawAllocator & clone()
+      {
+      return *(new (*this) CustomAllocator(_allocateFunction, _deallocateFunction, _noLongerUsedFunction));
+      }
+
+   virtual RawMemory allocate(size_t size, const std::nothrow_t tag, void * hint = 0) const throw()
+      {
+      return (*_allocateFunction)(size, hint);
+      }
+
+   virtual void deallocate(RawMemory p) const throw()
+      {
+      (*_deallocateFunction)(p);
+      }
+
+   virtual void noLongerUsed(RawMemory p, size_t size) const throw()
+      {
+      if (_noLongerUsedFunction)
+         (*_noLongerUsedFunction)(p, size);
+      }
+
+private:
+   AllocateFunction   _allocateFunction;
+   DeallocateFunction _deallocateFunction;
+   NoLongerUsedFunction    _noLongerUsedFunction;
+   };
+
+} // namespace OMR
+
+#endif // OMR_CUSTOMALLOCATOR_INCL

--- a/compiler/env/newmemory/DebugAllocator.cpp
+++ b/compiler/env/newmemory/DebugAllocator.cpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+#include <sys/mman.h>
+#if defined(__APPLE__) || !defined(MAP_ANONYMOUS)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#elif defined(OMR_OS_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
+#include <string.h>
+#endif /* defined(OMR_OS_WINDOWS) */
+
+#include <stddef.h>  // for size_t
+#include <cstdlib>   // for free, malloc
+#include <new>       // for bad_alloc, nothrow, nothrow_t
+#include "infra/Assert.hpp"
+#include "env/mem/DebugAllocator.hpp"
+
+void *
+OMR::DebugAllocator::allocate(size_t size, const std::nothrow_t tag,void * hint) const throw()
+   {
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+   void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+   return (p == MAP_FAILED) ? NULL : p;
+#elif defined(OMR_OS_WINDOWS)
+   return  VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+#else
+   return this->TR::MallocAllocator::allocate(size, tag, hint);
+#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+   }
+
+void
+OMR::DebugAllocator::deallocate(void* p) const throw()
+   {
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+   TR_ASSERT(0, "DebugAllocator does not support deallocation without size parameter on this platform");
+#elif defined(OMR_OS_WINDOWS)
+   VirtualFree(p, 0, MEM_RELEASE);
+#else
+   this->TR::MallocAllocator::deallocate(p);
+#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+   }
+
+void
+OMR::DebugAllocator::deallocate(void *p, size_t size) const throw()
+   {
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+   munmap(p, size);
+#else
+   deallocate(p); // other platforms can deallocate without size
+#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+   }
+
+void
+OMR::DebugAllocator::noLongerUsed(void *p, size_t size) const throw()
+   {
+#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+   void * remap = mmap(p, size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+   TR_ASSERT(remap == p, "Remapping of memory failed!");
+#elif defined(OMR_OS_WINDOWS)
+   VirtualFree(p, size, MEM_DECOMMIT);
+   VirtualAlloc(p, size, MEM_COMMIT, PAGE_NOACCESS);
+#else
+   memset(p, 0xEF, size);
+#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+   }

--- a/compiler/env/newmemory/DebugAllocator.hpp
+++ b/compiler/env/newmemory/DebugAllocator.hpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_DEBUGALLOCATOR_INCL
+#define OMR_DEBUGALLOCATOR_INCL
+
+#pragma once
+
+#include "env/newmemory/MallocAllocator.hpp"
+
+// OMR::DebugAllocator is used when debugging use-after-free problems. When used in conjunction
+// with a TR::DebugSegmentAllocator, deallocated memory will not actually be deallocated but
+// rather access protected against reads (implemented inside the noLongerUsed() notification, which
+// should be called by DebugSegmentAllocator at the same time deallocate() would normally have been
+// called). Only when the DebugSegmentAllocator object dies will the memory segments be returned via
+// deallocate(). While not memory efficient (because it holds onto allocated memory for longer) it
+// can be extremely useful to catch use-after-free memory bugs.
+//
+// NOTE: noLongerUsed() is not really the right way to implement this "access protection" mechanism.
+//       The longer term solution here moves the noLongerUsed() implementation into deallocate()
+//       while adding a std::deque to remember the memory region (and NOT actually freeing the memory).
+//       In the destructor, then, walk the list and actually deallocate the memory regions. This
+//       approach makes the DebugRawAllocator stateful, which conflicts with an assumption in a few
+//       places in the JIT that RawAllocators are, in fact, stateless (they are copied by value).
+//       Once these spots have been updated, this more proper solution should be performed. At that
+//       point, parts of DebugSegmentAllocator should also melt away.
+//
+
+namespace OMR
+{
+
+class DebugAllocator : public OMR::MallocAllocator
+   {
+public:
+   DebugAllocator()
+      : OMR::MallocAllocator()
+      { }
+
+   virtual TR::RawAllocator & clone()
+      {
+      return *(new (*this) DebugAllocator());
+      }
+
+   virtual RawMemory allocate(size_t size, const std::nothrow_t tag,void * hint = 0) const throw();
+   virtual void deallocate(RawMemory p) const throw();
+   virtual void deallocate(RawMemory p, const size_t size) const throw();
+
+   // 
+   virtual void noLongerUsed(RawMemory p, const size_t size) const throw();
+   };
+
+} // namespace OMR
+
+#endif // OMR_DEBUGALLOCATOR_INCL

--- a/compiler/env/newmemory/MallocAllocator.hpp
+++ b/compiler/env/newmemory/MallocAllocator.hpp
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_MALLOCALLOCATOR_INCL
+#define OMR_MALLOCALLOCATOR_INCL
+
+#pragma once
+
+#include "env/newmemory/RawAllocator.hpp"
+
+namespace OMR {
+
+// MallocAllocator is a subclass of RawAllocator that uses malloc() and free() to manage
+// RawMemory. It provides no implementation for noLongerUsed().
+
+class MallocAllocator : public TR::RawAllocator
+   {
+public:
+   MallocAllocator()
+      : TR::RawAllocator()
+      { }
+
+   // virtual "copy constructor" used primarily to simplify lifetime management for RawAllocator objects
+   virtual TR::RawAllocator & clone()
+      {
+      return *(new (*this) TR::MallocAllocator());
+      }
+
+   virtual RawMemory allocate(size_t size, const std::nothrow_t tag, void * hint = 0) const throw()
+      {
+      return malloc(size);
+      }
+
+   virtual void deallocate(RawMemory p) const throw()
+      {
+      free(p);
+      }
+
+   };
+
+}
+
+#endif // defined(OMR_MALLOCALLOCATOR_INCL)

--- a/compiler/env/newmemory/RawAllocator.hpp
+++ b/compiler/env/newmemory/RawAllocator.hpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef TR_RAWALLOCATOR_INCL
+#define TR_RAWALLOCATOR_INCL
+
+#pragma once
+
+#include <stddef.h>  // for size_t
+#include <cstdlib>   // for free, malloc
+#include <new>       // for bad_alloc, nothrow, nothrow_t
+#include "env/TypedAllocator.hpp"
+
+
+namespace TR {
+
+typedef void *RawMemory;
+
+// RawAllocator is an abstract class used by the rest of the compiler to interact
+// with RawMemory allocators (e.g. concrete subclasses like MallocAllocator,
+// DebugRawAllocator, etc.). RawAllocator objects are expected to be thread-safe,
+// and to be *interchangeable*. Interchangeable means that objects *of a particular
+// subclass* are supposed to be like one another in that it should be perfectly valid
+// for one object to allocate a piece of RawMemory and for a different object to be used
+// to deallocate that RawMemory.
+//
+// It is not expected that objects from different subclasses of RawAllocator will be
+// interchangeable, since different subclasses may allocate/deallocate memory using
+// different facilities.
+//
+
+class RawAllocator
+   {
+public:
+   RawAllocator()
+      { }
+
+   // virtual "copy constructor" used primarily to simplify lifetime management for RawAllocator objects
+   // Once cloned, it is the cloner's responsibility to clean up the cloned object
+   virtual TR::RawAllocator & clone() = 0;
+
+   // allocate() tries to allocate a RawMemory block that can hold at least size bytes.
+   // On failure, this version of allocate() returns NULL.
+   virtual RawMemory allocate(size_t size, const std::nothrow_t tag, void * hint = 0) const throw() =  0;
+
+   // allocate() tries to allocate a RawMemory blocvk that can hold at least size bytes.
+   // On failure, this version of allocate() will throw std::bad_alloc()
+   RawMemory allocate(size_t size, void * hint = 0) const
+      {
+      RawMemory const alloc = allocate(size, std::nothrow, hint);
+      if (!alloc) throw std::bad_alloc();
+      return alloc;
+      }
+
+   // deallocate the RawMemory block pointed to by p
+   // Less preferable alternative to deallocate(p, size) in that some RawAllocator subclasses may not
+   // be able to support deallocating without a size. If you have a size, please convey it.
+   virtual void deallocate(RawMemory p) const throw() = 0;
+
+   // default simplification: deallocate() does not need a size.
+   // Despite defaulting to deallocate(p), this implementation is the preferred one to use if a size
+   // is available. Some RawAllocator subclasses may be more effective when a size is known.
+   virtual void deallocate(RawMemory p, const size_t size) const throw()
+      {
+      deallocate(p);
+      }
+
+   // Notify the RawAllocator that this memory should no longer be accessed until it is deallocated
+   // Typically used in debugging scenarios where, at the usual deallocate() point, noLongerUsed()
+   // is called to remove access to the memory region so that any unexpected subsequent access to
+   // that memory will fault (alternatively for platforms that don't support access protection, the
+   // memory can be painted with a value to make accesses more obvious). See DebugAllocator for how
+   // noLongerUsed() can be implemented. By default, noLongerUsed() will do nothing. Also note that
+   // future work should probably remove this service as described in the DebugAllocator header file.
+   virtual void noLongerUsed(RawMemory p, size_t size) const throw()
+      { }
+
+   template <typename T>
+   operator TR::typed_allocator<T, RawAllocator &>() throw()
+      {
+      return TR::typed_allocator<T, RawAllocator &>(*this);
+      }
+
+   };
+
+}
+
+// Allocate from a RawAllocator using placement new and a RawAllocator reference
+inline void * operator new(size_t size, const TR::RawAllocator & allocator)
+   {
+   return allocator.allocate(size);
+   }
+
+inline void * operator new[](size_t size, const TR::RawAllocator & allocator)
+   {
+   return allocator.allocate(size);
+   }
+
+inline void * operator new(size_t size, const TR::RawAllocator & allocator, const std::nothrow_t& tag) throw()
+   {
+   return allocator.allocate(size, tag);
+   }
+
+inline void * operator new[](size_t size, const TR::RawAllocator & allocator, const std::nothrow_t& tag) throw()
+   {
+   return allocator.allocate(size, tag);
+   }
+
+// Corresponding delete operators that deallocate using the RawAllocator
+inline void operator delete(void *ptr, const TR::RawAllocator & allocator) throw()
+   {
+   allocator.deallocate(ptr);
+   }
+
+inline void operator delete[](void *ptr, const TR::RawAllocator & allocator) throw()
+   {
+   allocator.deallocate(ptr);
+   }
+
+#endif
+


### PR DESCRIPTION
This commit adds the new TR::RawAllocator hierarchy of classes used
for allocating TR::RawMemory (void *).

TR::RawAllocator is an abstract base class for all of these allocators
and  is the class to be used by the rest of the compiler (as opposed
to referencing a subclass directly). RawAllocator defines the following
basic API:
	allocate() to allocate requested size in bytes
	deallocate() to deallocate a previously allocated chunk of RawMemory
	protect() to remove read access permission to a previously
                  allocated chunk of RawMemory

TR::MallocAllocator implements the API using malloc() and free() from the
C library. It does not implement protect(). TR::MallocAllocator is the
equivalent of the current TR::RawAllocator class.

TR::DebugAllocator implements the API using e.g. mmap/munmap on platforms
that support it. The protect() function is also implemented. TR::DebugAllocator
is used when debugging use-after-free memory problems because it will
trap when memory is used after supposedly being freed.

TR::CustomAllocator takes arguments at construction time to implement the
API. It declares AllocateFunction, DeallocateFunction, and ProtectFunction
function types that match the signature of allocate(), deallocate(), and
protect(), respectively. TR::CustomAllocator offers more flexibility but
at the cost of an extra pointer indirection per call to the API.

These classes are all part of a refactoring of the lower level memory
allocation layers in the OMR compiler. They are not yet used by any
other code in OMR but will eventually replace TR::RawAllocator as well
as functionality in DebugSegmentAllocator.

The new memory allocator classes are created in compiler/env/newmemory.
When they are finally enabled by default, these files will move from
newmemory into compiler/env and replace the implementations there.
For now, the new files will not be referenced or even built by anything,
to avoid any functional issues before the integration code is completed.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>