### PR TITLE
CMake: Fix option handling for MSVC

### DIFF
--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -88,7 +88,7 @@ macro(omr_toolconfig_global_setup)
 	omr_remove_flags(CMAKE_EXE_LINKER_FLAGS    /INCREMENTAL)
 	omr_remove_flags(CMAKE_SHARED_LINKER_FLAGS /INCREMENTAL)
 
-	foreach(build_type IN LISTS CMAKE_CONFIGURATION_TYPES)
+	foreach(build_type IN ITEMS ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
 		string(TOUPPER ${build_type} build_type)
 		omr_remove_flags(CMAKE_EXE_LINKER_FLAGS_${build_type}    /INCREMENTAL)
 		omr_remove_flags(CMAKE_SHARED_LINKER_FLAGS_${build_type} /INCREMENTAL)


### PR DESCRIPTION
CMAKE_CONFIGURATION_TYPES is only set for multi-configuration generators
(eg Visual Studio). For single configuration generators (eg makefiles)
this will be empty, but we still need to remove configuration specific
flags.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>