### PR TITLE
Remove deprecated addDependency from Linkage files

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -51,26 +51,6 @@ namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
 namespace TR { class ResolvedMethodSymbol; }
 
-/**
- * @brief Adds dependency
- */
-inline void
-addDependency(
-      TR::RegisterDependencyConditions *dep,
-      TR::Register *vreg,
-      TR::RealRegister::RegNum rnum,
-      TR_RegisterKinds rk,
-      TR::CodeGenerator *cg)
-   {
-   if (vreg == NULL)
-      {
-      vreg = cg->allocateRegister(rk);
-      }
-
-   dep->addPreCondition(vreg, rnum);
-   dep->addPostCondition(vreg, rnum);
-   }
-
 namespace TR {
 
 class ARM64MemoryArgument

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -44,18 +44,6 @@ namespace OMR { typedef OMR::ARM::Linkage LinkageConnector; }
 namespace TR { class CodeGenerator; }
 namespace TR { class Register; }
 
-static inline void addDependency(TR::RegisterDependencyConditions *dep,
-                          TR::Register *vreg,
-                          TR::RealRegister ::RegNum rnum,
-                          TR_RegisterKinds rk,
-                          TR::CodeGenerator *codeGen)
-   {
-   if (vreg == NULL)
-      vreg = codeGen->allocateRegister(rk);
-   dep->addPreCondition(vreg, rnum);
-   dep->addPostCondition(vreg, rnum);
-   }
-
 namespace TR {
 
 class ARMMemoryArgument

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -54,24 +54,6 @@ namespace TR { class ParameterSymbol; }
 namespace TR { class ResolvedMethodSymbol; }
 template <class T> class List;
 
-inline void
-addDependency(
-      TR::RegisterDependencyConditions *dep,
-      TR::Register *vreg,
-      TR::RealRegister::RegNum rnum,
-      TR_RegisterKinds rk,
-      TR::CodeGenerator *cg)
-   {
-   if (vreg == NULL)
-      {
-      vreg = cg->allocateRegister(rk);
-      vreg->setPlaceholderReg();
-      }
-
-   dep->addPreCondition(vreg, rnum);
-   dep->addPostCondition(vreg, rnum);
-   }
-
 namespace TR {
 
 class PPCMemoryArgument


### PR DESCRIPTION
Subsumed by the versions in CodeGeneratorUtils.hpp.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>