### PR TITLE
Don't inline thunk archetype in VP

### DIFF
--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -5032,6 +5032,14 @@ static void devirtualizeCall(OMR::ValuePropagation *vp, TR::Node *node)
    if (methodSymbol->isComputed())
       {
 #ifdef J9_PROJECT_SPECIFIC
+      if (node->getSymbol()->getMethodSymbol()->getMethod()->isArchetypeSpecimen()
+          && vp->optimizer()->getOptimization(OMR::methodHandleInvokeInliningGroup)->requested())
+         {
+         if (vp->trace())
+            traceMsg(vp->comp(), "Not inlining call [%p] because the MethodHandle.invoke inlining group will do a better job\n", node);
+         return;
+         }
+
       if (methodSymbol->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact && !symRef->isUnresolved())
          {
          TR::Node *receiver = node->getArgument(0);


### PR DESCRIPTION
Leave the thunk archetype to methodHandleInvokeInliningGroup if it is
requested.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>