### PR TITLE
Code clean related to Label Instruction on X86

### DIFF
--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3423,7 +3423,7 @@ TR::Register *OMR::X86::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
       if (node->getNumChildren() > 0)
          inst = generateLabelInstruction(LABEL, node, label, node->getFirstChild(), &popRegisters, cg);
       else
-         inst = generateLabelInstruction(LABEL, node, node->getLabel(), true, cg);
+         inst = generateLabelInstruction(LABEL, node, node->getLabel(), cg);
 
       if (inst->getDependencyConditions())
          inst->getDependencyConditions()->setMayNeedToPopFPRegisters(true);
@@ -3505,14 +3505,12 @@ TR::Register *OMR::X86::TreeEvaluator::BBEndEvaluator(TR::Node *node, TR::CodeGe
          machine->createRegisterAssociationDirective(cg->getAppendInstruction());
          }
 
-      bool needVMThreadDep = true;
-
       // This label is also used by RegisterDependency to detect the end of a block.
       TR::Instruction *labelInst = NULL;
       if (node->getNumChildren() > 0)
          labelInst = generateLabelInstruction(LABEL, node, generateLabelSymbol(cg), node->getFirstChild(), NULL, cg);
       else
-         labelInst = generateLabelInstruction(LABEL, node, generateLabelSymbol(cg), needVMThreadDep, cg);
+         labelInst = generateLabelInstruction(LABEL, node, generateLabelSymbol(cg), cg);
 
        node->getBlock()->setLastInstruction(labelInst);
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -154,59 +154,59 @@ TR::RealRegister *assignGPRegister(TR::Instruction   *instr,
 ////////////////////////////////////////////////////////////////////////////////
 // TR::X86LabelInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
-
-TR::X86LabelInstruction::X86LabelInstruction(TR_X86OpCodes    op,
-                                                 TR::Node          *node,
-                                                 TR::LabelSymbol    *sym,
-                                                 TR::CodeGenerator *cg,
-                                                 bool b)
-  : TR::Instruction(node, op, cg), _symbol(sym),_needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
+void TR::X86LabelInstruction::initialize(TR::LabelSymbol* sym, bool b)
    {
-   if (sym && op == LABEL)
+   _symbol = sym;
+   _needToClearFPStack = b;
+   _outlinedInstructionBranch = NULL;
+   _reloType = TR_NoRelocation;
+   _permitShortening = true;
+   if (sym && self()->getOpCodeValue() == LABEL)
       sym->setInstruction(this);
    else if (sym)
       sym->setDirectlyTargeted();
    }
 
-TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction   *precedingInstruction,
-                                                 TR_X86OpCodes    op,
-                                                 TR::LabelSymbol    *sym,
-                                                 TR::CodeGenerator *cg,
-                                                 bool b)
-  : TR::Instruction(op, precedingInstruction, cg), _symbol(sym), _needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
+TR::X86LabelInstruction::X86LabelInstruction(TR_X86OpCodes      op,
+                                             TR::Node*          node,
+                                             TR::LabelSymbol*   sym,
+                                             TR::CodeGenerator* cg,
+                                             bool               b)
+  : TR::Instruction(node, op, cg)
    {
-   if (sym && op == LABEL)
-      sym->setInstruction(this);
-   else if (sym)
-      sym->setDirectlyTargeted();
+   initialize(sym, b);
    }
 
-TR::X86LabelInstruction::X86LabelInstruction(TR_X86OpCodes                       op,
-                                                 TR::Node                             *node,
-                                                 TR::LabelSymbol                       *sym,
-                                                 TR::RegisterDependencyConditions  *cond,
-                                                 TR::CodeGenerator                    *cg,
-                                                 bool b)
-  : TR::Instruction(cond, node, op, cg), _symbol(sym), _needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
+TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction*   precedingInstruction,
+                                             TR_X86OpCodes      op,
+                                             TR::LabelSymbol*   sym,
+                                             TR::CodeGenerator* cg,
+                                             bool               b)
+  : TR::Instruction(op, precedingInstruction, cg)
    {
-   if (sym && op == LABEL)
-      sym->setInstruction(this);
-   else if (sym)
-      sym->setDirectlyTargeted();
+   initialize(sym, b);
    }
 
-TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction                      *precedingInstruction,
-                                                 TR_X86OpCodes                       op,
-                                                 TR::LabelSymbol                       *sym,
-                                                 TR::RegisterDependencyConditions  *cond,
-                                                 TR::CodeGenerator                    *cg,
-                                                 bool b)
-  : TR::Instruction(cond, op, precedingInstruction, cg), _symbol(sym), _needToClearFPStack(b), _outlinedInstructionBranch(NULL), _reloType(TR_NoRelocation), _permitShortening(true)
+TR::X86LabelInstruction::X86LabelInstruction(TR_X86OpCodes                     op,
+                                             TR::Node*                         node,
+                                             TR::LabelSymbol*                  sym,
+                                             TR::RegisterDependencyConditions* cond,
+                                             TR::CodeGenerator*                cg,
+                                             bool                              b)
+  : TR::Instruction(cond, node, op, cg)
    {
-   if (sym && op == LABEL)
-      sym->setInstruction(this);
-   else if (sym)
-      sym->setDirectlyTargeted();
+   initialize(sym, b);
+   }
+
+TR::X86LabelInstruction::X86LabelInstruction(TR::Instruction*                  precedingInstruction,
+                                             TR_X86OpCodes                     op,
+                                             TR::LabelSymbol*                  sym,
+                                             TR::RegisterDependencyConditions* cond,
+                                             TR::CodeGenerator*                cg,
+                                             bool                              b)
+  : TR::Instruction(cond, op, precedingInstruction, cg)
+   {
+   initialize(sym, b);
    }
 
 TR::X86LabelInstruction  *TR::X86LabelInstruction::getX86LabelInstruction()
@@ -3923,6 +3923,12 @@ TR::AMD64RegImm64SymInstruction::autoSetReloKind()
 ////////////////////////////////////////////////////////////////////////////////
 
 TR::Instruction  *
+generateInstruction(TR::Instruction *prev, TR_X86OpCodes op, TR::CodeGenerator *cg)
+   {
+   return new (cg->trHeapMemory()) TR::Instruction(op, prev, cg);
+   }
+
+TR::Instruction  *
 generateInstruction(TR_X86OpCodes op, TR::Node * node, TR::CodeGenerator *cg)
    {
    return new (cg->trHeapMemory()) TR::Instruction(node, op, cg);
@@ -4160,18 +4166,6 @@ generateLongLabelInstruction(TR_X86OpCodes                       op,
    }
 
 TR::X86LabelInstruction  *
-generateLongLabelInstruction(TR_X86OpCodes     op,
-                             TR::Node          *node,
-                             TR::LabelSymbol    *sym,
-                             bool              needsVMThreadRegister,
-                             TR::CodeGenerator *cg)
-   {
-   TR::X86LabelInstruction *instr = new (cg->trHeapMemory()) TR::X86LabelInstruction(op, node, sym, cg);
-   instr->prohibitShortening();
-   return instr;
-   }
-
-TR::X86LabelInstruction  *
 generateLabelInstruction(TR_X86OpCodes     opCode,
                          TR::Node           *node,
                          TR::LabelSymbol     *label,
@@ -4265,7 +4259,7 @@ generateConditionalJumpInstruction(
       }
    else
       {
-      inst = generateLabelInstruction(opCode, ifNode, destinationLabel, false, cg);
+      inst = generateLabelInstruction(opCode, ifNode, destinationLabel, cg);
       }
 
    return inst;

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -307,58 +307,14 @@ class X86LabelInstruction : public TR::Instruction
    bool _needToClearFPStack;
    uint8_t _reloType;
    bool _permitShortening;
+   void initialize(TR::LabelSymbol *sym, bool b);
 
    public:
 
-   X86LabelInstruction(TR::LabelSymbol *sym, TR::Node * node, TR_X86OpCodes op, TR::CodeGenerator *cg, bool b = false)
-     : TR::Instruction(node, op, cg), _symbol(sym), _needToClearFPStack(b), _reloType(TR_NoRelocation),
-       _permitShortening(true)
-      {
-      if (sym && op == LABEL)
-         sym->setInstruction(this);
-      else if (sym)
-         sym->setDirectlyTargeted();
-      }
-
-   X86LabelInstruction(TR::LabelSymbol *sym,
-                          TR_X86OpCodes op,
-                          TR::Instruction *precedingInstruction,
-                          TR::CodeGenerator *cg,
-                          bool b = false)
-      : TR::Instruction(op, precedingInstruction, cg),
-        _symbol(sym),
-        _needToClearFPStack(b),
-        _outlinedInstructionBranch(NULL),
-        _reloType(TR_NoRelocation),
-        _permitShortening(true)
-      {
-      if (sym && op == LABEL)
-         sym->setInstruction(this);
-      else if (sym)
-         sym->setDirectlyTargeted();
-      }
-
    X86LabelInstruction(TR_X86OpCodes op, TR::Node * node, TR::LabelSymbol *sym, TR::CodeGenerator *cg, bool b = false);
-
-   X86LabelInstruction(TR::Instruction *precedingInstruction,
-                          TR_X86OpCodes op,
-                          TR::LabelSymbol *sym,
-                          TR::CodeGenerator *cg,
-                          bool b = false);
-
-   X86LabelInstruction(TR_X86OpCodes op,
-                          TR::Node *node,
-                          TR::LabelSymbol *sym,
-                          TR::RegisterDependencyConditions *cond,
-                          TR::CodeGenerator *cg,
-                          bool b = false);
-
-   X86LabelInstruction(TR::Instruction *precedingInstruction,
-                          TR_X86OpCodes op,
-                          TR::LabelSymbol *sym,
-                          TR::RegisterDependencyConditions *cond,
-                          TR::CodeGenerator *cg,
-                          bool b = false);
+   X86LabelInstruction(TR::Instruction *precedingInstruction, TR_X86OpCodes op, TR::LabelSymbol *sym, TR::CodeGenerator *cg, bool b = false);
+   X86LabelInstruction(TR_X86OpCodes op, TR::Node *node, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, bool b = false);
+   X86LabelInstruction(TR::Instruction *precedingInstruction, TR_X86OpCodes op, TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::CodeGenerator *cg, bool b = false);
 
    void prohibitShortening() { _permitShortening = false; }
 
@@ -2961,6 +2917,7 @@ TR::X86RegRegInstruction  * generateRegRegInstruction(TR::Instruction *, TR_X86O
 
 TR::Instruction  * generateInstruction(TR_X86OpCodes, TR::Node *, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
 TR::Instruction  * generateInstruction(TR_X86OpCodes op, TR::Node * node, TR::CodeGenerator *cg);
+TR::Instruction  * generateInstruction(TR::Instruction *prev, TR_X86OpCodes op, TR::CodeGenerator *cg);
 
 TR::X86ImmInstruction  * generateImmInstruction(TR_X86OpCodes op, TR::Node * node, int32_t imm, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
 TR::X86ImmInstruction  * generateImmInstruction(TR_X86OpCodes op, TR::Node * node, int32_t imm, TR::CodeGenerator *cg, int32_t reloKind=TR_NoRelocation);
@@ -2972,9 +2929,6 @@ TR::X86RegInstruction  * generateRegInstruction(TR_X86OpCodes op, TR::Node *, TR
 
 TR::X86MemImmSymInstruction  * generateMemImmSymInstruction(TR_X86OpCodes op, TR::Node *, TR::MemoryReference  * mr, int32_t imm, TR::SymbolReference *sr, TR::CodeGenerator *cg);
 
-TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
-TR::X86LabelInstruction  * generateLabelInstruction(TR::Instruction *prev, TR_X86OpCodes op, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
-
 TR::X86PaddingInstruction  * generatePaddingInstruction(uint8_t length, TR::Node * node, TR::CodeGenerator *cg);
 TR::X86PaddingInstruction  * generatePaddingInstruction(TR::Instruction *precedingInstruction, uint8_t length, TR::CodeGenerator *cg);
 
@@ -2985,29 +2939,17 @@ TR::X86AlignmentInstruction  * generateAlignmentInstruction(TR::Node * node, uin
 TR::X86AlignmentInstruction  * generateAlignmentInstruction(TR::Instruction *precedingInstruction, uint8_t boundary, TR::CodeGenerator *cg);
 TR::X86AlignmentInstruction  * generateAlignmentInstruction(TR::Instruction *precedingInstruction, uint8_t boundary, uint8_t margin, TR::CodeGenerator *cg);
 
+TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
+TR::X86LabelInstruction  * generateLabelInstruction(TR::Instruction *prev, TR_X86OpCodes op, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
 TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *node, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
-inline TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *node, TR::LabelSymbol *sym, bool needsVMThreadRegister, TR::CodeGenerator *cg)
-   { return generateLabelInstruction(op, node, sym, cg); }
-
 TR::X86LabelInstruction  * generateLabelInstruction(TR::Instruction *i, TR_X86OpCodes op, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
-inline TR::X86LabelInstruction  * generateLabelInstruction(TR::Instruction *i, TR_X86OpCodes op, TR::LabelSymbol *sym, bool needsVMThreadRegister, TR::CodeGenerator *cg)
-   { return generateLabelInstruction(i, op, sym, cg); }
-
-
-TR::X86LabelInstruction  * generateLongLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
-TR::X86LabelInstruction  * generateLongLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
-
-TR::X86LabelInstruction  * generateLongLabelInstruction(TR_X86OpCodes op, TR::Node *node, TR::LabelSymbol *sym, bool needsVMThreadRegister, TR::CodeGenerator *cg);
-
-
 TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::Node * glRegDep, List<TR::Register> *popRegs, bool evaluateGlRegDeps, TR::CodeGenerator *cg);
-
 inline TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *node, TR::LabelSymbol *sym, TR::Node * glRegDep, List<TR::Register> *popRegs, TR::CodeGenerator *cg)
    { return generateLabelInstruction(op, node, sym, glRegDep, popRegs, true, cg); }
-
 inline TR::X86LabelInstruction  * generateLabelInstruction(TR_X86OpCodes op, TR::Node *node, TR::LabelSymbol *sym, TR::Node * glRegDep, TR::CodeGenerator *cg)
    { return generateLabelInstruction(op, node, sym, glRegDep, 0, true, cg); }
-
+TR::X86LabelInstruction  * generateLongLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::RegisterDependencyConditions  * cond, TR::CodeGenerator *cg);
+TR::X86LabelInstruction  * generateLongLabelInstruction(TR_X86OpCodes op, TR::Node *, TR::LabelSymbol *sym, TR::CodeGenerator *cg);
 
 TR::X86LabelInstruction  * generateJumpInstruction(TR_X86OpCodes op, TR::Node * jumpNode, TR::CodeGenerator *cg, bool needsVMThreadRegister = false, bool evaluateGlRegDeps = true);
 

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -3318,8 +3318,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
       TR::Register                         *cmpRegister = NULL;
       TR::RegisterDependencyConditions  *deps        = NULL;
 
-      bool needVMThreadDep = true;
-
       if ((lowValue | highValue) == 0)
          {
          TR::Node     *landConstChild;
@@ -3368,7 +3366,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             generateRegRegInstruction(OR4RegReg, node, targetRegister, cmpRegister->getHighOrder(), cg);
             }
 
-         generateConditionalJumpInstruction(JE4, node, cg, needVMThreadDep);
+         generateConditionalJumpInstruction(JE4, node, cg);
 
          if (targetNeedsToBeExplicitlyStopped)
             {
@@ -3409,9 +3407,9 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpeqEvaluator(TR::Node *node, T
             }
          else
             {
-            generateLabelInstruction(JNE4, node, doneLabel, needVMThreadDep, cg);
+            generateLabelInstruction(JNE4, node, doneLabel, cg);
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);
-            generateLabelInstruction(JE4, node, destinationLabel, needVMThreadDep, cg);
+            generateLabelInstruction(JE4, node, destinationLabel, cg);
             deps = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
             deps->addPostCondition(cmpRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
             deps->addPostCondition(cmpRegister->getHighOrder(), TR::RealRegister::NoReg, cg);
@@ -3456,8 +3454,6 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
       TR::Node                             *firstChild  = node->getFirstChild();
       TR::Register                         *cmpRegister = NULL;
       TR::RegisterDependencyConditions  *deps        = NULL;
-
-      bool needVMThreadDep = true;
 
       if ((lowValue | highValue) == 0)
          {
@@ -3506,7 +3502,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             generateRegRegInstruction(OR4RegReg, node, targetRegister, cmpRegister->getHighOrder(), cg);
             }
 
-         generateConditionalJumpInstruction(JNE4, node, cg, needVMThreadDep);
+         generateConditionalJumpInstruction(JNE4, node, cg);
 
          if (targetNeedsToBeExplicitlyStopped)
             {
@@ -3547,9 +3543,9 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpneEvaluator(TR::Node *node, T
             }
          else
             {
-            generateLabelInstruction(JNE4, node, destinationLabel, needVMThreadDep, cg);
+            generateLabelInstruction(JNE4, node, destinationLabel, cg);
             compareGPRegisterToConstantForEquality(node, highValue, cmpRegister->getHighOrder(), cg);
-            generateLabelInstruction(JNE4, node, destinationLabel, needVMThreadDep, cg);
+            generateLabelInstruction(JNE4, node, destinationLabel, cg);
             }
          }
 


### PR DESCRIPTION
1. Removed deprecated constructor and generation helper;
2. Consolidated private field initialization,

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>