### PR TITLE
Remove workaround for missing remainderf on older MSVC versions

### DIFF
--- a/compiler/env/OMRArithEnv.cpp
+++ b/compiler/env/OMRArithEnv.cpp
@@ -61,15 +61,7 @@ OMR::ArithEnv::floatDivideFloat(float a, float b)
 float
 OMR::ArithEnv::floatRemainderFloat(float a, float b)
    {
-
-   // C99 IEEE remainder is not available in older MSVC versions
-
-#if defined (_MSC_VER)
-   return 0;
-#else
    return remainderf(a, b);
-#endif
-
    }
 
 float
@@ -107,11 +99,7 @@ OMR::ArithEnv::doubleDivideDouble(double a, double b)
 double
 OMR::ArithEnv::doubleRemainderDouble(double a, double b)
    {
-#if defined (_MSC_VER)
-   return 0;
-#else
    return remainder(a, b);
-#endif
    }
 
 double


### PR DESCRIPTION
The older versions of MSVC that did not have `std::remainder()` and
`std::remainderf()` are no longer supported, so the work around is no
longer needed.

Signed-off-by: Leonardo Banderali <leonardo2718@protonmail.com>