### PR TITLE
Run OSR live range analysis and OSR def analysis first

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -840,6 +840,7 @@ OMR::Compilation::requiresAnalysisOSRPoint(TR::Node *node)
    if (!self()->isPotentialOSRPoint(node, &osrNode))
       {
       TR_ASSERT(0, "requiresAnalysisOSRPoint should only be called on OSR points\n");
+      return false;
       }
 
    // Calls require an analysis and transition point as liveness may change across them

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -538,14 +538,14 @@ const OptimizationStrategy finalGlobalOpts[] =
 static const OptimizationStrategy ilgenStrategyOpts[] =
    {
 #ifdef J9_PROJECT_SPECIFIC
+   { osrLiveRangeAnalysis,          IfOSR   },
+   { osrDefAnalysis,                IfInvoluntaryOSR },
    { varHandleTransformer,          MustBeDone     },
    { unsafeFastPath                                },
    { recognizedCallTransformer                     },
    { coldBlockMarker                               },
    { allocationSinking,             IfNews         },
    { invariantArgumentPreexistence, IfNotClassLoadPhaseAndNotProfiling }, // Should not run if a recompilation is possible
-   { osrLiveRangeAnalysis,          IfOSR   },
-   { osrDefAnalysis,                IfInvoluntaryOSR },
 #endif
    { endOpts },
    };


### PR DESCRIPTION
OSR live range analysis and OSR def analysis gathers information to
decide what to copy into the OSR buffer during OSR transition. This
should not change regardless of when they are performed. Optimizations
can create nodes with incorrect bytecode index. Those nodes are usually
not important and side effect free, such as `iconst` node. However, such
nodes bring difficulty on OSR live range analysis and OSR def analysis
since the two opts rely highly on the correctness of bytecode info.
Thus, move then up as the first two ilgen opts.

Also fix two minor issues found in OSR live range analysis.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>