### PR TITLE
Introduce empty CPU extension classes for ARM and AArch64

### DIFF
--- a/compiler/aarch64/CMakeLists.txt
+++ b/compiler/aarch64/CMakeLists.txt
@@ -1,5 +1,5 @@
 #################################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,5 +41,6 @@ compiler_library(aarch64
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRTreeEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OpBinary.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
+	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRDebugEnv.cpp
 )

--- a/compiler/aarch64/env/OMRCPU.cpp
+++ b/compiler/aarch64/env/OMRCPU.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "env/CPU.hpp"

--- a/compiler/aarch64/env/OMRCPU.hpp
+++ b/compiler/aarch64/env/OMRCPU.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_ARM64_CPU_INCL
+#define OMR_ARM64_CPU_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_CPU_CONNECTOR
+#define OMR_CPU_CONNECTOR
+namespace OMR { namespace ARM64 { class CPU; } }
+namespace OMR { typedef OMR::ARM64::CPU CPUConnector; }
+#else
+#error OMR::ARM64::CPU expected to be a primary connector, but an OMR connector is already defined
+#endif
+
+#include "compiler/env/OMRCPU.hpp"
+
+
+namespace OMR
+{
+
+namespace ARM64
+{
+
+class CPU : public OMR::CPU
+   {
+protected:
+
+   CPU() : OMR::CPU() {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/compiler/arm/env/OMRCPU.cpp
+++ b/compiler/arm/env/OMRCPU.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "env/CPU.hpp"

--- a/compiler/arm/env/OMRCPU.hpp
+++ b/compiler/arm/env/OMRCPU.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_ARM_CPU_INCL
+#define OMR_ARM_CPU_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_CPU_CONNECTOR
+#define OMR_CPU_CONNECTOR
+namespace OMR { namespace ARM { class CPU; } }
+namespace OMR { typedef OMR::ARM::CPU CPUConnector; }
+#else
+#error OMR::ARM::CPU expected to be a primary connector, but an OMR connector is already defined
+#endif
+
+#include "compiler/env/OMRCPU.hpp"
+
+
+namespace OMR
+{
+
+namespace ARM
+{
+
+class CPU : public OMR::CPU
+   {
+protected:
+
+   CPU() : OMR::CPU() {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/fvtest/compilertest/build/files/target/arm.mk
+++ b/fvtest/compilertest/build/files/target/arm.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,6 +46,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/SubtractAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/OMRTreeEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/UnaryEvaluator.cpp \
-    $(JIT_OMR_DIRTY_DIR)/arm/env/OMRCompilerEnv.cpp
+    $(JIT_OMR_DIRTY_DIR)/arm/env/OMRCompilerEnv.cpp \
+    $(JIT_OMR_DIRTY_DIR)/arm/env/OMRCPU.cpp
 
 JIT_PRODUCT_SOURCE_FILES+=

--- a/jitbuilder/build/files/target/aarch64.mk
+++ b/jitbuilder/build/files/target/aarch64.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,7 +43,8 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OpBinary.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/UnaryEvaluator.cpp
 
-#environement files
+#environment files
 
 JIT_PRODUCT_BACKEND_SOURCES+= \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/env/OMRCPU.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/env/OMRDebugEnv.cpp

--- a/jitbuilder/build/files/target/arm.mk
+++ b/jitbuilder/build/files/target/arm.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,5 +47,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/SubtractAnalyser.cpp \
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/OMRTreeEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/arm/codegen/UnaryEvaluator.cpp \
-    $(JIT_OMR_DIRTY_DIR)/arm/env/OMRCompilerEnv.cpp
+    $(JIT_OMR_DIRTY_DIR)/arm/env/OMRCompilerEnv.cpp \
+    $(JIT_OMR_DIRTY_DIR)/arm/env/OMRCPU.cpp
 


### PR DESCRIPTION
To prevent downstream project breakages, introduce empty extensions
to the CPU hierarchy for ARM and AArch64.  Once merged, downstream
projects can make changes to their build systems to accommodate the new
files before new CPU functionality is added in #3479.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>