### PR TITLE
Rename CodeCache::reserve/unreserveTrampoline

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -457,34 +457,46 @@ OMR::CodeCache::allocateTempTrampoline()
    return freeTrampolineSlot;
    }
 
-// Reserve space for a trampoline
-//
-// The returned trampoline pointer is meaningless, ie should not be used to
-// create trampoline code in just yet.
-//
+
 OMR::CodeCacheTrampolineCode *
 OMR::CodeCache::reserveTrampoline()
    {
+   return self()->reserveSpaceForTrampoline();
+   }
+
+
+OMR::CodeCacheTrampolineCode *
+OMR::CodeCache::reserveSpaceForTrampoline()
+   {
    TR::CodeCacheConfig &config = _manager->codeCacheConfig();
 
-   // see if we are hitting against the method body allocation pointer
+   // See if we are hitting against the method body allocation pointer
    // indicating that there is no more free space left in this code cache
+   //
    if (_trampolineReservationMark < _trampolineBase + config.trampolineCodeSize())
       {
-      // no free trampoline space
+      // No free trampoline space
+      //
       return NULL;
       }
 
-   // advance the reservation mark
+   // Advance the reservation mark
+   //
    _trampolineReservationMark -= config.trampolineCodeSize();
 
    return (CodeCacheTrampolineCode *) _trampolineReservationMark;
    }
 
-// Cancel a reservation for a trampoline
-//
+
 void
 OMR::CodeCache::unreserveTrampoline()
+   {
+   self()->unreserveSpaceForTrampoline();
+   }
+
+
+void
+OMR::CodeCache::unreserveSpaceForTrampoline()
    {
    // sanity check, should never have the reservation mark dip past the
    // allocation mark

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -144,9 +144,36 @@ public:
    TR_YesNoMaybe almostFull()                 { return _almostFull; }
    void setAlmostFull(TR_YesNoMaybe fullness) { _almostFull = fullness; }
 
+   /**
+    * @brief Reserve space for a trampoline in the current code cache
+    *
+    * @return The returned trampoline pointer is meaningless and should not
+    *         be used to create trampoline code in just yet.
+    */
+   CodeCacheTrampolineCode *reserveSpaceForTrampoline();
+
+   /**
+    * @brief This function is deprecated.  It simply invokes reserveSpaceForTrampoline().
+    *        It will be removed when downstream dependencies are changed to call
+    *        reserveSpaceForTrampoline() directly.
+    */
    CodeCacheTrampolineCode *reserveTrampoline();
+
    CodeCacheErrorCode::ErrorCode reserveNTrampolines(int64_t n);
+
+   /**
+    * @brief Reclaim the previously reserved space for a single trampoline in the
+    *        current code cache.
+    */
+   void unreserveSpaceForTrampoline();
+
+   /**
+    * @brief This function is deprecated.  It simply invokes unreserveSpaceForTrampoline().
+    *        It will be removed when downstream dependencies are changed to call
+    *        unreserveSpaceForTrampoline() directly.
+    */
    void unreserveTrampoline();
+
    CodeCacheTrampolineCode *allocateTrampoline();
    CodeCacheTrampolineCode *allocateTempTrampoline();
    CodeCacheTrampolineCode *findTrampoline(TR_OpaqueMethodBlock *method);


### PR DESCRIPTION
Provide more meaningful names to accurately reflect their function
and mitigate confusion with reserveResolvedTrampoline.

* reserveSpaceForTrampoline
* unreserveSpaceForTrampoline

Signed-off-by: Daryl Maier <maier@ca.ibm.com>