### PR TITLE
Unify and fix codeCacheFull functionality

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1749,7 +1749,7 @@ OMR::CodeGenerator::allocateCodeMemoryInner(
       {
       TR::Compilation *comp = self()->comp();
 
-      if (TR::CodeCacheManager::instance()->codeCacheIsFull())
+      if (TR::CodeCacheManager::instance()->codeCacheFull())
          {
          comp->failCompilation<TR::CodeCacheError>("Code Cache Full");
          }

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -55,7 +55,7 @@ TR::CodeCacheSymbolContainer * OMR::CodeCacheManager::_symbolContainer = NULL;
 OMR::CodeCacheManager::CodeCacheManager(TR::RawAllocator rawAllocator) :
    _rawAllocator(rawAllocator),
    _initialized(false),
-   _codeCacheIsFull(false)
+   _codeCacheFull(false)
    {
    }
 

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -129,8 +129,18 @@ public:
       };
 
    TR::CodeCacheConfig & codeCacheConfig() { return _config; }
-   bool codeCacheIsFull() { return _codeCacheIsFull; }
-   void setCodeCacheIsFull(bool codeCacheIsFull) { _codeCacheIsFull = codeCacheIsFull; }
+
+   /**
+    * @brief Inquires whether the code cache full flag has been set
+    *
+    * @return true if code cache full flag is set; false otherwise.
+    */
+   bool codeCacheFull() { return _codeCacheFull; }
+
+   /**
+    * @brief Sets the flag indicating a full code cache
+    */
+   void setCodeCacheFull() { _codeCacheFull = true; };
 
    TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
    void lateInitialization();
@@ -235,7 +245,6 @@ public:
                                            uint8_t ** coldCode,
                                            bool needsToBeContiguous,
                                            bool isMethodHeaderNeeded=true);
-   void setCodeCacheFull() { };  // default does nothing
    void setHasFailedCodeCacheAllocation() { }
 
    bool initialized() const                 { return _initialized; }
@@ -278,7 +287,7 @@ protected:
 
    bool                           _initialized;                       /*!< flag to indicate if code cache manager has been initialized or not */
    bool                           _lowCodeCacheSpaceThresholdReached; /*!< true if close to exhausting available code cache */
-   bool                           _codeCacheIsFull;
+   bool                           _codeCacheFull;
 
 #if (HOST_OS == OMR_LINUX)
    public:


### PR DESCRIPTION
There are confusingly two independent means in CodeCacheManager for
testing/setting whether the code cache is full.  Neither is behaving
as it should.

The `setCodeCacheIsFull` is never used in OMR nor any downstream project,
although the flag is tested on code memory allocation failure in
`OMR::CodeGenerator::allocateCodeMemoryInner`.

The `setCodeCacheFull` does not have an implementation in OMR (it does
in downstream projects), yet it is invoked in a number of spots in OMR.

Unify the functionality of these functions such that `setCodeCacheFull`
sets the boolean indicating that the code cache is full.  Remove the
`setCodeCacheIsFull` and `codeCacheIsFull` functions.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>