### PR TITLE
Remove callingMethod from getMethodFromName()

### DIFF
--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -170,7 +170,7 @@ TR_FrontEnd::getFormattedName(
 
 
 TR_OpaqueMethodBlock*
-TR_FrontEnd::getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod)
+TR_FrontEnd::getMethodFromName(char * className, char *methodName, char *signature)
    {
    notImplemented("getMethodFromName");
    return 0;

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -146,7 +146,7 @@ public:
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
    virtual OMR::MethodMetaDataPOD *createMethodMetaData(TR::Compilation *comp) { return NULL; }
 
-   virtual TR_OpaqueMethodBlock * getMethodFromName(char * className, char *methodName, char *signature, TR_OpaqueMethodBlock *callingMethod=0);
+   virtual TR_OpaqueMethodBlock * getMethodFromName(char * className, char *methodName, char *signature);
    virtual uint32_t offsetOfIsOverriddenBit();
 
    // Needs VMThread

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -955,7 +955,7 @@ OMR::SymbolReferenceTable::methodSymRefFromName(TR::ResolvedMethodSymbol * ownin
    // No existing symref.  Create a new one.
    //
 
-   TR_OpaqueMethodBlock *method = fe()->getMethodFromName(className, methodName, methodSignature, comp()->getCurrentMethod()->getNonPersistentIdentifier());
+   TR_OpaqueMethodBlock *method = fe()->getMethodFromName(className, methodName, methodSignature);
    TR_ASSERT(method, "methodSymRefFromName: method must exist: %s.%s%s", className, methodName, methodSignature);
    TR_ASSERT(kind != TR::MethodSymbol::Virtual, "methodSymRefFromName doesn't support virtual methods"); // Until we're able to look up vtable index
 


### PR DESCRIPTION
`getMethodFromName()` is used for fabricating calls to methods about which the compiler has special knowledge. Since these names originate in the compiler (and not in any particular method we happen to be compiling), the lookups should behave as such, so the `callingMethod` is irrelevant.