### PR TITLE
WIP: Enable TransparentHugePage for Nursery region under [madvise]

### DIFF
--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -375,6 +375,12 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 		}
 	}
 
+#if defined(LINUX)
+	if ((NULL != instance) && (gc_policy_gencon == extensions->configurationOptions._gcPolicy)) {
+		instance->adviseHugepage();
+	}
+#endif /* defined(LINUX) */
+
 #if defined(OMR_VALGRIND_MEMCHECK)
 	//Use handle's Memory Base to refer valgrind memory pool
 	valgrindCreateMempool(extensions, env, (uintptr_t)handle->getMemoryBase());

--- a/gc/base/VirtualMemory.cpp
+++ b/gc/base/VirtualMemory.cpp
@@ -21,7 +21,6 @@
  *******************************************************************************/
 
 #include <string.h>
-#include <sys/mman.h>
 
 #include "omrcomp.h"
 #include "omrport.h"
@@ -160,27 +159,28 @@ MM_VirtualMemory::reserveMemory(J9PortVmemParams* params)
 		addressToReturn = (void*)MM_Math::roundToCeiling(_heapAlignment, (uintptr_t)_baseAddress);
 	}
 
-#if defined (LINUX) && defined (OMR_GC_MODRON_SCAVENGER)
+	return addressToReturn;
+}
+
+void
+MM_VirtualMemory::adviseHugepage()
+{
+#if defined(LINUX)
+	OMRPORT_ACCESS_FROM_OMRVM(_extensions->getOmrVM());
 	if (omrvmem_supported_page_sizes()[0] == _pageSize) {
 		if ((_extensions->enableSplitHeap)) {
 			if (MM_GCExtensionsBase::HEAP_INITIALIZATION_SPLIT_HEAP_NURSERY == _extensions->splitHeapSection) {
-				/* TODO - memory advise should be a port library function
-				* omrvmem_advise_hugepage(_baseAddress, _reserveSize);
-				*/
-				madvise(_baseAddress, _reserveSize, MADV_HUGEPAGE);
-				printf("madvise called for vmem address %p, size %ld\n", _baseAddress, _reserveSize);
+				omrvmem_advise_hugepage(_baseAddress, _reserveSize);
 			}
 		} else {
 			/* Caculate the start address (theoretical lower bound) of Nursery space */
 			uintptr_t tenureSize = MM_Math::roundToCeiling(_pageSize, _reserveSize - _extensions->maxNewSpaceSize);
 			uintptr_t start_address = (uintptr_t)_baseAddress + tenureSize;
 
-			madvise((void*)start_address, _reserveSize - tenureSize, MADV_HUGEPAGE);
-			printf("madvise called for vmem address %p, size %ld\n", (void*)start_address, _reserveSize - tenureSize);
+			omrvmem_advise_hugepage((void*)start_address, _reserveSize - tenureSize);
 		}
 	}
-#endif /* OMR_GC_MODRON_SCAVENGER */
-	return addressToReturn;
+#endif /* defined(LINUX) */
 }
 
 bool MM_VirtualMemory::freeMemory()

--- a/gc/base/VirtualMemory.hpp
+++ b/gc/base/VirtualMemory.hpp
@@ -81,6 +81,7 @@ protected:
 	virtual void tearDown(MM_EnvironmentBase* env);
 
 	virtual void* reserveMemory(J9PortVmemParams* params);
+	virtual void adviseHugepage();
 
 	MM_VirtualMemory(MM_EnvironmentBase* env, uintptr_t heapAlignment, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t tailPadding, uintptr_t mode)
 		: MM_BaseVirtual()

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1341,6 +1341,8 @@ typedef struct OMRPortLibrary {
 	void *(*vmem_reserve_memory)(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize,  uint32_t category) ;
 	/** see @ref omrvmem.c::omrvmem_reserve_memory_ex "omrvmem_reserve_memory_ex"*/
 	void *(*vmem_reserve_memory_ex)(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params) ;
+	/** see @ref omrvmem.c::omrvmem_advise_hugepage "omrvmem_advise_hugepage"*/
+	void (*vmem_advise_hugepage)(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount) ;
 	/** see @ref omrvmem.c::omrvmem_get_page_size "omrvmem_get_page_size"*/
 	uintptr_t (*vmem_get_page_size)(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier) ;
 	/** see @ref omrvmem.c::omrvmem_get_page_flags "omrvmem_get_page_flags"*/
@@ -1913,6 +1915,7 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrvmem_vmem_params_init(param1) privateOmrPortLibrary->vmem_vmem_params_init(privateOmrPortLibrary, (param1))
 #define omrvmem_reserve_memory(param1,param2,param3,param4,param5,param6) privateOmrPortLibrary->vmem_reserve_memory(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5), (param6))
 #define omrvmem_reserve_memory_ex(param1,param2) privateOmrPortLibrary->vmem_reserve_memory_ex(privateOmrPortLibrary, (param1), (param2))
+#define omrvmem_advise_hugepage(param1,param2) privateOmrPortLibrary->vmem_advise_hugepage(privateOmrPortLibrary, (param1), (param2))
 #define omrvmem_get_page_size(param1) privateOmrPortLibrary->vmem_get_page_size(privateOmrPortLibrary, (param1))
 #define omrvmem_get_page_flags(param1) privateOmrPortLibrary->vmem_get_page_flags(privateOmrPortLibrary, (param1))
 #define omrvmem_supported_page_sizes() privateOmrPortLibrary->vmem_supported_page_sizes(privateOmrPortLibrary)

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -171,6 +171,7 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrvmem_vmem_params_init, /* vmem_vmem_params_init */
 	omrvmem_reserve_memory, /* vmem_reserve_memory */
 	omrvmem_reserve_memory_ex, /* vmem_reserve_memory_ex */
+	omrvmem_advise_hugepage, /* vmem_advise_hugepage */
 	omrvmem_get_page_size, /* vmem_get_page_size */
 	omrvmem_get_page_flags, /* omrvmem_get_page_flags */
 	omrvmem_supported_page_sizes, /* vmem_supported_page_sizes */

--- a/port/common/omrvmem.c
+++ b/port/common/omrvmem.c
@@ -201,6 +201,23 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 }
 
 /**
+ * Advise memory to enable use of Transparent HugePages (THP) (Linux Only)
+ * 
+ * Notify kernel that the virtual memory region specified by address and byteAmount should be labelled
+ * with MADV_HUGEPAGE, where the khugepage process could promote to THP when possible.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] address The starting virtual address.
+ * @param[in] byteAmount The amount of bytes after address to map to hugepage.
+ * 
+ */
+void
+omrvmem_advise_hugepage(struct OMRPortLibrary *portLibrary, void* address, uintptr_t byteAmount)
+{
+	return;
+}
+
+/**
  * Get the page size used to back a region of virtual memory.
  *
  * @param[in] portLibrary The port library.

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -863,6 +863,12 @@ reserveLargePages(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifie
 	return memoryPointer;
 }
 
+void
+omrvmem_advise_hugepage(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount)
+{
+	madvise(address, byteAmount, MADV_HUGEPAGE);
+}
+
 uintptr_t
 omrvmem_get_page_size(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier)
 {

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -679,6 +679,8 @@ extern J9_CFUNC void *
 omrvmem_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier, uintptr_t mode, uintptr_t pageSize, uint32_t category);
 extern J9_CFUNC void *
 omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params);
+extern J9_CFUNC void
+omrvmem_advise_hugepage(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount);
 extern J9_CFUNC uintptr_t
 omrvmem_get_page_size(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier);
 extern J9_CFUNC uintptr_t


### PR DESCRIPTION
When Linux TransparentHugePage is set to [madvise], set the `MADV_HUGEPAGE` flag for nursery region using `madvise()` call. This change apply to Gencon policy only.

- add portlibrary api `omrvmem_advise_memory()`
- add `adviseHugepage()` wrapper function to `MM_VirtualMemory` class

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>