### PR TITLE
Fix handling of unsigned 32-bit and 64-bit division on Z

### DIFF
--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -800,7 +800,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             {
             firstRegister = cg->gprClobberEvaluate(firstChild);
 
-            // This adjustment only applies to signed division as we are effctively trying to skirt the sign bit during
+            // This adjustment only applies to signed division as we are effectively trying to skirt the sign bit during
             // the shift operation below
             if (!isUnsigned && !firstChild->isNonNegative())
                {
@@ -836,7 +836,7 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
             TR::LabelSymbol * done = generateLabelSymbol(cg);
             TR::RegisterDependencyConditions *deps = NULL;
 
-            // This adjustment only applies to signed division as we are effctively trying to skirt the sign bit during
+            // This adjustment only applies to signed division as we are effectively trying to skirt the sign bit during
             // the shift operation below
             if (!isUnsigned && !firstChild->isNonNegative())
                {
@@ -907,9 +907,10 @@ lDivRemGenericEvaluator64(TR::Node * node, TR::CodeGenerator * cg, bool isDivisi
    dependencies->addPostCondition(remRegister, TR::RealRegister::LegalEvenOfPair);
    dependencies->addPostCondition(quoRegister, TR::RealRegister::LegalOddOfPair);
 
-   // TODO: Remove this Java-ism from OMR and push it into OpenJ9
-   if (!isUnsigned && !doConditionalRemainder &&
+   // TODO(#3685): Remove this Java-ism from OMR and push it into OpenJ9
+   if (!doConditionalRemainder &&
          !node->isSimpleDivCheck() &&
+         !isUnsigned &&
          !firstChild->isNonNegative() &&
          !secondChild->isNonNegative() &&
          !(secondChild->getOpCodeValue() == TR::lconst &&
@@ -1052,8 +1053,9 @@ iDivRemGenericEvaluator(TR::Node * node, TR::CodeGenerator * cg, bool isDivision
    //    R1+1 -> Quotient
    //
    // Note:  D and DR require that R1=0 before executing the division
-   // TODO: Remove this Java-ism from OMR and push it into OpenJ9
-   bool needCheck = (!node->getOpCode().isUnsigned() && !node->isSimpleDivCheck()            &&
+   // TODO(#3685): Remove this Java-ism from OMR and push it into OpenJ9
+   bool needCheck = (!node->isSimpleDivCheck()            &&
+                     !node->getOpCode().isUnsigned() && 
                      !firstChild->isNonNegative()         &&
                      !secondChild->isNonNegative());
 


### PR DESCRIPTION
There is some Java-ism built into the Z *div evaluators in which we
special case a few corner cases for Java. Technically this code does
not belong in OMR, however that is a separate issue (#3685).

In this commit we disable the need to generate such checks for unsigned
division.

Fixes: #3674

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>