### PR TITLE
Reduce default output of tracegen

### DIFF
--- a/tools/tracegen/CFileWriter.cpp
+++ b/tools/tracegen/CFileWriter.cpp
@@ -45,7 +45,9 @@ CFileWriter::writeOutputFiles(J9TDFOptions *options, J9TDFFile *tdf, J9TDFGroup 
 	time_t targetFileMtime = FileUtils::getMtime(fileName);
 
 	if ((false == options->force) && (targetFileMtime > sourceFileMtime)) {
-		printf("C file is already up-to-date: %s\n", fileName);
+		if (options->verboseOutput) {
+			printf("C file is already up-to-date: %s\n", fileName);
+		}
 		Port::omrmem_free((void **)&fileName);
 		return RC_OK;
 	}

--- a/tools/tracegen/DATFileWriter.cpp
+++ b/tools/tracegen/DATFileWriter.cpp
@@ -49,7 +49,9 @@ DATFileWriter::writeOutputFiles(J9TDFOptions *options, J9TDFFile *tdf)
 	time_t targetFileMtime = FileUtils::getMtime(fileName);
 
 	if ((false == options->force) && (targetFileMtime > sourceFileMtime)) {
-		printf("pdat file is already up-to-date: %s\n", fileName);
+		if (options->verboseOutput) {
+			printf("pdat file is already up-to-date: %s\n", fileName);
+		}
 		Port::omrmem_free((void **)&fileName);
 		return RC_OK;
 	}

--- a/tools/tracegen/TraceHeaderWriter.cpp
+++ b/tools/tracegen/TraceHeaderWriter.cpp
@@ -141,12 +141,14 @@ TraceHeaderWriter::writeOutputFiles(J9TDFOptions *options, J9TDFFile *tdf)
 	time_t targetFileMtime = FileUtils::getMtime(fileName);
 
 	if (false == options->force && targetFileMtime > sourceFileMtime) {
-		printf("Header file is already up-to-date: %s\n", fileName);
+		if (options->verboseOutput) {
+			printf("Header file is already up-to-date: %s\n", fileName);
+		}
 		Port::omrmem_free((void **)&fileName);
 		return RC_OK;
 	}
 
-	if (true == options->verboseOutput) {
+	if (options->verboseOutput) {
 		printf("Creating header file: %s\n", fileName);
 	}
 


### PR DESCRIPTION
Make tracegen not output any information unless verbose is enabled.

Signed-off-by: Andrew Young <youngar17@gmail.com>