### PR TITLE
Adopt new read/write barrier kind

### DIFF
--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -439,7 +439,7 @@ OMR::CodeGenPhase::performSetupForInstructionSelectionPhase(TR::CodeGenerator * 
    {
    TR::Compilation *comp = cg->comp();
 
-   if (TR::Compiler->target.cpu.isZ() && TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
+   if (TR::Compiler->target.cpu.isZ() && TR::Compiler->om.readBarrierType() != gc_modron_readbar_none)
       {
       // TODO (GuardedStorage): We need to come up with a better solution than anchoring aloadi's
       // to enforce certain evaluation order

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1891,22 +1891,11 @@ public:
    static bool createDebug();
    static TR_Debug * findOrCreateDebug();
 
-   TR_WriteBarrierKind getGcMode()           { return _gcMode; }
    uintptr_t           getGcCardSize()       { return _gcCardSize; }
    uintptr_t           getHeapBase()         { return _heapBase; }
    uintptr_t           getHeapTop()         { return _heapTop; }
 
-   bool generateWriteBarriers() { return _gcMode != TR_WrtbarNone; }
-   bool alwaysCallWriteBarrier() { return _gcMode == TR_WrtbarAlways; }
-   bool gcIsUsingConcurrentMark()
-      {
-      return    _gcMode == TR_WrtbarCardMark
-             || _gcMode == TR_WrtbarCardMarkAndOldCheck
-             || _gcMode == TR_WrtbarCardMarkIncremental;
-      }
-   bool needWriteBarriers();
-
-   void setGcMode(TR_WriteBarrierKind g) { _gcMode = g; }
+   void setGcMode(TR_WriteBarrierKind g) { /* deprecated */ }
    void setGcCardSize(uintptr_t g)       { _gcCardSize = g; }
    void setHeapBase(uintptr_t g)         { _heapBase = g; }
    void setHeapTop(uintptr_t g)          { _heapTop = g; }
@@ -2312,7 +2301,6 @@ protected:
    TR::SimpleRegex *            _memUsage;
    TR::SimpleRegex *            _classesWithFolableFinalFields;
    TR::SimpleRegex *            _disabledIdiomPatterns;
-   TR_WriteBarrierKind         _gcMode;
    uintptr_t                   _gcCardSize;
    uintptr_t                   _heapBase;
    uintptr_t                   _heapTop;

--- a/compiler/control/OMROptions_inlines.hpp
+++ b/compiler/control/OMROptions_inlines.hpp
@@ -87,12 +87,6 @@ OMR::Options::getNumLimitedGRARegsWithheld()
          return regsToWithhold;
       }
 
-inline bool
-OMR::Options::needWriteBarriers()
-   {
-   return (self()->gcIsUsingConcurrentMark() || _gcMode == TR_WrtbarOldCheck);
-   }
-
 
 inline bool
 OMR::Options::getTraceRAOption(uint32_t mask)

--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -122,11 +122,6 @@ class ObjectModel
    MM_GCWriteBarrierType writeBarrierType() { return gc_modron_wrtbar_none;  }
 
    /**
-   * @brief: Returns true if concurrent scavenging enabled in the VM's GC
-   */
-   bool shouldGenerateReadBarriersForFieldLoads() { return false; };
-
-   /**
    * @brief: Returns true if option for software read barriers is enabled in the VM's GC
    */
    bool shouldReplaceGuardedLoadWithSoftwareReadBarrier() { return false; };

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -968,7 +968,18 @@ TR_LoopReducer::generateArraycopy(TR_InductionVariable * indVar, TR::Block * loo
       return false;
       }
 
-   bool needWriteBarrier = comp()->getOptions()->needWriteBarriers();;
+   bool needWriteBarrier = false;
+   switch (TR::Compiler->om.writeBarrierType())
+      {
+      case gc_modron_wrtbar_oldcheck:
+      case gc_modron_wrtbar_cardmark:
+      case gc_modron_wrtbar_cardmark_and_oldcheck:
+      case gc_modron_wrtbar_cardmark_incremental:
+         needWriteBarrier = true;
+         break;
+      default:
+         break;
+      }
    //FUTURE: can eliminate wrtbar when src and dest are equal. Currently we don't reduce arraycopy like this.
    if (arraycopyLoop.hasWriteBarrier() && needWriteBarrier && !comp()->cg()->getSupportsReferenceArrayCopy())
       {

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3480,8 +3480,8 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
                }
 
             //SPECpower Work
-            if ( comp()->getOptions()->getGcMode() == TR_WrtbarCardMarkAndOldCheck ||
-                 comp()->getOptions()->getGcMode() == TR_WrtbarOldCheck)
+            if (TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_cardmark_and_oldcheck ||
+                TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_oldcheck)
                {
                TR::Node *possibleAwrtbariNode = currentTree->getNode();
                if ((currentOpCode.getOpCodeValue() != TR::awrtbari) &&
@@ -4406,7 +4406,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          TR::TreeTop *nextTreeTop = arrayStoreCheckTree->getNextTreeTop();
          TR::TreeTop *firstNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getFirstChild()), NULL, NULL);
          TR::Node *child = arrayStoreCheckNode->getFirstChild();
-         if (child->getOpCodeValue() == TR::awrtbari && comp()->getOptions()->getGcMode() == TR_WrtbarNone &&
+         if (child->getOpCodeValue() == TR::awrtbari && TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none &&
             performTransformation(comp(), "%sChanging awrtbari node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
             {
             TR::Node::recreate(child, TR::astorei);
@@ -4420,7 +4420,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          TR_ASSERT((arrayStoreCheckNode->getNumChildren() == 2), "Unknown array store check tree\n");
          secondNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getSecondChild()), NULL, NULL);
          child = arrayStoreCheckNode->getSecondChild();
-         if (child->getOpCodeValue() == TR::awrtbari && comp()->getOptions()->getGcMode() == TR_WrtbarNone &&
+         if (child->getOpCodeValue() == TR::awrtbari && TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none &&
              performTransformation(comp(), "%sChanging awrtbari node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
             {
             TR::Node::recreate(child, TR::astorei);

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2936,7 +2936,7 @@ void canRemoveWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
    TR::VPConstraint *constraint = vp->getConstraint(node, isGlobal);
    if (constraint)
       {
-      if (constraint->isNullObject() && !vp->comp()->getOptions()->alwaysCallWriteBarrier() && !vp->comp()->getOptions()->realTimeGC())
+      if (constraint->isNullObject() && TR::Compiler->om.writeBarrierType() != gc_modron_wrtbar_always && !vp->comp()->getOptions()->realTimeGC())
          {
          if (node->getOpCode().isIndirect())
             {
@@ -2998,7 +2998,7 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
 
    static bool doOpt = feGetEnv("TR_DisableWrtBarOpt") ? false : true;
 
-   if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
+   if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none)
       {
       // The optimization below targets the following type of code:
       // 
@@ -3015,11 +3015,11 @@ TR::Node *constrainWrtBar(OMR::ValuePropagation *vp, TR::Node *node)
       doOpt = false;
       }
 
-   TR_WriteBarrierKind gcMode = vp->comp()->getOptions()->getGcMode();
+   auto gcMode = TR::Compiler->om.writeBarrierType();
 
    if (doOpt &&
-       ((gcMode == TR_WrtbarCardMarkAndOldCheck) ||
-        (gcMode == TR_WrtbarOldCheck)) &&
+       ((gcMode == gc_modron_wrtbar_cardmark_and_oldcheck) ||
+        (gcMode == gc_modron_wrtbar_oldcheck)) &&
        (node->getOpCodeValue() == TR::awrtbari) &&
        !node->skipWrtBar())
       {

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -1075,7 +1075,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
    bool needArrayCheck = true;
    bool needArrayStoreCheck = true;
    bool needWriteBarrier = true;
-   bool needReadBarrier = TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads();
+   bool needReadBarrier = TR::Compiler->om.readBarrierType() != gc_modron_readbar_none;
 
    bool primitiveTransform = cg()->getSupportsPrimitiveArrayCopy();
    bool referenceTransform = cg()->getSupportsReferenceArrayCopy();
@@ -1103,12 +1103,29 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
    if (srcVN == dstVN)
       {
       needArrayStoreCheck = false;
-      if (!comp()->getOptions()->gcIsUsingConcurrentMark())
-         needWriteBarrier = false;
+      switch (TR::Compiler->om.writeBarrierType())
+         {
+         case gc_modron_wrtbar_cardmark:
+         case gc_modron_wrtbar_cardmark_and_oldcheck:
+         case gc_modron_wrtbar_cardmark_incremental:
+            break;
+         default:
+            needWriteBarrier = false;
+            break;
+         }
       }
 
-   if (!comp()->getOptions()->needWriteBarriers())
-      needWriteBarrier = false;
+   switch (TR::Compiler->om.writeBarrierType())
+      {
+      case gc_modron_wrtbar_oldcheck:
+      case gc_modron_wrtbar_cardmark:
+      case gc_modron_wrtbar_cardmark_and_oldcheck:
+      case gc_modron_wrtbar_cardmark_incremental:
+         break;
+      default:
+         needWriteBarrier = false;
+         break;
+      }
 
    TR::VPArrayInfo *srcArrayInfo;
    TR::VPArrayInfo *dstArrayInfo;
@@ -1274,7 +1291,7 @@ void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
                // Array types are different types so the arraycopy will fail
                transformTheCall = false;
                }
-            else if (comp()->getOptions()->alwaysCallWriteBarrier())
+            else if (TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_always)
                {
                transformTheCall = false;
                }

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -282,7 +282,7 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    /*
     * TODO: TM is currently not compatible with read barriers. If read barriers are required, TM is disabled until the issue is fixed.
     */
-   if (TR::Compiler->target.cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM) && !TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
+   if (TR::Compiler->target.cpu.getPPCSupportsTM() && !self()->comp()->getOption(TR_DisableTM) && TR::Compiler->om.readBarrierType() == gc_modron_readbar_none)
       self()->setSupportsTM();
 
    // enable LM if hardware supports instructions and running the reduced-pause GC policy

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2268,7 +2268,7 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
 
                // For concurrent scavenge the source is loaded and shifted by the guarded load, thus we need to use CG
                // here for a non-zero compressedrefs shift value
-               if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads())
+               if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none)
                   {
                   cmpOpCode = TR::InstOpCode::getCmpOpCode();
                   }

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -5202,7 +5202,7 @@ aloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
                   {
                   auto loadMnemonic = TR::InstOpCode::BAD;
 
-                  if (TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() &&
+                  if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none &&
                       ((node->getOpCodeValue() == TR::aloadi) ||
                        (node->getOpCodeValue() == TR::aload && node->getSymbol()->isStatic())) &&
                       tempReg->containsCollectedReference())
@@ -11478,7 +11478,7 @@ void
 OMR::Z::TreeEvaluator::forwardArrayCopySequenceGenerator(TR::Node *node, TR::CodeGenerator *cg, TR::Register *byteSrcReg, TR::Register *byteDstReg, TR::Register *byteLenReg, TR::Node *byteLenNode, TR_S390ScratchRegisterManager *srm, TR::LabelSymbol *mergeLabel)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   bool mustGenerateOOLGuardedLoadPath = TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() &&
+   bool mustGenerateOOLGuardedLoadPath = TR::Compiler->om.readBarrierType() != gc_modron_readbar_none &&
                                          node->getArrayCopyElementType() == TR::Address;
    if (mustGenerateOOLGuardedLoadPath)
       {
@@ -11548,7 +11548,7 @@ TR::RegisterDependencyConditions *
 OMR::Z::TreeEvaluator::backwardArrayCopySequenceGenerator(TR::Node *node, TR::CodeGenerator *cg, TR::Register *byteSrcReg, TR::Register *byteDstReg, TR::Register *byteLenReg, TR::Node *byteLenNode, TR_S390ScratchRegisterManager *srm, TR::LabelSymbol *mergeLabel)
    {
 #ifdef J9_PROJECT_SPECIFIC
-   bool mustGenerateOOLGuardedLoadPath = TR::Compiler->om.shouldGenerateReadBarriersForFieldLoads() &&
+   bool mustGenerateOOLGuardedLoadPath = TR::Compiler->om.readBarrierType() != gc_modron_readbar_none &&
                                          node->getArrayCopyElementType() == TR::Address;
    if (mustGenerateOOLGuardedLoadPath)
       {


### PR DESCRIPTION
eclipse/omr#3168 has introduced new read/write barrier kind; and known
downstream projects have adopted it; therefore OMR is fully moving to
this new read/write barrier kind.

Signed-off-by: Victor Ding <dvictor@ca.ibm.com>