### PR TITLE
Travis: Update to use Xenial vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,9 +24,8 @@ os:
   - linux
 compiler:
   - gcc
-sudo: false
 cache: ccache # https://docs.travis-ci.com/user/caching/
-dist: trusty
+dist: xenial
 addons:
   apt:
     sources:
@@ -41,9 +40,6 @@ matrix:
     - os: linux
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty
           packages:
             - bison
             - clang-3.8
@@ -51,7 +47,6 @@ matrix:
             - llvm-3.8
             - llvm-3.8-dev
       env: RUN_LINT=yes RUN_BUILD=no SPEC=linux_x86-64 PLATFORM=amd64-linux64-gcc LLVM_CONFIG=llvm-config-3.8 CLANG=clang++-3.8 CXX_PATH=clang++-3.8 CXX=clang++-3.8
-      dist: trusty
 before_script:
   - ulimit -c unlimited
   - ccache -s -z


### PR DESCRIPTION
Travis has deprecated Trusty machines, as well as container-based images.

https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>