### PR TITLE
S390: Fix type of FPC register

### DIFF
--- a/port/linuxs390/omrsignal_context.c
+++ b/port/linuxs390/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -207,7 +207,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *inf
 	case 2:
 		*name = "fpc";
 		*value = &(mcontext->fpregs.fpc);
-		return OMRPORT_SIG_VALUE_ADDRESS;
+		return OMRPORT_SIG_VALUE_32;
 	case OMRPORT_SIG_CONTROL_S390_BEA:
 	case 3:
 		*name = "bea";

--- a/port/zos390/omrsignal_context.c
+++ b/port/zos390/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -363,7 +363,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 	case 0:
 		*name = "fpc";
 		*value = &(info->platformSignalInfo.context->__mc_fpc);
-		return OMRPORT_SIG_VALUE_ADDRESS;
+		return OMRPORT_SIG_VALUE_32;
 	case 1:
 		*name = "psw0";
 		if (info->platformSignalInfo.context->__mc_psw_flag) {

--- a/port/zos390/omrsignal_context_ceehdlr.c
+++ b/port/zos390/omrsignal_context_ceehdlr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -303,7 +303,7 @@ infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *in
 	case 0:
 		*name = "fpc";
 		*value = &(j9mch->fpc);
-		return OMRPORT_SIG_VALUE_ADDRESS;
+		return OMRPORT_SIG_VALUE_32;
 	case 1:
 		*name = "psw0";
 		*value = &(j9mch->psw0);

--- a/port/ztpf/omrsignal_context.c
+++ b/port/ztpf/omrsignal_context.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -620,7 +620,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *inf
 	case 2:
 		*name = "fpc";
 		*value = &(mcontext->fpregs.fpc);
-		return OMRPORT_SIG_VALUE_ADDRESS;
+		return OMRPORT_SIG_VALUE_32;
 	case OMRPORT_SIG_CONTROL_S390_BEA:
 	case 3:
 		*name = "bea";


### PR DESCRIPTION
In the S/390 architecture, the FPC register is 32-bits wide independent of whether a process is running in 31-bit or 64-bit mode. `infoForControl()` and `infoForControl_ceehdlr()` were incorrectly
returning `OMRPORT_SIG_VALUE_ADDRESS` instead of `OMRPORT_SIG_VALUE_32`.