### PR TITLE
CMake DDR: Ignore header include guards

### DIFF
--- a/cmake/modules/ddr/cmake_ddr.awk
+++ b/cmake/modules/ddr/cmake_ddr.awk
@@ -78,9 +78,11 @@ function write_flag_defined(macro_name) {
 }
 
 function define_flag_macro(macro_name) {
-	# TODO if not include guard
-	write_flag_macro(macro_name);
-	write_flag_defined(macro_name);
+	# Don't process any include guard macros
+	if(match(macro_name, /_[Hh]([Pp]{2})?_?$/) == 0){
+		write_flag_macro(macro_name);
+		write_flag_defined(macro_name);
+	}
 }
 
 function undef_flag_macro(macro_name) {


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>