### PR TITLE
Create CodeGenerator trimCodeMemoryToActualSize() API

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -97,12 +97,6 @@ TR_FrontEnd::allocateCodeMemory(TR::Compilation *, uint32_t warmCodeSize, uint32
    return 0;
    }
 
-void
-TR_FrontEnd::resizeCodeMemory(TR::Compilation *, uint8_t *, uint32_t numBytes)
-   {
-   notImplemented("resizeCodeMemory");
-   }
-
 /*
  * Return conservative approximation of code-cache base.
  */

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -241,7 +241,6 @@ public:
    // --------------------------------------------------------------------------
 
    virtual uint8_t * allocateCodeMemory(TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t ** coldCode, bool isMethodHeaderNeeded=true);
-   virtual void resizeCodeMemory(TR::Compilation *, uint8_t *, uint32_t numBytes);
    virtual void releaseCodeMemory(void *, uint8_t);
    virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation* comp); // MCT
    virtual void reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -165,7 +165,7 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
 
    cg->processRelocations();
 
-   cg->resizeCodeMemory();
+   cg->trimCodeMemoryToActualSize();
    cg->registerAssumptions();
 
    cg->syncCode(cg->getBinaryBufferStart(), cg->getBinaryBufferCursor() - cg->getBinaryBufferStart());

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1753,10 +1753,12 @@ OMR::CodeGenerator::allocateCodeMemory(uint32_t size, bool isCold, bool isMethod
    }
 
 void
-OMR::CodeGenerator::resizeCodeMemory()
+OMR::CodeGenerator::trimCodeMemoryToActualSize()
    {
-   int32_t codeLength = self()->getCodeEnd()-self()->getBinaryBufferStart();
-   self()->fe()->resizeCodeMemory(self()->comp(), self()->getBinaryBufferStart(), codeLength);
+   uint8_t *bufferStart = self()->getBinaryBufferStart();
+   size_t actualCodeLengthInBytes = self()->getCodeEnd() - bufferStart;
+
+   self()->getCodeCache()->trimCodeMemoryAllocation(bufferStart, actualCodeLengthInBytes);
    }
 
 bool

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -785,7 +785,15 @@ class OMR_EXTENSIBLE CodeGenerator
    void  reserveCodeCache();
    uint8_t * allocateCodeMemory(uint32_t size, bool isCold, bool isMethodHeaderNeeded=true);
    uint8_t * allocateCodeMemory(uint32_t warmSize, uint32_t coldSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
-   void  resizeCodeMemory();
+
+   /**
+    * \brief Trim the size of code memory required by this method to match the
+    *        actual code length required, allowing the reclaimed memory to be
+    *        reused.  This is needed when the conservative length estimate
+    *        exceeds the actual memory requirement.
+    */
+   void trimCodeMemoryToActualSize();
+
    void  registerAssumptions() {}
 
    static void syncCode(uint8_t *codeStart, uint32_t codeSize);

--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -96,7 +96,6 @@ class FEBase : public FECommon
 
    virtual uint8_t *allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize, uint32_t coldCodeSize,
                                        uint8_t **coldCode, bool isMethodHeaderNeeded);
-   virtual void resizeCodeMemory(TR::Compilation * comp, uint8_t *bufferStart, uint32_t numBytes);
    virtual uint8_t * allocateRelocationData(TR::Compilation* comp, uint32_t size);
 
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void * callSite);

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -146,14 +146,4 @@ FEBase<Derived>::indexedTrampolineLookup(int32_t helperIndex, void * callSite)
    return (intptrj_t)tramp;
    }
 
-template <class Derived>
-void
-FEBase<Derived>::resizeCodeMemory(TR::Compilation * comp, uint8_t *bufferStart, uint32_t numBytes)
-   {
-   // I don't see a reason to acquire VM access for this call
-   TR::CodeCache *codeCache = comp->getCurrentCodeCache();
-   codeCache->resizeCodeMemory(bufferStart, numBytes);
-   }
-
-
 } /* namespace TR */


### PR DESCRIPTION
* Rename CodeGenerator `resizeCodeMemory` to more accurate `trimCodeMemoryToActualSize` and
  fix up references.
* Delete unused FrontEnd `resizeCodeMemory` APIs.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>