### PR TITLE
Define TR_ALLOC everywhere

### DIFF
--- a/compiler/ilgen/IlInjector.hpp
+++ b/compiler/ilgen/IlInjector.hpp
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 #include "env/jittypes.h"
+#include "env/TRMemory.hpp"
 #include "il/ILOpCodes.hpp"
 #include "ilgen/IlGen.hpp"
 
@@ -50,11 +51,6 @@ namespace TR { class SymbolReferenceTable; }
 namespace TR { class TreeTop; }
 namespace TR { class IlType; }
 namespace TR { class TypeDictionary; }
-
-// This macro reduces dependencies for this header file
-#ifndef TR_ALLOC
-#define TR_ALLOC(x)
-#endif
 
 namespace OMR
 {

--- a/compiler/ilgen/OMRIlType.hpp
+++ b/compiler/ilgen/OMRIlType.hpp
@@ -22,13 +22,8 @@
 #ifndef OMR_ILTYPE_INCL
 #define OMR_ILTYPE_INCL
 
+#include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
-
-class TR_Memory;
-#ifndef TR_ALLOC
-#define TR_ALLOC(x)
-#endif
-
 
 namespace TR { class IlType; }
 namespace TR { class TypeDictionary; }

--- a/compiler/ilgen/OMRIlValue.hpp
+++ b/compiler/ilgen/OMRIlValue.hpp
@@ -22,10 +22,8 @@
 #ifndef OMR_ILVALUE_INCL
 #define OMR_ILVALUE_INCL
 
+#include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
-#ifndef TR_ALLOC
-#define TR_ALLOC(x)
-#endif
 
 namespace TR { class Node; }
 namespace TR { class TreeTop; }

--- a/compiler/ilgen/OMRMethodBuilder.hpp
+++ b/compiler/ilgen/OMRMethodBuilder.hpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <set>
 #include <fstream>
+#include "env/TRMemory.hpp"
 #include "ilgen/IlBuilder.hpp"
 #include "env/TypedAllocator.hpp"
 
@@ -39,12 +40,6 @@ namespace TR { class VirtualMachineState; }
 
 namespace TR { class SegmentProvider; }
 namespace TR { class Region; }
-class TR_Memory;
-
-#ifndef TR_ALLOC
-#define TR_ALLOC(x)
-#endif
-
 
 extern "C"
 {

--- a/jitbuilder/apigen/cppgen.py
+++ b/jitbuilder/apigen/cppgen.py
@@ -386,7 +386,7 @@ class CppGenerator:
         ```
         Constructor(...) {
             arg_set
-            auto impl = new TR::Constructor(...);
+            auto impl = ::new TR::Constructor(...);
             arg_return
             impl->setClient(this);
             initializeFromImpl(impl);
@@ -403,7 +403,7 @@ class CppGenerator:
         for parm in ctor_desc.parameters():
             self.write_arg_setup(writer, parm)
         args = self.generate_arg_list(ctor_desc.parameters())
-        writer.write("auto * impl = new {cname}({args});\n".format(cname=self.get_impl_class_name(class_desc), args=args))
+        writer.write("auto * impl = ::new {cname}({args});\n".format(cname=self.get_impl_class_name(class_desc), args=args))
         for parm in ctor_desc.parameters():
             self.write_arg_return(writer, parm)
         writer.write("{impl_cast}->setClient(this);\n".format(impl_cast=self.to_impl_cast(class_desc,"impl")))


### PR DESCRIPTION
With the JitBuilder public API in place, env/TRMemory.hpp is now available everywhere, and 
we can fully define the TR_ALLOC macro everywhere.

As a work around in the internals of the JitBuilder API, we have to use the global new operator to allocate internal compiler types.

Signed-off-by: Robert Young <rwy0717@gmail.com>