### PR TITLE
Fix jitbuildertest CMake warning

### DIFF
--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,7 +39,7 @@ add_executable(jitbuildertest
 
 if(OMR_HOST_ARCH STREQUAL "x86")
 	if(OMR_HOST_OS STREQUAL "linux" OR OMR_HOST_OS STREQUAL "osx")
-		target_sources(jitbuildertest PUBLIC CallReturnTest.cpp)
+		target_sources(jitbuildertest PRIVATE CallReturnTest.cpp)
 	endif()
 endif()
 


### PR DESCRIPTION
By making the source private, we no longer have to worry about giving an
absolute path to the source.

CMake Warning (dev) at fvtest/jitbuildertest/CMakeLists.txt:42 (target_sources):
    Policy CMP0076 is not set: target_sources() command converts relative paths
    to absolute.  Run "cmake --help-policy CMP0076" for policy details.  Use
    the cmake_policy command to set the policy and suppress this warning.

    An interface source of target "jitbuildertest" has a relative path.
    This warning is for project developers.  Use -Wno-dev to suppress it.

Signed-off-by: Andrew Young <youngar17@gmail.com>