### PR TITLE
Use the Test Compiler with Tril tests instead of JitBuilder

### DIFF
--- a/fvtest/compilertest/Jit.hpp
+++ b/fvtest/compilertest/Jit.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,5 +26,6 @@ namespace TR { class MethodBuilder; }
 class TR_Memory;
 
 extern "C" bool initializeJit();
+extern "C" bool initializeJitWithOptions(char * options);
 extern "C" uint32_t compileMethodBuilder(TR::MethodBuilder *m, uint8_t **entry);
 extern "C" void shutdownJit();

--- a/fvtest/compilertest/control/TestJit.cpp
+++ b/fvtest/compilertest/control/TestJit.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -203,11 +203,6 @@ shutdownJit()
 
    TR::CodeCacheManager &codeCacheManager = fe->codeCacheManager();
    codeCacheManager.destroy();
-#if defined(TR_TARGET_POWER)
-   delete fe->getPersistentInfo()->getPersistentTOC();
-   fe->getPersistentInfo()->setPersistentTOC(NULL);
-#endif
-
    }
 
 extern "C"

--- a/fvtest/compilertriltest/BitPermuteTest.cpp
+++ b/fvtest/compilertriltest/BitPermuteTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ const uint32_t intLengths[]   = {0, 1, 19, 32};
 const uint32_t longLengths[]  = {0, 1, 35, 64};
 
 template <typename VarType>
-class BitPermuteTest : public ::testing::TestWithParam<std::tuple<VarType, const uint8_t*, uint32_t, VarType (*) (VarType, const uint8_t*, uint32_t)>>
+class BitPermuteTest : public TRTest::TestWithPortLib, public ::testing::WithParamInterface<std::tuple<VarType, const uint8_t*, uint32_t, VarType (*) (VarType, const uint8_t*, uint32_t)>>
    {
    public:
 
@@ -339,6 +339,9 @@ class sBitPermuteTest : public BitPermuteTest<uint16_t> {};
 
 TEST_P(sBitPermuteTest, ConstAddressLengthTest)
    {
+   std::string arch = omrsysinfo_get_CPU_architecture();
+   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -376,6 +379,9 @@ TEST_P(sBitPermuteTest, ConstAddressLengthTest)
 
 TEST_P(sBitPermuteTest, ConstAddressTest)
    {
+   std::string arch = omrsysinfo_get_CPU_architecture();
+   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -412,6 +418,9 @@ TEST_P(sBitPermuteTest, ConstAddressTest)
 
 TEST_P(sBitPermuteTest, NoConstTest)
    {
+   std::string arch = omrsysinfo_get_CPU_architecture();
+   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -449,6 +458,9 @@ class bBitPermuteTest : public BitPermuteTest<uint8_t> {};
 
 TEST_P(bBitPermuteTest, ConstAddressLengthTest)
    {
+   std::string arch = omrsysinfo_get_CPU_architecture();
+   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];
@@ -486,6 +498,9 @@ TEST_P(bBitPermuteTest, ConstAddressLengthTest)
 
 TEST_P(bBitPermuteTest, ConstAddressTest)
    {
+   std::string arch = omrsysinfo_get_CPU_architecture();
+   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];
@@ -522,6 +537,9 @@ TEST_P(bBitPermuteTest, ConstAddressTest)
 
 TEST_P(bBitPermuteTest, NoConstTest)
    {
+   std::string arch = omrsysinfo_get_CPU_architecture();
+   SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+      << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -30,6 +30,7 @@
 #include "optimizer/Optimizer.hpp"
 #include "ilgen/MethodBuilder.hpp"
 #include "omrport.h"
+#include "Jit.hpp"
 
 #define ASSERT_NULL(pointer) ASSERT_EQ(NULL, (pointer))
 #define ASSERT_NOTNULL(pointer) ASSERT_TRUE(NULL != (pointer))
@@ -37,11 +38,6 @@
 #define EXPECT_NOTNULL(pointer) EXPECT_TRUE(NULL != (pointer))
 
 #define TRIL(code) #code
-
-bool initializeJit();
-bool initializeJitWithOptions(char *options);
-int32_t compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
-void shutdownJit();
 
 namespace TRTest
 {

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -195,6 +195,10 @@ TEST_P(Int8ShiftAndRotate, UsingConst) {
 
 TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     auto param = TRTest::to_struct(GetParam());
+
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(param.opcode == "bshr" && (OMRPORT_ARCH_PPC == arch || OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), KnownBug)
+        << "The POWER code generator zero-extends the input argument instead of sign-extending (see issue #3535)";
 
     char inputTrees[120] = {0};
     std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (b2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
@@ -399,6 +403,10 @@ TEST_P(UInt16ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_PPC == arch || OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch, KnownBug)
+        << "The POWER code generator sign-extends the input argument instead of zero-extending (see issue #3535)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -199,6 +199,8 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(param.opcode == "bshr" && (OMRPORT_ARCH_PPC == arch || OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch), KnownBug)
         << "The POWER code generator zero-extends the input argument instead of sign-extending (see issue #3535)";
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     char inputTrees[120] = {0};
     std::snprintf(inputTrees, 120, "(method return=Int8 args=[Int8, Int32] (block (ireturn (b2i (%s (bload parm=0) (iload parm=1)) ))))", param.opcode.c_str());
@@ -240,6 +242,10 @@ TEST_P(Int16ShiftAndRotate, UsingConst) {
 
 #if !defined(TR_TARGET_POWER)
 TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
@@ -363,6 +369,10 @@ TEST_P(UInt8ShiftAndRotate, UsingConst) {
 }
 
 TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[120] = {0};
@@ -406,6 +416,8 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_PPC == arch || OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC64LE == arch, KnownBug)
         << "The POWER code generator sign-extends the input argument instead of zero-extending (see issue #3535)";
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -92,6 +92,10 @@ TEST_P(Int8ToInt32, UsingConst) {
 }
 
 TEST_P(Int8ToInt32, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -147,6 +151,10 @@ TEST_P(UInt8ToInt32, UsingConst) {
 }
 
 TEST_P(UInt8ToInt32, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -202,6 +210,10 @@ TEST_P(Int8ToInt64, UsingConst) {
 }
 
 TEST_P(Int8ToInt64, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -257,6 +269,10 @@ TEST_P(UInt8ToInt64, UsingConst) {
 }
 
 TEST_P(UInt8ToInt64, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -312,6 +328,10 @@ TEST_P(Int16ToInt32, UsingConst) {
 }
 
 TEST_P(Int16ToInt32, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -367,6 +387,10 @@ TEST_P(UInt16ToInt32, UsingConst) {
 }
 
 TEST_P(UInt16ToInt32, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -422,6 +446,10 @@ TEST_P(Int16ToInt64, UsingConst) {
 }
 
 TEST_P(Int16ToInt64, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =
@@ -477,6 +505,10 @@ TEST_P(UInt16ToInt64, UsingConst) {
 }
 
 TEST_P(UInt16ToInt64, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char *inputTrees =

--- a/fvtest/compilertriltest/main.cpp
+++ b/fvtest/compilertriltest/main.cpp
@@ -26,30 +26,6 @@ extern "C" {
 int omr_main_entry(int argc, char **argv, char **envp);
 }
 
-extern bool internal_initializeJit();
-extern bool internal_initializeJitWithOptions(char *options);
-extern int32_t internal_compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
-extern void internal_shutdownJit();
-
-bool initializeJit() {
-   auto ret = internal_initializeJit();
-   return ret;
-}
-
-bool initializeJitWithOptions(char * options) {
-auto ret = internal_initializeJitWithOptions(options);
-return ret;
-}
-
-int32_t compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint) {
-   auto ret = internal_compileMethodBuilder(methodBuilder, entryPoint);
-   return ret;
-}
-
-void shutdownJit() {
-   internal_shutdownJit();
-}
-
 OMRPortLibrary TRTest::TestWithPortLib::PortLib;
 omrthread_t TRTest::TestWithPortLib::current_thread = NULL;
 

--- a/fvtest/tril/examples/incordec/main.cpp
+++ b/fvtest/tril/examples/incordec/main.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,29 +20,12 @@
  *******************************************************************************/
 
 #include "default_compiler.hpp"
+#include "Jit.hpp"
 
 #include <assert.h>
 #include <stdio.h>
 
 typedef int32_t (IncOrDecFunction)(int32_t*);
-
-extern bool internal_initializeJit();
-extern int32_t internal_compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
-extern void internal_shutdownJit();
-
-bool initializeJit() {
-   auto ret = internal_initializeJit();
-   return ret;
-}
-
-int32_t compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint) {
-   auto ret = internal_compileMethodBuilder(methodBuilder, entryPoint);
-   return ret;
-}
-
-void shutdownJit() {
-   internal_shutdownJit();
-}
 
 int main(int argc, char const * const * const argv) {
     assert(argc == 2);

--- a/fvtest/tril/examples/mandelbrot/main.cpp
+++ b/fvtest/tril/examples/mandelbrot/main.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,29 +20,12 @@
  *******************************************************************************/
 
 #include "default_compiler.hpp"
+#include "Jit.hpp"
 
 #include <assert.h>
 #include <stdio.h>
 
 typedef void (MandelbrotFunction) (int32_t, int32_t, int32_t*);
-
-extern bool internal_initializeJit();
-extern int32_t internal_compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
-extern void internal_shutdownJit();
-
-bool initializeJit() {
-   auto ret = internal_initializeJit();
-   return ret;
-}
-
-int32_t compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint) {
-   auto ret = internal_compileMethodBuilder(methodBuilder, entryPoint);
-   return ret;
-}
-
-void shutdownJit() {
-   internal_shutdownJit();
-}
 
 int main(int argc, char const * const * const argv) {
     assert(argc == 2);

--- a/fvtest/tril/test/JitTest.hpp
+++ b/fvtest/tril/test/JitTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,6 +24,7 @@
 
 #include <gtest/gtest.h>
 #include "ilgen/MethodBuilder.hpp"
+#include "Jit.hpp"
 
 bool initializeJit();
 int32_t compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);

--- a/fvtest/tril/test/main.cpp
+++ b/fvtest/tril/test/main.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,24 +24,6 @@
 
 extern "C" {
 int omr_main_entry(int argc, char **argv, char **envp);
-}
-
-extern bool internal_initializeJit();
-extern int32_t internal_compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
-extern void internal_shutdownJit();
-
-bool initializeJit() {
-   auto ret = internal_initializeJit();
-   return ret;
-}
-
-int32_t compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint) {
-   auto ret = internal_compileMethodBuilder(methodBuilder, entryPoint);
-   return ret;
-}
-
-void shutdownJit() {
-   internal_shutdownJit();
 }
 
 int omr_main_entry(int argc, char **argv, char **envp) {

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -51,11 +51,7 @@ FLEX_TARGET(tril_scanner tril.l ${CMAKE_CURRENT_BINARY_DIR}/tril.scanner.c
 )
 ADD_FLEX_BISON_DEPENDENCY(tril_scanner tril_parser)
 
-if(TRIL_TEST_COMPILER)
-    set(TRIL_BACKEND_LIB      testcompiler)
-else()
-    set(TRIL_BACKEND_LIB      jitbuilder)
-endif()
+set(TRIL_BACKEND_LIB      testcompiler)
 
 add_library(tril STATIC
 	${BISON_tril_parser_OUTPUTS}
@@ -68,14 +64,14 @@ add_library(tril STATIC
 # This is mildly peculiar. Because tril relies
 # on jitbuilder as a 'backend' of sorts, we use
 # its includes. Tril exports this as interface
-make_compiler_target(tril PUBLIC COMPILER ${TRIL_BACKEND_LIB}) 
+make_compiler_target(tril PUBLIC COMPILER ${TRIL_BACKEND_LIB})
 
 target_include_directories(tril PUBLIC
 	${CMAKE_CURRENT_BINARY_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(tril PUBLIC 
+target_link_libraries(tril PUBLIC
 	${TRIL_BACKEND_LIB}
 	${CMAKE_DL_LIBS}
 )

--- a/fvtest/tril/tril/compiler.cpp
+++ b/fvtest/tril/tril/compiler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,11 +20,9 @@
  *******************************************************************************/
 
 #include "default_compiler.hpp"
+#include "Jit.hpp"
 #include <cstdio>
 #include <string>
-
-extern bool internal_initializeJit();
-extern void internal_shutdownJit();
 
 int main(int argc, char** argv)
    { 
@@ -48,12 +46,12 @@ int main(int argc, char** argv)
       printTrees(out, trees, 1); 
       if (!isDumper) 
          {
-         internal_initializeJit();
+         initializeJit();
          Tril::DefaultCompiler compiler{trees}; 
          if (compiler.compile() != 0) { 
             fprintf(out, "Error compiling trees!"); 
          }
-         internal_shutdownJit();
+         shutdownJit();
          }
       }
    else


### PR DESCRIPTION
The dependency on JitBuilder is broken by only providing the Test
Compiler as a target link library. A few workarounds for JitBuilder's
new client API are also removed. Lastly, the function to initialize the
Test Compiler with specific options is also exposed.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>