### PR TITLE
Support of i/a typed ternary opcode on P codegen

### DIFF
--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -568,11 +568,11 @@ TR::Instruction *generateShiftRightLogicalImmediateLong(TR::CodeGenerator *cg, T
 
 
 TR::Instruction *generateControlFlowInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
-   TR::RegisterDependencyConditions *deps, TR::Instruction *preced)
+   TR::RegisterDependencyConditions *deps, TR::Instruction *preced, bool useRegPairForResult, bool useRegPairForCond)
    {
    if (preced)
-      return new (cg->trHeapMemory()) TR::PPCControlFlowInstruction(op, n, preced, cg, deps);
-   return new (cg->trHeapMemory()) TR::PPCControlFlowInstruction(op, n, cg, deps);
+      return new (cg->trHeapMemory()) TR::PPCControlFlowInstruction(op, n, preced, cg, deps, useRegPairForResult, useRegPairForCond);
+   return new (cg->trHeapMemory()) TR::PPCControlFlowInstruction(op, n, cg, deps, useRegPairForResult, useRegPairForCond);
    }
 
 TR::Instruction *generateAdminInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,

--- a/compiler/p/codegen/GenerateInstructions.hpp
+++ b/compiler/p/codegen/GenerateInstructions.hpp
@@ -344,7 +344,9 @@ TR::Instruction *generateControlFlowInstruction(
                    TR::InstOpCode::Mnemonic                       op,
                    TR::Node                            *n,
                    TR::RegisterDependencyConditions *deps=NULL,
-                   TR::Instruction                     *preced = 0);
+                   TR::Instruction                     *preced = 0,
+                   bool                                useRegPairForResult = false,
+                   bool                                useRegPairForCond = false);
 
 TR::Instruction *generateAdminInstruction(
                    TR::CodeGenerator      *cg,

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -911,10 +911,20 @@ int32_t TR::PPCControlFlowInstruction::estimateBinaryLength(int32_t currentEstim
       case TR::InstOpCode::ldiv:
       case TR::InstOpCode::ifx:
       case TR::InstOpCode::iternary:
-         if (getNumSources() == 3)
-            setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 4);
+         if (useRegPairForResult())
+            {
+            if (!useRegPairForCond())
+               setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 6);
+            else
+               setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 8);
+            }
          else
-            setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 6);
+            {
+            if (!useRegPairForCond())
+               setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 4);
+            else
+               setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 6);
+            }
          break;
       case TR::InstOpCode::setbflt:
          setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 5);

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1571,16 +1571,43 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          {
          cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(0), 0, cursor));
 
-         cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(1), cursor));
+         if (useRegPairForResult())
+            {
+            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(1), cursor));
+            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(2), getSourceRegister(2), cursor));
+            }
+         else
+            {
+            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(1), cursor));
+            }
          cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
 
-         if (getNumSources() == 4)
+         if (useRegPairForResult())
             {
-            cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(3), 0, cursor));
-            cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
+            if (useRegPairForCond())
+               {
+               cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(5), 0, cursor));
+               cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
+               }
+            }
+         else
+            {
+            if (useRegPairForCond())
+               {
+               cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(3), 0, cursor));
+               cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
+               }
             }
 
-         cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(2), cursor));
+         if (useRegPairForResult())
+            {
+            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(3), cursor));
+            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(2), getSourceRegister(4), cursor));
+            }
+         else
+            {
+            cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction   (cg(), getOpCode2Value(), currentNode, getTargetRegister(1), getSourceRegister(2), cursor));
+            }
          cg()->traceRAInstruction(cursor = generateLabelInstruction      (cg(), TR::InstOpCode::label,currentNode, label2, cursor));
          }
          break;

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -1820,28 +1820,38 @@ class PPCControlFlowInstruction : public TR::Instruction
    TR::InstOpCode _opCode2;
    TR::InstOpCode _opCode3;
    TR::InstOpCode _cmpOp;
+   bool _useRegPairForResult;
+   bool _useRegPairForCond;
 
    public:
 
    PPCControlFlowInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n,
       TR::CodeGenerator *codeGen,
-      TR::RegisterDependencyConditions *deps=NULL)
+      TR::RegisterDependencyConditions *deps=NULL,
+      bool useRegPairForResult=false,
+      bool useRegPairForCond=false)
       : TR::Instruction(op, n, codeGen), _numSources(0), _numTargets(0), _label(NULL),
-        _opCode2(TR::InstOpCode::bad), _conditions(deps)
+        _opCode2(TR::InstOpCode::bad), _conditions(deps), _useRegPairForResult(useRegPairForResult),
+        _useRegPairForCond(useRegPairForCond)
       {
       if (deps!=NULL) deps->bookKeepingRegisterUses(this, codeGen);
       }
    PPCControlFlowInstruction(TR::InstOpCode::Mnemonic  op, TR::Node * n,
       TR::Instruction *preceedingInstruction,
       TR::CodeGenerator *codeGen,
-      TR::RegisterDependencyConditions *deps=NULL)
+      TR::RegisterDependencyConditions *deps=NULL,
+      bool useRegPairForResult=false,
+      bool useRegPairForCond=false)
       : TR::Instruction(op, n, preceedingInstruction, codeGen),
         _numSources(0), _numTargets(0), _label(NULL), _opCode2(TR::InstOpCode::bad),
-        _conditions(deps)
+        _conditions(deps), _useRegPairForResult(useRegPairForResult),
+         _useRegPairForCond(useRegPairForCond)
       {
       if (deps!=NULL) deps->bookKeepingRegisterUses(this, codeGen);
       }
 
+   bool useRegPairForResult() { return _useRegPairForResult; }
+   bool useRegPairForCond() { return _useRegPairForCond; }
    virtual Kind getKind() { return IsControlFlow; }
 
    int32_t getNumSources()                    {return _numSources;}


### PR DESCRIPTION
Currently ternary opcodes are not widely used, however there are upcoming
optimizer changes in CFG simplification that will generate more integer
and address-typed ternary opcoe (i.e. iternary, lternary, aternary). This
change fixes long ternary (lternary) evaluation on 32 bit platforms where
the result and operands need to be represented by register pairs, in all
various cases handled in evaluator; also, for address-typed ternary
(aternary), it marks the result register(s) as collected reference if
required.

Signed-off-by: Yan Luo <Yan_Luo@ca.ibm.com>