### PR TITLE
Remove CodeCache and CodeCacheManager from FETraits

### DIFF
--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -69,8 +69,6 @@ class FEBase : public FECommon
    public:
    // Define our types in terms of the Traits
    typedef typename TR::FETraits<Derived>::JitConfig        JitConfig;
-   typedef typename TR::FETraits<Derived>::CodeCacheManager CodeCacheManager;
-   typedef typename TR::FETraits<Derived>::CodeCache        CodeCache;
 
    private:
    JitConfig            _config;

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,9 @@
 #include "compile/Compilation.hpp"
 #include "env/FEBase.hpp"
 #include "env/jittypes.h"
+#include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheExceptions.hpp"
+#include "runtime/CodeCacheManager.hpp"
 
 namespace TR
 {

--- a/fvtest/compilertest/env/FrontEnd.hpp
+++ b/fvtest/compilertest/env/FrontEnd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,6 @@
 #include "env/FEBase.hpp"
 #include "env/jittypes.h"
 #include "runtime/TestJitConfig.hpp"
-#include "runtime/CodeCache.hpp"
 
 namespace TR { class GCStackAtlas; }
 namespace OMR { struct MethodMetaDataPOD; }
@@ -39,8 +38,6 @@ namespace TR
 template <> struct FETraits<TestCompiler::FrontEnd>
    {
    typedef TestCompiler::JitConfig      JitConfig;
-   typedef TR::CodeCacheManager CodeCacheManager;
-   typedef TR::CodeCache        CodeCache;
    static const size_t  DEFAULT_SEG_SIZE = (128 * 1024); // 128kb
    };
 

--- a/jitbuilder/env/FrontEnd.hpp
+++ b/jitbuilder/env/FrontEnd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,6 @@
 #include "env/FEBase.hpp"
 #include "env/jittypes.h"
 #include "runtime/JBJitConfig.hpp"
-#include "runtime/CodeCache.hpp"
 
 namespace TR { class GCStackAtlas; }
 namespace OMR { struct MethodMetaDataPOD; }
@@ -40,8 +39,6 @@ namespace TR
 template <> struct FETraits<JitBuilder::FrontEnd>
    {
    typedef JitBuilder::JitConfig      JitConfig;
-   typedef TR::CodeCacheManager CodeCacheManager;
-   typedef TR::CodeCache        CodeCache;
    static const size_t  DEFAULT_SEG_SIZE = (128 * 1024); // 128kb
    };
 


### PR DESCRIPTION
The FrontEnd trait scheme predates the extensible class mechanism and
is not necessary.  Use the concrete extensible class for CodeCache and
CodeCacheManager directly.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>