### PR TITLE
Add double map API for LINUX and balanced GC policy

### DIFF
--- a/cmake/modules/platform/os/linux.cmake
+++ b/cmake/modules/platform/os/linux.cmake
@@ -48,18 +48,6 @@ elseif(OMR_HOST_ARCH STREQUAL "s390")
 	)
 endif()
 
-# Check that we need to pull librt to get clock_gettime/settime family of functions
-if(NOT DEFINED OMR_NEED_LIBRT)
-	check_symbol_exists(clock_gettime time.h OMR_LIBC_HAS_CLOCK_GETTIME)
-	if(OMR_LIBC_HAS_CLOCK_GETTIME)
-		set(OMR_NEED_LIBRT FALSE CACHE BOOL "")
-	else()
-		set(OMR_NEED_LIBRT TRUE CACHE BOOL "")
-		set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lrt")
-	endif()
-	mark_as_advanced(OMR_NEED_LIBRT)
-endif()
-
 # Testarossa build variables. Longer term the distinction between TR and the rest
 # of the OMR code should be heavily reduced. In the mean time, we keep
 # the distinction

--- a/example/glue/ArrayletObjectModel.hpp
+++ b/example/glue/ArrayletObjectModel.hpp
@@ -69,6 +69,12 @@ public:
 		Assert_MM_unimplemented();
 		return 0;
 	}
+
+	MMINLINE bool
+	isDoubleMappingEnabled()
+	{
+		return false;
+	}
 };
 
 #endif /*OMR_GC_ARRAYLETS */

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -45,6 +45,8 @@
 #define TWO_GIG_BAR 0x7FFFFFFF
 #define ONE_MB (1*1024*1024)
 #define FOUR_KB (4*1024)
+#define SIXTEEN_KB (16*1024)
+#define SIXTEEN_MB (0x1000000LL)
 #define TWO_GB	(0x80000000LL)
 #define SIXTY_FOUR_GB (0x1000000000LL)
 
@@ -54,6 +56,8 @@
 #define D512M (512*1024*1024)
 #define D256M (256*1024*1024)
 #define DEFAULT_NUM_ITERATIONS 50
+#define ARRAYLET_COUNT 8
+#define LEAF_SIZE_LIMIT (ONE_MB * 2)
 
 #define MAX_ALLOC_SIZE 256 /**<@internal largest size to allocate */
 
@@ -503,6 +507,300 @@ TEST(PortVmemTest, vmem_test_shared_file_handle)
 			}
 		}
 	}
+	portTestEnv->changeIndent(-1);
+exit:
+	reportTestExit(OMRPORTLIB, testName);
+}
+
+/**
+ * @internal
+ * Helper function for memory management verification.
+ * 
+ * Given a pointer to an memory chunk verify it is
+ * \arg a non NULL pointer
+ * \arg correct size
+ * \arg writeable
+ * \arg aligned
+ * \arg double aligned
+ * 
+ * @param[in] portLibrary The port library under test
+ * @param[in] testName The name of the test requesting this functionality
+ * @param[in] pageSize
+ * @param[in] arraylet leaf size
+ * @param[in] contiguous block of memory pointer
+ * @param[in] arraylet leaves addresses
+ * @param[in] allocName Calling function name to display in errors
+ */
+static void 
+verifyContiguousMem(struct OMRPortLibrary *portLibrary, const char *testName, size_t pagesize, size_t arrayletSize, void * contiguous, void* addresses[], char *vals, const char *allocName) 
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
+	char * contiguousMap = (char*)contiguous;
+	size_t i = 0;
+	size_t firstBytes = 32;
+	size_t jump = 48;
+	size_t secondBytes = 16;
+
+	/* Verify if arraylet leaves and contiguous block of memory contain expected data */
+	for(i = 0; i < ARRAYLET_COUNT; i++) {
+		char *address = (char*)addresses[i];
+		char *arrayletData = contiguousMap + (i * arrayletSize);
+		size_t j = 0;
+		for(; j < arrayletSize; j++) {
+			if(address[j] == vals[i] && address[j] == arrayletData[j]) {} /* Good */
+			else {
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "%s failed address verification.\n", allocName);
+				return;	
+			}
+		}
+	}
+
+	/* Fill contiguous region of memory with asterisks */
+	for(i = 0; i < ARRAYLET_COUNT; i++) {
+		/* Get the address representing the beginning of each arraylet */
+		char *arrayletData = contiguousMap + (i * arrayletSize);
+
+		/* write a pattern to the first page of each arraylet to verify proper mappings */
+		memset(arrayletData, '*', firstBytes);
+		char *arrayletData2 = arrayletData + jump;
+		memset(arrayletData2, '*', secondBytes);
+
+		/* Write to the first byte of each of the other pages in the arraylet to ensure all pages are touched */
+		for (size_t j = 1; j < (arrayletSize / pagesize); j++) {
+			char *pageData = arrayletData + (j * pagesize);
+			*pageData = '*';
+		}
+	}
+
+	/* Verify if addresses were modified with the above changes */
+	for(i = 0; i < ARRAYLET_COUNT; i++) {
+		char *address = (char*)addresses[i];
+		char *arrayletData = contiguousMap + (i * arrayletSize);
+
+		/* Verify first 32 chars are * (asterisks) */
+		size_t j = 0;
+		for(; j < firstBytes; j++) {
+			if(arrayletData[j] == '*' && arrayletData[j] == address[j]) {} /* Good */
+			else { /* Verification failed. Fail double map. */
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "%s failed double mapping test at 0\n", allocName);
+				return;
+			}
+		}
+		char *arrayletData2 = arrayletData + jump;
+		char *address2 = address + jump;
+		for(j = 0; j < secondBytes; j++) {
+			if(arrayletData2[j] == '*' && arrayletData2[j] == address2[j]) {} /* Good */
+			else { /* Verification failed. Fail double map. */
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "%s failed double mapping test at 1\n", allocName);
+				return;
+			}
+		}
+		/* Verify first byte of each of the other pages in the arraylet to ensure all pages were modified in the heap */
+		for (j = 1; j < (arrayletSize / pagesize); j++) {
+			char *pageData = arrayletData + (j * pagesize);
+			char *addressData = address + (j * pagesize);
+			if(*pageData == '*' && *pageData == *addressData) {} /* Good */
+			else { /* Verification failed. Fail double map. */
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "%s failed double mapping test at 2\n", allocName);
+				return;
+			}
+		}
+	}
+}
+
+TEST(PortVmemTest, vmem_test_double_mapping)
+{
+	portTestEnv->changeIndent(1);
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	const char *testName = "vmem_test_double_mapping";
+	char *memPtr = NULL;
+	uintptr_t *pageSizes = NULL;
+#if defined(J9ZOS390)
+	uintptr_t *pageFlags = NULL;
+#endif /* J9ZOS390 */
+	struct J9PortVmemIdentifier vmemID;
+	struct J9PortVmemIdentifier newIdentifier;
+	char allocName[allocNameSize];
+	int32_t rc = 0;
+	char *lastErrorMessage = NULL;
+	int32_t lastErrorNumber = 0;
+	size_t HEAP_SIZE = SIXTEEN_MB; // 16MB
+	size_t arrayletLeafSize = SIXTEEN_KB; // 16KB
+	char vals[ARRAYLET_COUNT] = {'3', '5', '6', '8', '9', '0', '1', '2'};
+	size_t totalArrayletSize = 0;
+	void* arrayletLeaveAddrs[ARRAYLET_COUNT];
+
+	reportTestEntry(OMRPORTLIB, testName);
+
+	/* First get all the supported page sizes */
+	pageSizes = omrvmem_supported_page_sizes();
+	uintptr_t pageSize = pageSizes[0];
+#if defined(J9ZOS390)
+	pageFlags = omrvmem_supported_page_flags();
+#endif /* J9ZOS390 */
+
+	/* Make sure arrayletLeafSize is a multiple of pagesize */
+	if(arrayletLeafSize / pageSize == 0 && (arrayletLeafSize < pageSize)) {
+		/* Leaf size limit is 2 MB due to heap size and number of leaves. If pageSize is too big for test skip */
+		if(pageSize > LEAF_SIZE_LIMIT) {
+			goto exit;
+		}
+		arrayletLeafSize = pageSize;
+	}
+
+	/* reserve and commit memory for heap size */
+	{
+		uintptr_t initialBlocks = 0;
+		uintptr_t initialBytes = 0;
+
+		/* Sample baseline category data */
+		getPortLibraryMemoryCategoryData(OMRPORTLIB, &initialBlocks, &initialBytes);
+
+		/* reserve and commit */
+#if defined(J9ZOS390)
+		/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
+		if (isNewPageSize(pageSizes[0], pageFlags[0])) {
+			goto J9ZOS390_exit;
+		}
+#endif /* J9ZOS390 */
+		memPtr = (char *)omrvmem_reserve_memory(
+						0, HEAP_SIZE, &vmemID,
+						OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT | OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN,
+						pageSize, OMRMEM_CATEGORY_PORT_LIBRARY);
+
+
+		/* did we get any memory? */
+		if (memPtr == NULL) {
+			lastErrorMessage = (char *)omrerror_last_error_message();
+			lastErrorNumber = omrerror_last_error_number();
+			/* Succeed instead of error then continue since the platform is not supported */
+			if (OMRPORT_ERROR_VMEM_NOT_SUPPORTED == lastErrorNumber) {
+				goto exit;
+			}
+			outputErrorMessage(PORTTEST_ERROR_ARGS, "unable to reserve and commit 0x%zx bytes with page size 0x%zx.\n"
+					"\tlastErrorNumber=%d, lastErrorMessage=%s\n", HEAP_SIZE, pageSize, lastErrorNumber, lastErrorMessage);
+
+			if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
+				portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+				portTestEnv->changeIndent(1);
+				portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+				portTestEnv->changeIndent(-1);
+			}
+			goto exit;
+		} else {
+			uintptr_t finalBlocks = 0;
+			uintptr_t finalBytes = 0;
+			portTestEnv->log("reserved and committed 0x%zx bytes with page size 0x%zx at address 0x%zx\n", HEAP_SIZE, vmemID.pageSize, memPtr);
+
+			getPortLibraryMemoryCategoryData(OMRPORTLIB, &finalBlocks, &finalBytes);
+
+			if (finalBlocks <= initialBlocks) {
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "vmem reserve didn't increment category block as expected. Final blocks=%zu, initial blocks=%zu, page size=%zu.\n", finalBlocks, initialBlocks, pageSize);
+			}
+
+			if (finalBytes < (initialBytes + pageSize)) {
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "vmem reserve didn't increment category bytes as expected. Initial bytes=%zu, final bytes=%zu, page size=%zu.\n", finalBytes, initialBytes, pageSize);
+			}
+		}
+		/* can we read and write to the memory? */
+		omrstr_printf(allocName, allocNameSize, "omrvmem_reserve_memory(%d)", HEAP_SIZE);
+		verifyMemory(OMRPORTLIB, testName, memPtr, HEAP_SIZE, allocName);
+		/* Memory verified successfully */
+		{
+			/* Initialize arraylet offsets to different ranges */
+			long arrayLetOffsets[ARRAYLET_COUNT];
+			/* Must be multiple of pagesize: sysconf(_SC_PAGE_SIZE) 	Simulates the order of arraylet leaves in an array */
+			arrayLetOffsets[0] = 0;								/* 1 */
+			arrayLetOffsets[1] = (HEAP_SIZE / 2) + (HEAP_SIZE / 8);				/* 6 */
+			arrayLetOffsets[2] = HEAP_SIZE / 4;						/* 3 */
+			arrayLetOffsets[3] = (HEAP_SIZE / 4) + (HEAP_SIZE / 8);				/* 4 */
+			arrayLetOffsets[4] = HEAP_SIZE / 2;						/* 5 */
+			arrayLetOffsets[5] = (HEAP_SIZE / 2) + (HEAP_SIZE / 4) + (HEAP_SIZE / 8);	/* 8 */
+			arrayLetOffsets[6] = (HEAP_SIZE / 8);						/* 2 */
+			arrayLetOffsets[7] = (HEAP_SIZE / 2) + (HEAP_SIZE / 4);				/* 7 */
+
+			size_t i = 0;
+			for(; i < ARRAYLET_COUNT; i++) {
+				arrayletLeaveAddrs[i] = memPtr + arrayLetOffsets[i];
+				totalArrayletSize += arrayletLeafSize;
+			}
+
+			for(i = 0; i < ARRAYLET_COUNT; i++) {
+				memset(arrayletLeaveAddrs[i], vals[i%ARRAYLET_COUNT], arrayletLeafSize);
+			}
+			/* Arraylet initialization complete */
+			
+			OMRMemCategory *category = omrmem_get_category(OMRMEM_CATEGORY_PORT_LIBRARY);
+
+			/* Now create contiguous block of memory and then double map arraylet leaves. */
+			void *contiguous = omrvmem_get_contiguous_region_memory(arrayletLeaveAddrs, ARRAYLET_COUNT, arrayletLeafSize, (ARRAYLET_COUNT * arrayletLeafSize),
+										&vmemID, &newIdentifier, 
+										OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT,
+										pageSize,
+										category);
+			if(contiguous == NULL) {
+				portTestEnv->log(LEVEL_ERROR, "Double mapping failed\n");
+				lastErrorMessage = (char *)omrerror_last_error_message();
+				lastErrorNumber = omrerror_last_error_number();
+				if (OMRPORT_ERROR_VMEM_NOT_SUPPORTED == lastErrorNumber) {
+					portTestEnv->log(LEVEL_ERROR, "Double mapping not supported. Skipping test...\n");
+					goto exit;
+				}
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "unable to reserve and double map 0x%zx bytes with page size 0x%zx.\n"
+						"\tlastErrorNumber=%d, lastErrorMessage=%s\n", HEAP_SIZE, pageSize, lastErrorNumber, lastErrorMessage);
+
+				if (OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES == lastErrorNumber) {
+					portTestEnv->log(LEVEL_ERROR, "Portable error OMRPORT_ERROR_VMEM_INSUFFICENT_RESOURCES...\n");
+					portTestEnv->changeIndent(1);
+					portTestEnv->log(LEVEL_ERROR, "REBOOT THE MACHINE to free up resources AND TRY THE TEST AGAIN\n");
+					portTestEnv->changeIndent(-1);
+				}
+				goto exit;
+			} else {
+				/* Double mapping successfull */
+				/* Check if changing contiguous block of memory also changes heap. */
+				verifyContiguousMem(OMRPORTLIB, testName, pageSize, arrayletLeafSize, contiguous, arrayletLeaveAddrs, vals, allocName);
+
+				/* Free contiguous block of memory. */
+				uintptr_t byteAmount = ARRAYLET_COUNT * arrayletLeafSize;
+				int32_t rc_contiguous = omrvmem_free_memory(contiguous, byteAmount, &newIdentifier);
+				if (rc_contiguous != 0) {
+					outputErrorMessage(
+						PORTTEST_ERROR_ARGS,
+						"omrvmem_free_memory returned %i when trying to free 0x%zx bytes at 0x%zx\n",
+						rc_contiguous, byteAmount, contiguous);
+					goto exit;
+				}
+			}
+		}
+		/* free the memory (reuse the vmemID) */
+		rc = omrvmem_free_memory(memPtr, HEAP_SIZE, &vmemID);
+		if (rc != 0) {
+			outputErrorMessage(
+				PORTTEST_ERROR_ARGS,
+				"omrvmem_free_memory returned %i when trying to free 0x%zx bytes at 0x%zx\n",
+				rc, HEAP_SIZE, memPtr);
+			goto exit;
+		}
+
+		{
+			uintptr_t finalBlocks = 0;
+			uintptr_t finalBytes = 0;
+
+			getPortLibraryMemoryCategoryData(OMRPORTLIB, &finalBlocks, &finalBytes);
+
+			if (finalBlocks != initialBlocks) {
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "vmem free didn't decrement category block as expected. Final blocks=%zu, initial blocks=%zu, page size=%zu.\n", finalBlocks, initialBlocks, pageSize);
+			}
+
+			if (finalBytes != initialBytes) {
+				outputErrorMessage(PORTTEST_ERROR_ARGS, "vmem free didn't decrement category bytes as expected. Initial bytes=%zu, final bytes=%zu, page size=%zu.\n", initialBytes, finalBytes, pageSize);
+			}
+		}
+	}
+#if defined(J9ZOS390)
+J9ZOS390_exit:
+#endif /* J9ZOS390 */
 	portTestEnv->changeIndent(-1);
 exit:
 	reportTestExit(OMRPORTLIB, testName);

--- a/gc/base/Heap.hpp
+++ b/gc/base/Heap.hpp
@@ -115,6 +115,7 @@ public:
 	
 	virtual void *getHeapBase() = 0;
 	virtual void *getHeapTop() = 0;
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize) = 0;
 
 	virtual uintptr_t getMaximumPhysicalRange() = 0;
 

--- a/gc/base/HeapSplit.cpp
+++ b/gc/base/HeapSplit.cpp
@@ -183,6 +183,13 @@ MM_HeapSplit::getPageFlags()
 	return (_lowExtent->getPageSize() < _highExtent->getPageSize()) ? _lowExtent->getPageFlags() : _highExtent->getPageFlags();
 }
 
+void*
+MM_HeapSplit::doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+{
+	/* Unreachable */
+	return NULL;
+}
+
 /**
  * Answer the largest size the heap will ever consume.
  * The value returned represents the difference between the lowest and highest possible address range

--- a/gc/base/HeapSplit.hpp
+++ b/gc/base/HeapSplit.hpp
@@ -61,6 +61,7 @@ public:
 	virtual uintptr_t getPageFlags();
 	virtual void *getHeapBase();
 	virtual void *getHeapTop();
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 
 	virtual uintptr_t getMaximumPhysicalRange();
 

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -174,6 +174,13 @@ MM_HeapVirtualMemory::getHeapTop()
 	return memoryManager->getHeapTop(&_vmemHandle);
 }
 
+void*
+MM_HeapVirtualMemory::doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+{
+	MM_MemoryManager* memoryManager = MM_GCExtensionsBase::getExtensions(_omrVM)->memoryManager;
+	return memoryManager->doubleMapArraylet(&_vmemHandle, env, arrayletLeaves, arrayletLeafCount, arrayletLeafSize, byteAmount, newIdentifier, pageSize);
+}
+
 uintptr_t
 MM_HeapVirtualMemory::getPageSize()
 {

--- a/gc/base/HeapVirtualMemory.hpp
+++ b/gc/base/HeapVirtualMemory.hpp
@@ -56,6 +56,7 @@ public:
 	virtual uintptr_t getPageFlags();
 	virtual void* getHeapBase();
 	virtual void* getHeapTop();
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 
 	virtual uintptr_t getMaximumPhysicalRange();
 

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -95,6 +95,12 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 		}
 	}
 
+#if defined(LINUX)
+	if(extensions->isVLHGC() && extensions->indexableObjectModel.isDoubleMappingEnabled()) {
+		mode |= OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN;
+	}
+#endif /* defined(LINUX) */
+
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	if (extensions->enableSplitHeap) {
 		/* currently (ceiling != NULL) is using to recognize CompressedRefs so must be NULL for 32 bit platforms */
@@ -545,6 +551,15 @@ MM_MemoryManager::destroyVirtualMemory(MM_EnvironmentBase* env, MM_MemoryHandle*
 	valgrindDestroyMempool(env->getExtensions());
 #endif /* defined(OMR_VALGRIND_MEMCHECK) */
 
+}
+
+void*
+MM_MemoryManager::doubleMapArraylet(MM_MemoryHandle* handle, MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+{
+	Assert_MM_true(NULL != handle);
+	MM_VirtualMemory* memory = handle->getVirtualMemory();
+	Assert_MM_true(NULL != memory);
+	return memory->doubleMapArraylet(env, arrayletLeaves, arrayletLeafCount, arrayletLeafSize, byteAmount, newIdentifier, pageSize);
 }
 
 bool

--- a/gc/base/MemoryManager.hpp
+++ b/gc/base/MemoryManager.hpp
@@ -176,6 +176,21 @@ public:
 	 */
 	void destroyVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryHandle* handle);
 	
+	/**
+ 	 * Double maps arraylets, arrays that does not fit into one region are split into leaves, 
+ 	 * which are then double mapped by this function 
+ 	 *
+ 	 * @param pointer to memory handle
+ 	 * @param env environment
+ 	 * @param arrayletLeaveAddrs, list of arraylet leaves addresses
+ 	 * @param arrayletLeafCount, number of arraylet leaves
+ 	 * @param arrayletLeafSize, size of each arraylet leaf
+ 	 * @param byteAmount, total byte amount to be allocate contiguous block of meory to double map 
+ 	 * @param newIdentifier, hold information of newly created contiguous block of memory
+ 	 * @param pageSize
+ 	 * @param category
+  	 */
+	void *doubleMapArraylet(MM_MemoryHandle* handle, MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 
 	/**
 	 * Commit memory for range for specified virtual memory instance

--- a/gc/base/VirtualMemory.cpp
+++ b/gc/base/VirtualMemory.cpp
@@ -161,6 +161,16 @@ MM_VirtualMemory::reserveMemory(J9PortVmemParams* params)
 	return addressToReturn;
 }
 
+void*
+MM_VirtualMemory::doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+{
+	OMRPORT_ACCESS_FROM_OMRVM(_extensions->getOmrVM());
+	struct J9PortVmemIdentifier *oldIdentifier = &_identifier;
+	uintptr_t mode = OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT;
+
+	return omrvmem_get_contiguous_region_memory(arrayletLeaves, arrayletLeafCount, arrayletLeafSize, byteAmount, oldIdentifier, newIdentifier, mode, pageSize, omrmem_get_category(OMRMEM_CATEGORY_MM));
+}
+
 bool MM_VirtualMemory::freeMemory()
 {
 	OMRPORT_ACCESS_FROM_OMRVM(_extensions->getOmrVM());

--- a/gc/base/VirtualMemory.hpp
+++ b/gc/base/VirtualMemory.hpp
@@ -81,6 +81,7 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase* env);
 
 	virtual void* reserveMemory(J9PortVmemParams* params);
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 
 	MM_VirtualMemory(MM_EnvironmentBase* env, uintptr_t heapAlignment, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t tailPadding, uintptr_t mode)
 		: MM_BaseVirtual()

--- a/gc/base/j9mm.tdf
+++ b/gc/base/j9mm.tdf
@@ -914,3 +914,5 @@ TraceEvent=Trc_MM_LOAResize_contractWithRange Overhead=1 Level=1 Group=loaresize
 TraceEvent=Trc_MM_Scavenger_percolate_concurrentMarkExhausted Overhead=1 Level=1 Group=percolate Template="Percolating due to exhausted Concurrent Mark"
 TraceEvent=Trc_MM_Scavenger_percolate_preventTenureExpand Overhead=1 Level=1 Group=percolate Template="Percolating to prevent Tenure expand"
 TraceEvent=Trc_MM_Scavenger_percolate_tenureMaxFree Overhead=1 Level=1 Group=percolate Template="Percolating due to meeting Tenure max free"
+
+TraceAssert=Assert_MM_double_map_unreachable noEnv Overhead=1 Level=1 Assert="(false)"

--- a/gc/include/RootScannerTypes.h
+++ b/gc/include/RootScannerTypes.h
@@ -41,6 +41,7 @@ typedef enum RootScannerEntity {
 	RootScannerEntity_StringTable,
 	RootScannerEntity_JNIGlobalReferences,
 	RootScannerEntity_JNIWeakGlobalReferences,
+	RootScannerEntity_DoubleMappedObjects,
 	RootScannerEntity_DebuggerReferences,
 	RootScannerEntity_DebuggerClassReferences,
 	RootScannerEntity_MonitorReferences,

--- a/glue/ArrayletObjectModel.hpp
+++ b/glue/ArrayletObjectModel.hpp
@@ -57,6 +57,12 @@ public:
 	{
 		/* No-op */
 	}
+
+	MMINLINE bool
+	isDoubleMappingEnabled()
+	{
+		return false;
+	}
 };
 
 #endif /*OMR_GC_ARRAYLETS */

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -222,6 +222,7 @@
 #define OMRPORT_VMEM_MEMORY_MODE_EXECUTE 0x00000004
 #define OMRPORT_VMEM_MEMORY_MODE_COMMIT 0x00000008
 #define OMRPORT_VMEM_MEMORY_MODE_VIRTUAL 0x00000010
+#define OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN 0x000000200
 #define OMRPORT_VMEM_ALLOCATE_TOP_DOWN 0x00000020
 #define OMRPORT_VMEM_ALLOCATE_PERSIST 0x00000040
 #define OMRPORT_VMEM_NO_AFFINITY 0x00000080
@@ -961,6 +962,7 @@ typedef struct J9PortVmemIdentifier {
 	uintptr_t pageFlags;
 	uintptr_t mode;
 	uintptr_t allocator;
+	int fd;
 	OMRMemCategory *category;
 } J9PortVmemIdentifier;
 

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1345,6 +1345,8 @@ typedef struct OMRPortLibrary {
 	void *(*vmem_reserve_memory)(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize,  uint32_t category) ;
 	/** see @ref omrvmem.c::omrvmem_reserve_memory_ex "omrvmem_reserve_memory_ex"*/
 	void *(*vmem_reserve_memory_ex)(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params) ;
+	/** see @ref omrvmem.c::omrvmem_get_contiguous_region_memory "omrvmem_get_contiguous_region_memory"*/
+	void *(*vmem_get_contiguous_region_memory)(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
 	/** see @ref omrvmem.c::omrvmem_get_page_size "omrvmem_get_page_size"*/
 	uintptr_t (*vmem_get_page_size)(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier) ;
 	/** see @ref omrvmem.c::omrvmem_get_page_flags "omrvmem_get_page_flags"*/
@@ -1918,6 +1920,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrvmem_vmem_params_init(param1) privateOmrPortLibrary->vmem_vmem_params_init(privateOmrPortLibrary, (param1))
 #define omrvmem_reserve_memory(param1,param2,param3,param4,param5,param6) privateOmrPortLibrary->vmem_reserve_memory(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5), (param6))
 #define omrvmem_reserve_memory_ex(param1,param2) privateOmrPortLibrary->vmem_reserve_memory_ex(privateOmrPortLibrary, (param1), (param2))
+#define omrvmem_get_contiguous_region_memory(param1, param2, param3, param4, param5, param6, param7, param8, param9) privateOmrPortLibrary->vmem_get_contiguous_region_memory(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5), (param6), (param7), (param8), (param9))
 #define omrvmem_get_page_size(param1) privateOmrPortLibrary->vmem_get_page_size(privateOmrPortLibrary, (param1))
 #define omrvmem_get_page_flags(param1) privateOmrPortLibrary->vmem_get_page_flags(privateOmrPortLibrary, (param1))
 #define omrvmem_supported_page_sizes() privateOmrPortLibrary->vmem_supported_page_sizes(privateOmrPortLibrary)

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -393,6 +393,10 @@ target_link_libraries(omrport
 		${OMR_THREAD_LIB}
 )
 
+if(OMR_HOST_OS STREQUAL "linux")
+    target_link_libraries(omrport PRIVATE rt)
+endif()
+
 #TODO hack to get to compile. Need platform checks
 if(NOT OMR_HOST_OS STREQUAL "win")
 	if(NOT OMR_HOST_OS STREQUAL "zos")

--- a/port/aix/omrvmem.c
+++ b/port/aix/omrvmem.c
@@ -1516,3 +1516,10 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary, J9VMemMemory
 	Trc_PRT_vmem_get_process_memory_exit(result, *memorySize);
 	return result;
 }
+
+void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+{
+	portLibrary->error_set_last_error(portLibrary, errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+	return NULL;
+}

--- a/port/aix/omrvmem.c
+++ b/port/aix/omrvmem.c
@@ -747,6 +747,11 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
 	int protMask;
 	void *result = NULL;
 
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+		return result;
+	}
+
 	Trc_PRT_vmem_default_reserve_entry(address, byteAmount);
 
 	if (0 != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -172,6 +172,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrvmem_vmem_params_init, /* vmem_vmem_params_init */
 	omrvmem_reserve_memory, /* vmem_reserve_memory */
 	omrvmem_reserve_memory_ex, /* vmem_reserve_memory_ex */
+	omrvmem_get_contiguous_region_memory, /* vmem_get_contiguous_region_memory */
 	omrvmem_get_page_size, /* vmem_get_page_size */
 	omrvmem_get_page_flags, /* omrvmem_get_page_flags */
 	omrvmem_supported_page_sizes, /* vmem_supported_page_sizes */

--- a/port/common/omrvmem.c
+++ b/port/common/omrvmem.c
@@ -201,6 +201,25 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 }
 
 /**
+ * Maps a contiguous region of memory to double map addresses[] passed in.
+ *
+ * @param OMRPortLibrary       *portLibrary            [in] The portLibrary object
+ * @param void*                addressesOffeset[]      [in] Addresses to be double mapped
+ * @param uintptr_t            byteAmount              [in] Total size to allocate for contiguous block of memory
+ * @param struct J9PortVmemIdentifier *oldIdentifier   [in]  old Identifier containing file descriptor
+ * @param struct J9PortVmemIdentifier *newIdentifier   [out] new Identifier for new block of memory. The structure to be updated
+ * @param uintptr_t            mode,           [in] Access Mode
+ * @paramuintptr_t             pageSize,       [in] onstant describing pageSize
+ * @param OMRMemCategory       *category       [in] Memory allocation category
+ */
+
+void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+{
+	return NULL;
+}
+
+/**
  * Get the page size used to back a region of virtual memory.
  *
  * @param[in] portLibrary The port library.

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -64,6 +64,7 @@
 #endif
 
 #define INVALID_KEY -1
+#define FILE_NAME_SIZE 64
 
 #if 0
 #define OMRVMEM_DEBUG
@@ -125,7 +126,7 @@ static void *default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary,
 #if defined(OMR_PORT_NUMA_SUPPORT)
 static void port_numa_interleave_memory(struct OMRPortLibrary *portLibrary, void *start, uintptr_t size);
 #endif /* OMR_PORT_NUMA_SUPPORT */
-static void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category);
+static void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category, int fd);
 static uintptr_t get_hugepages_info(struct OMRPortLibrary *portLibrary, vmem_hugepage_info_t *page_info);
 static int get_protectionBits(uintptr_t mode);
 
@@ -685,16 +686,21 @@ omrvmem_free_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t
 	 * free the memory
 	 */
 	uintptr_t allocator = identifier->allocator;
+	int fd = identifier->fd;
 	Trc_PRT_vmem_omrvmem_free_memory_Entry(address, byteAmount);
 
 	/* CMVC 180372 - Identifier must be cleared before memory is freed, see comment above */
-	update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+	update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
 
 	/* Default page Size */
 	if (OMRPORT_VMEM_RESERVE_USED_SHM != allocator) {
 		ret = (int32_t)munmap(address, (size_t)byteAmount);
 	} else {
 		ret = (int32_t)shmdt(address);
+	}
+
+	if((identifier->mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) && fd != -1) {
+		close(fd);
 	}
 
 	omrmem_categories_decrement_counters(category, byteAmount);
@@ -750,7 +756,7 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 
 	/* Invalid input */
 	if (0 == params->pageSize) {
-		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
 		Trc_PRT_vmem_omrvmem_reserve_memory_invalid_input();
 	} else if (PPG_vmem_pageSize[0] == params->pageSize) {
 		uintptr_t alignmentInBytes = OMR_MAX(params->pageSize, params->alignmentInBytes);
@@ -784,12 +790,12 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 					memoryPointer = getMemoryInRangeForDefaultPages(portLibrary, identifier, category, params->byteAmount, params->startAddress, params->endAddress, alignmentInBytes, params->options, params->mode);
 				}
 			} else {
-				update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+				update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
 			}
 		}
 	} else {
 		/* If the pageSize is not one of the supported page sizes, error */
-		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
 		Trc_PRT_vmem_omrvmem_reserve_memory_unsupported_page_size(params->pageSize);
 	}
 #if defined(OMR_PORT_NUMA_SUPPORT)
@@ -859,7 +865,7 @@ reserveLargePages(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifie
 	}
 
 	if (NULL == memoryPointer) {
-		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
 	}
 
 #if defined(OMRVMEM_DEBUG)
@@ -961,21 +967,53 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
 	 * Any changes made here may need to be reflected in that version.
 	 */
 	int fd = -1;
-	int flags = MAP_PRIVATE;
+	int ft = -1;
+	int flags = 0;
 	void *result = NULL;
 	int protectionFlags = PROT_NONE;
+	BOOLEAN useBackingSharedFile = FALSE;
+	BOOLEAN useBackingFile = FALSE;
 
 	Trc_PRT_vmem_default_reserve_entry(address, byteAmount);
 
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		flags |= MAP_SHARED;
+		useBackingSharedFile = TRUE;
+	} else {
 #if defined(MAP_ANONYMOUS)
-	flags |= MAP_ANONYMOUS;
+		flags |= MAP_ANONYMOUS | MAP_PRIVATE;
+		useBackingSharedFile = FALSE;
 #elif defined(MAP_ANON)
-	flags |= MAP_ANON;
+		flags |= MAP_ANON | MAP_PRIVATE;
+		useBackingSharedFile = FALSE;
 #else
-	fd = portLibrary->file_open(portLibrary, "/dev/zero", EsOpenRead | EsOpenWrite, 0);
-	if (-1 != fd)
+		useBackingFile = TRUE;
+		flags |= MAP_PRIVATE;
 #endif
-	{
+	}
+
+	if (useBackingSharedFile) {
+		char filename[FILE_NAME_SIZE + 1];
+		sprintf(filename, "omrvmem_temp_%zu_%09d_%zu",  (size_t)omrtime_current_time_millis(portLibrary), 
+								getpid(), 
+								(size_t)pthread_self()); 
+		fd = shm_open(filename, O_RDWR | O_CREAT, 0600);
+		shm_unlink(filename);
+		ft = ftruncate(fd, byteAmount);
+
+		if (fd == -1 || ft == -1) {
+			Trc_PRT_vmem_default_reserve_failed(address, byteAmount);
+			update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
+			Trc_PRT_vmem_default_reserve_exit(result, address, byteAmount);
+			return result;
+		}
+	} else if(useBackingFile) {
+		fd = portLibrary->file_open(portLibrary, "/dev/zero", EsOpenRead | EsOpenWrite, 0);
+	}
+
+	if((fd == -1 && (!useBackingSharedFile && !useBackingFile)) || 
+	   (fd != -1 && (useBackingSharedFile || useBackingFile))) {
+	
 		if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
 			protectionFlags = get_protectionBits(mode);
 		} else {
@@ -987,15 +1025,17 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
 		 */
 		result = mmap(address, (size_t)byteAmount, protectionFlags, flags, fd, 0);
 
-#if !defined(MAP_ANONYMOUS) && !defined(MAP_ANON)
-		portLibrary->file_close(portLibrary, fd);
-#endif
-
+		if(useBackingFile) {
+			portLibrary->file_close(portLibrary, fd); 
+		}
+	
 		if (MAP_FAILED == result) {
+			if(useBackingSharedFile && fd != -1)
+				close(fd);
 			result = NULL;
 		} else {
 			/* Update identifier and commit memory if required, else return reserved memory */
-			update_vmemIdentifier(identifier, result, result, byteAmount, mode, pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, OMRPORT_VMEM_RESERVE_USED_MMAP, category);
+			update_vmemIdentifier(identifier, result, result, byteAmount, mode, pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, OMRPORT_VMEM_RESERVE_USED_MMAP, category, fd);
 			omrmem_categories_increment_counters(category, byteAmount);
 			if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
 				if (NULL == omrvmem_commit_memory(portLibrary, result, byteAmount, identifier)) {
@@ -1009,7 +1049,7 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
 
 	if (NULL == result) {
 		Trc_PRT_vmem_default_reserve_failed(address, byteAmount);
-		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, 0, NULL, -1);
 	}
 
 	Trc_PRT_vmem_default_reserve_exit(result, address, byteAmount);
@@ -1031,7 +1071,7 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
  * @param[in] category Memory allocation category
  */
 static void
-update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category)
+update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t allocator, OMRMemCategory *category, int fd)
 {
 	identifier->address = address;
 	identifier->handle = handle;
@@ -1041,6 +1081,7 @@ update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *han
 	identifier->mode = mode;
 	identifier->allocator = allocator;
 	identifier->category = category;
+	identifier->fd = fd;
 }
 
 static int
@@ -1405,7 +1446,7 @@ allocateMemoryForLargePages(struct OMRPortLibrary *portLibrary, struct J9PortVme
 	void *memoryPointer = shmat(addressKey, currentAddress, 0);
 
 	if (MAP_FAILED != memoryPointer) {
-		update_vmemIdentifier(identifier, memoryPointer, (void *)(uintptr_t)addressKey, byteAmount, mode, pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, OMRPORT_VMEM_RESERVE_USED_SHM, category);
+		update_vmemIdentifier(identifier, memoryPointer, (void *)(uintptr_t)addressKey, byteAmount, mode, pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, OMRPORT_VMEM_RESERVE_USED_SHM, category, -1);
 		omrmem_categories_increment_counters(category, byteAmount);
 	}
 

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -681,6 +681,8 @@ extern J9_CFUNC void *
 omrvmem_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize, uint32_t category);
 extern J9_CFUNC void *
 omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params);
+extern J9_CFUNC void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
 extern J9_CFUNC uintptr_t
 omrvmem_get_page_size(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier);
 extern J9_CFUNC uintptr_t

--- a/port/osx/omrvmem.c
+++ b/port/osx/omrvmem.c
@@ -431,6 +431,11 @@ reserveMemory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteA
 	void *result = NULL;
 	int protectionFlags = PROT_NONE;
 
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+		return result;
+	}
+
 	flags |= MAP_ANON;
 	if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
 		protectionFlags = get_protectionBits(mode);

--- a/port/osx/omrvmem.c
+++ b/port/osx/omrvmem.c
@@ -788,3 +788,10 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary, J9VMemMemory
 	Trc_PRT_vmem_get_process_memory_exit(result, *memorySize);
 	return result;
 }
+
+void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+{
+	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+	return NULL;
+}

--- a/port/win32/omrvmem.c
+++ b/port/win32/omrvmem.c
@@ -786,11 +786,15 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 	intptr_t direction = 1;
 	void *currentAddress = startAddress;
 	void *oldAddress;
-	void *memoryPointer;
+	void *memoryPointer = NULL;
 #if defined(OMRVMEM_DEBUG)
 	static int count = 0;
 #endif
 
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+		return memoryPointer;
+	}
 
 	/* check allocation direction */
 	if (0 != (vmemOptions & OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN)) {

--- a/port/win32/omrvmem.c
+++ b/port/win32/omrvmem.c
@@ -1557,3 +1557,10 @@ OLD_IMPL:
 	}
 	return rc;
 }
+
+void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+{
+	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+	return NULL;
+}

--- a/port/zos390/omrvmem.c
+++ b/port/zos390/omrvmem.c
@@ -700,6 +700,11 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, uintptr_t by
 	uintptr_t allocSize = 0;
 	uintptr_t allocator = OMRPORT_VMEM_RESERVE_USED_INVALID;
 
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+		return ptr;
+	}
+
 	Trc_PRT_vmem_default_reserve_entry(FOUR_GIG_LIMIT, byteAmount);
 
 	if (OMR_ARE_ANY_BITS_SET(OMRPORT_VMEM_MEMORY_MODE_VIRTUAL, mode)) {

--- a/port/zos390/omrvmem.c
+++ b/port/zos390/omrvmem.c
@@ -1586,3 +1586,10 @@ isRmode64Supported()
 	return FALSE;
 }
 #endif
+
+void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+{
+	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+	return NULL;
+}

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -973,6 +973,11 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary,
 	void *result = NULL;
 	int protectionFlags = PROT_NONE;
 
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+		return result;
+	}
+
 	Trc_PRT_vmem_default_reserve_entry(address, byteAmount);
 
 #if defined(MAP_ANONYMOUS)
@@ -1051,6 +1056,11 @@ default_pageSize_reserve_memory_32bit(struct OMRPortLibrary *portLibrary,
 	int flags = MAP_PRIVATE;
 	void *result = NULL;
 	int protectionFlags = PROT_NONE;
+
+	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
+		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+		return result;
+	}
 
 	Trc_PRT_vmem_default_reserve_entry(address, byteAmount);
 

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1878,3 +1878,10 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary,
 
 	return result;
 }
+
+void *
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+{
+	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
+	return NULL;
+}


### PR DESCRIPTION
Include one test in fvtest to test reserve API with file handles

This is the initial step for the upcoming arraylet double mapping API
which will be included in incremental subsequent PRs

Co-authored-by: Charlie Gracie <charlie.gracie@gmail.com>

Signed-off-by: Igor Braga <higorb1@gmail.com>