### PR TITLE
Clean up c-style formatting

### DIFF
--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -56,6 +56,7 @@
 #include "ras/Debug.hpp"
 #include "env/SystemSegmentProvider.hpp"
 #include "env/DebugSegmentProvider.hpp"
+#include "omrformatconsts.h"
 #include "runtime/CodeCacheManager.hpp"
 
 #if defined (_MSC_VER) && _MSC_VER < 1900
@@ -80,7 +81,7 @@ writePerfToolEntry(void *start, uint32_t size, const char *name)
       static const int maxPerfFilenameSize = 15 + sizeof(jvmPid)* 3; // "/tmp/perf-%ld.map"
       char perfFilename[maxPerfFilenameSize] = { 0 };
 
-      int numCharsWritten = snprintf(perfFilename, maxPerfFilenameSize, "/tmp/perf-%ld.map", jvmPid);
+      int numCharsWritten = snprintf(perfFilename, maxPerfFilenameSize, "/tmp/perf-%" OMR_PRId64 ".map", static_cast<int64_t>(jvmPid));
       if (numCharsWritten > 0 && numCharsWritten < maxPerfFilenameSize)
          {
          perfFile = fopen(perfFilename, "a");

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -37,6 +37,7 @@
 #include "infra/Assert.hpp"
 #include "infra/CriticalSection.hpp"
 #include "infra/Monitor.hpp"
+#include "omrformatconsts.h"
 #include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/CodeCacheMemorySegment.hpp"
@@ -1275,8 +1276,8 @@ void
 OMR::CodeCache::dumpCodeCache()
    {
    printf("Code Cache @%p\n", this);
-   printf("  |-- warmCodeAlloc          = 0x%08x\n", _warmCodeAlloc );
-   printf("  |-- coldCodeAlloc          = 0x%08x\n", _coldCodeAlloc );
+   printf("  |-- warmCodeAlloc          = 0x%08" OMR_PRIxPTR "\n", (uintptr_t)_warmCodeAlloc );
+   printf("  |-- coldCodeAlloc          = 0x%08" OMR_PRIxPTR "\n", (uintptr_t)_coldCodeAlloc );
    printf("  |-- tempTrampsMax          = %d\n",     _tempTrampolinesMax );
    printf("  |-- flags                  = %d\n",     _flags );
    printf("  |-- next                   = 0x%p\n",   _next );
@@ -1287,18 +1288,18 @@ void
 OMR::CodeCache::printOccupancyStats()
    {
    fprintf(stderr, "Code Cache @%p flags=0x%x almostFull=%d\n", this, _flags, _almostFull);
-   fprintf(stderr, "   cold-warm hole size        = %8u bytes\n", self()->getFreeContiguousSpace());
+   fprintf(stderr, "   cold-warm hole size        = %8" OMR_PRIuSIZE " bytes\n", self()->getFreeContiguousSpace());
    fprintf(stderr, "   warmCodeAlloc=%p coldCodeAlloc=%p\n", (void*)_warmCodeAlloc, (void*)_coldCodeAlloc);
    if (_freeBlockList)
       {
-      fprintf(stderr, "   sizeOfLargestFreeColdBlock = %8d bytes\n", _sizeOfLargestFreeColdBlock);
-      fprintf(stderr, "   sizeOfLargestFreeWarmBlock = %8d bytes\n", _sizeOfLargestFreeWarmBlock);
+      fprintf(stderr, "   sizeOfLargestFreeColdBlock = %8" OMR_PRIuSIZE " bytes\n", _sizeOfLargestFreeColdBlock);
+      fprintf(stderr, "   sizeOfLargestFreeWarmBlock = %8" OMR_PRIuSIZE " bytes\n", _sizeOfLargestFreeWarmBlock);
       fprintf(stderr, "   reclaimed sizes:");
       // scope for critical section
          {
          CacheCriticalSection resolveAndCreateTrampoline(self());
          for (CodeCacheFreeCacheBlock *currLink = _freeBlockList; currLink; currLink = currLink->_next)
-            fprintf(stderr, " %u", currLink->_size);
+            fprintf(stderr, " %" OMR_PRIuSIZE, currLink->_size);
          }
       fprintf(stderr, "\n");
       }
@@ -1411,12 +1412,12 @@ OMR::CodeCache::checkForErrors()
             } // end for
          if (_sizeOfLargestFreeWarmBlock != maxFreeWarmSize)
             {
-            fprintf(stderr, "checkForErrors cache %p: Error: _sizeOfLargestFreeWarmBlock(%d) != maxFreeWarmSize(%d)\n", this, _sizeOfLargestFreeWarmBlock, maxFreeWarmSize);
+            fprintf(stderr, "checkForErrors cache %p: Error: _sizeOfLargestFreeWarmBlock(%" OMR_PRIuSIZE ") != maxFreeWarmSize(%" OMR_PRIuSIZE ")\n", this, _sizeOfLargestFreeWarmBlock, maxFreeWarmSize);
             doCrash = true;
             }
          if (_sizeOfLargestFreeColdBlock != maxFreeColdSize)
             {
-            fprintf(stderr, "checkForErrors cache %p: Error: _sizeOfLargestFreeColdBlock(%d) != maxFreeColdSize(%d)\n", this, _sizeOfLargestFreeColdBlock, maxFreeColdSize);
+            fprintf(stderr, "checkForErrors cache %p: Error: _sizeOfLargestFreeColdBlock(%" OMR_PRIuSIZE ") != maxFreeColdSize(%" OMR_PRIuSIZE ")\n", this, _sizeOfLargestFreeColdBlock, maxFreeColdSize);
             doCrash = true;
             }
 

--- a/fvtest/compilertriltest/BitPermuteTest.cpp
+++ b/fvtest/compilertriltest/BitPermuteTest.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 #include "JitTest.hpp"
 #include "default_compiler.hpp"
+#include "omrformatconsts.h"
 
 uint8_t byteValues[] = {
    0x00,
@@ -146,10 +147,10 @@ TEST_P(lBitPermuteTest, ConstAddressLengthTest)
       "  (lreturn                         "
       "  (lbitpermute                     "
       "   (lload parm=0)                  "
-      "   (aconst %llu)                   "
-      "   (iconst %llu)                   "
+      "   (aconst %" OMR_PRIuPTR ")       "
+      "   (iconst %" OMR_PRIu32 ")        "
       "  ))))                             ",
-      param.arrayAddress,
+      reinterpret_cast<uintptr_t>(param.arrayAddress),
       param.arrayLength
       );
 
@@ -178,10 +179,10 @@ TEST_P(lBitPermuteTest, ConstAddressTest)
       "  (lreturn                                "
       "  (lbitpermute                            "
       "   (lload parm=0)                         "
-      "   (aconst %llu)                          "
+      "   (aconst %" OMR_PRIuPTR ")              "
       "   (iload parm=1)                         "
       "  ))))                                    ",
-      param.arrayAddress
+      reinterpret_cast<uintptr_t>(param.arrayAddress)
       );
 
    auto trees = parseString(inputTrees);
@@ -245,10 +246,10 @@ TEST_P(iBitPermuteTest, ConstAddressLengthTest)
       "  (ireturn                         "
       "  (ibitpermute                     "
       "   (iload parm=0)                  "
-      "   (aconst %llu)                   "
-      "   (iconst %llu)                   "
+      "   (aconst %" OMR_PRIuPTR ")       "
+      "   (iconst %" OMR_PRIu32 ")        "
       "  ))))                             ",
-      maskedIndices,
+      reinterpret_cast<uintptr_t>(maskedIndices),
       param.arrayLength
       );
 
@@ -281,10 +282,10 @@ TEST_P(iBitPermuteTest, ConstAddressTest)
       "  (ireturn                                "
       "  (ibitpermute                            "
       "   (iload parm=0)                         "
-      "   (aconst %llu)                          "
+      "   (aconst %" OMR_PRIuPTR ")              "
       "   (iload parm=1)                         "
       "  ))))                                    ",
-      maskedIndices
+      reinterpret_cast<uintptr_t>(maskedIndices)
       );
 
    auto trees = parseString(inputTrees);
@@ -356,10 +357,10 @@ TEST_P(sBitPermuteTest, ConstAddressLengthTest)
       "  (su2i                            "
       "  (sbitpermute                     "
       "   (sload parm=0)                  "
-      "   (aconst %llu)                   "
-      "   (iconst %llu)                   "
+      "   (aconst %" OMR_PRIuPTR ")       "
+      "   (iconst %" OMR_PRIu32 ")        "
       "  )))))                            ",
-      maskedIndices,
+      reinterpret_cast<uintptr_t>(maskedIndices),
       param.arrayLength
       );
 
@@ -396,10 +397,10 @@ TEST_P(sBitPermuteTest, ConstAddressTest)
       "  (su2i                                   "
       "  (sbitpermute                            "
       "   (sload parm=0)                         "
-      "   (aconst %llu)                          "
+      "   (aconst %" OMR_PRIuPTR ")              "
       "   (iload parm=1)                         "
       "  )))))                                   ",
-      maskedIndices
+      reinterpret_cast<uintptr_t>(maskedIndices)
       );
 
    auto trees = parseString(inputTrees);
@@ -475,10 +476,10 @@ TEST_P(bBitPermuteTest, ConstAddressLengthTest)
       "  (bu2i                          "
       "  (bbitpermute                   "
       "   (bload parm=0)                "
-      "   (aconst %llu)                 "
-      "   (iconst %llu)                 "
+      "   (aconst %" OMR_PRIuPTR ")     "
+      "   (iconst %" OMR_PRIu32 ")      "
       "  )))))                          ",
-      maskedIndices,
+      reinterpret_cast<uintptr_t>(maskedIndices),
       param.arrayLength
       );
 
@@ -515,10 +516,10 @@ TEST_P(bBitPermuteTest, ConstAddressTest)
       "  (bu2i                                 "
       "  (bbitpermute                          "
       "   (bload parm=0)                       "
-      "   (aconst %llu)                        "
+      "   (aconst %" OMR_PRIuPTR ")            "
       "   (iload parm=1)                       "
       "  )))))                                 ",
-      maskedIndices
+      (uintptr_t)maskedIndices
       );
 
    auto trees = parseString(inputTrees);

--- a/fvtest/compilertriltest/LogicalTest.cpp
+++ b/fvtest/compilertriltest/LogicalTest.cpp
@@ -22,6 +22,7 @@
 
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
+#include "omrformatconsts.h"
 
 int32_t ineg(int32_t l) {
     return -l;
@@ -166,8 +167,8 @@ TEST_P(Int64LogicalBinary, UsingConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %li)"
-        "        (lconst %li) ) ) ) )", 
+        "        (lconst %" OMR_PRId64 ")"
+        "        (lconst %" OMR_PRId64 ") ) ) ) )",
         param.opcode.c_str(), param.lhs, param.rhs);
     auto trees = parseString(inputTrees);
 
@@ -228,7 +229,7 @@ TEST_P(Int64LogicalUnary, UsingConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %ld) )"
+        "        (lconst %" OMR_PRId64 ") )"
         ")))",
         param.opcode.c_str(),
         param.value);

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,6 +21,7 @@
 
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
+#include "omrformatconsts.h"
 
 int32_t imax(int32_t l, int32_t r) {
   return std::max(l,r);
@@ -48,8 +49,8 @@ TEST_P(Int32MaxMin, UsingConst) {
         "  (block"
         "    (ireturn"
         "      (%s"
-        "        (iconst %lld)"
-        "        (iconst %lld))"
+        "        (iconst %" OMR_PRId32 ")"
+        "        (iconst %" OMR_PRId32 "))"
         ")))",
         param.opcode.c_str(),
         param.lhs,
@@ -109,8 +110,8 @@ TEST_P(Int64MaxMin, UsingConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %lld)"
-        "        (lconst %lld))"
+        "        (lconst %" OMR_PRId64 ")"
+        "        (lconst %" OMR_PRId64 "))"
         ")))",
         param.opcode.c_str(),
         param.lhs,

--- a/include_core/omrformatconsts.h
+++ b/include_core/omrformatconsts.h
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMRFORMATCONSTANTS_H_
+#define OMRFORMATCONSTANTS_H_
+
+#include "omrcfg.h"
+
+#include <stdint.h>
+
+/* OMR_PRId8: int8_t */
+#if defined(PRId8)
+#define OMR_PRId8 PRId8
+#elif defined(__GNUC__) || defined(__clang__) || defined(__xlC__)
+#define OMR_PRId8 "hhd"
+#else
+#define OMR_PRId8 "d" /* promote to int */
+#endif
+
+/* OMR_PRIu8: uint8_t */
+#if defined(PRIu8)
+#define OMR_PRIu8 PRIu8
+#elif defined(__GNUC__) || defined(__clang__) || defined(__xlC__)
+#define OMR_PRIu8 "hhu"
+#else
+#define OMR_PRIu8 "u" /* promote to unsigned int */
+#endif
+
+/* OMR_PRIx8: uint8_t (hex) */
+#if defined(PRIx8)
+#define OMR_PRIx8 PRIx8
+#elif defined(__GNUC__) || defined(__clang__) || defined(__xlC__)
+#define OMR_PRIx8 "hhx"
+#else
+#define OMR_PRIx8 "x" /* promote to unsigned int */
+#endif
+
+/* OMR_PRId16: int16_t */
+#if defined(PRId16)
+#define OMR_PRId16 PRId16
+#else
+#define OMR_PRId16 "hd"
+#endif
+
+/* OMR_PRIu16: uint16_t */
+#if defined(PRIu16)
+#define OMR_PRIu16 PRIu16
+#else
+#define OMR_PRIu16 "hu"
+#endif
+
+/* OMR_PRIx16: uint16_t (hex) */
+#if defined(PRIx16)
+#define OMR_PRIx16 PRIx16
+#else
+#define OMR_PRIx16 "hx"
+#endif
+
+/* OMR_PRId32: int32_t */
+#if defined(_MSC_VER) && (1900 <= _MSC_VER)
+/* msvc has a badly defined format macro for int32 */
+#define OMR_PRId32 "I32d"
+#elif defined(PRId32)
+#define OMR_PRId32 PRId32
+#else
+#define OMR_PRId32 "d"
+#endif
+
+/* OMR_PRIu32: uint32_t */
+#if defined(_MSC_VER) && (1900 <= _MSC_VER)
+/* msvc has a badly defined format macro for int32 */
+#define OMR_PRIu32 "I32u"
+#elif defined(PRIu32)
+#define OMR_PRIu32 PRIu32
+#else
+#define OMR_PRIu32 "u"
+#endif
+
+/* OMR_PRIx32: uint32_t (hex) */
+#if defined(_MSC_VER) && (1900 <= _MSC_VER)
+/* msvc has a badly defined format macro for int32 */
+#define OMR_PRIx32 "I32x"
+#elif defined(PRIu32)
+#define OMR_PRIx32 PRIx32
+#else
+#define OMR_PRIx32 "x"
+#endif
+
+/* OMR_PRId64: int64_t */
+#if defined(PRId64)
+#define OMR_PRId64 PRId64
+#elif defined(_MSC_VER)
+#define OMR_PRId64 "I64d"
+#else
+#define OMR_PRId64 "lld"
+#endif
+
+/* OMR_PRIu64: uint64_t */
+#if defined(PRIu64)
+#define OMR_PRIu64 PRIu64
+#elif defined(_MSC_VER)
+#define OMR_PRIu64 "I64u"
+#else
+#define OMR_PRIu64 "llu"
+#endif
+
+/* OMR_PRIx64: uint64_t (hex) */
+#if defined(PRIx64)
+#define OMR_PRIx64 PRIx64
+#elif defined(_MSC_VER)
+#define OMR_PRIx64 "I64x"
+#else
+#define OMR_PRIx64 "llx"
+#endif
+
+/* OMR_PRIdSIZE: signed size_t */
+#if defined(_MSC_VER)
+#define OMR_PRIdSIZE "Iu"
+#else
+#define OMR_PRIdSIZE "zu"
+#endif
+
+/* OMR_PRIuSIZE: size_t */
+#if defined(_MSC_VER)
+#define OMR_PRIuSIZE "Iu"
+#else
+#define OMR_PRIuSIZE "zu"
+#endif
+
+/* OMR_PRIxSIZE: size_t */
+#if defined(_MSC_VER)
+#define OMR_PRIxSIZE "Ix"
+#else
+#define OMR_PRIxSIZE "zx"
+#endif
+
+/* PRIdPTR: intptr_t */
+#if defined(PRIdPTR)
+#define OMR_PRIdPTR PRIdPTR
+#elif defined(_MSC_VER)
+#define OMR_PRIdPTR "Id"
+#else
+#define OMR_PRIdPTR "zd"
+#endif
+
+/* PRIuPTR: uintptr_t */
+#if defined(PRIuPTR)
+#define OMR_PRIuPTR PRIuPTR
+#elif defined(_MSC_VER)
+#define OMR_PRIuPTR "Iu"
+#else
+#define OMR_PRIuPTR "zu"
+#endif
+
+/* PRIxPTR: uintptr_t (hex) */
+#if defined(PRIxPTR)
+#define OMR_PRIxPTR PRIxPTR
+#elif defined(_MSC_VER)
+#define OMR_PRIxPTR "Iu"
+#else
+#define OMR_PRIxPTR "zu"
+#endif
+
+/* OMR_PRIdPTRDIFF: ptrdiff_t */
+#if defined(_MSC_VER)
+#define OMR_PRIdPTRDIFF "Id"
+#else
+#define OMR_PRIdPTRDIFF "td"
+#endif
+
+/* OMR_PRIuPTRDIFF: ptrdiff_t */
+#if defined(_MSC_VER)
+#define OMR_PRIuPTRDIFF "Iu"
+#else
+#define OMR_PRIuPTRDIFF "tu"
+#endif
+
+/* OMR_PRIxPTRDIFF: unsigned ptrdiff_t (hex) */
+#if defined(_MSC_VER)
+#define OMR_PRIxPTRDIFF "Ix"
+#else
+#define OMR_PRIxPTRDIFF "tx"
+#endif
+
+#endif // OMRFORMATCONSTANTS_H_


### PR DESCRIPTION
Introduce a new header, `omrformatconsts.h`, which defines a set of portable constants for building format strings for special integral types. This header  provides platform-independent format specifiers for the following data types:

- int8_t / uint8_t
- int16_t / uint16_t
- int32_t / uint32_t
- int64 / uint64_t
- size_t
- intptr_t / uintptr_t
- ptrdiff_t

The following formats are provided in this PR:
- x: unsigned hexadecimal format
- u: unsigned decimal format
- d: signed decimal format

(notably missing: i)

Normally, there are either special macros defined by the C library, or
special format characters in the case of size_t / ptrdiff_t.
Unfortunately, because of poor standards compliance across our
compilers, these aren't universally available.

The names of the constants follow the convention of those normally
provided by stdint.h.

As well, I've gone through and fixed a number of locations with format strings that generate errors.