### PR TITLE
Provide explicit cast for findHelperTrampoline

### DIFF
--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -518,7 +518,7 @@ OMR::CodeCacheManager::findHelperTrampoline(int32_t helperIndex, void *callSite)
 OMR::CodeCacheTrampolineCode *
 OMR::CodeCacheManager::findHelperTrampoline(void *callingPC, int32_t helperIndex)
    {
-   return self()->findHelperTrampoline(helperIndex, callingPC);
+   return reinterpret_cast<OMR::CodeCacheTrampolineCode *>(self()->findHelperTrampoline(helperIndex, callingPC));
    }
 
 // Synchronize temporary trampolines in all code caches


### PR DESCRIPTION
The cast is required in order to change the return type of
`findHelperTrampoline` to a `intptrj_t` to allow downstream
projects to continue to build without breaking.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>