### PR TITLE
Remove OMR refactoring scaffolding

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -259,7 +259,6 @@ OMR::Compilation::Compilation(
    _numNestingLevels(0),
    _usesPreexistence(options.getOption(TR_ForceUsePreexistence)),
    _loopVersionedWrtAsyncChecks(false),
-   _codeCacheSwitched(false),
    _commitedCallSiteInfo(false),
    _containsBigDecimalLoad(false),
    _osrStateIsReliable(true),
@@ -2028,27 +2027,6 @@ OMR::Compilation::setCurrentCodeCache(TR::CodeCache * codeCache)
    if (_codeGenerator) _codeGenerator->setCodeCache(codeCache);
    }
 
-void OMR::Compilation::switchCodeCache(TR::CodeCache *newCodeCache)
-   {
-   TR_ASSERT( self()->getCurrentCodeCache() != newCodeCache, "Attempting to switch to the currently held code cache");
-   self()->setCurrentCodeCache(newCodeCache);  // Even if we signal, we need to update the reserved code cache for recompilations.
-   self()->cg()->setCodeCacheSwitched(true);
-
-#ifdef TR_TARGET_X86
-   self()->cg()->setNumReservedIPICTrampolines(0);
-#endif
-
-   if ( self()->cg()->committedToCodeCache() || !newCodeCache )
-      {
-      if (newCodeCache)
-         {
-         self()->failCompilation<TR::RecoverableCodeCacheError>("Already committed to current code cache");
-         }
-
-      self()->failCompilation<TR::CodeCacheError>("Already committed to current code cache");
-      }
-   }
-
 void OMR::Compilation::validateIL(TR::ILValidationContext ilValidationContext)
    {
    TR_ASSERT_FATAL(_ilValidator != NULL, "Attempting to validate the IL without the ILValidator being initialized");
@@ -2773,30 +2751,4 @@ void OMR::Compilation::invalidateAliasRegion()
 bool OMR::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
    {
    return false;
-   }
-
-int32_t OMR::Compilation::getNumReservedIPICTrampolines()
-   {
-#ifdef TR_TARGET_X86
-   return self()->cg()->getNumReservedIPICTrampolines();
-#else
-   return 0;
-#endif
-   }
-
-void OMR::Compilation::setNumReservedIPICTrampolines(int32_t n)
-   {
-#ifdef TR_TARGET_X86
-   return self()->cg()->setNumReservedIPICTrampolines(n);
-#endif
-   }
-
-bool OMR::Compilation::getCodeCacheSwitched()
-   {
-   return self()->cg()->hasCodeCacheSwitched();
-   }
-
-void OMR::Compilation::setCodeCacheSwitched(bool s)
-   {
-   self()->cg()->setCodeCacheSwitched(s);
    }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -519,15 +519,6 @@ public:
    //
    // J9
 
-   /**
-    * These functions are deprecated and live in Compilation only to redirect
-    * downstream projects to the new CodeGenerator API.  They will be removed
-    * once all downstream projects have been updated to the new API once it is
-    * merged (currently only OpenJ9).
-    */
-   int32_t getNumReservedIPICTrampolines();
-   void setNumReservedIPICTrampolines(int32_t n);
-
    TR::list<TR::Instruction*> *getStaticPICSites() {return &_staticPICSites;}
    TR::list<TR::Instruction*> *getStaticHCRPICSites() {return &_staticHCRPICSites;}
    TR::list<TR::Instruction*> *getStaticMethodPICSites() {return &_staticMethodPICSites;}
@@ -538,17 +529,6 @@ public:
    TR::list<TR::Snippet*> *getMethodSnippetsToBePatchedOnClassUnload() { return &_methodSnippetsToBePatchedOnClassUnload; }
    TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition() { return &_snippetsToBePatchedOnClassRedefinition; }
    TR::list<TR_Pair<TR::Snippet,TR_ResolvedMethod> *> *getSnippetsToBePatchedOnRegisterNative() { return &_snippetsToBePatchedOnRegisterNative; }
-
-   void switchCodeCache(TR::CodeCache *newCodeCache);
-
-   /**
-    * These functions are deprecated and live in Compilation only to redirect
-    * downstream projects to the new CodeGenerator API.  They will be removed
-    * once all downstream projects have been updated to the new API once it is
-    * merged (currently only OpenJ9).
-    */
-   bool getCodeCacheSwitched();
-   void setCodeCacheSwitched(bool s);
 
    void setCurrentCodeCache(TR::CodeCache *codeCache);
    TR::CodeCache *getCurrentCodeCache();
@@ -1177,7 +1157,6 @@ private:
 
    bool                              _usesPreexistence;
    bool                              _loopVersionedWrtAsyncChecks;
-   bool                              _codeCacheSwitched;
    bool                              _commitedCallSiteInfo;
    bool                              _containsBigDecimalLoad;
    bool                              _isOptServer;

--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -106,8 +106,6 @@ class FEBase : public FECommon
    virtual TR_PersistentMemory       * persistentMemory() { return &_persistentMemory; }
    virtual TR::PersistentInfo * getPersistentInfo() { return _persistentMemory.getPersistentInfo(); }
 
-   private:
-   virtual void switchCodeCache(TR::CodeCache *newCache);
    };
 
 } /* namespace TR */

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -127,13 +127,6 @@ FEBase<Derived>::allocateRelocationData(TR::Compilation* comp, uint32_t size)
   #undef NO_MAP_ANONYMOUS
 #endif
 
-template <class Derived>
-void
-FEBase<Derived>::switchCodeCache(TR::CodeCache *newCache)
-   {
-   TR::Compilation *comp = TR::comp();
-   comp->cg()->switchCodeCacheTo(newCache);
-   }
 
 template <class Derived>
 intptrj_t


### PR DESCRIPTION
Now that #3371 is merged and downstream projects have been updated, remove
the support scaffolding:

* delete Compilation NumReservedIPICTrampoline getter/setter
* delete Compilation codeCacheSwitched getter/setter
* delete FrontEnd switchCodeCache()

Signed-off-by: Daryl Maier <maier@ca.ibm.com>