### PR TITLE
Fix incorrect ldiv magic values on BE platforms

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2059,22 +2059,17 @@ OMR::CodeGenerator::compute64BitMagicValues(
 
    // Cache some common denominators and their magic values.  The key values in this
    // array MUST be in numerically increasing order for the binary search to work.
-   //
-   // The table is composed of 32-bit values because the compiler seems to have a problem
-   // statically initializing it with int64_t constant values.
 
    #define NUM_64BIT_MAGIC_VALUES 6
-   #define TOINT64(x) (*( (int64_t *) &x))
-   static uint32_t div64BitMagicValues[NUM_64BIT_MAGIC_VALUES][6] =
+   static int64_t div64BitMagicValues[NUM_64BIT_MAGIC_VALUES][3] =
+   //     Denominator                     Magic Value   Shift
 
-   //     Denominator        Magic Value          Shift
-
-      { {    3, 0,    0x55555556, 0x55555555,    0, 0 },
-        {    5, 0,    0x66666667, 0x66666666,    1, 0 },
-        {    7, 0,    0x24924925, 0x49249249,    1, 0 },
-        {    9, 0,    0x71c71c72, 0x1c71c71c,    0, 0 },
-        {   10, 0,    0x66666667, 0x66666666,    2, 0 },
-        {   12, 0,    0xaaaaaaab, 0x2aaaaaaa,    1, 0 } };
+      { {           3, CONSTANT64(0x5555555555555556),      0 },
+        {           5, CONSTANT64(0x6666666666666667),      1 },
+        {           7, CONSTANT64(0x4924924924924925),      1 },
+        {           9, CONSTANT64(0x1c71c71c71c71c72),      0 },
+        {          10, CONSTANT64(0x6666666666666667),      2 },
+        {          12, CONSTANT64(0x2aaaaaaaaaaaaaab),      1 } };
 
    // Quick check if 'd' is cached.
    first = 0;
@@ -2082,13 +2077,13 @@ OMR::CodeGenerator::compute64BitMagicValues(
    while (first <= last)
       {
       mid = (first + last) / 2;
-      if (TOINT64(div64BitMagicValues[mid][0]) == d)
+      if (div64BitMagicValues[mid][0] == d)
          {
-         *m = TOINT64(div64BitMagicValues[mid][2]);
-         *s = TOINT64(div64BitMagicValues[mid][4]);
+         *m = div64BitMagicValues[mid][1];
+         *s = div64BitMagicValues[mid][2];
          return;
          }
-      else if (d > TOINT64(div64BitMagicValues[mid][0]))
+      else if (d > div64BitMagicValues[mid][0])
          {
          first = mid+1;
          }


### PR DESCRIPTION
When performing 64-bit signed division by a constant which is not a
power of 2, the division can be replaced with a multiplication using
some fixed point arithmetic trickery. Our previous implementation of
doing this had some hard-coded magic values for common divisors. For
unknown historical reasons, the table containing the 64-bit magic values
was actually an array of 32-bit integers which were being read as 64-bit
integers.

However, the order of 32-bit integers in the aforementioned array was
assuming that the platform was little endian. On big endian platforms,
the values of this table were being read with the two 32-bit parts of
each of the 64-bit integers swapped. As a result, 64-bit signed divides
of non-constant values by certain large constants such as 0x300000000
were being optimized using incorrect magic values on big endian
platforms.

This issue has been resolved by using an array of 64-bit integers
instead of an array of 32-bit integers read as 64-bit integers. Doing
this results in the endianness of the values being correctly handled at
compile time.

Signed-off-by: Ben Thomas <ben@benthomas.ca>