### PR TITLE
Fix bug in arraycopy evaluator for constant byte length

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -658,12 +658,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setSupportsSearchCharString(); // CISC Transformation into SRSTU loop - only on z9.
    self()->setSupportsTranslateAndTestCharString(); // CISC Transformation into TRTE loop - only on z6.
 
-   // On 31-Bit zOS/zLinux We rely on optimizer to generate array copy trees specialized for direction
-   if (TR::Compiler->target.is32Bit())
-      {
-      self()->setSupportsPostProcessArrayCopy();
-      }
-
    if (_processorInfo.supportsArch(TR_S390ProcessorInfo::TR_z10))
       {
       self()->setSupportsTranslateAndTestCharString();

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -12753,7 +12753,9 @@ OMR::Z::TreeEvaluator::primitiveArraycopyEvaluator(TR::Node* node, TR::CodeGener
       TR::Register *checkBoundReg = srm->findOrCreateScratchRegister();
       if (byteLenReg == NULL)
          {
-         byteLenReg = cg->gprClobberEvaluate(byteLenNode);
+         TR_ASSERT_FATAL(isConstantByteLen, "byteLenNode can be not evaluated only when we have constant length");
+         byteLenReg = cg->allocateRegister();
+         genLoadLongConstant(cg, node, byteLenNode->getConst<int64_t>(), byteLenReg);
          }
       cursor = generateRXInstruction(cg, TR::InstOpCode::LA, node, checkBoundReg, generateS390MemoryReference(byteSrcReg, byteLenReg, 0, cg));
       iComment("nextPointerToLastElement=byteSrcPointer+lengthInBytes");


### PR DESCRIPTION
With the change to generate instructions for array copy
direction test in codegen, we had a bug in case of constant
byte length array copy.

As it is constant byte length array copy, we exploit that information
in our forward direction copy path where we generate loop and encode
instruction with known constant length so in this case byte length
node won't be evaluated. In case of backward array copy we need to load
length into register where it will be used in the copying loop.
This leaves us with a diamond case where we have clobber evaluated
a byteLen node in one path but did not evaluate it in other path.
This was causing a rare bug when you have a constant length array copy
whose byte length node has more than one references and we end up using
a register set to the constant node which will have correct value in only
one path.

Fixes: #3229

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>