### PR TITLE
Node API computeIsCollectedReference support for ternary node

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2416,14 +2416,64 @@ OMR::Node::computeIsInternalPointer()
 bool
 OMR::Node::computeIsCollectedReference()
    {
+   TR::Compilation * comp = TR::comp();
+   TR::NodeChecklist processedNodesCollected(comp);
+   TR::NodeChecklist processedNodesNotCollected(comp);
+   return (self()->computeIsCollectedReferenceImpl(processedNodesCollected, processedNodesNotCollected) != TR_no);
+   }
+
+static TR_YesNoMaybe
+recordProcessedNodeResult(TR::Node *node, TR_YesNoMaybe collectedness, TR::NodeChecklist &processedNodesCollected, TR::NodeChecklist &processedNodesNotCollected)
+   {
+   switch (collectedness)
+      {
+      case TR_yes:
+         processedNodesCollected.add(node);
+         break;
+      case TR_no:
+         processedNodesNotCollected.add(node);
+         break;
+      case TR_maybe:
+         processedNodesCollected.add(node);
+         processedNodesNotCollected.add(node);
+         break;
+      default:
+         TR_ASSERT_FATAL(false, "Invalid collectedness result for Node %p\n", node);
+         break;
+      }
+   return collectedness;
+   }
+
+TR_YesNoMaybe
+OMR::Node::computeIsCollectedReferenceImpl(TR::NodeChecklist &processedNodesCollected, TR::NodeChecklist &processedNodesNotCollected)
+   {
    TR::Node *curNode = self();
+   TR::Node *receiverNode = curNode;
    if (curNode->getOpCode().isTreeTop())
-      return false;
+      return TR_no;
+
+   // In order to prevent from walking the same node repeatedly when
+   // one is referenced multiple times in a very deep tree structure
+   // (e.g. ternary whose child is a ternary and so on),
+   // Use 2 checklists to record following states:
+   // -- The node is not contained in either collected or uncollected checklists - first time encounter, process the node
+   //    and add it to the appropriate checklist(s) based on the result.
+   // -- Node is seen in both checklitsts - previously processed with result of TR_maybe
+   // -- Node is seen in processedNodesCollected - previously processed with result of TR_yes
+   // -- Node is seen in processedNodesNotCollected - previously processed with result of TR_no
+   bool ternarySeenCollected = processedNodesCollected.contains(receiverNode);
+   bool ternarySeenNotCollected = processedNodesNotCollected.contains(receiverNode);
+   if (ternarySeenCollected && ternarySeenNotCollected)
+      return TR_maybe;
+   else if (ternarySeenCollected)
+      return TR_yes;
+   else if (ternarySeenNotCollected)
+      return TR_no;
 
    while (curNode)
       {
       if (curNode->isInternalPointer())
-         return true;
+         return recordProcessedNodeResult(receiverNode, TR_yes, processedNodesCollected, processedNodesNotCollected);
 
       TR::ILOpCode op = curNode->getOpCode();
       TR::ILOpCodes opValue = curNode->getOpCodeValue();
@@ -2431,16 +2481,28 @@ OMR::Node::computeIsCollectedReference()
       // If a language can handle a collected reference going via a non-address type,
       // then the logic would need to be augmented to handle that
       if (op.isConversion())
-         return false;
+         return recordProcessedNodeResult(receiverNode, TR_no, processedNodesCollected, processedNodesNotCollected);
 
       if (op.getDataType() != TR::Address)
-         return false;
+         return recordProcessedNodeResult(receiverNode, TR_no, processedNodesCollected, processedNodesNotCollected);
       // The following are all opcodes that are address type, non-TreeTop and non-conversion
 
       if (op.isAdd())
          {
          curNode = curNode->getFirstChild();
          continue;
+         }
+
+      if (op.isTernary())
+         {
+         TR_YesNoMaybe secondChildResult = curNode->getSecondChild()->computeIsCollectedReferenceImpl(processedNodesCollected, processedNodesNotCollected);
+         if (TR_maybe == secondChildResult)
+            {
+            TR_YesNoMaybe thirdChildResult = curNode->getThirdChild()->computeIsCollectedReferenceImpl(processedNodesCollected, processedNodesNotCollected);
+            return recordProcessedNodeResult(receiverNode, thirdChildResult, processedNodesCollected, processedNodesNotCollected);
+            }
+         else
+            return recordProcessedNodeResult(receiverNode, secondChildResult, processedNodesCollected, processedNodesNotCollected);
          }
 
       // opcodes associated with a symref, we should
@@ -2452,16 +2514,17 @@ OMR::Node::computeIsCollectedReference()
          // isCollectedReference() responds false to generic int shadows because their type
          // is int. However, address type generic int shadows refer to collected slots.
          if (opValue == TR::aloadi && symbol == TR::comp()->getSymRefTab()->findGenericIntShadowSymbol())
-            return true;
+            return recordProcessedNodeResult(receiverNode, TR_yes, processedNodesCollected, processedNodesNotCollected);
          else
-            return symbol->isCollectedReference();
+            return recordProcessedNodeResult(receiverNode, (symbol->isCollectedReference() ? TR_yes : TR_no),
+                  processedNodesCollected, processedNodesNotCollected);
          }
 
       // Symbols for calls and news does not contain collectedness information.
       // Current implementation treats all object references collectable, and also
       // assumes that the return of an acall* is an object reference.
       if (op.isNew() || op.isCall() || opValue == TR::variableNew || opValue == TR::variableNewArray)
-         return true;
+         return recordProcessedNodeResult(receiverNode, TR_yes, processedNodesCollected, processedNodesNotCollected);
 
       switch (opValue)
          {
@@ -2472,15 +2535,33 @@ OMR::Node::computeIsCollectedReference()
             // only problem is: we might mark an aladd/aiadd on a temp whose value is null as
             // an internal pointer, thus creating a temp, pinning array and internal pointer
             // map for it.
-            return self() == curNode && curNode->getAddress() == 0;
+
+            // Preserve the existing logic which is as follows:
+            // true iff not under aladd and null,
+            // if non-null, always false.
+            // if under aladd, always false.
+
+            // non-null constant return false.
+            if (curNode->getAddress() != 0)
+               return recordProcessedNodeResult(receiverNode, TR_no, processedNodesCollected, processedNodesNotCollected);
+            else
+               {
+               // null constant under aladd, return false.
+               // Null constant under ternary (i.e. we reached here via recursive calls), return maybe
+               // to indicate need to check the other child.
+               if (self() != curNode)
+                  return recordProcessedNodeResult(receiverNode, TR_no, processedNodesCollected, processedNodesNotCollected);
+               else
+                  return recordProcessedNodeResult(receiverNode, TR_maybe, processedNodesCollected, processedNodesNotCollected);
+               }
          case TR::getstack:
-            return false;
+            return recordProcessedNodeResult(receiverNode, TR_no, processedNodesCollected, processedNodesNotCollected);
          default:
             TR_ASSERT(false, "Unsupported opcode %s on node " POINTER_PRINTF_FORMAT, op.getName(), curNode);
-            return false;
+            return TR_no;
          }
       }
-   return false;
+   return TR_no;
    }
 
 bool

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -67,6 +67,7 @@ namespace TR { class Symbol; }
 namespace TR { class SymbolReference; }
 namespace TR { class TreeTop; }
 namespace TR { class NodeExtension; }
+namespace TR { class NodeChecklist; }
 template <class T> class List;
 
 #define NUM_DEFAULT_CHILDREN    2
@@ -1832,6 +1833,7 @@ protected:
 // Private functionality.
 private:
    TR::Node * getExtendedChild(int32_t c);
+   TR_YesNoMaybe computeIsCollectedReferenceImpl(TR::NodeChecklist &processedNodesCollected, TR::NodeChecklist &processedNodesNotCollected);
 
    friend class ::TR_DebugExt;
    friend class TR::NodePool;


### PR DESCRIPTION
Current implementation of Node::computeIsCollectedReference cannot handle
ternary nodes as it is unaware of the two value children, both of which
may need to be checked in order to answer its collected-ness. This change
provides support for ternary nodes by recursively calling the API on the
true-value child, and then, if the answer is inconclusive (i.e. true-value
node is a NULL constant), on the false-value child node. The recursion
continues if a value child is itself a ternary node. The existing
implementation logic is preserved and reused in the tail call to answer
the collected-ness of the value child nodes. The current implementation of
computeIsCollectedReference is refectored into a private method
`computeIsCollectedReferenceImpl` which preserves the logic and existing
behavior for all supported nodes and answers either `TR_yes` or `TR_no`;
in adding support for ternary nodes, a `TR_maybe` answer is possible if
both its value children returns inconclusive answer - e.g. when both
children are NULL constant, which is not impossible during some
optimization pass. Under such case, a `TR_maybe` is considered not
collected.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>