### PR TITLE
WIP : Fix undefined reference to backtrace

### DIFF
--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -175,6 +175,18 @@ const char *TR_PPCCallStackIterator::getProcedureName()
 #include <execinfo.h>
 #include <cxxabi.h>
 
+#if defined(MUSL)
+char ** backtrace_symbols(void *const *trace, int size)
+{
+	return NULL;
+}
+
+int backtrace(void **trace, int size)
+{
+	return 0;
+}
+#endif
+
 void TR_LinuxCallStackIterator::printSymbol(int32_t frame, char *sig, TR::Compilation *comp)
    {
    char lib[256];

--- a/port/linux/omrosbacktrace_impl.c
+++ b/port/linux/omrosbacktrace_impl.c
@@ -42,6 +42,13 @@
 uintptr_t protectedBacktrace(struct OMRPortLibrary *port, void *arg);
 uintptr_t backtrace_sigprotect(struct OMRPortLibrary *portLibrary, J9PlatformThread *threadInfo, void **address_array, int capacity);
 
+#if defined(MUSL)
+int backtrace(void **trace, int size)
+{
+	return 0;
+}
+#endif
+
 struct frameData {
 	void **address_array;
 	unsigned int capacity;


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :

```
/usr/local/bin/../lib/gcc/x86_64-linux-musl/7.3.0/../../../../x86_64-linux-musl/bin/ld: ../../libtestjit_base.a(CallStack.o): in function `TR_LinuxCallStackIterator::printStackBacktrace(TR::Compilation*)':
CallStack.cpp:(.text+0x2e1): undefined reference to `backtrace'
/usr/local/bin/../lib/gcc/x86_64-linux-musl/7.3.0/../../../../x86_64-linux-musl/bin/ld: CallStack.cpp:(.text+0x2ed): undefined reference to `backtrace_symbols'
collect2: error: ld returned 1 exit status
make[3]: *** [../../fvtest/compilertest/build/rules/gnu/common.mk:53: ../../testjit] Error 1
make[3]: Leaving directory '/root/omr/fvtest/compilertest'
make[2]: *** [Makefile:79: testjit] Error 2
make[2]: Leaving directory '/root/omr/fvtest/compilertest'
make[1]: *** [GNUmakefile:284: fvtest/compilertest] Error 2
make[1]: Leaving directory '/root/omr'
make: *** [GNUmakefile:216: mainbuild] Error 2
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Work still need to be done :**
I need to add `libunwind` to get backtrace info. Will remove WIP tag after its ready.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>