### PR TITLE
Remove dead evaluators from OMRTreeEvaluator.cpp in Z codegen

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1684,27 +1684,6 @@ OMR::Z::TreeEvaluator::lcmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    return lcmpHelper64(node, cg);
    }
 
-TR::Register *
-OMR::Z::TreeEvaluator::lucmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   PRINT_ME("lucmp", node, cg);
-   return TR::TreeEvaluator::badILOpEvaluator(node, cg);
-   }
-
-TR::Register *
-OMR::Z::TreeEvaluator::icmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   PRINT_ME("icmp", node, cg);
-   return TR::TreeEvaluator::badILOpEvaluator(node, cg);
-   }
-
-TR::Register *
-OMR::Z::TreeEvaluator::iucmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
-   {
-   PRINT_ME("iucmp", node, cg);
-   return TR::TreeEvaluator::badILOpEvaluator(node, cg);
-   }
-
 void OMR::Z::TreeEvaluator::tableEvaluatorCaseLabelHelper(TR::Node * node, TR::CodeGenerator * cg, tableKind tableKindToBeEvaluated, int32_t numBranchTableEntries, TR::Register * selectorReg, TR::Register * branchTableReg, TR::Register *reg1)
    {
    TR::Compilation *comp = cg->comp();

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -86,7 +86,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    {
    public:
 
-   static TR::Register *badILOpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -121,7 +120,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *indirectCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *libmFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *libxloptFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fenceEvaluator(TR::Node * node, TR::CodeGenerator *cg);
    static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aiaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -409,7 +407,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *lookupEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static void tableEvaluatorCaseLabelHelper(TR::Node * node, TR::CodeGenerator * cg, tableKind tableKindToBeEvaluated, int32_t numBranchTableEntries, TR::Register * selectorReg, TR::Register * branchTableReg, TR::Register *reg1  );
    static TR::Register *tableEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *exceptionRangeFenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *loadaddrEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *NULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ZEROCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -719,9 +716,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *BBEndEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *lcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *lucmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *icmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *iucmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bu2aEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *bu2iEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -744,15 +738,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *minEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *maxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
-   static TR::Register *composeEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *aletEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-
    static TR::Register *evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool needsResolve, TR::CodeGenerator * cg);
-
-   static bool genNullTestForCompressedPointers(TR::Node *node, TR::CodeGenerator *cg, TR::Register *targetRegister, TR::LabelSymbol * &skipAdd);
-
-   static TR::Register *getstackEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *deallocaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
@@ -762,12 +748,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *trtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *integerHighestOneBit(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerBitCount(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longHighestOneBit(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *longLowestOneBit(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longBitCount(TR::Node *node, TR::CodeGenerator *cg);
@@ -787,10 +771,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *fsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *dnintEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fnintEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *memcmpEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *ixfrsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *lxfrsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *fxfrsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
 // VM dependent routines
 
@@ -799,8 +779,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Instruction* genLoadForObjectHeaders      (TR::CodeGenerator *cg, TR::Node *node, TR::Register *reg, TR::MemoryReference *tempMR, TR::Instruction *iCursor);
    static TR::Instruction* genLoadForObjectHeadersMasked(TR::CodeGenerator *cg, TR::Node *node, TR::Register *reg, TR::MemoryReference *tempMR, TR::Instruction *iCursor);
 
-   static TR::Register       *inlineIfTestDataClassHelper(TR::Node *node, TR::CodeGenerator *cg, bool &inlined);
-   static void         evaluateRegLoads(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *inlineIfTestDataClassHelper(TR::Node *node, TR::CodeGenerator *cg, bool &inlined);
    static TR::Register *vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg, TR::Register *inReg, TR::Register *outReg);
@@ -899,7 +878,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    
    static void         commonButestEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register* ifFoldingHelper(TR::Node *node, TR::CodeGenerator *cg, bool &handledBIF);
-   static bool         isCandidateForBIFEvaluation(TR::Node * node);
    };
 
 }

--- a/compiler/z/codegen/S390Evaluator.hpp
+++ b/compiler/z/codegen/S390Evaluator.hpp
@@ -138,12 +138,6 @@ TR::Register * sloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryRe
 
 TR::Register *getLitPoolBaseReg(TR::Node *node, TR::CodeGenerator * cg);
 
-TR::InstOpCode::S390BranchCondition intToBrCond(const int32_t brCondInt);
-int32_t brCondToInt(const TR::InstOpCode::S390BranchCondition brCond);
-TR::InstOpCode::S390BranchCondition getOppositeBranchCondition(TR::InstOpCode::S390BranchCondition brCond);
-void orInPlace(TR::InstOpCode::S390BranchCondition& brCond, const TR::InstOpCode::S390BranchCondition other);
-
-
 enum LoadForm
    {
    RegReg,
@@ -222,7 +216,6 @@ extern template TR::Register * TR::TreeEvaluator::addressCastEvaluator<64, false
 
 TR::Register *getConditionCode(TR::Node *node, TR::CodeGenerator *cg, TR::Register *programRegister = NULL);
 TR::RegisterDependencyConditions *getGLRegDepsDependenciesFromIfNode(TR::CodeGenerator *cg, TR::Node* ificmpNode);
-void generateLongDoubleStore(TR::Node *node, TR::CodeGenerator *cg, TR::Register *reg, TR::Register *addressReg);
 
 class TR_S390ComputeCC : public TR::TreeEvaluator
    {

--- a/compiler/z/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/TreeEvaluatorTable.hpp
@@ -670,8 +670,8 @@
    TR::TreeEvaluator::lookupEvaluator,      // TR::trtLookup
    TR::TreeEvaluator::NOPEvaluator,         // TR::Case
    TR::TreeEvaluator::tableEvaluator,       // TR::table
-   TR::TreeEvaluator::exceptionRangeFenceEvaluator,       // TR::exceptionRangeFence
-   TR::TreeEvaluator::exceptionRangeFenceEvaluator,       // TR::dbgFence
+   TR::TreeEvaluator::unImpOpEvaluator,       // TR::exceptionRangeFence
+   TR::TreeEvaluator::unImpOpEvaluator,       // TR::dbgFence
    TR::TreeEvaluator::NULLCHKEvaluator,     // TR::NULLCHK
    TR::TreeEvaluator::badILOpEvaluator,     // TR::ResolveCHK
    TR::TreeEvaluator::resolveAndNULLCHKEvaluator, // TR::ResolveAndNULLCHK
@@ -708,9 +708,9 @@
    TR::TreeEvaluator::badILOpEvaluator,     // TR::bcmp
    TR::TreeEvaluator::badILOpEvaluator,     // TR::sucmp
    TR::TreeEvaluator::badILOpEvaluator,     // TR::scmp
-   TR::TreeEvaluator::iucmpEvaluator,       // TR::iucmp
-   TR::TreeEvaluator::icmpEvaluator,        // TR::icmp
-   TR::TreeEvaluator::lucmpEvaluator,       // TR::lucmp
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::iucmp
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::icmp
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::lucmp
 
    TR::TreeEvaluator::ifxcmpoEvaluator,     // TR::ificmpo
    TR::TreeEvaluator::ifxcmpoEvaluator,     // TR::ificmpno
@@ -751,9 +751,9 @@
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::fuexp
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::duexp
 
-   TR::TreeEvaluator::ixfrsEvaluator,       // TR::ixfrs
-   TR::TreeEvaluator::lxfrsEvaluator,       // TR::lxfrs
-   TR::TreeEvaluator::fxfrsEvaluator,       // TR::fxfrs
+   TR::TreeEvaluator::unImpOpEvaluator,       // TR::ixfrs
+   TR::TreeEvaluator::unImpOpEvaluator,       // TR::lxfrs
+   TR::TreeEvaluator::unImpOpEvaluator,       // TR::fxfrs
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::dxfrs
 
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::fint
@@ -764,8 +764,8 @@
    TR::TreeEvaluator::fsqrtEvaluator,       // TR::fsqrt
    TR::TreeEvaluator::dsqrtEvaluator,       // TR::dsqrt
 
-   TR::TreeEvaluator::getstackEvaluator,    // TR::getstack
-   TR::TreeEvaluator::deallocaEvaluator,    // TR::dealloca
+   TR::TreeEvaluator::unImpOpEvaluator,    // TR::getstack
+   TR::TreeEvaluator::unImpOpEvaluator,    // TR::dealloca
 
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::ishfl
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::lshfl
@@ -823,12 +823,12 @@
    TR::TreeEvaluator::trtEvaluator,         // TR::trtSimple
 
    TR::TreeEvaluator::integerHighestOneBit,              // TR::ihbit (J9)
-   TR::TreeEvaluator::integerLowestOneBit,               // TR::ilbit (J9)
+   TR::TreeEvaluator::unImpOpEvaluator,               // TR::ilbit (J9)
    TR::TreeEvaluator::integerNumberOfLeadingZeros,       // TR::inolz (J9)
    TR::TreeEvaluator::integerNumberOfTrailingZeros,      // TR::inotz (J9)
    TR::TreeEvaluator::integerBitCount,                   // TR::ipopcnt
    TR::TreeEvaluator::longHighestOneBit,                 // TR::lhbit (J9)
-   TR::TreeEvaluator::longLowestOneBit,                  // TR::llbit (J9)
+   TR::TreeEvaluator::unImpOpEvaluator,                  // TR::llbit (J9)
    TR::TreeEvaluator::longNumberOfLeadingZeros,          // TR::lnolz (J9)
    TR::TreeEvaluator::longNumberOfTrailingZeros,         // TR::lnotz (J9)
    TR::TreeEvaluator::longBitCount,                      // TR::lpopcnt


### PR DESCRIPTION
The OMRTreeEvaluator.cpp file is very large, totaling at over 18000
lines. GitHub does not play nice with large files as we hit certain
line limits and size limits [1]. As a first step in cleaning this up we
remove all unused evaluators which we do not foresee using in the
future.

Next step will be to do a big code migration of a ton of OpenJ9
evaluators into the OpenJ9 codebase. This commit however should
alleviate the immediate issue.

[1] https://help.github.com/articles/limits-for-viewing-content-and-diffs-in-a-repository/

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>