### PR TITLE
Make mcc_printf a variadic function macro

### DIFF
--- a/compiler/runtime/CodeCacheTypes.cpp
+++ b/compiler/runtime/CodeCacheTypes.cpp
@@ -37,7 +37,7 @@ CodeCacheHashTable::dumpHashUnresolvedMethod(void)
       {
       entry = _buckets[i];
       if (entry)
-         mcc_printf("index = %d, constPool = 0x%x  cpIndex = %d\n", i, entry->_info._unresolved._constPool,entry->_info._unresolved._constPoolIndex);
+         mcc_printf("index = %d, constPool = 0x%p  cpIndex = %d\n", i, entry->_info._unresolved._constPool,entry->_info._unresolved._constPoolIndex);
       }
    return;
    }

--- a/compiler/runtime/CodeCacheTypes.hpp
+++ b/compiler/runtime/CodeCacheTypes.hpp
@@ -26,19 +26,23 @@
 #define __TPF_DO_NOT_MAP_ATOE_REMOVE
 #endif
 
+#undef CODECACHE_DEBUG
+
 #include <stddef.h>
 #include <stdint.h>
+#if defined(CODECACHE_DEBUG)
+#include <stdio.h>
+#endif /* CODECACHE_DEBUG */
+
 #include "runtime/MethodExceptionData.hpp"
 
 /*
  *  Debugging help
  */
-#ifdef CODECACHE_DEBUG
-#define mcc_printf if (CodeCacheDebug) printf
-#define mcc_hashprintf /*printf*/
+#if defined(CODECACHE_DEBUG)
+#define mcc_printf(fmt, ...) printf(fmt, ##__VA_ARGS__)
 #else
-#define mcc_printf
-#define mcc_hashprintf
+#define mcc_printf(fmt, ...) ((void)0)
 #endif
 
 class TR_OpaqueMethodBlock;

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -37,6 +37,7 @@
 #include "infra/Assert.hpp"
 #include "infra/CriticalSection.hpp"
 #include "infra/Monitor.hpp"
+#include "omrformatconsts.h"
 #include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/CodeCacheMemorySegment.hpp"
@@ -129,9 +130,9 @@ OMR::CodeCacheManager::initialize(
       }
 
    mcc_printf("mcc_initialize: initializing %d code cache(s)\n", numberOfCodeCachesToCreateAtStartup);
-   mcc_printf("mcc_initialize: code cache size = %u kb\n",  config.codeCacheKB());
-   mcc_printf("mcc_initialize: code cache pad size = %u kb\n",  config.codeCachePadKB());
-   mcc_printf("mcc_initialize: code cache total size = %u kb\n",  config.codeCacheTotalKB());
+   mcc_printf("mcc_initialize: code cache size = %" OMR_PRIuSIZE " kb\n",  config.codeCacheKB());
+   mcc_printf("mcc_initialize: code cache pad size = %" OMR_PRIuSIZE " kb\n",  config.codeCachePadKB());
+   mcc_printf("mcc_initialize: code cache total size = %" OMR_PRIuSIZE " kb\n",  config.codeCacheTotalKB());
 
    // Initialize the list of code caches
    //


### PR DESCRIPTION
Make the mcc_printf macro an inline function

mcc_printf is a variable-like macro which aliases the token printf.
However, when CODECACHE_DEBUG is disabled, mcc_printf is defined to
nothing. When this happens, the arguments at each "call site" will stick
around as a parenthesized expression. These unused expressions generate
compiler warnings.

So a call like:
    mcc_printf("hello %s\n", my_name);

is transformed to the expression:
    ("hello %s\n", my_name);

This PR makes mcc_printf a variadic function-like macro that calls
printf when CODECACHE_DEBUG is on, and expanding to nothing otherwise.
By expanding the entire call to nothing, we can ensure that there are no
leftover artifacts of the disabled code.

This PR also drops the additional test against the variable
CodeCacheDebug, which isn't defined anywhere. Another define,
mcc_hashprintf, was deleted, because it simply doesn't appear in any
codebase.