### PR TITLE
Deprecate FrontEnd allocateCodeMemory

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -91,13 +91,6 @@ TR_FrontEnd::classHasBeenReplaced(TR_OpaqueClassBlock *)
    }
 
 uint8_t *
-TR_FrontEnd::allocateCodeMemory(TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t ** coldCode, bool isMethodHeaderNeeded)
-   {
-   notImplemented("allocateCodeMemory");
-   return 0;
-   }
-
-uint8_t *
 TR_FrontEnd::allocateRelocationData(TR::Compilation * comp, uint32_t numBytes)
    {
    notImplemented("allocateRelocationData");

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -236,7 +236,6 @@ public:
    // Code cache
    // --------------------------------------------------------------------------
 
-   virtual uint8_t * allocateCodeMemory(TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t ** coldCode, bool isMethodHeaderNeeded=true);
    virtual void reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);
    virtual intptrj_t methodTrampolineLookup(TR::Compilation *, TR::SymbolReference *symRef, void * callSite);
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void * callSite); // No TR::Compilation parameter so this can be called from runtime code

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -783,8 +783,57 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::CodeCache * getCodeCache() { return _codeCache; }
    void  setCodeCache(TR::CodeCache * codeCache) { _codeCache = codeCache; }
    void  reserveCodeCache();
-   uint8_t * allocateCodeMemory(uint32_t size, bool isCold, bool isMethodHeaderNeeded=true);
-   uint8_t * allocateCodeMemory(uint32_t warmSize, uint32_t coldSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
+
+   /**
+    * \brief Allocates code memory of the specified size in the specified area of
+    *        the code cache.  The compilation will fail if unsuccessful.
+    *
+    * \param[in]  codeSizeInBytes : the number of bytes to allocate
+    * \param[in]  isCold : whether the allocation should be done in the cold area or not
+    * \param[in]  isMethodHeaderNeeded : boolean indicating whether space for a
+    *                method header must be allocated
+    *
+    * \return address of the allocated code (if allocated)
+    */
+   uint8_t *allocateCodeMemory(uint32_t codeSizeInBytes, bool isCold, bool isMethodHeaderNeeded=true);
+
+   /**
+    * \brief Allocates code memory of the specified size in the specified area of
+    *        the code cache.  The compilation will fail if unsuccessful.
+    *
+    * \param[in]  warmCodeSizeInBytes : the number of bytes to allocate in the warm area
+    * \param[in]  coldCodeSizeInBytes : the number of bytes to allocate in the cold area
+    * \param[out] coldCode : address of the cold code (if allocated)
+    * \param[in]  isMethodHeaderNeeded : boolean indicating whether space for a
+    *                method header must be allocated
+    *
+    * \return address of the allocated warm code (if allocated)
+    */
+   uint8_t *allocateCodeMemory(
+      uint32_t warmCodeSizeInBytes,
+      uint32_t coldCodeSizeInBytes,
+      uint8_t **coldCode,
+      bool isMethodHeaderNeeded=true);
+
+   /**
+    * \brief Allocates code memory of the specified size in the specified area of
+    *        the code cache.  The compilation will fail if unsuccessful.  This function
+    *        provides a means of specialization in the allocation process for downstream
+    *        consumers of this API.
+    *
+    * \param[in]  warmCodeSizeInBytes : the number of bytes to allocate in the warm area
+    * \param[in]  coldCodeSizeInBytes : the number of bytes to allocate in the cold area
+    * \param[out] coldCode : address of the cold code (if allocated)
+    * \param[in]  isMethodHeaderNeeded : boolean indicating whether space for a
+    *                method header must be allocated
+    *
+    * \return address of the allocated warm code (if allocated)
+    */
+   uint8_t *allocateCodeMemoryInner(
+      uint32_t warmCodeSizeInBytes,
+      uint32_t coldCodeSizeInBytes,
+      uint8_t **coldCode,
+      bool isMethodHeaderNeeded);
 
    /**
     * \brief Trim the size of code memory required by this method to match the

--- a/compiler/env/FEBase.hpp
+++ b/compiler/env/FEBase.hpp
@@ -92,8 +92,6 @@ class FEBase : public FECommon
    JitConfig *jitConfig() { return &_config; }
    TR::CodeCacheManager &codeCacheManager() { return _codeCacheManager; }
 
-   virtual uint8_t *allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize, uint32_t coldCodeSize,
-                                       uint8_t **coldCode, bool isMethodHeaderNeeded);
    virtual uint8_t * allocateRelocationData(TR::Compilation* comp, uint32_t size);
 
    virtual intptrj_t indexedTrampolineLookup(int32_t helperIndex, void * callSite);

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -35,44 +35,6 @@
 namespace TR
 {
 
-template <class Derived>
-uint8_t *
-FEBase<Derived>::allocateCodeMemory(TR::Compilation *comp, uint32_t warmCodeSize, uint32_t coldCodeSize,
-                            uint8_t **coldCode, bool isMethodHeaderNeeded)
-   {
-   TR::CodeGenerator *cg = comp->cg();
-   TR::CodeCache *codeCache = cg->getCodeCache();
-
-   TR_ASSERT(codeCache->isReserved(), "Code cache should have been reserved.");
-
-   uint8_t *warmCode = codeCacheManager().allocateCodeMemory(warmCodeSize, coldCodeSize, &codeCache,
-                                                             coldCode, false, isMethodHeaderNeeded);
-
-   if (codeCache != cg->getCodeCache())
-      {
-      // Either we didn't get a code cache, or the one we get should be reserved
-      TR_ASSERT(!codeCache || codeCache->isReserved(), "Substitute code cache isn't marked as reserved");
-      comp->setRelocatableMethodCodeStart(warmCode);
-      cg->switchCodeCacheTo(codeCache);
-      }
-
-   if (warmCode == NULL)
-      {
-      if (codeCacheManager().codeCacheIsFull())
-         {
-         comp->failCompilation<TR::CodeCacheError>("Code Cache Full");
-         }
-      else
-         {
-         comp->failCompilation<TR::RecoverableCodeCacheError>("Failed to allocate code memory");
-         }
-      }
-
-   TR_ASSERT( !((warmCodeSize && !warmCode) || (coldCodeSize && !coldCode)), "Allocation failed but didn't throw an exception");
-
-   return warmCode;
-   }
-
 // This code does not really belong here (along with allocateRelocationData, really)
 // We should be relying on the port library to allocate memory, but this connection
 // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9,


### PR DESCRIPTION
* introduce a CodeGenerator `allocateCodeMemoryInner` function that takes
  the place of the FrontEnd function and that downstream projects can
  override.
* improve documentation for existing CodeGenerator `allocateCodeMemory`
   functions
* remove FrontEnd API

Signed-off-by: Daryl Maier <maier@ca.ibm.com>