### PR TITLE
Remove deprecated option EnableMethodTrampolineReservation

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -705,7 +705,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
        SET_OPTION_BIT(TR_EnableLowerCompilationLimitsDecisionMaking), "F", NOT_IN_SUBSET},
    {"enableMetadataBytecodePCToIAMap",   "O\tenable bytecode pc to IA map in the metadata", SET_OPTION_BIT(TR_EnableMetadataBytecodePCToIAMap), "F", NOT_IN_SUBSET},
    {"enableMetadataReclamation",         "I\tenable J9JITExceptionTable reclamation", RESET_OPTION_BIT(TR_DisableMetadataReclamation), "F", NOT_IN_SUBSET},
-   {"enableMethodTrampolineReservation", "O\tReserve method trampolines even if they are not needed; only applicable on x86 and zLinux", SET_OPTION_BIT(TR_EnableMethodTrampolineReservation), "F"},
    {"enableMHCustomizationLogicCalls",   "C\tinsert calls to MethodHandle.doCustomizationLogic for handle invocations outside of thunks", SET_OPTION_BIT(TR_EnableMHCustomizationLogicCalls), "F"},
    {"enableMonitorCacheLookup",          "O\tenable  monitor cache lookup under lock nursery ",                       SET_OPTION_BIT(TR_EnableMonitorCacheLookup), "F"},
    {"enableMultipleGCRPeriods",          "M\tallow JIT to get in and out of GCR", SET_OPTION_BIT(TR_EnableMultipleGCRPeriods), "F", NOT_IN_SUBSET},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -955,7 +955,7 @@ enum TR_CompilationOptions
    TR_IncreaseCountsForNonBootstrapMethods            = 0x00080000 + 29,
    TR_ReduceCountsForMethodsCompiledDuringStartup     = 0x00100000 + 29,
    TR_IncreaseCountsForMethodsCompiledOutsideStartup  = 0x00200000 + 29,
-   TR_EnableMethodTrampolineReservation               = 0x00400000 + 29,
+   // Available                                       = 0x00400000 + 29,
    TR_UseGlueIfMethodTrampolinesAreNotNeeded          = 0x00800000 + 29,
    TR_EnableFpreductionAnnotation                     = 0x01000000 + 29,
    TR_ExtractExitsByInvalidatingStructure             = 0x02000000 + 29,

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -151,7 +151,6 @@ OMR::CodeCacheManager::initialize(
         || config.maxNumberOfCodeCaches() == 1
 #if !defined(TR_HOST_POWER)
         || (!TR::Options::getCmdLineOptions()->getOption(TR_StressTrampolines) &&
-            !TR::Options::getCmdLineOptions()->getOption(TR_EnableMethodTrampolineReservation) &&
             _codeCacheRepositorySegment &&
             config.codeCacheTotalKB() <= REACHEABLE_RANGE_KB)
 #endif


### PR DESCRIPTION
Not useful in OMR or any downstream project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>