### PR TITLE
Remove J9 from omrsig* code [Part 2]

### DIFF
--- a/include_core/unix/zos/leconditionhandler.h
+++ b/include_core/unix/zos/leconditionhandler.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 #include "edcwccwi.h"
 #include "omrport.h"
 
-typedef struct J9ZOSLEConditionHandlerRecord {
+typedef struct OMRZOSLEConditionHandlerRecord {
 	struct OMRPortLibrary *portLibrary;
 	omrsig_handler_fn handler;
 	void *handler_arg;
@@ -37,6 +37,9 @@ typedef struct J9ZOSLEConditionHandlerRecord {
 	struct __jumpinfo farJumpInfo;
 	uint32_t flags;
 	uint32_t recursiveCheck; /* if this is set to 1, the handler corresponding to this record has been invoked recursively */
-} J9ZOSLEConditionHandlerRecord;
+} OMRZOSLEConditionHandlerRecord;
+
+/* TODO Remove once downstream projects are updated */
+#define J9ZOSLEConditionHandlerRecord OMRZOSLEConditionHandlerRecord
 
 #endif /* leconditionhandler_h */

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -121,9 +121,9 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 			 * We can't use j9port_isFunctionOverridden to check for this because
 			 * the port library overrides sig_protect itself (with omrsig_protect_ceehdlr)
 			 * when the option OMRPORT_SIG_OPTIONS_ZOS_USE_CEEHDLR is passed into omrsig_set_options */
-			extern void j9vm_le_condition_handler(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBACK *newfc);
+			extern void omrsig_le_condition_handler(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBACK *newfc);
 
-			*(void (**)(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBACK *newfc))value = j9vm_le_condition_handler;
+			*(void (**)(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBACK *newfc))value = omrsig_le_condition_handler;
 			return 0;
 		} else {
 			return 1;

--- a/port/win64amd/omrsignal.c
+++ b/port/win64amd/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -66,7 +66,7 @@ typedef struct OMRCurrentSignal {
 
 /* key to get the current synchronous signal */
 static omrthread_tls_key_t tlsKeyCurrentSignal;
-static RUNTIME_FUNCTION *j9SigProtectFunction = NULL;
+static RUNTIME_FUNCTION *sigProtectFunction = NULL;
 
 struct OMRSignalHandlerRecord {
 	struct OMRSignalHandlerRecord *previous;
@@ -576,7 +576,7 @@ omrsig_startup(struct OMRPortLibrary *portLibrary)
 	}
 
 	memset(&unwindHistoryTable, 0, sizeof(UNWIND_HISTORY_TABLE));
-	j9SigProtectFunction = RtlLookupFunctionEntry((ULONG64)omrsig_protect, &imageBase, &unwindHistoryTable);
+	sigProtectFunction = RtlLookupFunctionEntry((ULONG64)omrsig_protect, &imageBase, &unwindHistoryTable);
 
 	omrthread_monitor_exit(globalMonitor);
 
@@ -746,7 +746,7 @@ tryExceptHandlerExistsOnStack(OMRPortLibrary *portLibrary, CONTEXT *originalCont
 			unwindInfo = (UNWIND_INFO *)(runtimeFunction->UnwindData + imageBase);
 			flags = unwindInfo->Flags;
 
-			if (runtimeFunction == j9SigProtectFunction) {
+			if (runtimeFunction == sigProtectFunction) {
 				return FALSE;
 			} else if (UNW_FLAG_EHANDLER == flags) {
 				/* we found a try/except handler */

--- a/port/zos390/omr__le_api.h
+++ b/port/zos390/omr__le_api.h
@@ -29,20 +29,20 @@
 /*
  * &NAME.HR_VALID   EQU   X'40'      High regs valid in REG_H field   @D3A
  */
-#define J9MCH_FLAGS_HGPRS_VALID 0x40
+#define OMRPORT_MCH_FLAGS_HGPRS_VALID 0x40
 /* if this bit is set in the mch_flags field of omr_31bit_mch, the values in the hgprs field in omr_31bit_mch are valid */
 /*
  * &NAME.INT_SF_VALID   EQU X'20'    Interrupt stackframe valid in    @D5A
  *                                 INT_SF field
  */
-#define J9MCH_FLAGS_INT_SF_VALID 0x20
+#define OMRPORT_MCH_FLAGS_INT_SF_VALID 0x20
 
 /*
  * If this bit is set in the mch_flags field of the omr_31bit_mch, the values in the VR registers in omr_31bit_mch are valid
  *
  * &NAME.VR_VALID	EQU X'2'	Vector registers saved in MCH
  */
-#define J9MCH_FLAGS_VR_VALID	0x2
+#define OMRPORT_MCH_FLAGS_VR_VALID	0x2
 
 /*
  * Derived from the assembler version, CEEMCH.COPY, as there is no C-mapping of the 31-bit (machine context)

--- a/port/zos390/omr__le_api.h
+++ b/port/zos390/omr__le_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,12 +25,12 @@
 
 #include "omrcomp.h"
 
-/* if this bit is set in the mch_flags field of j9_31bit_mch, the values in the hgprs field in j9_31bit_mch are valid */
+/* if this bit is set in the mch_flags field of omr_31bit_mch, the values in the hgprs field in omr_31bit_mch are valid */
 /*
  * &NAME.HR_VALID   EQU   X'40'      High regs valid in REG_H field   @D3A
  */
 #define J9MCH_FLAGS_HGPRS_VALID 0x40
-/* if this bit is set in the mch_flags field of j9_31bit_mch, the values in the hgprs field in j9_31bit_mch are valid */
+/* if this bit is set in the mch_flags field of omr_31bit_mch, the values in the hgprs field in omr_31bit_mch are valid */
 /*
  * &NAME.INT_SF_VALID   EQU X'20'    Interrupt stackframe valid in    @D5A
  *                                 INT_SF field
@@ -38,7 +38,7 @@
 #define J9MCH_FLAGS_INT_SF_VALID 0x20
 
 /*
- * If this bit is set in the mch_flags field of the j9_31bit_mch, the values in the VR registers in j9_31bit_mch are valid
+ * If this bit is set in the mch_flags field of the omr_31bit_mch, the values in the VR registers in omr_31bit_mch are valid
  *
  * &NAME.VR_VALID	EQU X'2'	Vector registers saved in MCH
  */
@@ -54,7 +54,7 @@
  * struct _CEECIB is accessible from a condition handler via the LE service CEE3CIB
  *
  */
-typedef struct j9_31bit_mch {
+typedef struct omr_31bit_mch {
 	/*
 	 * &NAME.EYEC       DC    CL4'CMCH'          Eye catcher
 	 * &NAME.SIZE       DC    H'0'               Size of area
@@ -128,6 +128,6 @@ typedef struct j9_31bit_mch {
 	uint32_t padding6[32];
 
 	U_128 vr[32];
-} j9_31bit_mch;
+} omr_31bit_mch;
 
 #endif /* omr__le_api_h */

--- a/port/zos390/omrsignal_ceehdlr.c
+++ b/port/zos390/omrsignal_ceehdlr.c
@@ -64,7 +64,7 @@ static void setCurrentSignal(struct OMRPortLibrary *portLibrary, uint32_t portLi
  *
  *	@param[in]	fc		A 12-byte condition token that identifies the current condition being processed.
  * 							Language Environment uses this parameter to tell your condition handler what condition has occurred.
- *	@param[in]	token 	An J9ZOSLEConditionHandlerRecord as specified when this handler was registered by @ref omrsig_protect_ceehdlr
+ *	@param[in]	token 	An OMRZOSLEConditionHandlerRecord as specified when this handler was registered by @ref omrsig_protect_ceehdlr
  *	@param[in]	leResult	A 4-byte integer that contains instructions about responses the user-written condition
  * 							handler wants Language Environment to make when processing the condition.
  * 							The result_code is passed by reference.
@@ -92,7 +92,7 @@ static void setCurrentSignal(struct OMRPortLibrary *portLibrary, uint32_t portLi
 void
 omrsig_le_condition_handler(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBACK *newfc)
 {
-	struct J9ZOSLEConditionHandlerRecord *thisRecord = (struct J9ZOSLEConditionHandlerRecord *)*token;
+	struct OMRZOSLEConditionHandlerRecord *thisRecord = (struct OMRZOSLEConditionHandlerRecord *)*token;
 	uint32_t handlerResult;
 	_FEEDBACK ceemrcrFc;
 	_INT4 ceemrcrType = 0;
@@ -238,7 +238,7 @@ int32_t
 omrsig_protect_ceehdlr(struct OMRPortLibrary *portLibrary,  omrsig_protected_fn fn, void *fn_arg, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, uintptr_t *result)
 {
 
-	struct J9ZOSLEConditionHandlerRecord thisRecord;
+	struct OMRZOSLEConditionHandlerRecord thisRecord;
 	_FEEDBACK fc;
 	_ENTRY leConditionHandler;
 	_INT4 token;

--- a/port/zos390/omrsignal_ceehdlr.c
+++ b/port/zos390/omrsignal_ceehdlr.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -160,7 +160,7 @@ j9vm_le_condition_handler(_FEEDBACK *fc, _INT4 *token, _INT4 *leResult, _FEEDBAC
 	if (OMR_ARE_ANY_BITS_SET(thisRecord->flags, portlibSignalNo)
 	 || ((0 == portlibSignalNo) && OMR_ARE_ANY_BITS_SET(thisRecord->flags, OMRPORT_SIG_FLAG_SIGALLSYNC))
 	) {
-		J9LEConditionInfo signalInfo;
+		OMRLEConditionInfo signalInfo;
 		_CEECIB *cib_ptr = NULL;
 		_FEEDBACK cibfc;
 

--- a/port/zos390/omrsignal_context.c
+++ b/port/zos390/omrsignal_context.c
@@ -352,7 +352,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 #else
 	_CEECIB *conditionInfoBlock = NULL;
 	_FEEDBACK cibfc;
-	j9_31bit_mch *j9mch = NULL;
+	omr_31bit_mch *j9mch = NULL;
 #endif
 
 	*name = "";
@@ -405,7 +405,7 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 
 		/* verify that CEE3CIB was successful */
 		if (0 == _FBCHECK(cibfc , CEE000)) {
-			j9mch = (j9_31bit_mch *)conditionInfoBlock->cib_machine;
+			j9mch = (omr_31bit_mch *)conditionInfoBlock->cib_machine;
 			info->platformSignalInfo.breakingEventAddr = *(uintptr_t *)(&j9mch->bea);
 #endif
 			*name = "bea";

--- a/port/zos390/omrsignal_context.c
+++ b/port/zos390/omrsignal_context.c
@@ -348,11 +348,11 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 {
 #if defined(OMR_ENV_DATA64)
 	struct __cib *conditionInfoBlock = NULL;
-	__mch_t *j9mch = NULL;
+	__mch_t *mchRegs = NULL;
 #else
 	_CEECIB *conditionInfoBlock = NULL;
 	_FEEDBACK cibfc;
-	omr_31bit_mch *j9mch = NULL;
+	omr_31bit_mch *mchRegs = NULL;
 #endif
 
 	*name = "";
@@ -397,16 +397,16 @@ infoForControl(struct OMRPortLibrary *portLibrary, OMRUnixSignalInfo *info, int3
 		conditionInfoBlock = __le_cib_get();
 
 		if (NULL != conditionInfoBlock) {
-			j9mch = (__mch_t *)conditionInfoBlock->cib_machine;
-			info->platformSignalInfo.breakingEventAddr = *(uintptr_t *)(&j9mch->__mch_bea);
+			mchRegs = (__mch_t *)conditionInfoBlock->cib_machine;
+			info->platformSignalInfo.breakingEventAddr = *(uintptr_t *)(&mchRegs->__mch_bea);
 #else
 		/* 31-bit: request the condition information block to access the machine context for BEA */
 		CEE3CIB(NULL, &conditionInfoBlock, &cibfc);
 
 		/* verify that CEE3CIB was successful */
 		if (0 == _FBCHECK(cibfc , CEE000)) {
-			j9mch = (omr_31bit_mch *)conditionInfoBlock->cib_machine;
-			info->platformSignalInfo.breakingEventAddr = *(uintptr_t *)(&j9mch->bea);
+			mchRegs = (omr_31bit_mch *)conditionInfoBlock->cib_machine;
+			info->platformSignalInfo.breakingEventAddr = *(uintptr_t *)(&mchRegs->bea);
 #endif
 			*name = "bea";
 			*value = &(info->platformSignalInfo.breakingEventAddr);

--- a/port/zos390/omrsignal_context_ceehdlr.c
+++ b/port/zos390/omrsignal_context_ceehdlr.c
@@ -37,7 +37,7 @@
  * This was derived from fillInJumpInfo in port/zos390/omrsignal_context.c
  */
 void
-fillInLEJumpInfo(struct OMRPortLibrary *portLibrary, j9_31bit_mch *regs, void *jumpInfo)
+fillInLEJumpInfo(struct OMRPortLibrary *portLibrary, omr_31bit_mch *regs, void *jumpInfo)
 {
 	int i = 0;
 	struct __jumpinfo *farJumpInfo  = (struct __jumpinfo *)jumpInfo;
@@ -140,7 +140,7 @@ infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 		"fpr14",
 		"fpr15"
 	};
-	j9_31bit_mch *j9mch = (j9_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
 
 
@@ -211,7 +211,7 @@ infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 		"hgpr15"
 #endif
 	};
-	j9_31bit_mch *j9mch = (j9_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
 
 	*name = "";
 
@@ -271,7 +271,7 @@ infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, i
 		"vr31"
 	};
 
-	j9_31bit_mch *j9mch = (j9_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
 
 	*name = "";
 
@@ -295,7 +295,7 @@ infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, i
 uint32_t
 infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
 {
-	j9_31bit_mch *j9mch = (j9_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
 
 	switch (index) {
@@ -361,7 +361,7 @@ infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *inf
 	return OMRPORT_SIG_VALUE_UNDEFINED;
 
 #else
-	j9_31bit_mch *j9mch = (j9_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
 
 	/* Input paramaters to CEETBCK
 	 * We don't know what the stack format was for the routine that triggered the condition,
@@ -461,7 +461,7 @@ infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *inf
 uint32_t
 infoForSignal_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
 {
-	j9_31bit_mch *j9mch = (j9_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
 
 	switch (index) {

--- a/port/zos390/omrsignal_context_ceehdlr.c
+++ b/port/zos390/omrsignal_context_ceehdlr.c
@@ -120,7 +120,7 @@ fillInLEJumpInfo(struct OMRPortLibrary *portLibrary, omr_31bit_mch *regs, void *
 
 /* infoForFPR_ceehdlr() follows the same convention as infoForFPR() in port/zos390/omrsignal_context.c */
 uint32_t
-infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
+infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value)
 {
 	const char *n_fpr[NUM_REGS] = {
 		"fpr0",
@@ -171,7 +171,7 @@ infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 
 /* infoForGPR_ceehdlr() follows the same convention as infoForGPR() in port/zos390/omrsignal_context.c */
 uint32_t
-infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
+infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value)
 {
 
 	const char *n_gpr[NUM_REGS * 2] = {
@@ -234,7 +234,7 @@ infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 
 /* infoForVR_ceehdlr() follows the same convention as infoForGPR() in port/zos390/omrsignal_context.c */
 uint32_t
-infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
+infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value)
 {
 	const char *const n_vr[NUM_VECTOR_REGS] = {
 		"vr0",
@@ -293,7 +293,7 @@ infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, i
  * for a specific register/attribute can requested.
  */
 uint32_t
-infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
+infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value)
 {
 	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
@@ -351,7 +351,7 @@ infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *in
  *
  */
 uint32_t
-infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
+infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value)
 {
 
 #if defined(J9ZOS39064)
@@ -459,7 +459,7 @@ infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *inf
  * for a specific register/attribute can requested.
  */
 uint32_t
-infoForSignal_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
+infoForSignal_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value)
 {
 	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";

--- a/port/zos390/omrsignal_context_ceehdlr.c
+++ b/port/zos390/omrsignal_context_ceehdlr.c
@@ -140,7 +140,7 @@ infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 		"fpr14",
 		"fpr15"
 	};
-	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
 
 
@@ -155,14 +155,14 @@ infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 
 		if (0 == (index % 2)) {
 			/* even index */
-			*value = &(j9mch->fprs_0246[index / 2]);
+			*value = &(mchRegs->fprs_0246[index / 2]);
 		} else {
 			/* odd index */
-			*value = &(j9mch->fprs_1357[(index - 1) / 2]);
+			*value = &(mchRegs->fprs_1357[(index - 1) / 2]);
 		}
 
 	} else if (8 <= index <= 15) {
-		*value = &(j9mch->fprs_8_15[index - 8]);
+		*value = &(mchRegs->fprs_8_15[index - 8]);
 	}
 
 	return OMRPORT_SIG_VALUE_64;
@@ -211,19 +211,19 @@ infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, 
 		"hgpr15"
 #endif
 	};
-	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 
 	*name = "";
 
 	if ((index >= 0) && (index < NUM_REGS)) {
 		*name = n_gpr[index];
-		*value = &(j9mch->gprs[index]);
+		*value = &(mchRegs->gprs[index]);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	}
 #if !defined(OMR_ENV_DATA64)
 	else if ((index >= NUM_REGS) && (index < NUM_REGS * 2)) {
 		*name = n_gpr[index];
-		*value = &(j9mch->hgprs[index - NUM_REGS]);
+		*value = &(mchRegs->hgprs[index - NUM_REGS]);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	}
 #endif
@@ -271,16 +271,16 @@ infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, i
 		"vr31"
 	};
 
-	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 
 	*name = "";
 
-	if (0 == (j9mch->mch_flags & J9MCH_FLAGS_VR_VALID)) {
+	if (0 == (mchRegs->mch_flags & J9MCH_FLAGS_VR_VALID)) {
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 	if ((index >= 0) && (index < NUM_VECTOR_REGS)) {
 		*name = n_vr[index];
-		*value = &(j9mch->vr[index]);
+		*value = &(mchRegs->vr[index]);
 		return OMRPORT_SIG_VALUE_128;
 	}
 
@@ -295,29 +295,29 @@ infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, i
 uint32_t
 infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
 {
-	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
 
 	switch (index) {
 	case OMRPORT_SIG_CONTROL_S390_FPC:
 	case 0:
 		*name = "fpc";
-		*value = &(j9mch->fpc);
+		*value = &(mchRegs->fpc);
 		return OMRPORT_SIG_VALUE_32;
 	case 1:
 		*name = "psw0";
-		*value = &(j9mch->psw0);
+		*value = &(mchRegs->psw0);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_CONTROL_PC:
 	case 2:
 		*name = "psw1";
-		*value = &(j9mch->psw1);
+		*value = &(mchRegs->psw1);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	case OMRPORT_SIG_CONTROL_SP:
 	case 3:
 		*name = "sp";
-		if (0 != (j9mch->mch_flags & J9MCH_FLAGS_INT_SF_VALID)) {
-			*value = &(j9mch->interrupt_stack_frame);
+		if (0 != (mchRegs->mch_flags & J9MCH_FLAGS_INT_SF_VALID)) {
+			*value = &(mchRegs->interrupt_stack_frame);
 			return OMRPORT_SIG_VALUE_ADDRESS;
 		} else {
 			return OMRPORT_SIG_VALUE_UNDEFINED;
@@ -325,7 +325,7 @@ infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *in
 	case OMRPORT_SIG_CONTROL_S390_BEA:
 	case 4:
 		*name = "bea";
-		*value = &(j9mch->bea);
+		*value = &(mchRegs->bea);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	/* Provide access to GPR7 when requested specifically, but
 	 * hide it from the iterator by only casing it with OMRPORT_SIG_CONTROL_S390_GPR7
@@ -333,7 +333,7 @@ infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *in
 	 */
 	case OMRPORT_SIG_CONTROL_S390_GPR7:
 		*name = "gpr7";
-		*value = &(j9mch->gprs[7]);
+		*value = &(mchRegs->gprs[7]);
 		return OMRPORT_SIG_VALUE_ADDRESS;
 	default:
 		return OMRPORT_SIG_VALUE_UNDEFINED;
@@ -361,7 +361,7 @@ infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *inf
 	return OMRPORT_SIG_VALUE_UNDEFINED;
 
 #else
-	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 
 	/* Input paramaters to CEETBCK
 	 * We don't know what the stack format was for the routine that triggered the condition,
@@ -461,7 +461,7 @@ infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *inf
 uint32_t
 infoForSignal_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value)
 {
-	omr_31bit_mch *j9mch = (omr_31bit_mch *)info->cib->cib_machine;
+	omr_31bit_mch *mchRegs = (omr_31bit_mch *)info->cib->cib_machine;
 	*name = "";
 
 	switch (index) {

--- a/port/zos390/omrsignal_context_ceehdlr.c
+++ b/port/zos390/omrsignal_context_ceehdlr.c
@@ -67,8 +67,8 @@ fillInLEJumpInfo(struct OMRPortLibrary *portLibrary, omr_31bit_mch *regs, void *
 	farJumpInfo->__ji_fl_res1a = 0;
 
 #if !defined(OMR_ENV_DATA64)
-	if (0 != (regs->mch_flags & J9MCH_FLAGS_HGPRS_VALID)) {
-		/* The J9MCH_FLAGS_HGPRS_VALID bit was set */
+	if (0 != (regs->mch_flags & OMRPORT_MCH_FLAGS_HGPRS_VALID)) {
+		/* The OMRPORT_MCH_FLAGS_HGPRS_VALID bit was set */
 		farJumpInfo->__ji_fl_hr	= 1;
 	} else {
 		farJumpInfo->__ji_fl_hr	= 0;
@@ -275,7 +275,7 @@ infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, 
 
 	*name = "";
 
-	if (0 == (mchRegs->mch_flags & J9MCH_FLAGS_VR_VALID)) {
+	if (0 == (mchRegs->mch_flags & OMRPORT_MCH_FLAGS_VR_VALID)) {
 		return OMRPORT_SIG_VALUE_UNDEFINED;
 	}
 	if ((index >= 0) && (index < NUM_VECTOR_REGS)) {
@@ -316,7 +316,7 @@ infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *i
 	case OMRPORT_SIG_CONTROL_SP:
 	case 3:
 		*name = "sp";
-		if (0 != (mchRegs->mch_flags & J9MCH_FLAGS_INT_SF_VALID)) {
+		if (0 != (mchRegs->mch_flags & OMRPORT_MCH_FLAGS_INT_SF_VALID)) {
 			*value = &(mchRegs->interrupt_stack_frame);
 			return OMRPORT_SIG_VALUE_ADDRESS;
 		} else {

--- a/port/zos390/omrsignal_context_ceehdlr.h
+++ b/port/zos390/omrsignal_context_ceehdlr.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,7 @@
 
 #define MAX_NAME 256
 
-typedef struct {
+typedef struct OMRLEConditionInfo {
 	_FEEDBACK *fc;
 	_CEECIB *cib;
 	uint16_t messageNumber;
@@ -43,12 +43,12 @@ typedef struct {
 	uint32_t portLibrarySignalType;
 	void *handlerAddress;
 	void *handlerAddress2;
-} J9LEConditionInfo;
+} OMRLEConditionInfo;
 
-uint32_t infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value);
-uint32_t infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value);
-uint32_t infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value);
-uint32_t infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value);
-uint32_t infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, J9LEConditionInfo *info, int32_t index, const char **name, void **value);
+uint32_t infoForFPR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value);
+uint32_t infoForGPR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value);
+uint32_t infoForVR_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value);
+uint32_t infoForControl_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value);
+uint32_t infoForModule_ceehdlr(struct OMRPortLibrary *portLibrary, OMRLEConditionInfo *info, int32_t index, const char **name, void **value);
 
 #endif /* omrsignal_context_ceehdlr_h */

--- a/port/ztpf/omrsignal.c
+++ b/port/ztpf/omrsignal.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -212,11 +212,6 @@ ztpf_fireSignalHandlers(void *portlib)
 #define MAX_PORTLIB_SIGNAL_TYPES 8
 
 typedef  void (*unix_sigaction) (int, siginfo_t *, void *, UDATA);
-
-/* CMVC 96193
- * Prototyping here to avoid including j9protos.h
- */
-extern J9_CFUNC void issueWriteBarrier(void);
 
 /* Store the previous signal handlers, we need to restore them when we're done */
 static struct {


### PR DESCRIPTION
- J9 was removed or renamed to OMR in the structures, functions and comments used in the omrsig library. 
- At some places, redundant code was removed.
- A macro with the old name is introduced to prevent breakage in the downstream projects. Such macros can be removed once the old names are no longer used in the downstream projects.
- These changes don't impact external projects.
- Related to https://github.com/eclipse/omr/issues/3713.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>