### PR TITLE
Fix 'HZ' undeclared

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -67,6 +67,11 @@
 #include <nl_types.h>
 #include <langinfo.h>
 #if !defined(USER_HZ) && !defined(OMRZTPF)
+#if defined(MUSL)
+#ifndef HZ
+#define HZ 100
+#endif
+#endif /* defined(MUSL) */
 #define USER_HZ HZ
 #endif /* !defined(USER_HZ) && !defined(OMRZTPF) */
 


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :
```
cc  -DOMRPORT_LIBRARY_DEFINE -I. -I./linuxamd64 -I./linux386 -I./linux -I./unix_include -I./unix -I./common -I./include -I./  -I../include_core -I../nls -DLINUX -DMUSL -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c  -MMD -MP -fno-strict-aliasing -fPIC -ggdb -m64 -Wimplicit -Wreturn-type -Werror -Wall -O3 -fno-strict-aliasing   -o omrsysinfo.o ./unix/omrsysinfo.c
./unix/omrsysinfo.c: In function 'omrsysinfo_get_CPU_utilization':
./unix/omrsysinfo.c:75:17: error: 'HZ' undeclared (first use in this function)
 #define USER_HZ HZ
                 ^
./unix/omrsysinfo.c:2584:43: note: in expansion of macro 'USER_HZ'
  const uintptr_t NS_PER_HZ = 1000000000 / USER_HZ;
                                           ^~~~~~~
./unix/omrsysinfo.c:75:17: note: each undeclared identifier is reported only once for each function it appears in
 #define USER_HZ HZ
                 ^
./unix/omrsysinfo.c:2584:43: note: in expansion of macro 'USER_HZ'
  const uintptr_t NS_PER_HZ = 1000000000 / USER_HZ;
                                           ^~~~~~~
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>