### PR TITLE
Introduce new Z Linkage constructor

### DIFF
--- a/compiler/z/codegen/Linkage.hpp
+++ b/compiler/z/codegen/Linkage.hpp
@@ -36,6 +36,9 @@ class OMR_EXTENSIBLE Linkage : public OMR::LinkageConnector
    {
    public:
 
+   Linkage(TR::CodeGenerator *cg)
+      : OMR::LinkageConnector(cg) {}
+
    Linkage(TR::CodeGenerator *cg, TR_S390LinkageConventions elc, TR_LinkageConventions le)
       : OMR::LinkageConnector(cg, elc, le) {}
    };

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -103,6 +103,37 @@ static int32_t getFirstMaskedBit(int16_t mask); ///< formward reference
 // TR::S390Linkage member functions
 ////////////////////////////////////////////////////////////////////////////////
 
+OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
+   : OMR::Linkage(),
+      _codeGen(codeGen), _explicitLinkageType(TR_S390LinkageDefault), _linkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+      _integerReturnRegister(TR::RealRegister::NoReg),
+      _floatReturnRegister(TR::RealRegister::NoReg),
+      _doubleReturnRegister(TR::RealRegister::NoReg),
+      _longLowReturnRegister(TR::RealRegister::NoReg),
+      _longHighReturnRegister(TR::RealRegister::NoReg),
+      _longReturnRegister(TR::RealRegister::NoReg),
+      _stackPointerRegister(TR::RealRegister::NoReg),
+      _entryPointRegister(TR::RealRegister::NoReg),
+      _litPoolRegister(TR::RealRegister::NoReg),
+      _staticBaseRegister(TR::RealRegister::NoReg),
+      _privateStaticBaseRegister(TR::RealRegister::NoReg),
+      _returnAddrRegister(TR::RealRegister::NoReg),
+      _raContextRestoreNeeded(true),
+      _firstSaved(TR::RealRegister::NoReg),
+      _lastSaved(TR::RealRegister::NoReg),
+      _lastPrologueInstr(NULL),
+      _firstPrologueInstr(NULL),
+      _frameType(standardFrame)
+   {
+   int32_t i;
+   self()->setProperties(0);
+   for (i=0; i<TR::RealRegister::NumRegisters;i++)
+      {
+      self()->setRegisterFlags(REGNUM(i),0);
+      }
+   }
+
+
 /**
  * Get or create the TR::Linkage object that corresponds to the given linkage
  * convention.

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -285,6 +285,8 @@ enum TR_DispatchType
    void setFrameType(enum FrameType type) { _frameType = type; }
    virtual bool getIsLeafRoutine();
 
+   Linkage(TR::CodeGenerator *);
+
    Linkage(TR::CodeGenerator *, TR_S390LinkageConventions, TR_LinkageConventions);
 
    TR_S390LinkageConventions getExplicitLinkageType() { return _explicitLinkageType; }


### PR DESCRIPTION
`Linkage(TR::CodeGenerator *cg)`

Provides sensible defaults for the linkage type and explicit linkage type.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>