### PR TITLE
Change enum for constant pool address symbol

### DIFF
--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -497,13 +497,12 @@ public:
       ConstString               = 0x80000000,
       AddressIsCPIndexOfStatic  = 0x40000000,
       RecognizedStatic          = 0x20000000,
-      // Available              = 0x10000000,
+      ConstantPoolAddress       = 0x10000000,
       SetUpDLPFlags             = 0xF0000000, ///< Used by TR::StaticSymbol::SetupDLPFlags(), == ConstString | AddressIsCPIndexOfStatic | RecognizedStatic
       CompiledMethod            = 0x08000000,
       StartPC                   = 0x04000000,
       CountForRecompile         = 0x02000000,
       RecompilationCounter      = 0x01000000,
-      ConstantPoolAddress       = 0x00800000,
       GCRPatchPoint             = 0x00400000,
 
       //Only Used by Symbols for which isResolvedMethod is true;


### PR DESCRIPTION
The previous enum overlapped with IsNamed and both can be set for static
symbol.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>