### PR TITLE
new jniCriticalRegionCount in CopyForwardStats

### DIFF
--- a/gc/stats/CopyForwardStatsCore.hpp
+++ b/gc/stats/CopyForwardStatsCore.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,8 @@ public:
 
 	bool _aborted;  /**< Flag indicating if the copy forward mechanism was aborted */
 
-	uintptr_t  _nonEvacuateRegionCount; /**< Counts the number of regions which are not scheduled to be evacuated in collection set(mark/compact regions) - unused in per-thread stats)*/
+	uintptr_t  _nonEvacuateRegionCount; /**< Counts the number of regions which are not scheduled to be evacuated in collection set(mark/compact regions) - unused in per-thread stats) */
+	uintptr_t _jniCriticalRegionCount; /**< Counts the number of regions which are JNI Critical in use in collection set - unused in per-thread stats) */
 	uintptr_t _edenEvacuateRegionCount;	/**< Counts the number of Eden regions selected to be evacuated in this copy-forward (only counted globally - unused in per-thread stats) */
 	uintptr_t _nonEdenEvacuateRegionCount;	/**< Counts the number of non-Eden selected to be evacuated in this copy-forward (only counted globally - unused in per-thread stats) */
 	uintptr_t _edenSurvivorRegionCount;	/**< Counts the number of Eden regions allocated for survivor space in this copy-forward (only counted globally - unused in per-thread stats) */
@@ -229,6 +230,7 @@ public:
 		_aborted = false;
 
 		_nonEvacuateRegionCount = 0;
+		_jniCriticalRegionCount = 0;
 		_edenEvacuateRegionCount = 0;
 		_nonEdenEvacuateRegionCount = 0;
 		_edenSurvivorRegionCount = 0;
@@ -359,6 +361,7 @@ public:
 		,_scanCacheOverflow(false)
 		,_aborted(false)
 		,_nonEvacuateRegionCount(0)
+		,_jniCriticalRegionCount(0)
 		,_edenEvacuateRegionCount(0)
 		,_nonEdenEvacuateRegionCount(0)
 		,_edenSurvivorRegionCount(0)


### PR DESCRIPTION
	- Add new field jniCriticalRegionCount in CopyForwardStats.
	It is the number of regions which are JNI Critical in use in
	collection set. It would be reported in verbose gc.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>