### PR TITLE
Enable CopyForwardMarkCompactHybrid mode

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1654,7 +1654,7 @@ public:
 		, tarokMinimumGMPWorkTargetBytes()
 		, tarokConcurrentMarkingCostWeight(0.05)
 		, tarokAutomaticDefragmentEmptinessThreshold(false)
-		, tarokEnableCopyForwardHybrid(false)
+		, tarokEnableCopyForwardHybrid(true)
 #endif /* defined (OMR_GC_VLHGC) */
 		, tarokEnableExpensiveAssertions(false)
 		, sweepPoolManagerAddressOrderedList(NULL)


### PR DESCRIPTION
	- enable CopyForwardMarkCompactHybrid mode by default for fully
	testing.
	CopyForwardMarkCompactHybrid mode intends to avoid MarkCompactOnly
	PGCs, which are caused by jniCritical or abort case during GMP.
	it would improve the GC performance for the most cases, but in
	some cases, it might be no performance difference or slight draw back.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>