### PR TITLE
Remove uses of OMR_INTERP_COMPRESSED_OBJECT_HEADER

### DIFF
--- a/example/glue/Object.hpp
+++ b/example/glue/Object.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 
 typedef uint8_t ObjectFlags;
 
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 typedef uint32_t RawObjectHeader;
 typedef uint32_t ObjectSize;
 #else

--- a/example/glue/ScavengerDelegate.cpp
+++ b/example/glue/ScavengerDelegate.cpp
@@ -175,16 +175,16 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 			(ObjectSize)objectModel->getConsumedSizeInBytesWithHeader(forwardedObject),
 			(uint8_t)objectModel->getObjectFlags(forwardedObject));
 
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 		/* Restore destroyed overlapped slot in the original object. This slot might need to be reversed
 		 * as well or it may be already reversed - such fixup will be completed at in a later pass.
 		 */
 		forwardedHeader->restoreDestroyedOverlap();
-#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 	}
 }
 
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 void
 MM_ScavengerDelegate::fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, MM_MemorySubSpaceSemiSpace *subSpaceNew)
 {
@@ -217,6 +217,6 @@ MM_ScavengerDelegate::fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHe
 		}
 	}
 }
-#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */

--- a/example/glue/ScavengerDelegate.hpp
+++ b/example/glue/ScavengerDelegate.hpp
@@ -211,7 +211,7 @@ public:
 	 */
 	void reverseForwardedObject(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject);
 
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	/**
 	 * This method is similar to reverseForwardedObject() but is called from a different context. The implementation
 	 * must first determine whether or not the compressed slot adjacent to the scavenger forwarding slot may contain an object
@@ -229,7 +229,7 @@ public:
 	 * @param[in] subSpaceNew Pointer to new space
 	 */
 	void fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject, MM_MemorySubSpaceSemiSpace *subSpaceNew);
-#endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/**

--- a/gc/base/HeapLinkedFreeHeader.hpp
+++ b/gc/base/HeapLinkedFreeHeader.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,7 +30,7 @@
 #include"AtomicOperations.hpp"
 
 /* Split pointer for all compressed platforms */
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 #define SPLIT_NEXT_POINTER
 #endif
 

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -487,11 +487,11 @@ public:
 				break;
 			}
 		}
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		while (oldFlags != MM_AtomicOperations::lockCompareExchangeU32(flagsPtr, oldFlags, newFlags));
-#else /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		while (oldFlags != MM_AtomicOperations::lockCompareExchange(flagsPtr, (uintptr_t)oldFlags, (uintptr_t)newFlags));
-#endif /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 		return result;
 	}
@@ -589,11 +589,11 @@ public:
 				break;
 			}
 		}
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		while (oldFlags != MM_AtomicOperations::lockCompareExchangeU32(flagsPtr, oldFlags, newFlags));
-#else /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		while (oldFlags != MM_AtomicOperations::lockCompareExchange(flagsPtr, (uintptr_t)oldFlags, (uintptr_t)newFlags));
-#endif /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 		return result;
 	}
@@ -633,11 +633,11 @@ public:
 				break;
 			}
 		}
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		while (oldFlags != MM_AtomicOperations::lockCompareExchangeU32(flagsPtr, oldFlags, newFlags));
-#else /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		while (oldFlags != MM_AtomicOperations::lockCompareExchange(flagsPtr, (uintptr_t)oldFlags, (uintptr_t)newFlags));
-#endif /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 		/* check to verify that this thread and no other thread atomically set flags -> toState */
 		return result ? (0 == (oldFlags & rememberedMask)) : false;
@@ -677,11 +677,11 @@ public:
 			}
 			newFlags = (oldFlags & ~rememberedMask) | to;
 		}
-#if defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(OMR_GC_COMPRESSED_POINTERS)
 		while (oldFlags != MM_AtomicOperations::lockCompareExchangeU32(flagsPtr, oldFlags, newFlags));
-#else /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		while (oldFlags != MM_AtomicOperations::lockCompareExchange(flagsPtr, (uintptr_t)oldFlags, (uintptr_t)newFlags));
-#endif /* defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
 		return result;
 	}

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3416,7 +3416,7 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 		}
 	}
 
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	GC_MemorySubSpaceRegionIteratorStandard evacuateRegionIterator1(_activeSubSpace);
 	while(NULL != (rootRegion = evacuateRegionIterator1.nextRegion())) {
 		if (isObjectInEvacuateMemory((omrobjectptr_t )rootRegion->getLowAddress())) {
@@ -3446,7 +3446,7 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 			}
 		}
 	}
-#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 }
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)

--- a/glue/ScavengerDelegate.cpp
+++ b/glue/ScavengerDelegate.cpp
@@ -156,7 +156,7 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 	 */
 }
 
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 void
 MM_ScavengerDelegate::fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedHeader, MM_MemorySubSpaceSemiSpace *subSpaceNew)
 {
@@ -166,5 +166,5 @@ MM_ScavengerDelegate::fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHe
 	 */
 	Assert_MM_unimplemented();
 }
-#endif /* defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER) */
+#endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 #endif /* defined(OMR_GC_MODRON_SCAVENGER) */

--- a/glue/ScavengerDelegate.hpp
+++ b/glue/ScavengerDelegate.hpp
@@ -209,7 +209,7 @@ public:
 	 */
 	void reverseForwardedObject(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject);
 
-#if defined (OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined (OMR_GC_COMPRESSED_POINTERS)
 	/**
 	 * This method is similar to reverseForwardedObject() but is called from a different context. The implementation
 	 * must first determine whether or not the compressed slot adjacent to the scavenger forwarding slot may contain an object
@@ -227,7 +227,7 @@ public:
 	 * @param[in] subSpaceNew Pointer to new space
 	 */
 	void fixupDestroyedSlot(MM_EnvironmentBase *env, MM_ForwardedHeader *forwardedObject, MM_MemorySubSpaceSemiSpace *subSpaceNew);
-#endif /* OMR_INTERP_COMPRESSED_OBJECT_HEADER */
+#endif /* OMR_GC_COMPRESSED_POINTERS */
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	/**

--- a/port/common/omrmem32helpers.c
+++ b/port/common/omrmem32helpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -418,7 +418,7 @@ void *
 allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, const char *callSite)
 {
 	void *returnPtr = NULL;
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	BOOLEAN useMalloc31 = FALSE;
 #elif defined(OMRZTPF)
 	/* malloc on z/TPF is 32 bits */
@@ -426,7 +426,7 @@ allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, cons
 #endif
 
 	Trc_PRT_mem_allocate_memory32_Entry(byteAmount);
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (OMRPORT_DISABLE_ENSURE_CAP32 == portLibrary->portGlobals->disableEnsureCap32) {
 		useMalloc31 = TRUE;
 	}
@@ -453,7 +453,7 @@ allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, cons
 		}
 
 		omrthread_monitor_exit(PPG_mem_mem32_subAllocHeapMem32.monitor);
-#if (defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)) || defined(OMRZTPF)
+#if (defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)) || defined(OMRZTPF)
 	}
 #endif
 
@@ -477,7 +477,7 @@ ensure_capacity32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount)
 
 	Trc_PRT_mem_ensure_capacity32_Entry(byteAmount);
 
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (OMRPORT_DISABLE_ENSURE_CAP32 == portLibrary->portGlobals->disableEnsureCap32) {
 		Trc_PRT_mem_ensure_capacity32_NotRequired_Exit();
 		return OMRPORT_ENSURE_CAPACITY_NOT_REQUIRED;
@@ -670,7 +670,7 @@ free_memory32(struct OMRPortLibrary *portLibrary, void *memoryPointer)
 #endif
 	Trc_PRT_mem_free_memory32_Entry(memoryPointer);
 
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (OMRPORT_DISABLE_ENSURE_CAP32 == portLibrary->portGlobals->disableEnsureCap32) {
 		free(memoryPointer);
 	} else {
@@ -720,7 +720,7 @@ free_memory32(struct OMRPortLibrary *portLibrary, void *memoryPointer)
 
 		omrthread_monitor_exit(PPG_mem_mem32_subAllocHeapMem32.monitor);
 
-#if (defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)) || defined(OMRZTPF)
+#if (defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)) || defined(OMRZTPF)
 	}
 #endif
 

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -272,7 +272,7 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 	}
 #endif
 
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (0 == strcmp(OMRPORT_CTLDATA_NOSUBALLOC32BITMEM, key)) {
 		portLibrary->portGlobals->disableEnsureCap32 = value;
 		return 0;

--- a/port/unix/omrmem.c
+++ b/port/unix/omrmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -75,7 +75,7 @@ omrmem_allocate_memory_basic(struct OMRPortLibrary *portLibrary, uintptr_t byteA
 {
 #if (defined(S390) || defined(J9ZOS390)) && !defined(OMR_ENV_DATA64)
 	return (void *)(((uintptr_t) malloc(byteAmount)) & 0x7FFFFFFF);
-#elif defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#elif defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	void *retval = NULL;
 	retval = malloc(byteAmount);
 	Assert_AddressAbove4GBBar((NULL == retval) || (0x100000000 <= ((uintptr_t)retval)));
@@ -189,7 +189,7 @@ omrmem_shutdown_basic(struct OMRPortLibrary *portLibrary)
 void
 omrmem_startup_basic(struct OMRPortLibrary *portLibrary, uintptr_t portGlobalSize)
 {
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	char tmpbuff[256];
 #endif
 
@@ -203,7 +203,7 @@ omrmem_startup_basic(struct OMRPortLibrary *portLibrary, uintptr_t portGlobalSiz
 	portLibrary->portGlobals->procSelfMap = omrmem_allocate_memory_basic(portLibrary, J9OSDUMP_SIZE);
 #endif /* defined(LINUX) */
 
-#if defined(J9ZOS390) && defined(OMR_INTERP_COMPRESSED_OBJECT_HEADER)
+#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	/* 'disableEnsureCap32' is set using omrport_control(OMRPORT_CTLDATA_NOSUBALLOC32BITMEM,...),
 	 * or by setting the J9_SUBALLOC_FOR_32 environment variable before starting the JVM.
 	 *


### PR DESCRIPTION
Replace with OMR_GC_COMPRESSED_POINTERS. In every build, either both or
neither the flags are set. Removal of the flag definitions will follow
later.

[ci skip]

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>