### PR TITLE
Remove deprecated functions reserveTrampoline/unreserveTrampoline

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -459,13 +459,6 @@ OMR::CodeCache::allocateTempTrampoline()
 
 
 OMR::CodeCacheTrampolineCode *
-OMR::CodeCache::reserveTrampoline()
-   {
-   return self()->reserveSpaceForTrampoline();
-   }
-
-
-OMR::CodeCacheTrampolineCode *
 OMR::CodeCache::reserveSpaceForTrampoline()
    {
    TR::CodeCacheConfig &config = _manager->codeCacheConfig();
@@ -485,13 +478,6 @@ OMR::CodeCache::reserveSpaceForTrampoline()
    _trampolineReservationMark -= config.trampolineCodeSize();
 
    return (CodeCacheTrampolineCode *) _trampolineReservationMark;
-   }
-
-
-void
-OMR::CodeCache::unreserveTrampoline()
-   {
-   self()->unreserveSpaceForTrampoline();
    }
 
 
@@ -534,7 +520,7 @@ OMR::CodeCache::reserveResolvedTrampoline(TR_OpaqueMethodBlock *method,
       if (!entry)
          {
          // reserve a new trampoline since we got no active reservation for given method */
-         CodeCacheTrampolineCode *trampoline = self()->reserveTrampoline();
+         CodeCacheTrampolineCode *trampoline = self()->reserveSpaceForTrampoline();
          if (trampoline)
             {
             // add hashtable entry

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -152,13 +152,6 @@ public:
     */
    CodeCacheTrampolineCode *reserveSpaceForTrampoline();
 
-   /**
-    * @brief This function is deprecated.  It simply invokes reserveSpaceForTrampoline().
-    *        It will be removed when downstream dependencies are changed to call
-    *        reserveSpaceForTrampoline() directly.
-    */
-   CodeCacheTrampolineCode *reserveTrampoline();
-
    CodeCacheErrorCode::ErrorCode reserveNTrampolines(int64_t n);
 
    /**
@@ -166,13 +159,6 @@ public:
     *        current code cache.
     */
    void unreserveSpaceForTrampoline();
-
-   /**
-    * @brief This function is deprecated.  It simply invokes unreserveSpaceForTrampoline().
-    *        It will be removed when downstream dependencies are changed to call
-    *        unreserveSpaceForTrampoline() directly.
-    */
-   void unreserveTrampoline();
 
    CodeCacheTrampolineCode *allocateTrampoline();
    CodeCacheTrampolineCode *allocateTempTrampoline();


### PR DESCRIPTION
Fix one final reference to now call reserveSpaceForTrampoline.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>