### PR TITLE
Dont crash when seeing invalid tree while tracing

### DIFF
--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1585,7 +1585,9 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
 
    if (node->getOpCode().isNullCheck())
       {
-      output.append(" on %s%dn", globalIndexPrefix.getStr(), node->getNullCheckReference()->getGlobalIndex());
+      if (node->getNullCheckReference())
+         output.append(" on %s%dn", globalIndexPrefix.getStr(), node->getNullCheckReference()->getGlobalIndex());
+      else output.append(" on null NullCheckReference ----- INVALID tree!!");
       }
    else if (node->getOpCodeValue() == TR::allocationFence)
       {


### PR DESCRIPTION
When seeing NULLChk without NULLChkReference while printing trees
to tracing log, we should try to continue printing the complete
trees which makes debugging easier.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>