### PR TITLE
CMake DDR: Fix bug where #undef statements were not recognized

### DIFF
--- a/cmake/modules/ddr/cmake_ddr.awk
+++ b/cmake/modules/ddr/cmake_ddr.awk
@@ -141,14 +141,14 @@ NR == 1 {
 # basic line cleanup
 {
 	# replace tabs with spaces, and cut multiple spaces
-	sub(/[ \t]+/, " ")
-	#clean up any space between '#' and define
-	sub(/^ ?# +define/, "#define")
-
+	gsub(/[ \t]+/, " ")
+	# clean up any space between '#' and define
+	sub(/^ ?# ?define/, "#define")
+	# Normalize #undefs, ie remove excess spaces, and possible leading '/*'
+	sub(/^ ?(\/\* ?)?# ?undef/, "#undef")
 }
 
-/^# ?define / {
-	sub(/^ ?# ?define /, "#define ")
+/^#define / {
 	macro_name = $2
 	# if this is a function style macro, ignore it
 	if(macro_name ~ /\(/) { next }
@@ -168,8 +168,6 @@ NR == 1 {
 	next
 }
 
-/^ ?(\/\*)? ?undef )/ {
-	# strip off leading #undef to get our flag name
-	sub(/^ ?(\/\*)? ?undef +)/, "", $0)
-	if(add_flags){undef_flag_macro($1)}
+/^#undef / {
+	if(add_flags){undef_flag_macro($2)}
 }


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>