### PR TITLE
Add APIs for creating temp symRef with known obj

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -989,30 +989,50 @@ OMR::SymbolReferenceTable::findOrCreateSymRefWithKnownObject(TR::SymbolReference
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, TR::KnownObjectTable::Index objectIndex)
+OMR::SymbolReferenceTable::findTempSymRefWithKnownObject(TR::KnownObjectTable::Index knownObjectIndex)
    {
-   TR_BitVector *bucket = _knownObjectSymrefsByObjectIndex[objectIndex];
+   return findSymRefWithKnownObject(NULL, knownObjectIndex);
+   }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findSymRefWithKnownObject(TR::Symbol *symbol, TR::KnownObjectTable::Index knownObjectIndex)
+   {
+   TR_BitVector *bucket = _knownObjectSymrefsByObjectIndex[knownObjectIndex];
    if (!bucket)
-      {
-      bucket = new (trHeapMemory()) TR_BitVector(baseArray.size(), trMemory(), heapAlloc, growable, TR_MemoryBase::SymbolReference);
-      _knownObjectSymrefsByObjectIndex[objectIndex] = bucket;
-      }
+      return NULL;
 
    TR_BitVectorIterator bvi(*bucket);
    while (bvi.hasMoreElements())
       {
       TR::SymbolReference *symRef = getSymRef(bvi.getNextElement());
-      if (symRef->getSymbol() == original->getSymbol())
+      if (symbol && symRef->getSymbol() == symbol)
+         return symRef;
+      if (!symbol && symRef->getSymbol()->isAuto()) //For temp, symbol can be NULL. Find any temp with the given knownObjectIndex.
          return symRef;
       }
+   return NULL;
+   }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateSymRefWithKnownObject(TR::SymbolReference *originalSymRef, TR::KnownObjectTable::Index knownObjectIndex)
+   {
+   TR::SymbolReference *symRef = findSymRefWithKnownObject(originalSymRef->getSymbol(), knownObjectIndex);
+   if (symRef)
+      return symRef;
 
    // Need a new one
-   TR::SymbolReference *result = new (trHeapMemory()) TR::SymbolReference(self(), *original, 0, objectIndex);
+   TR_BitVector *bucket = _knownObjectSymrefsByObjectIndex[knownObjectIndex];
+   if (!bucket)
+      {
+      bucket = new (trHeapMemory()) TR_BitVector(baseArray.size(), trMemory(), heapAlloc, growable, TR_MemoryBase::SymbolReference);
+      _knownObjectSymrefsByObjectIndex[knownObjectIndex] = bucket;
+      }
+   TR::SymbolReference *result = new (trHeapMemory()) TR::SymbolReference(self(), *originalSymRef, 0, knownObjectIndex);
    bucket->set(result->getReferenceNumber());
 
    // If the known object symref is created for an immutable array shadow, it should be aliased to other array shadows as well
    // Put the symRef in arrayElementSymRefs so that its alias set can be built correctly
-   if (isImmutableArrayShadow(original))
+   if (isImmutableArrayShadow(originalSymRef))
       {
       result->setReallySharesSymbol();
       int32_t index = result->getReferenceNumber();
@@ -1023,6 +1043,20 @@ OMR::SymbolReferenceTable::findOrCreateSymRefWithKnownObject(TR::SymbolReference
    return result;
    }
 
+TR::SymbolReference *
+OMR::SymbolReferenceTable::createTempSymRefWithKnownObject(TR::Symbol *symbol, mcount_t owningMethodIndex, int32_t slot, TR::KnownObjectTable::Index knownObjectIndex)
+   {
+   TR_ASSERT_FATAL(symbol->isAutoOrParm(), "createTempSymRefWithKnownObject can only be called for temp symbol %p", symbol);
+   TR_BitVector *bucket = _knownObjectSymrefsByObjectIndex[knownObjectIndex];
+   if (!bucket)
+      {
+      bucket = new (trHeapMemory()) TR_BitVector(baseArray.size(), trMemory(), heapAlloc, growable, TR_MemoryBase::SymbolReference);
+      _knownObjectSymrefsByObjectIndex[knownObjectIndex] = bucket;
+      }
+   TR::SymbolReference * symRef = new (trHeapMemory()) TR::SymbolReference(self(), symbol, owningMethodIndex, slot, 0 /*unresolvedIndex*/, knownObjectIndex);
+   bucket->set(symRef->getReferenceNumber());
+   return symRef;
+   }
 
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateMonitorExitSymbolRef(TR::ResolvedMethodSymbol *)
@@ -1496,10 +1530,14 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
    return symRef;
    }
 
-
-
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, bool isReference, bool isInternalPointer, bool reuseAuto, bool isAdjunct, size_t size)
+   {
+   return findOrCreateAutoSymbolImpl(owningMethodSymbol, slot, type, isReference, isInternalPointer, reuseAuto, isAdjunct, size, TR::KnownObjectTable::UNKNOWN);
+   }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateAutoSymbolImpl(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, bool isReference, bool isInternalPointer, bool reuseAuto, bool isAdjunct, size_t size, TR::KnownObjectTable::Index knownObjectIndex)
    {
    mcount_t owningMethodIndex = owningMethodSymbol->getResolvedMethodIndex();
    int32_t numberOfParms = owningMethodSymbol->getNumParameterSlots();
@@ -1630,7 +1668,11 @@ OMR::SymbolReferenceTable::findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * own
             sym->setGCMapIndex(-1);
          }
 
-      symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodIndex, slot);
+      if (knownObjectIndex == TR::KnownObjectTable::UNKNOWN)
+         symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodIndex, slot);
+      else
+         symRef = createTempSymRefWithKnownObject(sym, owningMethodIndex, slot, knownObjectIndex);
+
       if (isAdjunct)
          symRef->setIsAdjunct();
 
@@ -1671,6 +1713,7 @@ OMR::SymbolReferenceTable::findAvailableAuto(List<TR::SymbolReference> & availab
          if (type == a->getSymbol()->getDataType() &&
              !notSharing &&
              !a->getSymbol()->holdsMonitoredObject() &&
+             !a->hasKnownObjectIndex() &&
              (a->isAdjunct() == isAdjunct) &&
              (comp()->cg()->getSupportsJavaFloatSemantics() ||
               (type != TR::Float && type != TR::Double) ||
@@ -1696,11 +1739,16 @@ OMR::SymbolReferenceTable::makeAutoAvailableForIlGen(TR::SymbolReference * a)
 
 TR::ParameterSymbol *
 OMR::SymbolReferenceTable::createParameterSymbol(
-   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type)
+   TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, TR::KnownObjectTable::Index knownObjectIndex)
    {
    TR::ParameterSymbol * sym = TR::ParameterSymbol::create(trHeapMemory(),type,slot);
 
-   TR::SymbolReference *symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), slot);
+   TR::SymbolReference *symRef = NULL;
+   if (knownObjectIndex == TR::KnownObjectTable::UNKNOWN)
+      symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), slot);
+   else
+      symRef = createTempSymRefWithKnownObject(sym, owningMethodSymbol->getResolvedMethodIndex(), slot, knownObjectIndex);
+
    owningMethodSymbol->setParmSymRef(slot, symRef);
    owningMethodSymbol->getAutoSymRefs(slot).add(symRef);
 
@@ -1716,6 +1764,23 @@ OMR::SymbolReferenceTable::createTemporary(TR::ResolvedMethodSymbol * owningMeth
 #endif
 
    return findOrCreateAutoSymbol(owningMethodSymbol, owningMethodSymbol->incTempIndex(fe()), type, true, isInternalPointer, false, false, size);
+   }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateTemporaryWithKnowObjectIndex(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::KnownObjectTable::Index knownObjectIndex)
+   {
+   TR::SymbolReference *symRef = findTempSymRefWithKnownObject(knownObjectIndex);
+   if (symRef)
+      return symRef;
+   return findOrCreateAutoSymbolImpl(owningMethodSymbol,
+                                 owningMethodSymbol->incTempIndex(fe()),
+                                 TR::Address,
+                                 true /* isReference */,
+                                 false /* isInternalPointer*/,
+                                 false /* reuseAuto */,
+                                 false /* isAdjunct */,
+                                 0 /*size*/,
+                                 knownObjectIndex);
    }
 
 TR::SymbolReference *

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -399,7 +399,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateOSRFearPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induceOSRHelper);
 
-   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType);
+   TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);
    TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,
          bool isInternalPointer = false, bool reuseAuto = true, bool isAdjunct = false, size_t size = 0);
    TR::SymbolReference * createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer = false, size_t size = 0);
@@ -493,6 +493,12 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, uintptrj_t *referenceLocation);
    TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, uintptrj_t *referenceLocation, bool isArrayWithConstantElements);
    TR::SymbolReference * findOrCreateSymRefWithKnownObject(TR::SymbolReference *original, TR::KnownObjectTable::Index objectIndex);
+   /*
+    * The public API that should be used when the caller needs a temp to hold a known object
+    *
+    * \note If there is a temp with the same known object already use the existing one. Otherwise, create a new temp.
+    */
+   TR::SymbolReference * findOrCreateTemporaryWithKnowObjectIndex(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::KnownObjectTable::Index knownObjectIndex);
    TR::SymbolReference * findOrCreateThisRangeExtensionSymRef(TR::ResolvedMethodSymbol *owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateContiguousArraySizeSymbolRef();
    TR::SymbolReference * findOrCreateNewArrayNoZeroInitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
@@ -574,8 +580,38 @@ class SymbolReferenceTable
    TR_BitVector *getSharedAliases(TR::SymbolReference *sr);
 
    protected:
+   /** \brief
+    *    This function creates the symbol reference given a temp symbol and the known object index
+    *
+    *  \param symbol
+    *    the temp symbol needed for creating the symbol reference
+    *
+    *  \note
+    *    This function should only be called from functions inside symbol reference table when creating new autos or temps.
+    *    Code outside symbol reference table should use the public API findOrCreateTemporaryWithKnowObjectIndex.
+    */
+   TR::SymbolReference * createTempSymRefWithKnownObject(TR::Symbol *symbol, mcount_t owningMethodIndex, int32_t slot, TR::KnownObjectTable::Index knownObjectIndex);
 
+   /**\brief
+    *
+    * This is the lowest level of function to find the symbol reference of any type with known object index
+    *
+    * \param symbol
+    *       For temp symbol reference, \p symbol can be NULL.
+    *       For symbol reference type other than temp, an original symbol is needed to find its corresponding symbol reference.
+    *       Take a static field with known object index for example, \p symbol is the original static field symbol.
+    *
+    * \param knownObjectIndex
+    *
+    */
+   TR::SymbolReference * findSymRefWithKnownObject(TR::Symbol *symbol, TR::KnownObjectTable::Index knownObjectIndex);
+   /*
+    * For finding symbol reference with known object index for a temp
+    */
+   TR::SymbolReference * findTempSymRefWithKnownObject(TR::KnownObjectTable::Index knownObjectIndex);
    TR::SymbolReference * findOrCreateCPSymbol(TR::ResolvedMethodSymbol *, int32_t, TR::DataType, bool, void *, TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);
+   TR::SymbolReference * findOrCreateAutoSymbolImpl(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,
+         bool isInternalPointer = false, bool reuseAuto = true, bool isAdjunct = false, size_t size = 0, TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);
 
    bool shouldMarkBlockAsCold(TR_ResolvedMethod * owningMethod, bool isUnresolvedInCP);
    void markBlockAsCold();


### PR DESCRIPTION
This change adds APIs for creating temps with known obj index so
that the various local optimizations can see the known obj info
for temps without needing expensive global optimization like
global VP and global copy propagation.

Notice the existing API findOrCreateSymRefWithKnownObject always create
a symRef with known object index based on the given original symRef so
the symbols are shared by the 2 symRefs. It doesn't work for temps
because each temp symbol can only have one symbol reference.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>