### PR TITLE
Allow alternative path to merge to else block

### DIFF
--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -406,9 +406,15 @@ OMR::TransformUtil::createConditionalAlternatePath(TR::Compilation* comp,
    {
    cfg->setStructure(0);
 
+   bool mergeToElseBlock = (elseBlock == mergeBlock);
+
    TR::Block* ifBlock = elseBlock;
    ifBlock->prepend(ifTree);
    elseBlock = ifBlock->split(ifTree->getNextTreeTop(), cfg, false /*fixupCommoning*/, true /*copyExceptionSuccessors*/);
+
+   // Since `elseBlock` is changed above, update `mergeBlock`
+   if (mergeToElseBlock)
+      mergeBlock = elseBlock;
 
    TR::Block * thenBlock = TR::Block::createEmptyBlock(thenTree->getNode(), comp, 0, elseBlock);
    if (markCold)


### PR DESCRIPTION
If `elseBlock` and `mergeBlock` are identical, the user wants to create
an alternate path that after completion will jump back to the fall
through of the if test.

```
      ifBlock
       |    \
       |     \
       |   thenBlock
       |    /
       |   /
   mergeBlock/elseBlock
```
  
Under current implementation, `ifBlock` is constructed by splitting
`elseBlock` after prepending `ifTree` to `elseBlock`. The old
`elseBlock` will become `ifBlock`, `elseBlock` will get a new value
after split. If `mergeBlock` is the same as `elseBlock`, then it will be
the same as `ifBlock` after split. The alternate path `thenBlock` will
merge to `ifBlock` if we don't update `mergeBlock`, resulting in a
infinite loop. Fix it.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>