### PR TITLE
Thread final/non-final Release Caches

### DIFF
--- a/gc/base/standard/EnvironmentStandard.cpp
+++ b/gc/base/standard/EnvironmentStandard.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -99,7 +99,7 @@ MM_EnvironmentStandard::flushGCCaches()
 	if (getExtensions()->concurrentScavenger) {
 		if (MUTATOR_THREAD == getThreadType()) {
 			if (NULL != getExtensions()->scavenger) {
-				getExtensions()->scavenger->threadFinalReleaseCaches(this);
+				getExtensions()->scavenger->threadReleaseCaches(this, true);
 			}
 		}
 	}

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -624,10 +624,10 @@ public:
 	/* methods used by either mutator or GC threads */
 	/**
 	 * All open copy caches (even if not full) are pushed onto scan queue. Unused memory is abondoned.
-	 * @param env Invoking thread. Could be master thread on behalf on mutator threads (threadEnvironment) for which copy caches are to be released, or could be mutator or GC thread itself.
-	 * @param threadEnvironment Thread for which copy caches are to be released. Could be either GC or mutator thread.
+	 * @param env Invoking thread, for which copy caches are to be released. Could be either GC or mutator thread.
+	 * @param final If true (typically at the end of a cycle), abandon TLH remainders, too. Otherwise keep them for possible future copy cache refresh.
 	 */
-	void threadFinalReleaseCaches(MM_EnvironmentBase *env);
+	void threadReleaseCaches(MM_EnvironmentBase *env, bool final);
 	
 	/**
 	 * trigger STW phase (either start or end) of a Concurrent Scavenger Cycle 


### PR DESCRIPTION
threadFinalReleaseCaches method is generalized to be used in a middle of
a Scavenger cycle, when we do not want to flush Copy Cache Remainders,
since they can be re-used later.

Additional parameter is introduced to control, if we want to be final
release (when remainders are abandoned) or not.

At all existing call sites we set the parameter to true and we used to
abandon them always, what makes this a non-functional change. Future
users will set the parameter to false when needed.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>