### PR TITLE
Fix assertions in VerboseBuffer.cpp with CS

### DIFF
--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,8 @@ MM_VerboseHandlerOutput::newInstance(MM_EnvironmentBase *env, MM_VerboseManager 
 
 
 MM_VerboseHandlerOutput::MM_VerboseHandlerOutput(MM_GCExtensionsBase *extensions) :
-	_extensions(extensions)
+	_reportingLock()
+	,_extensions(extensions)
 	,_omrVM(NULL)
 	,_mmPrivateHooks(NULL)
 	,_mmOmrHooks(NULL)
@@ -70,6 +71,10 @@ MM_VerboseHandlerOutput::initialize(MM_EnvironmentBase *env, MM_VerboseManager *
 	_mmPrivateHooks = J9_HOOK_INTERFACE(_extensions->privateHookInterface);
 	_mmOmrHooks = J9_HOOK_INTERFACE(_extensions->omrHookInterface);
 	_manager = manager;
+
+	if (!_reportingLock.initialize(env, &env->getExtensions()->lnrlOptions, "MM_VerboseHandlerOutput:_reportingLock")) {
+		return false;
+	}
 
 	return true;
 }
@@ -85,6 +90,7 @@ MM_VerboseHandlerOutput::kill(MM_EnvironmentBase *env)
 void
 MM_VerboseHandlerOutput::tearDown(MM_EnvironmentBase *env)
 {
+	_reportingLock.tearDown();
 	return ;
 }
 
@@ -696,13 +702,13 @@ MM_VerboseHandlerOutput::handleAcquiredExclusiveToSatisfyAllocation(J9HookInterf
 void
 MM_VerboseHandlerOutput::enterAtomicReportingBlock()
 {
-	/* default implementation needs no special support */
+	_reportingLock.acquire();
 }
 
 void
 MM_VerboseHandlerOutput::exitAtomicReportingBlock()
 {
-	/* default implementation needs no special support */
+	_reportingLock.release();
 }
 
 void

--- a/gc/verbose/VerboseHandlerOutput.hpp
+++ b/gc/verbose/VerboseHandlerOutput.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,6 +30,8 @@
 
 #include "modronbase.h"
 
+#include "LightweightNonReentrantLock.hpp"
+
 class MM_CollectionStatistics;
 class MM_EnvironmentBase;
 class MM_GCExtensionsBase;
@@ -38,6 +40,8 @@ class MM_VerboseManager;
 class MM_VerboseHandlerOutput : public MM_Base
 {
 private:
+	MM_LightweightNonReentrantLock _reportingLock;
+
 protected:
 	MM_GCExtensionsBase *_extensions;
 	OMR_VM *_omrVM;

--- a/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
+++ b/gc/verbose/handler_standard/VerboseHandlerOutputStandard.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -129,6 +129,7 @@ public:
 	 * @param eventData hook specific event data.
 	 */
 	void handleScavengeEnd(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
+	void handleScavengeEndNoLock(J9HookInterface** hook, uintptr_t eventNum, void* eventData);
 
 	/**
 	 * Write verbose stanza for a percolate event.


### PR DESCRIPTION
Dedicated master GC thread in CS, which can report concurrent-start/end stanza races with some other asynchronous reporting (e.g. kickoff for concurrent mark)

1. Implementation for `enterAtomicReportingBlock` and `exitAtomicReportingBlock` with a lightweight lock. (Already implemented for Balanced and Metronome.. separate PR will be opened for OpenJ9 to make this common once OMR changes are in)

2. Introduced handleScavengeEndNoLock (wrapped by handleScavengeEnd), required by CS to avoid deadlock due to lock nesting. `handleConcurrentEnd` calls `handleScavengeEnd` with attempt to acquire a lock again, hence `handleScavengeEndNoLock` is called instead.

Fixes: #3619

Signed-off-by: Salman Rana <salman.rana@ibm.com>