### PR TITLE
Add double map API for WINDOWS and balanced GC policy

### DIFF
--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -802,7 +802,7 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 		/* Memory verified successfully */
 		{
 			/* Initialize arraylet offsets to different ranges */
-			long arrayLetOffsets[ARRAYLET_COUNT];
+			size_t arrayLetOffsets[ARRAYLET_COUNT];
 			/* Must be multiple of pagesize: sysconf(_SC_PAGE_SIZE) 	Simulates the order of arraylet leaves in an array */
 			arrayLetOffsets[0] = 0;								/* 1 */
 			arrayLetOffsets[1] = (HEAP_SIZE / 2) + (HEAP_SIZE / 8);				/* 6 */

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -626,7 +626,7 @@ exit:
  * @param[in] allocName Calling function name to display in errors
  */
 static void 
-verifyContiguousMem(struct OMRPortLibrary *portLibrary, const char *testName, size_t pagesize, size_t arrayletSize, void * contiguous, void* addresses[], char *vals, const char *allocName) 
+verifyContiguousMem(struct OMRPortLibrary *portLibrary, const char *testName, size_t pagesize, size_t arrayletSize, void * contiguous, uintptr_t *addresses, char *vals, const char *allocName) 
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	char * contiguousMap = (char*)contiguous;
@@ -722,24 +722,37 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 	size_t arrayletLeafSize = SIXTEEN_KB; // 16KB
 	char vals[ARRAYLET_COUNT] = {'3', '5', '6', '8', '9', '0', '1', '2'};
 	size_t totalArrayletSize = 0;
-	void* arrayletLeaveAddrs[ARRAYLET_COUNT];
+	/* In OpenJ9 we must malloc the leaves addresses, so we test it here as well */
+	uintptr_t *arrayletLeaveAddrs = (uintptr_t *)malloc(ARRAYLET_COUNT * sizeof(uintptr_t));
+	BOOLEAN shouldDealocateAddrs = TRUE;
 
 	reportTestEntry(OMRPORTLIB, testName);
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
 	uintptr_t pageSize = pageSizes[0];
+	uintptr_t systemGranularity = pageSize;
+
+	if(arrayletLeaveAddrs == NULL) {
+		shouldDealocateAddrs = FALSE;
+		outputErrorMessage(PORTTEST_ERROR_ARGS, "Unable to malloc and commit 0x%zx bytes with page size 0x%zx.\n", HEAP_SIZE, pageSize);
+		goto exit;
+        }
 #if defined(J9ZOS390)
 	pageFlags = omrvmem_supported_page_flags();
 #endif /* J9ZOS390 */
 
+#if defined(WINDOWS) || defined(WIN32)
+	systemGranularity = omrmmap_get_region_granularity(NULL);
+#endif  /* defined(WINDOWS) || defined(WIN32) */
+
 	/* Make sure arrayletLeafSize is a multiple of pagesize */
-	if(arrayletLeafSize / pageSize == 0 && (arrayletLeafSize < pageSize)) {
+	if(arrayletLeafSize / systemGranularity == 0 && (arrayletLeafSize < systemGranularity)) {
 		/* Leaf size limit is 2 MB due to heap size and number of leaves. If pageSize is too big for test skip */
-		if(pageSize > LEAF_SIZE_LIMIT) {
+		if(systemGranularity > LEAF_SIZE_LIMIT) {
 			goto exit;
 		}
-		arrayletLeafSize = pageSize;
+		arrayletLeafSize = systemGranularity;
 	}
 
 	/* reserve and commit memory for heap size */
@@ -815,12 +828,12 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 
 			size_t i = 0;
 			for(; i < ARRAYLET_COUNT; i++) {
-				arrayletLeaveAddrs[i] = memPtr + arrayLetOffsets[i];
+				arrayletLeaveAddrs[i] = (uintptr_t)(memPtr + arrayLetOffsets[i]);
 				totalArrayletSize += arrayletLeafSize;
 			}
 
 			for(i = 0; i < ARRAYLET_COUNT; i++) {
-				memset(arrayletLeaveAddrs[i], vals[i%ARRAYLET_COUNT], arrayletLeafSize);
+				memset((void *)arrayletLeaveAddrs[i], vals[i%ARRAYLET_COUNT], arrayletLeafSize);
 			}
 			/* Arraylet initialization complete */
 			
@@ -897,6 +910,9 @@ J9ZOS390_exit:
 #endif /* J9ZOS390 */
 	portTestEnv->changeIndent(-1);
 exit:
+	if (shouldDealocateAddrs) {
+		free((void *)arrayletLeaveAddrs);
+	}
 	reportTestExit(OMRPORTLIB, testName);
 }
 

--- a/gc/base/Heap.hpp
+++ b/gc/base/Heap.hpp
@@ -116,7 +116,7 @@ public:
 	virtual void *getHeapBase() = 0;
 	virtual void *getHeapTop() = 0;
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize) = 0;
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize) = 0;
 #endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */
 
 	virtual uintptr_t getMaximumPhysicalRange() = 0;

--- a/gc/base/HeapSplit.cpp
+++ b/gc/base/HeapSplit.cpp
@@ -185,7 +185,7 @@ MM_HeapSplit::getPageFlags()
 
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 void*
-MM_HeapSplit::doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+MM_HeapSplit::doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
 {
 	/* Unreachable */
 	return NULL;

--- a/gc/base/HeapSplit.hpp
+++ b/gc/base/HeapSplit.hpp
@@ -62,7 +62,7 @@ public:
 	virtual void *getHeapBase();
 	virtual void *getHeapTop();
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 #endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */
 
 	virtual uintptr_t getMaximumPhysicalRange();

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -176,7 +176,7 @@ MM_HeapVirtualMemory::getHeapTop()
 
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 void*
-MM_HeapVirtualMemory::doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+MM_HeapVirtualMemory::doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
 {
 	MM_MemoryManager* memoryManager = MM_GCExtensionsBase::getExtensions(_omrVM)->memoryManager;
 	return memoryManager->doubleMapArraylet(&_vmemHandle, env, arrayletLeaves, arrayletLeafCount, arrayletLeafSize, byteAmount, newIdentifier, pageSize);

--- a/gc/base/HeapVirtualMemory.hpp
+++ b/gc/base/HeapVirtualMemory.hpp
@@ -57,7 +57,7 @@ public:
 	virtual void* getHeapBase();
 	virtual void* getHeapTop();
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 #endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */
 
 	virtual uintptr_t getMaximumPhysicalRange();

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -555,7 +555,7 @@ MM_MemoryManager::destroyVirtualMemory(MM_EnvironmentBase* env, MM_MemoryHandle*
 
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 void*
-MM_MemoryManager::doubleMapArraylet(MM_MemoryHandle* handle, MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+MM_MemoryManager::doubleMapArraylet(MM_MemoryHandle* handle, MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
 {
 	Assert_MM_true(NULL != handle);
 	MM_VirtualMemory* memory = handle->getVirtualMemory();

--- a/gc/base/MemoryManager.hpp
+++ b/gc/base/MemoryManager.hpp
@@ -191,7 +191,7 @@ public:
  	 * @param category
   	 */
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-	void *doubleMapArraylet(MM_MemoryHandle* handle, MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
+	void *doubleMapArraylet(MM_MemoryHandle* handle, MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 #endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */
 
 	/**

--- a/gc/base/VirtualMemory.cpp
+++ b/gc/base/VirtualMemory.cpp
@@ -163,7 +163,7 @@ MM_VirtualMemory::reserveMemory(J9PortVmemParams* params)
 
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
 void*
-MM_VirtualMemory::doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
+MM_VirtualMemory::doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize)
 {
 	OMRPORT_ACCESS_FROM_OMRVM(_extensions->getOmrVM());
 	struct J9PortVmemIdentifier *oldIdentifier = &_identifier;

--- a/gc/base/VirtualMemory.hpp
+++ b/gc/base/VirtualMemory.hpp
@@ -82,7 +82,7 @@ protected:
 
 	virtual void* reserveMemory(J9PortVmemParams* params);
 #if defined(OMR_GC_DOUBLE_MAP_ARRAYLETS)
-	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, void* arrayletLeaves[], UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
+	virtual void *doubleMapArraylet(MM_EnvironmentBase *env, uintptr_t* arrayletLeaves, UDATA arrayletLeafCount, UDATA arrayletLeafSize, UDATA byteAmount, struct J9PortVmemIdentifier *newIdentifier, UDATA pageSize);
 #endif /* defined(OMR_GC_DOUBLE_MAP_ARRAYLETS) */
 
 	MM_VirtualMemory(MM_EnvironmentBase* env, uintptr_t heapAlignment, uintptr_t pageSize, uintptr_t pageFlags, uintptr_t tailPadding, uintptr_t mode)

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -972,7 +972,11 @@ typedef struct J9PortVmemIdentifier {
 	uintptr_t pageFlags;
 	uintptr_t mode;
 	uintptr_t allocator;
+#if defined(LINUX)
 	int fd;
+#elif (defined(WINDOWS) || defined(WIN32))
+	void *fd;
+#endif /* (defined(WINDOWS) || defined(WIN32)) */
 	OMRMemCategory *category;
 } J9PortVmemIdentifier;
 

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1360,7 +1360,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrvmem.c::omrvmem_reserve_memory_ex "omrvmem_reserve_memory_ex"*/
 	void *(*vmem_reserve_memory_ex)(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params) ;
 	/** see @ref omrvmem.c::omrvmem_get_contiguous_region_memory "omrvmem_get_contiguous_region_memory"*/
-	void *(*vmem_get_contiguous_region_memory)(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
+	void *(*vmem_get_contiguous_region_memory)(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
 	/** see @ref omrvmem.c::omrvmem_get_page_size "omrvmem_get_page_size"*/
 	uintptr_t (*vmem_get_page_size)(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier) ;
 	/** see @ref omrvmem.c::omrvmem_get_page_flags "omrvmem_get_page_flags"*/

--- a/port/aix/omrvmem.c
+++ b/port/aix/omrvmem.c
@@ -1524,7 +1524,7 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary, J9VMemMemory
 }
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	portLibrary->error_set_last_error(portLibrary, errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
 	return NULL;

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -725,6 +725,7 @@ TraceException=Trc_PRT_vmem_omrvmem_reserve_memory_ex_UnableToAllocateWithinSpec
 TraceException=Trc_PRT_vmem_omrvmem_reserve_memory_shmdt_failed Group=mem Overhead=1 Level=1 NoEnv Template="omrvmem_reserve_memory (shmdt failed) address=%p"
 
 TraceException=Trc_PRT_vmem_omrvmem_reserve_memory_ex_large_page_request_failed_reverting_to_default_page_size Group=mem Overhead=1 Level=1 NoEnv Template="omrvmem_reserve_memory_ex_large_page_request_failed_reverting_to_default_page_size, byteAmout: %u, numPages: %u"
+TraceException=Trc_PRT_vmem_omrvmem_reserve_memory_ex_file_handle_failed Group=mem Overhead=1 Level=3 NoEnv Template="omrvmem_reserve_memory_ex (unable to get file handle for %u bytes)"
 
 TraceException=Trc_PRT_vmem_omrvmem_startup_failed_to_close_dll Group=mem Overhead=1 Level=1 NoEnv Template="Failed to close DLL Kernel32"
 

--- a/port/common/omrvmem.c
+++ b/port/common/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -214,7 +214,7 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
  */
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	return NULL;
 }

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -1071,7 +1071,7 @@ default_pageSize_reserve_memory(struct OMRPortLibrary *portLibrary, void *addres
  */
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	int protectionFlags = PROT_READ | PROT_WRITE;
 	int flags = MAP_PRIVATE | MAP_ANON;
@@ -1120,9 +1120,9 @@ omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* a
 		fd = oldIdentifier->fd;
 #if defined(OMRVMEM_DEBUG)
 		printf("Found %zu arraylet leaves.\n", addressesCount);
-		int j = 0;
+		size_t j = 0;
 		for(j = 0; j < addressesCount; j++) {
-			printf("addresses[%d] = %p\n", j, addresses[j]);
+			printf("addresses[%zu] = %p\n", j, addresses[j]);
 		}
 		printf("Contiguous address is: %p\n", contiguousMap);
 		printf("About to double map arraylets. File handle got from old identifier: %d\n", fd);
@@ -1131,7 +1131,7 @@ omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* a
 		size_t i;
 		for (i = 0; i < addressesCount; i++) {
 			void *nextAddress = (void *)(contiguousMap + i * addressSize);
-			uintptr_t addressOffset = (uintptr_t)(addresses[i] - (uintptr_t)oldIdentifier->address);
+			uintptr_t addressOffset = addresses[i] - (uintptr_t)oldIdentifier->address;
 			void *address = mmap(
 					nextAddress,
 					addressSize,

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -682,7 +682,7 @@ omrvmem_reserve_memory(struct OMRPortLibrary *portLibrary, void *address, uintpt
 extern J9_CFUNC void *
 omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, struct J9PortVmemParams *params);
 extern J9_CFUNC void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category);
 extern J9_CFUNC uintptr_t
 omrvmem_get_page_size(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier);
 extern J9_CFUNC uintptr_t

--- a/port/osx/omrvmem.c
+++ b/port/osx/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -790,7 +790,7 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary, J9VMemMemory
 }
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
 	return NULL;

--- a/port/win32/omrvmem.c
+++ b/port/win32/omrvmem.c
@@ -792,7 +792,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 	void *memoryPointer = NULL;
 #if defined(OMRVMEM_DEBUG)
 	static int count = 0;
-#endif
+#endif /* defined(OMRVMEM_DEBUG) */
 
 	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
 		useBackingSharedFile = TRUE;
@@ -831,7 +831,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 		currentAddress = endAddress;
 #if defined(OMRVMEM_DEBUG)
 		printf("\t\t getMemoryInRange top down, start address: %p\n", currentAddress);
-#endif
+#endif /* defined(OMRVMEM_DEBUG) */
 
 	} else if (0 != (vmemOptions & OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP)) {
 		allocationFlags &= ~MEM_TOP_DOWN;
@@ -840,7 +840,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 		}
 #if defined(OMRVMEM_DEBUG)
 		printf("\t\t getMemoryInRange bottom up, start address: %p\n", currentAddress);
-#endif
+#endif /* defined(OMRVMEM_DEBUG) */
 
 	} else if (NULL == startAddress) {
 		if (OMRPORT_VMEM_MAX_ADDRESS == endAddress) {
@@ -883,7 +883,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 			printf("\t\t getMemoryInRange calling VirtualAlloc: address: %p, size: %p, allocationFlags: %x, protection: %x\n", (LPVOID)currentAddress, byteAmount, allocationFlags, protection);
 			fflush(stdout);
 		}
-#endif
+#endif /* defined(OMRVMEM_DEBUG) */
 
 		if (useBackingSharedFile) {
 			// Similar to mmap on POSIX
@@ -926,7 +926,7 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 			printf("\t\t\t getMemoryInRange returned from VirtualAlloc\n");
 			fflush(stdout);
 		}
-#endif
+#endif /* defined(OMRVMEM_DEBUG) */
 		/* stop if returned pointer is within range */
 		if (NULL != memoryPointer) {
 			if ((startAddress <= memoryPointer) && (endAddress >= memoryPointer)) {
@@ -1623,8 +1623,102 @@ OLD_IMPL:
 }
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t *addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
-	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-	return NULL;
+	BOOLEAN successfulContiguousMap = FALSE;
+	BOOLEAN shouldUnmapAddr = FALSE;
+	DWORD flAllocationType = MEM_RESERVE;
+	DWORD  flProtect = PAGE_NOACCESS;
+	HANDLE fd = NULL;
+	LPVOID contiguousMap = NULL;
+#if defined(OMRVMEM_DEBUG)
+	SYSTEM_INFO systemInfo;
+	GetSystemInfo(&systemInfo);
+#endif /* defined(OMRVMEM_DEBUG) */
+	byteAmount = addressesCount * addressSize;
+
+	/* Creates contiguous memory space for arraylets */
+	contiguousMap = VirtualAlloc(
+			NULL,		/* addr */
+			byteAmount, 	/* size */
+			flAllocationType,
+			flProtect);
+	if (contiguousMap == NULL) {
+		portLibrary->error_set_last_error_with_message(portLibrary, OMRPORT_ERROR_VMEM_OPFAILED, "Failed to map contiguous block of memory");
+	} else {
+		/* No need to commit memory because heap region is already commited */
+		shouldUnmapAddr = TRUE;
+		successfulContiguousMap = TRUE;
+		/* Update identifier and increment counter */
+		update_vmemIdentifier(newIdentifier, (void *)contiguousMap, (void *)contiguousMap, byteAmount, mode, pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, category, NULL);
+		omrmem_categories_increment_counters(category, byteAmount);
+	}
+
+	/* MUST free this address to map the file view */
+	if (VirtualFree(contiguousMap, 0, MEM_RELEASE) == 0) {
+		contiguousMap = NULL;
+		successfulContiguousMap = FALSE;
+#if defined(OMRVMEM_DEBUG)
+		printf("\tFailed to free contiguous\n");
+		fflush(stdout);
+#endif /* defined(OMRVMEM_DEBUG) */
+	}
+
+	/* First need to commit regions where arraylets will be stored
+	   In a normal application, this is not necessary because arraylets
+	   are only stored in regions that were commited already */
+
+
+	/* Perform double mapping  */
+	if(contiguousMap != NULL) {
+		SIZE_T i;
+		fd = oldIdentifier->fd;
+#if defined(OMRVMEM_DEBUG)
+		for(i = 0; i < addressesCount; i++) {
+			printf("addresses[%lld] = %p\n", i, (void *)addresses[i]);
+		}
+		printf("Contiguous address is: %p\n", contiguousMap);
+		printf("About to double map arraylets. File handle got from old identifier: %p\n", (void*)fd);
+		fflush(stdout);
+#endif /* defined(OMRVMEM_DEBUG) */
+		for (i = 0; i < addressesCount; i++) {
+			void *nextAddress = (void *)((uintptr_t)contiguousMap + i * addressSize);
+			DWORD addressOffset = (DWORD)(addresses[i] - (uintptr_t)oldIdentifier->address);
+			LPVOID address = MapViewOfFileEx(
+				fd,			/* file descriptor */
+				FILE_MAP_WRITE, 	/* read and write access */
+				0,			/* file descriptor offset high */
+				addressOffset,		/* file descriptor offset low (Offset into contiguous memory) */
+				addressSize,		/* number of bytes to map */
+				(LPVOID)nextAddress);	/* address in contiguous region to be mapped */
+
+			if (address == NULL) {
+				successfulContiguousMap = FALSE;
+				portLibrary->error_set_last_error_with_message(portLibrary, OMRPORT_ERROR_VMEM_OPFAILED, "Failed to double map.");
+#if defined(OMRVMEM_DEBUG)
+				printf("***************************** GetLastError(): %d\n", GetLastError());
+				printf("Failed to mmap address[%lld] at mmapContiguous(), nextAddress: %p, offset: %d, System.pagesize: %d, pagesize: %lld\n", i, nextAddress, addressOffset, systemInfo.dwAllocationGranularity, pageSize);
+				fflush(stdout);
+#endif /* defined(OMRVMEM_DEBUG) */
+				break;
+			} else if (nextAddress != address) {
+				successfulContiguousMap = FALSE;
+				portLibrary->error_set_last_error_with_message(portLibrary, OMRPORT_ERROR_VMEM_OPFAILED, "Double Map failed to provide the correct address");
+#if defined(OMRVMEM_DEBUG)
+				printf("Map failed to provide the correct address. nextAddress %p != %p, offset: %d\n", nextAddress, address, addressOffset);
+				fflush(stdout);
+#endif /* defined(OMRVMEM_DEBUG) */
+				break;
+			}
+		}
+	}
+
+	if (!successfulContiguousMap) {
+		if (shouldUnmapAddr) {
+			VirtualFree(contiguousMap, byteAmount, 0);
+		}
+		contiguousMap = NULL;
+	}
+
+	return contiguousMap;
 }

--- a/port/win32/omrvmem.c
+++ b/port/win32/omrvmem.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,7 +71,7 @@ typedef struct BindingNode {
 static void *getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, DWORD allocationFlags, DWORD protection, OMRMemCategory *category, uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode);
 static BOOLEAN rangeIsValid(struct J9PortVmemIdentifier *identifier, void *address, uintptr_t byteAmount);
 DWORD getProtectionBits(uintptr_t mode);
-void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, OMRMemCategory *category);
+void update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address, void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, OMRMemCategory *category, HANDLE fd);
 static void *commitAndTouch(struct OMRPortLibrary *portLibrary, J9PortVmemIdentifier *identifier, void *address, uintptr_t byteAmount);
 static void touchOnNumaNode(struct OMRPortLibrary *portLibrary, uintptr_t pageSizeInBytes, void *address, uintptr_t byteAmount, uintptr_t j9NumaNode);
 static intptr_t rangeInsertionComparator(J9AVLTree *tree, BindingNode *insertNode, BindingNode *walkNode);
@@ -213,12 +213,26 @@ int32_t
 omrvmem_free_memory(struct OMRPortLibrary *portLibrary, void *address, uintptr_t byteAmount, struct J9PortVmemIdentifier *identifier)
 {
 	int32_t ret = 0;
+	int32_t retUnmap = 0;
 	OMRMemCategory *category = identifier->category;
+	HANDLE fd = identifier->fd;
+	uintptr_t mode = identifier->mode;
 
 	Trc_PRT_vmem_omrvmem_free_memory_Entry(address, byteAmount);
-	update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL);
+	update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL, NULL);
 
-	ret = (int32_t)VirtualFree((LPVOID)address, (size_t)0, MEM_RELEASE);
+	if((mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) && fd != NULL) {
+		retUnmap = UnmapViewOfFile(address);
+		ret = CloseHandle(fd);
+		if(ret != 0 && retUnmap != 0) {
+			ret = 1;
+		} else {
+			ret = 0; /* Means it failed */
+		}
+	} else {
+		ret = (int32_t) ((LPVOID)address, (size_t)0, MEM_RELEASE);
+	}
+
 	if (ret != 0) {
 		/* ensure that we also delete any NUMA binding extents which describe the memory under this area */
 		/* (note that the sub-allocator can cause us to shut-down the binding pool prior to freeing the last reserved area so ignore NUMA clean-up if the pool is already gone) */
@@ -323,7 +337,7 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 
 	/* Invalid input */
 	if (0 == params->pageSize) {
-		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL);
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL, NULL);
 		Trc_PRT_vmem_omrvmem_reserve_memory_Exit1();
 	} else if (PPG_vmem_pageSize[0] == params->pageSize) {
 		uintptr_t alignmentInBytes = OMR_MAX(params->pageSize, params->alignmentInBytes);
@@ -345,12 +359,6 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 		/* Make sure that the alignment is a multiple of both requested alignment and page size (enforces that arguments are powers of two and, thus, their max is their lowest common multiple) */
 		if ((0 == minimumGranule) || (0 == (alignmentInBytes % minimumGranule))) {
 			memoryPointer = getMemoryInRange(portLibrary, identifier, allocationFlags, protection, category, params->byteAmount, params->startAddress, params->endAddress, alignmentInBytes, params->options, params->mode);
-		}
-		if (NULL == memoryPointer) {
-			Trc_PRT_vmem_omrvmem_reserve_memory_failure();
-			update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL);
-		} else {
-			update_vmemIdentifier(identifier, (void *)memoryPointer, (void *)memoryPointer, params->byteAmount, params->mode, PPG_vmem_pageSize[0], OMRPORT_VMEM_PAGE_FLAG_NOT_USED, category);
 		}
 		Trc_PRT_vmem_omrvmem_reserve_memory_Exit2(memoryPointer);
 	} else if (PPG_vmem_pageSize[1] == params->pageSize) {
@@ -401,20 +409,11 @@ omrvmem_reserve_memory_ex(struct OMRPortLibrary *portLibrary, struct J9PortVmemI
 				if ((0 == minimumGranule) || (0 == (alignmentInBytes % minimumGranule))) {
 					memoryPointer = getMemoryInRange(portLibrary, identifier, defaultAllocationFlags, defaultProtection, category, params->byteAmount, params->startAddress, params->endAddress, alignmentInBytes, params->options, params->mode);
 				}
-				if (NULL == memoryPointer) {
-					Trc_PRT_vmem_omrvmem_reserve_memory_failure();
-					update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL);
-				} else {
-					update_vmemIdentifier(identifier, (void *)memoryPointer, (void *)memoryPointer, params->byteAmount, params->mode, PPG_vmem_pageSize[0], OMRPORT_VMEM_PAGE_FLAG_NOT_USED, category);
-				}
 			} else {
 				Trc_PRT_vmem_omrvmem_reserve_memory_failure();
 				lastError = GetLastError();
 				portLibrary->error_set_last_error(portLibrary, lastError, findError(lastError));
-				update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL);
 			}
-		} else {
-			update_vmemIdentifier(identifier, (void *)memoryPointer, (void *)memoryPointer, totalAllocateSize, params->mode, largePageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, category);
 		}
 		SetLockPagesPrivilege(GetCurrentProcess(), FALSE);
 	}
@@ -635,7 +634,7 @@ omrvmem_supported_page_flags(struct OMRPortLibrary *portLibrary)
  * @param[in] category Memory allocation category
  */
 void
-update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address,  void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, OMRMemCategory *category)
+update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address,  void *handle, uintptr_t byteAmount, uintptr_t mode, uintptr_t pageSize, uintptr_t pageFlags, OMRMemCategory *category, HANDLE fd)
 {
 	identifier->address = address;
 	identifier->handle = handle;
@@ -644,6 +643,7 @@ update_vmemIdentifier(J9PortVmemIdentifier *identifier, void *address,  void *ha
 	identifier->pageFlags = pageFlags;
 	identifier->mode = mode;
 	identifier->category = category;
+	identifier->fd = fd;
 }
 
 
@@ -783,6 +783,9 @@ _end:
 static void *
 getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier *identifier, DWORD allocationFlags, DWORD protection, OMRMemCategory *category, uintptr_t byteAmount, void *startAddress, void *endAddress, uintptr_t alignmentInBytes, uintptr_t vmemOptions, uintptr_t mode)
 {
+	HANDLE fd = NULL;
+	BOOLEAN useBackingSharedFile = FALSE;
+	BOOLEAN isLargePages = FALSE;
 	intptr_t direction = 1;
 	void *currentAddress = startAddress;
 	void *oldAddress;
@@ -792,8 +795,33 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 #endif
 
 	if(mode & OMRPORT_VMEM_MEMORY_MODE_SHARE_FILE_OPEN) {
-		portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
-		return memoryPointer;
+		useBackingSharedFile = TRUE;
+	}
+
+		// Should not modify anything up until here, or should I??
+	if (useBackingSharedFile) {
+		DWORD allocationFlags = PAGE_READWRITE;
+		if (0 != (OMRPORT_VMEM_MEMORY_MODE_COMMIT & mode)) {
+			allocationFlags &= ~SEC_RESERVE;
+			allocationFlags |= SEC_COMMIT;
+		} else {
+			allocationFlags &= ~SEC_COMMIT;
+			allocationFlags |= SEC_RESERVE;
+		}
+		// Get heap file descriptior
+		fd = CreateFileMapping(
+			INVALID_HANDLE_VALUE,
+			NULL,
+			allocationFlags,
+			0,
+			(DWORD)byteAmount,
+			NULL);
+		if (fd == NULL) {
+			Trc_PRT_vmem_omrvmem_reserve_memory_ex_file_handle_failed(byteAmount);
+			update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL, NULL);
+			Trc_PRT_vmem_omrvmem_reserve_memory_failure();
+			return memoryPointer;
+		}
 	}
 
 	/* check allocation direction */
@@ -857,17 +885,38 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 		}
 #endif
 
-		/* See comment above concerning CMVC 194435 */
-		memoryPointer = VirtualAlloc((LPVOID)currentAddress, (SIZE_T)byteAmount, allocationFlags & ~MEM_LARGE_PAGES, protection);
+		if (useBackingSharedFile) {
+			// Similar to mmap on POSIX
+			memoryPointer = MapViewOfFileEx(
+				fd,
+				FILE_MAP_WRITE, // read and write access
+				0,
+				0,
+				(SIZE_T)byteAmount,
+				(LPVOID)currentAddress);
+			// For now not worring about allocating for large pages
+			if (NULL != memoryPointer) {
+				if ((startAddress <= memoryPointer) && (endAddress >= memoryPointer)) {
+					break;
+				} else {
+					UnmapViewOfFile(memoryPointer);
+					memoryPointer = NULL ; /* This is necessary, cause below OMRPORT_VMEM_STRICT_ADDRESS if statement might try to free the same memoryPointer*/
+				}
+			}
+		} else {
+			/* See comment above concerning CMVC 194435 */
+			memoryPointer = VirtualAlloc((LPVOID)currentAddress, (SIZE_T)byteAmount, allocationFlags & ~MEM_LARGE_PAGES, protection);
 
-		if (NULL != memoryPointer) {
-			if (MEM_LARGE_PAGES == (allocationFlags & MEM_LARGE_PAGES)) {
-				void *smallPagesMemoryPointer = memoryPointer;
+			if (NULL != memoryPointer) {
+				if (MEM_LARGE_PAGES == (allocationFlags & MEM_LARGE_PAGES)) {
+					void *smallPagesMemoryPointer = memoryPointer;
 
-				VirtualFree((LPVOID)smallPagesMemoryPointer, (size_t)0, MEM_RELEASE);
-				memoryPointer = VirtualAlloc((LPVOID)currentAddress, (SIZE_T)byteAmount, allocationFlags, protection);
-				if (NULL == memoryPointer) {
-					Trc_PRT_vmem_omrvmem_reserve_memory_ex_UnableToReallocateWithLargePages(byteAmount, smallPagesMemoryPointer);
+					isLargePages = TRUE;
+					VirtualFree((LPVOID)smallPagesMemoryPointer, (size_t)0, MEM_RELEASE);
+					memoryPointer = VirtualAlloc((LPVOID)currentAddress, (SIZE_T)byteAmount, allocationFlags, protection);
+					if (NULL == memoryPointer) {
+						Trc_PRT_vmem_omrvmem_reserve_memory_ex_UnableToReallocateWithLargePages(byteAmount, smallPagesMemoryPointer);
+					}
 				}
 			}
 		}
@@ -902,14 +951,29 @@ getMemoryInRange(struct OMRPortLibrary *portLibrary, struct J9PortVmemIdentifier
 	if (NULL == memoryPointer) {
 		if (0 == (OMRPORT_VMEM_STRICT_ADDRESS & vmemOptions)) {
 allocAnywhere:
-			memoryPointer = VirtualAlloc(NULL, (SIZE_T)byteAmount, allocationFlags, protection);
+			if (useBackingSharedFile) {
+				memoryPointer = MapViewOfFile(
+					fd,
+					FILE_MAP_WRITE, // read and write access
+					0,
+					0,
+					(SIZE_T)byteAmount);
+			} else {
+				memoryPointer = VirtualAlloc(NULL, (SIZE_T)byteAmount, allocationFlags, protection);
+			}
 		} else {
 			Trc_PRT_vmem_omrvmem_reserve_memory_ex_UnableToAllocateWithinSpecifiedRange(byteAmount, startAddress, endAddress);
 		}
 	}
 
 	if (NULL != memoryPointer) {
+		uintptr_t pageSize = isLargePages ? PPG_vmem_pageSize[1] : PPG_vmem_pageSize[0];
+		update_vmemIdentifier(identifier, (void *)memoryPointer, (void *)memoryPointer, byteAmount, mode, pageSize, OMRPORT_VMEM_PAGE_FLAG_NOT_USED, category, fd);
 		omrmem_categories_increment_counters(category, (SIZE_T)byteAmount);
+
+	} else {
+		update_vmemIdentifier(identifier, NULL, NULL, 0, 0, 0, 0, NULL, NULL);
+		Trc_PRT_vmem_omrvmem_reserve_memory_failure();
 	}
 
 	return memoryPointer;

--- a/port/win32/protect_helpers.c
+++ b/port/win32/protect_helpers.c
@@ -73,6 +73,9 @@ uintptr_t
 protect_region_granularity(struct OMRPortLibrary *portLibrary, void *address)
 {
 	uintptr_t granularity = 0;
-	granularity = omrvmem_supported_page_sizes(portLibrary)[0];
+	SYSTEM_INFO systemInfo;
+	GetSystemInfo(&systemInfo);
+	granularity = (uintptr_t)systemInfo.dwAllocationGranularity;
+
 	return granularity;
 }

--- a/port/zos390/omrvmem.c
+++ b/port/zos390/omrvmem.c
@@ -1595,7 +1595,7 @@ isRmode64Supported()
 #endif
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
 	return NULL;

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1880,7 +1880,7 @@ omrvmem_get_process_memory_size(struct OMRPortLibrary *portLibrary,
 }
 
 void *
-omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, void* addresses[], uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
+omrvmem_get_contiguous_region_memory(struct OMRPortLibrary *portLibrary, uintptr_t* addresses, uintptr_t addressesCount, uintptr_t addressSize, uintptr_t byteAmount, struct J9PortVmemIdentifier *oldIdentifier, struct J9PortVmemIdentifier *newIdentifier, uintptr_t mode, uintptr_t pageSize, OMRMemCategory *category)
 {
 	portLibrary->error_set_last_error(portLibrary,  errno, OMRPORT_ERROR_VMEM_NOT_SUPPORTED);
 	return NULL;


### PR DESCRIPTION
Add file share support for WINDOWS and balanced GC policy
Add double map API support for WINDOWS and balanced GC policy

More details on double map can be found on the
initial commit for LINUX here: github/eclipse#3555