### PR TITLE
WIP: Create Power-specific Node class.

### DIFF
--- a/compiler/p/CMakeLists.txt
+++ b/compiler/p/CMakeLists.txt
@@ -1,5 +1,5 @@
 #################################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,4 +50,5 @@ compiler_library(p
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/OMRConstantDataSnippet.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp
+	${CMAKE_CURRENT_LIST_DIR}/il/OMRNode.cpp
 )

--- a/compiler/p/il/OMRNode.cpp
+++ b/compiler/p/il/OMRNode.cpp
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "il/Node.hpp"
+#include "il/Node_inlines.hpp"

--- a/compiler/p/il/OMRNode.cpp
+++ b/compiler/p/il/OMRNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/p/il/OMRNode.hpp
+++ b/compiler/p/il/OMRNode.hpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_POWER_NODE_INCL
+#define OMR_POWER_NODE_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_NODE_CONNECTOR
+#define OMR_NODE_CONNECTOR
+namespace OMR { namespace Power { class Node; } }
+namespace OMR { typedef OMR::Power::Node NodeConnector; }
+#else
+#error OMR::Power::Node expected to be a primary connector, but a OMR connector is already defined
+#endif
+
+#include "compiler/il/OMRNode.hpp"
+
+#include "infra/Assert.hpp"  // for TR_ASSERT
+
+namespace OMR
+{
+
+namespace Power
+{
+
+class OMR_EXTENSIBLE Node : public OMR::Node
+   {
+protected:
+
+   Node() : OMR::Node() {}
+
+   Node(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren)
+      : OMR::Node(originatingByteCodeNode, op, numChildren)
+      {}
+
+   Node(TR::Node *from, uint16_t numChildren = 0)
+      : OMR::Node(from, numChildren)
+      {}
+
+   };
+
+}
+
+}
+
+#endif

--- a/compiler/p/il/OMRNode.hpp
+++ b/compiler/p/il/OMRNode.hpp
@@ -45,7 +45,7 @@ namespace Power
 
 class OMR_EXTENSIBLE Node : public OMR::Node
    {
-protected:
+public:
 
    Node() : OMR::Node() {}
 

--- a/compiler/p/il/OMRNode.hpp
+++ b/compiler/p/il/OMRNode.hpp
@@ -35,7 +35,7 @@ namespace OMR { typedef OMR::Power::Node NodeConnector; }
 
 #include "compiler/il/OMRNode.hpp"
 
-#include "infra/Assert.hpp"  // for TR_ASSERT
+#include "infra/Assert.hpp"
 
 namespace OMR
 {

--- a/compiler/p/il/OMRNode.hpp
+++ b/compiler/p/il/OMRNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/fvtest/compilertest/build/files/target/p.mk
+++ b/fvtest/compilertest/build/files/target/p.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -46,7 +46,8 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/p/codegen/TreeEvaluatorVMX.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/codegen/UnaryEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/codegen/OMRConstantDataSnippet.cpp \
-    $(JIT_OMR_DIRTY_DIR)/p/env/OMRCPU.cpp
+    $(JIT_OMR_DIRTY_DIR)/p/env/OMRCPU.cpp \
+    $(JIT_OMR_DIRTY_DIR)/p/il/OMRNode.cpp
 
 JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/p/codegen/Evaluator.cpp \

--- a/jitbuilder/build/files/target/p.mk
+++ b/jitbuilder/build/files/target/p.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2016 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,5 +49,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/p/codegen/OMRConstantDataSnippet.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/env/OMRCPU.cpp \
     $(JIT_OMR_DIRTY_DIR)/p/env/OMRDebugEnv.cpp \
+    $(JIT_OMR_DIRTY_DIR)/p/il/OMRNode.cpp \
     $(JIT_PRODUCT_DIR)/p/codegen/Evaluator.cpp
 


### PR DESCRIPTION
isRotateAndMask(TR::Node* node) is a function present inside common
OMR::CodeGenerator. This is a Power architecture question and pattern
match only, and really should be asked on the TR::Node itself.
Hence, need to relocate this API to power specific node class.
Since, making this complete change will require change in p.mk file in
OpenJ9 as well.

So, as part of this commit, just publishing the skeleton of OMRNode Class.
Once this gets in, will make PR for OpenJ9 and get back to final changes
with isRotateAndMask().

Issue: #1876

Signed-off-by: Somesh Sharma <someshsharma0312@gmail.com>