### PR TITLE
Ensure structures are updated correctly for versioned loop

### DIFF
--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3921,11 +3921,11 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
                if (!shouldOnlySpecializeLoops())
                   e->setFrequency((*edge)->getFrequency());
                else
-               {
-               int32_t specializedBlockFrequency = TR::Block::getScaledSpecializedFrequency((*edge)->getFrequency());
+                  {
+                  int32_t specializedBlockFrequency = TR::Block::getScaledSpecializedFrequency((*edge)->getFrequency());
 
-               e->setFrequency(specializedBlockFrequency);
-               }
+                  e->setFrequency(specializedBlockFrequency);
+                  }
                }
 
             nextClonedBlock->getLastRealTreeTop()->adjustBranchOrSwitchTreeTop(comp(), succ->getEntry(), clonedSucc->getEntry());
@@ -4414,35 +4414,35 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
             child->setNumChildren(2);
             }
 
-      TR::TreeTop *secondNewTree = NULL;
-      if (arrayStoreCheckNode->getNumChildren() > 1)
-         {
-         TR_ASSERT((arrayStoreCheckNode->getNumChildren() == 2), "Unknown array store check tree\n");
-         secondNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getSecondChild()), NULL, NULL);
-         child = arrayStoreCheckNode->getSecondChild();
-         if (child->getOpCodeValue() == TR::awrtbari && TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none &&
-             performTransformation(comp(), "%sChanging awrtbari node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
+         TR::TreeTop *secondNewTree = NULL;
+         if (arrayStoreCheckNode->getNumChildren() > 1)
             {
-            TR::Node::recreate(child, TR::astorei);
-            child->getChild(2)->recursivelyDecReferenceCount();
-            child->setNumChildren(2);
+            TR_ASSERT((arrayStoreCheckNode->getNumChildren() == 2), "Unknown array store check tree\n");
+            secondNewTree = TR::TreeTop::create(comp(), TR::Node::create(TR::treetop, 1, arrayStoreCheckNode->getSecondChild()), NULL, NULL);
+            child = arrayStoreCheckNode->getSecondChild();
+            if (child->getOpCodeValue() == TR::awrtbari && TR::Compiler->om.writeBarrierType() == gc_modron_wrtbar_none &&
+                performTransformation(comp(), "%sChanging awrtbari node [%p] to an iastore\n", OPT_DETAILS_LOOP_VERSIONER, child))
+               {
+               TR::Node::recreate(child, TR::astorei);
+               child->getChild(2)->recursivelyDecReferenceCount();
+               child->setNumChildren(2);
+               }
             }
+
+         prevTreeTop->join(firstNewTree);
+         if (secondNewTree)
+            {
+            firstNewTree->join(secondNewTree);
+            secondNewTree->join(nextTreeTop);
+            }
+         else
+            firstNewTree->join(nextTreeTop);
+
+         arrayStoreCheckNode->recursivelyDecReferenceCount();
+
+         nextTree = nextTree->getNextElement();
          }
-
-      prevTreeTop->join(firstNewTree);
-      if (secondNewTree)
-         {
-         firstNewTree->join(secondNewTree);
-         secondNewTree->join(nextTreeTop);
-         }
-      else
-         firstNewTree->join(nextTreeTop);
-
-      arrayStoreCheckNode->recursivelyDecReferenceCount();
-
-      nextTree = nextTree->getNextElement();
       }
-   }
 
    // Construct tests for invariant expressions
    //
@@ -4825,7 +4825,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    clonedInvariantBlockStructure->setCreatedByVersioning(true);
 
    if (!_neitherLoopCold)
-   clonedInnerWhileLoops->deleteAll();
+      clonedInnerWhileLoops->deleteAll();
    clonedInvariantBlockStructure->setAsLoopInvariantBlock(true);
    TR_RegionStructure *parentStructure = whileLoop->getParent()->asRegion();
    TR_RegionStructure *properRegion = new (_cfg->structureRegion()) TR_RegionStructure(comp(), chooserBlock->getNumber());

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -4909,28 +4909,22 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          succNode->removePredecessor(succEdge);
          subNode->removeSuccessor(succEdge);
 
-         TR::CFGEdge *toInvariantEdge = NULL;
-
          for (auto changedSuccEdge = succNode->getSuccessors().begin(); changedSuccEdge != succNode->getSuccessors().end(); ++changedSuccEdge)
             {
-            TR::CFGEdge *currEdge = *changedSuccEdge;
-
-            // Keep track of any edge from the original loop to the invariant
-            // block - it must be discarded from the list of successors of the
-            // new proper region in the context of the parent structure, as a
+            // 
+            // Watch for any edge from the original loop to the invariant
+            // block - it will now refer to the proper region node, and
+            // must be discarded from the list of predecessors of the
+            // proper region node in the context of the parent structure, as a
             // subgraph node must not have an edge to itself
-            if (currEdge->getTo() == properNode)
+            if ((*changedSuccEdge)->getTo() != properNode)
                {
-               toInvariantEdge = currEdge;
+               (*changedSuccEdge)->setFrom(properNode);
                }
-
-            (*changedSuccEdge)->setFrom(properNode);
-            }
-
-         if (toInvariantEdge)
-            {
-            properNode->removeSuccessor(toInvariantEdge);
-            properNode->removePredecessor(toInvariantEdge);
+            else
+               {
+               properNode->removePredecessor(*changedSuccEdge);
+               }
             }
 
          for (auto changedSuccEdge = succNode->getExceptionSuccessors().begin(); changedSuccEdge != succNode->getExceptionSuccessors().end(); ++changedSuccEdge)


### PR DESCRIPTION
In `versionNaturalLoop`, the loop that is being versioned and its clone are placed into a new proper region, along with the loop's invariant block, all preceded by a sequence of conditions.  In the process, all edges to the invariant block are made to be edges to the sequence of conditions at the start of the region.

However, if the original loop had an exit to the invariant block, we end up with a situation where the new proper region structure has an exit edge from the cloned original loop that refers to the original
invariant block, even though that block is part of that region.

Also in that same situation, the subgraph node for the cloned original loop in the new proper region ends up pointing to itself.

Made some changes to the updating of the structures to consider this case.

Also cleaned up some indentation issues.

Fixes:  #3682

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>