### PR TITLE
Fix typo in specifying cmake source dir

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ install:
 before_build:
   - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
   - set PATH=C:\Python37;%PATH%
-  - cmd: cmake -Wdev -G "Visual Studio 11 2012" -DOMR_ENV_DATA32=ON -Ccmake\caches\Appveyor.cmake.
+  - cmd: cmake -Wdev -G "Visual Studio 11 2012" -DOMR_ENV_DATA32=ON -Ccmake\caches\Appveyor.cmake .
 
 build:
   project: omr.sln


### PR DESCRIPTION
As of cmake 13.3, users must specify a source directory. Due to an old
typo in the appvyeyor config, the source directory "./" was attached to
the end of the cache name.

This PR adds back the missing space between the initial cache file and
the source directory.

Fixes: #3559

Signed-off-by: Robert Young <rwy0717@gmail.com>