### PR TITLE
Add Power-specific relocation types needed for SVM AOT

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -461,6 +461,8 @@ const char *TR::ExternalRelocation::_externalRelocationTargetKindNames[TR_NumExt
    "TR_ValidateImproperInterfaceMethodFromCP (97)",
    "TR_SymbolFromManager (98)",
    "TR_MethodCallAddress (99)",
+   "TR_DiscontiguousSymbolFromManager (100)",
+   "TR_ResolvedTrampolines (101)",
    };
 
 uintptr_t TR::ExternalRelocation::_globalValueList[TR_NumGlobalValueItems] =

--- a/compiler/runtime/Runtime.hpp
+++ b/compiler/runtime/Runtime.hpp
@@ -394,7 +394,9 @@ typedef enum
    TR_ValidateImproperInterfaceMethodFromCP=97,
    TR_SymbolFromManager                   = 98,
    TR_MethodCallAddress                   = 99,
-   TR_NumExternalRelocationKinds          = 100,
+   TR_DiscontiguousSymbolFromManager      = 100,
+   TR_ResolvedTrampolines                 = 101,
+   TR_NumExternalRelocationKinds          = 102,
    TR_ExternalRelocationTargetKindMask    = 0xff,
    } TR_ExternalRelocationTargetKind;
 


### PR DESCRIPTION
For the Power codegen to work correctly with the newly implemented
Symbol Validation Manager for AOT, a couple new relocation types need to
be added:

1. TR_DiscontiguousSymbolFromManager represents a discontiguous load
   sequence that needs to be relocated with a symbol from the SVM
2. TR_ResolvedTrampolines represents the need to reserve a trampoline
   for a resolved method

Signed-off-by: Ben Thomas <ben@benthomas.ca>