### PR TITLE
Enable Pre-/PostEscapeAnalysis optimizations for OpenJ9

### DIFF
--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -175,7 +175,9 @@ const OptimizationStrategy expensiveObjectAllocationOpts[] =
 
 const OptimizationStrategy eachEscapeAnalysisPassOpts[] =
    {
+   { preEscapeAnalysis,           IfOSR     },
    { escapeAnalysis                         },
+   { postEscapeAnalysis,          IfOSR     },
    { eachEscapeAnalysisPassGroup, IfEnabled }, // if another pass requested
    { endGroup                               }
    };
@@ -285,7 +287,9 @@ const OptimizationStrategy partialRedundancyEliminationOpts[] =
    { localReordering,             IfEnabled }, // PRE may create temp stores that can be moved closer to uses
    { globalValuePropagation,      IfEnabledAndMoreThanOneBlockMarkLastRun  }, // GVP (after PRE)
 #ifdef J9_PROJECT_SPECIFIC
+   { preEscapeAnalysis,           IfOSR     },
    { escapeAnalysis,              IfEAOpportunitiesMarkLastRun }, // to stack-allocate after loopversioner and localCSE
+   { postEscapeAnalysis,          IfOSR     },
 #endif
    { basicBlockOrdering,          IfLoops }, // early ordering with no extension
    { globalCopyPropagation,       IfLoops }, // for Loop Versioner


### PR DESCRIPTION
Enable new optimization passes for OpenJ9 associated with Escape Analysis, `preEscapeAnalysis` and `postEscapeAnalysis`, only under OSR.

Submitted on behalf of Andrew Craik <ajcraik@ca.ibm.com>

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>

This pull request is dependent upon [~OpenJ9 pull request 5737~](https://github.com/eclipse/openj9/pull/5737) [OpenJ9 pull request 6654](https://github.com/eclipse/openj9/pull/6654), which is in turn dependent upon pull request #3841