### PR TITLE
Fix for sigval_t error

### DIFF
--- a/port/unix_include/omrintrospect.h
+++ b/port/unix_include/omrintrospect.h
@@ -41,4 +41,8 @@
 
 typedef ucontext_t thread_context;
 
+#if defined(MUSL)
+typedef union sigval sigval_t;
+#endif
+
 #endif


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774 

In musl environment the OMR build fails with :
```
./unix/omrintrospect.c: In function 'suspend_all_preemptive':
./unix/omrintrospect.c:1045:3: error: unknown type name 'sigval_t'; did you mean 'sig_t'?
   sigval_t val;
   ^~~~~~~~
   sig_t
./unix/omrintrospect.c:1046:6: error: request for member 'sival_ptr' in something not a structure or union
   val.sival_ptr = data;
      ^
./unix/omrintrospect.c:1050:41: error: incompatible type for argument 3 of 'sigqueue'
    int ret = sigqueue(pid, SUSPEND_SIG, val);
                                         ^~~
In file included from /usr/local/x86_64-linux-musl/include/ucontext.h:9:0,
                 from ./unix/omrintrospect.c:35:
/usr/local/x86_64-linux-musl/include/signal.h:213:5: note: expected 'union sigval' but argument is of type 'int'
 int sigqueue(pid_t, int, union sigval);
     ^~~~~~~~
./unix/omrintrospect.c:1057:40: error: incompatible type for argument 3 of 'sigqueue'
       ret = sigqueue(pid, SUSPEND_SIG, val);
                                        ^~~
In file included from /usr/local/x86_64-linux-musl/include/ucontext.h:9:0,
                 from ./unix/omrintrospect.c:35:
/usr/local/x86_64-linux-musl/include/signal.h:213:5: note: expected 'union sigval' but argument is of type 'int'
 int sigqueue(pid_t, int, union sigval);
     ^~~~~~~~
./unix/omrintrospect.c: In function 'omrintrospect_threads_nextDo':
./unix/omrintrospect.c:1743:5: error: unknown type name 'sigval_t'; did you mean 'sig_t'?
     sigval_t val;
     ^~~~~~~~
     sig_t
./unix/omrintrospect.c:1744:8: error: request for member 'sival_ptr' in something not a structure or union
     val.sival_ptr = data;
        ^
./unix/omrintrospect.c:1750:37: error: incompatible type for argument 3 of 'sigqueue'
     sigqueue(getpid(), SUSPEND_SIG, val);
                                     ^~~
In file included from /usr/local/x86_64-linux-musl/include/ucontext.h:9:0,
                 from ./unix/omrintrospect.c:35:
/usr/local/x86_64-linux-musl/include/signal.h:213:5: note: expected 'union sigval' but argument is of type 'int'
 int sigqueue(pid_t, int, union sigval);
     ^~~~~~~~

```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support


Signed-off-by: bharathappali <bharath.appali@gmail.com>