### PR TITLE
On Windows omrfile_lastmod() should return -1 if an error occurs

### DIFF
--- a/fvtest/porttest/omrfileTest.cpp
+++ b/fvtest/porttest/omrfileTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4784,10 +4784,26 @@ exit:
 	reportTestExit(OMRPORTLIB, testName);
 }
 
+/**
+ * Verify omrfile_lastmod() returns -1 on an invalid file.
+ * @ref omrfile.c::omrfile_lastmod "omrfile_lastmod()"
+ */
+TEST_F(PortFileTest2, lastmod_failedToFindFile)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = APPEND_ASYNC(lastmod_failedToFindFile);
 
+	reportTestEntry(OMRPORTLIB, testName);
 
+	const char *fileName = "lastmod_failedToFindFile.tst";
+	omrfile_unlink(fileName);
 
-
+	int rc = omrfile_lastmod(fileName);
+	if (rc != -1) {
+		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_lastmod() did not return -1 on an invalid file.");
+	}
+	reportTestExit(OMRPORTLIB, testName);
+}
 
 /**
  * Verify port file system.

--- a/port/win32/omrfile.c
+++ b/port/win32/omrfile.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -404,7 +404,7 @@ omrfile_lastmod(struct OMRPortLibrary *portLibrary, const char *path)
 		WIN32_FILE_ATTRIBUTE_DATA myStat;
 		if (0 == GetFileAttributesExW(unicodePath, GetFileExInfoStandard, &myStat)) {
 			int32_t error = GetLastError();
-			result = portLibrary->error_set_last_error(portLibrary, error, findError(error));
+			portLibrary->error_set_last_error(portLibrary, error, findError(error));
 		} else {
 			/*
 			 * Search MSDN for 'Converting a time_t Value to a File Time' for following implementation.


### PR DESCRIPTION
Change omrfile_lastmod() to match its documentation that -1 should be
returned on error.

Signed-off-by: hangshao <hangshao@ca.ibm.com>