### PR TITLE
 Make fatal_assertion actually "no return"

### DIFF
--- a/compiler/infra/Assert.cpp
+++ b/compiler/infra/Assert.cpp
@@ -75,20 +75,12 @@ void OMR_NORETURN TR::trap()
       }
    }
 
-static void assumeDontCallMeDirectlyImpl( const char * file, int32_t line, const char *condition, const char *s, va_list ap, bool fatal)
+
+static void traceAssertionFailure(const char * file, int32_t line, const char *condition, const char *s, va_list ap)
    {
    TR::Compilation *comp = TR::comp();
 
-   // if the ignoreAssert option is set, then we ignore failing assert
-   if (comp && comp->getOption(TR_IgnoreAssert) && !fatal)
-      return;
-
    if (!condition) condition = "";
-
-   // Fatal assertions fire always, however, non fatal assertions
-   // can be disabled via TR_SoftFailOnAssume.
-   if (comp && comp->getOption(TR_SoftFailOnAssume) && !fatal)
-      comp->failCompilation<TR::AssertionFailure>("Assertion Failure");
 
    // Default is to always print to screen
    bool printOnscreen = true;
@@ -143,26 +135,31 @@ static void assumeDontCallMeDirectlyImpl( const char * file, int32_t line, const
          }
       comp->diagnosticImpl("\n");
       }
-
-   TR::trap();
    }
 
 namespace TR
    {
    void assertion(const char *file, int line, const char *condition, const char *format, ...)
       {
-      va_list ap;
-      va_start(ap, format);
-      assumeDontCallMeDirectlyImpl( file, line, condition, format, ap, false);
-      va_end(ap);
+      TR::Compilation *comp = TR::comp();
+      if (comp)
+         {
+         // TR_IgnoreAssert: ignore nonfatal assertion failures.
+         if (comp->getOption(TR_IgnoreAssert))
+            return;
+         // TR_SoftFailOnAssume: on nonfatal assertion failure, cancel the compilation without crashing the process.
+         if (comp->getOption(TR_SoftFailOnAssume))
+            comp->failCompilation<TR::AssertionFailure>("Assertion Failure");
+         }
+      fatal_assertion(file, line, condition, format);
       }
 
    void OMR_NORETURN fatal_assertion(const char *file, int line, const char *condition, const char *format, ...)
       {
       va_list ap;
       va_start(ap, format);
-      assumeDontCallMeDirectlyImpl( file, line, condition, format, ap, true);
+      traceAssertionFailure(file, line, condition, format, ap);
       va_end(ap);
+      TR::trap();
       }
-
    }


### PR DESCRIPTION
The function which actually triggers a trap, `assumeDontCallMeDirectlyImpl`, cannot be marked as no-return, because it only traps when handling fatal assertions.

Since fatal_assertion doesn't call any no-return functions, it cannot be marked as no-return.

Remove the OMR_NORETURN attribute from fatal_assertion and silence a compiler warning.

Signed-off-by: Robert Young <rwy0717@gmail.com>