### PR TITLE
AArch64: Fix lnegEvaluator to correctly generate 64-bit negate instruction

### DIFF
--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -81,7 +81,7 @@ TR::Register *OMR::ARM64::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeG
    {
    TR::Node *firstChild = node->getFirstChild();
    TR::Register *tempReg = cg->gprClobberEvaluate(firstChild);
-   generateNegInstruction(cg, node, tempReg, tempReg);
+   generateNegInstruction(cg, node, tempReg, tempReg, true);
    firstChild->decReferenceCount();
    return node->setRegister(tempReg);
    }


### PR DESCRIPTION
There was a minor issue in the previous lneg evaluator implementation. When calling the generateNegInstruction(), the boolean value should be true in the parameter for lneg evaluator. In previous implementation this boolean value is missing and so in this commit I updated that.

Signed-off-by: marufunb <mrahma15@unb.ca>