### PR TITLE
Provide Compilation API for checking for recursive calls

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -256,9 +256,6 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
 
    if (getOpCodeValue() == ARMOp_bl)
       {
-      TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
-      TR_ResolvedMethod *resolvedMethod = (sym==NULL)?NULL:sym->getResolvedMethod();
-
       label = getSymbolReference()->getSymbol()->getLabelSymbol();
 
       if (cg()->hasCodeCacheSwitched())
@@ -281,7 +278,9 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
             }
          }
 
-      if (resolvedMethod != NULL && resolvedMethod->isSameMethod(comp->getCurrentMethod()) && !comp->isDLT())
+      TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
+
+      if (comp->isRecursiveMethodTarget(sym))
          {
          uint32_t jitTojitStart = (uintptr_t) cg()->getCodeStart();
 

--- a/compiler/arm/codegen/ARMDebug.cpp
+++ b/compiler/arm/codegen/ARMDebug.cpp
@@ -423,7 +423,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARMImmSymInstruction * instr)
 
    bool longJump = imm &&
                    _cg->directCallRequiresTrampoline((intptrj_t)imm, (intptrj_t)bufferPos) &&
-                   (!callee || !callee->isSameMethod(_comp->getCurrentMethod()));
+                   !_comp->isRecursiveMethodTarget(sym);
 
    if (bufferPos != NULL && longJump)
       {

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1018,9 +1018,7 @@ TR_StackMemory OMR::ARM::Linkage::trStackMemory()
 
 TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNode, bool isSystem)
    {
-   TR::CodeGenerator *codeGen    = self()->cg();
-   TR::SymbolReference *callSymRef = callNode->getSymbolReference();
-   TR::MethodSymbol     *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
+   TR::CodeGenerator *codeGen = self()->cg();
 
    const TR::ARMLinkageProperties &pp = self()->getProperties();
    TR::RegisterDependencyConditions *dependencies =
@@ -1031,11 +1029,10 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    int32_t argSize = self()->buildArgs(callNode, dependencies, vftReg, false);
    dependencies->stopAddingConditions();
 
-   TR::ResolvedMethodSymbol *sym = callSymbol->getResolvedMethodSymbol();
-   TR_ResolvedMethod     *vmm = (sym == NULL) ? NULL : sym->getResolvedMethod();
-   bool isMyself;
+   TR::SymbolReference *callSymRef = callNode->getSymbolReference();
+   TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
 
-   isMyself = (vmm != NULL) && vmm->isSameMethod(codeGen->comp()->getCurrentMethod()) && !codeGen->comp()->isDLT();
+   bool isMyself = codeGen->comp()->isRecursiveMethodTarget(callSymbol);
 
    if (callSymRef->getReferenceNumber() >= TR_ARMnumRuntimeHelpers)
       codeGen->comp()->fe()->reserveTrampolineIfNecessary(codeGen->comp(), callSymRef, false);

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2741,3 +2741,25 @@ bool OMR::Compilation::incompleteOptimizerSupportForReadWriteBarriers()
    {
    return false;
    }
+
+
+bool OMR::Compilation::isRecursiveMethodTarget(TR_ResolvedMethod *targetResolvedMethod)
+   {
+   return targetResolvedMethod && targetResolvedMethod->isSameMethod(self()->getCurrentMethod()) && !self()->isDLT();
+   }
+
+
+bool OMR::Compilation::isRecursiveMethodTarget(TR::Symbol *targetSymbol)
+   {
+   bool isRecursive = false;
+
+   if (targetSymbol)
+      {
+      TR::MethodSymbol *methodSymbol = targetSymbol->isMethod() ? targetSymbol->castToMethodSymbol() : NULL;
+      TR::ResolvedMethodSymbol *resolvedSymbol = methodSymbol ? methodSymbol->getResolvedMethodSymbol() : NULL;
+      TR_ResolvedMethod *resolvedMethod  = resolvedSymbol ? resolvedSymbol->getResolvedMethod() : NULL;
+      isRecursive = self()->isRecursiveMethodTarget(resolvedMethod);
+      }
+
+   return isRecursive;
+   }

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -514,6 +514,28 @@ public:
    ToStringMap  &getToStringMap()  { return _toStringMap; }
    ToCommentMap &getToCommentMap() { return _toCommentMap; }
 
+   /**
+    * @brief Answers whether a call to the provided resolved method would represent a
+    *        recursive method call from the method currently being compiled.
+    *
+    * @param[in] targetResolvedMethod : the method symbol to check
+    *
+    * @return true if calling the targetResolvedMethod is a recursive call from the
+    *         method being compiled; false otherwise.
+    */
+   bool isRecursiveMethodTarget(TR_ResolvedMethod *targetResolvedMethod);
+
+   /**
+    * @brief Answers whether a call to the provided target symbol would represent a
+    *        recursive method call from the method currently being compiled.
+    *
+    * @param[in] targetSymbol : the method symbol to check
+    *
+    * @return true if calling the targetSymbol is a recursive call from the method
+    *         being compiled; false otherwise.
+    */
+   bool isRecursiveMethodTarget(TR::Symbol *targetSymbol);
+
    // ==========================================================================
    // Should be in Code Generator
    //

--- a/compiler/p/codegen/OMRInstruction.cpp
+++ b/compiler/p/codegen/OMRInstruction.cpp
@@ -230,10 +230,7 @@ uint8_t *TR::PPCDepImmSymInstruction::generateBinaryEncoding()
 
    if (getOpCodeValue() == TR::InstOpCode::bl || getOpCodeValue() == TR::InstOpCode::b)
       {
-      TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();
-      TR_ResolvedMethod *resolvedMethod = sym == NULL ? NULL : sym->getResolvedMethod();
-
-      if (resolvedMethod != NULL && resolvedMethod->isSameMethod(cg()->comp()->getCurrentMethod()))
+      if (cg()->comp()->isRecursiveMethodTarget(getSymbolReference()->getSymbol()))
          {
          uint8_t *jitTojitStart = cg()->getCodeStart();
          jitTojitStart += ((*(int32_t *)(jitTojitStart - 4)) >> 16) & 0x0000ffff;

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1065,19 +1065,20 @@ TR::X86ImmSymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
       if (getOpCode().isCallImmOp() || getOpCode().isBranchOp())
          {
-         TR::MethodSymbol *methodSym = sym->getMethodSymbol();
-         TR::ResolvedMethodSymbol *resolvedMethodSym = sym->getResolvedMethodSymbol();
-         TR_ResolvedMethod *resolvedMethod = resolvedMethodSym ? resolvedMethodSym->getResolvedMethod() : 0;
-         TR::LabelSymbol *labelSym = sym->getLabelSymbol();
-
-         if ( !(resolvedMethod && resolvedMethod->isSameMethod(comp->getCurrentMethod()) && !comp->isDLT()) )
+         if (!comp->isRecursiveMethodTarget(sym))
             {
+            TR::LabelSymbol *labelSym = sym->getLabelSymbol();
+
             if (labelSym)
                {
                cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelRelative32BitRelocation(cursor, labelSym));
                }
             else
                {
+               TR::MethodSymbol *methodSym = sym->getMethodSymbol();
+               TR::ResolvedMethodSymbol *resolvedMethodSym = sym->getResolvedMethodSymbol();
+               TR_ResolvedMethod *resolvedMethod = resolvedMethodSym ? resolvedMethodSym->getResolvedMethod() : 0;
+
                if (methodSym && methodSym->isHelper())
                   {
                   cg()->addProjectSpecializedRelocation(cursor, (uint8_t *)getSymbolReference(), NULL, TR_HelperAddress,
@@ -1214,16 +1215,12 @@ uint8_t* TR::X86ImmSymInstruction::generateOperand(uint8_t* cursor)
 
       if (getOpCode().isCallImmOp() || getOpCode().isBranchOp())
          {
-         TR::MethodSymbol *methodSym = sym->getMethodSymbol();
-         TR::ResolvedMethodSymbol *resolvedMethodSym = sym->getResolvedMethodSymbol();
-         TR_ResolvedMethod *resolvedMethod = resolvedMethodSym ? resolvedMethodSym->getResolvedMethod() : 0;
-         TR::LabelSymbol *labelSym = sym->getLabelSymbol();
-
          intptrj_t targetAddress = (int32_t)getSourceImmediate();
 
          if (TR::Compiler->target.is64Bit() && cg()->hasCodeCacheSwitched() && getOpCodeValue() == CALLImm4)
             {
             TR::SymbolReference *calleeSymRef = NULL;
+            TR::LabelSymbol *labelSym = sym->getLabelSymbol();
 
             if (labelSym==NULL)
                calleeSymRef = getSymbolReference();
@@ -1244,7 +1241,7 @@ uint8_t* TR::X86ImmSymInstruction::generateOperand(uint8_t* cursor)
          intptrj_t currentInstructionAddress = (intptrj_t)(cursor-1);
          intptrj_t nextInstructionAddress = (intptrj_t)(cursor+4);
 
-         if (resolvedMethod && resolvedMethod->isSameMethod(comp->getCurrentMethod()) && !comp->isDLT())
+         if (comp->isRecursiveMethodTarget(sym))
             {
             // Compute method's jit entry point
             //
@@ -1261,6 +1258,7 @@ uint8_t* TR::X86ImmSymInstruction::generateOperand(uint8_t* cursor)
             }
          else
             {
+            TR::LabelSymbol *labelSym = sym->getLabelSymbol();
             if (!labelSym)
                {
                // TODO:
@@ -1284,6 +1282,8 @@ uint8_t* TR::X86ImmSymInstruction::generateOperand(uint8_t* cursor)
                //
                // This logic/handshake will be cleaned up in a future release.
                //
+               TR::MethodSymbol *methodSym = sym->getMethodSymbol();
+
                if (TR::Compiler->target.is64Bit())
                   {
                   // Obtain the actual target of this call instruction.
@@ -1293,7 +1293,11 @@ uint8_t* TR::X86ImmSymInstruction::generateOperand(uint8_t* cursor)
                   //
                   TR::Node *symNode = getNode();
                   if (methodSym && methodSym->isJNI() && symNode && symNode->isPreparedForDirectJNI())
+                     {
+                     TR::ResolvedMethodSymbol *resolvedMethodSym = sym->getResolvedMethodSymbol();
+                     TR_ResolvedMethod *resolvedMethod = resolvedMethodSym ? resolvedMethodSym->getResolvedMethod() : 0;
                      targetAddress = (uintptrj_t)resolvedMethod->startAddressForJNIMethod(comp);
+                     }
                   else
                      targetAddress = (intptrj_t)getSymbolReference()->getMethodAddress();
                   }

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2426,7 +2426,6 @@ TR::S390RILInstruction::generateBinaryEncoding()
          }
 #endif
 
-      i2 = (int32_t)((getTargetPtr() - (uintptrj_t)cursor) / 2);
       (*(uint16_t *) cursor) = bos(0xC005);
       toRealRegister(getRegisterOperand(1))->setRegister1Field((uint32_t *) cursor);
 
@@ -2445,16 +2444,8 @@ TR::S390RILInstruction::generateBinaryEncoding()
           *     If targetAddress is not provided, TargetSymbol should be a method symbol.
           */
          TR_ASSERT(getTargetPtr() || (getTargetSymbol() && getTargetSymbol()->isMethod()),"targetAddress or method symbol should be provided for BRASL\n");
-         bool isRecursiveCall = false;
-         TR::MethodSymbol * callSymbol = NULL;
-         if (getTargetSymbol())
-            {
-            callSymbol = getTargetSymbol()->isMethod() ? getTargetSymbol()->castToMethodSymbol() : NULL;
-            TR::ResolvedMethodSymbol * sym = (callSymbol) ? callSymbol->getResolvedMethodSymbol() : NULL;
-            TR_ResolvedMethod * fem = sym ? sym->getResolvedMethod() : NULL;
-            isRecursiveCall = (fem != NULL && fem->isSameMethod(comp->getCurrentMethod()) && !comp->isDLT());
-            }
-         if (isRecursiveCall)
+
+         if (comp->isRecursiveMethodTarget(getTargetSymbol()))
             {
             // call myself case
             uint8_t * jitTojitStart = cg()->getCodeStart();
@@ -2465,6 +2456,14 @@ TR::S390RILInstruction::generateBinaryEncoding()
             }
          else
             {
+            TR::MethodSymbol *callSymbol = NULL;
+            if (getTargetSymbol())
+               {
+               callSymbol = getTargetSymbol()->isMethod() ? getTargetSymbol()->castToMethodSymbol() : NULL;
+               }
+
+            i2 = (int32_t)((getTargetPtr() - (uintptrj_t)cursor) / 2);
+
             if (getTargetPtr() == 0 && callSymbol)
                {
                i2 = (int32_t)(((uintptrj_t)(callSymbol->getMethodAddress()) - (uintptrj_t)cursor) / 2);


### PR DESCRIPTION
Provide an API in the Compilation class for checking whether calling a
given method symbol represents a recursive call to the method currently
being compiled.  Use the API throughout the code generators.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>