### PR TITLE
Remove unused lists from CodeGenerator

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -244,8 +244,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _variableSizeSymRefFreeList(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),
      _variableSizeSymRefAllocList(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),
      _accumulatorNodeUsage(0),
-     _nodesUnderComputeCCList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
-     _nodesToUncommonList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _nodesSpineCheckedList(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _collectedSpillList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
      _allSpillList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1907,8 +1907,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR::Register*> *_firstTimeLiveOOLRegisterList;
    TR::list<OMR::RegisterUsage*> *_referencedRegistersList;
    int32_t _currentPathDepth;
-   TR::list<TR::Node*> _nodesUnderComputeCCList;
-   TR::list<TR::Node*> _nodesToUncommonList;
    TR::list<TR::Node*> _nodesSpineCheckedList;
 
    TR::list<TR_Pair<TR_ResolvedMethod, TR::Instruction> *> _jniCallSites; // list of instrutions representing direct jni call sites


### PR DESCRIPTION
Not used in OMR nor any known downstream project:

* _nodesUnderComputeCCList
* _nodesToUncommonList

Signed-off-by: Daryl Maier <maier@ca.ibm.com>