### PR TITLE
Change signature of getNextSlotMap()

### DIFF
--- a/example/glue/MixedObjectScanner.hpp
+++ b/example/glue/MixedObjectScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -104,17 +104,17 @@ public:
 	 * @see GC_ObjectScanner::getNextSlotMap()
 	 */
 	virtual fomrobject_t *
-	getNextSlotMap(uintptr_t &slotMap, bool &hasNextSlotMap)
+	getNextSlotMap(uintptr_t *slotMap, bool *hasNextSlotMap)
 	{
 		intptr_t slotCount = _endPtr - _scanPtr;
 
 		/* Initialize the slot map assuming all slots are reference slots or NULL */
 		if (slotCount < _bitsPerScanMap) {
-			slotMap = (((uintptr_t)1) << slotCount) - 1;
-			hasNextSlotMap = false;
+			*slotMap = (((uintptr_t)1) << slotCount) - 1;
+			*hasNextSlotMap = false;
 		} else {
-			slotMap = ~((uintptr_t)0);
-			hasNextSlotMap = slotCount > _bitsPerScanMap;
+			*slotMap = ~((uintptr_t)0);
+			*hasNextSlotMap = slotCount > _bitsPerScanMap;
 		}
 
 		_mapPtr += _bitsPerScanMap;
@@ -123,12 +123,12 @@ public:
 
 #if defined(OMR_GC_LEAF_BITS)
 	/**
-	 * @see GC_ObjectScanner::getNextSlotMap(uintptr_t&, uintptr_t&, bool&)
+	 * @see GC_ObjectScanner::getNextSlotMap(uintptr_t *, uintptr_t *, bool *)
 	 */
 	virtual fomrobject_t *
-	getNextSlotMap(uintptr_t &slotMap, uintptr_t &leafMap, bool &hasNextSlotMap)
+	getNextSlotMap(uintptr_t *slotMap, uintptr_t *leafMap, bool *hasNextSlotMap)
 	{
-		leafMap = 0;
+		*leafMap = 0;
 		return getNextSlotMap(slotMap, hasNextSlotMap);
 	}
 #endif /* OMR_GC_LEAF_BITS */

--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -186,7 +186,7 @@ public:
 	 * @param[out] hasNextSlotMap set this to true if this method should be called again, false if this map is known to be last
 	 * @return a pointer to the first slot mapped by the least significant bit of the map, or NULL if no more slots
 	 */
-	virtual fomrobject_t *getNextSlotMap(uintptr_t &scanMap, bool &hasNextSlotMap) = 0;
+	virtual fomrobject_t *getNextSlotMap(uintptr_t *scanMap, bool *hasNextSlotMap) = 0;
 
 	/**
 	 * Get the next object slot if one is available.
@@ -213,7 +213,7 @@ public:
 			/* slot bit map is empty -- try to refresh it */
 			if (hasMoreSlots()) {
 				bool hasNextSlotMap;
-				_scanPtr = getNextSlotMap(_scanMap, hasNextSlotMap);
+				_scanPtr = getNextSlotMap(&_scanMap, &hasNextSlotMap);
 				if (!hasNextSlotMap) {
 					setNoMoreSlots();
 				}
@@ -238,7 +238,7 @@ public:
 	 * stack.
 	 *
 	 * If leaf information is available it should be expressed in the implementation
-	 * of getNextSlotMap(uintptr_t &, uintptr_t &, bool &). This method is called to
+	 * of getNextSlotMap(uintptr_t *, uintptr_t *, bool *). This method is called to
 	 * obtain a bit map of the contained leaf slots conforming to the reference slot
 	 * map. An initial leaf map is provided to the GC_ObjectScanner constructor and
 	 * it is refreshed when required.
@@ -256,7 +256,7 @@ public:
 	 * @param[out] hasNextSlotMap set this to true if this method should be called again, false if this map is known to be last
 	 * @return a pointer to the first slot mapped by the least significant bit of the map, or NULL if no more slots
 	 */
-	virtual fomrobject_t *getNextSlotMap(uintptr_t &scanMap, uintptr_t &leafMap, bool &hasNextSlotMap) = 0;
+	virtual fomrobject_t *getNextSlotMap(uintptr_t *scanMap, uintptr_t *leafMap, bool *hasNextSlotMap) = 0;
 
 	/**
 	 * Get the next object slot if one is available.
@@ -287,7 +287,7 @@ public:
 			/* slot bit map is empty -- try to refresh it */
 			if (hasMoreSlots()) {
 				bool hasNextSlotMap;
-				_scanPtr = getNextSlotMap(_scanMap, _leafMap, hasNextSlotMap);
+				_scanPtr = getNextSlotMap(&_scanMap, &_leafMap, &hasNextSlotMap);
 				if (!hasNextSlotMap) {
 					setNoMoreSlots();
 				}


### PR DESCRIPTION
Changing signature of GC_ObjectScanner::getNextSlotMap() to avoid using
parameters by reference. This is step 2. Step 1 was creation of
functions with new signature in OpenJ9, so it is ready and would not be
broken.  
However this change would break all other projects based on OMR -
correspondent functions signature should be updated accordingly.
Old signatures:
	getNextSlotMap(uintptr_t &, bool &) or
	getNextSlotMap(uintptr_t &, uintptr_t &, bool &)
New signatures:
	getNextSlotMap(uintptr_t *, bool *) or
	getNextSlotMap(uintptr_t *, uintptr_t *, bool *)

Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>