### PR TITLE
First pass of changes for mixed mode object references

### DIFF
--- a/example/glue/GlobalCollectorDelegate.hpp
+++ b/example/glue/GlobalCollectorDelegate.hpp
@@ -138,10 +138,10 @@ public:
 	void prepareHeapForWalk(MM_EnvironmentBase *env) {}
 
 	/* Read Barrier Verifier specific methods */
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	void poisonSlots(MM_EnvironmentBase *env) {}
 	void healSlots(MM_EnvironmentBase *env) {}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	/**
 	 * In order to allow the heap to remain walkable for diagnostics some fixup is required

--- a/example/glue/ScavengerDelegate.cpp
+++ b/example/glue/ScavengerDelegate.cpp
@@ -176,10 +176,12 @@ MM_ScavengerDelegate::reverseForwardedObject(MM_EnvironmentBase *env, MM_Forward
 			(uint8_t)objectModel->getObjectFlags(forwardedObject));
 
 #if defined (OMR_GC_COMPRESSED_POINTERS)
-		/* Restore destroyed overlapped slot in the original object. This slot might need to be reversed
-		 * as well or it may be already reversed - such fixup will be completed at in a later pass.
-		 */
-		forwardedHeader->restoreDestroyedOverlap();
+		if (env->compressObjectReferences()) {
+			/* Restore destroyed overlapped slot in the original object. This slot might need to be reversed
+			 * as well or it may be already reversed - such fixup will be completed at in a later pass.
+			 */
+			forwardedHeader->restoreDestroyedOverlap();
+		}
 #endif /* defined (OMR_GC_COMPRESSED_POINTERS) */
 	}
 }

--- a/example/glue/ScavengerDelegate.hpp
+++ b/example/glue/ScavengerDelegate.hpp
@@ -56,10 +56,10 @@ public:
 	void kill(MM_EnvironmentBase *env);
 
 	/* Read Barrier Verifier specific methods */
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	void poisonSlots(MM_EnvironmentBase *env) {}
 	void healSlots(MM_EnvironmentBase *env) {}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	/**
 	 * This method will be called on the master GC thread after each scavenger cycle, successful or

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -265,11 +265,11 @@ public:
 	void* heapBaseForBarrierRange0;
 	uintptr_t heapSizeForBarrierRange0;
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	void* shadowHeapBase; 	/* Read Barrier Verifier shadow heap base address */
 	void* shadowHeapTop;	/* Read Barrier Verifier shadow heap base address */
 	MM_MemoryHandle shadowHeapHandle; /* Read Barrier Verifier shadow heap Virtual Memory handle (descriptor) */
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	bool doOutOfLineAllocationTrace;
 	bool doFrequentObjectAllocationSampling; /**< Whether to track object allocations*/
@@ -388,13 +388,13 @@ public:
 
 	uintptr_t fvtest_forceSweepChunkArrayCommitFailure; /**< Force failure at Sweep Chunk Array commit operation */
 	uintptr_t fvtest_forceSweepChunkArrayCommitFailureCounter; /**< Force failure at Sweep Chunk Array commit operation counter */
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	uintptr_t fvtest_enableReadBarrierVerification; /**< Forces failure at all direct memory read sites */
 	uintptr_t fvtest_enableMonitorObjectsReadBarrierVerification; /**< Forces failure at all direct memory read sites for monitor slot objects */
 	uintptr_t fvtest_enableClassStaticsReadBarrierVerification; /**< Forces failure at all direct memory read sites for class statics */
 	uintptr_t fvtest_enableJNIGlobalWeakReadBarrierVerification; /**< Forces failure at all direct memory read sites for JNI Global weak references */
 	uintptr_t fvtest_enableHeapReadBarrierVerification; /**< Forces failure at all direct memory read sites for heap references */
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	uintptr_t fvtest_forceMarkMapCommitFailure; /**< Force failure at Mark Map commit operation */
 	uintptr_t fvtest_forceMarkMapCommitFailureCounter; /**< Force failure at Mark Map commit operation counter */
@@ -1296,11 +1296,11 @@ public:
 #endif /* defined(OMR_GC_REALTIME) */
 		, heapBaseForBarrierRange0(NULL)
 		, heapSizeForBarrierRange0(0)
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 		, shadowHeapBase(0)
 		, shadowHeapTop(0)
 		, shadowHeapHandle()
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 		, doOutOfLineAllocationTrace(true) /* Tracing after ever x bytes allocated per thread. Enabled by default. */
 		, doFrequentObjectAllocationSampling(false) /* Finds most frequently allocated classes. Disabled by default. */
 		, oolObjectSamplingBytesGranularity(16*1024*1024) /* Default granularity set to 16M (shows <1% perf loss). */
@@ -1394,13 +1394,13 @@ public:
 		, fvtest_disableInlineAllocation(0)
 		, fvtest_forceSweepChunkArrayCommitFailure(0)
 		, fvtest_forceSweepChunkArrayCommitFailureCounter(0)
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 		, fvtest_enableReadBarrierVerification(0)
 		, fvtest_enableMonitorObjectsReadBarrierVerification(0)
 		, fvtest_enableClassStaticsReadBarrierVerification(0)
 		, fvtest_enableJNIGlobalWeakReadBarrierVerification(0)
 		, fvtest_enableHeapReadBarrierVerification(0)
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 		, fvtest_forceMarkMapCommitFailure(0)
 		, fvtest_forceMarkMapCommitFailureCounter(0)
 		, fvtest_forceMarkMapDecommitFailure(0)

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -127,178 +127,181 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 		instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
 												 ceiling, mode, options, memoryCategory);
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
-		if (1 == extensions->fvtest_enableReadBarrierVerification) {
-			MM_VirtualMemory* instanceShadow = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags,
-					tailPadding, preferredAddress, (void*)OMR_MIN(NON_SCALING_LOW_MEMORY_HEAP_CEILING,
-					(uintptr_t)ceiling), mode, options, memoryCategory);
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
+		if (!env->compressObjectReferences()) {
+			if (1 == extensions->fvtest_enableReadBarrierVerification) {
+				MM_VirtualMemory* instanceShadow = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags,
+						tailPadding, preferredAddress, (void*)OMR_MIN(NON_SCALING_LOW_MEMORY_HEAP_CEILING,
+						(uintptr_t)ceiling), mode, options, memoryCategory);
 
-			extensions->shadowHeapBase = instanceShadow->getHeapBase();
-			extensions->shadowHeapTop = instanceShadow->getHeapTop();
-			extensions->shadowHeapHandle.setVirtualMemory(instanceShadow);
+				extensions->shadowHeapBase = instanceShadow->getHeapBase();
+				extensions->shadowHeapTop = instanceShadow->getHeapTop();
+				extensions->shadowHeapHandle.setVirtualMemory(instanceShadow);
+			}
 		}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 	} else {
 #if defined(OMR_GC_COMPRESSED_POINTERS)
-		OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
-		/*
-		 * This function is used for Compressed References platforms only
-		 * The ceiling for such platforms is set maximum memory value be supported (32G for 3-bit shift)
-		 * The ceiling it is 0 for all other platforms
-		 */
-		/* NON_SCALING_LOW_MEMORY_HEAP_CEILING is set to 4G for 64-bit platforms only, 0 for 32-bit platforms */
-		Assert_MM_true(NON_SCALING_LOW_MEMORY_HEAP_CEILING > 0);
+		if (env->compressObjectReferences()) {
+			OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
+			/*
+			 * This function is used for Compressed References platforms only
+			 * The ceiling for such platforms is set maximum memory value be supported (32G for 3-bit shift)
+			 * The ceiling it is 0 for all other platforms
+			 */
+			/* NON_SCALING_LOW_MEMORY_HEAP_CEILING is set to 4G for 64-bit platforms only, 0 for 32-bit platforms */
+			Assert_MM_true(NON_SCALING_LOW_MEMORY_HEAP_CEILING > 0);
 		
-		/*
-		 * Usually the suballocator memory should be allocated first (before heap) however
-		 * in case when preferred address is specified we will try to allocate heap first
-		 * to avoid possible interference with requested heap location
-		 */
-		bool shouldHeapBeAllocatedFirst = (NULL != preferredAddress);
-		void* startAllocationAddress = preferredAddress;
+			/*
+			 * Usually the suballocator memory should be allocated first (before heap) however
+			 * in case when preferred address is specified we will try to allocate heap first
+			 * to avoid possible interference with requested heap location
+			 */
+			bool shouldHeapBeAllocatedFirst = (NULL != preferredAddress);
+			void* startAllocationAddress = preferredAddress;
 
-		/* Set the commit size for the sub allocator. This needs to be completed before the call to omrmem_ensure_capacity32 */
-		omrport_control(OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE, extensions->suballocatorCommitSize);
+			/* Set the commit size for the sub allocator. This needs to be completed before the call to omrmem_ensure_capacity32 */
+			omrport_control(OMRPORT_CTLDATA_ALLOCATE32_COMMIT_SIZE, extensions->suballocatorCommitSize);
 
-		if (!shouldHeapBeAllocatedFirst) {
-			if (OMRPORT_ENSURE_CAPACITY_FAILED == omrmem_ensure_capacity32(extensions->suballocatorInitialSize)) {
-				extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_ALLOCATE_LOW_MEMORY_RESERVE;
-				return false;
+			if (!shouldHeapBeAllocatedFirst) {
+				if (OMRPORT_ENSURE_CAPACITY_FAILED == omrmem_ensure_capacity32(extensions->suballocatorInitialSize)) {
+					extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_ALLOCATE_LOW_MEMORY_RESERVE;
+					return false;
+				}
 			}
-		}
 
-		options |= OMRPORT_VMEM_STRICT_ADDRESS | OMRPORT_VMEM_ALLOC_QUICK;
+			options |= OMRPORT_VMEM_STRICT_ADDRESS | OMRPORT_VMEM_ALLOC_QUICK;
 
 #if defined(J9ZOS39064)
-		/* 2TO32G area is extended to 64G */
-		options |= OMRPORT_VMEM_ZOS_USE2TO32G_AREA;
+			/* 2TO32G area is extended to 64G */
+			options |= OMRPORT_VMEM_ZOS_USE2TO32G_AREA;
 
-		/*
-		 * On ZOS an address space below 2G can not be taken for virtual memory
-		 */
+			/*
+			 * On ZOS an address space below 2G can not be taken for virtual memory
+			 */
 #define TWO_GB_ADDRESS ((void*)((uintptr_t)2 * 1024 * 1024 * 1024))
-		if (NULL == preferredAddress) {
-			startAllocationAddress = TWO_GB_ADDRESS;
-		}
+			if (NULL == preferredAddress) {
+				startAllocationAddress = TWO_GB_ADDRESS;
+			}
 #endif /* defined(J9ZOS39064) */
 
-		void* requestedTopAddress = (void*)((uintptr_t)startAllocationAddress + allocateSize + tailPadding);
+			void* requestedTopAddress = (void*)((uintptr_t)startAllocationAddress + allocateSize + tailPadding);
 
-		if (extensions->isConcurrentScavengerHWSupported()) {
-			void * ceilingToRequest = ceiling;
-			/* Requested top address might be higher then ceiling because of added chunk */
-			if ((requestedTopAddress > ceiling) && ((void *)((uintptr_t)requestedTopAddress - concurrentScavengerPageSize) <= ceiling)) {
-				/* ZOS 2_TO_64/2_TO_32 options would not allow memory request larger then 64G/32G so total requested size including tail padding should not exceed it */
-				allocateSize = (uintptr_t)ceiling - (uintptr_t)startAllocationAddress - tailPadding;
+			if (extensions->isConcurrentScavengerHWSupported()) {
+				void * ceilingToRequest = ceiling;
+				/* Requested top address might be higher then ceiling because of added chunk */
+				if ((requestedTopAddress > ceiling) && ((void *)((uintptr_t)requestedTopAddress - concurrentScavengerPageSize) <= ceiling)) {
+					/* ZOS 2_TO_64/2_TO_32 options would not allow memory request larger then 64G/32G so total requested size including tail padding should not exceed it */
+					allocateSize = (uintptr_t)ceiling - (uintptr_t)startAllocationAddress - tailPadding;
 
-				if (extensions->isDebugConcurrentScavengerPageAlignment()) {
-					omrtty_printf("Total allocate size exceeds ceiling %p, reduce allocate size to 0x%zx\n", ceiling, allocateSize);
+					if (extensions->isDebugConcurrentScavengerPageAlignment()) {
+						omrtty_printf("Total allocate size exceeds ceiling %p, reduce allocate size to 0x%zx\n", ceiling, allocateSize);
+					}
+					/*
+					 * There is no way that Nursery will be pushed above ceiling for valid memory options however we have
+					 * no idea about start address. So to guarantee an allocation up to the ceiling we need to request extended chunk of memory. 
+					 * Set ceiling to NULL to disable ceiling control. This required bottom-up direction for allocation.
+					 */
+					ceilingToRequest = NULL;
 				}
-				/*
-				 * There is no way that Nursery will be pushed above ceiling for valid memory options however we have
-				 * no idea about start address. So to guarantee an allocation up to the ceiling we need to request extended chunk of memory. 
-				 * Set ceiling to NULL to disable ceiling control. This required bottom-up direction for allocation.
-				 */
-				ceilingToRequest = NULL;
-			}
 
-			options |= OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP;
-
-			/* An attempt to allocate memory chunk for heap for Concurrent Scavenger */
-			instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress, ceilingToRequest, mode, options, memoryCategory);
-		} else {
-			if (requestedTopAddress <= ceiling) {
-				bool allocationTopDown = true;
-				/* define the scan direction when reserving the GC heap in the range of (4G, 32G) */
-#if defined(S390) || defined(J9ZOS390)
-				/* s390 benefits from smaller shift values so allocate direction is bottom up */
 				options |= OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP;
-				allocationTopDown = false;
-#else
-				options |= OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN;
+
+				/* An attempt to allocate memory chunk for heap for Concurrent Scavenger */
+				instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress, ceilingToRequest, mode, options, memoryCategory);
+			} else {
+				if (requestedTopAddress <= ceiling) {
+					bool allocationTopDown = true;
+					/* define the scan direction when reserving the GC heap in the range of (4G, 32G) */
+#if defined(S390) || defined(J9ZOS390)
+					/* s390 benefits from smaller shift values so allocate direction is bottom up */
+					options |= OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP;
+					allocationTopDown = false;
+#else /* defined(S390) || defined(J9ZOS390) */
+					options |= OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN;
 #endif /* defined(S390) || defined(J9ZOS390) */
 
-				if (allocationTopDown && extensions->shouldForceSpecifiedShiftingCompression) {
-					/* force to allocate heap top-down from correspondent to shift address */
-					void* maxAddress = (void *)(((uintptr_t)1 << 32) << extensions->forcedShiftingCompressionAmount);
+					if (allocationTopDown && extensions->shouldForceSpecifiedShiftingCompression) {
+						/* force to allocate heap top-down from correspondent to shift address */
+						void* maxAddress = (void *)(((uintptr_t)1 << 32) << extensions->forcedShiftingCompressionAmount);
 
-					instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
-							maxAddress, mode, options, memoryCategory);
-				} else {
-					if (requestedTopAddress < (void*)NON_SCALING_LOW_MEMORY_HEAP_CEILING) {
-						/*
-						 * Attempt to allocate heap below 4G
-						 */
 						instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
-																 (void*)OMR_MIN(NON_SCALING_LOW_MEMORY_HEAP_CEILING, (uintptr_t)ceiling), mode, options, memoryCategory);
-					}
-
-					if ((NULL == instance) && (ceiling > (void*)NON_SCALING_LOW_MEMORY_HEAP_CEILING)) {
-
-#define THIRTY_TWO_GB_ADDRESS ((uintptr_t)32 * 1024 * 1024 * 1024)
-						if (requestedTopAddress <= (void *)THIRTY_TWO_GB_ADDRESS) {
+								maxAddress, mode, options, memoryCategory);
+					} else {
+						if (requestedTopAddress < (void*)NON_SCALING_LOW_MEMORY_HEAP_CEILING) {
 							/*
-							 * If requested object heap size is in range 28G-32G its allocation with 3-bit shift might compromise amount of low memory below 4G
-							 * To prevent this go straight to 4-bit shift if it possible.
-							 * Set of logical conditions to skip allocation attempt below 32G
-							 *  - 4-bit shift is available option
-							 *  - requested size is larger then 28G (32 minus 4)
-							 *  - allocation direction is top-down, otherwise it does not make sense
+							 * Attempt to allocate heap below 4G
 							 */
-							bool skipAllocationBelow32G = (ceiling > (void*)THIRTY_TWO_GB_ADDRESS)
-								 && (requestedTopAddress > (void*)(THIRTY_TWO_GB_ADDRESS - NON_SCALING_LOW_MEMORY_HEAP_CEILING))
-								 && allocationTopDown;
-
-							if (!skipAllocationBelow32G) {
-								/*
-								 * Attempt to allocate heap below 32G
-								 */
-								instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
-																		 (void*)OMR_MIN((uintptr_t)THIRTY_TWO_GB_ADDRESS, (uintptr_t)ceiling), mode, options, memoryCategory);
-							}
+							instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
+																	 (void*)OMR_MIN(NON_SCALING_LOW_MEMORY_HEAP_CEILING, (uintptr_t)ceiling), mode, options, memoryCategory);
 						}
 
-						/*
-						 * Attempt to allocate above 32G
-						 */
-						if ((NULL == instance) && (ceiling > (void *)THIRTY_TWO_GB_ADDRESS)) {
-							instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
-																	 ceiling, mode, options, memoryCategory);
+						if ((NULL == instance) && (ceiling > (void*)NON_SCALING_LOW_MEMORY_HEAP_CEILING)) {
+
+#define THIRTY_TWO_GB_ADDRESS ((uintptr_t)32 * 1024 * 1024 * 1024)
+							if (requestedTopAddress <= (void *)THIRTY_TWO_GB_ADDRESS) {
+								/*
+								 * If requested object heap size is in range 28G-32G its allocation with 3-bit shift might compromise amount of low memory below 4G
+								 * To prevent this go straight to 4-bit shift if it possible.
+								 * Set of logical conditions to skip allocation attempt below 32G
+								 *  - 4-bit shift is available option
+								 *  - requested size is larger then 28G (32 minus 4)
+								 *  - allocation direction is top-down, otherwise it does not make sense
+								 */
+								bool skipAllocationBelow32G = (ceiling > (void*)THIRTY_TWO_GB_ADDRESS)
+									 && (requestedTopAddress > (void*)(THIRTY_TWO_GB_ADDRESS - NON_SCALING_LOW_MEMORY_HEAP_CEILING))
+									 && allocationTopDown;
+
+								if (!skipAllocationBelow32G) {
+									/*
+									 * Attempt to allocate heap below 32G
+									 */
+									instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
+																			 (void*)OMR_MIN((uintptr_t)THIRTY_TWO_GB_ADDRESS, (uintptr_t)ceiling), mode, options, memoryCategory);
+								}
+							}
+
+							/*
+							 * Attempt to allocate above 32G
+							 */
+							if ((NULL == instance) && (ceiling > (void *)THIRTY_TWO_GB_ADDRESS)) {
+								instance = MM_VirtualMemory::newInstance(env, heapAlignment, allocateSize, pageSize, pageFlags, tailPadding, preferredAddress,
+																		 ceiling, mode, options, memoryCategory);
+							}
 						}
 					}
 				}
 			}
-		}
 
-		/*
-		 * If preferredAddress is requested check is it really taken: if not - release memory
-		 * for backward compatibility this check should be done for compressedrefs platforms only
-		 */
-		if ((NULL != preferredAddress) && (NULL != instance) && (instance->getHeapBase() != preferredAddress)) {
-			extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_INSTANTIATE_HEAP;
-			instance->kill(env);
-			instance = NULL;
-			return false;
-		}
-
-		if ((NULL != instance) && shouldHeapBeAllocatedFirst) {
-			if (OMRPORT_ENSURE_CAPACITY_FAILED == omrmem_ensure_capacity32(extensions->suballocatorInitialSize)) {
-				extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_ALLOCATE_LOW_MEMORY_RESERVE;
+			/*
+			 * If preferredAddress is requested check is it really taken: if not - release memory
+			 * for backward compatibility this check should be done for compressedrefs platforms only
+			 */
+			if ((NULL != preferredAddress) && (NULL != instance) && (instance->getHeapBase() != preferredAddress)) {
+				extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_INSTANTIATE_HEAP;
 				instance->kill(env);
 				instance = NULL;
 				return false;
 			}
-		}
-#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 
-		/*
-		 * Code above might be used for non-compressedrefs platforms but need a few adjustments on it for this:
-		 *  - NON_SCALING_LOW_MEMORY_HEAP_CEILING should be set
-		 *  - OMRPORT_VMEM_ZOS_USE2TO32G_AREA flag for ZOS is expected to be used for compressedrefs heap allocation only
-		 */
-		Assert_MM_unimplemented();
-
+			if ((NULL != instance) && shouldHeapBeAllocatedFirst) {
+				if (OMRPORT_ENSURE_CAPACITY_FAILED == omrmem_ensure_capacity32(extensions->suballocatorInitialSize)) {
+					extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_CAN_NOT_ALLOCATE_LOW_MEMORY_RESERVE;
+					instance->kill(env);
+					instance = NULL;
+					return false;
+				}
+			}
+		} else
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
+		{
+			/*
+			 * Code above might be used for non-compressedrefs platforms but need a few adjustments on it for this:
+			 *  - NON_SCALING_LOW_MEMORY_HEAP_CEILING should be set
+			 *  - OMRPORT_VMEM_ZOS_USE2TO32G_AREA flag for ZOS is expected to be used for compressedrefs heap allocation only
+			 */
+			Assert_MM_unimplemented();
+		}
 	}
 
 	if((NULL != instance) && extensions->largePageFailOnError && (instance->getPageSize() != extensions->requestedPageSize)) {
@@ -510,7 +513,7 @@ MM_MemoryManager::destroyVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_Memory
 {
 	destroyVirtualMemory(env, handle);
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	MM_GCExtensionsBase* extensions = env->getExtensions();
 	MM_VirtualMemory* shadowMemory = extensions->shadowHeapHandle.getVirtualMemory();
 	if (NULL != shadowMemory) {
@@ -519,7 +522,7 @@ MM_MemoryManager::destroyVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_Memory
 		extensions->shadowHeapHandle.setMemoryBase(NULL);
 		extensions->shadowHeapHandle.setMemoryTop(NULL);
 	}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 }
 
 void

--- a/gc/base/modronapicore.cpp
+++ b/gc/base/modronapicore.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,11 +42,7 @@ extern "C" {
 const char*
 omrgc_get_version(OMR_VM *omrVM)
 {
-	return OMR_VERSION_STRING
-#if defined (OMR_GC_COMPRESSED_POINTERS) 
-		"_CMPRSS"
-#endif /* OMR_GC_COMPRESSED_POINTERS */
-	;
+	return OMRVM_COMPRESS_OBJECT_REFERENCES(omvVM) ? OMR_VERSION_STRING "_CMPRSS" : OMR_VERSION_STRING;
 }
 
 uintptr_t

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,12 +40,12 @@
 #include "ParallelSweepScheme.hpp"
 
 /* Declaration of "C" style Read Barrier Verifier specific methods */
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 void poisonReferenceSlots(OMR_VMThread *omrVMThread, MM_HeapRegionDescriptor *region, omrobjectptr_t object, void *userData);
 void poisonReferenceSlot(MM_EnvironmentBase *env, GC_SlotObject *slotObject);
 void healReferenceSlot(MM_EnvironmentBase *env, GC_SlotObject *slotObject);
 void healReferenceSlots(OMR_VMThread *omrVMThread, MM_HeapRegionDescriptor *region, omrobjectptr_t object, void *userData);
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 class MM_CollectionStatisticsStandard;
 class MM_CompactScheme;
@@ -268,10 +268,10 @@ public:
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
 	virtual void collectorShutdown(MM_GCExtensionsBase *extensions);
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	void poisonHeap(MM_EnvironmentBase *env);
 	void healHeap(MM_EnvironmentBase *env);
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	/**
 	 *  Fixes up all unloaded objects so that the heap can be walked and only live objects returned

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -3417,32 +3417,34 @@ MM_Scavenger::backoutFixupAndReverseForwardPointersInSurvivor(MM_EnvironmentStan
 	}
 
 #if defined (OMR_GC_COMPRESSED_POINTERS)
-	GC_MemorySubSpaceRegionIteratorStandard evacuateRegionIterator1(_activeSubSpace);
-	while(NULL != (rootRegion = evacuateRegionIterator1.nextRegion())) {
-		if (isObjectInEvacuateMemory((omrobjectptr_t )rootRegion->getLowAddress())) {
-			/*
-			 * CMVC 179190:
-			 * The call to "reverseForwardedObject", above, destroys our ability to detect if this object needs its destroyed slot fixed up (but
-			 * the above loop must complete before we have the information with which to fixup the destroyed slot).  Fixing up a slot in dark
-			 * matter could crash, though, since the slot could point to contracted memory or could point to corrupted data updated in a previous
-			 * backout.  The simple work-around for this problem is to check if the slot points at a readable part of the heap (specifically,
-			 * tenure or survivor - the only locations which would require us to fix up the slot) and only read and fixup the slot in those cases.
-			 * This means that we could still corrupt the slot but we will never crash during fixup and nobody else should be trusting slots found
-			 * in dead objects.
-			 */
-			GC_ObjectHeapIteratorAddressOrderedList evacuateHeapIterator(_extensions, rootRegion, false);
-			omrobjectptr_t objectPtr = NULL;
+	if (env->compressObjectReferences()) {
+		GC_MemorySubSpaceRegionIteratorStandard evacuateRegionIterator1(_activeSubSpace);
+		while(NULL != (rootRegion = evacuateRegionIterator1.nextRegion())) {
+			if (isObjectInEvacuateMemory((omrobjectptr_t )rootRegion->getLowAddress())) {
+				/*
+				 * CMVC 179190:
+				 * The call to "reverseForwardedObject", above, destroys our ability to detect if this object needs its destroyed slot fixed up (but
+				 * the above loop must complete before we have the information with which to fixup the destroyed slot).  Fixing up a slot in dark
+				 * matter could crash, though, since the slot could point to contracted memory or could point to corrupted data updated in a previous
+				 * backout.  The simple work-around for this problem is to check if the slot points at a readable part of the heap (specifically,
+				 * tenure or survivor - the only locations which would require us to fix up the slot) and only read and fixup the slot in those cases.
+				 * This means that we could still corrupt the slot but we will never crash during fixup and nobody else should be trusting slots found
+				 * in dead objects.
+				 */
+				GC_ObjectHeapIteratorAddressOrderedList evacuateHeapIterator(_extensions, rootRegion, false);
+				omrobjectptr_t objectPtr = NULL;
 
-			while((objectPtr = evacuateHeapIterator.nextObjectNoAdvance()) != NULL) {
-				MM_ForwardedHeader header(objectPtr);
+				while((objectPtr = evacuateHeapIterator.nextObjectNoAdvance()) != NULL) {
+					MM_ForwardedHeader header(objectPtr);
 #if defined(OMR_SCAVENGER_TRACE_BACKOUT)
-				uint32_t originalOverlap = header.getPreservedOverlap();
+					uint32_t originalOverlap = header.getPreservedOverlap();
 #endif /* OMR_SCAVENGER_TRACE_BACKOUT */
-				_delegate.fixupDestroyedSlot(env, &header, _activeSubSpace);
+_delegate.fixupDestroyedSlot(env, &header, _activeSubSpace);
 #if defined(OMR_SCAVENGER_TRACE_BACKOUT)
-				omrobjectptr_t fwdObjectPtr = header.getForwardedObject();
-				omrtty_printf("{SCAV: Fixup destroyed slot %p@%p -> %u->%u}\n", objectPtr, fwdObjectPtr, originalOverlap, header.getPreservedOverlap());
+					omrobjectptr_t fwdObjectPtr = header.getForwardedObject();
+					omrtty_printf("{SCAV: Fixup destroyed slot %p@%p -> %u->%u}\n", objectPtr, fwdObjectPtr, originalOverlap, header.getPreservedOverlap());
 #endif /* OMR_SCAVENGER_TRACE_BACKOUT */
+				}
 			}
 		}
 	}
@@ -4057,11 +4059,13 @@ MM_Scavenger::getCollectorExpandSize(MM_EnvironmentBase *env)
 void
 MM_Scavenger::internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, uint32_t gcCode)
 {
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
-	if (1 == _extensions->fvtest_enableReadBarrierVerification) {
-		scavenger_healSlots(env);
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
+	if (!env->compressObjectReferences()) {
+		if (1 == _extensions->fvtest_enableReadBarrierVerification) {
+			scavenger_healSlots(env);
+		}
 	}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	env->_cycleState = &_cycleState;
 
@@ -4102,11 +4106,13 @@ MM_Scavenger::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *su
 
 	Assert_MM_true(env->_cycleState == &_cycleState);
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
-	if (1 == _extensions->fvtest_enableReadBarrierVerification) {
-		scavenger_poisonSlots(env);
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
+	if (!env->compressObjectReferences()) {
+		if (1 == _extensions->fvtest_enableReadBarrierVerification) {
+			scavenger_poisonSlots(env);
+		}
 	}
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 }
 
 /**
@@ -5171,7 +5177,7 @@ MM_Scavenger::completeConcurrentCycle(MM_EnvironmentBase *env)
 
 #endif /* OMR_GC_MODRON_SCAVENGER */
 
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 void
 MM_Scavenger::scavenger_poisonSlots(MM_EnvironmentBase *env)
 {
@@ -5184,4 +5190,4 @@ MM_Scavenger::scavenger_healSlots(MM_EnvironmentBase *env)
 	/* This will heal only the root slots */
 	_delegate.healSlots(env);
 }
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -596,10 +596,10 @@ public:
 	MM_ScavengerDelegate* getDelegate() { return &_delegate; }
 
 	/* Read Barrier Verifier specific methods */
-#if defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 	virtual void scavenger_poisonSlots(MM_EnvironmentBase *env);
 	virtual void scavenger_healSlots(MM_EnvironmentBase *env);
-#endif /* defined(OMR_ENV_DATA64) && !defined(OMR_GC_COMPRESSED_POINTERS) */
+#endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
 
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
 	virtual void collectorShutdown(MM_GCExtensionsBase* extensions);

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -271,12 +271,15 @@ MM_VerboseHandlerOutput::handleInitialized(J9HookInterface** hook, uintptr_t eve
 	writer->formatAndOutput(env, 1, "<attribute name=\"maxHeapSize\" value=\"0x%zx\" />", event->maxHeapSize);
 	writer->formatAndOutput(env, 1, "<attribute name=\"initialHeapSize\" value=\"0x%zx\" />", event->initialHeapSize);
 #if defined(OMR_GC_COMPRESSED_POINTERS)
-	writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefs\" value=\"true\" />");
-	writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefsDisplacement\" value=\"0x%zx\" />", 0);
-	writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefsShift\" value=\"0x%zx\" />", event->compressedPointersShift);
-#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
-	writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefs\" value=\"false\" />");
+	if (env->compressObjectReferences()) {
+		writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefs\" value=\"true\" />");
+		writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefsDisplacement\" value=\"0x%zx\" />", 0);
+		writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefsShift\" value=\"0x%zx\" />", event->compressedPointersShift);
+	} else
 #endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
+	{
+		writer->formatAndOutput(env, 1, "<attribute name=\"compressedRefs\" value=\"false\" />");
+	}
 	writer->formatAndOutput(env, 1, "<attribute name=\"pageSize\" value=\"0x%zx\" />", event->heapPageSize);
 	writer->formatAndOutput(env, 1, "<attribute name=\"pageType\" value=\"%s\" />", event->heapPageType);
 	writer->formatAndOutput(env, 1, "<attribute name=\"requestedPageSize\" value=\"0x%zx\" />", event->heapRequestedPageSize);

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -41,6 +41,10 @@
 #define OMR_COMPATIBLE_FUNCTION_POINTER(fp) ((void*)(fp))
 #endif /* J9ZOS390 */
 
+#if !defined(OMR_GC_COMPRESSED_POINTERS)
+#define OMR_GC_FULL_POINTERS
+#endif /* defined(J9VM_GC_FULL_POINTERS) */
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
In order to support both compressed and full pointers, code ifdeffed for
compressed or not must be changed.

Currently, OMR_GC_COMPRESS_POINTERS controls whether object references
are compressed or not. This needs to change to an optional runtime
check.

In the future, OMR_GC_COMPRESS_POINTERS will mean that compressed
references is a supported configuration. The new flag
OMR_GC_FULL_POINTERS will mean that uncompressed pointers are supported.
One or both of these will be allowed to be defined in a build.

For now, synthetically define OMR_GC_FULL_POINTERS only if
OMR_GC_COMPRESS_POINTERS is not defined (so
!defined(OMR_GC_COMPRESS_POINTERS) changes to
defined(OMR_GC_FULL_POINTERS)).

As a further migration step, add runtime checks (which currently
evaluate to true or false at compile-time) in a few places.

None of the changes here should have any effect on performance of any
single-reference-size build.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>