### PR TITLE
Rework OMRLinkage base class

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -159,15 +159,3 @@ OMR::ARM64::Linkage::numArgumentRegisters(TR_RegisterKinds kind)
          return 0;
       }
    }
-
-TR_HeapMemory
-OMR::ARM64::Linkage::trHeapMemory()
-   {
-   return self()->trMemory();
-   }
-
-TR_StackMemory
-OMR::ARM64::Linkage::trStackMemory()
-   {
-   return self()->trMemory();
-   }

--- a/compiler/aarch64/codegen/OMRLinkage.cpp
+++ b/compiler/aarch64/codegen/OMRLinkage.cpp
@@ -56,7 +56,6 @@ bool OMR::ARM64::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
 
 TR::MemoryReference *OMR::ARM64::Linkage::getOutgoingArgumentMemRef(TR::Register *argMemReg, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::ARM64MemoryArgument &memArg)
    {
-   TR::Machine *machine = cg()->machine();
    const TR::ARM64LinkageProperties& properties = self()->getProperties();
 
    TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(argMemReg, 8, cg()); // post-increment

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -390,38 +390,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     */
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode) = 0;
 
-   /**
-    * @brief Gets the CodeGenerator
-    * @return CodeGenerator
-    */
-   TR::CodeGenerator *cg() {return _cg;}
-   /**
-    * @brief Gets the Compilation
-    * @return Compilation
-    */
-   TR::Compilation *comp() {return _cg->comp();}
-   /**
-    * @brief Gets the FrontEnd
-    * @return FrontEnd
-    */
-   TR_FrontEnd *fe() {return _cg->fe();}
-
-   /**
-    * @brief Gets the TR_Memory
-    * @return TR_Memory
-    */
-   TR_Memory *trMemory() {return _cg->trMemory();}
-   /**
-    * @brief Gets the Heap Memory
-    * @return Heap Memory
-    */
-   TR_HeapMemory trHeapMemory();
-   /**
-    * @brief Gets the Stack Memory
-    * @return Stack Memory
-    */
-   TR_StackMemory trStackMemory();
-
    };
 } // ARM64
 } // TR

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -274,13 +274,9 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    /**
     * @brief Constructor
-    */
-   Linkage () : OMR::Linkage() {}
-   /**
-    * @brief Constructor
     * @param[in] cg : CodeGenerator
     */
-   Linkage (TR::CodeGenerator *cg) : _cg(cg) {}
+   Linkage (TR::CodeGenerator *cg) : OMR::Linkage(cg) {}
 
    /**
     * @brief Parameter has to be on stack or not
@@ -426,9 +422,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
     */
    TR_StackMemory trStackMemory();
 
-   protected:
-
-   TR::CodeGenerator*_cg;
    };
 } // ARM64
 } // TR

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -1007,15 +1007,6 @@ printf("done\n"); fflush(stdout);
    return totalSize;
    }
 
-TR_HeapMemory OMR::ARM::Linkage::trHeapMemory()
-   {
-   return self()->trMemory();
-   }
-
-TR_StackMemory OMR::ARM::Linkage::trStackMemory()
-   {
-   return self()->trMemory();
-   }
 
 TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNode, bool isSystem)
    {

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -83,10 +83,10 @@ void OMR::ARM::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbo
 TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
    {
    TR::CodeGenerator     *codeGen    = self()->cg();
-   TR::Machine           *machine    = codeGen->machine();
+   TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
-   TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
-   TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
+   TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
+   TR::Node                 *firstNode  = self()->comp()->getStartTree()->getNode();
 
    const TR::ARMLinkageProperties& properties = self()->getProperties();
 
@@ -152,10 +152,10 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
 TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
    {
    TR::CodeGenerator     *codeGen    = self()->cg();
-   TR::Machine           *machine    = codeGen->machine();
+   TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
-   TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
-   TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
+   TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
+   TR::Node                 *firstNode  = self()->comp()->getStartTree()->getNode();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    uint32_t                 numIntArgs = 0;
@@ -215,10 +215,10 @@ TR::Instruction *OMR::ARM::Linkage::loadUpArguments(TR::Instruction *cursor)
 TR::Instruction *OMR::ARM::Linkage::flushArguments(TR::Instruction *cursor)
    {
    TR::CodeGenerator     *codeGen    = self()->cg();
-   TR::Machine           *machine    = codeGen->machine();
+   TR::Machine           *machine    = self()->machine();
    TR::RealRegister      *stackPtr   = machine->getRealRegister(self()->getProperties().getStackPointerRegister());
-   TR::ResolvedMethodSymbol   *bodySymbol = codeGen->comp()->getJittedMethodSymbol();
-   TR::Node                 *firstNode  = codeGen->comp()->getStartTree()->getNode();
+   TR::ResolvedMethodSymbol   *bodySymbol = self()->comp()->getJittedMethodSymbol();
+   TR::Node                 *firstNode  = self()->comp()->getStartTree()->getNode();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
    TR::ParameterSymbol      *paramCursor = paramIterator.getFirst();
    uint32_t                 numIntArgs = 0;
@@ -575,7 +575,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
          {
          traceMsg(comp, "Special arg %s in %s\n",
             comp->getDebug()->getName(callNode->getChild(from)),
-            comp->getDebug()->getName(self()->cg()->machine()->getRealRegister(specialArgReg)));
+            comp->getDebug()->getName(self()->machine()->getRealRegister(specialArgReg)));
          }
       // Skip the special arg in the first loop
       from += step;
@@ -1024,16 +1024,16 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
    TR::SymbolReference *callSymRef = callNode->getSymbolReference();
    TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
 
-   bool isMyself = codeGen->comp()->isRecursiveMethodTarget(callSymbol);
+   bool isMyself = self()->comp()->isRecursiveMethodTarget(callSymbol);
 
    if (callSymRef->getReferenceNumber() >= TR_ARMnumRuntimeHelpers)
-      codeGen->comp()->fe()->reserveTrampolineIfNecessary(codeGen->comp(), callSymRef, false);
+      self()->fe()->reserveTrampolineIfNecessary(self()->comp(), callSymRef, false);
 
    TR::Instruction *gcPoint;
    TR::Register    *returnRegister;
 
    if ((callSymbol->isJITInternalNative() ||
-        (!callSymRef->isUnresolved() && !callSymbol->isInterpreted() && ((codeGen->comp()->compileRelocatableCode() && callSymbol->isHelper()) || !codeGen->comp()->compileRelocatableCode()))))
+        (!callSymRef->isUnresolved() && !callSymbol->isInterpreted() && ((self()->comp()->compileRelocatableCode() && callSymbol->isHelper()) || !self()->comp()->compileRelocatableCode()))))
       {
       gcPoint = generateImmSymInstruction(codeGen,
                                           ARMOp_bl,
@@ -1048,7 +1048,7 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
       TR::LabelSymbol *label = generateLabelSymbol(codeGen);
       TR::Snippet     *snippet;
 
-      if (callSymRef->isUnresolved() || codeGen->comp()->compileRelocatableCode())
+      if (callSymRef->isUnresolved() || self()->comp()->compileRelocatableCode())
          {
          snippet = new (self()->trHeapMemory()) TR::ARMUnresolvedCallSnippet(codeGen, callNode, label, argSize);
          }
@@ -1063,14 +1063,14 @@ TR::Register *OMR::ARM::Linkage::buildARMLinkageDirectDispatch(TR::Node *callNod
                                           callNode,
                                           0,
                                           dependencies,
-                                          new (self()->trHeapMemory()) TR::SymbolReference(codeGen->comp()->getSymRefTab(), label),
+                                          new (self()->trHeapMemory()) TR::SymbolReference(self()->comp()->getSymRefTab(), label),
                                           snippet);
 #else
       TR_ASSERT(false, "Attempting to handle Java in non-Java project");
 #endif
       }
    gcPoint->ARMNeedsGCMap(pp.getPreservedRegisterMapForGC());
-   codeGen->machine()->setLinkRegisterKilled(true);
+   self()->machine()->setLinkRegisterKilled(true);
    codeGen->setHasCall();
    TR::DataType resType = callNode->getType();
 

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -330,14 +330,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    virtual TR::Register *buildDirectDispatch(TR::Node *callNode) = 0;
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode) = 0;
 
-   TR_Debug        *getDebug()         {return _cg->getDebug();}
-   TR::CodeGenerator *cg()               {return _cg;}
-   TR::Compilation      *comp()             {return _cg->comp();}
-   TR_FrontEnd         *fe()               {return _cg->fe();}
-   TR_Memory *          trMemory()         {return _cg->trMemory(); }
-   TR_HeapMemory        trHeapMemory();
-   TR_StackMemory       trStackMemory();
-
    protected:
 
    TR::Register *buildARMLinkageDirectDispatch(TR::Node *callNode, bool isSystem = false);

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -294,7 +294,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    {
    public:
 
-   Linkage (TR::CodeGenerator *cg) : _cg(cg) {}
+   Linkage (TR::CodeGenerator *cg) : OMR::Linkage(cg) {}
 
    virtual bool hasToBeOnStack(TR::ParameterSymbol *parm);
    virtual void mapStack(TR::ResolvedMethodSymbol *method);
@@ -351,10 +351,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
                                TR::Register*                       &vftReg,
                                TR_LinkageConventions               conventions,
                                bool                                isVirtualOrJNI);
-
-protected:
-
-   TR::CodeGenerator*_cg;
    };
 }
 }

--- a/compiler/codegen/OMRLinkage.cpp
+++ b/compiler/codegen/OMRLinkage.cpp
@@ -26,11 +26,6 @@
 #include "il/Node.hpp"
 #include "il/symbol/ParameterSymbol.hpp"
 
-TR::Linkage *
-OMR::Linkage::self()
-   {
-   return static_cast<TR::Linkage*>(this);
-   }
 
 bool
 OMR::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -43,7 +43,7 @@ namespace OMR { typedef OMR::Linkage LinkageConnector; }
 
 class TR_BitVector;
 namespace TR { class AutomaticSymbol; }
-namespace TR { class Compilation; }
+namespace TR { class CodeGenerator; }
 namespace TR { class Linkage; }
 namespace TR { class Instruction; }
 namespace TR { class Node; }
@@ -63,7 +63,7 @@ class OMR_EXTENSIBLE Linkage
 
    TR_ALLOC(TR_Memory::Linkage)
 
-   Linkage() { }
+   Linkage(TR::CodeGenerator *cg) : _cg(cg) { }
 
    virtual void createPrologue(TR::Instruction *cursor) = 0;
    virtual void createEpilogue(TR::Instruction *cursor) = 0;
@@ -87,6 +87,9 @@ class OMR_EXTENSIBLE Linkage
 
    virtual TR_RegisterKinds argumentRegisterKind(TR::Node *argumentNode);
 
+protected:
+
+   TR::CodeGenerator *_cg;
    };
 }
 

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -42,9 +42,15 @@ namespace OMR { typedef OMR::Linkage LinkageConnector; }
 #include "infra/Annotations.hpp"
 
 class TR_BitVector;
+class TR_FrontEnd;
+class TR_HeapMemory;
+class TR_Memory;
+class TR_StackMemory;
 namespace TR { class AutomaticSymbol; }
 namespace TR { class CodeGenerator; }
+namespace TR { class Compilation; }
 namespace TR { class Linkage; }
+namespace TR { class Machine; }
 namespace TR { class Instruction; }
 namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
@@ -59,7 +65,42 @@ class OMR_EXTENSIBLE Linkage
    {
    public:
 
-   TR::Linkage* self();
+   inline TR::Linkage* self();
+
+   /**
+    * @return Cached CodeGenerator object
+    */
+   inline TR::CodeGenerator *cg();
+
+   /**
+    * @return Machine object from cached CodeGenerator
+    */
+   inline TR::Machine *machine();
+
+   /**
+    * @return Compilation object from cached CodeGenerator
+    */
+   inline TR::Compilation *comp();
+
+   /**
+    * @return FrontEnd object from cached CodeGenerator
+    */
+   inline TR_FrontEnd *fe();
+
+   /**
+    * @return TR_Memory object from cached CodeGenerator
+    */
+   inline TR_Memory *trMemory();
+
+   /**
+    * @return TR_HeapMemory object
+    */
+   inline TR_HeapMemory trHeapMemory();
+
+   /**
+    * @return TR_StackMemory object
+    */
+   inline TR_StackMemory trStackMemory();
 
    TR_ALLOC(TR_Memory::Linkage)
 

--- a/compiler/codegen/OMRLinkage_inlines.hpp
+++ b/compiler/codegen/OMRLinkage_inlines.hpp
@@ -22,4 +22,61 @@
 #ifndef OMR_LINKAGE_INLINES_INCL
 #define OMR_LINKAGE_INLINES_INCL
 
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/Linkage.hpp"
+#include "env/TRMemory.hpp"
+
+namespace TR { class Compilation; }
+namespace TR { class Machine; }
+class TR_FrontEnd;
+class TR_Memory;
+
+TR::Linkage *
+OMR::Linkage::self()
+   {
+   return static_cast<TR::Linkage*>(this);
+   }
+
+TR::CodeGenerator *
+OMR::Linkage::cg()
+   {
+   return _cg;
+   }
+
+TR::Machine *
+OMR::Linkage::machine()
+   {
+   return _cg->machine();
+   }
+
+TR::Compilation *
+OMR::Linkage::comp()
+   {
+   return _cg->comp();
+   }
+
+TR_FrontEnd *
+OMR::Linkage::fe()
+   {
+   return _cg->fe();
+   }
+
+TR_Memory *
+OMR::Linkage::trMemory()
+   {
+   return _cg->trMemory();
+   }
+
+TR_HeapMemory
+OMR::Linkage::trHeapMemory()
+   {
+   return self()->trMemory();
+   }
+
+TR_StackMemory
+OMR::Linkage::trStackMemory()
+   {
+   return self()->trMemory();
+   }
+
 #endif

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -79,7 +79,7 @@ bool OMR::Power::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
 
 TR::MemoryReference *OMR::Power::Linkage::getOutgoingArgumentMemRef(int32_t argSize, TR::Register *argReg, TR::InstOpCode::Mnemonic opCode, TR::PPCMemoryArgument &memArg, uint32_t length)
    {
-   TR::Machine *machine = self()->cg()->machine();
+   TR::Machine *machine = self()->machine();
    const TR::PPCLinkageProperties& properties = self()->getProperties();
 
    TR::MemoryReference *result = new (self()->trHeapMemory()) TR::MemoryReference(machine->getRealRegister(properties.getNormalStackPointerRegister()),
@@ -105,7 +105,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
    #define  REAL_REGISTER(ri)  machine->getRealRegister(ri)
    #define  REGNUM(ri)         ((TR::RealRegister::RegNum)(ri))
    const TR::PPCLinkageProperties& properties = self()->getProperties();
-   TR::Machine *machine = self()->cg()->machine();
+   TR::Machine *machine = self()->machine();
    TR::RealRegister      *stackPtr   = self()->cg()->getStackPointerRegister();
    TR::ResolvedMethodSymbol    *bodySymbol = self()->comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>   paramIterator(&parmList);
@@ -484,7 +484,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
       // would be better to use a different linkage for this purpose
       return cursor;
 
-   TR::Machine *machine = self()->cg()->machine();
+   TR::Machine *machine = self()->machine();
    TR::RealRegister      *stackPtr   = self()->cg()->getStackPointerRegister();
    TR::ResolvedMethodSymbol      *bodySymbol = self()->comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));
@@ -578,7 +578,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
 
 TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
    {
-   TR::Machine *machine = self()->cg()->machine();
+   TR::Machine *machine = self()->machine();
    TR::RealRegister      *stackPtr   = self()->cg()->getStackPointerRegister();
    TR::ResolvedMethodSymbol      *bodySymbol = self()->comp()->getJittedMethodSymbol();
    ListIterator<TR::ParameterSymbol>   paramIterator(&(bodySymbol->getParameterList()));

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -810,16 +810,3 @@ TR_ReturnInfo OMR::Power::Linkage::getReturnInfoFromReturnType(TR::DataType retu
 
    return TR_VoidReturn;
    }
-
-TR_HeapMemory
-OMR::Power::Linkage::trHeapMemory()
-   {
-   return self()->trMemory();
-   }
-
-
-TR_StackMemory
-OMR::Power::Linkage::trStackMemory()
-   {
-   return self()->trMemory();
-   }

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -381,9 +381,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    {
    public:
 
-   Linkage () : OMR::Linkage() {}
-
-   Linkage (TR::CodeGenerator *cg) : _cg(cg) {}
+   Linkage (TR::CodeGenerator *cg) : OMR::Linkage(cg) {}
 
    virtual bool hasToBeOnStack(TR::ParameterSymbol *parm);
    virtual void mapStack(TR::ResolvedMethodSymbol *method);
@@ -445,10 +443,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    virtual uintptr_t calculateParameterRegisterOffset(uintptr_t o, TR::ParameterSymbol& p) { return o; }
 
    TR_ReturnInfo getReturnInfoFromReturnType(TR::DataType);
-
-protected:
-
-   TR::CodeGenerator*_cg;
    };
 }
 }

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -422,14 +422,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    virtual TR::Register *buildIndirectDispatch(TR::Node *callNode) = 0;
 
-   TR::CodeGenerator *cg() {return _cg;}
-   TR::Compilation *comp() {return _cg->comp();}
-   TR_FrontEnd *fe() {return _cg->fe();}
-
-   TR_Memory *trMemory() {return _cg->trMemory(); }
-   TR_HeapMemory trHeapMemory();
-   TR_StackMemory trStackMemory();
-
    // Given an offset (generally into a stack frame) of the slot used
    // to hold a parameter, compute the offset of the data itself.
    // (in the case of 32-bit slots, the offset will be 3 for a char,

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -763,20 +763,6 @@ OMR::X86::Linkage::paramMovType(TR::ParameterSymbol *param)
    }
 
 
-TR_HeapMemory
-OMR::X86::Linkage::trHeapMemory()
-   {
-   return self()->trMemory();
-   }
-
-
-TR_StackMemory
-OMR::X86::Linkage::trStackMemory()
-   {
-   return self()->trMemory();
-   }
-
-
 TR_X86OpCodes OMR::X86::Linkage::_movOpcodes[NumMovOperandTypes][NumMovDataTypes] =
    {
    //    Int4         Int8        Float4         Float8

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -67,6 +67,18 @@ static uint32_t accumOrigSize = 0;
 static uint32_t accumMappedSize = 0;
 #endif
 
+
+OMR::X86::Linkage::Linkage(TR::CodeGenerator *cg) :
+      OMR::Linkage(cg),
+   _minimumFirstInstructionSize(0)
+   {
+   // Initialize the movOp table based on preferred load instructions for this target.
+   //
+   TR_X86OpCodes op = cg->getXMMDoubleLoadOpCode() ? cg->getXMMDoubleLoadOpCode() : MOVSDRegMem;
+   _movOpcodes[RegMem][Float8] = op;
+   }
+
+
 void OMR::X86::Linkage::mapCompactedStack(TR::ResolvedMethodSymbol *method)
    {
    ListIterator<TR::AutomaticSymbol>  automaticIterator(&method->getAutomaticList());

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -393,13 +393,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    protected:
 
-   Linkage(TR::CodeGenerator *cg) : OMR::Linkage(cg), _minimumFirstInstructionSize(0)
-      {
-      // Initialize the movOp table based on preferred load instructions for this target.
-      //
-      TR_X86OpCodes op = cg->getXMMDoubleLoadOpCode() ? cg->getXMMDoubleLoadOpCode() : MOVSDRegMem;
-      _movOpcodes[RegMem][Float8] = op;
-      }
+   Linkage(TR::CodeGenerator *cg);
 
    void stopUsingKilledRegisters(TR::RegisterDependencyConditions  *deps, TR::Register *returnRegister);
    void associatePreservedRegisters(TR::RegisterDependencyConditions  *deps, TR::Register *returnRegister);

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -401,7 +401,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    protected:
 
-   Linkage(TR::CodeGenerator *cg) : _cg(cg), _minimumFirstInstructionSize(0)
+   Linkage(TR::CodeGenerator *cg) : OMR::Linkage(cg), _minimumFirstInstructionSize(0)
       {
       // Initialize the movOp table based on preferred load instructions for this target.
       //
@@ -443,7 +443,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    private:
 
    static TR_X86OpCodes _movOpcodes[NumMovOperandTypes][NumMovDataTypes];
-   TR::CodeGenerator*   _cg;
    uint8_t              _minimumFirstInstructionSize;
 
    };

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -388,14 +388,6 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
       return _movOpcodes[operandType][dataType];
       }
 
-   TR::Machine *machine() {return _cg->machine();}
-   TR::CodeGenerator *cg() {return _cg;}
-   TR::Compilation *comp() {return _cg->comp();}
-   TR_FrontEnd *fe() {return _cg->fe();}
-   TR_Memory *trMemory() {return _cg->trMemory(); }
-   TR_HeapMemory trHeapMemory();
-   TR_StackMemory trStackMemory();
-
    void alignLocalObjectWithCollectedFields(uint32_t & stackIndex) {}
    void alignLocalObjectWithoutCollectedFields(uint32_t & stackIndex) {}
 

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -105,8 +105,8 @@ static int32_t getFirstMaskedBit(int16_t mask); ///< formward reference
 ////////////////////////////////////////////////////////////////////////////////
 
 OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
-   : OMR::Linkage(),
-      _codeGen(codeGen), _explicitLinkageType(TR_S390LinkageDefault), _linkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+   : OMR::Linkage(codeGen),
+      _explicitLinkageType(TR_S390LinkageDefault), _linkageType(TR_None), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),
@@ -141,8 +141,8 @@ OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen)
  * Even though this method is common, its implementation is machine-specific.
  */
 OMR::Z::Linkage::Linkage(TR::CodeGenerator * codeGen,TR_S390LinkageConventions elc, TR_LinkageConventions lc)
-   : OMR::Linkage(),
-      _codeGen(codeGen), _explicitLinkageType(elc), _linkageType(lc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
+   : OMR::Linkage(codeGen),
+      _explicitLinkageType(elc), _linkageType(lc), _stackSizeCheckNeeded(true), _raContextSaveNeeded(true),
       _integerReturnRegister(TR::RealRegister::NoReg),
       _floatReturnRegister(TR::RealRegister::NoReg),
       _doubleReturnRegister(TR::RealRegister::NoReg),

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -424,7 +424,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 
    uint32_t binLocalRegs = 0x1<<14;   // Binary pattern representing reg14 as free for local alloc
 
-   int8_t gprSize = self()->cg()->machine()->getGPRSize();
+   int8_t gprSize = self()->machine()->getGPRSize();
 
    bool unconditionalSave  = false;
 
@@ -2031,7 +2031,7 @@ void
 OMR::Z::Linkage::loadIntArgumentsFromStack(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies, TR::DataType argType, int32_t stackOffset, int32_t argSize, int32_t numIntegerArgs, TR::Register* stackRegister)
    {
    TR::RealRegister::RegNum argRegNum;
-   int8_t gprSize = self()->cg()->machine()->getGPRSize();
+   int8_t gprSize = self()->machine()->getGPRSize();
 
 
    argRegNum = self()->getIntegerArgumentRegister(numIntegerArgs);
@@ -2085,7 +2085,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
 
    TR::SystemLinkage * systemLinkage = (TR::SystemLinkage *) self()->cg()->getLinkage(TR_System);
 
-   int8_t gprSize = self()->cg()->machine()->getGPRSize();
+   int8_t gprSize = self()->machine()->getGPRSize();
    TR::Register * tempRegister;
    int32_t argIndex = 0, i, from, to, step, numChildren;
    int32_t argSize = 0;
@@ -2351,7 +2351,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
 
                if (self()->isAggregatesPassedInParmRegs())
                   {
-                  size_t slot = self()->cg()->machine()->getGPRSize();
+                  size_t slot = self()->machine()->getGPRSize();
                   size_t childSize = child->getSize();
                   size_t size = (childSize + slot - 1) & (~(slot - 1));
                   size_t slots = size / slot;
@@ -2992,7 +2992,7 @@ OMR::Z::Linkage::restorePreservedRegs(TR::RealRegister::RegNum firstUsedReg,
          cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(),
                    nextNode, self()->getRealRegister(REGNUM(curReg)), rsa, cursor);
 
-         curDisp += self()->cg()->machine()->getGPRSize();
+         curDisp += self()->machine()->getGPRSize();
          curReg++;
 
          // generate the next rsa
@@ -3018,7 +3018,7 @@ OMR::Z::Linkage::restorePreservedRegs(TR::RealRegister::RegNum firstUsedReg,
       cursor = generateRXInstruction(self()->cg(), TR::InstOpCode::getLoadOpCode(),
                 nextNode, self()->getRealRegister(REGNUM(newFirstUsedReg)), rsa, cursor);
 
-      rsa = generateS390MemoryReference(spReg, rsa->getOffset()+self()->cg()->machine()->getGPRSize(), self()->cg());
+      rsa = generateS390MemoryReference(spReg, rsa->getOffset()+self()->machine()->getGPRSize(), self()->cg());
       cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::getLoadMultipleOpCode(), nextNode,
                     self()->getRealRegister(REGNUM(newFirstUsedReg+1)),
                     self()->getRealRegister(REGNUM(newLastUsedReg)), rsa, cursor);
@@ -3291,5 +3291,5 @@ OMR::Z::Linkage::getJ9MethodArgumentRegisterRealRegister()
 TR::RealRegister *
 OMR::Z::Linkage::getRealRegister(TR::RealRegister::RegNum rNum)
    {
-   return self()->cg()->machine()->getRealRegister(rNum);
+   return self()->machine()->getRealRegister(rNum);
    }

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -3288,36 +3288,6 @@ OMR::Z::Linkage::getJ9MethodArgumentRegisterRealRegister()
    return self()->getRealRegister(_j9methodArgumentRegister);
    }
 
-TR::Compilation *
-OMR::Z::Linkage::comp()
-   {
-   return self()->cg()->comp();
-   }
-
-TR_FrontEnd *
-OMR::Z::Linkage::fe()
-   {
-   return self()->cg()->fe();
-   }
-
-TR_Memory *
-OMR::Z::Linkage::trMemory()
-   {
-   return self()->cg()->trMemory();
-   }
-
-TR_HeapMemory
-OMR::Z::Linkage::trHeapMemory()
-   {
-   return self()->trMemory();
-   }
-
-TR_StackMemory
-OMR::Z::Linkage::trStackMemory()
-   {
-   return self()->trMemory();
-   }
-
 TR::RealRegister *
 OMR::Z::Linkage::getRealRegister(TR::RealRegister::RegNum rNum)
    {

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -600,15 +600,6 @@ enum TR_DispatchType
 
    virtual int32_t setupLiteralPoolRegister(TR::Snippet *firstSnippet) { return -1; }
 
-// Just for convenience
-   TR::CodeGenerator * cg() { return _cg; }
-   TR::Compilation *   comp();
-   TR_FrontEnd *       fe();
-
-   TR_Memory *          trMemory();
-   TR_HeapMemory        trHeapMemory();
-   TR_StackMemory       trStackMemory();
-
    TR::RealRegister *  getRealRegister(TR::RealRegister::RegNum rNum);
 
    TR::RealRegister::RegNum getFirstSavedRegister(int32_t fromreg, int32_t toreg);

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -601,7 +601,7 @@ enum TR_DispatchType
    virtual int32_t setupLiteralPoolRegister(TR::Snippet *firstSnippet) { return -1; }
 
 // Just for convenience
-   TR::CodeGenerator * cg() { return _codeGen; }
+   TR::CodeGenerator * cg() { return _cg; }
    TR::Compilation *   comp();
    TR_FrontEnd *       fe();
 
@@ -631,7 +631,6 @@ private:
 
    enum FrameType _frameType;
 
-   TR::CodeGenerator * _codeGen;
    TR::Instruction * _lastPrologueInstr;
    TR::Instruction * _firstPrologueInstr;
    };


### PR DESCRIPTION
* Move CodeGenerator object into base of OMRLinkage
* Consolidate Linkage convenience functions
* Make use of Linkage convenience functions
* Remove concrete CodeGenerator dependence from x86 Linkage base header

Signed-off-by: Daryl Maier <maier@ca.ibm.com>