### PR TITLE
Acquire current CodeCache directly from CodeGenerator

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2015,18 +2015,6 @@ OMR::Compilation::getCounterFromStaticAddress(TR::SymbolReference *symRef)
       }
    }
 
-TR::CodeCache *
-OMR::Compilation::getCurrentCodeCache()
-   {
-   return _codeGenerator ? _codeGenerator->getCodeCache() : 0;
-   }
-
-void
-OMR::Compilation::setCurrentCodeCache(TR::CodeCache * codeCache)
-   {
-   if (_codeGenerator) _codeGenerator->setCodeCache(codeCache);
-   }
-
 void OMR::Compilation::validateIL(TR::ILValidationContext ilValidationContext)
    {
    TR_ASSERT_FATAL(_ilValidator != NULL, "Attempting to validate the IL without the ILValidator being initialized");

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -530,9 +530,6 @@ public:
    TR::list<TR::Snippet*> *getSnippetsToBePatchedOnClassRedefinition() { return &_snippetsToBePatchedOnClassRedefinition; }
    TR::list<TR_Pair<TR::Snippet,TR_ResolvedMethod> *> *getSnippetsToBePatchedOnRegisterNative() { return &_snippetsToBePatchedOnRegisterNative; }
 
-   void setCurrentCodeCache(TR::CodeCache *codeCache);
-   TR::CodeCache *getCurrentCodeCache();
-
    TR_RegisterCandidates *getGlobalRegisterCandidates() { return _globalRegisterCandidates; }
    void setGlobalRegisterCandidates(TR_RegisterCandidates *t) { _globalRegisterCandidates = t; }
 

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -405,7 +405,7 @@ compileMethodFromDetails(
             }
 
          if (
-               compiler.getOption(TR_PerfTool) 
+               compiler.getOption(TR_PerfTool)
             || compiler.getOption(TR_EmitExecutableELFFile)
             || compiler.getOption(TR_EmitRelocatableELFFile)
             )
@@ -454,7 +454,7 @@ compileMethodFromDetails(
 #else
       printCompFailureInfo(jitConfig, &compiler, exception.what());
 #endif
-      } 
+      }
    catch (const std::exception &exception)
       {
       // failed! :-(
@@ -472,7 +472,8 @@ compileMethodFromDetails(
    // TR::Compilation. We'll need exceptions working instead of setjmp
    // before we can get working, and we need to make sure the other
    // frontends are properly calling the destructor
-   TR::CodeCacheManager::instance()->unreserveCodeCache(compiler.getCurrentCodeCache());
+   TR::CodeCache *codeCache = compiler.cg() ? compiler.cg()->getCodeCache() : NULL;
+   TR::CodeCacheManager::instance()->unreserveCodeCache(codeCache);
 
    TR_OptimizationPlan::freeOptimizationPlan(plan);
 

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -50,19 +50,20 @@ uint8_t *
 FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize, uint32_t coldCodeSize,
                             uint8_t **coldCode, bool isMethodHeaderNeeded)
    {
-   TR::CodeCache *codeCache = static_cast<TR::CodeCache *>(comp->getCurrentCodeCache());
+   TR::CodeGenerator *cg = comp->cg();
+   TR::CodeCache *codeCache = static_cast<TR::CodeCache *>(cg->getCodeCache());
 
    TR_ASSERT(codeCache->isReserved(), "Code cache should have been reserved.");
 
    uint8_t *warmCode = codeCacheManager().allocateCodeMemory(warmCodeSize, coldCodeSize, &codeCache,
                                                              coldCode, false, isMethodHeaderNeeded);
 
-   if (codeCache != comp->getCurrentCodeCache())
+   if (codeCache != cg->getCodeCache())
       {
       // Either we didn't get a code cache, or the one we get should be reserved
       TR_ASSERT(!codeCache || codeCache->isReserved(), "Substitute code cache isn't marked as reserved");
       comp->setRelocatableMethodCodeStart(warmCode);
-      comp->cg()->switchCodeCacheTo(codeCache);
+      cg->switchCodeCacheTo(codeCache);
       }
 
    if (warmCode == NULL)

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -51,7 +51,7 @@ FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize
                             uint8_t **coldCode, bool isMethodHeaderNeeded)
    {
    TR::CodeGenerator *cg = comp->cg();
-   TR::CodeCache *codeCache = static_cast<TR::CodeCache *>(cg->getCodeCache());
+   TR::CodeCache *codeCache = cg->getCodeCache();
 
    TR_ASSERT(codeCache->isReserved(), "Code cache should have been reserved.");
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1559,8 +1559,8 @@ OMR::Z::CodeGenerator::insertInstructionPrefetchesForCalls(TR_BranchPreloadCallD
     */
    bool canReachWithBPRP = false;
 
-   intptrj_t codeCacheBase = (intptrj_t)(self()->comp()->getCurrentCodeCache()->getCodeBase());
-   intptrj_t codeCacheTop = (intptrj_t)(self()->comp()->getCurrentCodeCache()->getCodeTop());
+   intptrj_t codeCacheBase = (intptrj_t)(self()->getCodeCache()->getCodeBase());
+   intptrj_t codeCacheTop = (intptrj_t)(self()->getCodeCache()->getCodeTop());
 
    intptrj_t offset1 = (intptrj_t) data->_callSymRef->getMethodAddress() - codeCacheBase;
    intptrj_t offset2 = (intptrj_t) data->_callSymRef->getMethodAddress() - codeCacheTop;
@@ -5351,8 +5351,8 @@ OMR::Z::CodeGenerator::canUseRelativeLongInstructions(int64_t value)
 
    if (TR::Compiler->target.isLinux())
       {
-      intptrj_t codeCacheBase = (intptrj_t)(self()->comp()->getCurrentCodeCache()->getCodeBase());
-      intptrj_t codeCacheTop = (intptrj_t)(self()->comp()->getCurrentCodeCache()->getCodeTop());
+      intptrj_t codeCacheBase = (intptrj_t)(self()->getCodeCache()->getCodeBase());
+      intptrj_t codeCacheTop = (intptrj_t)(self()->getCodeCache()->getCodeTop());
 
       return ( (((intptrj_t)value - codeCacheBase ) <=  (intptrj_t)(INT_MAX))
             && (((intptrj_t)value - codeCacheBase ) >=  (intptrj_t)(INT_MIN))


### PR DESCRIPTION
Replace calls to Compilation get/setCurrentCodeCache with a direct
inquiry to the CodeGenerator.  The Compilation functions always delegate
to the CodeGenerator.  Delete the Compilation functions.

There is one instance in `CompileMethodFromDetails` where the CodeGenerator
object could be NULL (during an AOT load) and that scenario is handled
by passing a NULL CodeCache as the original Compilation function would have.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>