### PR TITLE
Fix OSSEMAPHORE implementation issue

### DIFF
--- a/include_core/unix/thrdsup.h
+++ b/include_core/unix/thrdsup.h
@@ -69,7 +69,7 @@ typedef void* WRAPPER_ARG;
 #define WRAPPER_RETURN() return NULL
 typedef WRAPPER_TYPE (*WRAPPER_FUNC)(WRAPPER_ARG);
 
-#if defined(OMR_USE_POSIX_SEMAPHORES)
+#if defined(OMR_USE_POSIX_SEMAPHORES) || defined(MUSL)
 #include <semaphore.h>
 typedef sem_t OSSEMAPHORE;
 #elif defined(OMR_USE_OSX_SEMAPHORES) /* defined(OMR_USE_POSIX_SEMAPHORES) */
@@ -332,7 +332,7 @@ extern pthread_condattr_t *defaultCondAttr;
 #define SEM_CREATE(threadLibrary, initValue) omrthread_allocate_memory(threadLibrary, sizeof(OSSEMAPHORE), OMRMEM_CATEGORY_THREADS)
 #define	SEM_FREE(lib, s)  	omrthread_free_memory(lib, s);
 
-#if defined(OMR_USE_POSIX_SEMAPHORES)
+#if defined(OMR_USE_POSIX_SEMAPHORES) || defined(MUSL)
 #define SEM_INIT(sm, pshrd, inval) (sem_init((sem_t *)(sm), pshrd, inval))
 #define SEM_DESTROY(sm) (sem_destroy((sem_t *)(sm)))
 #define SEM_POST(smP) (sem_post((sem_t *)(smP)))


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :

```
cc  -I. -I./ -I./linux -I./unix -I./common  -I../include_core -I../nls -DLINUX -DMUSL -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DJ9HAMMER -c  -MMD -MP -fno-strict-aliasing -fPIC -ggdb -m64 -Wimplicit -Wreturn-type -Werror -Wall -O3 -fno-strict-aliasing -Wno-unused  -o j9sem.o ./common/j9sem.c
In file included from ../include_core/./unix/thrdsup.h:86:0,
                 from ../include_core/thrdsup.h:35,
                 from ./common/j9sem.c:32:
../include_core/thrtypes.h:161:2: error: unknown type name 'OSSEMAPHORE'
  OSSEMAPHORE sem;
  ^~~~~~~~~~~
In file included from ../include_core/thrdsup.h:35:0,
                 from ./common/j9sem.c:32:
../include_core/./unix/thrdsup.h:356:2: error: #error Could not find semaphore implementation
 #error Could not find semaphore implementation
  ^~~~~
In file included from ../include_core/thrdsup.h:35:0,
                 from ./common/j9sem.c:32:
./common/j9sem.c: In function 'j9sem_init':
../include_core/./unix/thrdsup.h:332:94: error: 'OSSEMAPHORE' undeclared (first use in this function); did you mean '_SC_SEMAPHORES'?
 #define SEM_CREATE(threadLibrary, initValue) omrthread_allocate_memory(threadLibrary, sizeof(OSSEMAPHORE), OMRMEM_CATEGORY_THREADS)
                                                                                              ^
./common/j9sem.c:61:14: note: in expansion of macro 'SEM_CREATE'
  (*sp) = s = SEM_CREATE(lib, initValue);
              ^~~~~~~~~~
../include_core/./unix/thrdsup.h:332:94: note: each undeclared identifier is reported only once for each function it appears in
 #define SEM_CREATE(threadLibrary, initValue) omrthread_allocate_memory(threadLibrary, sizeof(OSSEMAPHORE), OMRMEM_CATEGORY_THREADS)
                                                                                              ^
./common/j9sem.c:61:14: note: in expansion of macro 'SEM_CREATE'
  (*sp) = s = SEM_CREATE(lib, initValue);
              ^~~~~~~~~~
./common/j9sem.c:63:8: error: implicit declaration of function 'SEM_INIT'; did you mean 'MUTEX_INIT'? [-Werror=implicit-function-declaration]
   rc = SEM_INIT(s, 0, initValue);
        ^~~~~~~~
        MUTEX_INIT
./common/j9sem.c: In function 'j9sem_post':
./common/j9sem.c:87:10: error: implicit declaration of function 'SEM_POST'; did you mean 'OMR_PORT'? [-Werror=implicit-function-declaration]
   return SEM_POST(s);
          ^~~~~~~~
          OMR_PORT
./common/j9sem.c: In function 'j9sem_wait':
./common/j9sem.c:112:10: error: implicit declaration of function 'SEM_WAIT'; did you mean 'COND_WAIT'? [-Werror=implicit-function-declaration]
   while (SEM_WAIT(s) != 0) {
          ^~~~~~~~
          COND_WAIT
./common/j9sem.c: In function 'j9sem_destroy':
./common/j9sem.c:144:10: error: implicit declaration of function 'SEM_DESTROY'; did you mean 'TLS_DESTROY'? [-Werror=implicit-function-declaration]
   rval = SEM_DESTROY(s);
          ^~~~~~~~~~~
          TLS_DESTROY
cc1: all warnings being treated as errors
make[2]: *** [../omrmakefiles/rules.mk:372: j9sem.o] Error 1
make[2]: Leaving directory '/root/omr/thread'
make[1]: *** [GNUmakefile:284: thread] Error 2
make[1]: Leaving directory '/root/omr'
make: *** [GNUmakefile:216: mainbuild] Error 2
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>