### PR TITLE
 Add JitBuilder services for unsigned division and remainder 

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -796,6 +796,16 @@ public:
       return TR::BadILOp;
       }
 
+   static TR::ILOpCodes unsignedDivideOpCode(TR::DataType type)
+      {
+      switch (type)
+         {
+         case TR::Int32: return TR::iudiv;
+         case TR::Int64: return TR::ludiv;
+         default: TR_ASSERT(0, "no unsigned div opcode for this datatype");
+         }
+      }
+
    static TR::ILOpCodes remainderOpCode(TR::DataType type)
       {
       switch(type)

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -261,7 +261,9 @@ public:
    TR::IlValue *Mul(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *MulWithOverflow(TR::IlBuilder **handler, TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *Div(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *UnsignedDiv(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *Rem(TR::IlValue *left, TR::IlValue *right);
+   TR::IlValue *UnsignedRem(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *And(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *Or(TR::IlValue *left, TR::IlValue *right);
    TR::IlValue *Xor(TR::IlValue *left, TR::IlValue *right);
@@ -705,6 +707,7 @@ protected:
    TR::IlValue *unaryOp(TR::ILOpCodes op, TR::IlValue *v);
    void doVectorConversions(TR::Node **leftPtr, TR::Node **rightPtr);
    TR::IlValue *widenIntegerTo32Bits(TR::IlValue *v);
+   TR::IlValue *widenIntegerTo32BitsUnsigned(TR::IlValue *v);
    TR::IlValue *binaryOpFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
    TR::Node *binaryOpNodeFromNodes(TR::ILOpCodes op, TR::Node *leftNode, TR::Node *rightNode);
    TR::IlValue *binaryOpFromOpMap(OpCodeMapper mapOp, TR::IlValue *left, TR::IlValue *right);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -6623,7 +6623,7 @@ TR::Node *constrainIdiv(OMR::ValuePropagation *vp, TR::Node *node)
          {
          int32_t lhsConst = lhs->asIntConst()->getInt();
          int32_t rhsConst = rhs->asIntConst()->getInt();
-         if (lhsConst == TR::getMinSigned<TR::Int32>() && rhsConst == -1)
+         if (lhsConst == TR::getMinSigned<TR::Int32>() && rhsConst == -1 && !isUnsigned)
             constraint = TR::VPIntConst::create(vp, TR::getMinSigned<TR::Int32>());
          else if (rhsConst != 0)
             {
@@ -6706,10 +6706,15 @@ TR::Node *constrainLdiv(OMR::ValuePropagation *vp, TR::Node *node)
       TR::VPConstraint *constraint = NULL;
       int64_t lhsConst = lhs->asLongConst()->getLong();
       int64_t rhsConst = rhs->asLongConst()->getLong();
-      if (lhsConst == TR::getMinSigned<TR::Int64>() && rhsConst == -1)
+      if (lhsConst == TR::getMinSigned<TR::Int64>() && rhsConst == -1 && !isUnsigned)
          constraint = TR::VPLongConst::create(vp, TR::getMinSigned<TR::Int64>());
       else if (rhsConst != 0L)
-         constraint = TR::VPLongConst::create(vp, TR::Compiler->arith.longDivideLong(lhsConst, rhsConst));
+         {
+         if (isUnsigned)
+            constraint = TR::VPLongConst::create(vp, ((uint64_t)lhsConst/(uint64_t)rhsConst));
+         else
+            constraint = TR::VPLongConst::create(vp, TR::Compiler->arith.longDivideLong(lhsConst, rhsConst));
+         }
       if (constraint)
          {
          vp->replaceByConstant(node, constraint, lhsGlobal);
@@ -6924,7 +6929,7 @@ TR::Node *constrainIrem(OMR::ValuePropagation *vp, TR::Node *node)
       {
       int32_t lhsConst = lhs->asIntConst()->getInt();
       int32_t rhsConst = rhs->asIntConst()->getInt();
-      if (lhsConst == TR::getMinSigned<TR::Int32>() && rhsConst == -1)
+      if (lhsConst == TR::getMinSigned<TR::Int32>() && rhsConst == -1 && !isUnsigned)
          constraint = TR::VPIntConst::create(vp, 0);
       else if (rhsConst != 0)
          {

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -35,13 +35,16 @@ add_executable(jitbuildertest
 	WorklistTest.cpp
 	FieldNameTest.cpp
 	ConvertBitsTest.cpp
-	UnsignedDivRemTest.cpp
 )
 
 if(OMR_HOST_ARCH STREQUAL "x86")
 	if(OMR_HOST_OS STREQUAL "linux" OR OMR_HOST_OS STREQUAL "osx")
 		target_sources(jitbuildertest PUBLIC CallReturnTest.cpp)
 	endif()
+endif()
+
+if(NOT OMR_HOST_ARCH STREQUAL "ppc")
+	target_sources(jitbuildertest PUBLIC UnsignedDivRemTest.cpp)
 endif()
 
 target_link_libraries(jitbuildertest

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(jitbuildertest
 	WorklistTest.cpp
 	FieldNameTest.cpp
 	ConvertBitsTest.cpp
+	UnsignedDivRemTest.cpp
 )
 
 if(OMR_HOST_ARCH STREQUAL "x86")

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -38,7 +38,8 @@ OBJECTS := \
 	IfThenElseTest \
 	CallReturnTest \
 	FieldNameTest \
-	ConvertBitsTest
+	ConvertBitsTest \
+	UnsignedDivRemTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 

--- a/fvtest/jitbuildertest/UnsignedDivRemTest.cpp
+++ b/fvtest/jitbuildertest/UnsignedDivRemTest.cpp
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+DEFINE_BUILDER(TestUInt64Div,
+               Int64,
+               PARAM("lhs", Int64),
+               PARAM("rhs", Int64))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedDiv(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt64Rem,
+               Int64,
+               PARAM("lhs", Int64),
+               PARAM("rhs", Int64))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedRem(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt32Div,
+               Int32,
+               PARAM("lhs", Int32),
+               PARAM("rhs", Int32))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedDiv(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt32Rem,
+               Int32,
+               PARAM("lhs", Int32),
+               PARAM("rhs", Int32))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedRem(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt16Div,
+               Int16,
+               PARAM("lhs", Int16),
+               PARAM("rhs", Int16))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedDiv(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt16Rem,
+               Int16,
+               PARAM("lhs", Int16),
+               PARAM("rhs", Int16))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedRem(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt8Div,
+               Int8,
+               PARAM("lhs", Int8),
+               PARAM("rhs", Int8))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedDiv(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestUInt8Rem,
+               Int8,
+               PARAM("lhs", Int8),
+               PARAM("rhs", Int8))
+   {
+   OMR::JitBuilder::IlValue *lhs = Load("lhs");
+   OMR::JitBuilder::IlValue *rhs = Load("rhs");
+   OMR::JitBuilder::IlValue *result = UnsignedRem(lhs, rhs);
+   Return(result);
+   return true;
+   }
+
+class UnsignedDivTest : public JitBuilderTest {};
+class UnsignedRemTest : public JitBuilderTest {};
+
+typedef uint64_t (*UInt64ReturnType)(uint64_t, uint64_t);
+TEST_F(UnsignedDivTest, UInt64_Test)
+   {
+   UInt64ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt64Div, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 1);
+   ASSERT_EQ(testFunction(1, 2), 0);
+   ASSERT_EQ(testFunction(10, 3), 3);
+   ASSERT_EQ(testFunction(static_cast<uint64_t>(INT64_MIN), static_cast<uint64_t>(-1)), 0);
+   ASSERT_EQ(testFunction(UINT64_MAX, 1), UINT64_MAX);
+   ASSERT_EQ(testFunction(UINT64_MAX, UINT64_MAX), 1);
+   ASSERT_EQ(testFunction(UINT64_MAX - 1, UINT64_MAX), 0);
+   ASSERT_EQ(testFunction(UINT64_MAX, UINT64_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint64_t>(INT64_MAX), UINT64_MAX), 0);
+   ASSERT_EQ(testFunction(UINT64_MAX, 10), UINT64_MAX / 10);
+   }
+
+TEST_F(UnsignedRemTest, UInt64_Test)
+   {
+   UInt64ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt64Rem, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 0);
+   ASSERT_EQ(testFunction(1, 2), 1);
+   ASSERT_EQ(testFunction(10, 3), 1);
+   ASSERT_EQ(testFunction(static_cast<uint64_t>(INT64_MIN), static_cast<uint64_t>(-1)), static_cast<uint64_t>(INT64_MIN));
+   ASSERT_EQ(testFunction(UINT64_MAX, 1), 0);
+   ASSERT_EQ(testFunction(UINT64_MAX, UINT64_MAX), 0);
+   ASSERT_EQ(testFunction(UINT64_MAX - 1, UINT64_MAX), UINT64_MAX - 1);
+   ASSERT_EQ(testFunction(UINT64_MAX, UINT64_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint64_t>(INT64_MAX), UINT64_MAX), static_cast<uint64_t>(INT64_MAX));
+   ASSERT_EQ(testFunction(UINT64_MAX, 10), UINT64_MAX % 10);
+   }
+
+typedef uint32_t (*UInt32ReturnType)(uint32_t, uint32_t);
+TEST_F(UnsignedDivTest, UInt32_Test)
+   {
+   UInt32ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt32Div, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 1);
+   ASSERT_EQ(testFunction(1, 2), 0);
+   ASSERT_EQ(testFunction(10, 3), 3);
+   ASSERT_EQ(testFunction(static_cast<uint32_t>(INT32_MIN), static_cast<uint32_t>(-1)), 0);
+   ASSERT_EQ(testFunction(UINT32_MAX, 1), UINT32_MAX);
+   ASSERT_EQ(testFunction(UINT32_MAX, UINT32_MAX), 1);
+   ASSERT_EQ(testFunction(UINT32_MAX - 1, UINT32_MAX), 0);
+   ASSERT_EQ(testFunction(UINT32_MAX, UINT32_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint32_t>(INT32_MAX), UINT32_MAX), 0);
+   ASSERT_EQ(testFunction(UINT32_MAX, 10), UINT32_MAX / 10);
+   }
+
+
+TEST_F(UnsignedRemTest, UInt32_Test)
+   {
+   UInt32ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt32Rem, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 0);
+   ASSERT_EQ(testFunction(1, 2), 1);
+   ASSERT_EQ(testFunction(10, 3), 1);
+   ASSERT_EQ(testFunction(static_cast<uint32_t>(INT32_MIN), static_cast<uint32_t>(-1)), static_cast<uint32_t>(INT32_MIN));
+   ASSERT_EQ(testFunction(UINT32_MAX, 1), 0);
+   ASSERT_EQ(testFunction(UINT32_MAX, UINT32_MAX), 0);
+   ASSERT_EQ(testFunction(UINT32_MAX - 1, UINT32_MAX), UINT32_MAX - 1);
+   ASSERT_EQ(testFunction(UINT32_MAX, UINT32_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint32_t>(INT32_MAX), UINT32_MAX), static_cast<uint32_t>(INT32_MAX));
+   ASSERT_EQ(testFunction(UINT32_MAX, 10), UINT32_MAX % 10);
+   }
+
+typedef uint16_t (*UInt16ReturnType)(uint16_t, uint16_t);
+TEST_F(UnsignedDivTest, UInt16_Test)
+   {
+   UInt16ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt16Div, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 1);
+   ASSERT_EQ(testFunction(1, 2), 0);
+   ASSERT_EQ(testFunction(10, 3), 3);
+   ASSERT_EQ(testFunction(static_cast<uint16_t>(INT16_MIN), static_cast<uint16_t>(-1)), 0);
+   ASSERT_EQ(testFunction(UINT16_MAX, 1), UINT16_MAX);
+   ASSERT_EQ(testFunction(UINT16_MAX, UINT16_MAX), 1);
+   ASSERT_EQ(testFunction(UINT16_MAX - 1, UINT16_MAX), 0);
+   ASSERT_EQ(testFunction(UINT16_MAX, UINT16_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint16_t>(INT16_MAX), UINT16_MAX), 0);
+   ASSERT_EQ(testFunction(UINT16_MAX, 10), UINT16_MAX / 10);
+   }
+
+
+TEST_F(UnsignedRemTest, UInt16_Test)
+   {
+   UInt16ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt16Rem, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 0);
+   ASSERT_EQ(testFunction(1, 2), 1);
+   ASSERT_EQ(testFunction(10, 3), 1);
+   ASSERT_EQ(testFunction(static_cast<uint16_t>(INT16_MIN), static_cast<uint16_t>(-1)), static_cast<uint16_t>(INT16_MIN));
+   ASSERT_EQ(testFunction(UINT16_MAX, 1), 0);
+   ASSERT_EQ(testFunction(UINT16_MAX, UINT16_MAX), 0);
+   ASSERT_EQ(testFunction(UINT16_MAX - 1, UINT16_MAX), UINT16_MAX - 1);
+   ASSERT_EQ(testFunction(UINT16_MAX, UINT16_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint16_t>(INT16_MAX), UINT16_MAX), static_cast<uint16_t>(INT16_MAX));
+   ASSERT_EQ(testFunction(UINT16_MAX, 10), UINT16_MAX % 10);
+   }
+
+typedef uint8_t (*UInt8ReturnType)(uint8_t, uint8_t);
+TEST_F(UnsignedDivTest, UInt8_Test)
+   {
+   UInt8ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt8Div, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 1);
+   ASSERT_EQ(testFunction(1, 2), 0);
+   ASSERT_EQ(testFunction(10, 3), 3);
+   ASSERT_EQ(testFunction(static_cast<uint8_t>(INT8_MIN), static_cast<uint8_t>(-1)), 0);
+   ASSERT_EQ(testFunction(UINT8_MAX, 1), UINT8_MAX);
+   ASSERT_EQ(testFunction(UINT8_MAX, UINT8_MAX), 1);
+   ASSERT_EQ(testFunction(UINT8_MAX - 1, UINT8_MAX), 0);
+   ASSERT_EQ(testFunction(UINT8_MAX, UINT8_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint8_t>(INT8_MAX), UINT8_MAX), 0);
+   ASSERT_EQ(testFunction(UINT8_MAX, 10), UINT8_MAX / 10);
+   }
+
+
+TEST_F(UnsignedRemTest, UInt8_Test)
+   {
+   UInt8ReturnType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestUInt8Rem, testFunction);
+   ASSERT_EQ(testFunction(1, 1), 0);
+   ASSERT_EQ(testFunction(1, 2), 1);
+   ASSERT_EQ(testFunction(10, 3), 1);
+   ASSERT_EQ(testFunction(static_cast<uint8_t>(INT8_MIN), static_cast<uint8_t>(-1)), static_cast<uint8_t>(INT8_MIN));
+   ASSERT_EQ(testFunction(UINT8_MAX, 1), 0);
+   ASSERT_EQ(testFunction(UINT8_MAX, UINT8_MAX), 0);
+   ASSERT_EQ(testFunction(UINT8_MAX - 1, UINT8_MAX), UINT8_MAX - 1);
+   ASSERT_EQ(testFunction(UINT8_MAX, UINT8_MAX - 1), 1);
+   ASSERT_EQ(testFunction(static_cast<uint8_t>(INT8_MAX), UINT8_MAX), static_cast<uint8_t>(INT8_MAX));
+   ASSERT_EQ(testFunction(UINT8_MAX, 10), UINT8_MAX % 10);
+   }
+

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -591,6 +591,15 @@
                     {"name":"right","type":"IlValue"}
                     ]
                 },
+                { "name": "UnsignedDiv"
+                , "overloadsuffix": ""
+                , "flags": []
+                , "return": "IlValue"
+                , "parms": [
+                    {"name":"left","type":"IlValue"},
+                    {"name":"right","type":"IlValue"}
+                    ]
+                },
                 { "name": "IndexAt"
                 , "overloadsuffix": ""
                 , "flags": []
@@ -636,6 +645,15 @@
                     ]
                 },
                 { "name": "Rem"
+                , "overloadsuffix": ""
+                , "flags": []
+                , "return": "IlValue"
+                , "parms": [
+                    {"name":"left","type":"IlValue"},
+                    {"name":"right","type":"IlValue"}
+                    ]
+                },
+                { "name": "UnsignedRem"
                 , "overloadsuffix": ""
                 , "flags": []
                 , "return": "IlValue"


### PR DESCRIPTION
This PR adds `UnsignedDiv` and `UnsignedRem` services on `IlBuilder` to perform unsigned division and remainder. Unfortunately, due to the lack of an `lurem` opcode at this time, a hack is necessary to allow taking the unsigned remainder of two 64-bit numbers: namely, the remainder is calculated as `lhs - ((lhs / rhs) * rhs)`.

Additionally, a couple of bugs in the value propagator handlers for division and remainder have been fixed. Specifically, their special cases for `INT_MIN / -1` are no longer erroneously applied when the opcode being used is unsigned.