### PR TITLE
Remove deprecated FrontEnd CodeCache boundary inquiry functions

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -97,18 +97,6 @@ TR_FrontEnd::allocateCodeMemory(TR::Compilation *, uint32_t warmCodeSize, uint32
    return 0;
    }
 
-/*
- * Return conservative approximation of code-cache base.
- */
-uint8_t * TR_FrontEnd::getCodeCacheBase()                          { return 0; }
-uint8_t * TR_FrontEnd::getCodeCacheBase(TR::CodeCache *codeCache)  { return 0; }
-
-/*
- * Return conservative approximation of code cache top.
- */
-uint8_t * TR_FrontEnd::getCodeCacheTop()                           { return (uint8_t*)(~0); }
-uint8_t * TR_FrontEnd::getCodeCacheTop(TR::CodeCache *codeCache)   { return (uint8_t*)(~0); }
-
 void
 TR_FrontEnd::releaseCodeMemory(void *, uint8_t)
    {

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -247,12 +247,6 @@ public:
    virtual intptrj_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void * callSite);
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void * callSite); // No TR::Compilation parameter so this can be called from runtime code
 
-   // Z only
-   virtual uint8_t * getCodeCacheBase();
-   virtual uint8_t * getCodeCacheBase(TR::CodeCache *);
-   virtual uint8_t * getCodeCacheTop();
-   virtual uint8_t * getCodeCacheTop(TR::CodeCache *);
-
    // --------------------------------------------------------------------------
    // Stay in FrontEnd
    // --------------------------------------------------------------------------


### PR DESCRIPTION
* `getCodeCacheTop`
* `getCodeCacheBase`

Signed-off-by: Daryl Maier <maier@ca.ibm.com>