### PR TITLE
Fix double initialization of MUTEX in OMRMonitor.cpp

### DIFF
--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -66,9 +66,12 @@ bool
 OMR::Monitor::init(char *name)
    {
    _name = name;
+#if defined(OMR_OS_WINDOWS)
    MUTEX_INIT(_monitor);
+#else
    bool rc = MUTEX_INIT(_monitor);
    TR_ASSERT(rc == true, "error initializing monitor\n");
+#endif /* defined(OMR_OS_WINDOWS) */
    return true;
    }
 


### PR DESCRIPTION
When the Windows support was added, or maybe after some subsequent
bad merge happened, it looks like a #if for the Windows platform
was missed or removed from OMR::Monitor::init(), leaving a double
call to MUTEX_INIT. This commit wraps the code in the proper
conditional #if...#else...#endif analogous to similar code in
the destroy(), enter(), and exit() functions.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>