### PR TITLE
Use known object temps for inlined callee

### DIFF
--- a/compiler/il/symbol/OMRSymbol_inlines.hpp
+++ b/compiler/il/symbol/OMRSymbol_inlines.hpp
@@ -214,19 +214,6 @@ OMR::Symbol::isPinningArrayPointer()
    }
 
 void
-OMR::Symbol::setAutoAddressTaken()
-   {
-   TR_ASSERT(self()->isAuto(), "assertion failure");
-   _flags.set(AutoAddressTaken);
-   }
-
-bool
-OMR::Symbol::isAutoAddressTaken()
-   {
-   return self()->isAuto() && _flags.testAny(AutoAddressTaken);
-   }
-
-void
 OMR::Symbol::setSpillTempLoaded()
    {
    if (self()->isAuto()) // For non auto spills (ie. to original location) we can't optimize removing spills

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -1364,7 +1364,6 @@ TR_DumbInliner::analyzeCallSite(
 //---------------------------------------------------------------------
 
 static TR::TreeTop * cloneAndReplaceCallNodeReference(TR::TreeTop *, TR::Node *, TR::Node *, TR::TreeTop *, TR::Compilation *);
-static void addSymRefsToList(List<TR::SymbolReference> &, List<TR::SymbolReference> &);
 
 static TR::Node *findPotentialDecompilationPoint(TR::ResolvedMethodSymbol *calleeSymbol, TR::Compilation *comp)
    {
@@ -2215,12 +2214,13 @@ bool rematerializeConstant(TR::Node *node, TR::Compilation *comp)
 ///////////////////////////////////////////////////////////////
 
 TR_ParameterToArgumentMapper::TR_ParameterToArgumentMapper(
-   TR::ResolvedMethodSymbol * callerSymbol, TR::ResolvedMethodSymbol * calleeSymbol, TR::Node * callNode,
+   TR::ResolvedMethodSymbol * callerSymbol, TR::ResolvedMethodSymbol * calleeSymbol, TR::Node * callNode, TR_PrexArgInfo *argInfo,
    List<TR::SymbolReference> & temps, List<TR::SymbolReference> & availableTemps, List<TR::SymbolReference> & availableTemps2,
    TR_InlinerBase *inliner)
    : _callerSymbol(callerSymbol),
      _calleeSymbol(calleeSymbol),
      _callNode(callNode),
+     _argInfo(argInfo),
      _tempList(temps),
      _availableTemps(availableTemps),
      _availableTemps2(availableTemps2),
@@ -2354,12 +2354,22 @@ TR_ParameterToArgumentMapper::initialize(TR_CallStack *callStack)
             else
                {
                TR::SymbolReference * symRef = NULL;
-
+               const static bool disableUseKnownObjectTempsForParms = feGetEnv("TR_DisableUseKnownObjectTempsForParmsInCallee") ? true: false;
+               int argOrdinal = argIndex - _callNode->getFirstArgumentIndex();
+               TR_PrexArgument * prexArgument = _argInfo->get(argOrdinal);
+               // use known object temp if the argument is a known object
+               if (!disableUseKnownObjectTempsForParms && prexArgument
+                   && !parmMap->_parmIsModified
+                   && TR_PrexArgument::knowledgeLevel(prexArgument) == KNOWN_OBJECT
+                   && !prexArgument->isTypeInfoForInlinedBody())
                   {
-                  tt = OMR_InlinerUtil::storeValueInATemp(comp(), arg, symRef, 0, _calleeSymbol, _tempList, _availableTemps, &_availableTemps2, false, &newValueStoreTreeTop);
+                  symRef  = comp()->getSymRefTab()->findOrCreateTemporaryWithKnowObjectIndex(_callerSymbol, prexArgument->getKnownObjectIndex());
+                  debugTrace(tracer(),"map arg %p into known object temp #%d as priv arg\n", arg, symRef->getReferenceNumber());
                   }
 
+               tt = OMR_InlinerUtil::storeValueInATemp(comp(), arg, symRef, 0, _calleeSymbol, _tempList, _availableTemps, &_availableTemps2, false, &newValueStoreTreeTop);
                symRef->getSymbol()->setBehaveLikeNonTemp();
+
                // set flag only if there is a virtual guard
                if (!hasStaticCallStack && !neverNeedPrivatizedArguments
                      && tt->getNode()->getOpCode().isStoreDirectOrReg()) // compjazz 53912: PLX sometimes privatizes using indirect stores
@@ -2367,32 +2377,35 @@ TR_ParameterToArgumentMapper::initialize(TR_CallStack *callStack)
                   tt->getNode()->setIsPrivatizedInlinerArg(true);
                   }
                parmMap->_replacementSymRef = symRef;
+
+
+               if (!disableUseKnownObjectTempsForParms && prexArgument
+                  && !parmMap->_parmIsModified
+                  && TR_PrexArgument::knowledgeLevel(prexArgument) == KNOWN_OBJECT
+                  && prexArgument->isTypeInfoForInlinedBody())  // use known object temp in inlined body only
+                  {
+                  TR::SymbolReference *origTempSymRef = symRef;
+                  TR::SymbolReference *knownObjectTempSymRef = comp()->getSymRefTab()->findOrCreateTemporaryWithKnowObjectIndex(_callerSymbol, prexArgument->getKnownObjectIndex());
+                  TR::TreeTop *storeToKnownObjTemp = TR::TreeTop::create(comp(), TR::Node::createStore(knownObjectTempSymRef, TR::Node::createLoad(_calleeSymbol->getFirstTreeTop()->getNode(), origTempSymRef)));
+                  storeToKnownObjTemp->insertNewTreeTop(_calleeSymbol->getFirstTreeTop(), _calleeSymbol->getFirstTreeTop()->getNextTreeTop());
+                  parmMap->_replacementSymRefForInlinedBody = knownObjectTempSymRef;
+                  debugTrace(tracer(),"created tree n%dn to store the priv arg #%d into a known object temp #%d on entry of the inlined body\n", storeToKnownObjTemp->getNode()->getGlobalIndex(), symRef->getReferenceNumber(), knownObjectTempSymRef->getReferenceNumber());
+                  }
                }
             }
 
-         if (_lastTempTreeTop)
-            {
-            if (newValueStoreTreeTop)
-               {
-               tt->join(newValueStoreTreeTop);
-               _lastTempTreeTop->join(tt);
-               _lastTempTreeTop = newValueStoreTreeTop;
-               }
-            else
-               {
-               _lastTempTreeTop->join(tt);
-               _lastTempTreeTop = tt;
-               }
-            }
-         else if (newValueStoreTreeTop)
-            {
+
+         if (!_firstTempTreeTop)
             _firstTempTreeTop = tt;
-            _firstTempTreeTop->join(newValueStoreTreeTop);
+         else
+            _lastTempTreeTop->join(tt);
+         _lastTempTreeTop = tt;
+
+         if (newValueStoreTreeTop)
+            {
+            _lastTempTreeTop->join(newValueStoreTreeTop);
             _lastTempTreeTop = newValueStoreTreeTop;
             }
-         else
-            _firstTempTreeTop = _lastTempTreeTop = tt;
-
 
          parmMap = parmMap->getNext();
          }
@@ -2519,13 +2532,13 @@ TR_ParameterToArgumentMapper::map(TR::Node * node, TR::ParameterSymbol * parm, b
             return newNode;
             }
 
-         if (parmMap->_addressTaken && parmMap->_replacementSymRef->getSymbol()->isAuto())
-            {
-            parmMap->_replacementSymRef->getSymbol()->setAutoAddressTaken();
-            }
          intptrj_t offset= node->getSymbolReference()->getOffset();
 
-         node->setSymbolReference(parmMap->_replacementSymRef);
+
+         if (!parmMap->_parmIsModified && parmMap->_replacementSymRefForInlinedBody && performTransformation(comp(), "%s set symRef on node n%dn to be known object symRef %p\n", OPT_DETAILS, node->getGlobalIndex(), parmMap->_replacementSymRefForInlinedBody))
+            node->setSymbolReference(parmMap->_replacementSymRefForInlinedBody);
+         else
+            node->setSymbolReference(parmMap->_replacementSymRef);
 
          if (offset != 0)
             {
@@ -2791,6 +2804,7 @@ TR_TransformInlinedFunction::transformNode(TR::Node * node, TR::Node * parent, u
       if (symbol->isParm())
          {
          TR::Node * newNode = _parameterMapper.map(node, symbol->getParmSymbol(), _crossedBasicBlock);
+
          if (newNode && newNode != node)
             {
             if (newNode->getOpCode().isLoadConst() && newNode->getType().isInt32() && node->getType().isInt8())
@@ -3669,17 +3683,6 @@ TR::TreeTop * TR_TransformInlinedFunction::findSimpleCallReference(TR::TreeTop *
       }
    return 0;
    }
-//migrated
-
-static void addSymRefsToList(List<TR::SymbolReference> & calleeSymRefs, List<TR::SymbolReference> & callerSymRefs)
-   {
-   ListIterator<TR::SymbolReference> i(&calleeSymRefs);
-   for (TR::SymbolReference * symRef = i.getFirst(); symRef; symRef = i.getNext())
-      callerSymRefs.add(symRef);
-   }
-
-//new findInlineTargets API
-
 
 bool TR_CallSite::findCallSiteTarget (TR_CallStack *callStack, TR_InlinerBase* inliner)
    {
@@ -4910,7 +4913,7 @@ bool TR_InlinerBase::inlineCallTarget2(TR_CallStack * callStack, TR_CallTarget *
       }
 
    TR_ScratchList<TR::SymbolReference> tempList(trMemory());
-   TR_ParameterToArgumentMapper pam(callerSymbol, calleeSymbol, callNode, tempList, _availableTemps, _availableBasicBlockTemps, this);
+   TR_ParameterToArgumentMapper pam(callerSymbol, calleeSymbol, callNode, calltarget->_prexArgInfo, tempList, _availableTemps, _availableBasicBlockTemps, this);
    pam.initialize(callStack);
 
    pam.printMapping();

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -446,12 +446,29 @@ class TR_InlineCall : public TR_DumbInliner
 struct TR_ParameterMapping : TR_Link<TR_ParameterMapping>
    {
    TR_ParameterMapping(TR::ParameterSymbol * ps)
-      : _parmSymbol(ps), _replacementSymRef(0), _parameterNode(0),
-       _parmIsModified(false), _addressTaken(false), _isConst(false)
-      { }
+      : _parmSymbol(ps),
+        _replacementSymRef(NULL),
+        _replacementSymRefForInlinedBody(NULL),
+        _parameterNode(NULL),
+        _parmIsModified(false),
+        _addressTaken(false),
+        _isConst(false)
+       { }
 
    TR::ParameterSymbol * _parmSymbol;
+
+   /*
+    * The symbol reference of the priv arg temp.
+    *
+    * Used for replacing both the parm symbol references in the inlined body and args on the taken side of the guard.
+    */
    TR::SymbolReference * _replacementSymRef;
+   /*
+    * Used for replacing parm symbol reference in the inlined body when this field not NULL.
+    * Otherwise, the \ref _replacementSymRef is used.
+    */
+   TR::SymbolReference * _replacementSymRefForInlinedBody;
+
    TR::Node *            _parameterNode;                 //The Node under the call which matches the argument at argIndex
    uint32_t             _argIndex;
    bool                 _parmIsModified;
@@ -464,7 +481,7 @@ class TR_ParameterToArgumentMapper
    public:
       TR_ALLOC(TR_Memory::Inliner)
 
-      TR_ParameterToArgumentMapper(TR::ResolvedMethodSymbol *, TR::ResolvedMethodSymbol *, TR::Node *,
+      TR_ParameterToArgumentMapper(TR::ResolvedMethodSymbol *, TR::ResolvedMethodSymbol *, TR::Node *, TR_PrexArgInfo *,
                                    List<TR::SymbolReference> &, List<TR::SymbolReference> &,
                                    List<TR::SymbolReference> &, TR_InlinerBase *);
 
@@ -504,6 +521,7 @@ class TR_ParameterToArgumentMapper
       List<TR::SymbolReference> &       _availableTemps2;
       TR_InlinerTracer *               _tracer;
       TR_InlinerBase *                 _inliner;
+      TR_PrexArgInfo *                 _argInfo;
    };
 
 class OMR_InlinerHelper

--- a/compiler/optimizer/PreExistence.cpp
+++ b/compiler/optimizer/PreExistence.cpp
@@ -50,6 +50,7 @@ TR_PrexArgument::TR_PrexArgument(
    _classKind(ClassIsUnknown),
    _class(0),
    _profiledClazz(0),
+   _isTypeInfoForInlinedBody(false),
    _knownObjectIndex(knownObjectIndex)
    {
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -50,12 +50,12 @@ class TR_PrexArgument
    TR_PrexArgument(
          ClassKind classKind,
          TR_OpaqueClassBlock *clazz = 0,
-         TR_OpaqueClassBlock *profiledClazz = 0,
-         bool p = false) :
+         TR_OpaqueClassBlock *profiledClazz = 0):
       _classKind(classKind),
       _class(clazz),
       _profiledClazz(profiledClazz),
-      _knownObjectIndex(TR::KnownObjectTable::UNKNOWN)
+      _knownObjectIndex(TR::KnownObjectTable::UNKNOWN),
+      _isTypeInfoForInlinedBody(false)
       { }
 
    static const char *priorKnowledgeStrings[];
@@ -82,6 +82,9 @@ class TR_PrexArgument
    TR::KnownObjectTable::Index getKnownObjectIndex() { return _knownObjectIndex; }
    bool hasKnownObjectIndex(){ return getKnownObjectIndex() != TR::KnownObjectTable::UNKNOWN; }
 
+   bool isTypeInfoForInlinedBody () { return _isTypeInfoForInlinedBody; }
+   void setTypeInfoForInlinedBody() { _isTypeInfoForInlinedBody = true; }
+
    private:
 
    ClassKind _classKind;
@@ -95,6 +98,7 @@ class TR_PrexArgument
    // optionally provided - when ObjectIsKnown
    //
    TR::KnownObjectTable::Index _knownObjectIndex;
+   bool _isTypeInfoForInlinedBody; // The prex arg info only apply to the inlined body but not on the taken side
    };
 
 class TR_PrexArgInfo


### PR DESCRIPTION
When inliner inlines a method and replaces the loads of parms with loads
of priv arg temps, the known object info we got from prex arguments are
lost. GlobalVP needs to run to propagate the known object info again
which is expensive and doesn't kick in at warm level. This change replaces
the priv args with known object temps when feasible.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>