### PR TITLE
Remove wrapper macros to support structs with J9* naming

### DIFF
--- a/include_core/unix/zos/leconditionhandler.h
+++ b/include_core/unix/zos/leconditionhandler.h
@@ -39,7 +39,4 @@ typedef struct OMRZOSLEConditionHandlerRecord {
 	uint32_t recursiveCheck; /* if this is set to 1, the handler corresponding to this record has been invoked recursively */
 } OMRZOSLEConditionHandlerRecord;
 
-/* TODO Remove once downstream projects are updated */
-#define J9ZOSLEConditionHandlerRecord OMRZOSLEConditionHandlerRecord
-
 #endif /* leconditionhandler_h */

--- a/port/linuxppc/omrsignal_context.h
+++ b/port/linuxppc/omrsignal_context.h
@@ -59,9 +59,6 @@ typedef struct OMRUnixSignalInfo {
 	siginfo_t *sigInfo;
 } OMRUnixSignalInfo;
 
-/* TODO Remove once downstream projects are updated */
-#define J9UnixSignalInfo OMRUnixSignalInfo
-
 uint32_t infoForFPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForGPR(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);
 uint32_t infoForModule(struct OMRPortLibrary *portLibrary, struct OMRUnixSignalInfo *info, int32_t index, const char **name, void **value);


### PR DESCRIPTION
In eclipse/openj9#5735, J9 renamed `J9*` to `OMR*` for the following structs:
- `J9ZOSLEConditionHandlerRecord` -> `OMRZOSLEConditionHandlerRecord`
- `J9UnixSignalInfo` -> `OMRUnixSignalInfo`

So, the wrapper macros for the above structs are no longer needed. Hence, the
defines for the two structs have been removed.

Related to https://github.com/eclipse/omr/issues/3713.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>