### PR TITLE
Rename J9VMGCRememberedSet to MM_GCRememberedSet

### DIFF
--- a/gc/base/standard/RememberedSetSATB.cpp
+++ b/gc/base/standard/RememberedSetSATB.cpp
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -88,7 +88,7 @@ MM_RememberedSetSATB::tearDown(MM_EnvironmentBase *env)
  * @param fragment The fragment to initialize.
  */
 void
-MM_RememberedSetSATB::initializeFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment)
+MM_RememberedSetSATB::initializeFragment(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment)
 {
 	fragment->fragmentAlloc = NULL;
 	fragment->fragmentTop = NULL;
@@ -113,7 +113,7 @@ MM_RememberedSetSATB::initializeFragment(MM_EnvironmentBase* env, J9VMGCRemember
  * @param value The value to store in the fragment. 
  */
 void
-MM_RememberedSetSATB::storeInFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment, UDATA* value)
+MM_RememberedSetSATB::storeInFragment(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment, UDATA* value)
 {
 	if (!isFragmentValid(env, fragment)) {
 		if (!refreshFragment(env, fragment)) {
@@ -133,7 +133,7 @@ MM_RememberedSetSATB::storeInFragment(MM_EnvironmentBase* env, J9VMGCRememberedS
  * @param fragment The fragment to validate. 
  */
 bool
-MM_RememberedSetSATB::isFragmentValid(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment)
+MM_RememberedSetSATB::isFragmentValid(MM_EnvironmentBase* env, const MM_GCRememberedSetFragment* fragment)
 {
 	if (fragment->fragmentStorage == NULL) {
 		return false;
@@ -150,7 +150,7 @@ MM_RememberedSetSATB::isFragmentValid(MM_EnvironmentBase* env, const J9VMGCRemem
  * @param fragment The fragment to preserve the index for.
  */
 void
-MM_RememberedSetSATB::preserveLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment)
+MM_RememberedSetSATB::preserveLocalFragmentIndex(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment)
 {
 	assume((fragment->localFragmentIndex != J9GC_REMEMBERED_SET_RESERVED_INDEX), "Attempt to preserve an already preserved fragment index.");
 	fragment->preservedLocalFragmentIndex = fragment->localFragmentIndex;
@@ -162,7 +162,7 @@ MM_RememberedSetSATB::preserveLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGC
  * @param fragment The fragment to restore.
  */
 void
-MM_RememberedSetSATB::restoreLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment)
+MM_RememberedSetSATB::restoreLocalFragmentIndex(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment)
 {
 	assume((fragment->localFragmentIndex == J9GC_REMEMBERED_SET_RESERVED_INDEX), "Attempt to restore a non-preserved fragment index.");
 	fragment->localFragmentIndex = fragment->preservedLocalFragmentIndex;
@@ -194,7 +194,7 @@ MM_RememberedSetSATB::restoreGlobalFragmentIndex(MM_EnvironmentBase* env)
  * @return the actual value corresponding to the fragment index, preserved or not.
  */
 UDATA
-MM_RememberedSetSATB::getLocalFragmentIndex(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment)
+MM_RememberedSetSATB::getLocalFragmentIndex(MM_EnvironmentBase* env, const MM_GCRememberedSetFragment* fragment)
 {
 	/* There should be no synchronization required based on the following assumptions:
 	 * 1) The thread starting the GC will call preserveLocalFragmentIndex on all threads "atomically".
@@ -271,7 +271,7 @@ MM_RememberedSetSATB::setGlobalIndex(MM_EnvironmentBase* env, UDATA indexValue)
  * is to be updated.
  */
 bool
-MM_RememberedSetSATB::refreshFragment(MM_EnvironmentBase *env, J9VMGCRememberedSetFragment* fragment)
+MM_RememberedSetSATB::refreshFragment(MM_EnvironmentBase *env, MM_GCRememberedSetFragment* fragment)
 {
 	MM_Packet *packet = NULL;
 	bool result = false;

--- a/gc/base/standard/RememberedSetSATB.hpp
+++ b/gc/base/standard/RememberedSetSATB.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,7 @@ class MM_RememberedSetSATB : public MM_BaseNonVirtual
 {
 /* Data members & types */
 public:
-	J9VMGCRememberedSet _rememberedSetStruct; /**< The VM-readable struct containing the remembered set "global" indexes. */
+	MM_GCRememberedSet _rememberedSetStruct; /**< The VM-readable struct containing the remembered set "global" indexes. */
 protected:
 private:
 	MM_WorkPacketsSATB *_workPackets; /**< The workPackets struct used as backing store for the rememberedSet */
@@ -62,11 +62,11 @@ public:
 	};
 	
 	/* New methods */
-	void initializeFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment); /* "Nulls" out a fragment. */
-	void storeInFragment(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment, UDATA* value); /* This guarantees the store will occur, but a new fragment may be fetched. */
-	bool isFragmentValid(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment);
-	void preserveLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment); /* Called by the code that enables the double-barrier. */
-	void restoreLocalFragmentIndex(MM_EnvironmentBase* env, J9VMGCRememberedSetFragment* fragment); /* Called by the root scanner to disable the double-barrier. */
+	void initializeFragment(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment); /* "Nulls" out a fragment. */
+	void storeInFragment(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment, UDATA* value); /* This guarantees the store will occur, but a new fragment may be fetched. */
+	bool isFragmentValid(MM_EnvironmentBase* env, const MM_GCRememberedSetFragment* fragment);
+	void preserveLocalFragmentIndex(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment); /* Called by the code that enables the double-barrier. */
+	void restoreLocalFragmentIndex(MM_EnvironmentBase* env, MM_GCRememberedSetFragment* fragment); /* Called by the root scanner to disable the double-barrier. */
 	void preserveGlobalFragmentIndex(MM_EnvironmentBase* env); /* Called by the code that disables the barrier. */
 	void restoreGlobalFragmentIndex(MM_EnvironmentBase* env); /* Called by the code that enables the barrier. */
 	/* Used to determine if the staccato write barrier is enabled. */
@@ -76,12 +76,12 @@ public:
 		return (J9GC_REMEMBERED_SET_RESERVED_INDEX == _rememberedSetStruct.globalFragmentIndex);
 	}
 	void flushFragments(MM_EnvironmentBase* env); /* Ensures all fragments will be seen as invalid next time they are accessed. */
-	bool refreshFragment(MM_EnvironmentBase *env, J9VMGCRememberedSetFragment* fragment);
+	bool refreshFragment(MM_EnvironmentBase *env, MM_GCRememberedSetFragment* fragment);
 	
 protected:
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);
-	UDATA getLocalFragmentIndex(MM_EnvironmentBase* env, const J9VMGCRememberedSetFragment* fragment);
+	UDATA getLocalFragmentIndex(MM_EnvironmentBase* env, const MM_GCRememberedSetFragment* fragment);
 	UDATA getGlobalFragmentIndex(MM_EnvironmentBase* env);
 	
 private:


### PR DESCRIPTION
Changing usage of old OpenJ9 structure J9VMGCRememberedSet to new OMR structure MM_GCRememberedSet. J9VMGCRememberedSet does not exist in OMR.
Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>