### PR TITLE
Misc. dead code cleanup

### DIFF
--- a/compiler/codegen/OMRRegister.cpp
+++ b/compiler/codegen/OMRRegister.cpp
@@ -45,8 +45,7 @@ OMR::Register::Register(uint32_t f):
    _outOfLineUseCount(0),
    _association(0),
    _kind(TR_GPR),
-   _index(0),
-   _cc(NULL)
+   _index(0)
    {}
 
 OMR::Register::Register(TR_RegisterKinds rk):
@@ -63,8 +62,7 @@ OMR::Register::Register(TR_RegisterKinds rk):
    _outOfLineUseCount(0),
    _association(0),
    _kind(rk),
-   _index(0),
-   _cc(NULL)
+   _index(0)
    {}
 
 OMR::Register::Register(TR_RegisterKinds rk, uint16_t ar):
@@ -81,8 +79,7 @@ OMR::Register::Register(TR_RegisterKinds rk, uint16_t ar):
    _outOfLineUseCount(0),
    _association(ar),
    _kind(rk),
-   _index(0),
-   _cc(NULL)
+   _index(0)
    {}
 
 TR::Register*

--- a/compiler/codegen/OMRRegister.hpp
+++ b/compiler/codegen/OMRRegister.hpp
@@ -114,10 +114,6 @@ class OMR_EXTENSIBLE Register
    uint32_t getIndex()           { return _index; }
    void     setIndex(uint32_t i) { _index=i; }
 
-   TR::Register *getCCRegister() { return _cc; }
-   void setCCRegister(TR::Register *s) { _cc = s; }
-
-
    /*
     * Get/Set Flag Value
     */
@@ -209,9 +205,6 @@ class OMR_EXTENSIBLE Register
 
    TR_RegisterKinds _kind;
    uint32_t         _index;             // index into register table
-
-   // Holds the condition codes produced by the operation that produced the container register.
-   TR::Register     *_cc;
    };
 
 }

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -133,7 +133,6 @@ TR::Register *computeCC_bitwise(TR::CodeGenerator *cg, TR::Node *node, TR::Regis
    // 0 - Result is zero
    // 1 - Result is not zero
    TR::Register *ccReg = computeCC_setNotZero(cg, node, NULL, testReg, needsZeroExtension);
-   testReg->setCCRegister(ccReg);
    return ccReg;
    }
 

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -65,8 +65,6 @@ extern TR::Register *inlineLongRotateLeft(TR::Node *node, TR::CodeGenerator *cg)
 static TR::Register *ldiv64Evaluator(TR::Node *node, TR::CodeGenerator *cg);
 static TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg);
 
-TR::Register *computeCC_bitwise(TR::CodeGenerator *cg, TR::Node *node, TR::Register *targetReg, bool needsZeroExtension = true);
-
 void generateZeroExtendInstruction(TR::Node *node,
                                    TR::Register *trgReg,
                                    TR::Register *srcReg,
@@ -105,36 +103,6 @@ void generateSignExtendInstruction(TR::Node *node,
    generateTrg1Src1Instruction(cg, signExtendOp, node, trgReg, srcReg);
    }
 
-TR::Register *computeCC_setNotZero(TR::CodeGenerator *cg, TR::Node *node, TR::Register *ccReg, TR::Register *testReg, bool needsZeroExtension)
-   {
-   if (ccReg == NULL)
-      ccReg = cg->allocateRegister();
-   int32_t size = node->getOpCode().getSize();
-
-   if (size < 8 && needsZeroExtension)
-      {
-      // this sequence doesn't work if there is any garbage in the top part of the testReg
-      generateZeroExtendInstruction(node, ccReg, testReg, size*8, cg);
-      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addic, node, ccReg, ccReg, -1);
-      }
-   else
-      {
-      generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addic, node, ccReg, testReg, -1);
-      }
-   generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, ccReg, 0);
-   generateTrg1Src1Instruction(cg, TR::InstOpCode::addze, node, ccReg, ccReg);
-
-   return ccReg;
-   }
-
-TR::Register *computeCC_bitwise(TR::CodeGenerator *cg, TR::Node *node, TR::Register *testReg, bool needsZeroExtension)
-   {
-   // Condition code settings:
-   // 0 - Result is zero
-   // 1 - Result is not zero
-   TR::Register *ccReg = computeCC_setNotZero(cg, node, NULL, testReg, needsZeroExtension);
-   return ccReg;
-   }
 
 // Do the work for evaluating integer or and exclusive or
 // Also called for long or and exclusive or when the upper

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -105,7 +105,6 @@
 #endif
 
 static int32_t identifyFarConditionalBranches(int32_t estimate, TR::CodeGenerator *cg);
-extern TR::Register *computeCC_bitwise(TR::CodeGenerator *cg, TR::Node *node, TR::Register *targetReg, bool needsZeroExtension = true);
 
 
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -1482,24 +1482,6 @@ TR::Register *OMR::X86::TreeEvaluator::SSE2ArraycmpLenEvaluator(TR::Node *node, 
    return resultReg;
    }
 
-void genCodeToPerformLeftToRightAndBlockConcurrentOpIfNeeded(
-   TR::Node *node,
-   TR::MemoryReference *memRef,
-   TR::Register *vReg,
-   TR::Register *tempReg,
-   TR::Register *tempReg1,
-   TR::Register *tempReg2,
-   TR::LabelSymbol * nonLockedOpLabel,
-   TR::LabelSymbol *&opDoneLabel,
-   TR::RegisterDependencyConditions *&deps,
-   uint8_t size,
-   TR::CodeGenerator* cg,
-   bool isLoad,
-   bool genOutOfline,
-   bool keepValueRegAlive,
-   TR::LabelSymbol *startControlFlowLabel)
-   {
-   }
 
 bool OMR::X86::TreeEvaluator::stopUsingCopyRegAddr(TR::Node* node, TR::Register*& reg, TR::CodeGenerator* cg)
    {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -2283,10 +2283,10 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
    // There are two variants of TR::arraycopy: one has 5 children, the other has 3 children. Details can be found from
    // compiler/il/ILOpCodeProperties.hpp
    //
-   // In most, if not all, cases, the 5-child variant requires language specific semantics, which OMR is not aware of. The fact 
+   // In most, if not all, cases, the 5-child variant requires language specific semantics, which OMR is not aware of. The fact
    // that a 5-child arraycopy is generated indicates at least one of the first two children must be needed when performing the
-   // copy; otherwise a 3-child arraycopy should be generated instead. Interpreting the meanings of the first two children 
-   // definitely requires language specific semantics. For example, the first two children may be for dealing with an arraycopy 
+   // copy; otherwise a 3-child arraycopy should be generated instead. Interpreting the meanings of the first two children
+   // definitely requires language specific semantics. For example, the first two children may be for dealing with an arraycopy
    // where the Garbage Collector may need to be notified about the copy or something to that affect.
    //
    // Therefore, this OMR evaluator only handles the 3-child variant, is an operation equivalent to C++'s std::memmove().
@@ -3829,7 +3829,6 @@ TR_X86ComputeCC::bitwise32(TR::Node *node, TR::Register *ccReg, TR::Register *ta
                              TR::CodeGenerator *cg)
    {
    generateRegInstruction(SETNE1Reg, node, ccReg, cg);
-   target->setCCRegister(ccReg);
    }
 
 bool

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3823,14 +3823,6 @@ TR::Register *OMR::X86::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::Cod
    return NULL;
    }
 
-
-void
-TR_X86ComputeCC::bitwise32(TR::Node *node, TR::Register *ccReg, TR::Register *target,
-                             TR::CodeGenerator *cg)
-   {
-   generateRegInstruction(SETNE1Reg, node, ccReg, cg);
-   }
-
 bool
 TR_X86ComputeCC::setCarryBorrow(TR::Node *flagNode, bool invertValue, TR::CodeGenerator *cg)
    {

--- a/compiler/x/codegen/X86Evaluator.hpp
+++ b/compiler/x/codegen/X86Evaluator.hpp
@@ -46,24 +46,6 @@ extern void constLengthArrayCopy(
    bool preserveSrcPointer,
    bool preserveDstPointer);
 
-extern void genCodeToPerformLeftToRightAndBlockConcurrentOpIfNeeded(
-   TR::Node *node,
-   TR::MemoryReference *memRef,
-   TR::Register *valueReg,
-   TR::Register *tempReg,
-   TR::Register *tempReg1,
-   TR::Register *tempReg2,
-   TR::LabelSymbol *nonLockedOpLabel,
-   TR::LabelSymbol *&opDoneLabel,
-   TR::RegisterDependencyConditions *&deps,
-   uint8_t size,
-   TR::CodeGenerator *cg,
-   bool isLoad,
-   bool genOutOfline,
-   bool keepValueRegAlive = false,
-   TR::LabelSymbol *startControlFlowLabel = NULL);
-
-
 
 class TR_X86ComputeCC : public TR::TreeEvaluator
    {

--- a/compiler/x/codegen/X86Evaluator.hpp
+++ b/compiler/x/codegen/X86Evaluator.hpp
@@ -69,7 +69,6 @@ class TR_X86ComputeCC : public TR::TreeEvaluator
    {
    public:
 
-   static void bitwise32(TR::Node *node, TR::Register *ccReg, TR::Register *target, TR::CodeGenerator *cg);
    static bool setCarryBorrow(TR::Node *flagNode, bool invertValue, TR::CodeGenerator *cg);
 
    };

--- a/compiler/x/codegen/X86Evaluator.hpp
+++ b/compiler/x/codegen/X86Evaluator.hpp
@@ -37,16 +37,6 @@ namespace TR { class Register; }
 namespace TR { class RegisterDependencyConditions; }
 
 
-extern void constLengthArrayCopy(
-   TR::Node *node,
-   TR::CodeGenerator *cg,
-   TR::Register *byteSrcReg,
-   TR::Register *byteDstReg,
-   TR::Node *byteLenNode,
-   bool preserveSrcPointer,
-   bool preserveDstPointer);
-
-
 class TR_X86ComputeCC : public TR::TreeEvaluator
    {
    public:


### PR DESCRIPTION
* Remove unused _cc OMR::Register field
* Remove obsolete P and X86 condition code manipulation functions
* Remove obsolete genCodeToPerformLeftToRightAndBlockConcurrentOpIfNeeded
* Remove unused X86 extern for constLengthArrayCopy
