### PR TITLE
Remove J9 from omrsig* code [Part 1]

### DIFF
--- a/port/aix/omrsignal_context.c
+++ b/port/aix/omrsignal_context.c
@@ -31,9 +31,9 @@
  * Note: mcontext_t is a typedeffed __jmpbuf structure
  */
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/aix/omrsignal_context.h
+++ b/port/aix/omrsignal_context.h
@@ -40,13 +40,13 @@
  * sigcontext structure until the uc_link structure, which
  * follows the sigcontext structure.
  */
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	struct ld_info ldInfo[128];
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/aix/omrsignal_context.h
+++ b/port/aix/omrsignal_context.h
@@ -58,5 +58,5 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 

--- a/port/aix/omrsignal_context.h
+++ b/port/aix/omrsignal_context.h
@@ -26,12 +26,6 @@
 #include <sys/ucontext.h>
 #include <stdlib.h>
 
-#ifdef PPC64
-#define J9SIG_VALUE_UDATA OMRPORT_SIG_VALUE_64
-#else
-#define J9SIG_VALUE_UDATA OMRPORT_SIG_VALUE_32
-#endif
-
 #define MAX_UNIX_SIGNAL_TYPES  SIGMAX32
 
 /*

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -243,7 +243,7 @@ omrsig_map_portlib_signal_to_os_signal(struct OMRPortLibrary *portLibrary, uint3
  * for the portlibSignalFlag signal are left unchanged when this function overrides the master
  * handler. When the master handler is re-registered with the portlibSignalFlag signal, then
  * the records associated with master handler don't need to be restored. An example of records
- * is J9*AsyncHandlerRecord(s) in asyncHandlerList.
+ * is OMR*AsyncHandlerRecord(s) in asyncHandlerList.
  *
  * Each platform variant of omrsignal.c should have a signalMap. signalMap should have a list of
  * signals, which are supported on a platform. This function supports all signals listed in

--- a/port/common/omrsignal.c
+++ b/port/common/omrsignal.c
@@ -62,7 +62,7 @@
  * \arg OMRPORT_SIG_VALUE_FLOAT_64 -- value is a (double*) and points to a floating point value. No assumptions should be made about the validity of the floating point number.
  *
  * @note The caller may modify the value returned in value for some entries. Only entries in the OMRPORT_SIG_GPR, OMRPORT_SIG_CONTROL or OMRPORT_SIG_FPR categories may be modified.
- * @note If the exception is resumed using J9SIG_EXCEPTION_CONTINUE_EXECUTION, the modified values will be used
+ * @note If the exception is resumed using OMRPORT_SIG_EXCEPTION_CONTINUE_EXECUTION, the modified values will be used
  */
 uint32_t
 omrsig_info(struct OMRPortLibrary *portLibrary, void *info, uint32_t category, int32_t index, const char **name, void **value)

--- a/port/linux386/omrsignal_context.c
+++ b/port/linux386/omrsignal_context.c
@@ -30,9 +30,9 @@
 
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/linux386/omrsignal_context.h
+++ b/port/linux386/omrsignal_context.h
@@ -47,5 +47,5 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 

--- a/port/linux386/omrsignal_context.h
+++ b/port/linux386/omrsignal_context.h
@@ -29,13 +29,13 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	Dl_info dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/linuxaarch64/omrsignal_context.c
+++ b/port/linuxaarch64/omrsignal_context.c
@@ -35,9 +35,9 @@
 #define RESERVED_SPACE_SZ 4096
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/linuxaarch64/omrsignal_context.h
+++ b/port/linuxaarch64/omrsignal_context.h
@@ -47,5 +47,5 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 

--- a/port/linuxaarch64/omrsignal_context.h
+++ b/port/linuxaarch64/omrsignal_context.h
@@ -29,13 +29,13 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	Dl_info dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/linuxamd64/omrsignal_context.c
+++ b/port/linuxamd64/omrsignal_context.c
@@ -27,9 +27,9 @@
 
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/linuxamd64/omrsignal_context.h
+++ b/port/linuxamd64/omrsignal_context.h
@@ -47,6 +47,6 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 
 

--- a/port/linuxamd64/omrsignal_context.h
+++ b/port/linuxamd64/omrsignal_context.h
@@ -29,13 +29,13 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	Dl_info dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/linuxarm/omrsignal_context.c
+++ b/port/linuxarm/omrsignal_context.c
@@ -30,9 +30,9 @@
 
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/linuxarm/omrsignal_context.h
+++ b/port/linuxarm/omrsignal_context.h
@@ -47,5 +47,5 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 

--- a/port/linuxarm/omrsignal_context.h
+++ b/port/linuxarm/omrsignal_context.h
@@ -29,13 +29,13 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	Dl_info dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/linuxppc/omrsignal_context.c
+++ b/port/linuxppc/omrsignal_context.c
@@ -35,9 +35,9 @@
 #define NGPRS 32
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/linuxppc/omrsignal_context.c
+++ b/port/linuxppc/omrsignal_context.c
@@ -25,13 +25,6 @@
 #include <sys/ucontext.h>
 #include "omrsignal_context.h"
 
-
-#ifdef PPC64
-#define J9SIG_VALUE_UDATA OMRPORT_SIG_VALUE_64
-#else
-#define J9SIG_VALUE_UDATA OMRPORT_SIG_VALUE_32
-#endif
-
 #define NGPRS 32
 
 void

--- a/port/linuxppc/omrsignal_context.h
+++ b/port/linuxppc/omrsignal_context.h
@@ -67,6 +67,6 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 
 

--- a/port/linuxppc/omrsignal_context.h
+++ b/port/linuxppc/omrsignal_context.h
@@ -35,7 +35,7 @@
  * sigcontext structure until the uc_link structure, which
  * follows the sigcontext structure.
  */
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 #if 0
 	/* This neutered chunk of code is left here for reference for the underlying types accessed
@@ -49,10 +49,10 @@ typedef struct J9PlatformSignalInfo {
 #endif
 	Dl_info dl_info;
 
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/linuxs390/omrsignal_context.c
+++ b/port/linuxs390/omrsignal_context.c
@@ -27,9 +27,9 @@
 #define NUM_REGS 16
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/linuxs390/omrsignal_context.h
+++ b/port/linuxs390/omrsignal_context.h
@@ -64,5 +64,5 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 

--- a/port/linuxs390/omrsignal_context.h
+++ b/port/linuxs390/omrsignal_context.h
@@ -32,14 +32,14 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	uintptr_t breakingEventAddr;
 	Dl_info dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/osx/omrsignal_context.c
+++ b/port/osx/omrsignal_context.c
@@ -26,9 +26,9 @@
 #include <unistd.h>
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/osx/omrsignal_context.h
+++ b/port/osx/omrsignal_context.h
@@ -47,4 +47,4 @@ uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);

--- a/port/osx/omrsignal_context.h
+++ b/port/osx/omrsignal_context.h
@@ -29,13 +29,13 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	Dl_info dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -157,8 +157,8 @@ static omrthread_monitor_t asyncReporterShutdownMonitor;
 static uint32_t asyncThreadCount;
 static uint32_t attachedPortLibraries;
 
-struct J9SignalHandlerRecord {
-	struct J9SignalHandlerRecord *previous;
+struct OMRSignalHandlerRecord {
+	struct OMRSignalHandlerRecord *previous;
 	struct OMRPortLibrary *portLibrary;
 	omrsig_handler_fn handler;
 	void *handler_arg;
@@ -167,7 +167,7 @@ struct J9SignalHandlerRecord {
 	struct __jumpinfo farJumpInfo;
 #endif /* defined(J9ZOS390) */
 	uint32_t flags;
-};
+} OMRSignalHandlerRecord;
 
 typedef struct OMRCurrentSignal {
 	int signal;
@@ -331,7 +331,7 @@ omrsig_info_count(struct OMRPortLibrary *portLibrary, void *info, uint32_t categ
 int32_t
 omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void *fn_arg, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, uintptr_t *result)
 {
-	struct J9SignalHandlerRecord thisRecord = {0};
+	struct OMRSignalHandlerRecord thisRecord = {0};
 	omrthread_t thisThread = NULL;
 	uint32_t flagsSignalsOnly = flags & OMRPORT_SIG_FLAG_SIGALLSYNC;
 	uint32_t flagsWithoutMasterHandlers = flagsSignalsOnly & ~signalsWithMasterHandlers;
@@ -963,7 +963,7 @@ masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 	uint32_t result = U_32_MAX;
 
 	if (NULL != thisThread) {
-		struct J9SignalHandlerRecord *thisRecord = NULL;
+		struct OMRSignalHandlerRecord *thisRecord = NULL;
 		struct OMRCurrentSignal currentSignal = {0};
 		struct OMRCurrentSignal *previousSignal = NULL;
 		uint32_t portLibType = mapOSSignalToPortLib(signal, sigInfo);

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -987,7 +987,7 @@ masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 		while (NULL != thisRecord) {
 			if (OMR_ARE_ANY_BITS_SET(thisRecord->flags, portLibType)) {
 				struct OMRUnixSignalInfo j9Info;
-				struct J9PlatformSignalInfo platformSignalInfo;
+				struct OMRPlatformSignalInfo platformSignalInfo;
 
 				/* the equivalent of these memsets were here before, but were they needed? */
 				memset(&j9Info, 0, sizeof(j9Info));

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -986,30 +986,30 @@ masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 
 		while (NULL != thisRecord) {
 			if (OMR_ARE_ANY_BITS_SET(thisRecord->flags, portLibType)) {
-				struct OMRUnixSignalInfo j9Info;
+				struct OMRUnixSignalInfo signalInfo;
 				struct OMRPlatformSignalInfo platformSignalInfo;
 
 				/* the equivalent of these memsets were here before, but were they needed? */
-				memset(&j9Info, 0, sizeof(j9Info));
+				memset(&signalInfo, 0, sizeof(signalInfo));
 				memset(&platformSignalInfo, 0, sizeof(platformSignalInfo));
 
-				j9Info.portLibrarySignalType = portLibType;
-				j9Info.handlerAddress = (void *)thisRecord->handler;
-				j9Info.handlerAddress2 = (void *)masterSynchSignalHandler;
-				j9Info.sigInfo = sigInfo;
-				j9Info.platformSignalInfo = platformSignalInfo;
+				signalInfo.portLibrarySignalType = portLibType;
+				signalInfo.handlerAddress = (void *)thisRecord->handler;
+				signalInfo.handlerAddress2 = (void *)masterSynchSignalHandler;
+				signalInfo.sigInfo = sigInfo;
+				signalInfo.platformSignalInfo = platformSignalInfo;
 
 				/* found a suitable handler */
 				/* what signal type do we want to pass on here? port or platform based ?*/
-				fillInUnixSignalInfo(thisRecord->portLibrary, contextInfo, &j9Info);
+				fillInUnixSignalInfo(thisRecord->portLibrary, contextInfo, &signalInfo);
 #if defined(S390) && defined(LINUX)
-				j9Info.platformSignalInfo.breakingEventAddr = breakingEventAddr;
+				signalInfo.platformSignalInfo.breakingEventAddr = breakingEventAddr;
 #endif
 
 				/* remove the handler we are about to invoke, now, in case the handler crashes */
 				omrthread_tls_set(thisThread, tlsKey, thisRecord->previous);
 
-				result = thisRecord->handler(thisRecord->portLibrary, portLibType, &j9Info, thisRecord->handler_arg);
+				result = thisRecord->handler(thisRecord->portLibrary, portLibType, &signalInfo, thisRecord->handler_arg);
 
 				/* The only case in which we don't want the previous handler back on top is if it just returned OMRPORT_SIG_EXCEPTION_RETURN
 				 * 		In this case we will remove it from the top after executing the siglongjmp */
@@ -1370,7 +1370,7 @@ mapOSSignalToPortLib(uint32_t signalNo, siginfo_t *sigInfo)
  *
  * Note that FPE signal codes (subtypes) all map to the same signal number and are not included
  *
- * @param portLibSignal The internal J9 Port Library signal number
+ * @param portLibSignal The internal port library signal number
  *
  * @return The corresponding Unix signal number or OMRPORT_SIG_ERROR (-1) if the portLibSignal
  *         could not be mapped

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -105,18 +105,18 @@ static uint32_t shutDownASynchReporter;
 
 static uint32_t attachedPortLibraries;
 
-typedef struct J9UnixAsyncHandlerRecord {
+typedef struct OMRUnixAsyncHandlerRecord {
 	OMRPortLibrary *portLib;
 	omrsig_handler_fn handler;
 	void *handler_arg;
 	uint32_t flags;
-	struct J9UnixAsyncHandlerRecord *next;
-} J9UnixAsyncHandlerRecord;
+	struct OMRUnixAsyncHandlerRecord *next;
+} OMRUnixAsyncHandlerRecord;
 
 /* holds the options set by omrsig_set_options */
 uint32_t signalOptionsGlobal;
 
-static J9UnixAsyncHandlerRecord *asyncHandlerList;
+static OMRUnixAsyncHandlerRecord *asyncHandlerList;
 
 #if !defined(J9ZOS390)
 
@@ -405,8 +405,8 @@ int32_t
 omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags)
 {
 	int32_t rc = 0;
-	J9UnixAsyncHandlerRecord *cursor = NULL;
-	J9UnixAsyncHandlerRecord **previousLink = NULL;
+	OMRUnixAsyncHandlerRecord *cursor = NULL;
+	OMRUnixAsyncHandlerRecord **previousLink = NULL;
 
 	Trc_PRT_signal_omrsig_set_async_signal_handler_entered(handler, handler_arg, flags);
 
@@ -465,7 +465,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handl
 	if (NULL == cursor) {
 		/* cursor will only be NULL if we failed to find it in the list */
 		if (0 != flags) {
-			J9UnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+			OMRUnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 
 			if (NULL == record) {
 				rc = OMRPORT_SIG_ERROR;
@@ -493,8 +493,8 @@ int32_t
 omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t portlibSignalFlag, void **oldOSHandler)
 {
 	uint32_t rc = 0;
-	J9UnixAsyncHandlerRecord *cursor = NULL;
-	J9UnixAsyncHandlerRecord **previousLink = NULL;
+	OMRUnixAsyncHandlerRecord *cursor = NULL;
+	OMRUnixAsyncHandlerRecord **previousLink = NULL;
 	BOOLEAN foundHandler = FALSE;
 
 	Trc_PRT_signal_omrsig_set_single_async_signal_handler_entered(handler, handler_arg, portlibSignalFlag);
@@ -566,7 +566,7 @@ omrsig_set_single_async_signal_handler(struct OMRPortLibrary *portLibrary, omrsi
 	}
 
 	if (!foundHandler && (0 != portlibSignalFlag)) {
-		J9UnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
+		OMRUnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record), OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 		if (NULL == record) {
 			rc = OMRPORT_SIG_ERROR;
 		} else {
@@ -756,7 +756,7 @@ countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t cat
 #if defined(OMR_PORT_ASYNC_HANDLER)
 /**
  * Given a port library signal flag and Unix signal value, execute the associated handlers
- * stored within asyncHandlerList (list of J9UnixAsyncHandlerRecord).
+ * stored within asyncHandlerList (list of OMRUnixAsyncHandlerRecord).
  *
  * @param asyncSignalFlag port library signal flag
  * @param unixSignal Unix signal value
@@ -766,7 +766,7 @@ countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t cat
 static void
 runHandlers(uint32_t asyncSignalFlag, int unixSignal)
 {
-	J9UnixAsyncHandlerRecord *cursor = asyncHandlerList;
+	OMRUnixAsyncHandlerRecord *cursor = asyncHandlerList;
 
 	/* report the signal recorded in signalType to all registered listeners (for this signal).
 	 * incrementing the asyncThreadCount will prevent the list from being modified while we use it.
@@ -1766,8 +1766,8 @@ static void
 removeAsyncHandlers(OMRPortLibrary *portLibrary)
 {
 	/* clean up the list of async handlers */
-	J9UnixAsyncHandlerRecord *cursor = NULL;
-	J9UnixAsyncHandlerRecord **previousLink = NULL;
+	OMRUnixAsyncHandlerRecord *cursor = NULL;
+	OMRUnixAsyncHandlerRecord **previousLink = NULL;
 
 	omrthread_monitor_enter(asyncMonitor);
 

--- a/port/win32/omrintrospect.c
+++ b/port/win32/omrintrospect.c
@@ -357,7 +357,7 @@ setup_native_thread(J9ThreadWalkState *state, CONTEXT *sigContext)
 J9PlatformThread *
 omrintrospect_threads_startDo_with_signal(struct OMRPortLibrary *portLibrary, J9Heap *heap, J9ThreadWalkState *state, void *signal_info)
 {
-	struct J9Win32SignalInfo *sigFaultInfo = signal_info;
+	struct OMRWin32SignalInfo *sigFaultInfo = signal_info;
 	DWORD processId = GetCurrentProcessId();
 	struct PlatformWalkData *data;
 	int result = 0;

--- a/port/win32/omrosbacktrace_impl.c
+++ b/port/win32/omrosbacktrace_impl.c
@@ -256,7 +256,7 @@ omrintrospect_backtrace_thread_raw(struct OMRPortLibrary *portLibrary, J9Platfor
 	CONTEXT threadContext = {0};
 	STACKFRAME64 stackFrame;
 	J9PlatformStackFrame **nextFrame;
-	struct J9Win32SignalInfo *sigInfo = (struct J9Win32SignalInfo *)signalInfo;
+	struct OMRWin32SignalInfo *sigInfo = (struct OMRWin32SignalInfo *)signalInfo;
 
 	if (threadInfo == NULL || (threadInfo->context == NULL && sigInfo == NULL)) {
 		return 0;

--- a/port/win32/omrosdump.c
+++ b/port/win32/omrosdump.c
@@ -110,7 +110,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 	HANDLE hThread;
 	MINIDUMP_EXCEPTION_INFORMATION mdei;
 	EXCEPTION_POINTERS exceptionPointers;
-	J9Win32SignalInfo *info = (J9Win32SignalInfo *)userData;
+	OMRWin32SignalInfo *info = (OMRWin32SignalInfo *)userData;
 
 	if (filename == NULL) {
 		return 1;

--- a/port/win32/omrsignal.c
+++ b/port/win32/omrsignal.c
@@ -98,15 +98,15 @@ static omrthread_monitor_t asyncReporterShutdownMonitor;
 static uint32_t shutDownASynchReporter;
 
 static uint32_t mapWin32ExceptionToPortlibType(uint32_t exceptionCode);
-static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
 static void removeAsyncHandlers(OMRPortLibrary *portLibrary);
-static void fillInWin32SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct J9Win32SignalInfo *signalInfo);
-static uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
-static uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
+static void fillInWin32SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct OMRWin32SignalInfo *signalInfo);
+static uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
 static uint32_t countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t category);
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType);
 int structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, EXCEPTION_POINTERS *exceptionInfo);
-static uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
 static intptr_t setCurrentSignal(struct OMRPortLibrary *portLibrary, intptr_t signal);
 
 static uint32_t mapOSSignalToPortLib(uint32_t signalNo);
@@ -485,7 +485,7 @@ structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn
 	uint32_t result;
 	uint32_t type;
 	intptr_t prevSigType;
-	struct J9Win32SignalInfo signalInfo;
+	struct OMRWin32SignalInfo signalInfo;
 
 	if ((exceptionInfo->ExceptionRecord->ExceptionCode & (ERROR_SEVERITY_ERROR | APPLICATION_ERROR_MASK)) != ERROR_SEVERITY_ERROR) {
 		return EXCEPTION_CONTINUE_SEARCH;
@@ -560,7 +560,7 @@ mapWin32ExceptionToPortlibType(uint32_t exceptionCode)
 }
 
 static void
-fillInWin32SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct J9Win32SignalInfo *signalInfo)
+fillInWin32SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct OMRWin32SignalInfo *signalInfo)
 {
 	memset(signalInfo, 0, sizeof(*signalInfo));
 
@@ -574,7 +574,7 @@ fillInWin32SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn hand
 }
 
 static uint32_t
-infoForSignal(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -640,7 +640,7 @@ infoForSignal(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info
 }
 
 static uint32_t
-infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -691,7 +691,7 @@ infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, i
 }
 
 static uint32_t
-infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForControl(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -748,7 +748,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *inf
 }
 
 static uint32_t
-infoForModule(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForModule(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	if (info->moduleBaseAddress == NULL) {
 		MEMORY_BASIC_INFORMATION mbi;

--- a/port/win32_include/omrsignal.h
+++ b/port/win32_include/omrsignal.h
@@ -25,7 +25,7 @@
 
 #include "omrcomp.h"
 
-typedef struct J9Win32SignalInfo {
+typedef struct OMRWin32SignalInfo {
 	uint32_t type;
 	void *handlerAddress;
 	void *handlerAddress2;
@@ -35,7 +35,7 @@ typedef struct J9Win32SignalInfo {
 	uint32_t offsetInDLL;
 	uint32_t threadId;
 	char moduleName[_MAX_PATH];
-} J9Win32SignalInfo;
+} OMRWin32SignalInfo;
 
 #endif     /* omrsignal_h */
 

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -59,10 +59,10 @@ typedef struct UNWIND_INFO {
 	OPTIONAL uint32_t ExceptionData[];
 } UNWIND_INFO;
 
-typedef struct J9CurrentSignal {
+typedef struct OMRCurrentSignal {
 	EXCEPTION_POINTERS *exceptionInfo;
 	uint32_t portLibSignalType;
-} J9CurrentSignal;
+} OMRCurrentSignal;
 
 /* key to get the current synchronous signal */
 static omrthread_tls_key_t tlsKeyCurrentSignal;
@@ -269,7 +269,7 @@ omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void 
 	/* We can not use setjmp/longjmp to jump out of a VectoredExceptionHandler (CMVC 175576), so use _try/_except semantics instead */
 	if (OMR_ARE_ALL_BITS_SET(flags, OMRPORT_SIG_FLAG_MAY_RETURN)) {
 
-		J9CurrentSignal *currentSignal = omrthread_tls_get(thisThread, tlsKeyCurrentSignal);
+		OMRCurrentSignal *currentSignal = omrthread_tls_get(thisThread, tlsKeyCurrentSignal);
 		int32_t exceptionStatus = OMRPORT_SIG_NO_EXCEPTION;
 
 		/* The VectoredExceptionHandler will get notified before the _except clause/block below,
@@ -646,7 +646,7 @@ intptr_t
 omrsig_get_current_signal(struct OMRPortLibrary *portLibrary)
 {
 	omrthread_t thisThread = omrthread_self();
-	struct J9CurrentSignal *currentSignal = omrthread_tls_get(thisThread, tlsKeyCurrentSignal);
+	struct OMRCurrentSignal *currentSignal = omrthread_tls_get(thisThread, tlsKeyCurrentSignal);
 
 	if (currentSignal != NULL) {
 		return currentSignal->portLibSignalType;
@@ -1143,8 +1143,8 @@ masterVectoredExceptionHandler(EXCEPTION_POINTERS *exceptionInfo)
 {
 	uint32_t portLibType;
 	struct J9SignalHandlerRecord *thisRecord;
-	struct J9CurrentSignal currentSignal;
-	struct J9CurrentSignal *previousSignal;
+	struct OMRCurrentSignal currentSignal;
+	struct OMRCurrentSignal *previousSignal;
 	omrthread_t thisThread = NULL;
 
 	if ((exceptionInfo->ExceptionRecord->ExceptionCode & (ERROR_SEVERITY_ERROR | APPLICATION_ERROR_MASK)) != ERROR_SEVERITY_ERROR) {
@@ -1242,8 +1242,8 @@ structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn
 	struct J9Win32SignalInfo signalInfo;
 	omrthread_t thisThread;
 	struct J9SignalHandlerRecord *thisRecord;
-	struct J9CurrentSignal currentSignal;
-	struct J9CurrentSignal *previousSignal;
+	struct OMRCurrentSignal currentSignal;
+	struct OMRCurrentSignal *previousSignal;
 
 	if ((exceptionInfo->ExceptionRecord->ExceptionCode & (ERROR_SEVERITY_ERROR | APPLICATION_ERROR_MASK)) != ERROR_SEVERITY_ERROR) {
 		return EXCEPTION_CONTINUE_SEARCH;

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -68,15 +68,15 @@ typedef struct OMRCurrentSignal {
 static omrthread_tls_key_t tlsKeyCurrentSignal;
 static RUNTIME_FUNCTION *j9SigProtectFunction = NULL;
 
-struct J9SignalHandlerRecord {
-	struct J9SignalHandlerRecord *previous;
+struct OMRSignalHandlerRecord {
+	struct OMRSignalHandlerRecord *previous;
 	struct OMRPortLibrary *portLibrary;
 	omrsig_handler_fn handler;
 	void *handler_arg;
 	jmp_buf returnBuf;
 	uint32_t flags;
 	BOOLEAN deferToTryExcept;
-};
+} OMRSignalHandlerRecord;
 
 typedef struct J9WinAMD64AsyncHandlerRecord {
 	OMRPortLibrary *portLib;
@@ -228,7 +228,7 @@ runInTryExcept(struct OMRPortLibrary *portLibrary,
 int32_t
 omrsig_protect(struct OMRPortLibrary *portLibrary, omrsig_protected_fn fn, void *fn_arg, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, uintptr_t *result)
 {
-	struct J9SignalHandlerRecord thisRecord;
+	struct OMRSignalHandlerRecord thisRecord;
 	uintptr_t rc = 0;
 	omrthread_t thisThread = omrthread_self();
 
@@ -1142,7 +1142,7 @@ static LONG WINAPI
 masterVectoredExceptionHandler(EXCEPTION_POINTERS *exceptionInfo)
 {
 	uint32_t portLibType;
-	struct J9SignalHandlerRecord *thisRecord;
+	struct OMRSignalHandlerRecord *thisRecord;
 	struct OMRCurrentSignal currentSignal;
 	struct OMRCurrentSignal *previousSignal;
 	omrthread_t thisThread = NULL;
@@ -1241,7 +1241,7 @@ structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn
 	uint32_t type;
 	struct J9Win32SignalInfo signalInfo;
 	omrthread_t thisThread;
-	struct J9SignalHandlerRecord *thisRecord;
+	struct OMRSignalHandlerRecord *thisRecord;
 	struct OMRCurrentSignal currentSignal;
 	struct OMRCurrentSignal *previousSignal;
 

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -147,16 +147,16 @@ static uint32_t shutDownASynchReporter;
 #endif /* defined(OMR_PORT_ASYNC_HANDLER) */
 
 static uint32_t mapWin32ExceptionToPortlibType(uint32_t exceptionCode);
-static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
-static uint32_t infoForFPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
-static uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
-static uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
-static uint32_t infoForOther(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForFPR(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
+static uint32_t infoForOther(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
 static uint32_t countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t category);
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType);
 static LONG WINAPI masterVectoredExceptionHandler(EXCEPTION_POINTERS *exceptionInfo);
-static uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value);
-static void fillInWinAMD64SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct J9Win32SignalInfo *signalInfo);
+static uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value);
+static void fillInWinAMD64SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct OMRWin32SignalInfo *signalInfo);
 static void sig_full_shutdown(struct OMRPortLibrary *portLibrary);
 static void destroySignalTools(OMRPortLibrary *portLibrary);
 static uint32_t addMasterVectoredExceptionHandler(struct OMRPortLibrary *portLibrary);
@@ -773,7 +773,7 @@ tryExceptHandlerExistsOnStack(OMRPortLibrary *portLibrary, CONTEXT *originalCont
 }
 
 static uint32_t
-infoForOther(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForOther(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -796,7 +796,7 @@ infoForOther(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info,
 
 
 static uint32_t
-infoForSignal(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -855,7 +855,7 @@ infoForSignal(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info
 }
 
 static uint32_t
-infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -956,7 +956,7 @@ infoForGPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, i
 }
 
 static uint32_t
-infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForControl(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -1007,7 +1007,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *inf
 }
 
 static uint32_t
-infoForModule(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForModule(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	if (info->moduleBaseAddress == NULL) {
 		MEMORY_BASIC_INFORMATION mbi;
@@ -1060,7 +1060,7 @@ countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t cat
 }
 
 static uint32_t
-infoForFPR(struct OMRPortLibrary *portLibrary, struct J9Win32SignalInfo *info, int32_t index, const char **name, void **value)
+infoForFPR(struct OMRPortLibrary *portLibrary, struct OMRWin32SignalInfo *info, int32_t index, const char **name, void **value)
 {
 	*name = "";
 
@@ -1183,7 +1183,7 @@ masterVectoredExceptionHandler(EXCEPTION_POINTERS *exceptionInfo)
 	/* walk the stack of registered handlers from top to bottom searching for one which handles this type of exception */
 	while (thisRecord) {
 		if (thisRecord->flags & portLibType) {
-			struct J9Win32SignalInfo signalInfo;
+			struct OMRWin32SignalInfo signalInfo;
 			uintptr_t result;
 
 			/* found a suitable handler */
@@ -1239,7 +1239,7 @@ structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn
 {
 	uintptr_t result;
 	uint32_t type;
-	struct J9Win32SignalInfo signalInfo;
+	struct OMRWin32SignalInfo signalInfo;
 	omrthread_t thisThread;
 	struct OMRSignalHandlerRecord *thisRecord;
 	struct OMRCurrentSignal currentSignal;
@@ -1469,7 +1469,7 @@ sig_full_shutdown(struct OMRPortLibrary *portLibrary)
 }
 
 static void
-fillInWinAMD64SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct J9Win32SignalInfo *signalInfo)
+fillInWinAMD64SignalInfo(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, EXCEPTION_POINTERS *exceptionInfo, struct OMRWin32SignalInfo *signalInfo)
 {
 	memset(signalInfo, 0, sizeof(*signalInfo));
 

--- a/port/win64amd/omrsignal.h
+++ b/port/win64amd/omrsignal.h
@@ -25,7 +25,7 @@
 
 #include "omrcomp.h"
 
-typedef struct J9Win32SignalInfo {
+typedef struct OMRWin32SignalInfo {
 	uint32_t systemType;
 	uint32_t portLibType;
 	void *handlerAddress;
@@ -37,7 +37,7 @@ typedef struct J9Win32SignalInfo {
 	char moduleName[_MAX_PATH];
 	BOOLEAN deferToTryExcept;
 	BOOLEAN tryExceptHandlerIgnore;
-} J9Win32SignalInfo;
+} OMRWin32SignalInfo;
 
 #endif     /* omrsignal_h */
 

--- a/port/zos390/omrsignal_ceehdlr.c
+++ b/port/zos390/omrsignal_ceehdlr.c
@@ -37,7 +37,7 @@
 #include "portnls.h"
 
 #if 0
-#define J9SIGNAL_DEBUG
+#define OMRSIGNAL_DEBUG
 #endif
 
 /* in port/unix/omrsignal.c */
@@ -104,7 +104,7 @@ j9vm_le_condition_handler(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBAC
 	const char *ceeEbcdic = "CEE";
 #pragma convlit(resume)
 
-#if defined(J9SIGNAL_DEBUG)
+#if defined(OMRSIGNAL_DEBUG)
 	static int count = 0;
 
 	printf("j9vm_le_condition_handler count: %i, %s%i, sev: %i\n", count, e2a_func(fc->tok_facid, 3), fc->tok_msgno, fc->tok_sev);
@@ -244,7 +244,7 @@ omrsig_protect_ceehdlr(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn 
 	_ENTRY leConditionHandler;
 	_INT4 token;
 
-#if defined(J9SIGNAL_DEBUG)
+#if defined(OMRSIGNAL_DEBUG)
 	printf(" \nomrsig_protect_ceehdlr\n");
 	fflush(NULL);
 #endif
@@ -270,7 +270,7 @@ omrsig_protect_ceehdlr(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn 
 
 		/* verify that CEEHDLR was successful */
 		if (_FBCHECK(fc, CEE000) != 0) {
-#if defined(J9SIGNAL_DEBUG)
+#if defined(OMRSIGNAL_DEBUG)
 			printf("CEEHDLR failed with message number %d\n", fc.tok_msgno);
 			fflush(stdout);
 #endif

--- a/port/zos390/omrsignal_context.c
+++ b/port/zos390/omrsignal_context.c
@@ -79,10 +79,10 @@ checkIfResumableTrapsSupported(struct OMRPortLibrary *portLibrary)
 
 
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
 	/* __mcontext_t_ is defined in port/zos390/edcwccwi.h and appears to overlay the ucontext_t structure */
-	j9Info->platformSignalInfo.context = (__mcontext_t_ *) contextInfo;
+	signalInfo->platformSignalInfo.context = (__mcontext_t_ *) contextInfo;
 	/* module info is filled on demand */
 }
 

--- a/port/zos390/omrsignal_context.h
+++ b/port/zos390/omrsignal_context.h
@@ -57,6 +57,6 @@ uint32_t infoForVR(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, 
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info);
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo);
 BOOLEAN checkIfResumableTrapsSupported(struct OMRPortLibrary *portLibrary);
 

--- a/port/zos390/omrsignal_context.h
+++ b/port/zos390/omrsignal_context.h
@@ -32,7 +32,7 @@
 #define NUM_REGS 16
 #define NUM_VECTOR_REGS 32
 
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	__mcontext_t_ *context;
 	uintptr_t breakingEventAddr;
 #if !defined(J9ZOS39064)
@@ -41,14 +41,14 @@ typedef struct J9PlatformSignalInfo {
 	char entry_name[MAX_NAME];
 	_INT4 entry_address;
 #endif
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 typedef struct OMRUnixSignalInfo {
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;
 	siginfo_t *sigInfo;
-	struct J9PlatformSignalInfo platformSignalInfo;
+	struct OMRPlatformSignalInfo platformSignalInfo;
 } OMRUnixSignalInfo;
 
 uint32_t infoForFPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -790,7 +790,7 @@ masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDA
 
 			if (OMR_ARE_ANY_BITS_SET(thisRecord->flags,portLibType)) {
 				struct OMRUnixSignalInfo j9Info;
-				struct J9PlatformSignalInfo platformSignalInfo;
+				struct OMRPlatformSignalInfo platformSignalInfo;
 
 				/*
 				 * the equivalent of these memsets were here before, but were they needed? 

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -234,18 +234,18 @@ static uint32_t	shutDownASynchReporter;
 
 static uint32_t	attachedPortLibraries;
 
-typedef struct J9UnixAsyncHandlerRecord {
+typedef struct OMRUnixAsyncHandlerRecord {
 	OMRPortLibrary* portLib;
 	omrsig_handler_fn handler;
 	void *handler_arg;
 	uint32_t flags;
-	struct J9UnixAsyncHandlerRecord	*next;
-} J9UnixAsyncHandlerRecord;
+	struct OMRUnixAsyncHandlerRecord *next;
+} OMRUnixAsyncHandlerRecord;
 
 /* holds the options set by omrsig_set_options */
 uint32_t signalOptionsGlobal;
 
-static J9UnixAsyncHandlerRecord	*asyncHandlerList = NULL;
+static OMRUnixAsyncHandlerRecord *asyncHandlerList = NULL;
 
 /* asyncSignalReporter synchronization	*/
 
@@ -462,8 +462,8 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handl
 							   void* handler_arg, uint32_t flags)
 {
 	int32_t rc = 0;
-	J9UnixAsyncHandlerRecord *cursor;
-	J9UnixAsyncHandlerRecord **previousLink;
+	OMRUnixAsyncHandlerRecord *cursor;
+	OMRUnixAsyncHandlerRecord **previousLink;
 
 	Trc_PRT_signal_omrsig_set_async_signal_handler_entered(handler, handler_arg, flags);
 	
@@ -525,7 +525,7 @@ omrsig_set_async_signal_handler(struct OMRPortLibrary* portLibrary, omrsig_handl
 
 	if (NULL == cursor) {							/* cursor will only be NULL if we failed to find it in the list */
 		if (0 != flags) {
-			J9UnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record),
+			OMRUnixAsyncHandlerRecord *record = portLibrary->mem_allocate_memory(portLibrary, sizeof(*record),
 																				OMR_GET_CALLSITE(),
 																				OMRMEM_CATEGORY_PORT_LIBRARY);
 			if (NULL == record) {
@@ -667,7 +667,7 @@ countInfoInCategory(struct OMRPortLibrary *portLibrary, void *info, uint32_t cat
 static int32_t J9THREAD_PROC
 asynchSignalReporter(void *userData) {
 
-	J9UnixAsyncHandlerRecord* cursor;
+	OMRUnixAsyncHandlerRecord *cursor;
 	uint32_t asyncSignalFlag = 0;
 	int result = 0;
 	omrthread_set_name(omrthread_self(), "Signal Reporter");
@@ -1350,8 +1350,8 @@ static void
 removeAsyncHandlers(OMRPortLibrary* portLibrary)
 {
 	/* clean up the list of async handlers */
-	J9UnixAsyncHandlerRecord* cursor;
-	J9UnixAsyncHandlerRecord** previousLink;
+	OMRUnixAsyncHandlerRecord *cursor;
+	OMRUnixAsyncHandlerRecord **previousLink;
 
 	omrthread_monitor_enter(asyncMonitor);
 

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -363,7 +363,7 @@ int32_t
 omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void* fn_arg,
 					 omrsig_handler_fn handler, void* handler_arg, uint32_t flags, UDATA *result )
 {
-	struct J9SignalHandlerRecord thisRecord;
+	struct OMRSignalHandlerRecord thisRecord;
 	omrthread_t thisThread;
 	uint32_t rc = 0;
 	uint32_t flagsSignalsOnly;
@@ -759,7 +759,7 @@ masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDA
 
 	if (NULL != thisThread) {
 		uint32_t portLibType;
-		struct J9SignalHandlerRecord* thisRecord;
+		struct OMRSignalHandlerRecord *thisRecord;
 		struct OMRCurrentSignal currentSignal; 
 		struct OMRCurrentSignal *previousSignal;
 		

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -412,7 +412,7 @@ omrsig_protect(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void
 	thisRecord.flags = flags;
 
 	if (OMR_ARE_ANY_BITS_SET(flags, OMRPORT_SIG_FLAG_MAY_RETURN)) {
-		J9CurrentSignal *currentSignal;
+		OMRCurrentSignal *currentSignal;
 		/* 
 		 * Record the current signal. We need to store this value back into tls if we
 		 * jump back into this function because any signals that may have occurred 
@@ -760,8 +760,8 @@ masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, UDA
 	if (NULL != thisThread) {
 		uint32_t portLibType;
 		struct J9SignalHandlerRecord* thisRecord;
-		struct J9CurrentSignal currentSignal; 
-		struct J9CurrentSignal *previousSignal;
+		struct OMRCurrentSignal currentSignal; 
+		struct OMRCurrentSignal *previousSignal;
 		
 		/* Trc_PRT_signal_masterSynchSignalHandler_entered(signal, sigInfo, contextInfo); */
 
@@ -1296,7 +1296,7 @@ omrsig_get_options(struct OMRPortLibrary *portLibrary)
 intptr_t
 omrsig_get_current_signal(struct OMRPortLibrary *portLibrary)
 {
-	J9CurrentSignal * currentSignal = omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
+	OMRCurrentSignal * currentSignal = omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
 	if (currentSignal == NULL) {
 		return 0;
 	}
@@ -1389,7 +1389,7 @@ void
 omrsig_chain_at_shutdown_and_exit(struct OMRPortLibrary *portLibrary)
 {
 
-	J9CurrentSignal *currentSignal = omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
+	OMRCurrentSignal *currentSignal = omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
 
 	Trc_PRT_signal_omrsig_chain_at_shutdown_and_exit_enter(portLibrary);
 

--- a/port/ztpf/omrsignal.h
+++ b/port/ztpf/omrsignal.h
@@ -31,14 +31,14 @@
  *	possibly unique to z/TPF at some later time.
  */
 
-struct J9SignalHandlerRecord {
-	struct J9SignalHandlerRecord *previous;
+struct OMRSignalHandlerRecord {
+	struct OMRSignalHandlerRecord *previous;
 	struct OMRPortLibrary *portLibrary;
 	omrsig_handler_fn handler;
 	void *handler_arg;
 	jmp_buf	mark;			
 	uint32_t flags;
-};
+} OMRSignalHandlerRecord;
 
 typedef struct OMRCurrentSignal {
 	int	signal;

--- a/port/ztpf/omrsignal.h
+++ b/port/ztpf/omrsignal.h
@@ -40,14 +40,14 @@ struct J9SignalHandlerRecord {
 	uint32_t flags;
 };
 
-typedef struct J9CurrentSignal {
+typedef struct OMRCurrentSignal {
 	int	signal;
 	siginfo_t *sigInfo;
 	void *contextInfo;
 	uintptr_t breakingEventAddr;
 	uint32_t portLibSignalType;
 	DIB	*ptrDIB;
-} J9CurrentSignal;
+} OMRCurrentSignal;
 
 void masterSynchSignalHandler(int signal, siginfo_t * sigInfo, void *contextInfo, uintptr_t breakingEventAddr);
 

--- a/port/ztpf/omrsignal_context.c
+++ b/port/ztpf/omrsignal_context.c
@@ -166,7 +166,7 @@ static uint32_t	regions_used;
  * before reusing it.
  *
  * This E/P must be exported! File module.xml is therefore modified conditionally to 
- * export this label, and it will appear in j9prt.exp when it is created for z/TPF, 
+ * export this label, and it will appear in omrprt.exp when it is created for z/TPF,
  * when the buildtools are built. z/TPF is the only known system which needs this 
  * kind of allocation. It is used exclusively for the translation of z/TPF-ish data 
  * into UNIX-ish context & signal blocks.
@@ -401,14 +401,14 @@ translateInterruptContexts( args *argv ) {
  *
  * \param[in]	portLibrary		Pointer to the OMRPortLibrary in use
  * \param[in]	contextInfo		Pointer to context information
- * \param[out]	j9info			Pointer to a OMRUnixSignalInfo structure
+ * \param[out]	signalinfo		Pointer to a OMRUnixSignalInfo structure
  *
  * \returns		Not a thing.
  */
 void
-fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)
+fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)
 {
-	j9Info->platformSignalInfo.context = (ucontext_t *)contextInfo;		/* module info is filled on demand */
+	signalInfo->platformSignalInfo.context = (ucontext_t *)contextInfo;		/* module info is filled on demand */
 }
 
 
@@ -417,13 +417,13 @@ fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, stru
  *
  * This routine stores the name and value attributes of a given signal 
  * described in a OMRUnixSignalInfo structure whose address is passed 
- * by the caller. The <TT>index</TT> parameter is the artificial J9
+ * by the caller. The <TT>index</TT> parameter is the artificial
  * signal value (or 'class type'?) associated with the kind of signal.
  *
  * \param[in]	portLibrary		The OMRPortLibrary in use
  * \param[in]	info			A pointer to the OMRUnixSignalInfo from which the information
  *								is taken
- * \param[in]	index			The J9 signal value assigned to the 'signal type'
+ * \param[in]	index			The signal value assigned to the 'signal type'
  * \param[out]	name			The name of the signal type class, double pointer to type char
  * \param[out]	value			The real (raw) signal number
  *
@@ -550,7 +550,7 @@ infoForFPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, i
  *			in z/TPF, no matter what it was. 
  * \note	This routine was unguarded as part of making the CP emulate kernel-space, UNIX-
  *			style implementations of reactions to program interrupts.
- * \note	There were guard macros here based on #ifndef J9VM_ENV_DATA64 which I've simply
+ * \note	There were guard macros here based on #ifndef OMR_ENV_DATA64 which I've simply
  *			removed. If the guard value were true, there were 16 more definition slots for
  *			the high parts of the general registers. All gone; we don't support 32-bit 
  *			hardware (even if we do grudgingly support AMODE=31).
@@ -591,7 +591,7 @@ infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, i
  *
  * \param[in]	portLibrary		Pointer to the portability library in use
  * \param[in]	info			Pointer to OMRUnixSignalInfo block
- * \param[in]	index			The J9 'type class' of the signal associated with this dump
+ * \param[in]	index			The 'type class' of the signal associated with this dump
  * \param[out]	name			Dbl pointer to a buffer large enough to hold an object name
  * \param[out]	value			Dbl pointer to a buffer large enough to hold an object value
  *

--- a/port/ztpf/omrsignal_context.h
+++ b/port/ztpf/omrsignal_context.h
@@ -36,19 +36,12 @@
 #include <dlfcn.h>
 #undef __USE_GNU
 
-
-/*
- * This structure declaration came in this file in this format from J9
- */
 typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	uintptr_t breakingEventAddr;
 	Dl_info	dl_info;
 } OMRPlatformSignalInfo;
 
-/*
- * This structure declaration came in this file in this format from J9
- */
 typedef struct OMRUnixSignalInfo {
 	struct OMRPlatformSignalInfo	platformSignalInfo;
 	uint32_t portLibrarySignalType;
@@ -126,5 +119,5 @@ uint32_t infoForControl(struct OMRPortLibrary *portLibrary, struct OMRUnixSignal
 
 uint32_t infoForSignal(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo* info, int32_t index, const char **name, void **value) __attribute__((nonnull(1,2,4,5)));
 
-void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *j9Info)  __attribute__((nonnull));
+void fillInUnixSignalInfo(struct OMRPortLibrary *portLibrary, void *contextInfo, struct OMRUnixSignalInfo *signalInfo)  __attribute__((nonnull));
 #endif

--- a/port/ztpf/omrsignal_context.h
+++ b/port/ztpf/omrsignal_context.h
@@ -40,17 +40,17 @@
 /*
  * This structure declaration came in this file in this format from J9
  */
-typedef struct J9PlatformSignalInfo {
+typedef struct OMRPlatformSignalInfo {
 	ucontext_t *context;
 	uintptr_t breakingEventAddr;
 	Dl_info	dl_info;
-} J9PlatformSignalInfo;
+} OMRPlatformSignalInfo;
 
 /*
  * This structure declaration came in this file in this format from J9
  */
 typedef struct OMRUnixSignalInfo {
-	struct J9PlatformSignalInfo	platformSignalInfo;
+	struct OMRPlatformSignalInfo	platformSignalInfo;
 	uint32_t portLibrarySignalType;
 	void* handlerAddress;
 	void* handlerAddress2;


### PR DESCRIPTION
J9 was removed or renamed to OMR in the internal structures, functions and comments used in the omrsig library.

These changes don't impact external projects.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>