### PR TITLE
Add omrsysinfo_gethostname

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -246,6 +246,32 @@ TEST(PortSysinfoTest, sysinfo_test1)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
+TEST(PortSysinfoTest, hostname_test)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+#define J9SYSINFO_HOSTNAME_LENGTH 1024
+	const char *testName = "omrsysinfo_hostname_test";
+	char hostname[J9SYSINFO_HOSTNAME_LENGTH];
+	intptr_t rc = 0;
+
+	reportTestEntry(OMRPORTLIB, testName);
+
+	rc = omrsysinfo_get_hostname(hostname, J9SYSINFO_HOSTNAME_LENGTH);
+	if (rc == -1) {
+		portTestEnv->log(LEVEL_ERROR, "omrsysinfo_get_hostname returned -1.\n");
+		reportTestExit(OMRPORTLIB, testName);
+		return;
+	} else {
+		char msg[256] = "";
+		omrstr_printf(msg, sizeof(msg), "Host name returned = \"%s\"\n", hostname);
+		portTestEnv->log(msg);
+	}
+	/* Don't check for buffers that are too small, since the call to gethostname() will
+	 * silently truncate the name and return 0 on some platforms, e.g. MacOS.
+	 */
+	reportTestExit(OMRPORTLIB, testName);
+}
+
 TEST(PortSysinfoTest, sysinfo_test2)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1161,6 +1161,8 @@ typedef struct OMRPortLibrary {
 	intptr_t (*sysinfo_get_username)(struct OMRPortLibrary *portLibrary, char *buffer, uintptr_t length) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_groupname "omrsysinfo_get_groupname"*/
 	intptr_t (*sysinfo_get_groupname)(struct OMRPortLibrary *portLibrary, char *buffer, uintptr_t length) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_get_hostname "omrsysinfo_get_hostname"*/
+	intptr_t (*sysinfo_get_hostname)(struct OMRPortLibrary *portLibrary, char *buffer, size_t length) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_load_average "omrsysinfo_get_load_average"*/
 	intptr_t (*sysinfo_get_load_average)(struct OMRPortLibrary *portLibrary, struct J9PortSysInfoLoadData *loadAverageData) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_CPU_utilization "omrsysinfo_get_CPU_utilization"*/
@@ -1822,6 +1824,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_get_executable_name(param1,param2) privateOmrPortLibrary->sysinfo_get_executable_name(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_username(param1,param2) privateOmrPortLibrary->sysinfo_get_username(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_groupname(param1,param2) privateOmrPortLibrary->sysinfo_get_groupname(privateOmrPortLibrary, (param1), (param2))
+#define omrsysinfo_get_hostname(param1,param2) privateOmrPortLibrary->sysinfo_get_hostname(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_load_average(param1) privateOmrPortLibrary->sysinfo_get_load_average(privateOmrPortLibrary, (param1))
 #define omrsysinfo_get_CPU_utilization(param1) privateOmrPortLibrary->sysinfo_get_CPU_utilization(privateOmrPortLibrary, (param1))
 #define omrsysinfo_limit_iterator_init(param1) privateOmrPortLibrary->sysinfo_limit_iterator_init(privateOmrPortLibrary, (param1))

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,6 +76,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_get_executable_name, /* sysinfo_get_executable_name */
 	omrsysinfo_get_username, /* sysinfo_get_username */
 	omrsysinfo_get_groupname, /* sysinfo_get_groupname */
+	omrsysinfo_get_hostname, /* sysinfo_get_hostname */
 	omrsysinfo_get_load_average, /* sysinfo_get_load_average */
 	omrsysinfo_get_CPU_utilization, /* omrsysinfo_get_CPU_utilization */
 	omrsysinfo_limit_iterator_init, /* sysinfo_limit_iterator_next */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1,4 +1,4 @@
-// Copyright (c) 1998, 2018 IBM Corp. and others
+// Copyright (c) 1998, 2019 IBM Corp. and others
 //
 // This program and the accompanying materials are made available under
 // the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1089,3 +1089,5 @@ TraceException=Trc_PRT_signal_unblockSignals_sigaddset_failed Group=signal Overh
 TraceException=Trc_PRT_signal_unblockSignals_pthread_sigmask_failed Group=signal Overhead=1 Level=1 NoEnv Template="omrsignal unblockSignals: pthread_sigmask failed with rc=%d and errno=%d"
 
 TraceException=Trc_PRT_sysinfo_get_open_file_count_memAllocFailed Group=sysinfo Overhead=1 Level=1 NoEnv Template="omrsysinfo_get_open_file_count: Error: memory allocation for proc_fdinfo failed."
+
+TraceException=Trc_PRT_sysinfo_gethostname_error Group=sysinfo Overhead=1 Level=1 NoEnv Template="gethostname failed: errno=%d"

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -419,6 +419,24 @@ omrsysinfo_get_groupname(struct OMRPortLibrary *portLibrary, char *buffer, uintp
 }
 
 /**
+ * Query the operating system for the name of the current host
+*
+* @param[in] portLibrary The port Library
+* @param[out] buffer Buffer for the name
+* @param[in,out] length The length of the buffer
+*
+* @return 0 on success, number of bytes required to hold the
+* information if the output buffer was too small, -1 on failure.
+*
+* @note buffer is undefined on error or when supplied buffer was too small.
+*/
+intptr_t
+omrsysinfo_get_hostname(struct OMRPortLibrary *portLibrary, char *buffer, uintptr_t length)
+{
+	return -1;
+}
+
+/**
  * Fetch the system limit associated with the specified resource.
  * This is roughly equivalent to the POSIX getrlimit API.
  *

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -479,6 +479,8 @@ extern J9_CFUNC void
 omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC intptr_t
 omrsysinfo_get_groupname(struct OMRPortLibrary *portLibrary, char *buffer, uintptr_t length);
+extern J9_CFUNC intptr_t
+omrsysinfo_get_hostname(struct OMRPortLibrary *portLibrary, char *buffer, size_t length);
 extern J9_CFUNC uintptr_t
 omrsysinfo_get_pid(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC uintptr_t

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -2231,6 +2231,17 @@ omrsysinfo_get_groupname(struct OMRPortLibrary *portLibrary, char *buffer, uintp
 	return 0;
 }
 
+intptr_t
+omrsysinfo_get_hostname(struct OMRPortLibrary *portLibrary, char *buffer, size_t length)
+{
+	if (0 != gethostname(buffer, length)) {
+		int32_t err = errno;
+		Trc_PRT_sysinfo_gethostname_error(findError(errno));
+		return portLibrary->error_set_last_error(portLibrary, err, findError(err));
+	}
+	return 0;
+}
+
 uint32_t
 omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, uint64_t *limit)
 {

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,11 @@
 #include <stdio.h>
 #include <windows.h>
 #include <WinSDKVer.h>
+/* Undefine the winsockapi because winsock2 defines it.  Removes warnings. */
+#if defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
+#undef _WINSOCKAPI_
+#endif
+#include <winsock2.h>
 
 #if defined(_WIN32_WINNT_WINBLUE) && (_WIN32_WINNT_MAXVER >= _WIN32_WINNT_WINBLUE)
 #include <VersionHelpers.h>
@@ -950,6 +955,16 @@ omrsysinfo_get_groupname(struct OMRPortLibrary *portLibrary, char *buffer, uintp
 {
 	/* Not applicable to Windows */
 	return -1;
+}
+
+intptr_t
+omrsysinfo_get_hostname(struct OMRPortLibrary *portLibrary, char *buffer, size_t length)
+{
+	if (0 != gethostname(buffer, (int) length)) {
+		Trc_PRT_sysinfo_gethostname_error(OMRPORT_ERROR_SYSINFO_OPFAILED);
+		return OMRPORT_ERROR_SYSINFO_OPFAILED;
+	}
+	return 0;
 }
 
 uint32_t


### PR DESCRIPTION
Also add unit test

This replaces the legacy `j9sock_gethostname()`.

Fixes in part https://github.com/eclipse/openj9/issues/1123.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>