### PR TITLE
AArch64: Add some members to ARM64LinkageProperties

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -108,9 +108,12 @@ TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)
    _properties._numAllocatableIntegerRegisters = 27;
    _properties._numAllocatableFloatRegisters   = 32;
 
+   _properties._preservedRegisterMapForGC   = 0x00000000; // ToDo: Determine the value
    _properties._methodMetaDataRegister      = TR::RealRegister::NoReg;
    _properties._stackPointerRegister        = TR::RealRegister::sp;
    _properties._framePointerRegister        = TR::RealRegister::x29;
+   _properties._vtableIndexArgumentRegister = TR::RealRegister::NoReg;
+   _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
 
    _properties._numberOfDependencyGPRegisters = 32; // To be determined
    _properties._offsetToFirstParm             = 0; // To be determined

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -93,9 +93,12 @@ struct ARM64LinkageProperties
    TR::RealRegister::RegNum _returnRegisters[TR::RealRegister::NumRegisters];
    uint8_t _numAllocatableIntegerRegisters;
    uint8_t _numAllocatableFloatRegisters;
+   uint32_t _preservedRegisterMapForGC;
    TR::RealRegister::RegNum _methodMetaDataRegister;
    TR::RealRegister::RegNum _stackPointerRegister;
    TR::RealRegister::RegNum _framePointerRegister;
+   TR::RealRegister::RegNum _vtableIndexArgumentRegister; // for icallVMprJavaSendPatchupVirtual
+   TR::RealRegister::RegNum _j9methodArgumentRegister; // for icallVMprJavaSendStatic
    uint8_t _numberOfDependencyGPRegisters;
    int8_t _offsetToFirstParm;
    int8_t _offsetToFirstLocal;
@@ -220,6 +223,11 @@ struct ARM64LinkageProperties
       return _numAllocatableFloatRegisters;
       }
 
+   uint32_t getPreservedRegisterMapForGC() const
+      {
+      return _preservedRegisterMapForGC;
+      }
+
    TR::RealRegister::RegNum getMethodMetaDataRegister() const
       {
       return _methodMetaDataRegister;
@@ -233,6 +241,16 @@ struct ARM64LinkageProperties
    TR::RealRegister::RegNum getFramePointerRegister() const
       {
       return _framePointerRegister;
+      }
+
+   TR::RealRegister::RegNum getVTableIndexArgumentRegister() const
+      {
+      return _vtableIndexArgumentRegister;
+      }
+
+   TR::RealRegister::RegNum getJ9MethodArgumentRegister() const
+      {
+      return _j9methodArgumentRegister;
       }
 
    int32_t getOffsetToFirstParm() const {return _offsetToFirstParm;}


### PR DESCRIPTION
This commit adds some members and their getters to ARM64LinkageProperties
for use in OpenJ9.

Signed-off-by: knn-k <konno@jp.ibm.com>