### PR TITLE
Add Eclipse OMR Jenkins build and pull request pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-/build*/
+build/
 objs/
 CMakeFiles/
 CMakeCache.txt

--- a/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
+++ b/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
@@ -1,0 +1,74 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/aix_ppc-64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'aix && ppc'}
+    environment {
+        PATH = "/home/u0020236/tools:$PATH"
+        LIBPATH="."
+        CCACHE_CPP2="1"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_JIT=OFF -DOMR_JITBUILDER=OFF -DOMR_TEST_COMPILER=OFF -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j8'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_390-64
@@ -1,0 +1,72 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_390-64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && 390'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_aarch64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_aarch64
@@ -1,0 +1,69 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_aarch64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && x86 && compile:aarch64'}
+    environment {
+        PATH = "/usr/lib/ccache/:/home/jenkins/aarch64/toolchain/bin:$PATH"
+        PLATFORM = "aarch64-linux-gcc"
+        CHOST = "aarch64-linux-gnu"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_aarch64'''
+                    
+                    echo 'Compile...'
+                    sh '''make -j4'''
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Currently no sanity tests..."
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_arm
+++ b/buildenv/jenkins/jobs/builds/Build-linux_arm
@@ -1,0 +1,69 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_arm"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && x86 && compile:arm'}
+    environment {
+        PATH = "/usr/lib/ccache/:/home/jenkins/arm/toolchain/bin:$PATH"
+        PLATFORM = "arm-linux-gcc"
+        CHOST = "arm-linux-gnueabihf"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_arm'''
+                    
+                    echo 'Compile...'
+                    sh '''make -j4'''
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Currently no sanity tests..."
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_ppc-64_le_gcc
+++ b/buildenv/jenkins/jobs/builds/Build-linux_ppc-64_le_gcc
@@ -1,0 +1,72 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_ppc-64_le_gcc"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && PPCLE'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86
@@ -1,0 +1,72 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_x86"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && x86'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -G Ninja -DOMR_ENV_DATA32=ON -DOMR_DDR=OFF -DOMR_JITBUILDER=OFF -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''ninja'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64
@@ -1,0 +1,72 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_x86-64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && x86'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64_cmprssptrs
@@ -1,0 +1,69 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/linux_x86-64_cmprssptrs"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Linux && x86'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+        EXTRA_CONFIGURE_ARGS = "--enable-DDR"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc HAS_AUTOCONF=1 distclean all'''
+                    
+                    echo 'Compile...'
+                    sh '''make -j4'''
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Sanity Test..."
+                    sh'''make test'''
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-osx_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-osx_x86-64
@@ -1,0 +1,73 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/osx_x86-64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'OSX && x86'}
+    environment {
+        GTEST_FILTER = "-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:*DeathTest*"
+        PATH = "/usr/local/opt/ccache/libexec:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-win_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-win_x86-64
@@ -1,0 +1,67 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/win_x86-64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'Windows && x86'}
+    environment {
+        GTEST_FILTER="-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:PortSysinfoTest.sysinfo_test0:PortSysinfoTest.sysinfo_test_get_tmp3:ThreadExtendedTest.TestOtherThreadCputime"
+        GTEST_COLOR="1"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -G "Visual Studio 11 2012 Win64" -C../cmake/caches/AppVeyor.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''cmake --build . -- /m'''
+                    }
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V -C Debug -j1'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/builds/Build-zos_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-zos_390-64
@@ -1,0 +1,69 @@
+def setBuildStatus(String message, String state, String sha) {
+    context = "continuous-integration/eclipse-omr/branch/zos_390-64"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "git://github.com/eclipse/omr"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
+        statusBackrefSource: [$class: "ManuallyEnteredBackrefSource", backref: "${BUILD_URL}flowGraphTable/"],
+        statusResultSource: [$class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
+pipeline {
+    agent{label 'zOS && 390'}
+    environment {
+        PATH = "/u/open1/rocket/bin:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'git://github.com/eclipse/omr.git']]])
+                    
+                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    //echo 'Output CCACHE stats before running and clear them'
+                    //echo '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    //TODO remove the EXTRA_CONFIGURE_ARGS once #1560 is merged
+                    sh'''make -f run_configure.mk OMRGLUE=./example/glue SPEC=zos_390-64 EXTRA_CONFIGURE_ARGS=--disable-warnings-as-errors'''
+                    
+                    echo 'Compile...'
+                    sh'''make -j4'''
+                    
+                    //echo 'Output CCACHE stats after running'
+                    //sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Sanity Test..."
+                    sh'''make SPEC=zos_390-64 -j1 test'''
+                }
+            }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+        }
+        failure {
+            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+        }
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
@@ -1,0 +1,53 @@
+pipeline {
+    agent{label 'aix && ppc'}
+    environment {
+        PATH = "/home/u0020236/tools:$PATH"
+        LIBPATH="."
+        CCACHE_CPP2="1"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_JIT=OFF -DOMR_JITBUILDER=OFF -DOMR_TEST_COMPILER=OFF -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_390-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_390-64
@@ -1,0 +1,51 @@
+pipeline {
+    agent{label 'Linux && 390'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_aarch64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_aarch64
@@ -1,0 +1,48 @@
+pipeline {
+    agent{label 'Linux && x86 && compile:aarch64'}
+    environment {
+        PATH = "/usr/lib/ccache/:/home/jenkins/aarch64/toolchain/bin:$PATH"
+        PLATFORM = "aarch64-linux-gcc"
+        CHOST = "aarch64-linux-gnu"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_aarch64'''
+                    
+                    echo 'Compile...'
+                    sh '''make -j4'''
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Currently no sanity tests..."
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_arm
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_arm
@@ -1,0 +1,48 @@
+pipeline {
+    agent{label 'Linux && x86 && compile:arm'}
+    environment {
+        PATH = "/usr/lib/ccache/:/home/jenkins/arm/toolchain/bin:$PATH"
+        PLATFORM = "arm-linux-gcc"
+        CHOST = "arm-linux-gnueabihf"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_arm'''
+                    
+                    echo 'Compile...'
+                    sh '''make -j4'''
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Currently no sanity tests..."
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_ppc-64_le_gcc
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_ppc-64_le_gcc
@@ -1,0 +1,51 @@
+pipeline {
+    agent{label 'Linux && PPCLE'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86
@@ -1,0 +1,51 @@
+pipeline {
+    agent{label 'Linux && x86'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -G Ninja -DOMR_ENV_DATA32=ON -DOMR_DDR=OFF -DOMR_JITBUILDER=OFF -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''ninja'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64
@@ -1,0 +1,51 @@
+pipeline {
+    agent{label 'Linux && x86'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64_cmprssptrs
@@ -1,0 +1,48 @@
+pipeline {
+    agent{label 'Linux && x86'}
+    environment {
+        PATH = "/usr/lib/ccache/:$PATH"
+        EXTRA_CONFIGURE_ARGS = "--enable-DDR"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc HAS_AUTOCONF=1 distclean all'''
+                    
+                    echo 'Compile...'
+                    sh '''make -j4'''
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Sanity Test..."
+                    sh'''make test'''
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-osx_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-osx_x86-64
@@ -1,0 +1,52 @@
+pipeline {
+    agent{label 'OSX && x86'}
+    environment {
+        GTEST_FILTER = "-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:*DeathTest*"
+        PATH = "/usr/local/opt/ccache/libexec:$PATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    echo 'Output CCACHE stats before running and clear them'
+                    sh '''ccache -s -z'''
+                    
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
+                    
+                    echo 'Output CCACHE stats after running'
+                    sh '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-win_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-win_x86-64
@@ -1,0 +1,46 @@
+pipeline {
+    agent{label 'Windows && x86'}
+    environment {
+        GTEST_FILTER="-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:PortSysinfoTest.sysinfo_test0:PortSysinfoTest.sysinfo_test_get_tmp3:ThreadExtendedTest.TestOtherThreadCputime"
+        GTEST_COLOR="1"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'https://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -G "Visual Studio 11 2012 Win64" -C../cmake/caches/AppVeyor.cmake ..''' 
+                       
+                        echo 'Compile...'
+                        sh '''cmake --build . -- /m'''
+                    }
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''ctest -V -C Debug -j1'''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-zos_390-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-zos_390-64
@@ -1,0 +1,63 @@
+pipeline {
+    agent{label 'zOS && 390'}
+    environment {
+        LIBPATH=".:$LIBPATH"
+    }
+    stages {
+        stage('Get Sources') {
+            steps {
+                timestamps {
+                    checkout poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[name: 'origin', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'git://github.com/eclipse/omr.git']]]
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                timestamps {
+                    //echo 'Output CCACHE stats before running and clear them'
+                    //echo '''ccache -s -z'''
+                    
+                    echo 'Configure...'
+                    sh'''make -f run_configure.mk OMRGLUE=./example/glue SPEC=zos_390-64'''
+                    
+                    echo 'Convert HDF files to EBCDIC'
+                    //sh'''for file in `find . -name '*.hdf'`;do;mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file";done'''
+                    //sh'''for file in `find . -name '*.hdf'`;do; chtag -p "$file" | grep -q "ISO8859-1"; if [[ $? == 0 ]]; then; mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file"; fi; done'''
+                    sh'''for file in `find . -name '*.hdf'`;do; chtag -p "$file" | grep -q "ISO8859-1"; if [ $? -eq 0 ]; then; mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file"; fi; done'''
+                    
+                    echo 'Convert TDF files to EBCDIC'
+                    //sh'''for file in `find . -name '*.tdf'`;do;mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file";done'''
+                    //sh'''for file in `find . -name '*.tdf'`;do; chtag -p "$file" | grep -q "ISO8859-1"; if [[ $? == 0 ]]; then; mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file"; fi; done
+                    sh'''for file in `find . -name '*.tdf'`;do; chtag -p "$file" | grep -q "ISO8859-1"; if [ $? -eq 0 ]; then; mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file"; fi; done'''
+                    
+                    echo 'Compile...'
+                    sh'''make -j4'''
+                    
+                    //echo 'Output CCACHE stats after running'
+                    //echo '''ccache -s'''
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                timestamps {
+                    echo "Sanity Test..."
+                    
+                    // Workaround: Convert XML files to EBCDIC 
+                    //sh'''for file in `find . -name '*.xml'`;do;mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file";done'''
+                    sh'''for file in `find . -name '*.xml'`;do; chtag -p "$file" | grep -q "ISO8859-1"; if [ $? -eq 0 ]; then; mv "$file" "$file.iso88591";iconv -f ISO8859-1 -t IBM-1047 "$file.iso88591" >"$file" && chtag -tc IBM-1047 "$file"; fi; done'''
+                    
+                    // Perform a subset of the testing until while we resolve the issues with the other tests
+                    sh'''set; make -f fvtest/omrtest.mk -j1 SPEC=zos_390-64 omr_algotest omr_vmtest omr_utiltest omr_sigtest omr_rastest'''
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo 'Cleanup workspace'
+            deleteDir()
+        }
+    }
+}
+


### PR DESCRIPTION
Migrate Eclipse OMR Jenkins build and pull request pipelines from the
configuration panel of the jobs themselves into the repository so that
we may modify the respective pipeline steps within PRs.

There is some concern that this change may increase build times as
Jenkins has to check out the repository to fetch the pipeline
definitions. These are shallow checkouts however. To figure out how
much this change will affect build times I've compiled statistics on
the average build times for each platform of our current setup and how
long the "Get Sources" step takes in each case.

There are however several steps done in the "Get Sources" stage and the
git commands are as follows:

```
git init /home/jenkins/workspace/PullRequest-linux_x86-64
git --version
git fetch --tags --progress https://github.com/eclipse/omr.git
+refs/heads/*:refs/remotes/origin/*
git config remote.origin.url https://github.com/eclipse/omr.git
git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
git config remote.origin.url https://github.com/eclipse/omr.git
git fetch --tags --progress https://github.com/eclipse/omr.git
+refs/pull/*:refs/remotes/origin/pr/*
git rev-parse refs/remotes/origin/pr/3782/merge^{commit}
git rev-parse refs/remotes/origin/origin/pr/3782/merge^{commit}
git config core.sparsecheckout
git checkout -f 46d332fb46aff75e40bebbd9180e33e466e857af
```

Jenkins will not perform all of these steps. So as a conservative
estimate I've estimated that Jenkins will take 1/3 of the time to run
the above steps. Here are the estimates for the build time increases:

| Build                               | Get Sources (sec) | Total Average (sec) | Projected Increase (%) | Projected Increase (sec) |
|-------------------------------------|-------------------|---------------------|------------------------|--------------------------|
| PullRequest-aix_ppc-64              | 50                | 332                 | 5%                     | 17                       |
| PullRequest-linux_390-64            | 10                | 343                 | 1%                     | 3                        |
| PullRequest-linux_aarch64           | 40                | 429                 | 3%                     | 13                       |
| PullRequest-linux_arm               | 40                | 485                 | 3%                     | 13                       |
| PullRequest-linux_ppc-64_le_gcc     | 35                | 523                 | 2%                     | 12                       |
| PullRequest-linux_x86               | 33                | 394                 | 3%                     | 11                       |
| PullRequest-linux_x86-64            | 42                | 660                 | 2%                     | 14                       |
| PullRequest-linux_x86-64_cmprssptrs | 40                | 601                 | 2%                     | 13                       |
| PullRequest-osx_x86-64              | 33                | 427                 | 3%                     | 11                       |
| PullRequest-win_x86-64              | 26                | 1197                | 1%                     | 9                        |
| PullRequest-zos_390-6               | 26                | 570                 | 2%                     | 9                        |

The absolute increase is at most 17 seconds which I find to be
reasonable.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>