### PR TITLE
Add support for generating SVM relocations on Power

### DIFF
--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -4056,6 +4056,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
          case TR_DirectMethodGuard:
          case TR_NonoverriddenGuard:
          case TR_InterfaceGuard:
+         case TR_AbstractGuard:
          case TR_MethodEnterExitGuard:
          case TR_HCRGuard:
             aotSite->setGuard(virtualGuard);

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -385,7 +385,23 @@ TR::PPCImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *)getSymbolReference(), TR_AbsoluteHelperAddress, cg()), __FILE__, __LINE__, getNode());
                break;
             case TR_RamMethod:
-               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+               if (comp()->getOption(TR_UseSymbolValidationManager))
+                  {
+                  cg()->addExternalRelocation(
+                     new (comp()->trHeapMemory()) TR::ExternalRelocation(
+                        cursor,
+                        (uint8_t *)comp()->getJittedMethodSymbol()->getResolvedMethod()->resolvedMethodAddress(),
+                        (uint8_t *)TR::SymbolType::typeMethod,
+                        TR_SymbolFromManager,
+                        cg()),
+                     __FILE__,
+                     __LINE__,
+                     getNode());
+                  }
+               else
+                  {
+                  cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, NULL, TR_RamMethod, cg()), __FILE__, __LINE__, getNode());
+                  }
                break;
             case TR_BodyInfoAddress:
                cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, 0, TR_BodyInfoAddress, cg()), __FILE__, __LINE__, getNode());


### PR DESCRIPTION
This PR adds support to the Power codegen to generate `TR_SymbolFromManager` and `TR_DiscontiguousSymbolFromManager` relocations where necessary instead of the old relocation types when SVM is enabled.