### PR TITLE
Remove common implementation of isRotateAndMask(...)

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1264,9 +1264,6 @@ class OMR_EXTENSIBLE CodeGenerator
    // Unclassified
    //
 
-   // P now
-   bool isRotateAndMask(TR::Node *node) { return false; }
-
    TR::Instruction *generateNop(TR::Node *node, TR::Instruction *instruction=0, TR_NOPKind nopKind=TR_NOPStandard);
    bool isOutOfLineHotPath() { TR_ASSERT(0, "isOutOfLineHotPath is only implemented for 390 and ppc"); return false;}
 

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2865,27 +2865,26 @@ bool OMR::Power::CodeGenerator::isRotateAndMask(TR::Node * node)
 
    TR::Node *firstChild = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
+   TR::ILOpCodes firstOp  = firstChild->getOpCodeValue();
    TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
 
    if (secondChild->getOpCode().isLoadConst() &&
        secondChild->getRegister() == NULL &&
 
-         ((secondOp == TR::iconst || secondOp == TR::iuconst) &&
+         (secondOp == TR::iconst &&
           contiguousBits(secondChild->getInt()) &&
           firstChild->getReferenceCount() == 1 &&
           firstChild->getRegister() == NULL &&
-          (((firstChild->getOpCodeValue() == TR::imul ||
-             firstChild->getOpCodeValue() == TR::iumul) &&
-            (firstChild->getSecondChild()->getOpCodeValue() == TR::iconst ||
-             firstChild->getSecondChild()->getOpCodeValue() == TR::iuconst) &&
+          (((firstOp == TR::imul ||
+             firstOp == TR::iumul) &&
+             firstChild->getSecondChild()->getOpCodeValue() == TR::iconst &&
             firstChild->getSecondChild()->getInt() > 0 &&
             isNonNegativePowerOf2(firstChild->getSecondChild()->getInt())) ||
-           ((firstChild->getOpCodeValue() == TR::ishr ||
-             firstChild->getOpCodeValue() == TR::iushr) &&
-            (firstChild->getSecondChild()->getOpCodeValue() == TR::iconst ||
-             firstChild->getSecondChild()->getOpCodeValue() == TR::iuconst) &&
+           ((firstOp == TR::ishr ||
+             firstOp == TR::iushr) &&
+             firstChild->getSecondChild()->getOpCodeValue() == TR::iconst  &&
             firstChild->getSecondChild()->getInt() > 0 &&
-            (firstChild->getOpCodeValue() == TR::iushr ||
+            (firstOp == TR::iushr ||
              leadingZeroes(secondChild->getInt()) >=
               firstChild->getSecondChild()->getInt())))))
       return true;


### PR DESCRIPTION
isRotateAndMask() API is just power specific and hence, getting rid of
it from the common codegen. Also, removing deprecated opcodes.

Closes: #1876

Signed-off-by: Somesh Sharma <someshsharma0312@gmail.com>