### PR TITLE
Remove an unused query

### DIFF
--- a/compiler/env/OMRObjectModel.hpp
+++ b/compiler/env/OMRObjectModel.hpp
@@ -120,12 +120,6 @@ class ObjectModel
    * @brief: Returns the write type kind of VM's GC
    */
    MM_GCWriteBarrierType writeBarrierType() { return gc_modron_wrtbar_none;  }
-
-   /**
-   * @brief: Returns true if option for software read barriers is enabled in the VM's GC
-   */
-   bool shouldReplaceGuardedLoadWithSoftwareReadBarrier() { return false; };
-
    };
 }
 


### PR DESCRIPTION
Retire the shouldReplaceGuardedLoadWithSoftwareReadBarrier() API.

Signed-off-by: Nigel Yu <yunigel@ca.ibm.com>