### PR TITLE
Increase _coldUpgradeSampleThreshold to 20

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -5108,7 +5108,7 @@ void OMR::Options::setGlobalAggressiveAOT()
    // setOption(TR_NoOptServer); // questionable
 
    // conservative upgrades
-   _coldUpgradeSampleThreshold = 10; // instead of 3 or even 2
+   _coldUpgradeSampleThreshold = 20; // instead of 3 or even 2
 
    //setOption(TR_VaryInlinerAggressivenessWithTime); // aggressiveness will go gradually down; for non-AOT warm compilations
 


### PR DESCRIPTION
`_coldUpgradeSampleThreshold` is currently only used in the OpenJ9 project. Because the SVM has resulted in better AOT code quality, under `AGGRESSIVE_AOT`, this PR makes the upgrade sample threshold more conservative by increasing it to 20. 