### PR TITLE
Change OmrTracegen message from a warning to a status

### DIFF
--- a/cmake/modules/OmrTracegen.cmake
+++ b/cmake/modules/OmrTracegen.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,10 +29,9 @@ set_property(TARGET run_tracegen PROPERTY FOLDER tracegen)
 
 # Setup a default trace root if one has not alreay been set
 if(NOT DEFINED OMR_TRACE_ROOT)
-	message(WARNING "OMR: No trace root has been set. Defaulting to '${CMAKE_CURRENT_BINARY_DIR}'")
 	set(OMR_TRACE_ROOT "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
-
+message(STATUS "OMR: trace root is '${OMR_TRACE_ROOT}'")
 
 # Process an <input> tracegen file to produce trace headers, sources, and pdat files.
 # Usage: omr_add_tracegen(<input> [<output>])


### PR DESCRIPTION
Old warning message was quite verbose, and not a real warning.  By
changing the message to status the output is less alarming.

From:
```
CMake Warning at cmake/modules/OmrTracegen.cmake:32 (message):
  OMR: No trace root has been set.  Defaulting to
  '/home/aryoung/wsp/omr/build'
Call Stack (most recent call first):
  CMakeLists.txt:43 (include)
```

To:
```
-- OMR: No trace root has been set. Defaulting to '/home/aryoung/wsp/omr/build'
```

Signed-off-by: Andrew Young <youngar17@gmail.com>