### PR TITLE
Fix pthread_attr_getstackaddr error

### DIFF
--- a/thread/common/omrthreadinspect.c
+++ b/thread/common/omrthreadinspect.c
@@ -317,7 +317,7 @@ omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd
 	}
 
 	/* Retrieve base stack address and stack size from pthread_attr_t */
-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600)
+#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(OMR_MUSL_CLIB))
 	if ((rc = pthread_attr_getstack(&attr, stackStart, &stackSize)) != 0) {
 		thread->os_errno = rc;
 		return (J9THREAD_ERR_GETSTACK | J9THREAD_ERR_OS_ERRNO_SET);


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :

```
cc  -I. -I./ -I./linux -I./unix -I./common  -I../include_core -I../nls -DLINUX -DMUSL -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c  -MMD -MP -fno-strict-aliasing -fPIC -ggdb -m64 -Wimplicit -Wreturn-type -Werror -Wall -O3 -fno-strict-aliasing -Wno-unused  -o omrthreadinspect.o omrthreadinspect.c
In file included from omrthreadinspect.c:30:0:
common/omrthreadinspect.c: In function 'omrthread_get_stack_range':
common/omrthreadinspect.c:326:12: error: implicit declaration of function 'pthread_attr_getstackaddr'; did you mean 'pthread_attr_getstack'? [-Werror=implicit-function-declaration]
  if ((rc = pthread_attr_getstackaddr(&attr, stackStart)) != 0) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~
            pthread_attr_getstack
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>