### PR TITLE
Fix check for whether wide relocation offsets are needed on Power

### DIFF
--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -132,19 +132,7 @@ uint8_t TR::ExternalRelocation::collectModifier()
    {
    TR::Compilation *comp = TR::comp();
    uint8_t * relocatableMethodCodeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
-   uint8_t * updateLocation;
-
-   if (TR::Compiler->target.cpu.isPower() &&
-          (_kind == TR_ArrayCopyHelper || _kind == TR_ArrayCopyToc || _kind == TR_RamMethod || _kind == TR_GlobalValue || _kind == TR_BodyInfoAddressLoad || _kind == TR_DataAddress || _kind == TR_JNISpecialTargetAddress || _kind == TR_JNIStaticTargetAddress || _kind == TR_JNIVirtualTargetAddress
-                || _kind == TR_StaticRamMethodConst || _kind == TR_VirtualRamMethodConst || _kind == TR_SpecialRamMethodConst || _kind == TR_DebugCounter))
-      {
-      TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
-      updateLocation = instr->getBinaryEncoding();
-      }
-   else
-      {
-      updateLocation = getUpdateLocation();
-      }
+   uint8_t * updateLocation = getUpdateLocation();
 
    int32_t distanceFromStartOfBuffer = updateLocation - relocatableMethodCodeStart;
    int32_t distanceFromStartOfMethod = updateLocation - comp->cg()->getCodeStart();


### PR DESCRIPTION
Previously, there was special-case code in the collectModifier method on
TR::ExternalRelocation which was trying to handle relocations whose
targets were actually the address of the TR::Instruction rather than the
binary-encoded instruction. However, this is now being handled by
TR::BeforeBinaryEncodingExternalRelocation overriding the
getUpdateLocation method. As a result, this check was calculating the
wrong update location. The apply method was using the correct update
location and thus only calculation of whether wide offsets were needed
was affected by this problem.

This issue went unnoticed for a considerable length of time since the
pseudo-random nature of the incorrect update location would almost
always result in wide offsets being used. Using wide offsets when not
needed is unnecessary, but does not cause any correctness issues.

Signed-off-by: Ben Thomas <ben@benthomas.ca>