### PR TITLE
Introduce OMRVMMethodEnv.cpp stub

### DIFF
--- a/compiler/env/CMakeLists.txt
+++ b/compiler/env/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@ compiler_library(env
 	${CMAKE_CURRENT_LIST_DIR}/OMRClassEnv.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRDebugEnv.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRVMEnv.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRVMMethodEnv.cpp
 	${CMAKE_CURRENT_LIST_DIR}/SegmentAllocator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/SegmentProvider.cpp
 	${CMAKE_CURRENT_LIST_DIR}/SystemSegmentProvider.cpp

--- a/compiler/env/OMRVMMethodEnv.cpp
+++ b/compiler/env/OMRVMMethodEnv.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -72,6 +72,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/env/OMRClassEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRDebugEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRVMEnv.cpp \
+    $(JIT_OMR_DIRTY_DIR)/env/OMRVMMethodEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/SegmentProvider.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/SegmentAllocator.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/SystemSegmentProvider.cpp \

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -71,6 +71,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/env/OMRClassEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRDebugEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/OMRVMEnv.cpp \
+    $(JIT_OMR_DIRTY_DIR)/env/OMRVMMethodEnv.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/SegmentProvider.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/SegmentAllocator.cpp \
     $(JIT_OMR_DIRTY_DIR)/env/SystemSegmentProvider.cpp \


### PR DESCRIPTION
Add an empty file for project-specialized method queries and functions.

The staged approach is needed to prevent downstream breakages.  The file
will be populated when downstream projects are modified to build the new
file.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>