### PR TITLE
Optimize floating point store of constant +0.0

### DIFF
--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -409,7 +409,14 @@ TR::Register *OMR::X86::TreeEvaluator::floatingPointStoreEvaluator(TR::Node *nod
          if (TR::Compiler->target.is64Bit())
             {
             TR::Register *floatConstReg = cg->allocateRegister(TR_GPR);
-            generateRegImm64Instruction(MOV8RegImm64, node, floatConstReg, valueChild->getLongInt(), cg);
+            if (valueChild->getLongInt() == 0)
+               {
+               generateRegRegInstruction(XOR8RegReg, node, floatConstReg, floatConstReg, cg);
+               }
+            else
+               {
+               generateRegImm64Instruction(MOV8RegImm64, node, floatConstReg, valueChild->getLongInt(), cg);
+               }
             exceptionPoint = generateMemRegInstruction(S8MemReg, node, tempMR, floatConstReg, cg);
             cg->stopUsingRegister(floatConstReg);
             }


### PR DESCRIPTION
For 64-bit x86 targets simply XOR the register rather than using a
10-byte immediate load to the register.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>