### PR TITLE
Add a new TR_UNIMPLEMENTED() assertion to the compiler

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -181,7 +181,7 @@ uint8_t *TR::ARM64CompareBranchInstruction::generateBinaryEncoding()
    uint8_t *cursor = instructionStart;
    TR::LabelSymbol *label = getLabelSymbol();
 
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
 
    return cursor;
    }

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -650,7 +650,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64LabelInstruction *instr)
       print(pOutFile, label);
       if (snippet)
          {
-         TR_ASSERT(false, "Not implemented yet.");
+         TR_UNIMPLEMENTED();
          }
       }
    printInstructionComment(pOutFile, 1, instr);
@@ -675,7 +675,7 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64CompareBranchInstruction *instr)
    {
    printPrefix(pOutFile, instr);
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }
 
 void
@@ -955,7 +955,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference *mr)
 void
 TR_Debug::printARM64GCRegisterMap(TR::FILE *pOutFile, TR::GCRegisterMap *map)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }
 
 void
@@ -1054,5 +1054,5 @@ TR_Debug::getARM64RegisterName(uint32_t regNum, bool is64bit)
 
 void TR_Debug::printARM64OOLSequences(TR::FILE *pOutFile)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
@@ -25,7 +25,7 @@
 uint8_t *
 TR::ARM64HelperCallSnippet::emitSnippetBody()
    {
-   TR_ASSERT(false, "Not implemented yet");
+   TR_UNIMPLEMENTED();
 
    uint8_t *buffer = cg()->getBinaryBufferCursor();
    return buffer;
@@ -34,7 +34,6 @@ TR::ARM64HelperCallSnippet::emitSnippetBody()
 uint32_t
 TR::ARM64HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
    {
-   TR_ASSERT(false, "Not implemented yet");
-
+   TR_UNIMPLEMENTED();
    return 0;
    }

--- a/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
+++ b/compiler/aarch64/codegen/ARM64OutOfLineCodeSection.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,10 +34,10 @@ TR_ARM64OutOfLineCodeSection::TR_ARM64OutOfLineCodeSection(TR::Node *callNode,
 
 void TR_ARM64OutOfLineCodeSection::assignRegisters(TR_RegisterKinds kindsToBeAssigned)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }
 
 void TR_ARM64OutOfLineCodeSection::generateARM64OutOfLineCodeSectionDispatch()
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -388,7 +388,7 @@ TR::ARM64SystemLinkage::createPrologue(TR::Instruction *cursor, List<TR::Paramet
       }
    else
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
       }
 
    // save link register (x30)
@@ -522,7 +522,7 @@ TR::ARM64SystemLinkage::createEpilogue(TR::Instruction *cursor)
       }
    else
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
       }
 
    // return
@@ -840,7 +840,6 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
 
 TR::Register *TR::ARM64SystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return NULL;
    }

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -125,7 +125,7 @@ OMR::ARM64::CodeGenerator::beginInstructionSelection()
    TR::Node *startNode = comp->getStartTree()->getNode();
    if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private)
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
 
       _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::ARM64ImmInstruction(TR::InstOpCode::dd, startNode, 0, self());
       }
@@ -274,7 +274,7 @@ TR::Linkage *OMR::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 
 void OMR::ARM64::CodeGenerator::emitDataSnippets()
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    /*
     * Commented out until TR::ConstantDataSnippet is implemented
    self()->setBinaryBufferCursor(_constantData->emitSnippetBody());
@@ -288,7 +288,7 @@ bool OMR::ARM64::CodeGenerator::hasDataSnippets()
 
 int32_t OMR::ARM64::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    return 0;
    /*
     * Commented out until TR::ConstantDataSnippet is implemented
@@ -303,7 +303,7 @@ void OMR::ARM64::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    if (outFile == NULL)
       return;
 
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    /*
     * Commented out until TR::ConstantDataSnippet is implemented
    _constantData->print(outFile);
@@ -314,7 +314,7 @@ void OMR::ARM64::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
 
 TR::Instruction *OMR::ARM64::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
 
    return NULL;
    }
@@ -338,7 +338,7 @@ TR::Register *OMR::ARM64::CodeGenerator::gprClobberEvaluate(TR::Node *node)
 
 void OMR::ARM64::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }
 
 
@@ -360,15 +360,13 @@ bool OMR::ARM64::CodeGenerator::allowGlobalRegisterAcrossBranch(TR_RegisterCandi
 
 int32_t OMR::ARM64::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::Node *node)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 int32_t OMR::ARM64::CodeGenerator::getMaximumNumberOfFPRsAllowedAcrossEdge(TR::Node *node)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -389,8 +387,7 @@ bool OMR::ARM64::CodeGenerator::isGlobalRegisterAvailable(TR_GlobalRegisterNumbe
 
 TR_GlobalRegisterNumber OMR::ARM64::CodeGenerator::getLinkageGlobalRegisterNumber(int8_t linkageRegisterIndex, TR::DataType type)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,22 +68,19 @@ TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register
 
 TR::Instruction *OMR::ARM64::Linkage::saveArguments(TR::Instruction *cursor)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return cursor;
    }
 
 TR::Instruction *OMR::ARM64::Linkage::loadUpArguments(TR::Instruction *cursor)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return cursor;
    }
 
 TR::Instruction *OMR::ARM64::Linkage::flushArguments(TR::Instruction *cursor)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return cursor;
    }
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -107,7 +107,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
       {
       if (ref->isUnresolved())
          {
-         TR_ASSERT(false, "Not implemented yet.");
+         TR_UNIMPLEMENTED();
          }
       self()->populateMemoryReference(rootLoadOrStore->getFirstChild(), cg);
       }
@@ -115,7 +115,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
       {
       if (symbol->isStatic())
          {
-         TR_ASSERT(false, "Not implemented yet.");
+         TR_UNIMPLEMENTED();
          }
       else
          {
@@ -132,7 +132,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
    self()->addToOffset(rootLoadOrStore, ref->getOffset(), cg);
    if (self()->getUnresolvedSnippet() != NULL)
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
       }
    }
 
@@ -153,13 +153,13 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _offset(0),
    _symbolReference(symRef)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }
 
 
 bool OMR::ARM64::MemoryReference::useIndexedForm()
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
 
    return false;
    }
@@ -337,7 +337,7 @@ void OMR::ARM64::MemoryReference::populateMemoryReference(TR::Node *subTree, TR:
 
          if (symbol->isStatic())
             {
-            TR_ASSERT(false, "Not implemented yet.");
+            TR_UNIMPLEMENTED();
             }
          if (symbol->isRegisterMappedSymbol())
             {
@@ -402,7 +402,7 @@ void OMR::ARM64::MemoryReference::consolidateRegisters(TR::Register *srcReg, TR:
 
    if (self()->getUnresolvedSnippet() != NULL)
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
       }
    else
       {
@@ -618,7 +618,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
 
    if (self()->getUnresolvedSnippet())
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
       }
    else
       {
@@ -638,7 +638,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
 
             if (self()->getScale() != 0)
                {
-               TR_ASSERT(false, "Not implemented yet.");
+               TR_UNIMPLEMENTED();
                }
 
             cursor += ARM64_INSTRUCTION_LENGTH;
@@ -688,7 +688,7 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
          else
             {
             /* Register pair, literal, exclusive instructions to be supported */
-            TR_ASSERT(false, "Not implemented yet.");
+            TR_UNIMPLEMENTED();
             }
          }
       }
@@ -701,7 +701,7 @@ uint32_t OMR::ARM64::MemoryReference::estimateBinaryLength(TR::InstOpCode op)
    {
    if (self()->getUnresolvedSnippet() != NULL)
       {
-      TR_ASSERT(false, "Not implemented yet.");
+      TR_UNIMPLEMENTED();
       }
    else
       {
@@ -748,7 +748,7 @@ uint32_t OMR::ARM64::MemoryReference::estimateBinaryLength(TR::InstOpCode op)
          else
             {
             /* Register pair, literal, exclusive instructions to be supported */
-            TR_ASSERT(false, "Not implemented yet.");
+            TR_UNIMPLEMENTED();
             }
          }
       }

--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ OMR::ARM64::RegisterDependencyConditions::RegisterDependencyConditions(
                                        uint32_t          extranum,
                                        TR::Instruction  **cursorPtr)
    {
-   TR_ASSERT(false, "Not implemented yet.");
+   TR_UNIMPLEMENTED();
    }
 
 void OMR::ARM64::RegisterDependencyConditions::unionNoRegPostCondition(TR::Register *reg, TR::CodeGenerator *cg)
@@ -148,8 +148,7 @@ OMR::ARM64::RegisterDependencyConditions::clone(
    TR::CodeGenerator *cg,
    TR::RegisterDependencyConditions *added)
    {
-   TR_ASSERT(false, "Not implemented yet.");
-
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -598,6 +598,6 @@ TR::Register *TR::ARMSystemLinkage::buildDirectDispatch(TR::Node *callNode)
 
 TR::Register *TR::ARMSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    {
-   TR_ASSERT(0, "unimplemented");
+   TR_UNIMPLEMENTED();
    return NULL;
    }

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1115,7 +1115,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lrolEvaluator(TR::Node *node, TR::CodeGen
       }
    else
       {
-      TR_ASSERT(false, "TR::lrol - Not Implemented yet");
+      TR_UNIMPLEMENTED();
       }
 
    node->setRegister(trgReg);

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -758,50 +758,50 @@ TR::Register *OMR::ARM::TreeEvaluator::monexitfenceEvaluator(TR::Node *node, TR:
    return NULL;         //this op code does not evaluate to anything
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::integerHighestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::integerNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::integerNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::integerBitCount(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::longLowestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::longNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
-TR::Register *OMR::ARM::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::integerHighestOneBit(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::integerNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::integerNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::integerBitCount(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::longLowestOneBit(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::longNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
+TR::Register *OMR::ARM::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
 
 TR::Register *OMR::ARM::TreeEvaluator::reverseLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "reverseLoad not implemented yet for this platform");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 TR::Register *OMR::ARM::TreeEvaluator::reverseStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "reverseStore not implemented yet for this platform");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 TR::Register *OMR::ARM::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "arraytranslateAndTest not implemented yet for this platform");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 TR::Register *OMR::ARM::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "arraytranslate not implemented yet for this platform");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 TR::Register *OMR::ARM::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "arrayset not implemented yet for this platform");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 TR::Register *OMR::ARM::TreeEvaluator::arraycmpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "arraycmp not implemented yet for this platform");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 

--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -39,61 +39,57 @@
 #include <unistd.h>
 #endif
 
-
-#define notImplemented(A) TR_ASSERT(0, "TR_FrontEnd::%s is undefined", (A) )
-
-
 TR_ResolvedMethod *
 TR_FrontEnd::createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod *, TR_OpaqueClassBlock *)
    {
-   notImplemented("createResolvedMethod");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uint32_t
 TR_FrontEnd::offsetOfIsOverriddenBit()
    {
-   notImplemented("offsetOfIsOverriddenBit");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR_Debug *
 TR_FrontEnd::createDebug(TR::Compilation *comp)
    {
-   notImplemented("createDebug");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 void
 TR_FrontEnd::acquireLogMonitor()
    {
-   notImplemented("acquireLogMonitor");
+   TR_UNIMPLEMENTED();
    }
 
 void
 TR_FrontEnd::releaseLogMonitor()
    {
-   notImplemented("releaseLogMonitor");
+   TR_UNIMPLEMENTED();
    }
 
 bool
 TR_FrontEnd::classHasBeenExtended(TR_OpaqueClassBlock *)
    {
-   notImplemented("classHasBeenExtended");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_FrontEnd::classHasBeenReplaced(TR_OpaqueClassBlock *)
    {
-   notImplemented("classHasBeenReplaced");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 uint8_t *
 TR_FrontEnd::allocateRelocationData(TR::Compilation * comp, uint32_t numBytes)
    {
-   notImplemented("allocateRelocationData");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -106,36 +102,36 @@ TR_FrontEnd::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
 int32_t
 TR_FrontEnd::getArraySpineShift(int32_t)
    {
-   notImplemented("getArraySpineShift");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 int32_t
 TR_FrontEnd::getArrayletMask(int32_t)
    {
-   notImplemented("getArrayletMask");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 int32_t
 TR_FrontEnd::getArrayletLeafIndex(int32_t, int32_t)
    {
-   notImplemented("getArrayletLeafIndex");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 
-uintptrj_t TR_FrontEnd::getObjectHeaderSizeInBytes()              { notImplemented("getObjectHeaderSizeInBytes"); return 0; }
-uintptrj_t TR_FrontEnd::getOffsetOfContiguousArraySizeField()     { notImplemented("getOffsetOfContiguousArraySizeField"); return 0; }
-uintptrj_t TR_FrontEnd::getOffsetOfDiscontiguousArraySizeField()  { notImplemented("getOffsetOfDiscontiguousArraySizeField"); return 0; }
+uintptrj_t TR_FrontEnd::getObjectHeaderSizeInBytes()              { TR_UNIMPLEMENTED(); return 0; }
+uintptrj_t TR_FrontEnd::getOffsetOfContiguousArraySizeField()     { TR_UNIMPLEMENTED(); return 0; }
+uintptrj_t TR_FrontEnd::getOffsetOfDiscontiguousArraySizeField()  { TR_UNIMPLEMENTED(); return 0; }
 
-uintptrj_t TR_FrontEnd::getOffsetOfIndexableSizeField()           { notImplemented("getOffsetOfIndexableSizeField"); return 0; }
+uintptrj_t TR_FrontEnd::getOffsetOfIndexableSizeField()           { TR_UNIMPLEMENTED(); return 0; }
 
 
 int32_t
 TR_FrontEnd::getObjectAlignmentInBytes()
    {
-   notImplemented("getObjectAlignmentInBytes");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -172,7 +168,7 @@ TR_FrontEnd::getFormattedName(
 TR_OpaqueMethodBlock*
 TR_FrontEnd::getMethodFromName(char * className, char *methodName, char *signature)
    {
-   notImplemented("getMethodFromName");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -180,7 +176,7 @@ TR_FrontEnd::getMethodFromName(char * className, char *methodName, char *signatu
 TR_OpaqueClassBlock *
 TR_FrontEnd::getClassOfMethod(TR_OpaqueMethodBlock *method)
    {
-   notImplemented("getClassOfMethod");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -188,28 +184,28 @@ TR_FrontEnd::getClassOfMethod(TR_OpaqueMethodBlock *method)
 TR_OpaqueClassBlock *
 TR_FrontEnd::getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass)
    {
-   notImplemented("getComponentClassFromArrayClass");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR_OpaqueClassBlock *
 TR_FrontEnd::getArrayClassFromComponentClass(TR_OpaqueClassBlock * componentClass)
    {
-   notImplemented("getArrayClassFromComponentClass");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR_OpaqueClassBlock *
 TR_FrontEnd::getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass)
    {
-   notImplemented("getLeafComponentClassFromArrayClass");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 int32_t
 TR_FrontEnd::getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz)
    {
-   notImplemented("getNewArrayTypeFromClass");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -227,14 +223,14 @@ TR_FrontEnd::getClassFromNewArrayType(int32_t arrayType)
 TR_OpaqueClassBlock *
 TR_FrontEnd::getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT)
    {
-   notImplemented("getClassFromSignature");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR_OpaqueClassBlock *
 TR_FrontEnd::getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMethodBlock *method, bool isVettedForAOT)
    {
-   notImplemented("getClassFromSignature");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -242,7 +238,7 @@ TR_FrontEnd::getClassFromSignature(const char * sig, int32_t length, TR_OpaqueMe
 TR_YesNoMaybe
 TR_FrontEnd::isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBlock * castClass, bool instanceIsFixed, bool castIsFixed, bool optimizeForAOT)
    {
-   notImplemented("isInstanceOf");
+   TR_UNIMPLEMENTED();
    return TR_maybe;
    }
 
@@ -250,21 +246,21 @@ TR_FrontEnd::isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBloc
 TR_OpaqueClassBlock *
 TR_FrontEnd::getSuperClass(TR_OpaqueClassBlock * classPointer)
    {
-   notImplemented("getSuperClass");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 bool
 TR_FrontEnd::isUnloadAssumptionRequired(TR_OpaqueClassBlock *, TR_ResolvedMethod *)
    {
-   notImplemented("isUnloadAssumptionRequired");
+   TR_UNIMPLEMENTED();
    return true;
    }
 
 const char *
 TR_FrontEnd::sampleSignature(TR_OpaqueMethodBlock * aMethod, char * bug, int32_t bufLen, TR_Memory *memory)
    {
-   notImplemented("sampleSignature");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -284,21 +280,21 @@ TR_FrontEnd::getInlinedCallSiteMethod(TR_InlinedCallSite *ics)
 TR_OpaqueClassBlock *
 TR_FrontEnd::getClassFromMethodBlock(TR_OpaqueMethodBlock *mb)
    {
-   notImplemented("getClassFromMethodBlock");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 intptrj_t
 TR_FrontEnd::getStringUTF8Length(uintptrj_t objectPointer)
    {
-   notImplemented("getStringUTF8Length");
+   TR_UNIMPLEMENTED();
    return -1;
    }
 
 char *
 TR_FrontEnd::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t bufferSize)
    {
-   notImplemented("getStringUTF8");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -307,19 +303,19 @@ TR_FrontEnd::getStringUTF8(uintptrj_t objectPointer, char *buffer, intptrj_t buf
 TR_OpaqueClassBlock *
 TR_FrontEnd::getClassClassPointer(TR_OpaqueClassBlock *objectClassPointer)
    {
-   notImplemented("getClassClassPointer");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 void
 TR_FrontEnd::reserveTrampolineIfNecessary(TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding)
    {
-   notImplemented("reserveTrampolineIfNecessary");
+   TR_UNIMPLEMENTED();
    }
 
 intptrj_t
 TR_FrontEnd::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference *symRef, void * callSite)
    {
-   notImplemented("methodTrampolineLookup");
+   TR_UNIMPLEMENTED();
    return 0;
    }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1058,7 +1058,7 @@ void OMR::CodeGenerator::initializeLinkage()
 
 TR::Linkage *OMR::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   TR_ASSERT(0, "Unimplemented createLinkage");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 

--- a/compiler/codegen/OMRELFRelocationResolver.cpp
+++ b/compiler/codegen/OMRELFRelocationResolver.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2017 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,7 @@
 uint32_t
 OMR::ELFRelocationResolver::resolveRelocationType(const TR::StaticRelocation &relocation)
    {
-   TR_ASSERT(false, "Unimplemented for this platform.");
+   TR_UNIMPLEMENTED();
    return static_cast<uint32_t>(-1);
    }
 

--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -297,280 +297,275 @@ bool TR_ResolvedMethod::isDAAIntrinsicMethod()
 #endif
    }
 
-#define notImplemented(A) TR_ASSERT(0, "TR_Method::%s is undefined", (A) )
-
-uint32_t              TR_Method::numberOfExplicitParameters() { notImplemented("numberOfExplicitParameters"); return 0; }
-TR::DataType        TR_Method::parmType(uint32_t)           { notImplemented("parmType"); return TR::NoType; }
-TR::ILOpCodes          TR_Method::directCallOpCode()           { notImplemented("directCallOpCode"); return TR::BadILOp; }
-TR::ILOpCodes          TR_Method::indirectCallOpCode()         { notImplemented("indirectCallOpCode"); return TR::BadILOp; }
-TR::DataType        TR_Method::returnType()                 { notImplemented("returnType"); return TR::NoType; }
-bool                  TR_Method::returnTypeIsUnsigned()       { notImplemented("returnTypeIsUnsigned"); return TR::NoType;}
-uint32_t              TR_Method::returnTypeWidth()            { notImplemented("returnTypeWidth"); return 0; }
-TR::ILOpCodes          TR_Method::returnOpCode()               { notImplemented("returnOpCode"); return TR::BadILOp; }
-uint16_t              TR_Method::classNameLength()            { notImplemented("classNameLength"); return 0; }
-uint16_t              TR_Method::nameLength()                 { notImplemented("nameLength"); return 0; }
-uint16_t              TR_Method::signatureLength()            { notImplemented("signatureLength"); return 0; }
-char *                TR_Method::classNameChars()             { notImplemented("classNameChars"); return 0; }
-char *                TR_Method::nameChars()                  { notImplemented("nameChars"); return 0; }
-char *                TR_Method::signatureChars()             { notImplemented("signatureChars"); return 0; }
-bool                  TR_Method::isConstructor()              { notImplemented("isConstructor"); return false; }
-bool                  TR_Method::isFinalInObject()            { notImplemented("isFinalInObject"); return false; }
-const char *          TR_Method::signature(TR_Memory *, TR_AllocationKind) { notImplemented("signature"); return 0; }
-void                  TR_Method::setArchetypeSpecimen(bool b)            { notImplemented("setArchetypeSpecimen"); }
+uint32_t              TR_Method::numberOfExplicitParameters() { TR_UNIMPLEMENTED(); return 0; }
+TR::DataType          TR_Method::parmType(uint32_t)           { TR_UNIMPLEMENTED(); return TR::NoType; }
+TR::ILOpCodes         TR_Method::directCallOpCode()           { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+TR::ILOpCodes         TR_Method::indirectCallOpCode()         { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+TR::DataType          TR_Method::returnType()                 { TR_UNIMPLEMENTED(); return TR::NoType; }
+bool                  TR_Method::returnTypeIsUnsigned()       { TR_UNIMPLEMENTED(); return TR::NoType;}
+uint32_t              TR_Method::returnTypeWidth()            { TR_UNIMPLEMENTED(); return 0; }
+TR::ILOpCodes         TR_Method::returnOpCode()               { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+uint16_t              TR_Method::classNameLength()            { TR_UNIMPLEMENTED(); return 0; }
+uint16_t              TR_Method::nameLength()                 { TR_UNIMPLEMENTED(); return 0; }
+uint16_t              TR_Method::signatureLength()            { TR_UNIMPLEMENTED(); return 0; }
+char *                TR_Method::classNameChars()             { TR_UNIMPLEMENTED(); return 0; }
+char *                TR_Method::nameChars()                  { TR_UNIMPLEMENTED(); return 0; }
+char *                TR_Method::signatureChars()             { TR_UNIMPLEMENTED(); return 0; }
+bool                  TR_Method::isConstructor()              { TR_UNIMPLEMENTED(); return false; }
+bool                  TR_Method::isFinalInObject()            { TR_UNIMPLEMENTED(); return false; }
+const char *          TR_Method::signature(TR_Memory *, TR_AllocationKind) { TR_UNIMPLEMENTED(); return 0; }
+void                  TR_Method::setArchetypeSpecimen(bool b) { TR_UNIMPLEMENTED(); }
 
 TR_MethodParameterIterator *
 TR_Method::getParameterIterator(TR::Compilation&, TR_ResolvedMethod *)
    {
-   notImplemented("getParameterIterator");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 bool
 TR_Method::isBigDecimalMethod(TR::Compilation * comp)
    {
-   notImplemented("isBigDecimalMethod");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_Method::isUnsafeCAS(TR::Compilation * comp)
    {
-   notImplemented("isUnsafeCAS");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_Method::isUnsafeWithObjectArg(TR::Compilation * comp)
    {
-   notImplemented("isUnsafeWithObjectArg");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_Method::isBigDecimalConvertersMethod(TR::Compilation * comp)
    {
-   notImplemented("isBigDecimalConvertersMethod");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
-#undef notImplemented
-#define notImplemented(A) TR_ASSERT(0, "TR_ResolvedMethod::%s is undefined for %p", (A), this )
+TR_Method *  TR_ResolvedMethod::convertToMethod()                          { TR_UNIMPLEMENTED(); return 0; }
+uint32_t     TR_ResolvedMethod::numberOfParameters()                       { TR_UNIMPLEMENTED(); return 0; }
+uint32_t     TR_ResolvedMethod::numberOfExplicitParameters()               { TR_UNIMPLEMENTED(); return 0; }
+TR::DataType TR_ResolvedMethod::parmType(uint32_t)                         { TR_UNIMPLEMENTED(); return TR::NoType; }
+TR::ILOpCodes TR_ResolvedMethod::directCallOpCode()                        { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+TR::ILOpCodes TR_ResolvedMethod::indirectCallOpCode()                      { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+TR::DataType TR_ResolvedMethod::returnType()                               { TR_UNIMPLEMENTED(); return TR::NoType; }
+uint32_t     TR_ResolvedMethod::returnTypeWidth()                          { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::returnTypeIsUnsigned()                     { TR_UNIMPLEMENTED(); return 0; }
+TR::ILOpCodes TR_ResolvedMethod::returnOpCode()                            { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+uint16_t     TR_ResolvedMethod::classNameLength()                          { TR_UNIMPLEMENTED(); return 0; }
+uint16_t     TR_ResolvedMethod::nameLength()                               { TR_UNIMPLEMENTED(); return 0; }
+uint16_t     TR_ResolvedMethod::signatureLength()                          { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::classNameChars()                           { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::nameChars()                                { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::signatureChars()                           { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isConstructor()                            { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isStatic()                                 { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isAbstract()                               { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isCompilable(TR_Memory *)                  { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isInlineable(TR::Compilation *)            { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isNative()                                 { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isSynchronized()                           { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isPrivate()                                { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isProtected()                              { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isPublic()                                 { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isFinal()                                  { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isStrictFP()                               { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isInterpreted()                            { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isInterpretedForHeuristics()               { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::hasBackwardBranches()                      { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isObjectConstructor()                      { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isNonEmptyObjectConstructor()              { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isCold(TR::Compilation *, bool, TR::ResolvedMethodSymbol * /* = NULL */)             { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isSubjectToPhaseChange(TR::Compilation *) { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isSameMethod(TR_ResolvedMethod *)          { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isNewInstanceImplThunk()                   { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isJNINative()                              { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isJITInternalNative()                      { TR_UNIMPLEMENTED(); return false; }
+//bool         TR_ResolvedMethod::isUnsafeWithObjectArg(TR::Compilation *)    { TR_UNIMPLEMENTED(); return false; }
+void *       TR_ResolvedMethod::resolvedMethodAddress()                    { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::startAddressForJittedMethod()              { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::startAddressForJNIMethod(TR::Compilation *) { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::startAddressForJITInternalNativeMethod()   { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::startAddressForInterpreterOfJittedMethod() { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *) { TR_UNIMPLEMENTED(); return 0; }
+void         TR_ResolvedMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *){ TR_UNIMPLEMENTED(); return; }
 
-TR_Method *  TR_ResolvedMethod::convertToMethod()                          { notImplemented("convertToMethod"); return 0; }
-uint32_t     TR_ResolvedMethod::numberOfParameters()                       { notImplemented("numberOfParameters"); return 0; }
-uint32_t     TR_ResolvedMethod::numberOfExplicitParameters()               { notImplemented("numberOfExplicitParameters"); return 0; }
-TR::DataType TR_ResolvedMethod::parmType(uint32_t)                         { notImplemented("parmType"); return TR::NoType; }
-TR::ILOpCodes TR_ResolvedMethod::directCallOpCode()                         { notImplemented("directCallOpCode"); return TR::BadILOp; }
-TR::ILOpCodes TR_ResolvedMethod::indirectCallOpCode()                       { notImplemented("indirectCallOpCode"); return TR::BadILOp; }
-TR::DataType TR_ResolvedMethod::returnType()                               { notImplemented("returnType"); return TR::NoType; }
-uint32_t     TR_ResolvedMethod::returnTypeWidth()                          { notImplemented("returnTypeWidth"); return 0; }
-bool         TR_ResolvedMethod::returnTypeIsUnsigned()                     { notImplemented("returnTypeIsUnsigned"); return 0; }
-TR::ILOpCodes TR_ResolvedMethod::returnOpCode()                             { notImplemented("returnOpCode"); return TR::BadILOp; }
-uint16_t     TR_ResolvedMethod::classNameLength()                          { notImplemented("classNameLength"); return 0; }
-uint16_t     TR_ResolvedMethod::nameLength()                               { notImplemented("nameLength"); return 0; }
-uint16_t     TR_ResolvedMethod::signatureLength()                          { notImplemented("signatureLength"); return 0; }
-char *       TR_ResolvedMethod::classNameChars()                           { notImplemented("classNameChars"); return 0; }
-char *       TR_ResolvedMethod::nameChars()                                { notImplemented("nameChars"); return 0; }
-char *       TR_ResolvedMethod::signatureChars()                           { notImplemented("signatureChars"); return 0; }
-bool         TR_ResolvedMethod::isConstructor()                            { notImplemented("isConstructor"); return false; }
-bool         TR_ResolvedMethod::isStatic()                                 { notImplemented("isStatic"); return false; }
-bool         TR_ResolvedMethod::isAbstract()                               { notImplemented("isAbstract"); return false; }
-bool         TR_ResolvedMethod::isCompilable(TR_Memory *)                  { notImplemented("isCompilable"); return false; }
-bool         TR_ResolvedMethod::isInlineable(TR::Compilation *)             { notImplemented("isInlineable"); return false; }
-bool         TR_ResolvedMethod::isNative()                                 { notImplemented("isNative"); return false; }
-bool         TR_ResolvedMethod::isSynchronized()                           { notImplemented("isSynchronized"); return false; }
-bool         TR_ResolvedMethod::isPrivate()                                { notImplemented("isPrivate"); return false; }
-bool         TR_ResolvedMethod::isProtected()                              { notImplemented("isProtected"); return false; }
-bool         TR_ResolvedMethod::isPublic()                                 { notImplemented("isPublic"); return false; }
-bool         TR_ResolvedMethod::isFinal()                                  { notImplemented("isFinal"); return false; }
-bool         TR_ResolvedMethod::isStrictFP()                               { notImplemented("isStrictFP"); return false; }
-bool         TR_ResolvedMethod::isInterpreted()                            { notImplemented("isInterpreted"); return false; }
-bool         TR_ResolvedMethod::isInterpretedForHeuristics()               { notImplemented("isInterpretedForHeuristics"); return false; }
-bool         TR_ResolvedMethod::hasBackwardBranches()                      { notImplemented("hasBackwardBranches"); return false; }
-bool         TR_ResolvedMethod::isObjectConstructor()                      { notImplemented("isObjectConstructor"); return false; }
-bool         TR_ResolvedMethod::isNonEmptyObjectConstructor()              { notImplemented("isNonEmptyObjectConstructor"); return false; }
-bool         TR_ResolvedMethod::isCold(TR::Compilation *, bool, TR::ResolvedMethodSymbol * /* = NULL */)             { notImplemented("isCold"); return false; }
-bool         TR_ResolvedMethod::isSubjectToPhaseChange(TR::Compilation *) { notImplemented("isSubjectToPhaseChange"); return false; }
-bool         TR_ResolvedMethod::isSameMethod(TR_ResolvedMethod *)          { notImplemented("isSameMethod"); return false; }
-bool         TR_ResolvedMethod::isNewInstanceImplThunk()                   { notImplemented("isNewInstanceImplThunk"); return false; }
-bool         TR_ResolvedMethod::isJNINative()                              { notImplemented("isJNINative"); return false; }
-bool         TR_ResolvedMethod::isJITInternalNative()                      { notImplemented("isJITInternalNative"); return false; }
-//bool         TR_ResolvedMethod::isUnsafeWithObjectArg(TR::Compilation *)    { notImplemented("isUnsafeWithObjectArg"); return false; }
-void *       TR_ResolvedMethod::resolvedMethodAddress()                    { notImplemented("resolvedMethodAddress"); return 0; }
-void *       TR_ResolvedMethod::startAddressForJittedMethod()              { notImplemented("startAddressForJittedMethod"); return 0; }
-void *       TR_ResolvedMethod::startAddressForJNIMethod(TR::Compilation *) { notImplemented("startAddressForJNIMethod"); return 0; }
-void *       TR_ResolvedMethod::startAddressForJITInternalNativeMethod()   { notImplemented("startAddressForJITInternalNativeMethod"); return 0; }
-void *       TR_ResolvedMethod::startAddressForInterpreterOfJittedMethod() { notImplemented("startAddressForInterpreterOfJittedMethod"); return 0; }
-bool         TR_ResolvedMethod::isWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *) { notImplemented("isWarmCallGraphTooBig"); return 0; }
-void         TR_ResolvedMethod::setWarmCallGraphTooBig(uint32_t bcIndex, TR::Compilation *){ notImplemented("setWarmCallGraphTooBig"); return; }
+TR_FrontEnd *TR_ResolvedMethod::fe()                                       { TR_UNIMPLEMENTED(); return 0; }
+intptrj_t    TR_ResolvedMethod::getInvocationCount()                       { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::setInvocationCount(intptrj_t, intptrj_t)   { TR_UNIMPLEMENTED(); return false; }
+uint16_t     TR_ResolvedMethod::numberOfParameterSlots()                   { TR_UNIMPLEMENTED(); return 0; }
+uint16_t     TR_ResolvedMethod::archetypeArgPlaceholderSlot(TR_Memory *)   { TR_UNIMPLEMENTED(); return 0; }
+uint16_t     TR_ResolvedMethod::numberOfTemps()                            { TR_UNIMPLEMENTED(); return 0; }
+uint16_t     TR_ResolvedMethod::numberOfPendingPushes()                    { TR_UNIMPLEMENTED(); return 0; }
+uint8_t *    TR_ResolvedMethod::bytecodeStart()                            { TR_UNIMPLEMENTED(); return 0; }
+uint32_t     TR_ResolvedMethod::maxBytecodeIndex()                         { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::ramConstantPool()                          { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::constantPool()                             { TR_UNIMPLEMENTED(); return 0; }
 
-TR_FrontEnd *TR_ResolvedMethod::fe()                                       { notImplemented("fe"); return 0; }
-intptrj_t    TR_ResolvedMethod::getInvocationCount()                       { notImplemented("getInvocationCount"); return 0; }
-bool         TR_ResolvedMethod::setInvocationCount(intptrj_t, intptrj_t)   { notImplemented("setInvocationCount"); return false; }
-uint16_t     TR_ResolvedMethod::numberOfParameterSlots()                   { notImplemented("numberOfParameterSlots"); return 0; }
-uint16_t     TR_ResolvedMethod::archetypeArgPlaceholderSlot(TR_Memory *)   { notImplemented("numberOfParameterSlots"); return 0; }
-uint16_t     TR_ResolvedMethod::numberOfTemps()                            { notImplemented("numberOfTemps"); return 0; }
-uint16_t     TR_ResolvedMethod::numberOfPendingPushes()                    { notImplemented("numberOfPendingPushes"); return 0; }
-uint8_t *    TR_ResolvedMethod::bytecodeStart()                            { notImplemented("bytecodeStart"); return 0; }
-uint32_t     TR_ResolvedMethod::maxBytecodeIndex()                         { notImplemented("maxBytecodeIndex"); return 0; }
-void *       TR_ResolvedMethod::ramConstantPool()                          { notImplemented("ramConstantPool"); return 0; }
-void *       TR_ResolvedMethod::constantPool()                             { notImplemented("constantPool"); return 0; }
+TR::DataType TR_ResolvedMethod::getLDCType(int32_t)                        { TR_UNIMPLEMENTED(); return TR::NoType; }
+bool         TR_ResolvedMethod::isClassConstant(int32_t cpIndex)           { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isStringConstant(int32_t cpIndex)          { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isMethodTypeConstant(int32_t cpIndex)      { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isMethodHandleConstant(int32_t cpIndex)    { TR_UNIMPLEMENTED(); return false; }
+uint32_t     TR_ResolvedMethod::intConstant(int32_t)                       { TR_UNIMPLEMENTED(); return 0; }
+uint64_t     TR_ResolvedMethod::longConstant(int32_t)                      { TR_UNIMPLEMENTED(); return 0; }
+float *      TR_ResolvedMethod::floatConstant(int32_t)                     { TR_UNIMPLEMENTED(); return 0; }
+double *     TR_ResolvedMethod::doubleConstant(int32_t, TR_Memory *)       { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::stringConstant(int32_t)                    { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isUnresolvedString(int32_t, bool optimizeForAOT)                { TR_UNIMPLEMENTED(); return false; }
+void *       TR_ResolvedMethod::getConstantDynamicTypeFromCP(int32_t cpIndex)   { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isConstantDynamic(int32_t cpIndex)            { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isUnresolvedConstantDynamic(int32_t cpIndex)  { TR_UNIMPLEMENTED(); return false; }
+void *       TR_ResolvedMethod::dynamicConstant(int32_t cpIndex)              { TR_UNIMPLEMENTED(); return 0; }
+void *       TR_ResolvedMethod::methodTypeConstant(int32_t)                { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isUnresolvedMethodType(int32_t)            { TR_UNIMPLEMENTED(); return false; }
+void *       TR_ResolvedMethod::methodHandleConstant(int32_t)              { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isUnresolvedMethodHandle(int32_t)          { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) { TR_UNIMPLEMENTED(); return false; }
+void *       TR_ResolvedMethod::callSiteTableEntryAddress(int32_t callSiteIndex)      { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex) { TR_UNIMPLEMENTED(); return false; }
+void *       TR_ResolvedMethod::methodTypeTableEntryAddress(int32_t cpIndex)      { TR_UNIMPLEMENTED(); return 0; }
 
-TR::DataType TR_ResolvedMethod::getLDCType(int32_t)                        { notImplemented("getLDCType"); return TR::NoType; }
-bool         TR_ResolvedMethod::isClassConstant(int32_t cpIndex)           { notImplemented("isClassConstant"); return false; }
-bool         TR_ResolvedMethod::isStringConstant(int32_t cpIndex)          { notImplemented("isStringConstant"); return false; }
-bool         TR_ResolvedMethod::isMethodTypeConstant(int32_t cpIndex)      { notImplemented("isMethodTypeConstant"); return false; }
-bool         TR_ResolvedMethod::isMethodHandleConstant(int32_t cpIndex)    { notImplemented("isMethodHandleConstant"); return false; }
-uint32_t     TR_ResolvedMethod::intConstant(int32_t)                       { notImplemented("intConstant"); return 0; }
-uint64_t     TR_ResolvedMethod::longConstant(int32_t)                      { notImplemented("longConstant"); return 0; }
-float *      TR_ResolvedMethod::floatConstant(int32_t)                     { notImplemented("floatConstant"); return 0; }
-double *     TR_ResolvedMethod::doubleConstant(int32_t, TR_Memory *)       { notImplemented("doubleConstant"); return 0; }
-void *       TR_ResolvedMethod::stringConstant(int32_t)                    { notImplemented("stringConstant"); return 0; }
-bool         TR_ResolvedMethod::isUnresolvedString(int32_t, bool optimizeForAOT)                { notImplemented("isUnresolvedString"); return false; }
-void *       TR_ResolvedMethod::getConstantDynamicTypeFromCP(int32_t cpIndex)   { notImplemented("ConstantDynamic"); return 0; }
-bool         TR_ResolvedMethod::isConstantDynamic(int32_t cpIndex)            { notImplemented("ConstantDynamic"); return false; }
-bool         TR_ResolvedMethod::isUnresolvedConstantDynamic(int32_t cpIndex)  { notImplemented("ConstantDynamic"); return false; }
-void *       TR_ResolvedMethod::dynamicConstant(int32_t cpIndex)              { notImplemented("ConstantDynamic"); return 0; }
-void *       TR_ResolvedMethod::methodTypeConstant(int32_t)                { notImplemented("methodTypeConstant"); return 0; }
-bool         TR_ResolvedMethod::isUnresolvedMethodType(int32_t)            { notImplemented("isUnresolvedMethodType"); return false; }
-void *       TR_ResolvedMethod::methodHandleConstant(int32_t)              { notImplemented("methodHandleConstant"); return 0; }
-bool         TR_ResolvedMethod::isUnresolvedMethodHandle(int32_t)          { notImplemented("isUnresolvedMethodHandle"); return false; }
-bool         TR_ResolvedMethod::isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) { notImplemented("isUnresolvedCallSiteTableEntry"); return false; }
-void *       TR_ResolvedMethod::callSiteTableEntryAddress(int32_t callSiteIndex)      { notImplemented("callSiteTableEntryAddress"); return 0; }
-bool         TR_ResolvedMethod::isUnresolvedMethodTypeTableEntry(int32_t cpIndex) { notImplemented("isUnresolvedMethodTypeTableEntry"); return false; }
-void *       TR_ResolvedMethod::methodTypeTableEntryAddress(int32_t cpIndex)      { notImplemented("methodTypeTableEntryAddress"); return 0; }
+TR_OpaqueClassBlock *TR_ResolvedMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)  { TR_UNIMPLEMENTED(); return 0; }
+int32_t      TR_ResolvedMethod::classCPIndexOfFieldOrStatic(int32_t)       { TR_UNIMPLEMENTED(); return 0; }
+const char * TR_ResolvedMethod::signature(TR_Memory *, TR_AllocationKind)  { TR_UNIMPLEMENTED(); return 0; }
+const char * TR_ResolvedMethod::externalName(TR_Memory *, TR_AllocationKind)  { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::fieldName (int32_t, TR_Memory *, TR_AllocationKind kind)           { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::staticName(int32_t, TR_Memory *, TR_AllocationKind kind)           { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, TR_Memory *){ /*TR_UNIMPLEMENTED();*/ return 0; }
+char *       TR_ResolvedMethod::fieldName (int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind) { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::staticName(int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind) { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, int32_t&, TR_Memory *){ /*TR_UNIMPLEMENTED();*/ return 0; }
+char *       TR_ResolvedMethod::fieldNameChars(int32_t, int32_t &)         { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::fieldSignatureChars(int32_t, int32_t &)    { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::staticSignatureChars(int32_t, int32_t &)   { TR_UNIMPLEMENTED(); return 0; }
+void * &     TR_ResolvedMethod::addressOfClassOfMethod()                   { TR_UNIMPLEMENTED(); return *(void **)0; }
+uint32_t     TR_ResolvedMethod::vTableSlot(uint32_t)                       { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::virtualMethodIsOverridden()                { TR_UNIMPLEMENTED(); return false; }
+void         TR_ResolvedMethod::setVirtualMethodIsOverridden()             { TR_UNIMPLEMENTED(); }
+void *       TR_ResolvedMethod::addressContainingIsOverriddenBit()         { TR_UNIMPLEMENTED(); return 0; }
+int32_t     TR_ResolvedMethod::virtualCallSelector(uint32_t)               { TR_UNIMPLEMENTED(); return 0; }
+uint32_t     TR_ResolvedMethod::numberOfExceptionHandlers()                { TR_UNIMPLEMENTED(); return 0; }
+uint8_t *    TR_ResolvedMethod::allocateException(uint32_t,TR::Compilation*){ TR_UNIMPLEMENTED(); return 0; }
 
-TR_OpaqueClassBlock *TR_ResolvedMethod::getDeclaringClassFromFieldOrStatic(TR::Compilation *comp, int32_t cpIndex)  { notImplemented("getDeclaringClassFromFieldOrStatic"); return 0; }
-int32_t      TR_ResolvedMethod::classCPIndexOfFieldOrStatic(int32_t)       { notImplemented("classCPIndexOfFieldOrStatic"); return 0; }
-const char * TR_ResolvedMethod::signature(TR_Memory *, TR_AllocationKind)  { notImplemented("signature"); return 0; }
-const char * TR_ResolvedMethod::externalName(TR_Memory *, TR_AllocationKind)  { notImplemented("signature"); return 0; }
-char *       TR_ResolvedMethod::fieldName (int32_t, TR_Memory *, TR_AllocationKind kind)           { notImplemented("fieldName"); return 0; }
-char *       TR_ResolvedMethod::staticName(int32_t, TR_Memory *, TR_AllocationKind kind)           { notImplemented("staticName"); return 0; }
-char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, TR_Memory *){ /*notImplemented("localName");*/ return 0; }
-char *       TR_ResolvedMethod::fieldName (int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind){ notImplemented("fieldName"); return 0; }
-char *       TR_ResolvedMethod::staticName(int32_t, int32_t &, TR_Memory *, TR_AllocationKind kind){ notImplemented("staticName"); return 0; }
-char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, int32_t&, TR_Memory *){ /*notImplemented("localName");*/ return 0; }
-char *       TR_ResolvedMethod::fieldNameChars(int32_t, int32_t &)         { notImplemented("fieldNameChars"); return 0; }
-char *       TR_ResolvedMethod::fieldSignatureChars(int32_t, int32_t &)    { notImplemented("fieldSignatureChars"); return 0; }
-char *       TR_ResolvedMethod::staticSignatureChars(int32_t, int32_t &)   { notImplemented("staticSignatureChars"); return 0; }
-void * &     TR_ResolvedMethod::addressOfClassOfMethod()                   { notImplemented("addressOfClassOfMethod"); return *(void **)0; }
-uint32_t     TR_ResolvedMethod::vTableSlot(uint32_t)                       { notImplemented("vTableSlot"); return 0; }
-bool         TR_ResolvedMethod::virtualMethodIsOverridden()                { notImplemented("virtualMethodIsOverridden"); return false; }
-void         TR_ResolvedMethod::setVirtualMethodIsOverridden()             { notImplemented("setVirtualMethodIsOverridden"); }
-void *       TR_ResolvedMethod::addressContainingIsOverriddenBit()         { notImplemented("addressContainingIsOverriddenBit"); return 0; }
-int32_t     TR_ResolvedMethod::virtualCallSelector(uint32_t)               { notImplemented("virtualCallSelector"); return 0; }
-uint32_t     TR_ResolvedMethod::numberOfExceptionHandlers()                { notImplemented("numberOfExceptionHandlers"); return 0; }
-uint8_t *    TR_ResolvedMethod::allocateException(uint32_t,TR::Compilation*){ notImplemented("allocateException"); return 0; }
-
-int32_t      TR_ResolvedMethod::exceptionData(int32_t, int32_t *, int32_t *, int32_t *) { notImplemented("exceptionData"); return 0; }
-char *       TR_ResolvedMethod::getClassNameFromConstantPool(uint32_t, uint32_t &)      { notImplemented("getClassNameFromConstantPool"); return 0; }
-bool         TR_ResolvedMethod::fieldsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame)    { notImplemented("fieldsAreSame"); return false; }
-bool         TR_ResolvedMethod::staticsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame)   { notImplemented("staticsAreSame"); return false; }
-char *       TR_ResolvedMethod::classNameOfFieldOrStatic(int32_t, int32_t &)            { notImplemented("classNameOfFieldOrStatic"); return 0; }
-char *       TR_ResolvedMethod::classSignatureOfFieldOrStatic(int32_t, int32_t &)       { notImplemented("classSignatureOfFieldOrStatic"); return 0; }
-char *       TR_ResolvedMethod::staticNameChars(int32_t, int32_t &)                     { notImplemented("staticNameChars"); return 0; }
-const char * TR_ResolvedMethod::newInstancePrototypeSignature(TR_Memory *, TR_AllocationKind)        { notImplemented("newInstancePrototypeSignature"); return 0; }
+int32_t      TR_ResolvedMethod::exceptionData(int32_t, int32_t *, int32_t *, int32_t *) { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::getClassNameFromConstantPool(uint32_t, uint32_t &)      { TR_UNIMPLEMENTED(); return 0; }
+bool         TR_ResolvedMethod::fieldsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame)    { TR_UNIMPLEMENTED(); return false; }
+bool         TR_ResolvedMethod::staticsAreSame(int32_t, TR_ResolvedMethod *, int32_t, bool &sigSame)   { TR_UNIMPLEMENTED(); return false; }
+char *       TR_ResolvedMethod::classNameOfFieldOrStatic(int32_t, int32_t &)            { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::classSignatureOfFieldOrStatic(int32_t, int32_t &)       { TR_UNIMPLEMENTED(); return 0; }
+char *       TR_ResolvedMethod::staticNameChars(int32_t, int32_t &)                     { TR_UNIMPLEMENTED(); return 0; }
+const char * TR_ResolvedMethod::newInstancePrototypeSignature(TR_Memory *, TR_AllocationKind)          { TR_UNIMPLEMENTED(); return 0; }
 
 bool
 TR_ResolvedMethod::getUnresolvedFieldInCP(int32_t)
    {
-   notImplemented("getUnresolvedFieldInCP");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_ResolvedMethod::getUnresolvedStaticMethodInCP(int32_t)
    {
-   notImplemented("getUnresolvedStaticMethodInCP");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_ResolvedMethod::getUnresolvedSpecialMethodInCP(int32_t)
    {
-   notImplemented("getUnresolvedSpecialMethodInCP");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_ResolvedMethod::getUnresolvedVirtualMethodInCP(int32_t)
    {
-   notImplemented("getUnresolvedVirtualMethod");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_ResolvedMethod::fieldAttributes(TR::Compilation *, int32_t, uint32_t *, TR::DataType *, bool *, bool *, bool *, bool, bool *, bool)
    {
-   notImplemented("fieldAttributes");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
 TR_ResolvedMethod::staticAttributes(TR::Compilation *, int32_t, void * *, TR::DataType *, bool *, bool *, bool *, bool, bool *, bool)
    {
-   notImplemented("staticAttributes");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
-TR_OpaqueClassBlock * TR_ResolvedMethod::containingClass()                                 { notImplemented("containingClass"); return 0; }
-TR_OpaqueClassBlock * TR_ResolvedMethod::getClassFromConstantPool(TR::Compilation *, uint32_t, bool) { notImplemented("getClassFromConstantPool"); return 0; }
-TR_OpaqueClassBlock * TR_ResolvedMethod::classOfStatic(int32_t, bool)                            { notImplemented("classOfStatic"); return 0; }
-TR_OpaqueClassBlock * TR_ResolvedMethod::classOfMethod()                                   { notImplemented("classOfMethod"); return 0; }
-uint32_t              TR_ResolvedMethod::classCPIndexOfMethod(uint32_t)                    { notImplemented("classCpIndexOfMethod"); return 0; }
+TR_OpaqueClassBlock * TR_ResolvedMethod::containingClass()                                 { TR_UNIMPLEMENTED(); return 0; }
+TR_OpaqueClassBlock * TR_ResolvedMethod::getClassFromConstantPool(TR::Compilation *, uint32_t, bool) { TR_UNIMPLEMENTED(); return 0; }
+TR_OpaqueClassBlock * TR_ResolvedMethod::classOfStatic(int32_t, bool)                            { TR_UNIMPLEMENTED(); return 0; }
+TR_OpaqueClassBlock * TR_ResolvedMethod::classOfMethod()                                   { TR_UNIMPLEMENTED(); return 0; }
+uint32_t              TR_ResolvedMethod::classCPIndexOfMethod(uint32_t)                    { TR_UNIMPLEMENTED(); return 0; }
 
-TR_OpaqueMethodBlock *TR_ResolvedMethod::getNonPersistentIdentifier()                      { notImplemented("getNonPersistentIdentifier"); return 0; }
-TR_OpaqueMethodBlock *TR_ResolvedMethod::getPersistentIdentifier()                         { notImplemented("getPersistentIdentifier"); return 0; }
-TR_OpaqueClassBlock * TR_ResolvedMethod::getResolvedInterfaceMethod(int32_t, uintptrj_t *) { notImplemented("getResolvedInterfaceMethod"); return 0; }
+TR_OpaqueMethodBlock *TR_ResolvedMethod::getNonPersistentIdentifier()                      { TR_UNIMPLEMENTED(); return 0; }
+TR_OpaqueMethodBlock *TR_ResolvedMethod::getPersistentIdentifier()                         { TR_UNIMPLEMENTED(); return 0; }
+TR_OpaqueClassBlock * TR_ResolvedMethod::getResolvedInterfaceMethod(int32_t, uintptrj_t *) { TR_UNIMPLEMENTED(); return 0; }
 
-TR_ResolvedMethod * TR_ResolvedMethod::owningMethod()                                      { notImplemented("owningMethod"); return 0; }
-void TR_ResolvedMethod::setOwningMethod(TR_ResolvedMethod*)                                { notImplemented("setOwningMethod");  }
+TR_ResolvedMethod * TR_ResolvedMethod::owningMethod()                                      { TR_UNIMPLEMENTED(); return 0; }
+void TR_ResolvedMethod::setOwningMethod(TR_ResolvedMethod*)                                { TR_UNIMPLEMENTED();  }
 
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedStaticMethod (TR::Compilation *, int32_t, bool *)           { notImplemented("getResolvedStaticMethod"); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedSpecialMethod(TR::Compilation *, int32_t, bool *)           { notImplemented("getResolvedSpecialMethod"); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedVirtualMethod(TR::Compilation *, int32_t, bool, bool *)     { notImplemented("getResolvedVirtualMethod"); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedDynamicMethod(TR::Compilation *, int32_t, bool *)           { notImplemented("getResolvedDynamicMethod"); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethod (TR::Compilation *, int32_t, bool *)           { notImplemented("getResolvedHandleMethod"); return 0; }
-TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethodWithSignature(TR::Compilation *, int32_t, char *){notImplemented("getResolvedHandleMethodWithSignature"); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedStaticMethod (TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedSpecialMethod(TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedVirtualMethod(TR::Compilation *, int32_t, bool, bool *)     { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedDynamicMethod(TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethod (TR::Compilation *, int32_t, bool *)           { TR_UNIMPLEMENTED(); return 0; }
+TR_ResolvedMethod * TR_ResolvedMethod::getResolvedHandleMethodWithSignature(TR::Compilation *, int32_t, char *) { TR_UNIMPLEMENTED(); return 0; }
 
 uint32_t
 TR_ResolvedMethod::getResolvedInterfaceMethodOffset(TR_OpaqueClassBlock *, int32_t)
    {
-   notImplemented("getResolvedInterfaceMethodOffset");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR_ResolvedMethod *
 TR_ResolvedMethod::getResolvedInterfaceMethod(TR::Compilation *, TR_OpaqueClassBlock *, int32_t)
    {
-   notImplemented("getResolvedInterfaceMethod");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR_ResolvedMethod *
 TR_ResolvedMethod::getResolvedVirtualMethod(TR::Compilation *, TR_OpaqueClassBlock *, int32_t, bool)
    {
-   notImplemented("getResolvedVirtualMethod");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 void
 TR_ResolvedMethod::setMethodHandleLocation(uintptrj_t *location)
    {
-   notImplemented("setMethodHandleLocation");
+   TR_UNIMPLEMENTED();
    }
 
 TR::IlGeneratorMethodDetails *
 TR_ResolvedMethod::getIlGeneratorMethodDetails()
    {
-   notImplemented("getIlGeneratorMethodDetails");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR::SymbolReferenceTable *
 TR_ResolvedMethod::_genMethodILForPeeking(TR::ResolvedMethodSymbol *, TR::Compilation *, bool resetVisitCount, TR_PrexArgInfo  *argInfo)
    {
-   notImplemented("genMethodILForPeeking");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -448,7 +448,7 @@ char *       TR_ResolvedMethod::localName (uint32_t, uint32_t, int32_t&, TR_Memo
 char *       TR_ResolvedMethod::fieldNameChars(int32_t, int32_t &)         { TR_UNIMPLEMENTED(); return 0; }
 char *       TR_ResolvedMethod::fieldSignatureChars(int32_t, int32_t &)    { TR_UNIMPLEMENTED(); return 0; }
 char *       TR_ResolvedMethod::staticSignatureChars(int32_t, int32_t &)   { TR_UNIMPLEMENTED(); return 0; }
-void * &     TR_ResolvedMethod::addressOfClassOfMethod()                   { TR_UNIMPLEMENTED(); return *(void **)0; }
+void * &     TR_ResolvedMethod::addressOfClassOfMethod()                   { TR_UNIMPLEMENTED(); }
 uint32_t     TR_ResolvedMethod::vTableSlot(uint32_t)                       { TR_UNIMPLEMENTED(); return 0; }
 bool         TR_ResolvedMethod::virtualMethodIsOverridden()                { TR_UNIMPLEMENTED(); return false; }
 void         TR_ResolvedMethod::setVirtualMethodIsOverridden()             { TR_UNIMPLEMENTED(); }

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -195,8 +195,6 @@ char *feGetEnv(const char *s)
    }
 
 
-#define notImplemented(A) TR_ASSERT(0, "This function is not defined for FEBase %s", (A) )
-
 // Brought this debug stuff from Compilation.cpp
 //
 // Limit on the size of the debug string
@@ -266,20 +264,20 @@ void TR_LinkageInfo::setHasFailedRecompilation()
 
 // S390 specific fucntion - FIXME: make this only be a problem when HOST is s390.  Also, use a better
 // name for this
-void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName,  TR::Compilation *comp) { notImplemented("setDllSlip"); }
+void setDllSlip(char*CodeStart,char*CodeEnd,char*dllName,  TR::Compilation *comp) { TR_UNIMPLEMENTED(); }
 
 // runtime assumptions
 #ifdef J9_PROJECT_SPECIFIC
 // FIXME:
 #include "runtime/RuntimeAssumptions.hpp"
-void TR::PatchNOPedGuardSite::compensate(TR_FrontEnd *fe, bool isSMP, uint8_t *location, uint8_t *destination) { notImplemented("TR::PatchNOPedGuardSite::compensate"); }
-void TR_PersistentClassInfo::removeASubClass(TR_PersistentClassInfo *) { notImplemented("TR_PersistentClassInfo::removeASubClass"); }
-bool isOrderedPair(uint8_t recordType) { notImplemented("isOrderedPair"); return false; }
-void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption** sentinel) { notImplemented("addToRAT"); }
-void OMR::RuntimeAssumption::dumpInfo(char *subclassName) { notImplemented("dumpInfo"); }
-void TR_PatchJNICallSite::compensate(TR_FrontEnd*, bool, void *) { notImplemented("TR_PatchJNICallSite::compensate"); }
-void TR_PreXRecompile::compensate(TR_FrontEnd*, bool, void *) { notImplemented("TR_PreXRecompile::compensate"); }
-TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInitialize::make(TR_FrontEnd *fe, TR_PersistentMemory *, char*, unsigned int, unsigned char*, unsigned char*, OMR::RuntimeAssumption**) { notImplemented("TR_PatchNOPedGuardSiteOnClassPreInitialize::allocate"); return 0; }
+void TR::PatchNOPedGuardSite::compensate(TR_FrontEnd *fe, bool isSMP, uint8_t *location, uint8_t *destination) { TR_UNIMPLEMENTED(); }
+void TR_PersistentClassInfo::removeASubClass(TR_PersistentClassInfo *) { TR_UNIMPLEMENTED(); }
+bool isOrderedPair(uint8_t recordType) { TR_UNIMPLEMENTED(); return false; }
+void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory * persistentMemory, TR_RuntimeAssumptionKind kind, TR_FrontEnd *fe, OMR::RuntimeAssumption** sentinel) { TR_UNIMPLEMENTED(); }
+void OMR::RuntimeAssumption::dumpInfo(char *subclassName) { TR_UNIMPLEMENTED(); }
+void TR_PatchJNICallSite::compensate(TR_FrontEnd*, bool, void *) { TR_UNIMPLEMENTED(); }
+void TR_PreXRecompile::compensate(TR_FrontEnd*, bool, void *) { TR_UNIMPLEMENTED(); }
+TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInitialize::make(TR_FrontEnd *fe, TR_PersistentMemory *, char*, unsigned int, unsigned char*, unsigned char*, OMR::RuntimeAssumption**) { TR_UNIMPLEMENTED(); return 0; }
 #endif
 
 

--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -27,8 +27,6 @@
 #include "infra/Assert.hpp"
 #include "compile/Compilation.hpp"
 
-#define notImplemented(A) TR_ASSERT(0, "OMR::ClassEnv::%s is undefined", (A) )
-
 char *
 OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef, int32_t & len)
    {
@@ -40,7 +38,7 @@ OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef
 uintptrj_t
 OMR::ClassEnv::getArrayElementWidthInBytes(TR::Compilation *comp, TR_OpaqueClassBlock* arrayClass)
    {
-   notImplemented("getArrayElementWidthInBytes");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/compiler/env/OMRDebugEnv.cpp
+++ b/compiler/env/OMRDebugEnv.cpp
@@ -36,6 +36,6 @@ OMR::DebugEnv::breakPoint()
 #if defined(LINUX) || defined(AIXPPC)
    raise(SIGTRAP);
 #else
-   TR_ASSERT(0, "Not implemented yet: OMR::DebugEnv::breakPoint");
+   TR_UNIMPLEMENTED();
 #endif
    }

--- a/compiler/env/OMRKnownObjectTable.cpp
+++ b/compiler/env/OMRKnownObjectTable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,9 +28,6 @@
 #include "env/CompilerEnv.hpp"
 
 
-#define notImplemented(A) TR_ASSERT(0, "TR_FrontEnd::%s is undefined", (A) )
-
-
 OMR::KnownObjectTable::KnownObjectTable(TR::Compilation *comp) :
       _comp(comp),
       _fe(comp->fe()),
@@ -47,14 +44,14 @@ OMR::KnownObjectTable::self()
 TR::KnownObjectTable::Index
 OMR::KnownObjectTable::getEndIndex()
    {
-   notImplemented("OMR::KnownObjectTable::getEndIndex");
+   TR_UNIMPLEMENTED();
    return -1;
    }
 
 TR::KnownObjectTable::Index
 OMR::KnownObjectTable::getIndex(uintptrj_t objectPointer)
    {
-   notImplemented("OMR::KnownObjectTable::getIndex");
+   TR_UNIMPLEMENTED();
    return -1;
    }
 
@@ -92,21 +89,21 @@ OMR::KnownObjectTable::isArrayWithConstantElements(Index index)
 uintptrj_t *
 OMR::KnownObjectTable::getPointerLocation(Index index)
    {
-   notImplemented("OMR::KnownObjectTable::getPointerLocation");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 bool
 OMR::KnownObjectTable::isNull(Index index)
    {
-   notImplemented("OMR::KnownObjectTable::isNull");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 void
 OMR::KnownObjectTable::dumpTo(TR::FILE *file, TR::Compilation *comp)
    {
-   notImplemented("OMR::KnownObjectTable::dumpTo");
+   TR_UNIMPLEMENTED();
    }
 
 TR::KnownObjectTable::Index

--- a/compiler/env/OMRObjectModel.cpp
+++ b/compiler/env/OMRObjectModel.cpp
@@ -32,8 +32,6 @@
 
 namespace TR { class Node; }
 
-#define notImplemented(A) TR_ASSERT(0, "OMR::ObjectModel::%s is undefined", (A) )
-
 OMR::ObjectModel::ObjectModel()
    {
    }
@@ -41,7 +39,7 @@ OMR::ObjectModel::ObjectModel()
 int32_t
 OMR::ObjectModel::sizeofReferenceField()
    {
-   notImplemented("sizeofReferenceField");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -54,7 +52,7 @@ OMR::ObjectModel::sizeofReferenceAddress()
 uintptrj_t
 OMR::ObjectModel::elementSizeOfBooleanArray()
    {
-   notImplemented("elementSizeOfBooleanArray");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -62,7 +60,7 @@ OMR::ObjectModel::elementSizeOfBooleanArray()
 uint32_t
 OMR::ObjectModel::getSizeOfArrayElement(TR::Node * node)
    {
-   notImplemented("getSizeOfArrayElement");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -81,42 +79,42 @@ OMR::ObjectModel::maxArraySizeInElements(int32_t knownMinElementSize, TR::Compil
 bool
 OMR::ObjectModel::isDiscontiguousArray(TR::Compilation* comp, uintptrj_t objectPointer)
    {
-   notImplemented("isDiscontiguousArray");
+   TR_UNIMPLEMENTED();
    return false;
    }
 
 intptrj_t
 OMR::ObjectModel::getArrayLengthInElements(TR::Compilation* comp, uintptrj_t objectPointer)
    {
-   notImplemented("getArrayLengthInElements");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uintptrj_t
 OMR::ObjectModel::getArrayLengthInBytes(TR::Compilation* comp, uintptrj_t objectPointer)
    {
-   notImplemented("getArrayLengthInBytes");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uintptrj_t
 OMR::ObjectModel::getArrayElementWidthInBytes(TR::DataType type)
    {
-   notImplemented("getArrayElementWidthInBytes");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uintptrj_t
 OMR::ObjectModel::getArrayElementWidthInBytes(TR::Compilation* comp, uintptrj_t objectPointer)
    {
-   notImplemented("getArrayElementWidthInBytes");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uintptrj_t
 OMR::ObjectModel::decompressReference(TR::Compilation* comp, uintptrj_t compressedReference)
    {
-   notImplemented("decompressReference");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/compiler/env/OMRVMEnv.cpp
+++ b/compiler/env/OMRVMEnv.cpp
@@ -38,9 +38,6 @@
 
 namespace TR { class Node; }
 
-#define notImplemented(A) TR_ASSERT(0, "OMR::VMEnv::%s is undefined", (A) )
-
-
 TR::VMEnv *
 OMR::VMEnv::self()
    {
@@ -51,7 +48,7 @@ OMR::VMEnv::self()
 uintptrj_t
 OMR::VMEnv::heapBaseAddress()
    {
-   notImplemented("heapBaseAddress");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/compiler/infra/Assert.hpp
+++ b/compiler/infra/Assert.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/infra/Assert.hpp
+++ b/compiler/infra/Assert.hpp
@@ -43,6 +43,10 @@
  * \def TR_ASSERT               a macro that defines an assertion which is compiled out
  *                              (including format strings) during production builds
  *
+ * \def TR_UNIMPLEMENTED        a macro that expands into an unconditional assertion
+ *                              failure. Used to indicate that a function has not been
+ *                              implemented and may not be called.
+ *
  * We also provide Expect and Ensure, based on the developing C++ Core guidelines [1].
  *
  * \def Expect                  Precondition macro, only defined for DEBUG and
@@ -66,6 +70,9 @@
 
 #include "infra/Annotations.hpp"                // OMR_NORETURN
 #include "compile/CompilationException.hpp"
+
+#include <cstddef>
+
 namespace TR
    {
    void OMR_NORETURN trap();
@@ -99,6 +106,9 @@ namespace TR
 
 #define TR_ASSERT_FATAL(condition, format, ...) \
          do { (condition) ? (void)0 : TR::fatal_assertion(__FILE__, __LINE__, #condition, format, ##__VA_ARGS__); } while(0)
+
+#define TR_UNIMPLEMENTED() \
+         ::TR::fatal_assertion(__FILE__, __LINE__, NULL, "Unimplemented function: %s", __FUNCTION__)
 
 #if defined(DEBUG) || defined(PROD_WITH_ASSUMES)
 

--- a/compiler/infra/List.hpp
+++ b/compiler/infra/List.hpp
@@ -653,7 +653,7 @@ template <class T> class TR_Queue : public TR_ScratchList<T>
 
    ListElement<T> *getLastElement()      { return getListTail(); }
 
-   T *remove(T *elem) { TR_ASSERT(0, "remove is not implemented for ListHeadAndTail"); }
+   T *remove(T *elem) { TR_UNIMPLEMENTED(); }
    };
 
 

--- a/compiler/infra/OMRMonitor.hpp
+++ b/compiler/infra/OMRMonitor.hpp
@@ -34,9 +34,6 @@ namespace OMR { typedef OMR::Monitor MonitorConnector; }
 
 namespace TR { class Monitor; }
 
-#define NOT_IMPL { TR_ASSERT(false, "not implemented by project"); return 0; }
-#define NOT_IMPL_VOID { TR_ASSERT(false, "not implemented by project"); }
-
 namespace OMR
 {
 
@@ -50,14 +47,14 @@ class Monitor
    static TR::Monitor *create(char *name);
    static void destroy(TR::Monitor *monitor);
    void enter();
-   int32_t try_enter() NOT_IMPL;
+   int32_t try_enter() { TR_UNIMPLEMENTED(); }
    int32_t exit(); // returns 0 on success
    void destroy();
-   void wait() NOT_IMPL_VOID;
-   intptr_t wait_timed(int64_t millis, int32_t nanos) NOT_IMPL;
-   void notify() NOT_IMPL_VOID;
-   void notifyAll() NOT_IMPL_VOID;
-   int32_t num_waiting() NOT_IMPL;
+   void wait() { TR_UNIMPLEMENTED(); }
+   intptr_t wait_timed(int64_t millis, int32_t nanos) { TR_UNIMPLEMENTED(); }
+   void notify() { TR_UNIMPLEMENTED(); }
+   void notifyAll() { TR_UNIMPLEMENTED(); }
+   int32_t num_waiting() { TR_UNIMPLEMENTED(); }
    char const *getName();
    bool init(char *name);
 
@@ -71,8 +68,5 @@ class Monitor
    };
 
 }
-
-#undef NOT_IMPL
-#undef NOT_IMPL_VOID
 
 #endif

--- a/compiler/infra/OMRMonitorTable.hpp
+++ b/compiler/infra/OMRMonitorTable.hpp
@@ -43,8 +43,8 @@ class OMR_EXTENSIBLE MonitorTable
 
    static TR::MonitorTable *get() { return _instance; }
 
-   void free() { TR_ASSERT(false, "not implemented by project"); }
-   void removeAndDestroy(TR::Monitor *monitor) { TR_ASSERT(false, "not implemented by project"); }
+   void free() { TR_UNIMPLEMENTED(); }
+   void removeAndDestroy(TR::Monitor *monitor) { TR_UNIMPLEMENTED(); }
 
    TR::Monitor *getMemoryAllocMonitor() { return _memoryAllocMonitor; }
    TR::Monitor *getScratchMemoryPoolMonitor() { return _scratchMemoryPoolMonitor; }
@@ -69,7 +69,7 @@ class OMR_EXTENSIBLE MonitorTable
    friend class TR::Monitor;
    friend class TR::MonitorTable;
 
-   TR::Monitor *create(char *name) { TR_ASSERT(false, "not implemented by project"); return 0; }
+   TR::Monitor *create(char *name) { TR_UNIMPLEMENTED(); return 0; }
    };
 
 }

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -3401,7 +3401,6 @@ TR::Node *constrainMonexitfence(OMR::ValuePropagation *vp, TR::Node *node)
 
 TR::Node *constrainTstart(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   //TR_ASSERT(0, "Not implemented!");
    constrainChildren(vp,node);
    vp->setUnreachablePath(); // no fallthrough
    return node;
@@ -3409,14 +3408,12 @@ TR::Node *constrainTstart(OMR::ValuePropagation *vp, TR::Node *node)
 
 TR::Node *constrainTfinish(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   //TR_ASSERT(0, "Not implemented!");
    constrainChildren(vp,node);
    return node;
    }
 
 TR::Node *constrainTabort(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   //TR_ASSERT(0, "Not implemented!");
    constrainChildren(vp,node);
    return node;
    }

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -2353,13 +2353,13 @@ TR::Register *OMR::Power::TreeEvaluator::fRegStoreEvaluator(TR::Node *node, TR::
 
 TR::Register *OMR::Power::TreeEvaluator::iexpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "not implemented");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 TR::Register *OMR::Power::TreeEvaluator::lexpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "not implemented");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
@@ -2367,7 +2367,7 @@ TR::Register *OMR::Power::TreeEvaluator::lexpEvaluator(TR::Node *node, TR::CodeG
 // also handles fexp
 TR::Register *OMR::Power::TreeEvaluator::dexpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "not implemented");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -3669,7 +3669,7 @@ TR::Register *OMR::Power::TreeEvaluator::reverseStoreEvaluator(TR::Node *node, T
 #endif
       {
       // somehow break here because we have an unimplemented
-      TR_ASSERT(0, "reverseStore not implemented yet for this platform");
+      TR_UNIMPLEMENTED();
       return NULL;
       }
    }
@@ -3693,7 +3693,7 @@ TR::Register *OMR::Power::TreeEvaluator::reverseLoadEvaluator(TR::Node *node, TR
 #endif
      {
      // somehow break here because we have an unimplemented
-     TR_ASSERT(0, "reverseLoad not implemented yet for this platform");
+     TR_UNIMPLEMENTED();
      return NULL;
      }
    }
@@ -6125,7 +6125,7 @@ TR::Register *OMR::Power::TreeEvaluator::integerHighestOneBit(
    return inlineIntegerHighestOneBit(node, cg);
    }
 
-TR::Register *OMR::Power::TreeEvaluator::integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
+TR::Register *OMR::Power::TreeEvaluator::integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_UNIMPLEMENTED(); return NULL; }
 
 TR::Register *OMR::Power::TreeEvaluator::integerNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -6147,7 +6147,7 @@ TR::Register *OMR::Power::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::C
    return inlineLongHighestOneBit(node, cg);
    }
 
-TR::Register *OMR::Power::TreeEvaluator::longLowestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_ASSERT(0, "not implemented!"); return NULL; }
+TR::Register *OMR::Power::TreeEvaluator::longLowestOneBit(TR::Node *node, TR::CodeGenerator *cg){ TR_UNIMPLEMENTED(); return NULL; }
 
 TR::Register *OMR::Power::TreeEvaluator::longNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -2730,7 +2730,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bmul", node, cg);
-   TR_ASSERT( 0,"bmulEvaluator: not implemented\n");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -2741,7 +2741,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::smulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("smul", node, cg);
-   TR_ASSERT( 0, "smulEvaluator: not implemented\n");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -2902,7 +2902,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bdivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("bdiv", node, cg);
-   TR_ASSERT( 0, "bdivEvaluator: not implemented\n");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -2914,7 +2914,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sdivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("sdiv", node, cg);
-   TR_ASSERT( 0,"sdivEvaluator: not implemented\n");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -3054,7 +3054,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("brem", node, cg);
-   TR_ASSERT( 0, "bremEvaluator: not implemented\n");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -3066,7 +3066,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::sremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    PRINT_ME("srem", node, cg);
-   TR_ASSERT( 0, "sremEvaluator: not implemented\n");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 

--- a/compiler/z/codegen/CompareAnalyser.cpp
+++ b/compiler/z/codegen/CompareAnalyser.cpp
@@ -46,7 +46,7 @@ void
 TR_S390CompareAnalyser::integerCompareAnalyser(TR::Node * root, TR::InstOpCode::Mnemonic regRegOpCode, TR::InstOpCode::Mnemonic regMemOpCode,
    TR::InstOpCode::Mnemonic memRegOpCode)
    {
-   TR_ASSERT( 0, "TR_S390CompareAnalyser::integerCompareAnalyser: Not implemented yet");
+   TR_UNIMPLEMENTED();
    return;
    }
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -9749,7 +9749,7 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
       else
          {
          // We probably have not yet implemented all possible cases here.
-         TR_ASSERT(0, "loadaddrEvaluator: Not Implemented yet\n");
+         TR_UNIMPLEMENTED();
          }
       }
    return targetRegister;
@@ -14334,7 +14334,7 @@ TR::Register *OMR::Z::TreeEvaluator::integerNumberOfTrailingZeros(TR::Node *node
 
 TR::Register *OMR::Z::TreeEvaluator::integerBitCount(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "not implemented!");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
@@ -14355,7 +14355,7 @@ TR::Register *OMR::Z::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, T
 
 TR::Register *OMR::Z::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(0, "not implemented!");
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 

--- a/fvtest/compilertest/env/FrontEnd.cpp
+++ b/fvtest/compilertest/env/FrontEnd.cpp
@@ -41,8 +41,6 @@
 
 #define RANGE_NEEDS_FOUR_BYTE_OFFSET(r) (((r) >= (USHRT_MAX   )) ? 1 : 0)
 
-#define notImplemented(A) TR_ASSERT(0, "This function is not defined for TestCompiler::FrontEnd %s", (A) )
-
 namespace TestCompiler
 {
 
@@ -72,7 +70,7 @@ FrontEnd::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMet
 intptrj_t
 FrontEnd::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference *symRef, void *callSite)
    {
-   TR_ASSERT(0, "methodTrampolineLookup not implemented yet");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/fvtest/compilertest/p/codegen/Evaluator.cpp
+++ b/fvtest/compilertest/p/codegen/Evaluator.cpp
@@ -27,6 +27,3 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-
-
-#define NOT_IMPLEMENTED { TR_ASSERT(0, "This function is not implemented in Test JIT"); }

--- a/fvtest/compilertest/tests/FooBarTest.cpp
+++ b/fvtest/compilertest/tests/FooBarTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -127,7 +127,7 @@ FooBarTest::invokeTests()
 } // namespace TestCompiler
 
 // This test will get assertion on S390-64, because of
-// "compiler/codegen/FrontEnd.cpp" TR_FrontEnd::methodTrampolineLookup is "notImplemented("methodTrampolineLookup");" and
+// "compiler/codegen/FrontEnd.cpp" TR_FrontEnd::methodTrampolineLookup is unimplemented and
 // "test/env/FrontEnd.cpp"  TestCompiler::FrontEnd::methodTrampolineLookup is "methodTrampolineLookup not implemented yet".
 // This test also failed intermittent (segfault) on PPCLE, temporarily disabled this test on PPCLE, under track of Work Item
 // Please remove this #ifdef after those functions are implemented.

--- a/fvtest/compilertest/z/codegen/Evaluator.cpp
+++ b/fvtest/compilertest/z/codegen/Evaluator.cpp
@@ -28,28 +28,24 @@
 #include "il/Node_inlines.hpp"
 #include "env/IO.hpp"
 
-
-#define NOT_IMPLEMENTED { TR_ASSERT_FATAL(0, "This function is not implemented in TestCompiler JIT"); }
-
-
 uint32_t
 TR::S390RestoreGPR7Snippet::getLength(int32_t estimatedSnippetStart)
    {
-   NOT_IMPLEMENTED;
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uint8_t *
 TR::S390RestoreGPR7Snippet::emitSnippetBody()
    {
-   NOT_IMPLEMENTED;
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RestoreGPR7Snippet *snippet)
    {
-   NOT_IMPLEMENTED;
+   TR_UNIMPLEMENTED();
    }
 
 void

--- a/jitbuilder/env/FrontEnd.cpp
+++ b/jitbuilder/env/FrontEnd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -43,8 +43,6 @@
 
 #define RANGE_NEEDS_FOUR_BYTE_OFFSET(r) (((r) >= (USHRT_MAX   )) ? 1 : 0)
 
-#define notImplemented(A) TR_ASSERT(0, "This function is not defined for JitBuilder::FrontEnd %s", (A) )
-
 namespace JitBuilder
 {
 
@@ -75,7 +73,7 @@ FrontEnd::createResolvedMethod(TR_Memory * trMemory, TR_OpaqueMethodBlock * aMet
 intptrj_t
 FrontEnd::methodTrampolineLookup(TR::Compilation *comp, TR::SymbolReference *symRef, void *callSite)
    {
-   TR_ASSERT(0, "methodTrampolineLookup not implemented yet");
+   TR_UNIMPLEMENTED();
    return 0;
    }
 

--- a/jitbuilder/p/codegen/Evaluator.cpp
+++ b/jitbuilder/p/codegen/Evaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corp. and others
+ * Copyright (c) 2014, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,7 +28,3 @@
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 #include "env/CompilerEnv.hpp"
-
-
-#define NOT_IMPLEMENTED { TR_ASSERT(0, "This function is not implemented in JitBuilder"); }
-

--- a/jitbuilder/z/codegen/Evaluator.cpp
+++ b/jitbuilder/z/codegen/Evaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,28 +29,24 @@
 #include "il/Node_inlines.hpp"
 #include "env/IO.hpp"
 
-
-#define NOT_IMPLEMENTED { TR_ASSERT_FATAL(0, "This function is not implemented in JitBuilder"); }
-
-
 uint32_t
 TR::S390RestoreGPR7Snippet::getLength(int32_t estimatedSnippetStart)
    {
-   NOT_IMPLEMENTED;
+   TR_UNIMPLEMENTED();
    return 0;
    }
 
 uint8_t *
 TR::S390RestoreGPR7Snippet::emitSnippetBody()
    {
-   NOT_IMPLEMENTED;
+   TR_UNIMPLEMENTED();
    return NULL;
    }
 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::S390RestoreGPR7Snippet *snippet)
    {
-   NOT_IMPLEMENTED;
+   TR_UNIMPLEMENTED();
    }
 
 void


### PR DESCRIPTION
The new `TR_UNIMPLEMENTED` macro is a fatal assert, used to indicate that a function has not been implemented. Since this is a fatal assertion, callers are not obligated to return values, because the program will abort.

In as many places as I could find, I've replace code that looks like this:

```c++
TR_ASSERT(false, "Not implemented yet.");
return NULL;
```

with this:
```c++
TR_UNIMPLEMENTED();
return NULL;
```