### PR TITLE
z/TPF updates resulting from build env changes

### DIFF
--- a/omrmakefiles/rules.ztpf.mk
+++ b/omrmakefiles/rules.ztpf.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -108,7 +108,7 @@ ifneq (,$(findstring executable,$(ARTIFACT_TYPE)))
     GLOBAL_LDFLAGS+=$(DEFAULT_LIBS)
 endif
 
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/redhat/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit
 
 ###
 ### Shared Libraries
@@ -136,6 +136,7 @@ ifeq (gcc,$(OMR_TOOLCHAIN))
     GLOBAL_LDFLAGS+=-Wl,--as-needed
     GLOBAL_LDFLAGS+=-Wl,--eh-frame-hdr
     GLOBAL_LDFLAGS+=$(foreach d,$(TPF_ROOT),-L$d/base/lib)
+    GLOBAL_LDFLAGS+=$(foreach d,$(TPF_ROOT),-L$d/base/stdlib)
     GLOBAL_LDFLAGS+=$(foreach d,$(TPF_ROOT),-L$d/opensource/stdlib)
     GLOBAL_LDFLAGS+=-lgcc
     GLOBAL_LDFLAGS+=-lCTOE

--- a/thread/common/thrprof.c
+++ b/thread/common/thrprof.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -721,7 +721,7 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 		}
 #endif	/* defined(OMR_OS_WINDOWS) */
 
-#if (defined(LINUX) && !defined(J9ZTPF)) || defined(AIXPPC) || defined(OSX)
+#if (defined(LINUX) || defined(AIXPPC) || defined(OSX)
 		struct rusage rUsage;
 		memset(&rUsage, 0, sizeof(rUsage));
 


### PR DESCRIPTION
The following changes were needed for a clean omr build:
 omrmakfiles/rules.ztpf.mk updated for new build directories
 thread/common/thrprof.c updated for new getrusage() implementation.

Signed-off-by: Peter Lemieszewski <lemie@us.ibm.com>