### PR TITLE
WIP: Add rdbar handling in NullChk evaluator

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2746,7 +2746,8 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
       {
       hasCompressedPointers = true;
       TR::ILOpCodes loadOp = comp->il.opCodeForIndirectLoad(TR::Int32);
-      while (n->getOpCodeValue() != loadOp)
+      TR::ILOpCodes rdbarOp = comp->il.opCodeForIndirectReadBarrier(TR::Int32);
+      while (n->getOpCodeValue() != loadOp && n->getOpCodeValue() != rdbarOp)
          n = n->getFirstChild();
       reference = n->getFirstChild();
       }

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -1175,7 +1175,8 @@ OMR::Z::Instruction::setupThrowsImplicitNullPointerException(TR::Node *n, TR::Me
                firstChild->getOpCodeValue() == TR::l2a)
             {
             TR::ILOpCodes loadOp = comp->il.opCodeForIndirectLoad(TR::Int32);
-            while (firstChild->getOpCodeValue() != loadOp)
+            TR::ILOpCodes rdbarOp = comp->il.opCodeForIndirectReadBarrier(TR::Int32);
+            while (firstChild->getOpCodeValue() != loadOp && firstChild->getOpCodeValue() != rdbarOp)
                firstChild = firstChild->getFirstChild();
             nullCheckReference = firstChild->getFirstChild();
             }


### PR DESCRIPTION
NullChk's special case in compressed pointers where the node to be null checked is not the iiload but its child (ex. an aload) will now also handle the case where the child is rdbar node.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>