### PR TITLE
WIP: Remove FrontEnd getDesignatedCodeCache

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -361,15 +361,6 @@ TR_FrontEnd::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    return 0;
    }
 
-
-TR::CodeCache *
-TR_FrontEnd::getDesignatedCodeCache(TR::Compilation *comp)
-   {
-   notImplemented("getDesignatedCodeCache");
-   return 0;
-   }
-
-
 void
 TR_FrontEnd::reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding)
    {

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -242,7 +242,6 @@ public:
 
    virtual uint8_t * allocateCodeMemory(TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t ** coldCode, bool isMethodHeaderNeeded=true);
    virtual void releaseCodeMemory(void *, uint8_t);
-   virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation* comp); // MCT
    virtual void reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);
    virtual intptrj_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void * callSite);
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void * callSite); // No TR::Compilation parameter so this can be called from runtime code

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -107,6 +107,7 @@
 #include "ras/Delimiter.hpp"                        // for Delimiter
 #include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheExceptions.hpp"
+#include "runtime/CodeCacheManager.hpp"
 #include "runtime/Runtime.hpp"                      // for HI_VALUE, etc
 #include "stdarg.h"                                 // for va_end, etc
 
@@ -1711,19 +1712,25 @@ OMR::CodeGenerator::addressesMatch(TR::Node *addr1, TR::Node *addr2, bool addres
 void
 OMR::CodeGenerator::reserveCodeCache()
    {
-   _codeCache = self()->fe()->getDesignatedCodeCache(self()->comp());
+   int32_t numReserved = 0;
+   int32_t compThreadID = 0;
+
+   _codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(false, 0, compThreadID, &numReserved);
+
    if (!_codeCache) // Cannot reserve a cache; all are used
       {
-      // We may reach this point if all code caches have been used up
-      // If some code caches have some space but cannot be used because they are reserved
-      // we will throw an exception in the call to getDesignatedCodeCache
+      TR::Compilation *comp = self()->comp();
 
-      if (self()->comp()->compileRelocatableCode())
+      // We may reach this point if all code caches have been used up.
+      // If some code caches have some space but cannot be used because they are reserved
+      // we will throw an exception in the call to TR::CodeCacheManager::reserveCodeCache
+      //
+      if (comp->compileRelocatableCode())
          {
-         self()->comp()->failCompilation<TR::RecoverableCodeCacheError>("Cannot reserve code cache");
+         comp->failCompilation<TR::RecoverableCodeCacheError>("Cannot reserve code cache");
          }
 
-      self()->comp()->failCompilation<TR::CodeCacheError>("Cannot reserve code cache");
+      comp->failCompilation<TR::CodeCacheError>("Cannot reserve code cache");
       }
    }
 

--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -92,8 +92,6 @@ class FEBase : public FECommon
    JitConfig *jitConfig() { return &_config; }
    TR::CodeCacheManager &codeCacheManager() { return _codeCacheManager; }
 
-   virtual TR::CodeCache *getDesignatedCodeCache(TR::Compilation *);
-
    virtual uint8_t *allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize, uint32_t coldCodeSize,
                                        uint8_t **coldCode, bool isMethodHeaderNeeded);
    virtual uint8_t * allocateRelocationData(TR::Compilation* comp, uint32_t size);

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -36,16 +36,6 @@ namespace TR
 {
 
 template <class Derived>
-TR::CodeCache *
-FEBase<Derived>::getDesignatedCodeCache(TR::Compilation *)
-   {
-   int32_t numReserved = 0;
-   int32_t compThreadID = 0;
-   return codeCacheManager().reserveCodeCache(false, 0, compThreadID, &numReserved);
-   }
-
-
-template <class Derived>
 uint8_t *
 FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize, uint32_t coldCodeSize,
                             uint8_t **coldCode, bool isMethodHeaderNeeded)


### PR DESCRIPTION
Replace with a direct call to the `CodeCacheManager::reserveCodeCache`
function instead.  Remove FrontEnd API.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>