### PR TITLE
AArch64: Add VirtualGuardRuntime.cpp

### DIFF
--- a/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include <stdint.h>
+#include <infra/Assert.hpp>
+
+extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
+   {
+   TR_UNIMPLEMENTED();
+   }


### PR DESCRIPTION
This commit adds VirtualGuardRuntime.cpp in compiler/aarch64/runtime
to declare _patchVirtualGuard().  It is not implemented yet.

Signed-off-by: knn-k <konno@jp.ibm.com>