### PR TITLE
Remove unnecessary use of grep '-h' option

### DIFF
--- a/ddr/tools/getmacros
+++ b/ddr/tools/getmacros
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -272,7 +272,8 @@ main() {
 	date "+[%F %T] Scraping anotations from preprocessed code ..."
 	find ${scan_dir} -type f -name '*.i' \
 		| sort \
-		| xargs -L1 grep -hE -e '^@(DDRFILE|MACRO|TYPE)_' \
+		| xargs cat \
+		| grep -E -e '^@(DDRFILE|MACRO|TYPE)_' \
 		| awk "${dedup_filter[*]}" \
 		> ${macroList_file}
 


### PR DESCRIPTION
* remove use of 'grep -h' as it's not supported on z/OS
* improve scraping of anotations from preprocessed code by using using 'xargs cat | grep' instead of 'xargs -L1 grep' to spawn fewer processes