### PR TITLE
Prevent object movement in Nursery contract

### DIFF
--- a/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
+++ b/gc/base/standard/PhysicalSubArenaVirtualMemorySemiSpace.cpp
@@ -547,6 +547,19 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::contract(MM_EnvironmentBase *env, uin
 
 		/* Check if the move location actually does in fact move any valid heap */
 		if(allocateSegmentBase > allocateLeadingFreeTop) {
+			if (extensions->isConcurrentScavengerEnabled()) {
+				/* Fixup logic does not account for possible object growth, which would be required for objects
+				 * that have been allocated and hashed during the last concurrent phase (hence, in hybrid Survivor-Allocate
+				 * that is subject to movement).
+				 */
+				if(debug) {
+					omrtty_printf("\tHeap movement (%p %p) to (%p %p) required, but not allowed with CS enabled.\n",
+						allocateLeadingFreeTop, allocateTrailingFreeBase,
+						allocateSegmentBase, ((uintptr_t)allocateSegmentBase) + heapSizeToMove);
+				}
+				return 0;
+			}
+
 			/* Adjust all fields that point to the refered to region */
 			struct Modron_psavmssMoveData psavmssMoveData;
 			psavmssMoveData.env = env;
@@ -716,6 +729,19 @@ MM_PhysicalSubArenaVirtualMemorySemiSpace::contract(MM_EnvironmentBase *env, uin
 
 		/* Check if the move location actually does in fact move any valid heap */
 		if(allocateSegmentBase > allocateLeadingFreeTop) {
+			if (extensions->isConcurrentScavengerEnabled()) {
+				/* Fixup logic does not account for possible object growth, which would be required for objects
+				 * that have been allocated and hashed during the last concurrent phase (hence, in hybrid Survivor-Allocate
+				 * that is subject to movement).
+				 */
+				if(debug) {
+					omrtty_printf("\tHeap movement (%p %p) to (%p %p) required, but not allowed with CS enabled.\n",
+						allocateLeadingFreeTop, allocateTrailingFreeBase,
+						allocateSegmentBase, ((uintptr_t)allocateSegmentBase) + heapSizeToMove);
+				}
+				return 0;
+			}
+
 			/* Adjust all fields that point to the refered to region */
 			struct Modron_psavmssMoveData psavmssMoveData;
 			psavmssMoveData.env = env;


### PR DESCRIPTION
In a rare case (with very small or no Nursery tilt), that Nursery
contraction triggers object movement (sliding), refuse to contract, if
Concurrent Scavenger (CS) is enabled.

Firstly, it may cause significant pauses, negating the low pause
benefits of CS.
Secondly, and more importantly, it's not safe to do in presence of CS.
The area being moved is hybrid Survivor and Allocate. Objects that have
just been allocated during concurrent phase of the cycle, and have been
hashed, would need to grow (by a hash slot). The current reference fix
up logic does not account of that, since STW Scavenger would move only
pure Survived objects, that already grew, if really needed.

Adjusting the fix up logic is not trivial if possible at all (would
probably need an additional pass to figure out what is to grow).
Adjusting tilt ratio to contract by smaller amount so to avoid object
movement, is probably possible, but messy and semantically not really
that important - it's just simpler to defer the contract attempt for
another Scavenger cycle (if we are very little tilted, we should
probably end up expanding, not contracting).
In a forced case of very limited or disabled tilting, however, it may
mean that we may not ever (or rather rarely) end up contracting Nursery.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>