### PR TITLE
Fix struct prctl_mm_map redefinition

### DIFF
--- a/port/linux/omrosdump_helpers.c
+++ b/port/linux/omrosdump_helpers.c
@@ -33,7 +33,9 @@
 #include <sys/stat.h>
 #if defined(LINUX)
 #include <sys/prctl.h>
+#if !defined(MUSL)
 #include <linux/prctl.h>
+#endif
 #include <sys/resource.h>
 #endif
 #include <elf.h>

--- a/thread/unix/thrdsup.c
+++ b/thread/unix/thrdsup.c
@@ -31,7 +31,9 @@
 
 #if defined(LINUX) && !defined(OMRZTPF)
 #include <sys/prctl.h>
+#if !defined(MUSL)
 #include <linux/prctl.h>
+#endif /* defined(MUSL) */
 #endif /* defined(LINUX) */
 
 #if defined(OMRZTPF)


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774 

In musl environment the OMR build fails with :
```
cc  -DOMRPORT_LIBRARY_DEFINE -I. -I./linuxamd64 -I./linux386 -I./linux -I./unix_include -I./unix -I./common -I./include -I./  -I../include_core -I../nls -DLINUX -DMUSL -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c  -MMD -MP -fno-strict-aliasing -fPIC -ggdb -m64 -Wimplicit -Wreturn-type -Werror -Wall -O3 -fno-strict-aliasing   -o omrosdump_helpers.o ./linux/omrosdump_helpers.c
In file included from ./linux/omrosdump_helpers.c:37:0:
/usr/local/x86_64-linux-musl/include/linux/prctl.h:133:8: error: redefinition of 'struct prctl_mm_map'
 struct prctl_mm_map {
        ^~~~~~~~~~~~
In file included from ./linux/omrosdump_helpers.c:35:0:
/usr/local/x86_64-linux-musl/include/sys/prctl.h:88:8: note: originally defined here
 struct prctl_mm_map {
        ^~~~~~~~~~~~
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>