### PR TITLE
Correct register dependencies for x86 tableEvaluator

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -491,22 +491,23 @@ TR::Register *OMR::X86::TreeEvaluator::tableEvaluator(TR::Node *node, TR::CodeGe
       }
 
    TR::X86MemTableInstruction *jmpTableInstruction = NULL;
+   TR::RegisterDependencyConditions *deps = NULL;
+
+   // Add GlRegDep dependencies to indirect jump
+   //
+   if (secondChild->getNumChildren() > 0)
+      {
+      deps = generateRegisterDependencyConditions(secondChild->getFirstChild(), cg, 0, NULL);
+      deps->stopAddingConditions();
+      }
 
    if (cg->getLinkage()->getProperties().getMethodMetaDataRegister() != TR::RealRegister::NoReg)
       {
-      TR::RegisterDependencyConditions *deps = NULL;
-
-      if (secondChild->getNumChildren() > 0)
-         {
-         deps = generateRegisterDependencyConditions(secondChild->getFirstChild(), cg, 0, NULL);
-         deps->stopAddingConditions();
-         }
-
       jmpTableInstruction = generateMemTableInstruction(JMPMem, node, jumpMR, numBranchTableEntries, deps, cg);
       }
    else
       {
-      generateMemInstruction(JMPMem, node, jumpMR, cg);
+      generateMemInstruction(JMPMem, node, jumpMR, deps, cg);
       }
 
    for (i = 2; i < node->getNumChildren(); ++i)
@@ -2318,7 +2319,7 @@ static bool virtualGuardHelper(TR::Node *node, TR::CodeGenerator *cg)
       {
       site = virtualGuard->addNOPSite();
       }
-   else 
+   else
       {
       site = comp->addSideEffectNOPSite();
       }


### PR DESCRIPTION
For non-Java projects the register dependencies for GlRegDeps were not
added to the indirect jump instruction, leading to incorrect register
assignment.  Add the appropriate register dependencies.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>