### PR TITLE
Improve coverage of IsolatedStoreElimination

### DIFF
--- a/compiler/optimizer/IsolatedStoreElimination.cpp
+++ b/compiler/optimizer/IsolatedStoreElimination.cpp
@@ -1154,7 +1154,7 @@ TR_IsolatedStoreElimination::findStructuresAndNodesUsedIn(TR_UseDefInfo *info, T
             {
             int32_t useIndex = (int32_t)useCursor + info->getFirstUseIndex();
             TR::Node *useNode = info->getNode(useIndex);
-            if (useNode && useNode->getReferenceCount() > 0 && !nodesInStructure->get(useNode->getGlobalIndex()))
+            if (useNode && useNode->getReferenceCount() > 0 && !nodesInStructure->get(useNode->getUseDefIndex()))
                {
                if (trace())
                   {
@@ -1228,7 +1228,8 @@ TR_IsolatedStoreElimination::findStructuresAndNodesUsedIn(TR_UseDefInfo *info, T
                       (loopTestNode->getOpCodeValue() == TR::ificmple) ||
                       (loopTestNode->getOpCodeValue() == TR::iflcmple))
                      {
-                     isIncreasing = true;
+                     if (loopTestNode->getBranchDestination()->getNode()->getBlock() == entryBlock)
+                        isIncreasing = true;
                      loopTestTree = nextBlock->getLastRealTreeTop();
                      }
                   else if ((loopTestNode->getOpCodeValue() == TR::ificmpgt) ||
@@ -1236,6 +1237,8 @@ TR_IsolatedStoreElimination::findStructuresAndNodesUsedIn(TR_UseDefInfo *info, T
                       (loopTestNode->getOpCodeValue() == TR::ificmpge) ||
                       (loopTestNode->getOpCodeValue() == TR::iflcmpge))
                      {
+                     if (loopTestNode->getBranchDestination()->getNode()->getBlock() != entryBlock)
+                        isIncreasing = true;
                      loopTestTree = nextBlock->getLastRealTreeTop();
                      }
                   }


### PR DESCRIPTION
This improves the cases recognized by the IsolateStoreElimiation
optimization. The optimization was previously recognizing
induction variables as not increasing when they were in fact
increasing. This change improves the recognition and more cases
can now be covered.

Also early in the optimization a nodes GlobalIndex was used to
check to verify that all defs were used within the current region.
This should be using the UseDefIndex to properly perform this check.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>