### PR TITLE
Remove call to VMJ9 traceAssumeFailure

### DIFF
--- a/compiler/infra/Assert.cpp
+++ b/compiler/infra/Assert.cpp
@@ -85,11 +85,6 @@ static void assumeDontCallMeDirectlyImpl( const char * file, int32_t line, const
 
    if (!condition) condition = "";
 
-#ifdef J9_PROJECT_SPECIFIC
-   if (comp && comp->fej9()->traceIsEnabled())
-      comp->fej9()->traceAssumeFailure(line, file);
-#endif
-
    // Fatal assertions fire always, however, non fatal assertions
    // can be disabled via TR_SoftFailOnAssume.
    if (comp && comp->getOption(TR_SoftFailOnAssume) && !fatal)


### PR DESCRIPTION
In J9, [traceAssumeFailure](https://github.com/eclipse/openj9/blob/master/runtime/compiler/env/VMJ9.cpp#L5443-L5446) has been disabled, so calling it has no
effect. This is the only call site, so once it is removed,
traceAssumeFailure can be removed from the J9 VM.

Signed-off-by: Robert Young <rwy0717@gmail.com>