### PR TITLE
Remove OpenJ9-specific FrontEnd functions

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -193,12 +193,6 @@ TR_FrontEnd::getFormattedName(
 
    }
 
-uintptrj_t
-TR_FrontEnd::getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer)
-   {
-   notImplemented("getClassDepthAndFlagsValue");
-   return 0;
-   }
 
 TR_OpaqueMethodBlock*
 TR_FrontEnd::getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod)
@@ -317,13 +311,6 @@ TR_FrontEnd::getClassFromMethodBlock(TR_OpaqueMethodBlock *mb)
    {
    notImplemented("getClassFromMethodBlock");
    return NULL;
-   }
-
-int32_t
-TR_FrontEnd::getStringLength(uintptrj_t objectPointer)
-   {
-   notImplemented("getStringLength");
-   return 0;
    }
 
 intptrj_t

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -228,10 +228,6 @@ public:
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass);
    virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass);
 
-   // to J9
-   virtual uintptrj_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
-   virtual int32_t getStringLength(uintptrj_t objectPointer);
-
    // Null-terminated.  bufferSize >= 1+getStringUTF8Length(objectPointer).  Returns buffer just for convenience.
    virtual char *getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t bufferSize);
    virtual intptrj_t getStringUTF8Length(uintptrj_t objectPointer);


### PR DESCRIPTION
* getClassDepthAndFlagsValue
* getStringLength

These are only used in OpenJ9-guarded code.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>