### PR TITLE
AArch64: Implement arm64CodeSync()

### DIFF
--- a/compiler/aarch64/CMakeLists.txt
+++ b/compiler/aarch64/CMakeLists.txt
@@ -43,4 +43,5 @@ compiler_library(aarch64
 	${CMAKE_CURRENT_LIST_DIR}/codegen/UnaryEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRCPU.cpp
 	${CMAKE_CURRENT_LIST_DIR}/env/OMRDebugEnv.cpp
+	${CMAKE_CURRENT_LIST_DIR}/runtime/CodeSync.cpp
 )

--- a/compiler/aarch64/runtime/CodeSync.cpp
+++ b/compiler/aarch64/runtime/CodeSync.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+// make sure the code gets from the data cache to the instruction cache
+void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize)
+   {
+#if defined(TR_HOST_ARM64)
+#if defined(__GNUC__)
+   // GCC built-in function
+   __builtin___clear_cache(codeStart, codeStart+codeSize);
+#else
+#error Not supported yet
+#endif
+#endif
+   }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1977,6 +1977,8 @@ OMR::CodeGenerator::processRelocations()
 
 #if defined(TR_HOST_ARM)
 void armCodeSync(uint8_t *start, uint32_t size);
+#elif defined(TR_HOST_ARM64)
+void arm64CodeSync(uint8_t *start, uint32_t size);
 #elif defined(TR_HOST_POWER)
 void ppcCodeSync(uint8_t *start, uint32_t size);
 #else
@@ -1988,6 +1990,8 @@ OMR::CodeGenerator::syncCode(uint8_t *start, uint32_t size)
    {
 #if defined(TR_HOST_ARM)
    armCodeSync(start, size);
+#elif defined(TR_HOST_ARM64)
+   arm64CodeSync(start, size);
 #elif defined(TR_HOST_POWER)
    ppcCodeSync(start, size);
 #else

--- a/jitbuilder/build/files/host/aarch64.mk
+++ b/jitbuilder/build/files/host/aarch64.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2018 IBM Corp. and others
+# Copyright (c) 2018, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,4 +20,5 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-# JIT_PRODUCT_BACKEND_SOURCES+= 
+JIT_PRODUCT_BACKEND_SOURCES+= \
+	$(JIT_OMR_DIRTY_DIR)/aarch64/runtime/CodeSync.cpp


### PR DESCRIPTION
This commit implements arm64CodeSync() using a GCC built-in function,
and adds a call to it in OMR::CodeGenerator::syncCode().

Signed-off-by: knn-k <konno@jp.ibm.com>