### PR TITLE
Improve assertion output for large object stats

### DIFF
--- a/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
+++ b/gc/base/MemoryPoolSplitAddressOrderedListBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -186,7 +186,7 @@ MM_MemoryPoolSplitAddressOrderedListBase::initialize(MM_EnvironmentBase* env)
 		return false;
 	} else {
 		for (uintptr_t i = 0; i < _heapFreeListCountExtended; ++i) {
-			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats();
+			new (&_largeObjectAllocateStatsForFreeList[i]) MM_LargeObjectAllocateStats(env);
 
 			/* set multiple factor = 2 for doubling _maxVeryLargeEntrySizes to avoid run out of _veryLargeEntryPool (minus count during decrement) */
 			if (!_largeObjectAllocateStatsForFreeList[i].initialize(env, (uint16_t)extensions->largeObjectAllocationProfilingTopK, extensions->largeObjectAllocationProfilingThreshold, extensions->largeObjectAllocationProfilingVeryLargeObjectThreshold, (float)extensions->largeObjectAllocationProfilingSizeClassRatio / (float)100.0,

--- a/gc/stats/LargeObjectAllocateStats.hpp
+++ b/gc/stats/LargeObjectAllocateStats.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corp. and others
+ * Copyright (c) 2012, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -148,7 +148,7 @@ public:
 class MM_LargeObjectAllocateStats : public MM_Base {
 public:
 private:
-	OMRPortLibrary *_portLibrary;
+	MM_EnvironmentBase *_env;				/**< cached thread environment */
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	uintptr_t _tlhMaximumSize;				/**< cached value of _tlhMaximumSize */
 	uintptr_t _tlhMinimumSize;				/**< cached value of _tlhMinimumSize */
@@ -325,8 +325,8 @@ public:
 	uintptr_t getFreeMemoryBeforeEstimate() { return _freeMemoryBeforeEstimate; }
 	uintptr_t getMaxHeapSize() {return _maxHeapSize; }
 
-	MM_LargeObjectAllocateStats() :
-		_portLibrary(NULL),
+	MM_LargeObjectAllocateStats(MM_EnvironmentBase* env) :
+		_env(env),
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 		_tlhMaximumSize(0),
 		_tlhMinimumSize(0),


### PR DESCRIPTION
Log() calculation can be broken in OS or output of the function might be
corrupted. This change improves assertions output.

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>