### PR TITLE
WIP: Rename Aggressive AOT methods

### DIFF
--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1442,6 +1442,7 @@ public:
       QUICKSTART,
       AGGRESSIVE_QUICKSTART,
       AGGRESSIVE_AOT,
+      VIRTUALIZED_ENVIRONMENT = AGGRESSIVE_AOT,
       CONSERVATIVE_DEFAULT,
       DEFAULT,
    };
@@ -1689,10 +1690,15 @@ public:
    void setQuickStart();
    void setConservativeQuickStart();
    void setAggressiveQuickStart();
+   void setConservativeDefaultBehavior();
+
    void setGlobalAggressiveAOT();
    void setLocalAggressiveAOT();
    void setInlinerOptionsForAggressiveAOT();
-   void setConservativeDefaultBehavior();
+
+   void setGlobalVirtualizedEnvOptions();
+   void setLocalVirtualizedEnvOptions();
+   void setVirtualizedEnvOptionsForInliner();
 
    static bool getCountsAreProvidedByUser() { return _countsAreProvidedByUser; } // set very late in setCounts()
    static TR_YesNoMaybe startupTimeMatters() { return _startupTimeMatters; } // set very late in setCounts()


### PR DESCRIPTION
1. This change is only affects the OpenJ9 project
2. `setGlobalAggressiveAOT` is used for AOT and non-AOT alike; this PR is opened to rename it so that it is more representative of the conditions under which it is called.