### PR TITLE
Prepare to consolidate trampoline space reservation functions

### DIFF
--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -520,27 +520,19 @@ OMR::CodeCache::reserveResolvedTrampoline(TR_OpaqueMethodBlock *method,
       CodeCacheHashEntry *entry = _resolvedMethodHT->findResolvedMethod(method);
       if (!entry)
          {
-         // reserve a new trampoline since we got no active reservation for given method */
-         CodeCacheTrampolineCode *trampoline = self()->reserveSpaceForTrampoline();
-         if (trampoline)
+         // Reserve a new trampoline since there is not an active reservation for given method
+         //
+         retValue = self()->reserveSpaceForTrampoline_bridge();
+         if (retValue == OMR::CodeCacheErrorCode::ERRORCODE_SUCCESS)
             {
             // add hashtable entry
             if (!self()->addResolvedMethod(method))
                retValue = CodeCacheErrorCode::ERRORCODE_FATALERROR; // couldn't allocate memory from VM
             }
-         else // no space in this code cache; must allocate a new one
-            {
-            _almostFull = TR_yes;
-            retValue = CodeCacheErrorCode::ERRORCODE_INSUFFICIENTSPACE;
-            if (config.verboseCodeCache())
-               {
-               TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "CodeCache %p marked as full in reserveResolvedTrampoline", this);
-               }
-            }
          }
       }
 
-      return retValue;
+   return retValue;
    }
 
 
@@ -1682,6 +1674,40 @@ OMR::CodeCache::reserveNTrampolines(int64_t n)
          if (config.verboseCodeCache())
             {
             TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "CodeCache %p marked as full in reserveNTrampoline", this);
+            }
+         }
+      }
+
+   return status;
+   }
+
+
+OMR::CodeCacheErrorCode::ErrorCode
+OMR::CodeCache::reserveSpaceForTrampoline_bridge(int32_t numTrampolines)
+   {
+   CacheCriticalSection ReserveSpaceForTrampoline(self());
+
+   CodeCacheErrorCode::ErrorCode status = CodeCacheErrorCode::ERRORCODE_SUCCESS;
+
+   TR::CodeCacheConfig &config = _manager->codeCacheConfig();
+   size_t size = numTrampolines * config.trampolineCodeSize();
+
+   if (size)
+      {
+      // See if we are hitting against the method body allocation pointer
+      // indicating that there is no more free space left in this code cache
+      //
+      if (_trampolineReservationMark >= _trampolineBase + size)
+         {
+         _trampolineReservationMark -= size;
+         }
+      else
+         {
+         status = CodeCacheErrorCode::ERRORCODE_INSUFFICIENTSPACE;
+         _almostFull = TR_yes;
+         if (config.verboseCodeCache())
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE, "CodeCache %p marked as full in reserveSpaceForTrampoline", self());
             }
          }
       }

--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -152,6 +152,21 @@ public:
     */
    CodeCacheTrampolineCode *reserveSpaceForTrampoline();
 
+   /**
+    * @brief Reserve space for a trampoline in the current code cache.
+    *
+    * @details
+    *    Space for multiple trampolines can be reserved at once.
+    *    Upon a reservation failure, the code cache is marked as nearing capacity.
+    *
+    * @param[in] numTrampolines : optional parameter for the number of trampolines to
+    *               request at once.  Default value is 1.
+    *
+    * @return : ERRORCODE_SUCCESS on success; ERRORCODE_INSUFFICIENTSPACE on failure
+    */
+   CodeCacheErrorCode::ErrorCode reserveSpaceForTrampoline_bridge(int32_t numTrampolines = 1);
+
+
    CodeCacheErrorCode::ErrorCode reserveNTrampolines(int64_t n);
 
    /**


### PR DESCRIPTION
Consolidate `CodeCache::reserveSpaceForTrampoline` and
`CodeCache::reserveNTrampolines` into a single function.  The
error handling functionality from `reserveNTrampolines` will
be incorporated in the merged function as current consumers
of `reserveSpaceForTrampoline` performed the same functionality
now anyway.

The merged function does not unreserve the code cache on failure
(as the current `reserveNTrampolines` function does) as that
functionality is beyond the scope of this function.  Downstream
consumers will need to be modified if they're expecting that
behaviour.

This PR introduces a temporary "bridge" function while necessary
downstream changes are made.  It will become the permanent function
when such changes are complete.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>