### PR TITLE
Remove now deprecated resizeCodeMemory function from CodeCache

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -197,18 +197,6 @@ OMR::CodeCache::writeMethodHeader(void *freeBlock, size_t size, bool isCold)
    }
 
 
-// Resize code memory within a code cache
-//
-// Deprecated API.  This will be deleted when known downstream consumers of
-// this API are changed to use `trimCodeMemoryAllocation`
-//
-bool
-OMR::CodeCache::resizeCodeMemory(void *memoryBlock, size_t newSize)
-   {
-   return self()->trimCodeMemoryAllocation(memoryBlock, newSize);
-   }
-
-
 bool
 OMR::CodeCache::trimCodeMemoryAllocation(void *codeMemoryStart, size_t actualSizeInBytes)
    {

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -116,7 +116,6 @@ public:
                                uint8_t **coldCode,
                                bool needsToBeContiguous,
                                bool isMethodHeaderNeeded=true);
-   bool resizeCodeMemory(void *memoryBlock, size_t newSize);
 
    /**
     * @brief Trims the size of the previously allocated code memory in this


### PR DESCRIPTION
Signed-off-by: Daryl Maier <maier@ca.ibm.com>