### PR TITLE
Transpose parameters to findHelperTrampoline

### DIFF
--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -87,7 +87,7 @@ template <class Derived>
 intptrj_t
 FEBase<Derived>::indexedTrampolineLookup(int32_t helperIndex, void * callSite)
    {
-   void * tramp = codeCacheManager().findHelperTrampoline(callSite, helperIndex);
+   void * tramp = codeCacheManager().findHelperTrampoline(helperIndex, callSite);
    TR_ASSERT(tramp!=NULL, "Error: CodeCache is not initialized properly.\n");
    return (intptrj_t)tramp;
    }

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -491,23 +491,34 @@ OMR::CodeCacheManager::findMethodTrampoline(TR_OpaqueMethodBlock *method, void *
    return codeCache->findTrampoline(method);
    }
 
-// Helper trampoline Lookup
-// Find the trampoline for the given helper in the code cache containing the
-// callingPC.
-//
+
 OMR::CodeCacheTrampolineCode *
-OMR::CodeCacheManager::findHelperTrampoline(void *callingPC, int32_t helperIndex)
+OMR::CodeCacheManager::findHelperTrampoline(int32_t helperIndex, void *callSite)
    {
    /* does the platform need trampolines at all? */
    TR::CodeCacheConfig &config = self()->codeCacheConfig();
    if (!config.trampolineCodeSize())
       return NULL;
 
-   TR::CodeCache *codeCache = self()->findCodeCacheFromPC(callingPC);
+   TR::CodeCache *codeCache = self()->findCodeCacheFromPC(callSite);
    if (!codeCache)
       return NULL;
 
    return codeCache->findTrampoline(helperIndex);
+   }
+
+
+// Helper trampoline Lookup
+// Find the trampoline for the given helper in the code cache containing the
+// callingPC.
+//
+// This function is deprecated and simply calls findHelperTrampoline() with
+// parameters transposed.
+//
+OMR::CodeCacheTrampolineCode *
+OMR::CodeCacheManager::findHelperTrampoline(void *callingPC, int32_t helperIndex)
+   {
+   return self()->findHelperTrampoline(helperIndex, callingPC);
    }
 
 // Synchronize temporary trampolines in all code caches

--- a/compiler/runtime/OMRCodeCacheManager.hpp
+++ b/compiler/runtime/OMRCodeCacheManager.hpp
@@ -196,6 +196,18 @@ public:
 
    TR::CodeCache * findCodeCacheFromPC(void *inCacheAddress);
 
+   /**
+    * @brief Finds a helper trampoline for the given helper reachable from the
+    *        given code cache address.
+    *
+    * @param[in] helperIndex : the index of the helper requested
+    * @param[in] callSite : the call site address
+    *
+    * @return The address of the helper trampoline in the same code cache as
+    *         the call site address
+    */
+   CodeCacheTrampolineCode * findHelperTrampoline(int32_t helperIndex, void *callSite);
+
    CodeCacheTrampolineCode * findMethodTrampoline(TR_OpaqueMethodBlock *method, void *callingPC);
    CodeCacheTrampolineCode * findHelperTrampoline(void *callingPC, int32_t helperIndex);
    void synchronizeTrampolines();


### PR DESCRIPTION
It is more readable and intuitive if the helper you're asking about
is the first parameter.  Fixup uses of this API.

The original API remains in the code and simply redirects to the new
API, and will be removed once downstream projects have been changed.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>