### PR TITLE
 Implement a primitive SKIP_IF macro to allow tests to be skipped

### DIFF
--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -24,7 +24,7 @@
 
 #include <gtest/gtest.h>
 #include <vector>
-#include <stdexcept> 
+#include <stdexcept>
 #include "control/Options.hpp"
 #include "optimizer/Optimizer.hpp"
 #include "ilgen/MethodBuilder.hpp"
@@ -60,7 +60,7 @@ class JitTest : public ::testing::Test
    JitTest()
       {
       auto initSuccess = initializeJitWithOptions((char*)"-Xjit:acceptHugeMethods,enableBasicBlockHoisting,omitFramePointer,useILValidator,paranoidoptcheck");
-      if (!initSuccess) 
+      if (!initSuccess)
          throw std::runtime_error("Failed to initialize jit");
       }
 
@@ -71,26 +71,26 @@ class JitTest : public ::testing::Test
    };
 
 /**
- * @brief A fixture for testing with a customized optimization strategy. 
+ * @brief A fixture for testing with a customized optimization strategy.
  *
- * The design of this is such that it is expected sublasses will 
+ * The design of this is such that it is expected sublasses will
  * call addOptimization inside their constructor, so that SetUp will
  * know what opts to use.
  */
-class JitOptTest : public JitTest 
+class JitOptTest : public JitTest
    {
    public:
 
    JitOptTest() :
       JitTest(), _optimizations(), _strategy(NULL)
       {
-      } 
+      }
 
    virtual void SetUp()
       {
       JitTest::SetUp();
 
-      // This is an allocated pointer because the strategy needs to 
+      // This is an allocated pointer because the strategy needs to
       // live as long as this fixture
       _strategy = new OptimizationStrategy[_optimizations.size() + 1];
 
@@ -99,7 +99,7 @@ class JitOptTest : public JitTest
       }
 
 
-   ~JitOptTest() 
+   ~JitOptTest()
       {
       TR::Optimizer::setMockStrategy(NULL);
       delete[] _strategy;
@@ -243,7 +243,7 @@ std::vector<T> const_values()
                       static_cast<T>(std::numeric_limits<T>::min() + 1),
                       static_cast<T>(std::numeric_limits<T>::max() - 1)
                     };
-   
+
    return std::vector<T>(inputArray, inputArray + sizeof(inputArray) / sizeof(T));
    }
 

--- a/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
+++ b/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -84,7 +84,7 @@ TEST(TRTestCombineVectorTest, CombineEmptyVectorsOfDifferentTypes)
 TEST(TRTestCombineVectorTest, CombineEmptyAndNonEmptyVectorsOfSameType)
    {
    using namespace std;
-   int test_array[3] = {1, 2 ,3}; 
+   int test_array[3] = {1, 2 ,3};
    auto v = TRTest::combine(vector<int>{}, vector<int> (test_array, test_array+3));
    ::testing::StaticAssertTypeEq<vector<tuple<int,int>>, decltype (v)>();
    ASSERT_TRUE(v.empty())

--- a/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
+++ b/fvtest/compilertriltest/JitTestUtilitiesTest.cpp
@@ -284,3 +284,19 @@ TEST(TRTestFilter, FilterVectorWithManyOccurrences)
    ASSERT_EQ(0, std::count_if(v_out.cbegin(), v_out.cend(), isChar_c))
          << "Filtering should leave no elements matching the filter predicate.";
    }
+
+TEST(SkipTest, SkipIfTrue)
+   {
+   SKIP_IF(true, UnsupportedFeature) << "Test is itentionally skipped to verify that skipping works";
+   FAIL() << "SKIP_IF did not skip this test";
+   }
+
+TEST(SkipTest, SkipIfFalse)
+   {
+   EXPECT_FATAL_FAILURE(
+      {
+         SKIP_IF(false, KnownBug) << "Test should not have been skipped! SKIP_IF must have a bug.";
+         FAIL() << "This test should not be skipped by SKIP_IF";
+      },
+      "This test should not be skipped by SKIP_IF");
+   }


### PR DESCRIPTION
This change set introduces the SKIP_IF macro, which allows Tril-based compiler tests to be conditionally skipped without failing or disabling the test. This commit only intends to introduce the syntax for skipping tests and the underlaying machinery needed for skipping test execution. Support for features such as logging and reporting of skipped tests is still primitive. No built-in support for platform detection is provided.

The basic syntax is for skipping a test is:

    SKIP_IF(<condition>, <reason>);

The <condition> parameter can be any boolean expression and specifies when a test should be skipped. The <reason> parameter must be a value from the `SkipReason` enum; it is mainly intended for use in logging and reporting, although the current implementation makes little use of it.

Optionally, a "skip message" can also be streamed using the same syntax as is used Google Test's ASSERT*() macros:

    SKIP_IF(<condition>, <reason>) << <message>;

When a test is skipped it will print a message stating the reason, the test name, and the skip message. For example:

    [----------] 2 tests from SkipTest
    Unsupported Feature: Skipping test: SkipIfTrue
        Test is itentionally skipped to verify that skipping works
    [----------] 2 tests from SkipTest (0 ms total)

Issue #1843