### PR TITLE
Misc. Linkage base class cleanup

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -2882,19 +2882,6 @@ OMR::CodeGenerator::simulateTreeEvaluation(TR::Node *node, TR_RegisterPressureSt
             TR::Symbol * rcSymbol = state->_candidate->getSymbolReference()->getSymbol();
             TR::Linkage *linkage = self()->getLinkage();
 
-#if defined(TR_TARGET_S390)
-            TR_BitVector* killedRegisters = linkage->getKilledRegisters(node);
-            if (killedRegisters)
-               {
-               TR_BitVectorIterator bvi;
-               bvi.setBitVector(*killedRegisters);
-               while (bvi.hasMoreElements())
-                  {
-                  int32_t realRegNum = bvi.getNextElement();   // GPR0..GPR15, realRegNum 0..15
-                  summary->spill((TR_SpillKinds)(TR_gpr0Spill + realRegNum), self());
-                  }
-               }
-#endif
             // In Xplink, 31-bit mode, each call has a special argument passed in GPR12
             // Incoming special argument can be  passed to the call,
             // otherwise, TR_linkageSpill has to be set so that other candidates don't get

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -75,27 +75,17 @@ class OMR_EXTENSIBLE Linkage
 
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method, List<TR::ParameterSymbol> &parm)
       {
-      TR_ASSERT(0, "setParameterLinkageRegisterIndex has to be implemented for this linkage\n");
+      TR_UNIMPLEMENTED();
       }
-
-   virtual int32_t numArgumentRegisters(TR_RegisterKinds kind) = 0;
-   virtual TR_RegisterKinds argumentRegisterKind(TR::Node *argumentNode);
 
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method)
       {
-      TR_ASSERT(0, "setParameterLinkageRegisterIndex(2) has to be implemented for this linkage\n");
+      TR_UNIMPLEMENTED();
       }
 
-   virtual  TR_BitVector * getKilledRegisters(TR::Node *node)
-      {
-      return NULL;
-      }
-   virtual  TR_BitVector * getSavedRegisters(TR::Node *node, int32_t entryId = 0)
-      {
-      return NULL;
-      }
-   
-   virtual bool isSpecialNonVolatileArgumentRegister(int8_t) { return false; }
+   virtual int32_t numArgumentRegisters(TR_RegisterKinds kind) = 0;
+
+   virtual TR_RegisterKinds argumentRegisterKind(TR::Node *argumentNode);
 
    };
 }


### PR DESCRIPTION
* remove obsolete functions not used in OMR nor any known downstream project
* use TR_UNIMPLEMENTED rather than bespoke macros
* logically re-order function declarations

Signed-off-by: Daryl Maier <maier@ca.ibm.com>