### PR TITLE
Update limit constants to use numeric_limits<>::max()

### DIFF
--- a/ddr/lib/ddr-blobgen/CMakeLists.txt
+++ b/ddr/lib/ddr-blobgen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,4 +32,8 @@ target_link_libraries(omr_ddr_blobgen
 	omr_ddr_ir
 	omr_ddr_macros
 	omr_ddr_scanner
+)
+
+target_compile_definitions(omr_ddr_blobgen
+	PRIVATE __STDC_LIMIT_MACROS
 )

--- a/ddr/lib/ddr-ir/CMakeLists.txt
+++ b/ddr/lib/ddr-ir/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,4 +40,8 @@ set_property(TARGET omr_ddr_ir PROPERTY CXX_STANDARD 11)
 
 target_link_libraries(omr_ddr_ir
 	omr_ddr_base
+)
+
+target_compile_definitions(omr_ddr_ir
+	PRIVATE __STDC_LIMIT_MACROS
 )

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,7 +62,7 @@ TEST(TestBytes, IsPow2)
 	EXPECT_FALSE(isPow2(6));
 	EXPECT_FALSE(isPow2(7));
 	EXPECT_FALSE(isPow2(9));
-	EXPECT_FALSE(isPow2(SIZE_MAX));
+	EXPECT_FALSE(isPow2(std::numeric_limits<size_t>::max()));
 }
 
 TEST(TestBytes, AlignedUnsafe)
@@ -180,8 +180,8 @@ TEST(TestBytes, AlignAndOverflow)
 TEST(TestBytes, AlignMaximumSizeFor16byteAlignment)
 {
 	// hand crafted maximums for a 16 byte alignment
-	EXPECT_EQ(SIZE_MAX - 15, align(SIZE_MAX - 17, 16));
-	EXPECT_EQ(SIZE_MAX, align(SIZE_MAX, 1));
+	EXPECT_EQ(std::numeric_limits<size_t>::max() - 15, align(std::numeric_limits<size_t>::max() - 17, 16));
+	EXPECT_EQ(std::numeric_limits<size_t>::max(), align(std::numeric_limits<size_t>::max(), 1));
 }
 
 }  // namespace OMR

--- a/include_core/OMR/Bytes.hpp
+++ b/include_core/OMR/Bytes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2018, 2018 IBM and others
+ *  Copyright (c) 2018, 2019 IBM and others
  *
  *  This program and the accompanying materials are made available under
  *  the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <limits>
 
 namespace OMR
 {
@@ -63,10 +64,10 @@ isPow2(size_t x)
 }
 
 /// The maximum safe alignment, when aligning sizes up to UNALIGNED_SIZE_MAX.
-static const size_t ALIGNMENT_MAX = (SIZE_MAX >> 1) + 1;
+static const size_t ALIGNMENT_MAX = (std::numeric_limits<size_t>::max() >> 1) + 1;
 
 /// The maximum safe size, when aligning up to ALIGNMENT_MAX.
-static const size_t UNALIGNED_SIZE_MAX = (SIZE_MAX >> 1) + 1;
+static const size_t UNALIGNED_SIZE_MAX = (std::numeric_limits<size_t>::max() >> 1) + 1;
 
 /// True if size is aligned to alignment. No safety checks.
 /// alignment must be a power of two.
@@ -103,7 +104,7 @@ inline size_t
 align(size_t size, size_t alignment)
 {
 	assert(isPow2(alignment));
-	assert(size <= SIZE_MAX - alignment + 1); // overflow check
+	assert(size <= std::numeric_limits<size_t>::max() - alignment + 1); // overflow check
 	return alignNoCheck(size, alignment);
 }
 


### PR DESCRIPTION
Update limit constants to use numeric_limits<size_t>::max()
Instead of SIZE_MAX 

Update limit constants to use numeric_limits<uint32_t>::max()
Instead of UINT32_MAX

Updates fix Linux build 