### PR TITLE
Add missing dereference in copying register arrays

### DIFF
--- a/compiler/x/codegen/OMRMachine.cpp
+++ b/compiler/x/codegen/OMRMachine.cpp
@@ -1709,7 +1709,7 @@ OMR::X86::Machine::cloneRegisterFile(TR::RealRegister **registerFile, TR_Allocat
    for (i = TR::RealRegister::FirstGPR; i <= endReg; i = ((i==TR::RealRegister::LastAssignableGPR) ? TR::RealRegister::FirstXMMR : i+1))
       {
       registerFileClone[i] = (TR::RealRegister *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), allocKind);
-      registerFileClone[i] = registerFile[i];
+      *registerFileClone[i] = *registerFile[i];
       }
 
    // the vfp entry is a real register and it must always point to the same _frameRegister pointer so the memRef assignRegisters check
@@ -1858,12 +1858,12 @@ TR::RealRegister **OMR::X86::Machine::captureRegisterFile()
       {
       registerFileClone[i] =
          (TR::RealRegister *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
-      registerFileClone[i] = _registerFile[i];
+      *registerFileClone[i] = *_registerFile[i];
       }
 
    registerFileClone[TR::RealRegister::vfp] =
       (TR::RealRegister *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::RealRegister), heapAlloc);
-   registerFileClone[TR::RealRegister::vfp] = _registerFile[TR::RealRegister::vfp];
+   *registerFileClone[TR::RealRegister::vfp] = *_registerFile[TR::RealRegister::vfp];
 
    return registerFileClone;
    }
@@ -1901,7 +1901,7 @@ void OMR::X86::Machine::installRegisterFile(TR::RealRegister **registerFileCopy)
       //
       bool wasAssigned = _registerFile[i]->getHasBeenAssignedInMethod();
 
-      _registerFile[i] = registerFileCopy[i];
+      *_registerFile[i] = *registerFileCopy[i];
 
       // Copy the sticky bits.
       //
@@ -1918,7 +1918,7 @@ void OMR::X86::Machine::installRegisterFile(TR::RealRegister **registerFileCopy)
          }
       }
 
-   _registerFile[TR::RealRegister::vfp] = registerFileCopy[TR::RealRegister::vfp];
+   *_registerFile[TR::RealRegister::vfp] = *registerFileCopy[TR::RealRegister::vfp];
    }
 
 TR::Register **OMR::X86::Machine::captureRegisterAssociations()
@@ -1935,7 +1935,7 @@ TR::Register **OMR::X86::Machine::captureRegisterAssociations()
          {
          registerAssociationsClone[i] =
             (TR::Register *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
-         registerAssociationsClone[i] = _registerAssociations[i];
+         *registerAssociationsClone[i] = *_registerAssociations[i];
          }
       else
          {
@@ -1947,7 +1947,7 @@ TR::Register **OMR::X86::Machine::captureRegisterAssociations()
       {
       registerAssociationsClone[TR::RealRegister::vfp] =
          (TR::Register *)self()->cg()->trMemory()->allocateMemory(sizeof(TR::Register), heapAlloc);
-      registerAssociationsClone[TR::RealRegister::vfp] = _registerAssociations[TR::RealRegister::vfp];
+      *registerAssociationsClone[TR::RealRegister::vfp] = *_registerAssociations[TR::RealRegister::vfp];
       }
    else
       {


### PR DESCRIPTION
There are a few places where we perform a deep copy of arrays of
register objects in the X OMRMachine. This used to be implemented by
memcpy'ing the elements over copies. In translating this code from using
memcpy to simple assignment, I forgot to dereference the register
pointers in the array. The result is that the array is shallow-copied,
which is very wrong. This PR adds the missing dereference operators, so
now the objects will be deep copied into the new array as intended.

The PR that introduced the error was #3604.

Signed-off-by: Robert Young <rwy0717@gmail.com>