### PR TITLE
Stop printing compiler definitions when running cmake

### DIFF
--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -77,8 +77,7 @@ function(make_compiler_target TARGET_NAME SCOPE)
 		${COMPILER_DEFINES}
 	)
 
-	message("Made ${TARGET_NAME} into a compiler target,for ${TARGET_COMPILER}.")
-	message("Defines are ${COMPILER_DEFINES} and ${TR_COMPILE_DEFINITIONS}, arch is ${TR_TARGET_ARCH} and ${TR_TARGET_SUBARCH}, compile options are ${TR_COMPILE_OPTIONS} ")
+	message(STATUS "Adding ${SCOPE} compiler options to ${TARGET_NAME} for ${TARGET_COMPILER}.")
 endfunction(make_compiler_target)
 
 # Filter through the provided list, and rewrite any
@@ -180,7 +179,6 @@ function(spp2s_files out_var compiler)
 	set(SPP_INCLUDES ${${compiler}_INCLUDES})
 	set(SPP_DEFINES  ${${compiler}_DEFINES} ${compile_defs})
 
-	message(STATUS "Set SPP defines to ${SPP_DEFINES}")
 	omr_add_prefix(SPP_INCLUDES "-I" ${SPP_INCLUDES})
 	omr_add_prefix(SPP_DEFINES  "-D" ${SPP_DEFINES})
 	set(result "")
@@ -319,10 +317,10 @@ function(create_omr_compiler_library)
 		)
 
 	if(COMPILER_SHARED)
-		message("Creating shared library for ${COMPILER_NAME}")
+		message(STATUS "Creating shared library for ${COMPILER_NAME}")
 		set(LIB_TYPE SHARED)
 	else()
-		message("Creating static library for ${COMPILER_NAME}")
+		message(STATUS "Creating static library for ${COMPILER_NAME}")
 		set(LIB_TYPE STATIC)
 	endif()
 
@@ -344,8 +342,6 @@ function(create_omr_compiler_library)
 		${COMPILER_INCLUDES}
 		CACHE INTERNAL "Include header list for ${COMPILER}"
 	)
-
-	message("${COMPILER_NAME}_ROOT = ${${COMPILER_NAME}_ROOT}")
 
 	# Generate a build name file.
 	set(BUILD_NAME_FILE "${CMAKE_BINARY_DIR}/${COMPILER_NAME}Name.cpp")


### PR DESCRIPTION
- Make messages have the status flag
- Reword message for `make_compiler_target`
- Stop printing compiler defines in `make compiler_target`
- Stop printing defines for SPP

Signed-off-by: Andrew Young <youngar17@gmail.com>