### PR TITLE
Typo: use x to print in hex, not u

### DIFF
--- a/include_core/omrformatconsts.h
+++ b/include_core/omrformatconsts.h
@@ -174,9 +174,9 @@
 #if defined(PRIxPTR)
 #define OMR_PRIxPTR PRIxPTR
 #elif defined(_MSC_VER)
-#define OMR_PRIxPTR "Iu"
+#define OMR_PRIxPTR "Ix"
 #else
-#define OMR_PRIxPTR "zu"
+#define OMR_PRIxPTR "zx"
 #endif
 
 /* OMR_PRIdPTRDIFF: ptrdiff_t */


### PR DESCRIPTION
u mean "unsigned integer", x means "unsigned integer in hex".

Signed-off-by: Robert Young <rwy0717@gmail.com>