### PR TITLE
Miscellaneous updates specific to z/TPF

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -18,6 +18,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+#ifdef J9ZTPF
+#define __TPF_DO_NOT_MAP_ATOE_REMOVE
+#endif
 
 #include "optimizer/Inliner.hpp"
 

--- a/omrmakefiles/rules.ztpf.mk
+++ b/omrmakefiles/rules.ztpf.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,7 +42,7 @@ endif
 ### Global Flags
 ###
 
-GLOBAL_CPPFLAGS += -DLINUX -D_REENTRANT -DJ9ZTPF -DOMRZTPF -DOMRPORT_JSIG_SUPPORT
+GLOBAL_CPPFLAGS += -DLINUX -D_REENTRANT -DJ9ZTPF -DOMRZTPF -DOMRPORT_JSIG_SUPPORT -DIBMLOCKS
 GLOBAL_CPPFLAGS += -D_GNU_SOURCE -DIBM_ATOE -D_TPF_SOURCE -D_TPF_THREADS -DZTPF_POSIX_SOCKET
 
 ifeq (s390,$(OMR_HOST_ARCH))
@@ -108,7 +108,7 @@ ifneq (,$(findstring executable,$(ARTIFACT_TYPE)))
     GLOBAL_LDFLAGS+=$(DEFAULT_LIBS)
 endif
 
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/redhat/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/gnu/all /ztpf/commit
 
 ###
 ### Shared Libraries
@@ -136,6 +136,7 @@ ifeq (gcc,$(OMR_TOOLCHAIN))
     GLOBAL_LDFLAGS+=-Wl,--as-needed
     GLOBAL_LDFLAGS+=-Wl,--eh-frame-hdr
     GLOBAL_LDFLAGS+=$(foreach d,$(TPF_ROOT),-L$d/base/lib)
+    GLOBAL_LDFLAGS+=$(foreach d,$(TPF_ROOT),-L$d/base/stdlib)
     GLOBAL_LDFLAGS+=$(foreach d,$(TPF_ROOT),-L$d/opensource/stdlib)
     GLOBAL_LDFLAGS+=-lgcc
     GLOBAL_LDFLAGS+=-lCTOE

--- a/port/ztpf/omrintrospect.c
+++ b/port/ztpf/omrintrospect.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -725,11 +725,11 @@ upcall_handler(int signal, siginfo_t *siginfo, void *context_arg)
  * queue full error, but then we can't queue additional signals to prompt thread scheduling. Also it may not be
  * capped on all systems).
  *
- * @param data - the platform specific data, ignored 
+ * @param data - the platform specific data, ignored
  * @return number of threads in the process
  */
 static int
-count_threads( struct PlatformWalkData *data ) { 
+count_threads( struct PlatformWalkData *data ) {
 	struct iproc		*pProc;
 	struct ithgl		*pThgl;
 	if( is_threaded_ecb() ) {
@@ -817,10 +817,10 @@ resume_all_preempted(struct PlatformWalkData *data)
 	struct OMRPortLibrary *portLibrary = state->portLibrary;
 	int	test_sig = SUSPEND_SIG;
 
-	/* 
-	 * We skip everything but the semaphores and the process mask if we didn't 
-	 * successfully install the signal handlers. Now there are no outstanding 
-	 * signals on the queue we can drop the handler 
+	/*
+	 * We skip everything but the semaphores and the process mask if we didn't
+	 * successfully install the signal handlers. Now there are no outstanding
+	 * signals on the queue we can drop the handler
 	 */
 	if (data->threadsOutstanding > 0) {
 		/* inhibit collection of contexts from any of the outstanding threads we release */
@@ -882,7 +882,7 @@ resume_all_preempted(struct PlatformWalkData *data)
 }
 
 
-int  __attribute__((optimize(O0)))
+int  __attribute__((optimize(0)))
 J9ZTPF_getcontext( void *region )
 {
         register char *rgn asm("r2") = (char *)region;
@@ -1076,7 +1076,7 @@ omrintrospect_threads_startDo_with_signal(struct OMRPortLibrary *portLibrary, J9
 
 /*
  *	The following preprocessor guard will stop all attempts at attempting to walk the
- *	native thread stacks, thus avoiding some pretty sticky code which may or may not 
+ *	native thread stacks, thus avoiding some pretty sticky code which may or may not
  *	work on z/TPF. We'll leave this gate open for now, with a pending decision to close
  *	it or not.
  */

--- a/port/ztpf/omrosdump_helpers.c
+++ b/port/ztpf/omrosdump_helpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -993,7 +993,7 @@ ztpf_nonpreemptible_helper(void)
 	/*
 	 *    Only proceed if (1) the signal is currently NOT blocked, and (2)
 	 *    if no other interrupt has queued itself. In the interim, if
-	 *    applicable, sleep for 50 ms. IOW, serialize all synchronous
+	 *    applicable, sleep for 10 ms. IOW, serialize all synchronous
 	 *    signals -- we have to, we only have one JDB.
 	 */
 	sigemptyset(&newmask); /* Ensure our 'constant' mask word is zeros    */
@@ -1003,7 +1003,7 @@ ztpf_nonpreemptible_helper(void)
 		PROC_LOCK(&(s->pPROC->iproc_JVMLock), holdkey);
 		if (s->pPROC->iproc_tdibptr) { /* Are we blocked because we're already    working    */
 			PROC_UNLOCK(&(s->pPROC->iproc_JVMLock), holdkey); /* another signal? If so,unlock    */
-			usleep(50000); /* and sleep for 50 ms.            */
+			usleep(10000); /* and sleep for 10 ms.            */
 		}
 		pthread_sigmask(SIG_BLOCK, NULL, &oldmask); /* Test the signal mask again.    */
 	} while ((newmask & oldmask) || (s->pPROC->iproc_tdibptr));

--- a/thread/common/thrprof.c
+++ b/thread/common/thrprof.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -721,7 +721,7 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 		}
 #endif	/* defined(OMR_OS_WINDOWS) */
 
-#if (defined(LINUX) && !defined(J9ZTPF)) || defined(AIXPPC) || defined(OSX)
+#if defined(LINUX) || defined(AIXPPC) || defined(OSX)
 		struct rusage rUsage;
 		memset(&rUsage, 0, sizeof(rUsage));
 


### PR DESCRIPTION
z/TPF had a build path change which needs to be propagated to the
build (redhat subpath is now gnu).  Additionally, z/TPF now supports
some features of getrusage.  A micro sleep was reduced during
system dump processing to improve reliability and performance.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>