### PR TITLE
Remove unused linkage conventions

### DIFF
--- a/compiler/codegen/OMRLinkageConventions.enum
+++ b/compiler/codegen/OMRLinkageConventions.enum
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,7 +27,5 @@
    TR_None = 0,
    TR_Private,
    TR_System,
-   TR_AllRegister,
-   TR_InterpretedStatic,
    TR_Helper,
    TR_J9JNILinkage,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -4237,10 +4237,6 @@ TR_Debug::getLinkageConventionName(uint8_t lc)
          return "Private";
       case TR_System:
          return "System";
-      case TR_AllRegister:
-         return "AllRegister";
-      case TR_InterpretedStatic:
-         return "InterpretedStatic";
       case TR_Helper:
          return "Helper";
       default:


### PR DESCRIPTION
* TR_AllRegister
* TR_InterpretedStatic

Are not used in OMR nor any known downstream project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>