### PR TITLE
CMake: Add OMR_EXE_LAUNCHER variable

### DIFF
--- a/cmake/modules/OmrHookgen.cmake
+++ b/cmake/modules/OmrHookgen.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ function(omr_add_hookgen)
 
 	add_custom_command(
 		OUTPUT "${OPT_PRIVATE_DIR}/${private_header}" "${OPT_PUBLIC_DIR}/${public_header}"
-		COMMAND hookgen "${CMAKE_CURRENT_BINARY_DIR}/${input_filename}"
+		COMMAND ${OMR_EXE_LAUNCHER} $<TARGET_FILE:hookgen> "${CMAKE_CURRENT_BINARY_DIR}/${input_filename}"
 		DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${OPT_INPUT}"
 	)
 

--- a/cmake/modules/OmrTracegen.cmake
+++ b/cmake/modules/OmrTracegen.cmake
@@ -64,7 +64,7 @@ function(omr_add_tracegen input)
 
 	add_custom_command(
 		OUTPUT "${generated_filename}.c" "${generated_filename}.h" "${generated_filename}.pdat"
-		COMMAND tracegen -w2cd -treatWarningAsError -generatecfiles -threshold 1 -file ${CMAKE_CURRENT_SOURCE_DIR}/${input}
+		COMMAND ${OMR_EXE_LAUNCHER} $<TARGET_FILE:tracegen> -w2cd -treatWarningAsError -generatecfiles -threshold 1 -file ${CMAKE_CURRENT_SOURCE_DIR}/${input}
 		DEPENDS ${input} tracegen  # adding tracegen as a dependency should be automatic, but for some reason doesnt happen on ninja generators
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	)
@@ -81,7 +81,7 @@ endmacro(add_tracegen)
 # However this is really only a build order dependency in cmake. In order to have proper dependency tracking
 # based on the output .pdat files we use the generator expression.
 add_custom_command(OUTPUT tracemerge.stamp
-	COMMAND tracemerge -majorversion 5 -minorversion 1 -root ${OMR_TRACE_ROOT}
+	COMMAND ${OMR_EXE_LAUNCHER} $<TARGET_FILE:tracemerge> -majorversion 5 -minorversion 1 -root ${OMR_TRACE_ROOT}
 	COMMAND ${CMAKE_COMMAND} -E touch tracemerge.stamp
 	DEPENDS run_tracegen $<TARGET_PROPERTY:run_tracegen,OMR_TRACE_PDATS>
 	WORKING_DIRECTORY ${OMR_TRACE_ROOT}


### PR DESCRIPTION
Add OMR_EXE_LAUNCHER variable which is prepended to the command line before
running executables compiled as part of the build.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>