### PR TITLE
Remove dead code

### DIFF
--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -105,15 +105,7 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
    TR::Register * secondRegister = secondChild->getRegister();
    TR::Compilation *comp = TR::comp();
 
-   TR::SymbolReference * firstReference = firstChild->getOpCode().hasSymbolReference() ? firstChild->getSymbolReference() : NULL;
-   TR::SymbolReference * secondReference = secondChild->getOpCode().hasSymbolReference() ? secondChild->getSymbolReference() : NULL;
-
-   setInputs(firstChild, firstRegister, secondChild, secondRegister,
-             false, false, comp,
-             (cg()->isAddressOfStaticSymRefWithLockedReg(firstReference) ||
-              cg()->isAddressOfPrivateStaticSymRefWithLockedReg(firstReference)),
-             (cg()->isAddressOfStaticSymRefWithLockedReg(secondReference) ||
-              cg()->isAddressOfPrivateStaticSymRefWithLockedReg(secondReference)));
+   setInputs(firstChild, firstRegister, secondChild, secondRegister, false, false, comp, false, false);
 
    /*
     * Check if SH or CH can be used to evaluate this integer subtract/compare node.

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1145,11 +1145,6 @@ OMR::Z::CodeGenerator::considerTypeForGRA(TR::SymbolReference *symRef)
    if (symRef &&
        symRef->getSymbol())
       {
-      if (self()->isAddressOfStaticSymRefWithLockedReg(symRef))
-         return false;
-
-      if (self()->isAddressOfPrivateStaticSymRefWithLockedReg(symRef))
-         return false;
 #ifdef J9_PROJECT_SPECIFIC
       if (symRef->getSymbol()->getDataType().isBCD())
          return false;
@@ -5187,18 +5182,6 @@ OMR::Z::CodeGenerator::setGlobalStaticBaseRegisterOnFlag()
    {
    if (self()->comp()->getOption(TR_DisableGlobalStaticBaseRegister))
       self()->setGlobalStaticBaseRegisterOn(false);
-   }
-
-bool
-OMR::Z::CodeGenerator::isAddressOfStaticSymRefWithLockedReg(TR::SymbolReference *symRef)
-   {
-   return false;
-   }
-
-bool
-OMR::Z::CodeGenerator::isAddressOfPrivateStaticSymRefWithLockedReg(TR::SymbolReference *symRef)
-   {
-   return false;
    }
 
 /**

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -713,9 +713,6 @@ public:
    virtual void setGlobalPrivateStaticBaseRegisterOn(bool val)     { _cgFlags.set(S390CG_globalPrivateStaticBaseRegisterOn, val); }
    virtual bool isGlobalPrivateStaticBaseRegisterOn () { return _cgFlags.testAny(S390CG_globalPrivateStaticBaseRegisterOn); }
 
-   bool isAddressOfStaticSymRefWithLockedReg(TR::SymbolReference *symRef);
-   bool isAddressOfPrivateStaticSymRefWithLockedReg(TR::SymbolReference *symRef);
-
    bool canUseRelativeLongInstructions(int64_t value);
    bool supportsOnDemandLiteralPool();
 

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1823,16 +1823,6 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
          {
          self()->populateLoadAddrTree(subTree, cg);
          }
-      else if (subTree->getOpCodeValue() == TR::aload &&
-               cg->isAddressOfStaticSymRefWithLockedReg(subTree->getSymbolReference()))
-         {
-         self()->populateAloadTree(subTree, cg, false);
-         }
-      else if (subTree->getOpCodeValue() == TR::aload &&
-               cg->isAddressOfPrivateStaticSymRefWithLockedReg(subTree->getSymbolReference()))
-         {
-         self()->populateAloadTree(subTree, cg, true);
-         }
       else if (subTree->getOpCodeValue() == TR::aconst)
          {
          if (TR::Compiler->target.is64Bit())
@@ -3277,15 +3267,6 @@ OMR::Z::MemoryReference::doEvaluate(TR::Node * subTree, TR::CodeGenerator * cg)
       self()->setForceEvaluation();
       return false;
       }
-
-   if (subTree->getOpCodeValue() == TR::aload &&
-       cg->isAddressOfStaticSymRefWithLockedReg(subTree->getSymbolReference()))
-      return false;
-
-   if (subTree->getOpCodeValue() == TR::aload &&
-       cg->isAddressOfPrivateStaticSymRefWithLockedReg(subTree->getSymbolReference()))
-      return false;
-
 
    if (subTree->getOpCodeValue() != TR::loadaddr && subTree->getReferenceCount() > 1)
       return true;

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5188,33 +5188,6 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
       return tempReg;
       }
 
-
-   if ((node->getOpCodeValue() == TR::aload)
-       && cg->isAddressOfStaticSymRefWithLockedReg(node->getSymbolReference()))
-      {
-      tempReg = cg->allocateRegister();
-      generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, tempReg, cg->getS390Linkage()->getStaticBaseRealRegister());
-      node->setRegister(tempReg);
-      return tempReg;
-      }
-
-   if ((node->getOpCodeValue() == TR::aload)
-       && cg->isAddressOfPrivateStaticSymRefWithLockedReg(node->getSymbolReference()))
-      {
-      if (node->getSymbol()->getSize() == 8)
-         {
-         tempReg = cg->allocateRegister();
-         }
-      else
-         {
-         tempReg = cg->allocateRegister();
-         }
-
-      generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, tempReg, cg->getS390Linkage()->getPrivateStaticBaseRealRegister());
-      node->setRegister(tempReg);
-      return tempReg;
-      }
-
    TR::SymbolReference * symRef = node->getSymbolReference();
    TR::Symbol * symbol = symRef->getSymbol();
    TR::Node *constNode=(TR::Node *) (node->getSymbolReference()->getOffset());
@@ -6119,15 +6092,6 @@ astoreHelper(TR::Node * node, TR::CodeGenerator * cg)
 
    TR::MemoryReference * tempMR = NULL;
 
-   if (cg->isAddressOfStaticSymRefWithLockedReg(node->getSymbolReference()))
-      {
-      storeToStaticBaseNodeHelper(node, valueChild, cg, cg->getS390Linkage()->getStaticBaseRealRegister());
-      }
-   else if(cg->isAddressOfPrivateStaticSymRefWithLockedReg(node->getSymbolReference()))
-      {
-      storeToStaticBaseNodeHelper(node, valueChild, cg, cg->getS390Linkage()->getPrivateStaticBaseRealRegister());
-      }
-
    if (!relativeLongStoreHelper(cg, node, valueChild))
       {
       // Determine the Store OpCode.
@@ -6171,8 +6135,6 @@ astoreHelper(TR::Node * node, TR::CodeGenerator * cg)
               valueChild->getRegister() == NULL &&
               generateS390MemoryReference(node, cg)->getIndexRegister() == NULL &&
               !valueChild->getSymbolReference()->isLiteralPoolAddress() &&
-              !(cg->isAddressOfStaticSymRefWithLockedReg(valueChild->getSymbolReference())) &&
-              !(cg->isAddressOfPrivateStaticSymRefWithLockedReg(valueChild->getSymbolReference())) &&
         node->getSymbol()->getSize() == node->getSize() &&
         node->getSymbol()->getSize() == valueChild->getSymbol()->getSize() &&
         !cg->getConditionalMovesEvaluationMode())


### PR DESCRIPTION
Remove isAddressOfStaticSymRefWithLockedReg() and
isAddressOfPrivateStaticSymRefWithLockedReg() since they always return
false.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>