### PR TITLE
Enhance JIT version generation script

### DIFF
--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,6 @@ if(OMR_COMPILER_SUPPORT_)
 	return()
 endif()
 set(OMR_COMPILER_SUPPORT_ 1)
-
 
 # This file contains a number of support pieces required to build the compiler
 # component.
@@ -119,7 +118,6 @@ function(pasm2asm_files out_var compiler)
 	set(${out_var} "${result}" PARENT_SCOPE)
 endfunction()
 
-
 # Filter through the provided list, and rewrite any
 # .asm files to .s files, and add the .s file to the list
 # in lieu of the .asm file.
@@ -175,7 +173,6 @@ function(spp2s_files out_var compiler)
 	# Convert an SPP file to an IPP using the pre-processor.
 	# Rewrite the IPP file to a .s file using sed.
 
-
 	# Get the definitions already set in this directory
 	# - A concern would be how this would interact with target_compile_definitions
 	get_property(compile_defs DIRECTORY PROPERTY COMPILE_DEFINITIONS)
@@ -223,7 +220,6 @@ function(spp2s_files out_var compiler)
 	set(${out_var} "${result}" PARENT_SCOPE)
 endfunction()
 
-
 # Some source files in OMR don't map well into the transforms
 # CMake already knows about. This generates a pipeline of custom commands
 # to transform these source files into files that CMake _does_ understand.
@@ -236,7 +232,6 @@ function(omr_inject_object_modification_targets result compiler_name)
 
 	# Run masm2gas on contained .asm files
 	masm2gas_asm_files(arg ${compiler_name} ${arg})
-
 
 	# COnvert SPP files to .s files
 	spp2s_files(arg ${compiler_name} ${arg})
@@ -333,7 +328,6 @@ function(create_omr_compiler_library)
 
 	set_tr_compile_options()
 
-
 	get_filename_component(abs_root ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE)
 	# We use the cache to allow passing information about compiler targets
 	# from function to function without having to use lots of temps.
@@ -353,11 +347,10 @@ function(create_omr_compiler_library)
 
 	message("${COMPILER_NAME}_ROOT = ${${COMPILER_NAME}_ROOT}")
 
-
 	# Generate a build name file.
 	set(BUILD_NAME_FILE "${CMAKE_BINARY_DIR}/${COMPILER_NAME}Name.cpp")
 	add_custom_command(OUTPUT ${BUILD_NAME_FILE}
-		COMMAND perl ${omr_SOURCE_DIR}/tools/compiler/scripts/generateVersion.pl ${COMPILER_NAME} > ${BUILD_NAME_FILE}
+		COMMAND perl ${omr_SOURCE_DIR}/tools/compiler/scripts/generateVersion.pl ${COMPILER_NAME} ${BUILD_NAME_FILE}
 		VERBATIM
 		COMMENT "Generate ${BUILD_NAME_FILE}"
 	)
@@ -385,14 +378,10 @@ function(create_omr_compiler_library)
 		list(REMOVE_ITEM core_compiler_objects ${abs_filename})
 	endforeach()
 
-
-
 	omr_inject_object_modification_targets(core_compiler_objects ${COMPILER_NAME} ${core_compiler_objects})
 
 	# Append to the compiler sources list
 	target_sources(${COMPILER_NAME} PRIVATE ${core_compiler_objects})
-
-
 
 	# Set include paths and defines.
 	make_compiler_target(${COMPILER_NAME} PRIVATE COMPILER ${COMPILER_NAME})

--- a/fvtest/compilertest/build/rules/gnu/common.mk
+++ b/fvtest/compilertest/build/rules/gnu/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -69,7 +69,7 @@ $(call RULE.cpp,$(JIT_PRODUCT_BUILDNAME_OBJ),$(JIT_PRODUCT_BUILDNAME_SRC))
     
 .PHONY: $(JIT_PRODUCT_BUILDNAME_SRC)
 $(JIT_PRODUCT_BUILDNAME_SRC): | jit_createdirs
-	$(PERL_PATH) $(GENERATE_VERSION_SCRIPT) $(PRODUCT_RELEASE) > $@
+	$(PERL_PATH) $(GENERATE_VERSION_SCRIPT) $(PRODUCT_RELEASE) $@
 
 JIT_DIR_LIST+=$(dir $(JIT_PRODUCT_BUILDNAME_SRC))
 

--- a/jitbuilder/build/rules/gnu/common.mk
+++ b/jitbuilder/build/rules/gnu/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2016 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -63,7 +63,7 @@ $(call RULE.cpp,$(JIT_PRODUCT_BUILDNAME_OBJ),$(JIT_PRODUCT_BUILDNAME_SRC))
 .phony: $(JIT_PRODUCT_BUILDNAME_SRC)
 $(JIT_PRODUCT_BUILDNAME_SRC):
 	@mkdir -p $(dir $@)
-	$(PERL_PATH) $(GENERATE_VERSION_SCRIPT) $(PRODUCT_RELEASE) > $@
+	$(PERL_PATH) $(GENERATE_VERSION_SCRIPT) $(PRODUCT_RELEASE) $@
 
 jit_clean::
 	rm -f $(JIT_PRODUCT_BUILDNAME_SRC)


### PR DESCRIPTION
When invoked with an optional second argument, it will write to the named (output) file only if the contents need to change. This avoids recompiling the generated source file and downstream (linking, etc.) when no JIT changes have been made.