### PR TITLE
 Enable minimum ALS asserts as fatal in Z codegen

### DIFF
--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -311,7 +311,7 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
    /**  Attempt to use SGH to subtract halfword (64 <- 16).
     * The second child is a halfword from memory */
    bool is16BitMemory2Operand = false;
-   if (TR::Compiler->target.cpu.getS390SupportsZ14() &&
+   if (cg()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z14) &&
        secondChild->getOpCodeValue() == TR::s2l &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
        secondChild->isSingleRefUnevaluated() &&

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -246,7 +246,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
    bool isLoadNodeNested = false;
 
    // TODO: add MH and MHY here; outside of the z14 if check.
-   if(TR::Compiler->target.cpu.getS390SupportsZ14())
+   if(cg()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z14))
       {
       bool isSetReg2Mem1 = false;
 
@@ -340,7 +340,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
          }
       else
          {
-         if(TR::Compiler->target.cpu.getS390SupportsZ14())
+         if(cg()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z14))
             {
             // Check for multiplications on z14
             TR::InstOpCode::Mnemonic z14OpCode = TR::InstOpCode::BAD;
@@ -605,7 +605,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
          tempMR->addToOffset(4);
          tempMR->setDispAdjusted();
          }
-      
+
       auto instructionFormat = TR::InstOpCode(memToRegOpCode).getInstructionFormat();
 
       if (instructionFormat == RXE_FORMAT)
@@ -739,7 +739,7 @@ TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOp
       }
 
    /**  Attempt to use AGH to add halfworf from memory */
-   if (TR::Compiler->target.cpu.getS390SupportsZ14() &&
+   if (cg()->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z14) &&
        secondChild->getOpCodeValue() == TR::s2l &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
        secondChild->isSingleRefUnevaluated() &&

--- a/compiler/z/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/z/codegen/OMRInstOpCodeProperties.hpp
@@ -34,7 +34,7 @@
    /* .format      = */ PSEUDO,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None
-   },   
+   },
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::BAD,
@@ -45,7 +45,7 @@
    /* .format      = */ PSEUDO,
    /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_None
-   },   
+   },
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::BREAK,
@@ -8127,7 +8127,7 @@
                         S390OpProp_SetsOperand2 |
                         S390OpProp_UsesTarget
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::MVIY,
    /* .name        = */ "MVIY",
@@ -8157,7 +8157,7 @@
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::NIY,
    /* .name        = */ "NIY",
@@ -8191,7 +8191,7 @@
                         S390OpProp_LongDispSupported |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::OG,
    /* .name        = */ "OG",
@@ -15322,7 +15322,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x4C,
    /* .format      = */ RXYa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
                         S390OpProp_BranchOp |
@@ -15350,7 +15350,7 @@
    /* .opcode[0]   = */ 0xE3,
    /* .opcode[1]   = */ 0x48,
    /* .format      = */ RXYa_FORMAT,
-   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_z14,
+   /* .minimumALS  = */ TR_S390ProcessorInfo::TR_UnknownArchitecture,
    /* .properties  = */ S390OpProp_IsLoad |
                         S390OpProp_Is64Bit |
                         S390OpProp_BranchOp |
@@ -15930,7 +15930,7 @@
                         S390OpProp_IsStore |
                         S390OpProp_HasTwoMemoryReferences
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::NCGRK,
    /* .name        = */ "NCGRK",
@@ -15986,7 +15986,7 @@
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::NOGRK,
    /* .name        = */ "NOGRK",
@@ -16014,7 +16014,7 @@
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::NXGRK,
    /* .name        = */ "NXGRK",
@@ -16042,7 +16042,7 @@
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::OCGRK,
    /* .name        = */ "OCGRK",
@@ -16056,7 +16056,7 @@
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::OCRK,
    /* .name        = */ "OCRK",
@@ -16070,7 +16070,7 @@
                         S390OpProp_SetsZeroFlag |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::SELGR,
    /* .name        = */ "SELGR",
@@ -16084,7 +16084,7 @@
                         S390OpProp_IsRegCopy |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::SELHHHR,
    /* .name        = */ "SELHHHR",
@@ -16101,7 +16101,7 @@
                         S390OpProp_Src2HW |
                         S390OpProp_SetsOperand1
    },
-   
+
    {
    /* .mnemonic    = */ OMR::InstOpCode::SELR,
    /* .name        = */ "SELR",

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -85,7 +85,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
 
    self()->initialize();
    }
@@ -95,7 +95,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedin
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(cg->getS390ProcessorInfo()->supportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
 
    self()->initialize(precedingInstruction, true);
    }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5222,15 +5222,7 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
                      loadMnemonic = TR::InstOpCode::getLoadOpCode();
                      }
 
-                  if (loadMnemonic == TR::InstOpCode::LLGFSG ||
-                      loadMnemonic == TR::InstOpCode::LGG)
-                     {
-                     generateRXInstruction(cg, loadMnemonic, node, tempReg, tempMR);
-                     }
-                  else
-                     {
-                     generateRXInstruction(cg, loadMnemonic, node, tempReg, tempMR);
-                     }
+                  generateRXInstruction(cg, loadMnemonic, node, tempReg, tempMR);
                   }
                }
             }

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -2653,7 +2653,7 @@ TR_S390PostRAPeephole::reloadLiteralPoolRegisterForCatchBlock()
    // This causes a failure when we come back to a catch block because the register context will not be preserved.
    // Hence, we can not assume that R6 will still contain the lit pool register and hence need to reload it.
 
-   bool isZ10 = TR::Compiler->target.cpu.getS390SupportsZ10();
+   bool isZ10 = _cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z10);
 
    // we only need to reload literal pool for Java on older z architecture on zos when on demand literal pool is off
    if ( TR::Compiler->target.isZOS() && !isZ10 && !_cg->isLiteralPoolOnDemandOn())


### PR DESCRIPTION
This pull request enables fatal asserts in the OMRInstruction
constructor so that instructions not supported by the
architecture level will not be generated.
