### PR TITLE
Add missing RememberedSet structures from OpenJ9

### DIFF
--- a/include_core/j9nongenerated.h
+++ b/include_core/j9nongenerated.h
@@ -212,4 +212,22 @@ typedef struct J9MemorySegmentList {
 	uintptr_t flags;
 } J9MemorySegmentList;
 
+#if defined(OMR_GC_STACCATO)
+
+typedef struct MM_GCRememberedSet {
+	uintptr_t globalFragmentIndex;
+	uintptr_t preservedGlobalFragmentIndex;
+} MM_GCRememberedSet;
+
+typedef struct MM_GCRememberedSetFragment {
+	uintptr_t** fragmentAlloc;
+	uintptr_t** fragmentTop;
+	void* fragmentStorage;
+	uintptr_t localFragmentIndex;
+	uintptr_t preservedLocalFragmentIndex;
+	struct MM_GCRememberedSet* fragmentParent;
+} MM_GCRememberedSetFragment;
+
+#endif /* defined(OMR_GC_STACCATO) */
+
 #endif /* j9nongenerated_h */


### PR DESCRIPTION
Code which uses structure J9VMGCRememberedSet has been added to OMR, but not the structure. The intended plan is to add MM_GCRememberedSet to OMR and then replace the J9VMRememberedSet structure in OpenJ9 with a typedef to MM_GC_RememberedSet. This should allow changing usage of J9VMRememberedSet to MM_GCRememberedSet in OMR and OpenJ9 separately without breaking builds.

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>