### PR TITLE
Remove enter/exit tracing methods

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -103,18 +103,6 @@ TR_FrontEnd::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
    return false;
    }
 
-bool
-TR_FrontEnd::isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-   return false;
-   }
-
-bool
-TR_FrontEnd::isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method)
-   {
-   return false;
-   }
-
 int32_t
 TR_FrontEnd::getArraySpineShift(int32_t)
    {

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -151,12 +151,8 @@ public:
 
    // Needs VMThread
 
-   // In practice we never enable methodEnterTracing without methodExitTracing.
-   // Combine them into one method: isMethodTracingEnabled() which should be used
-   // to replace all usages of isMethodEnterTracingEnabled() and isMethodExitTracingEnabled().
+   // Check if method entry and exit tracing is enabled
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
-   virtual bool isMethodEnterTracingEnabled(TR_OpaqueMethodBlock *method);
-   virtual bool isMethodExitTracingEnabled(TR_OpaqueMethodBlock *method);
 
    virtual const char * sampleSignature(TR_OpaqueMethodBlock * aMethod, char * bug = 0, int32_t bufLen = 0,TR_Memory *memory = NULL);
 


### PR DESCRIPTION
In practice we never enable methodEnterTracing without
methodExitTracing. These two methods are replaced by
isMethodTracingEnabled(). Reference issue:
eclipse/openj9#3585

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>