### PR TITLE
Explicitly widen the source immediate before casting to pointer

### DIFF
--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -891,7 +891,7 @@ TR::X86ImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                   {
                   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                            (uint8_t *)getSourceImmediate(),
+                                                                                            (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                             (uint8_t *)symbolKind,
                                                                                             TR_SymbolFromManager,
                                                                                             cg()),
@@ -1136,7 +1136,7 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
                if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                   {
                   cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                            (uint8_t *)getSourceImmediate(),
+                                                                                            (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                             (uint8_t *)TR::SymbolType::typeClass,
                                                                                             TR_SymbolFromManager,
                                                                                             cg()),
@@ -1567,7 +1567,7 @@ TR::X86RegImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                {
                cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                         (uint8_t *)getSourceImmediate(),
+                                                                                         (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                          (uint8_t *)symbolKind,
                                                                                          TR_SymbolFromManager,
                                                                                          cg()),
@@ -1692,7 +1692,7 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
             if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
                {
                cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                         (uint8_t *)getSourceImmediate(),
+                                                                                         (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                          (uint8_t *)TR::SymbolType::typeClass,
                                                                                          TR_SymbolFromManager,
                                                                                          cg()),
@@ -1735,7 +1735,7 @@ TR::X86RegImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)getSourceImmediate(),
+                                                                                      (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                       (uint8_t *)symbolKind,
                                                                                       TR_SymbolFromManager,
                                                                                       cg()),
@@ -1987,7 +1987,7 @@ TR::X86MemImmInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)getSourceImmediate(),
+                                                                                      (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                       (uint8_t *)TR::SymbolType::typeClass,
                                                                                       TR_SymbolFromManager,
                                                                                       cg()),
@@ -2149,7 +2149,7 @@ TR::X86MemImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
          if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
-                                                                                      (uint8_t *)getSourceImmediate(),
+                                                                                      (uint8_t *)(uintptr_t)getSourceImmediate(),
                                                                                       (uint8_t *)TR::SymbolType::typeClass,
                                                                                       TR_SymbolFromManager,
                                                                                       cg()),


### PR DESCRIPTION
This patch fixes a pile of bad casts where we're converting from a 32bit
integer to a 64bit pointer. The warnings are silenced by performing an
intermediate cast to a uintptr_t, before casting to a pointer.

Signed-off-by: Robert Young <rwy0717@gmail.com>