### PR TITLE
Replace enter/exit tracing method with isMethodTracingEnabled

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2692,7 +2692,7 @@ TR_TransformInlinedFunction::transform()
    if (comp()->getOption(TR_EnableJProfiling) ||
        (firstBlock->getPredecessors().size() > 1) ||
        firstBlock->hasExceptionSuccessors() ||
-       comp()->fe()->isMethodEnterTracingEnabled(calleeResolvedMethod->getPersistentIdentifier()) ||
+       comp()->fe()->isMethodTracingEnabled(calleeResolvedMethod->getPersistentIdentifier()) ||
        TR::Compiler->vm.canMethodEnterEventBeHooked(comp()))
       {
       int32_t freq = firstBlock->getFrequency();


### PR DESCRIPTION
In practice we never enable methodEnterTracing without methodExitTracing.
These two methods are replaced with isMethodTracingEnabled().
Reference issue: eclipse/openj9#3585

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>