### PR TITLE
CMake: Add validation to OMR_THR_YIELD_ALG option

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -153,6 +153,12 @@ set(OMR_THR_THREE_TIER_LOCKING OFF CACHE BOOL "TODO: Document")
 set(OMR_THR_CUSTOM_SPIN_OPTIONS OFF CACHE BOOL "TODO: Document")
 set(OMR_THR_SPIN_WAKE_CONTROL OFF CACHE BOOL "TODO: Document")
 set(OMR_THR_YIELD_ALG OFF CACHE BOOL "TODO: Document")
+if(OMR_THR_YIELD_ALG)
+	omr_assert(FATAL_ERROR
+		TEST OMR_OS_LINUX OR OMR_OS_OSX OR OMR_OS_AIX
+		MESSAGE "OMR_THR_YIELD_ALG enabled, but not supported on current platform"
+	)
+endif()
 #TODO set to disabled. Stuff fails to compile when its on
 set(OMR_THR_TRACING OFF CACHE BOOL "TODO: Document")
 

--- a/include_core/unix/thrdsup.h
+++ b/include_core/unix/thrdsup.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -227,6 +227,10 @@ extern pthread_condattr_t *defaultCondAttr;
 		sched_yield();\
 	}\
 }
+#endif
+#else /* (defined(LINUX) || defined(AIXPPC) || defined(OSX)) */
+#ifdef OMR_THR_YIELD_ALG
+#error 'OMR_THR_YIELD_ALG' is not supported on this platform
 #endif
 #endif /* (defined(LINUX) || defined(AIXPPC) || defined(OSX)) */
 


### PR DESCRIPTION
Check that platform is supported if OMR_THR_YIELD_ALG is enabled.
Previously, if it were enabled on an unsupported platform, the result
would be a link error due to undefined reference to `THREAD_YIELD_NEW`

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>