### PR TITLE
CMake DDR: Fix bug where include paths and defines not properly passed

### DIFF
--- a/cmake/modules/ddr/DDRSetStub.cmake.in
+++ b/cmake/modules/ddr/DDRSetStub.cmake.in
@@ -142,6 +142,7 @@ function(process_target target)
 		SOURCE_DIR "${OPT_SOURCE_DIR}"
 		OUTPUT_ANNOTATED project_annt_src
 		INCLUDE_DIRS ${OPT_INCLUDE_PATH}
+		DEFINES ${OPT_DEFINES}
 
 	)
 	list(APPEND annotated_files ${project_annt_src})
@@ -153,6 +154,8 @@ function(process_target target)
 		TARGET "${target}"
 		SOURCE_DIR "${OPT_SOURCE_DIR}"
 		OUTPUT_ANNOTATED project_annt_hdr
+		INCLUDE_DIRS ${OPT_INCLUDE_PATH}
+		DEFINES ${OPT_DEFINES}
 		#TODO need to add pre-include files
 	)
 	list(APPEND annotated_files ${project_annt_hdr})


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>