### PR TITLE
Find appropriate semaphore implementation

### DIFF
--- a/cmake/modules/OmrDetectSystemInformation.cmake
+++ b/cmake/modules/OmrDetectSystemInformation.cmake
@@ -19,6 +19,54 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #############################################################################
 
+include(CheckSymbolExists)
+
+# Determine semaphore implementation to use on platform
+macro(omr_find_semaphore_implementation)
+	set(OMR_SEMAPHORE_IMPLEMENTATION "-NOTFOUND" CACHE STRING "What semaphore implementation to use")
+	set_property(CACHE OMR_SEMAPHORE_IMPLEMENTATION PROPERTY STRINGS posix osx windows zos)
+	mark_as_advanced(OMR_SEMAPHORE_IMPLEMENTATION)
+	if(NOT OMR_SEMAPHORE_IMPLEMENTATION)
+		if(OMR_OS_OSX)
+			set(OMR_SEMAPHORE_IMPLEMENTATION osx)
+		elseif(OMR_OS_WINDOWS)
+			set(OMR_SEMAPHORE_IMPLEMENTATION windows)
+		elseif(OMR_OS_ZOS)
+			set(OMR_SEMAPHORE_IMPLEMENTATION zos)
+		else()
+			# for now we assume that if sem_init exists, the rest of the posix semaphore functions are there
+			# Note: cmake requires that test source be able to compile and link, which requires us to tell it
+			# to link against pthread
+			set(_OLD_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+			set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} pthread)
+			check_symbol_exists(sem_init "semaphore.h" HAS_SEM_INIT)
+			set(CMAKE_REQUIRED_LIBRARIES "${_OLD_REQUIRED_LIBRARIES}")
+			if(HAS_SEM_INIT)
+				set(OMR_SEMAPHORE_IMPLEMENTATION posix)
+			endif()
+		endif()
+		# Force value of OMR_SEMAPHORE_IMPLEMENTATION
+		set_property(CACHE OMR_SEMAPHORE_IMPLEMENTATION PROPERTY VALUE "${OMR_SEMAPHORE_IMPLEMENTATION}")
+	endif()
+
+	unset(OMR_USE_OSX_SEMAPHORES)
+	unset(OMR_USE_POSIX_SEMAPHORES)
+	unset(OMR_USE_WINDOWS_SEMAPHORES)
+	unset(OMR_USE_ZOS_SEMAPHORES)
+
+	if(OMR_SEMAPHORE_IMPLEMENTATION STREQUAL osx)
+		set(OMR_USE_OSX_SEMAPHORES TRUE)
+	elseif(OMR_SEMAPHORE_IMPLEMENTATION STREQUAL posix)
+		set(OMR_USE_POSIX_SEMAPHORES TRUE)
+	elseif(OMR_SEMAPHORE_IMPLEMENTATION STREQUAL windows)
+		set(OMR_USE_WINDOWS_SEMAPHORES TRUE)
+	elseif(OMR_SEMAPHORE_IMPLEMENTATION STREQUAL zos)
+		set(OMR_USE_ZOS_SEMAPHORES TRUE)
+	else()
+		message(SEND_ERROR "'${OMR_SEMAPHORE_IMPLEMENTATION}' is not a valid value for OMR_SEMAPHORE_IMPLEMENTATION")
+	endif()
+endmacro()
+
 # Translate from CMake's view of the system to the OMR view of the system.
 # Exports a number of variables indicicating platform, os, endianness, etc.
 # - OMR_ARCH_{AARCH64,X86,ARM,S390} # TODO: Add POWER
@@ -147,4 +195,5 @@ macro(omr_detect_system_information)
 	message(STATUS "OMR: The tool configuration is ${OMR_TOOLCONFIG}")
 	message(STATUS "OMR: The target data size is ${OMR_ENV_TARGET_DATASIZE}")
 
+	omr_find_semaphore_implementation()
 endmacro(omr_detect_system_information)

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -254,4 +254,17 @@
  */
 #undef OMRPORT_OMRSIG_SUPPORT
 
+/**
+ * Platform config options.
+ * Note: these are determined at configure time with cmake.
+ * For the autoconf builds, we just hard code them based on platform
+ */
+#if defined(LINUX) || defined(AIXPPC)
+#define OMR_USE_POSIX_SEMAPHORES
+#elif defined(OSX)
+#define OMR_USE_OSX_SEMAPHORES
+#elif defined(J9ZOS390)
+#define OMR_USE_ZOS_SEMAPHORES
+#endif
+
 #endif /* !defined(OMRCFG_H_) */

--- a/include_core/unix/thrdsup.h
+++ b/include_core/unix/thrdsup.h
@@ -22,6 +22,8 @@
 #ifndef thrdsup_h
 #define thrdsup_h
 
+#include "omrcfg.h"
+
 #if !defined(J9ZOS390)
 #define J9_POSIX_THREADS
 #endif
@@ -67,19 +69,17 @@ typedef void* WRAPPER_ARG;
 #define WRAPPER_RETURN() return NULL
 typedef WRAPPER_TYPE (*WRAPPER_FUNC)(WRAPPER_ARG);
 
-#if defined(LINUX) || defined(AIXPPC)
+#if defined(OMR_USE_POSIX_SEMAPHORES)
 #include <semaphore.h>
 typedef sem_t OSSEMAPHORE;
-#elif defined(OSX) /* defined(LINUX) || defined(AIXPPC) */
+#elif defined(OMR_USE_OSX_SEMAPHORES) /* defined(OMR_USE_POSIX_SEMAPHORES) */
 typedef semaphore_t OSSEMAPHORE;
-#elif defined(J9ZOS390) /* defined(OSX) */
+#elif defined(OMR_USE_ZOS_SEMAPHORES) /* defined(OMR_USE_OSX_SEMAPHORES) */
 typedef struct zos_sem_t {
 	int count;
 	struct J9ThreadMonitor *monitor;
 } zos_sem_t;
 typedef zos_sem_t OSSEMAPHORE;
-#else /* defined(J9ZOS390) */
-typedef intptr_t OSSEMAPHORE;
 #endif /* defined(LINUX) || defined(AIXPPC) */
 
 
@@ -328,83 +328,34 @@ extern pthread_condattr_t *defaultCondAttr;
 #define TLS_GET(key) (pthread_getspecific(key))
 #endif
 
-/* SEM_CREATE */
-
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX)
+/* Semaphore functions */
 #define SEM_CREATE(threadLibrary, initValue) omrthread_allocate_memory(threadLibrary, sizeof(OSSEMAPHORE), OMRMEM_CATEGORY_THREADS)
-#else /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
-#define SEM_CREATE(threadLibrary, initValue)
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
-/* SEM_INIT */
+#define	SEM_FREE(lib, s)  	omrthread_free_memory(lib, s);
 
-#if defined(LINUX) || defined(AIXPPC)
-#define SEM_INIT(sm, pshrd, inval)	\
-	(sem_init((sem_t *)(sm), pshrd, inval))
-#elif defined(OSX)
+#if defined(OMR_USE_POSIX_SEMAPHORES)
+#define SEM_INIT(sm, pshrd, inval) (sem_init((sem_t *)(sm), pshrd, inval))
+#define SEM_DESTROY(sm) (sem_destroy((sem_t *)(sm)))
+#define SEM_POST(smP) (sem_post((sem_t *)(smP)))
+#define SEM_WAIT(smP) (sem_wait((sem_t *)(smP)))
+#define SEM_GETVALUE(smP, intP) (sem_getvalue(smP, intP))
+#elif defined(OMR_USE_OSX_SEMAPHORES)
 #define SEM_INIT(sm, pshrd, inval)	\
 	(semaphore_create(mach_task_self(), (semaphore_t *)(sm), SYNC_POLICY_FIFO, inval))
-#elif defined(J9ZOS390)
-#define SEM_INIT(sm,pshrd,inval)  (sem_init_zos(sm, pshrd, inval))
-#else /* defined(J9ZOS390) */
-#define SEM_INIT(sm,pshrd,inval)
-#endif /* defined(J9ZOS390) */
-/* SEM_DESTROY */
-
-#if defined(LINUX) || defined(AIXPPC)
-#define SEM_DESTROY(sm)	\
-	(sem_destroy((sem_t *)(sm)))
-#elif defined(OSX)
 #define SEM_DESTROY(sm)	\
 	(semaphore_destroy(mach_task_self(), *(semaphore_t *)(sm)))
-#elif defined(J9ZOS390)
-#define SEM_DESTROY(sm)	\
-	(sem_destroy_zos(sm))
+#define SEM_POST(smP) (semaphore_signal(*(semaphore_t *)(smP)))
+#define SEM_WAIT(smP) (semaphore_wait(*(semaphore_t *)(smP)))
+#define SEM_GETVALUE(smP, intP)
+#elif defined(OMR_USE_ZOS_SEMAPHORES)
+#define SEM_INIT(sm,pshrd,inval) (sem_init_zos(sm, pshrd, inval))
+#define SEM_DESTROY(sm)	(sem_destroy_zos(sm))
+#define SEM_POST(smP) (sem_post_zos(smP))
+#define SEM_WAIT(smP) (sem_wait_zos(smP))
+#define SEM_GETVALUE(smP, intP) (sem_getvalue_zos(smP, intP))
 #else
-#define SEM_DESTROY(sm) 0
+#error Could not find semaphore implementation
 #endif
-/* SEM_FREE */
 
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX)
-#define	SEM_FREE(lib, s)  	omrthread_free_memory(lib, s);
-#else /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
-#define SEM_FREE(lib, s)
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
-/* SEM_POST */
-
-#if defined(LINUX) || defined(AIXPPC)
-#define SEM_POST(smP)	\
-	(sem_post((sem_t *)(smP)))
-#elif defined(OSX)
-#define SEM_POST(smP)	\
-	(semaphore_signal(*(semaphore_t *)(smP)))
-#elif defined(J9ZOS390)
-#define SEM_POST(smP)   (sem_post_zos(smP))
-#else
-#define SEM_POST(sm)
-#endif
-/* SEM_WAIT */
-
-#if defined(LINUX) || defined(AIXPPC)
-#define SEM_WAIT(smP)	\
-	(sem_wait((sem_t *)(smP)))
-#elif defined(OSX)
-#define SEM_WAIT(smP)	\
-	(semaphore_wait(*(semaphore_t *)(smP)))
-#elif defined(J9ZOS390)
-#define SEM_WAIT(smP)           (sem_wait_zos(smP))
-#else
-#define SEM_WAIT(sm)
-#endif
-/* SEM_GETVALUE */
-
-#if defined(LINUX) || defined(AIXPPC)
-#define SEM_GETVALUE(smP, intP)	\
-	(sem_getvalue(smP, intP))
-#elif defined(J9ZOS390)
-#define SEM_GETVALUE(sm) (sem_getvalue_zos(smP, intP))
-#else
-#define SEM_GETVALUE(sm)
-#endif
 /* GET_HIRES_CLOCK */
 
 #ifdef OMR_THR_JLM_HOLD_TIMES

--- a/omrcfg.CMakeTemplate.h
+++ b/omrcfg.CMakeTemplate.h
@@ -236,4 +236,9 @@
  */
 #cmakedefine OMRPORT_OMRSIG_SUPPORT
 
+/* Plaform config options */
+#cmakedefine OMR_USE_POSIX_SEMAPHORES
+#cmakedefine OMR_USE_OSX_SEMAPHORES
+#cmakedefine OMR_USE_ZOS_SEMAPHORES
+
 #endif /* !defined(OMRCFG_H_) */


### PR DESCRIPTION
For cmake builds determine appropriate semapahore implementation at
configure time. Autoconf builds just set value according to OS.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>