### PR TITLE
Add (disabled) code to allow runtime compressed refs

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -76,6 +76,9 @@ typedef enum {
 class MM_EnvironmentBase : public MM_BaseVirtual
 {
 private:
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	bool const _compressObjectReferences;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	uintptr_t _slaveID;
 	uintptr_t _environmentId;
 
@@ -247,12 +250,16 @@ public:
 		return getExtensions()->getObjectAlignmentInBytes();
 	}
 
-	MMINLINE bool const compressObjectReferences() {
-#if defined (OMR_GC_COMPRESSED_POINTERS)
+	MMINLINE bool compressObjectReferences() {
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+		return _compressObjectReferences;
+#else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
-#else /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_FULL_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		return false;
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	}
 
 	/**
@@ -596,6 +603,9 @@ public:
 	 */
 	MM_EnvironmentBase(OMR_VMThread *omrVMThread) :
 		MM_BaseVirtual()
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+		, _compressObjectReferences(OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread))
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 		,_slaveID(0)
 		,_environmentId(0)
 		,_omrVM(omrVMThread->_vm)
@@ -645,6 +655,9 @@ public:
 
 	MM_EnvironmentBase(OMR_VM *omrVM) :
 		MM_BaseVirtual()
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+		, _compressObjectReferences(OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM))
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 		,_slaveID(0)
 		,_environmentId(0)
 		,_omrVM(omrVM)

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -67,6 +67,10 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 	uintptr_t *pageSizes = NULL;
 	uintptr_t *pageFlags = NULL;
+
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	_compressObjectReferences = env->compressObjectReferences();
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 
 	_omrVM = env->getOmrVM();
 

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -190,6 +190,9 @@ public:
 class MM_GCExtensionsBase : public MM_BaseVirtual {
 	/* Data Members */
 private:
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	bool _compressObjectReferences;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	void* _guaranteedNurseryStart; /**< lowest address guaranteed to be in the nursery */
 	void* _guaranteedNurseryEnd; /**< highest address guaranteed to be in the nursery */
@@ -817,12 +820,16 @@ public:
 	 */
 	MMINLINE OMR::GC::Forge* getForge() { return &_forge; }
 
-	MMINLINE bool const compressObjectReferences() {
-#if defined (OMR_GC_COMPRESSED_POINTERS)
+	MMINLINE bool compressObjectReferences() {
+#if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+		return _compressObjectReferences;
+#else /* defined(OMR_GC_FULL_POINTERS) */
 		return true;
-#else /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_FULL_POINTERS) */
+#else /* defined(OMR_GC_COMPRESSED_POINTERS) */
 		return false;
-#endif /* OMR_GC_COMPRESSED_POINTERS */
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) */
 	}
 
 	MMINLINE uintptr_t getRememberedCount()
@@ -1249,6 +1256,9 @@ public:
 
 	MM_GCExtensionsBase()
 		: MM_BaseVirtual()
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+		, _compressObjectReferences(false)
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 		, _guaranteedNurseryStart(NULL)
 		, _guaranteedNurseryEnd(NULL)
@@ -1705,5 +1715,6 @@ public:
 	{
 		_typeId = __FUNCTION__;
 	}
+
 };
 #endif /* GCEXTENSIONSBASE_HPP_ */

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -117,6 +117,9 @@ typedef struct OMR_ExclusiveVMAccessStats {
 typedef struct OMR_VM {
 	struct OMR_Runtime *_runtime;
 	void *_language_vm;
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	uintptr_t _compressObjectReferences;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	struct OMR_VM *_linkNext;
 	struct OMR_VM *_linkPrevious;
 	struct OMR_VMThread *_vmThreadList;
@@ -154,7 +157,11 @@ typedef struct OMR_VM {
 } OMR_VM;
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+#define OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) (0 != (omrVM)->_compressObjectReferences)
+#else /* OMR_GC_FULL_POINTERS */
 #define OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) TRUE
+#endif /* OMR_GC_FULL_POINTERS */
 #else /* OMR_GC_COMPRESSED_POINTERS */
 #define OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) FALSE
 #endif /* OMR_GC_COMPRESSED_POINTERS */
@@ -162,6 +169,9 @@ typedef struct OMR_VM {
 typedef struct OMR_VMThread {
 	struct OMR_VM *_vm;
 	uint32_t _sampleStackBackoff;
+#if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
+	uint32_t _compressObjectReferences;
+#endif /* defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS) */
 	void *_language_vmthread;
 	omrthread_t _os_thread;
 	struct OMR_VMThread *_linkNext;
@@ -201,7 +211,11 @@ typedef struct OMR_VMThread {
 } OMR_VMThread;
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
+#if defined(OMR_GC_FULL_POINTERS)
+#define OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) (0 != (omrVMThread)->_compressObjectReferences)
+#else /* OMR_GC_FULL_POINTERS */
 #define OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) TRUE
+#endif /* OMR_GC_FULL_POINTERS */
 #else /* OMR_GC_COMPRESSED_POINTERS */
 #define OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) FALSE
 #endif /* OMR_GC_COMPRESSED_POINTERS */


### PR DESCRIPTION
Add fields and code (under ifdef) to allow the language to choose
compressed or full pointers at runtime.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>