### PR TITLE
Fix _GLIBC_PREREQ and gettid

### DIFF
--- a/thread/unix/rasthrsup.c
+++ b/thread/unix/rasthrsup.c
@@ -27,32 +27,10 @@
 #include "omrthread.h"
 
 #if defined(LINUX)
-#if __GLIBC_PREREQ(2,4)
 #include <sys/syscall.h>
-#endif /* __GLIBC_PREREQ(2,4) */
 #elif defined(OSX)
 #include <pthread.h>
 #include <sys/syscall.h>
-#endif /* defined(LINUX) */
-
-#if defined(LINUX)
-/**
- * This is required to pick up correct thread IDs on Linux
- */
-
-#if !__GLIBC_PREREQ(2,4) && !defined(OMRZTPF)
-/**
- * Even though we don't use errno directly, it is used by the _syscall0 macro and some
- * distros incorrectly assume that errno is an int, in their header.  Including it here will
- * force them to behave properly
- */
-#include <errno.h>
-#include <sys/types.h>
-#include <linux/unistd.h>
-
-/* this line is needed to build the syscall macro which is called (as gettid) within the function */
-_syscall0(pid_t, gettid);
-#endif /* !__GLIBC_PREREQ(2,4) && !defined(OMRZTPF) */
 #endif /* defined(LINUX) */
 
 uintptr_t
@@ -61,16 +39,7 @@ omrthread_get_ras_tid(void)
 	uintptr_t threadID = 0;
 
 #if defined(LINUX) && !defined(OMRZTPF)
-#if __GLIBC_PREREQ(2,4)
-	/* Want thread id that shows up in /proc etc.  gettid() does not cut it */
-	threadID = syscall(SYS_gettid);
-#else /* __GLIBC_PREREQ(2,4) */
-	/*
-	 * On Linux (and probably other Unices but testing to follow), pthread_self is not the kernel's thread ID!
-	 * We will use the gettid call to get the actual ID of the thread
-	 */
-	threadID = (uintptr_t) gettid();
-#endif /* __GLIBC_PREREQ(2,4) */
+	threadID = (uintptr_t) syscall(SYS_gettid);
 #elif defined(OSX)
     uint64_t tid64;
     pthread_threadid_np(NULL, &tid64);


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :

```
cc  -I. -I./ -I./linux -I./unix -I./common  -I../include_core -I../nls -DLINUX -DMUSL -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c  -MMD -MP -fno-strict-aliasing -fPIC -ggdb -m64 -Wimplicit -Wreturn-type -Werror -Wall -O3 -fno-strict-aliasing -Wno-unused  -o rasthrsup.o ./unix/rasthrsup.c
./unix/rasthrsup.c:30:19: error: missing binary operator before token "("
 #if __GLIBC_PREREQ(2,4)
                   ^
./unix/rasthrsup.c:43:20: error: missing binary operator before token "("
 #if !__GLIBC_PREREQ(2,4) && !defined(OMRZTPF)
                    ^
./unix/rasthrsup.c: In function 'omrthread_get_ras_tid':
./unix/rasthrsup.c:64:19: error: missing binary operator before token "("
 #if __GLIBC_PREREQ(2,4)
                   ^
./unix/rasthrsup.c:72:25: error: implicit declaration of function 'gettid'; did you mean 'getgid'? [-Werror=implicit-function-declaration]
  threadID = (uintptr_t) gettid();
                         ^~~~~~
                         getgid
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>