### PR TITLE
Fix warning `hides overloaded virtual function`

### DIFF
--- a/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -109,8 +109,9 @@ OMR::VirtualMachineOperandStack::Reload(TR::IlBuilder* b)
    }
 
 void
-OMR::VirtualMachineOperandStack::MergeInto(TR::VirtualMachineOperandStack* other, TR::IlBuilder* b)
+OMR::VirtualMachineOperandStack::MergeInto(TR::VirtualMachineState* o, TR::IlBuilder* b)
    {
+   TR::VirtualMachineOperandStack *other = static_cast<TR::VirtualMachineOperandStack *>(o);
    TR_ASSERT(_stackTop == other->_stackTop, "stacks are not same size");
    for (int32_t i=_stackTop;i >= 0;i--)
       {

--- a/compiler/ilgen/OMRVirtualMachineOperandStack.hpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandStack.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -135,7 +135,7 @@ class VirtualMachineOperandStack : public TR::VirtualMachineState
     * @param other operand stack for the builder object control is merging into
     * @param b builder object where the operations will be added to make the current operand stack the same as the other
     */
-   virtual void MergeInto(TR::VirtualMachineOperandStack *other, TR::IlBuilder *b);
+   virtual void MergeInto(TR::VirtualMachineState *o, TR::IlBuilder *b);
 
    /**
     * @brief update the values used to read and write the virtual machine stack

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -1961,7 +1961,7 @@
                 , "flags": []
                 , "return": "none"
                 , "parms": [
-                    {"name":"vmState","type":"VirtualMachineOperandArray"},
+                    {"name":"vmState","type":"VirtualMachineState"},
                     {"name":"b","type":"IlBuilder"}
                     ]
                 }
@@ -2048,7 +2048,7 @@
                 , "flags": []
                 , "return": "none"
                 , "parms": [
-                    {"name":"vmState","type":"VirtualMachineOperandStack"},
+                    {"name":"vmState","type":"VirtualMachineState"},
                     {"name":"b","type":"IlBuilder"}
                     ]
                 }


### PR DESCRIPTION
The first parameter to VirtualMachineState::MergeInto is declared
as `VirtualMachineState *`. In the client API and in
VirtualMachineOperandStack the first parameter is defined to be
the subclass type which Clang warns about.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>