### PR TITLE
Fix __THROW and __sighandler_t errors

### DIFF
--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -36,6 +36,13 @@ extern "C" {
 #define __THROW
 #endif /* defined(OSX) */
 
+#if defined(OMR_MUSL_CLIB)
+#ifndef __THROW
+#define __THROW
+#endif
+typedef sighandler_t __sighandler_t;
+#endif
+
 #if defined(LINUXPPC)
 typedef __sighandler_t sighandler_t;
 #elif defined(LINUX) || defined(OSX)


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :

```
c++  -I.  -I../include_core -I../nls -DLINUX -DMUSL -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c  -MMD -MP -fno-strict-aliasing -std=c++0x -fno-exceptions -fno-rtti -fno-threadsafe-statics -fPIC -ggdb -m64 -Wreturn-type -Werror -Wall -Wno-non-virtual-dtor -O3 -fno-strict-aliasing   -o omrsig.o omrsig.cpp
In file included from omrsig.cpp:42:0:
../include_core/omrsig.h:102:82: error: expected initializer before '__THROW'
 int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) __THROW;
                                                                                  ^~~~~~~
../include_core/omrsig.h:103:55: error: expected initializer before '__THROW'
 sighandler_t signal(int signum, sighandler_t handler) __THROW;
                                                       ^~~~~~~
../include_core/omrsig.h:105:49: error: expected initializer before '__THROW'
 sighandler_t sigset(int sig, sighandler_t disp) __THROW;
                                                 ^~~~~~~
../include_core/omrsig.h:106:24: error: expected initializer before '__THROW'
 int sigignore(int sig) __THROW;
                        ^~~~~~~
../include_core/omrsig.h:107:59: error: expected initializer before '__THROW'
 sighandler_t bsd_signal(int signum, sighandler_t handler) __THROW;
                                                           ^~~~~~~
../include_core/omrsig.h:109:60: error: expected initializer before '__THROW'
 sighandler_t sysv_signal(int signum, sighandler_t handler) __THROW;
                                                            ^~~~~~~
../include_core/omrsig.h:112:1: error: '__sighandler_t' does not name a type; did you mean 'sighandler_t'?
 __sighandler_t __sysv_signal(int sig, __sighandler_t handler) __THROW;
 ^~~~~~~~~~~~~~
 sighandler_t
../include_core/omrsig.h:113:53: error: expected initializer before '__THROW'
 sighandler_t ssignal(int sig, sighandler_t handler) __THROW;
                                                     ^~~~~~~
omrsig.cpp:241:42: error: expected initializer before '__THROW'
 signal(int signum, sighandler_t handler) __THROW
                                          ^~~~~~~
omrsig.cpp:293:78: error: expected initializer before '__THROW'
 sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) __THROW
                                                                              ^~~~~~~
omrsig.cpp:464:1: error: '__sighandler_t' does not name a type; did you mean 'sighandler_t'?
 __sighandler_t
 ^~~~~~~~~~~~~~
 sighandler_t
omrsig.cpp:471:40: error: expected initializer before '__THROW'
 ssignal(int sig, sighandler_t handler) __THROW
                                        ^~~~~~~
omrsig.cpp:575:36: error: expected initializer before '__THROW'
 sigset(int sig, sighandler_t disp) __THROW
                                    ^~~~~~~
omrsig.cpp:623:20: error: expected initializer before '__THROW'
 sigignore(int sig) __THROW
                    ^~~~~~~
omrsig.cpp:634:46: error: expected initializer before '__THROW'
 bsd_signal(int signum, sighandler_t handler) __THROW
                                              ^~~~~~~
omrsig.cpp:655:47: error: expected initializer before '__THROW'
 sysv_signal(int signum, sighandler_t handler) __THROW
                                               ^~~~~~~
omrsig.cpp:255:1: error: 'void (* omrsig_signal_internal(int, sighandler_t))(int)' defined but not used [-Werror=unused-function]
 omrsig_signal_internal(int signum, sighandler_t handler)
 ^~~~~~~~~~~~~~~~~~~~~~
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>