### PR TITLE
Add some new usability methods for TR_HashTab and TR_HashTabIterator

### DIFF
--- a/compiler/infra/HashTab.cpp
+++ b/compiler/infra/HashTab.cpp
@@ -65,6 +65,15 @@ void * TR_HashTab::getData(TR_HashId id)
    }
 
 
+void * TR_HashTab::getKey(TR_HashId id)
+   {
+   TR_HashTableEntry * entry = _table[id];
+   TR_ASSERT(id < _tableSize,"%d >= %d\n",id,_tableSize);
+   TR_ASSERT(entry,"entry is null for id %d\n",id);
+   return entry->_key;
+   }
+
+
 // will allocate table on demand
 void TR_HashTab::init(uint32_t newSize, bool growth)
    {

--- a/compiler/infra/HashTab.hpp
+++ b/compiler/infra/HashTab.hpp
@@ -56,7 +56,23 @@ class TR_HashTabIterator
    void *getCurrent ();
 
    void *getFirst() { _curHashIndex = 0; return getCurrent(); }
+
+   void *getFirst(TR_HashId& hashId)
+      {
+      _curHashIndex = 0;
+      void *result = getCurrent();
+      hashId = result ? _curHashIndex : 0;
+      return result;
+      }
+
    void *getNext() { ++_curHashIndex; return getCurrent(); }
+   void *getNext(TR_HashId& hashId)
+      {
+      ++_curHashIndex;
+      void *result = getCurrent();
+      hashId = result ? _curHashIndex : 0;
+      return result;
+      }
    void reset() { _curHashIndex = 0; }
    bool atEnd();
 
@@ -122,6 +138,7 @@ class TR_HashTab
       _table[id]->_data = data;
       return;
       }
+   void *getKey(TR_HashId id);
    void setKey(TR_HashId id, void* key) { _table[id]->_key = key;return; } ;
 
  /**


### PR DESCRIPTION
Currently `TR_HashTabIterator` simply returns each item of data stored in the hashtable.  Added versions of `getFirst` and `getNext` methods that take a reference to a `TR_HashId`.  Also added a `TR_HashTab::getKey` method.  Together, they allow the iteration to retrieve the key that is
associated with each entry.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>