### PR TITLE
Deprecate PRINT_ME and TRACE_EVAL macros on Z

### DIFF
--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -49,8 +49,6 @@
 
 namespace TR { class Instruction; }
 
-#define   ENABLE_ZARCH_FOR_32    1
-
 void
 TR_S390BinaryAnalyser::remapInputs(TR::Node * firstChild, TR::Register * firstRegister,
                                     TR::Node * secondChild, TR::Register * secondRegister)

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -52,8 +52,6 @@
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390Instruction.hpp"
 
-#define ENABLE_ZARCH_FOR_32    1
-
 void
 TR_S390BinaryCommutativeAnalyser::remapInputs(TR::Node * firstChild, TR::Register *firstRegister,
                                               TR::Node * secondChild, TR::Register *secondRegister,

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -67,21 +67,6 @@
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390Instruction.hpp"
 
-
-//#define TRACE_EVAL
-#if defined(TRACE_EVAL)
-#define EVAL_BLOCK
-#if defined (EVAL_BLOCK)
-#define PRINT_ME(string,node,cg) TR::Delimiter evalDelimiter(TR::comp(), TR::comp()->getOption(TR_TraceCG), "EVAL", string)
-#else
-extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
-#endif
-#else
-#define PRINT_ME(string,node,cg)
-#endif
-
-#define ENABLE_ZARCH_FOR_32    1
-
 /**
  * lnegFor32bit - 32 bit code generation to negate a long integer
  */
@@ -183,9 +168,7 @@ laddConst(TR::Node * node, TR::CodeGenerator * cg, TR::RegisterPair * targetRegi
    TR::Register * lowOrder = targetRegisterPair->getLowOrder();
    TR::Register * highOrder = targetRegisterPair->getHighOrder();
 
-   if ( ENABLE_ZARCH_FOR_32 &&
-         performTransformation(comp, "O^O Use AL/ALC to perform long add.\n")
-      )
+   if (performTransformation(comp, "O^O Use AL/ALC to perform long add.\n"))
       {     // wrong carry bit to be set
       if ( l_value != 0 )
          {
@@ -533,34 +516,25 @@ generic32BitAddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       int32_t value;
       switch (secondChild->getDataType())
          {
-         case TR::Address:
-            TR_ASSERT( TR::Compiler->target.is32Bit(),"Should not be here for 64bit!");
-         case TR::Int32:
+         case TR::Int8:
             {
-            PRINT_ME("iconst", node, cg);
-            value = secondChild->getInt();
+            value = (int32_t) secondChild->getByte();
             break;
             }
          case TR::Int16:
             {
-            PRINT_ME("sconst", node, cg);
             value = (int32_t) secondChild->getShortInt();
             break;
             }
-//          case TR_UInt16:
-//             {
-//             PRINT_ME("cconst", node, cg);
-//             value = (int32_t) secondChild->getConst<uint16_t>();
-//             break;
-//             }
-         case TR::Int8:
+         case TR::Int32:
             {
-            PRINT_ME("bconst", node, cg);
-            value = (int32_t) secondChild->getByte();
+            value = secondChild->getInt();
             break;
             }
+         case TR::Address:
+            TR_ASSERT_FATAL(TR::Compiler->target.is32Bit(), "Unexpected address data type for generic32BitAddEvaluator");
          default:
-            TR_ASSERT( 0, "generic32BitAddEvaluator: Unexpected Type\n");
+            TR_ASSERT_FATAL(false, "Unexpected data type (%s) in generic32BitAddEvaluator", secondChild->getDataType().toString());
             break;
          }
 
@@ -658,34 +632,25 @@ generic32BitSubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
       switch (secondChild->getDataType())
          {
-         case TR::Address:
-            TR_ASSERT( TR::Compiler->target.is32Bit(), "generic32BitSubEvaluator(): unexpected data type for 64bit code-gen!");
-         case TR::Int32:
+         case TR::Int8:
             {
-            PRINT_ME("iconst", node, cg);
-            value = secondChild->getInt();
+            value = (int32_t) secondChild->getByte();
             break;
             }
          case TR::Int16:
             {
-            PRINT_ME("sconst", node, cg);
             value = (int32_t) secondChild->getShortInt();
-            }
             break;
-//          case TR_UInt16:
-//             {
-//             PRINT_ME("cconst", node, cg);
-//             value = (int32_t) secondChild->getConst<uint16_t>();
-//             break;
-//             }
-         case TR::Int8:
+            }
+         case TR::Int32:
             {
-            PRINT_ME("bconst", node, cg);
-            value = (int32_t) secondChild->getByte();
+            value = secondChild->getInt();
             break;
             }
+         case TR::Address:
+            TR_ASSERT_FATAL(TR::Compiler->target.is32Bit(), "Unexpected address data type for generic32BitSubEvaluator");
          default:
-            TR_ASSERT( 0, "generic32BitAddEvaluator: Unexpected Type\n");
+            TR_ASSERT_FATAL(false, "Unexpected data type (%s) in generic32BitSubEvaluator", secondChild->getDataType().toString());
             break;
          }
 
@@ -1452,7 +1417,6 @@ genericIntShift(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::Mnemoni
 TR::Register *
 OMR::Z::TreeEvaluator::iaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iadd", node, cg);
    return generic32BitAddEvaluator(node, cg);
    }
 
@@ -1462,7 +1426,6 @@ OMR::Z::TreeEvaluator::iaddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::laddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ladd", node, cg);
    return laddHelper64(node, cg);
    }
 
@@ -2280,7 +2243,6 @@ lmulHelper64(TR::Node * node, TR::CodeGenerator * cg)
 
    if (secondChildIsConstant)
       {
-      PRINT_ME("lconst", node, cg);
       int64_t value = secondChild->getLongInt();
 
       // LA Ry,(Rx,Rx) is the best instruction scale array index by 2
@@ -2335,8 +2297,6 @@ lmulHelper64(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::baddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("badd", node, cg);
-
    return generic32BitAddEvaluator(node, cg);
    }
 
@@ -2346,8 +2306,6 @@ OMR::Z::TreeEvaluator::baddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::saddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sadd", node, cg);
-
    return generic32BitAddEvaluator(node, cg);
    }
 
@@ -2357,8 +2315,6 @@ OMR::Z::TreeEvaluator::saddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::caddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("cadd", node, cg);
-
    return generic32BitAddEvaluator(node, cg);
    }
 
@@ -2369,8 +2325,6 @@ OMR::Z::TreeEvaluator::caddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::isubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("isub", node, cg);
-
    if ((node->getOpCodeValue() == TR::asub) && TR::Compiler->target.is64Bit())
       {
       return lsubHelper64(node, cg);
@@ -2388,7 +2342,6 @@ OMR::Z::TreeEvaluator::isubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lsub", node, cg);
    return lsubHelper64(node, cg);
    }
 
@@ -2400,8 +2353,6 @@ OMR::Z::TreeEvaluator::lsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bsub", node, cg);
-
    return generic32BitSubEvaluator(node, cg);
    }
 
@@ -2412,8 +2363,6 @@ OMR::Z::TreeEvaluator::bsubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ssubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ssub", node, cg);
-
    return generic32BitSubEvaluator(node, cg);
    }
 
@@ -2424,8 +2373,6 @@ OMR::Z::TreeEvaluator::ssubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::csubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("csub", node, cg);
-
    return generic32BitSubEvaluator(node, cg);
    }
 
@@ -2435,8 +2382,6 @@ OMR::Z::TreeEvaluator::csubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lmulh", node, cg);
-
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    if (node->isDualCyclic() || needsUnsignedHighMulOnly)
       {
@@ -2460,8 +2405,6 @@ OMR::Z::TreeEvaluator::lmulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    if (secondChild->getOpCodeValue() == TR::lconst)
       {
-      PRINT_ME("lconst", node, cg);
-
       int64_t value = secondChild->getLongInt();
       int64_t absValue = value > 0 ? value : -value;
 
@@ -2523,7 +2466,6 @@ TR::Register *
 OMR::Z::TreeEvaluator::mulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    bool isUnsigned = (node->getOpCodeValue() == TR::iumulh);
-   PRINT_ME("imulh", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
    TR::Register * firstRegister = cg->gprClobberEvaluate(firstChild);
@@ -2569,7 +2511,6 @@ OMR::Z::TreeEvaluator::mulhEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::imulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("imul", node, cg);
    TR::Node* secondChild = node->getSecondChild();
    TR::Node* firstChild = node->getFirstChild();
    TR::Node* halfwordNode = NULL;
@@ -2600,7 +2541,6 @@ OMR::Z::TreeEvaluator::imulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    if (secondChild->getOpCode().isLoadConst())
       {
-      PRINT_ME("iconst", node, cg);
       int32_t value = secondChild->getInt();
 
       // LA Ry,(Rx,Rx) is the best instruction scale array index by 2
@@ -2713,7 +2653,6 @@ OMR::Z::TreeEvaluator::imulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lmul", node, cg);
    bool needsUnsignedHighMulOnly = (node->getOpCodeValue() == TR::lumulh) && !node->isDualCyclic();
    if (node->isDualCyclic() || needsUnsignedHighMulOnly)
       {
@@ -2729,7 +2668,6 @@ OMR::Z::TreeEvaluator::lmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bmul", node, cg);
    TR_UNIMPLEMENTED();
    return NULL;
    }
@@ -2740,7 +2678,6 @@ OMR::Z::TreeEvaluator::bmulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::smulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("smul", node, cg);
    TR_UNIMPLEMENTED();
    return NULL;
    }
@@ -2752,8 +2689,6 @@ OMR::Z::TreeEvaluator::smulEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("idiv", node, cg);
-
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
    TR::Register * targetRegister = NULL;
@@ -2890,7 +2825,6 @@ OMR::Z::TreeEvaluator::idivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ldivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ldiv", node, cg);
    return lDivRemGenericEvaluator64(node, cg, DIVISION);
    }
 
@@ -2901,7 +2835,6 @@ OMR::Z::TreeEvaluator::ldivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bdivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bdiv", node, cg);
    TR_UNIMPLEMENTED();
    return NULL;
    }
@@ -2913,7 +2846,6 @@ OMR::Z::TreeEvaluator::bdivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sdivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sdiv", node, cg);
    TR_UNIMPLEMENTED();
    return NULL;
    }
@@ -2925,8 +2857,6 @@ OMR::Z::TreeEvaluator::sdivEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::iremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("irem", node, cg);
-
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
    TR::Register * targetRegister = NULL;
@@ -3042,7 +2972,6 @@ OMR::Z::TreeEvaluator::iremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lrem", node, cg);
    return lDivRemGenericEvaluator64(node, cg, REMAINDER);
    }
 
@@ -3053,7 +2982,6 @@ OMR::Z::TreeEvaluator::lremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("brem", node, cg);
    TR_UNIMPLEMENTED();
    return NULL;
    }
@@ -3065,7 +2993,6 @@ OMR::Z::TreeEvaluator::bremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("srem", node, cg);
    TR_UNIMPLEMENTED();
    return NULL;
    }
@@ -3076,7 +3003,6 @@ OMR::Z::TreeEvaluator::sremEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::inegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ineg", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * sourceRegister;
    TR::Register * targetRegister = cg->allocateRegister();
@@ -3133,7 +3059,6 @@ OMR::Z::TreeEvaluator::inegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lnegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lneg", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * targetRegister = NULL;
    TR::Register * sourceRegister;
@@ -3166,7 +3091,6 @@ OMR::Z::TreeEvaluator::lnegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bnegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bneg", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * sourceRegister = cg->evaluate(firstChild);
    TR::Register * targetRegister = cg->allocateRegister();
@@ -3188,7 +3112,6 @@ OMR::Z::TreeEvaluator::bnegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::snegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sneg", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * sourceRegister = cg->evaluate(firstChild);
    TR::Register * targetRegister = cg->allocateRegister();
@@ -3212,8 +3135,6 @@ OMR::Z::TreeEvaluator::snegEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ishlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ishl", node, cg);
-
    auto altShiftOp = TR::InstOpCode::SLLG;
 
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
@@ -3231,7 +3152,6 @@ OMR::Z::TreeEvaluator::ishlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lshl", node, cg);
    return genericLongShiftSingle(node, cg, TR::InstOpCode::SLLG);
    }
 
@@ -3242,8 +3162,6 @@ OMR::Z::TreeEvaluator::lshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bshl", node, cg);
-
    auto altShiftOp = TR::InstOpCode::SLLG;
 
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
@@ -3261,8 +3179,6 @@ OMR::Z::TreeEvaluator::bshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sshl", node, cg);
-
    auto altShiftOp = TR::InstOpCode::SLLG;
 
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
@@ -3280,7 +3196,6 @@ OMR::Z::TreeEvaluator::sshlEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ishrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ishr", node, cg);
    TR::InstOpCode::Mnemonic altShiftOp = TR::InstOpCode::SRAG;
    return genericIntShift(node, cg, TR::InstOpCode::SRA, altShiftOp);
    }
@@ -3292,7 +3207,6 @@ OMR::Z::TreeEvaluator::ishrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lshr", node, cg);
    return genericLongShiftSingle(node, cg, TR::InstOpCode::SRAG);
    }
 
@@ -3303,7 +3217,6 @@ OMR::Z::TreeEvaluator::lshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bshr", node, cg);
    TR::InstOpCode::Mnemonic altShiftOp = TR::InstOpCode::SRAG;
    return genericIntShift(node, cg, TR::InstOpCode::SRA, altShiftOp);
    }
@@ -3315,7 +3228,6 @@ OMR::Z::TreeEvaluator::bshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sshr", node, cg);
    TR::InstOpCode::Mnemonic altShiftOp = TR::InstOpCode::SRAG;
    return genericIntShift(node, cg, TR::InstOpCode::SRA, altShiftOp);
    }
@@ -3327,8 +3239,6 @@ OMR::Z::TreeEvaluator::sshrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::iushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iushr", node, cg);
-
    auto altShiftOp = TR::InstOpCode::SRLG;
 
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
@@ -3346,7 +3256,6 @@ OMR::Z::TreeEvaluator::iushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lushr", node, cg);
    return genericLongShiftSingle(node, cg, TR::InstOpCode::SRLG);
    }
 
@@ -3357,8 +3266,6 @@ OMR::Z::TreeEvaluator::lushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bushr", node, cg);
-
    auto altShiftOp = TR::InstOpCode::SRLG;
 
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
@@ -3376,8 +3283,6 @@ OMR::Z::TreeEvaluator::bushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sushrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sushr", node, cg);
-
    auto altShiftOp = TR::InstOpCode::SRLG;
 
    if (cg->getS390ProcessorInfo()->supportsArch(TR_S390ProcessorInfo::TR_z196))
@@ -3438,7 +3343,6 @@ OMR::Z::TreeEvaluator::integerRolEvaluator(TR::Node *node, TR::CodeGenerator *cg
 TR::Register *
 OMR::Z::TreeEvaluator::iandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iand", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
@@ -3455,7 +3359,6 @@ OMR::Z::TreeEvaluator::iandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    if (secondChild->getOpCode().isLoadConst())
       {
-      PRINT_ME("iconst", node, cg);
       int32_t value = getIntegralValue(secondChild);
       targetRegister = cg->gprClobberEvaluate(firstChild);
 
@@ -3481,7 +3384,6 @@ OMR::Z::TreeEvaluator::iandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::landEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("land", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
@@ -3525,7 +3427,6 @@ OMR::Z::TreeEvaluator::landEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("band", node, cg);
    return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
@@ -3535,7 +3436,6 @@ OMR::Z::TreeEvaluator::bandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sand", node, cg);
    return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
@@ -3545,7 +3445,6 @@ OMR::Z::TreeEvaluator::sandEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::candEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("cand", node, cg);
    return TR::TreeEvaluator::iandEvaluator(node, cg);
    }
 
@@ -3556,14 +3455,12 @@ OMR::Z::TreeEvaluator::candEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::iorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ior", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
 
    if (secondChild->getOpCode().isLoadConst())
       {
-      PRINT_ME("iconst", node, cg);
       targetRegister = cg->gprClobberEvaluate(firstChild);
 
       int32_t value=getIntegralValue(secondChild);
@@ -3590,7 +3487,6 @@ OMR::Z::TreeEvaluator::iorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lor", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
@@ -3635,7 +3531,6 @@ OMR::Z::TreeEvaluator::lorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::borEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bor", node, cg);
    return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
@@ -3645,7 +3540,6 @@ OMR::Z::TreeEvaluator::borEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sor", node, cg);
    return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
@@ -3655,7 +3549,6 @@ OMR::Z::TreeEvaluator::sorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::corEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("cor", node, cg);
    return TR::TreeEvaluator::iorEvaluator(node, cg);
    }
 
@@ -3665,14 +3558,12 @@ OMR::Z::TreeEvaluator::corEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ixorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ixor", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
 
    if (secondChild->getOpCode().isLoadConst())
       {
-      PRINT_ME("iconst", node, cg);
       targetRegister = cg->gprClobberEvaluate(firstChild);
 
       int32_t value=getIntegralValue(secondChild);
@@ -3699,7 +3590,6 @@ OMR::Z::TreeEvaluator::ixorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lxor", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
@@ -3744,7 +3634,6 @@ OMR::Z::TreeEvaluator::lxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bxor", node, cg);
    return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
@@ -3754,7 +3643,6 @@ OMR::Z::TreeEvaluator::bxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sxor", node, cg);
    return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
@@ -3764,7 +3652,6 @@ OMR::Z::TreeEvaluator::sxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::cxorEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("cxor", node, cg);
    return TR::TreeEvaluator::ixorEvaluator(node, cg);
    }
 
@@ -3773,7 +3660,6 @@ OMR::Z::TreeEvaluator::dexpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR_ASSERT(0, "This evaluator is not functionally correct. Do Not use.");
 
-
    return TR::TreeEvaluator::libmFuncEvaluator(node, cg);
    }
 
@@ -3781,7 +3667,6 @@ TR::Register *
 OMR::Z::TreeEvaluator::fexpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR_ASSERT(0, "This evaluator is not functionally correct. Do Not use.");
-
 
    return TR::TreeEvaluator::libmFuncEvaluator(node, cg);
    }

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -531,8 +531,6 @@ generic32BitAddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             value = secondChild->getInt();
             break;
             }
-         case TR::Address:
-            TR_ASSERT_FATAL(TR::Compiler->target.is32Bit(), "Unexpected address data type for generic32BitAddEvaluator");
          default:
             TR_ASSERT_FATAL(false, "Unexpected data type (%s) in generic32BitAddEvaluator", secondChild->getDataType().toString());
             break;
@@ -647,8 +645,6 @@ generic32BitSubEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             value = secondChild->getInt();
             break;
             }
-         case TR::Address:
-            TR_ASSERT_FATAL(TR::Compiler->target.is32Bit(), "Unexpected address data type for generic32BitSubEvaluator");
          default:
             TR_ASSERT_FATAL(false, "Unexpected data type (%s) in generic32BitSubEvaluator", secondChild->getDataType().toString());
             break;
@@ -1427,23 +1423,6 @@ TR::Register *
 OMR::Z::TreeEvaluator::laddEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    return laddHelper64(node, cg);
-   }
-
-
-/**
- * address add helper function
- */
-TR::Register *
-OMR::Z::TreeEvaluator::addrAddHelper(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   if (node->getOpCodeValue() == TR::aiadd)
-      return generic32BitAddEvaluator(node, cg);
-   else if (node->getOpCodeValue() == TR::aladd)
-      return TR::TreeEvaluator::laddEvaluator(node, cg);
-   else
-      TR_ASSERT(0,"Wrong il-opCode for calling addAddHelper!\n");
-
-   return NULL;
    }
 
 TR::Register *

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -89,18 +89,6 @@ generateS390PackedCompareAndBranchOps(TR::Node * node,
                                       TR::InstOpCode::S390BranchCondition &retBranchOpCond,
                                       TR::LabelSymbol *branchTarget = NULL);
 
-//#define TRACE_EVAL
-#if defined(TRACE_EVAL)
-#define EVAL_BLOCK
-#if defined (EVAL_BLOCK)
-#define PRINT_ME(string,node,cg) TR::Delimiter evalDelimiter(TR::comp(),TR::comp()->getOption(TR_TraceCG),"EVAL", string)
-#else
-extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
-#endif
-#else
-#define PRINT_ME(string,node,cg)
-#endif
-
 extern TR::Register *
 iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision, TR::MemoryReference * divchkDivisorMR);
 
@@ -289,7 +277,6 @@ generateS390lcmpEvaluator64(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpC
 TR::Register *
 OMR::Z::TreeEvaluator::fcmplEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("fcmpl", node, cg);
    TR::InstOpCode::Mnemonic branchOp;
    TR::InstOpCode::S390BranchCondition brCond ;
 
@@ -531,7 +518,6 @@ OMR::Z::TreeEvaluator::mbranchEvaluator(TR::Node * node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::Z::TreeEvaluator::gotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("goto", node, cg);
    TR::Node * temp = node->getBranchDestination()->getNode();
 
    if (node->getNumChildren() > 0)
@@ -556,7 +542,6 @@ OMR::Z::TreeEvaluator::gotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::igotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("igoto", node, cg);
    TR_ASSERT( node->getNumChildren() >= 1, "at least one child expected for igoto");
 
    TR::Node * child = node->getFirstChild();
@@ -591,7 +576,6 @@ OMR::Z::TreeEvaluator::igotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("return", node, cg);
    TR::Compilation *comp = cg->comp();
 
    if ((node->getOpCodeValue() == TR::Return) && node->isReturnDummy()) return NULL;
@@ -803,7 +787,6 @@ static inline void generateMergedGuardCodeIfNeeded(TR::Node *node, TR::CodeGener
 TR::Register *
 OMR::Z::TreeEvaluator::ificmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ificmpeq", node, cg);
    TR::Compilation *comp = cg->comp();
 
    if (virtualGuardHelper(node, cg))
@@ -923,8 +906,6 @@ TR::Register* OMR::Z::TreeEvaluator::ifFoldingHelper(TR::Node *node, TR::CodeGen
 TR::Register *
 OMR::Z::TreeEvaluator::ificmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ificmplt", node, cg);
-
    bool inlined = false;
    TR::Register *reg;
 
@@ -946,7 +927,6 @@ OMR::Z::TreeEvaluator::ificmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ificmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ificmpge", node, cg);
    bool inlined = false;
 
    TR::Register *reg;
@@ -969,7 +949,6 @@ OMR::Z::TreeEvaluator::ificmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ificmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ificmpgt", node, cg);
    bool inlined = false;
 
    TR::Register *reg;
@@ -992,7 +971,6 @@ OMR::Z::TreeEvaluator::ificmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ificmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ificmple", node, cg);
    bool inlined = false;
 
    TR::Register *reg;
@@ -1014,7 +992,6 @@ OMR::Z::TreeEvaluator::ificmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::iflcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iflcmpeq", node, cg);
    generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
    generateMergedGuardCodeIfNeeded(node, cg);
    return NULL;
@@ -1026,8 +1003,6 @@ OMR::Z::TreeEvaluator::iflcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::iflcmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iflcmpne", node, cg);
-
    if (virtualGuardHelper(node, cg))
       {
       return NULL;
@@ -1044,7 +1019,6 @@ OMR::Z::TreeEvaluator::iflcmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::iflcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iflcmple", node, cg);
    generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, TR::InstOpCode::COND_BNL);
    return NULL;
    }
@@ -1055,7 +1029,6 @@ OMR::Z::TreeEvaluator::iflcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::iflcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iflcmplt", node, cg);
    generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, TR::InstOpCode::COND_BH);
    return NULL;
    }
@@ -1066,7 +1039,6 @@ OMR::Z::TreeEvaluator::iflcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::iflcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iflcmpge", node, cg);
    generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, TR::InstOpCode::COND_BNH);
    return NULL;
    }
@@ -1077,7 +1049,6 @@ OMR::Z::TreeEvaluator::iflcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::iflcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iflcmpgt", node, cg);
    generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, TR::InstOpCode::COND_BL);
    return NULL;
    }
@@ -1088,7 +1059,6 @@ OMR::Z::TreeEvaluator::iflcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifacmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifacmpeq", node, cg);
    return TR::TreeEvaluator::ificmpeqEvaluator(node, cg);
    }
 
@@ -1098,7 +1068,6 @@ OMR::Z::TreeEvaluator::ifacmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifacmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifacmpne", node, cg);
    return TR::TreeEvaluator::ificmpeqEvaluator(node, cg);
    }
 
@@ -1109,7 +1078,6 @@ OMR::Z::TreeEvaluator::ifacmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifbcmpeq", node, cg);
    if (node->getOpCodeValue() == TR::ifbcmpeq || node->getOpCodeValue() == TR::ifbucmpeq)
       {
       return generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
@@ -1130,7 +1098,6 @@ OMR::Z::TreeEvaluator::ifbcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifbcmplt", node, cg);
    return TR::TreeEvaluator::ificmpltEvaluator(node, cg);
    }
 
@@ -1140,7 +1107,6 @@ OMR::Z::TreeEvaluator::ifbcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifbcmpge", node, cg);
    return TR::TreeEvaluator::ificmpgeEvaluator(node, cg);
    }
 
@@ -1150,7 +1116,6 @@ OMR::Z::TreeEvaluator::ifbcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifbcmpgt", node, cg);
    return TR::TreeEvaluator::ificmpgtEvaluator(node, cg);
    }
 
@@ -1160,7 +1125,6 @@ OMR::Z::TreeEvaluator::ifbcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifbcmple", node, cg);
    return TR::TreeEvaluator::ificmpleEvaluator(node, cg);
    }
 
@@ -1171,7 +1135,6 @@ OMR::Z::TreeEvaluator::ifbcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifscmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifscmpeq", node, cg);
    if (node->getOpCodeValue() == TR::ifscmpeq)
       {
       return generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
@@ -1188,7 +1151,6 @@ OMR::Z::TreeEvaluator::ifscmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifscmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifscmplt", node, cg);
    return TR::TreeEvaluator::ificmpltEvaluator(node, cg);
    }
 
@@ -1198,7 +1160,6 @@ OMR::Z::TreeEvaluator::ifscmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifscmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifscmpge", node, cg);
    return TR::TreeEvaluator::ificmpgeEvaluator(node, cg);
    }
 
@@ -1208,7 +1169,6 @@ OMR::Z::TreeEvaluator::ifscmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifscmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifscmpgt", node, cg);
    return TR::TreeEvaluator::ificmpgtEvaluator(node, cg);
    }
 
@@ -1218,7 +1178,6 @@ OMR::Z::TreeEvaluator::ifscmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifscmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifscmple", node, cg);
    return TR::TreeEvaluator::ificmpleEvaluator(node, cg);
    }
 
@@ -1229,7 +1188,6 @@ OMR::Z::TreeEvaluator::ifscmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifsucmpeq", node, cg);
    if (node->getOpCodeValue() == TR::ifsucmpeq)
       {
       return generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
@@ -1246,7 +1204,6 @@ OMR::Z::TreeEvaluator::ifsucmpeqEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifsucmplt", node, cg);
    return TR::TreeEvaluator::ificmpltEvaluator(node, cg);
    }
 
@@ -1256,7 +1213,6 @@ OMR::Z::TreeEvaluator::ifsucmpltEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifsucmpge", node, cg);
    return TR::TreeEvaluator::ificmpgeEvaluator(node, cg);
    }
 
@@ -1266,7 +1222,6 @@ OMR::Z::TreeEvaluator::ifsucmpgeEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifsucmpgt", node, cg);
    return TR::TreeEvaluator::ificmpgtEvaluator(node, cg);
    }
 
@@ -1276,7 +1231,6 @@ OMR::Z::TreeEvaluator::ifsucmpgtEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::ifsucmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ifsucmple", node, cg);
    return TR::TreeEvaluator::ificmpleEvaluator(node, cg);
    }
 
@@ -1289,7 +1243,6 @@ OMR::Z::TreeEvaluator::ifsucmpleEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::icmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("icmpeq", node, cg);
    if (node->getOpCodeValue() == TR::icmpeq ||
          node->getOpCodeValue() == TR::iucmpeq ||
          node->getOpCodeValue() == TR::acmpeq)
@@ -1346,8 +1299,6 @@ OMR::Z::TreeEvaluator::icmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::icmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("icmplt", node, cg);
-
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
 
@@ -1378,7 +1329,6 @@ OMR::Z::TreeEvaluator::icmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::icmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("icmpge", node, cg);
    return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, TR::InstOpCode::COND_BNH);
    }
 
@@ -1388,8 +1338,6 @@ OMR::Z::TreeEvaluator::icmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::icmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("icmpgt", node, cg);
-
    TR::Node * firstChild = node->getFirstChild();
    TR::Node * secondChild = node->getSecondChild();
 
@@ -1420,7 +1368,6 @@ OMR::Z::TreeEvaluator::icmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::icmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("icmple", node, cg);
    return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, TR::InstOpCode::COND_BNL);
    }
 
@@ -1430,7 +1377,6 @@ OMR::Z::TreeEvaluator::icmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmpeq", node, cg);
    return generateS390lcmpEvaluator64(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, CMP4BOOLEAN);
    }
 
@@ -1440,7 +1386,6 @@ OMR::Z::TreeEvaluator::lcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmpne", node, cg);
    return generateS390lcmpEvaluator64(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNE, CMP4BOOLEAN);
    }
 
@@ -1450,7 +1395,6 @@ OMR::Z::TreeEvaluator::lcmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmple", node, cg);
    return generateS390lcmpEvaluator64(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, CMP4BOOLEAN);
    }
 
@@ -1460,7 +1404,6 @@ OMR::Z::TreeEvaluator::lcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmplt", node, cg);
    return generateS390lcmpEvaluator64(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BL, CMP4BOOLEAN);
    }
 
@@ -1470,7 +1413,6 @@ OMR::Z::TreeEvaluator::lcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmpge", node, cg);
    return generateS390lcmpEvaluator64(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNL, CMP4BOOLEAN);
    }
 
@@ -1480,7 +1422,6 @@ OMR::Z::TreeEvaluator::lcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmpgt", node, cg);
    return generateS390lcmpEvaluator64(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BH, CMP4BOOLEAN);
    }
 
@@ -1491,7 +1432,6 @@ OMR::Z::TreeEvaluator::lcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::acmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("acmpeq", node, cg);
    return TR::TreeEvaluator::icmpeqEvaluator(node, cg);
    }
 
@@ -1506,7 +1446,6 @@ OMR::Z::TreeEvaluator::acmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bcmpeq", node, cg);
    if (node->getOpCodeValue() == TR::bcmpeq || node->getOpCodeValue() == TR::bucmpeq)
       {
       return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
@@ -1523,7 +1462,6 @@ OMR::Z::TreeEvaluator::bcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bcmplt", node, cg);
    return TR::TreeEvaluator::icmpltEvaluator(node, cg);
    }
 
@@ -1533,7 +1471,6 @@ OMR::Z::TreeEvaluator::bcmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bcmpge", node, cg);
    return TR::TreeEvaluator::icmpgeEvaluator(node, cg);
    }
 
@@ -1543,7 +1480,6 @@ OMR::Z::TreeEvaluator::bcmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bcmpgt", node, cg);
    return TR::TreeEvaluator::icmpgtEvaluator(node, cg);
    }
 
@@ -1553,7 +1489,6 @@ OMR::Z::TreeEvaluator::bcmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bcmple", node, cg);
    return TR::TreeEvaluator::icmpleEvaluator(node, cg);
    }
 
@@ -1564,7 +1499,6 @@ OMR::Z::TreeEvaluator::bcmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::scmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("scmpeq", node, cg);
    if (node->getOpCodeValue() == TR::scmpeq)
       {
       return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
@@ -1581,7 +1515,6 @@ OMR::Z::TreeEvaluator::scmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::scmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("scmplt", node, cg);
    return TR::TreeEvaluator::icmpltEvaluator(node, cg);
    }
 
@@ -1591,7 +1524,6 @@ OMR::Z::TreeEvaluator::scmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::scmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("scmpge", node, cg);
    return TR::TreeEvaluator::icmpgeEvaluator(node, cg);
    }
 
@@ -1601,7 +1533,6 @@ OMR::Z::TreeEvaluator::scmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::scmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("scmpgt", node, cg);
    return TR::TreeEvaluator::icmpgtEvaluator(node, cg);
    }
 
@@ -1611,7 +1542,6 @@ OMR::Z::TreeEvaluator::scmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::scmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("scmple", node, cg);
    return TR::TreeEvaluator::icmpleEvaluator(node, cg);
    }
 
@@ -1622,7 +1552,6 @@ OMR::Z::TreeEvaluator::scmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sucmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sucmpeq", node, cg);
    if (node->getOpCodeValue() == TR::sucmpeq)
       {
       return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
@@ -1639,7 +1568,6 @@ OMR::Z::TreeEvaluator::sucmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sucmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sucmplt", node, cg);
    return TR::TreeEvaluator::icmpltEvaluator(node, cg);
    }
 
@@ -1649,7 +1577,6 @@ OMR::Z::TreeEvaluator::sucmpltEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sucmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sucmpge", node, cg);
    return TR::TreeEvaluator::icmpgeEvaluator(node, cg);
    }
 
@@ -1659,7 +1586,6 @@ OMR::Z::TreeEvaluator::sucmpgeEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sucmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sucmpgt", node, cg);
    return TR::TreeEvaluator::icmpgtEvaluator(node, cg);
    }
 
@@ -1669,7 +1595,6 @@ OMR::Z::TreeEvaluator::sucmpgtEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sucmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sucmple", node, cg);
    return TR::TreeEvaluator::icmpleEvaluator(node, cg);
    }
 
@@ -1680,7 +1605,6 @@ OMR::Z::TreeEvaluator::sucmpleEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lcmpEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lcmp", node, cg);
    return lcmpHelper64(node, cg);
    }
 
@@ -1718,7 +1642,6 @@ void OMR::Z::TreeEvaluator::tableEvaluatorCaseLabelHelper(TR::Node * node, TR::C
 TR::Register *
 OMR::Z::TreeEvaluator::tableEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("table", node, cg);
    TR::Compilation *comp = cg->comp();
    int32_t i;
    uint32_t upperBound = node->getCaseIndexUpperBound();
@@ -1890,8 +1813,6 @@ bool isSwitchFoldableNoncall(TR::Node * node)
 TR::Register *
 OMR::Z::TreeEvaluator::lookupEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lookup", node, cg);
-
    //fold builtin if possible
    TR::Node* firstChild = node->getFirstChild();
 
@@ -2456,7 +2377,6 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
 TR::Register *
 OMR::Z::TreeEvaluator::NULLCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("NULLCHK", node, cg);
    return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, false, cg);
    }
 
@@ -2466,8 +2386,6 @@ OMR::Z::TreeEvaluator::NULLCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ZEROCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ZEROCHK", node, cg);
-
    // Labels for OOL path with helper and the merge point back from OOL path
    TR::LabelSymbol *slowPathOOLLabel = generateLabelSymbol(cg);;
    TR::LabelSymbol *doneLabel  = generateLabelSymbol(cg);;
@@ -2527,7 +2445,6 @@ OMR::Z::TreeEvaluator::ZEROCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::resolveAndNULLCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("resolveAndNULLCHK", node, cg);
    return TR::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(node, true, cg);
    }
 
@@ -2754,8 +2671,6 @@ TR::Node* OMR::Z::TreeEvaluator::DAAAddressPointer(TR::Node* callNode, TR::CodeG
 TR::Register *
 OMR::Z::TreeEvaluator::butestEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("butest", node, cg);
-
    TR::TreeEvaluator::commonButestEvaluator(node, cg);
    TR::Register *ccReg = getConditionCode(node, cg);
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -122,46 +122,6 @@ generateS390PackedCompareAndBranchOps(TR::Node * node,
                                       TR::LabelSymbol *branchTarget = NULL);
 #endif
 
-//#define TRACE_EVAL
-#if defined(TRACE_EVAL)
-//
-// this is a handy thing to turn on if you want to figure out what the common
-// code generator is mapping nodes to and what is really being driven through
-// evaluation.
-// It is not on by default (too noisy and expensive) but can be enabled
-// by just defining TRACE_EVAL for this file
-//
-// If we wanted to enable this by default, it would make sense to create a
-// new 'phase' for debugging that could be queried and to have the macro
-// be a test of the tracing before making a function call out, e.g.
-// instead of PRINT_ME(...) we would have:
-// if (compilation->getOutFile() != NULL && compilation->getTraceEval())
-//   {
-//     print("iadd", compilation->getOutFile());
-//   }
-// and then traceEval would be a forced no-inline method
-//
-// Add another version of PRINT_ME, undef EVAL_BLOCK to go back to the old one
-#define EVAL_BLOCK
-#if defined (EVAL_BLOCK)
-#include "ras/Delimiter.hpp"
-#define PRINT_ME(string,node,cg) TR::Delimiter evalDelimiter(cg->comp(), cg->comp()->getOption(TR_TraceCG), "EVAL", string)
-#else
-void
-PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg)
-   {
-   TR::Compilation * comp = cg->comp();
-   TR::FILE *outFile = comp->getOutFile();
-   if (outFile != NULL)
-      {
-      diagnostic("EVAL: %s\n", string);
-      }
-   }
-#endif
-#else
-#define PRINT_ME(string,node,cg)
-#endif
-
 TR::Instruction*
 generateLoad32BitConstant(TR::CodeGenerator* cg, TR::Node* node, int32_t value, TR::Register* targetRegister, bool canSetConditionCode, TR::Instruction* cursor, TR::RegisterDependencyConditions* dependencies, TR::Register* literalPoolRegister)
    {
@@ -4499,13 +4459,6 @@ genericLoad(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
       return genericLoadHelper<numberOfBits, 32, MemReg>(node, cg, tempMR, srcRegister, nodeSigned, false);
    }
 
-#if defined(TRACE_EVAL)
-#define CASE(x) if (cg->comp()->getOption(TR_TraceCG)) traceMsg(cg, "\t\t\tCase %d\n", x)
-#else
-#define CASE(x)
-#endif
-
-
 /**
  * This function may be used directly. However, there are couple of known wrappers for the big consumers
  *   - genericLoad -- wrapper for b-,s-,i-,l-... loadEvaluator
@@ -4704,7 +4657,6 @@ template<uint32_t otherSize, bool dirToAddr>
 TR::Register *
 OMR::Z::TreeEvaluator::addressCastEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("addressCast", node, cg);
    TR::Compilation *comp = cg->comp();
 
    // use getSize instead of getAddressPrecision since for some cases the address type node symbol size will be different than the address precesion value (RTC: 34855)
@@ -6024,7 +5976,6 @@ astoreHelper(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::aloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("aload", node, cg);
    return aloadHelper(node, cg, NULL);
    }
 
@@ -6141,7 +6092,6 @@ OMR::Z::TreeEvaluator::aladdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::riloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("riload", node, cg);
    return iloadHelper(node, cg, NULL, true);
    }
 
@@ -6152,7 +6102,6 @@ OMR::Z::TreeEvaluator::riloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::rlloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("rlload", node, cg);
    return lloadHelper64(node, cg, NULL, true);
    }
 
@@ -6163,7 +6112,6 @@ OMR::Z::TreeEvaluator::rlloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::rsloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("rsload", node, cg);
    return sloadHelper(node, cg, NULL, true);
    }
 
@@ -6174,7 +6122,6 @@ OMR::Z::TreeEvaluator::rsloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::iloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iload", node, cg);
    return iloadHelper(node, cg, NULL);
    }
 
@@ -6186,7 +6133,6 @@ OMR::Z::TreeEvaluator::iloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lload", node, cg);
    return lloadHelper64(node, cg, NULL);
    }
 
@@ -6197,7 +6143,6 @@ OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sload", node, cg);
    return sloadHelper(node, cg, NULL);
    }
 
@@ -6208,7 +6153,6 @@ OMR::Z::TreeEvaluator::sloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bload", node, cg);
    TR::Compilation *comp = cg->comp();
 
    TR::Register * tempReg;
@@ -6239,7 +6183,6 @@ OMR::Z::TreeEvaluator::bloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::ristoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("ristore", node, cg);
    istoreHelper(node, cg, true);
    return NULL;
    }
@@ -6250,7 +6193,6 @@ OMR::Z::TreeEvaluator::ristoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::rlstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("rlstore", node, cg);
    lstoreHelper64(node, cg, true);
    return NULL;
    }
@@ -6261,7 +6203,6 @@ OMR::Z::TreeEvaluator::rlstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::rsstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("rsstore", node, cg);
    sstoreHelper(node, cg, true);
    return NULL;
    }
@@ -6273,7 +6214,6 @@ OMR::Z::TreeEvaluator::rsstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::istoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("istore", node, cg);
    TR::Compilation *comp = cg->comp();
    bool adjustRefCnt = false;
 
@@ -6292,7 +6232,6 @@ OMR::Z::TreeEvaluator::istoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lstore", node, cg);
    lstoreHelper64(node, cg);
 
    return NULL;
@@ -6305,7 +6244,6 @@ OMR::Z::TreeEvaluator::lstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sstore", node, cg);
    sstoreHelper(node, cg);
    return NULL;
    }
@@ -6317,7 +6255,6 @@ OMR::Z::TreeEvaluator::sstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::cstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("cstore", node, cg);
    sstoreHelper(node, cg);
    return NULL;
    }
@@ -6329,7 +6266,6 @@ OMR::Z::TreeEvaluator::cstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::astoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("astore", node, cg);
    astoreHelper(node, cg);
    return NULL;
    }
@@ -6341,8 +6277,6 @@ OMR::Z::TreeEvaluator::astoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bstore", node, cg);
-
    if (directMemoryStoreHelper(cg, node))
       {
       return NULL;
@@ -9505,7 +9439,6 @@ OMR::Z::TreeEvaluator::directCallEvaluator(TR::Node * node, TR::CodeGenerator * 
 TR::Register *
 OMR::Z::TreeEvaluator::indirectCallEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("indirectCall", node, cg);
    // If the method to be called is marked as an inline method, see if it can
    // actually be generated inline.
    //
@@ -9537,7 +9470,6 @@ OMR::Z::TreeEvaluator::indirectCallEvaluator(TR::Node * node, TR::CodeGenerator 
 TR::Register *
 OMR::Z::TreeEvaluator::treetopEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("treetop", node, cg);
    TR::Compilation *comp = cg->comp();
 
    if (node->getFirstChild()->getReferenceCount() == 1)
@@ -9605,7 +9537,6 @@ OMR::Z::TreeEvaluator::treetopEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::fenceEvaluator(TR::Node * node, TR::CodeGenerator *cg)
    {
-   PRINT_ME("fence", node, cg);
    return NULL;
    }
 
@@ -9618,7 +9549,6 @@ OMR::Z::TreeEvaluator::fenceEvaluator(TR::Node * node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("loadaddr", node, cg);
    TR::Register * targetRegister = NULL;
    TR::SymbolReference * symRef = node->getSymbolReference();
    TR::Compilation *comp = cg->comp();
@@ -9758,7 +9688,6 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::passThroughEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("passThrough", node, cg);
    TR::Register * targetRegister = NULL;
    TR::Compilation *comp = cg->comp();
    if ((node->getOpCodeValue() != TR::PassThrough && cg->useClobberEvaluate()))
@@ -9852,12 +9781,6 @@ OMR::Z::TreeEvaluator::passThroughEvaluator(TR::Node * node, TR::CodeGenerator *
 TR::Register *
 OMR::Z::TreeEvaluator::BBStartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-#if defined(TRACE_EVAL)
-   char bbString[22];
-   sprintf(bbString, "BBStart >>> %d", node->getBlock()->getNumber());
-   PRINT_ME(bbString, node, cg);
-#endif
-
    TR::Instruction * firstInstr = NULL;
    TR::Block * block = node->getBlock();
    cg->setCurrentBlockIndex(block->getNumber());
@@ -9991,11 +9914,6 @@ OMR::Z::TreeEvaluator::BBEndEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    TR::Block *nextBlock = block->getNextBlock();
 
-#if defined(TRACE_EVAL)
-   char bbString[22];
-   sprintf(bbString, "BBEnd   <<< %d", block->getNumber());
-   PRINT_ME(bbString, node, cg);
-#endif
    TR::TreeTop * nextTT = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();
    TR::RegisterDependencyConditions * deps = NULL;
 
@@ -12220,7 +12138,6 @@ OMR::Z::TreeEvaluator::GlRegDepsEvaluator(TR::Node * node, TR::CodeGenerator * c
 TR::Register *
 OMR::Z::TreeEvaluator::NOPEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("NOP", node, cg);
    return NULL;
    }
 

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -124,7 +124,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aiaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aladdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *addrAddHelper(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *laddEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *faddEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/z/codegen/S390GenerateInstructions.hpp
+++ b/compiler/z/codegen/S390GenerateInstructions.hpp
@@ -1529,8 +1529,4 @@ void generateShiftAndKeepSelected31Bit(
       int aToBit, int aShiftAmount, bool aClearOtherBits, bool aSetConditionCode);
 
 TR::Instruction *generateZeroVector(TR::Node *node, TR::CodeGenerator *cg, TR::Register *vecZeroReg);
-
-#ifdef DEBUG
-#define TRACE_EVAL
-#endif
 #endif

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -59,18 +59,6 @@
 
 namespace TR { class SymbolReference; }
 
-//#define TRACE_EVAL
-#if defined(TRACE_EVAL)
-#define EVAL_BLOCK
-#if defined (EVAL_BLOCK)
-#define PRINT_ME(string,node,cg) TR::Delimiter evalDelimiter(cg->comp(),cg->comp()->getOption(TR_TraceCG),"EVAL", string)
-#else
-extern void PRINT_ME(char * string, TR::Node * node, TR::CodeGenerator * cg);
-#endif
-#else
-#define PRINT_ME(string,node,cg)
-#endif
-
 /**
  * 64bit version lconstHelper: load long integer constant (64-bit signed 2's complement)
  */
@@ -93,7 +81,6 @@ lconstHelper64(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::iconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
    generateLoad32BitConstant(cg, node, node->getInt(), tempReg, true);
    return tempReg;
@@ -105,7 +92,6 @@ OMR::Z::TreeEvaluator::iconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::aconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("aconst", node, cg);
    TR::Register* targetRegister = cg->allocateRegister();
 
    node->setRegister(targetRegister);
@@ -121,7 +107,6 @@ OMR::Z::TreeEvaluator::aconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::lconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("lconst", node, cg);
    return lconstHelper64(node, cg);
    }
 
@@ -131,7 +116,6 @@ OMR::Z::TreeEvaluator::lconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("bconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
    if (node->getOpCodeValue() == TR::buconst)
       generateLoad32BitConstant(cg, node, node->getByte() & 0xFF, tempReg, true);
@@ -149,7 +133,6 @@ OMR::Z::TreeEvaluator::bconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::sconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("sconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
    int32_t value = node->isUnsigned() ? node->getConst<uint16_t>() : node->getShortInt();
    generateLoad32BitConstant(cg, node, value, tempReg, true);
@@ -162,7 +145,6 @@ OMR::Z::TreeEvaluator::sconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::cconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("cconst", node, cg);
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
    generateLoad32BitConstant(cg, node, node->getConst<uint16_t>(), tempReg, true);
    return tempReg;
@@ -174,7 +156,6 @@ OMR::Z::TreeEvaluator::cconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::labsEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("labs", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Register * targetRegister = cg->allocateRegister();;
    TR::Register * sourceRegister = cg->evaluate(firstChild);
@@ -190,7 +171,6 @@ OMR::Z::TreeEvaluator::labsEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::iabsEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   PRINT_ME("iabs", node, cg);
    TR::Node * firstChild = node->getFirstChild();
    TR::Compilation *comp = cg->comp();
 
@@ -294,7 +274,6 @@ OMR::Z::TreeEvaluator::l2aEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    //      iiload f
    //         aload O
    //
-   PRINT_ME("l2a", node, cg);
    TR::Node *firstChild = node->getFirstChild();
    // after remat changes, this assume is no longer valid
    //


### PR DESCRIPTION
These macros have multiple definitions and are causing issues in debug
mode on z/OS. However the macros themselves are not very useful and are
actually expensive during tracing while providing no real value.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>