### PR TITLE
CMake: add support for exporting symbols from libraries

### DIFF
--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -113,6 +113,30 @@ macro(omr_platform_global_setup)
 		omr_toolconfig_global_setup()
 	endif()
 endmacro()
+
+# omr_process_exports(<target> [symbol]...)
+# performs appropriate processing to export symbols from a target.
+# Note: function is internaly guarded, so its safe to call multiple times
+function(omr_process_exports target)
+	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_process_exports called on invalid target '${target}'")
+
+	# Check if we have already processed the exports
+	get_target_property(has_processed ${target} OMR_EXPORTS_PROCESSED)
+
+	if((NOT has_processed) AND (COMMAND _omr_toolchain_process_exports))
+		_omr_toolchain_process_exports(${target})
+	endif()
+
+	set_target_properties(${target} PROPERTIES OMR_EXPORTS_PROCESSED TRUE)
+endfunction()
+
+# omr_add_exports(<target>)
+# Exports given symbols from a given target, and calls omr_process_exports
+function(omr_add_exports target)
+	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_add_exports called on invalid target '${target}'")
+	set_property(TARGET ${target} APPEND PROPERTY EXPORTED_SYMBOLS ${ARGN})
+	omr_process_exports(${target})
+endfunction()
 
 ###
 ### Flags we aren't using

--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -106,3 +106,19 @@ macro(omr_toolconfig_global_setup)
 	# Hack up output dir to fix dll dependency issues on windows
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 endmacro(omr_toolconfig_global_setup)
+
+function(_omr_toolchain_process_exports TARGET_NAME)
+	# we only need to do something if we are dealing with a shared library
+	get_target_property(target_type ${TARGET_NAME} TYPE)
+	if(NOT target_type STREQUAL "SHARED_LIBRARY")
+		return()
+	endif()
+
+	set(def_file "$<TARGET_PROPERTY:${TARGET_NAME},BINARY_DIR>/${TARGET_NAME}.def")
+
+	file(READ "${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/msvc_exports.def.in" template)
+	string(CONFIGURE "${template}" configured_template)
+	file(GENERATE OUTPUT "${def_file}" CONTENT "${configured_template}")
+
+	target_sources("${TARGET_NAME}" PRIVATE "${def_file}")
+endfunction()

--- a/cmake/modules/platform/toolcfg/msvc_exports.def.in
+++ b/cmake/modules/platform/toolcfg/msvc_exports.def.in
@@ -1,0 +1,24 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Copyright (c) 2019, 2019 IBM Corp. and others
+;
+; This program and the accompanying materials are made available under
+; the terms of the Eclipse Public License 2.0 which accompanies this
+; distribution and is available at http://eclipse.org/legal/epl-2.0
+; or the Apache License, Version 2.0 which accompanies this distribution
+; and is available at https://www.apache.org/licenses/LICENSE-2.0.
+;
+; This Source Code may also be made available under the following Secondary
+; Licenses when the conditions for such availability set forth in the
+; Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+; version 2 with the GNU Classpath Exception [1] and GNU General Public
+; License, version 2 with the OpenJDK Assembly Exception [2].
+;
+; [1] https://www.gnu.org/software/classpath/license.html
+; [2] http://openjdk.java.net/legal/assembly-exception.html
+;
+; SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+EXPORTS
+    $<JOIN:$<TARGET_PROPERTY:@TARGET_NAME@,EXPORTED_SYMBOLS>,
+    >

--- a/omrsigcompat/CMakeLists.txt
+++ b/omrsigcompat/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,63 +34,41 @@ if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(omrsig PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-#TODO need more comprehensive symbols
-set(exportedSyms
+if(OMR_HOST_OS STREQUAL "win")
+	target_compile_definitions(omrsig PRIVATE -DMSVC_RUNTIME_DLL="${OMR_MSVC_CRT}")
+endif()
+
+omr_add_exports(omrsig
 	omrsig_primary_signal
 	omrsig_handler
 	signal
 )
-
-#for now only export symbols on windows
-if(OMR_HOST_OS STREQUAL "win")
-
-	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/omrsig.exportlist" "EXPORTS\n" )
-	foreach(exportSymbol ${exportedSyms})
-		file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/omrsig.exportlist" "${exportSymbol}\n" )
-	endforeach()
-
-	set_target_properties(omrsig
-		PROPERTIES LINK_FLAGS "-def:${CMAKE_CURRENT_BINARY_DIR}/omrsig.exportlist")
-
-	target_compile_definitions(omrsig PRIVATE -DMSVC_RUNTIME_DLL="${OMR_MSVC_CRT}")
+if(NOT OMR_OS_WINDOWS)
+	omr_add_exports(omrsig
+		omrsig_primary_sigaction
+		sigaction
+		sigset
+		sigignore
+		bsd_signal
+		sysv_signal
+	)
 endif()
-
-#Symbols exported from source makefile:
-#EXPORT_FUNCTIONS_FILE := omrsig.exportlist
-#$(EXPORT_FUNCTIONS_FILE):
-	#@# all
-	#@echo omrsig_primary_signal >>$@
-	#@echo omrsig_handler >>$@
-	#@echo signal >>$@
-#ifeq (,$(findstring win,$(OMR_HOST_OS)))
-	#@# !windows
-	#@echo omrsig_primary_sigaction >>$@
-	#@echo sigaction >>$@
-	#@echo sigset >>$@
-	#@echo sigignore >>$@
-	#@echo bsd_signal >>$@
-	#@echo sysv_signal >>$@
-#endif
-#ifneq (,$(findstring linux,$(OMR_HOST_OS)))
-	#@# linux
-	#@echo __sysv_signal >>$@
-	#@echo ssignal >>$@
-#endif
-#ifneq (,$(findstring osx,$(OMR_HOST_OS)))
-	#@# osx
-	#@echo __sysv_signal >>$@
-	#@echo ssignal >>$@
-#endif
-#ifneq (,$(findstring zos,$(OMR_HOST_OS)))
-	#@# z/os
-	#@echo __sigactionset >>$@
-#endif
-#ifeq (,$(findstring win,$(OMR_HOST_OS)))
-#ifeq (,$(findstring zos,$(OMR_HOST_OS)))
-	#@# !win && !zos
-	#@echo sigvec >>$@
-#endif
-#endif
+if(OMR_OS_LINUX OR OMR_OS_OSX)
+	omr_add_exports(omrsig
+		__sysv_signal
+		ssignal
+	)
+endif()
+if(OMR_OS_ZOS)
+	omr_add_exports(omrsig
+		__sigactionset
+	)
+endif()
+if((NOT OMR_OS_WINDOWS) AND (NOT OMR_OS_ZOS))
+	omr_add_exports(omrsig
+		sigvec
+	)
+endif()
 
 target_link_libraries(omrsig
 	PRIVATE


### PR DESCRIPTION
Currently only supported for MSVC

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>