### PR TITLE
Fix GlobalVP handling of backedge constraints

### DIFF
--- a/compiler/optimizer/GlobalValuePropagation.hpp
+++ b/compiler/optimizer/GlobalValuePropagation.hpp
@@ -68,6 +68,7 @@ class GlobalValuePropagation : public TR::ValuePropagation
    void getImproperRegionStores(TR_StructureSubGraphNode *node, ValueConstraints &stores);
    bool buildInputConstraints(TR::CFGNode *node);
    void propagateOutputConstraints(TR_StructureSubGraphNode *node, bool lastTimeThrough, bool isNaturalLoop, List<TR::CFGEdge> &outEdges1, List<TR::CFGEdge> *outEdges2);
+   TR_BitVector *mergeDefinedOnAllPaths(TR_StructureSubGraphNode *node);
    // Blocks not included in this set will be skipped for speed.
    // NULL bitvector means the info is unavailable, and all blocks should be processed.
    //

--- a/compiler/optimizer/OMRValuePropagation.hpp
+++ b/compiler/optimizer/OMRValuePropagation.hpp
@@ -90,6 +90,9 @@ template <class T> class TR_Stack;
 typedef TR::Node* (* ValuePropagationPtr)(OMR::ValuePropagation *, TR::Node *);
 extern const ValuePropagationPtr constraintHandlers[];
 
+typedef TR::typed_allocator<std::pair<TR::CFGEdge * const, TR_BitVector*>, TR::Region &> DefinedOnAllPathsMapAllocator;
+typedef std::map<TR::CFGEdge *, TR_BitVector *, std::less<TR::CFGEdge *>, DefinedOnAllPathsMapAllocator> DefinedOnAllPathsMap;
+
 namespace TR {
 
 class ArraycopyTransformation : public TR::Optimization
@@ -672,6 +675,9 @@ class ValuePropagation : public TR::Optimization
    int32_t                         _firstInductionVariableValueNumber;
 
    ValueConstraints                _curConstraints;
+   TR_BitVector                    *_curDefinedOnAllPaths;
+   TR_BitVector                    *_defMergedNodes;
+   DefinedOnAllPathsMap            *_definedOnAllPaths;
    ValueConstraintHandler          _vcHandler;
 
    vcount_t                        _visitCount;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2769,6 +2769,8 @@ TR::Node *constrainStore(OMR::ValuePropagation *vp, TR::Node *node)
 
    if (node->getOpCode().isIndirect())
       constrainBaseObjectOfIndirectAccess(vp, node);
+   else if (vp->_curDefinedOnAllPaths && node->getSymbol()->isAutoOrParm())
+      vp->_curDefinedOnAllPaths->set(node->getSymbolReference()->getReferenceNumber());
 
    return node;
    }

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -252,6 +252,12 @@ void OMR::ValuePropagation::initialize()
 
    _edgesToBeRemoved = new (trStackMemory()) TR_Array<TR::CFGEdge *>(trMemory(), 8, false, stackAlloc);
    _blocksToBeRemoved = new (trStackMemory()) TR_Array<TR::CFGNode*>(trMemory(), 8, false, stackAlloc);
+   _curDefinedOnAllPaths = NULL;
+   if (_isGlobalPropagation)
+      _definedOnAllPaths = new (trStackMemory()) DefinedOnAllPathsMap(std::less<TR::CFGEdge *>(), trMemory()->currentStackRegion());
+   else
+      _definedOnAllPaths = NULL;
+   _defMergedNodes = new (trStackMemory()) TR_BitVector(0, trMemory(), stackAlloc, growable);
    _vcHandler.setRoot(_curConstraints, NULL);
 
    _relationshipCache.setFirst(NULL);


### PR DESCRIPTION
Global value propagation currently handles loops using a two pass
strategy. On the first pass we do not consider constraints entering
the loop and compute a set of backedge constraints. This set of
constraints represents the information produced by an iteration of the
loop. We then process the loop again using the entry constraints and
selectively merge the backedge constraints where required. The current
def constraint merging logic considers backedge constraints only when a
def has not been seen on the current iteration of the loop. This is
insufficient - a definition must have been seen on all paths from the
loop header to the def constraint merge point to be able to ignore the
constraints on the backedge. The intuition here is that if a def has not
happened on some path from the backedge the def from a previous
iteration could reach and so we must consider it and merge them in.

This change adds a map and bitvectors of value numbers to the global VP
representation. These bitvectors track the value numbers defined on all
paths for loops and these are consulted as part of merging definitions.
Exception edges are handled conservatively in this analysis at present -
we know nothing - this can be improved if required later.

Note that failing to produce a constraint for a node is represented with
with a NULL constraint. This constraint matches the unprocessed default value.
When merging def constraints it is only safe to do this at the point of a node's
first evaluation tracking of first evaluation point is included for correctness.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>