### PR TITLE
Add Platform Agnostic TM Query

### DIFF
--- a/compiler/env/OMRCPU.hpp
+++ b/compiler/env/OMRCPU.hpp
@@ -131,6 +131,12 @@ public:
    bool isI386() { return _minorArch == TR::m_arch_i386; }
    bool isAMD64() { return _minorArch == TR::m_arch_amd64; }
 
+   /** @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
+    *
+    *  @return false; this is the default answer unless overridden by an extending class.
+    */
+   bool supportsTransactionalMemoryInstructions() { return false; }
+
 private:
    TR_Processor _processor;
 

--- a/compiler/p/env/OMRCPU.cpp
+++ b/compiler/p/env/OMRCPU.cpp
@@ -34,6 +34,12 @@ OMR::Power::CPU::getPPCis64bit()
    }
 
 bool
+OMR::Power::CPU::supportsTransactionalMemoryInstructions()
+   {
+   return self()->getPPCSupportsTM();
+   }
+
+bool
 OMR::Power::CPU::isTargetWithinIFormBranchRange(intptrj_t targetAddress, intptrj_t sourceAddress)
    {
    intptrj_t range = targetAddress - sourceAddress;

--- a/compiler/p/env/OMRCPU.hpp
+++ b/compiler/p/env/OMRCPU.hpp
@@ -65,6 +65,13 @@ public:
    bool getPPCSupportsTM()  { return false; }
    bool getPPCSupportsLM()  { return false; }
 
+   /** @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
+    *         Alias of getPPCSupportsTM() as a platform agnostic query.
+    *
+    *  @return true if TM is available, false otherwise.
+    */
+   bool supportsTransactionalMemoryInstructions();
+
    /**
     * @brief Provides the maximum forward branch displacement in bytes reachable
     *        with an I-Form branch instruction.

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -24,6 +24,7 @@
 #include "env/CPU.hpp"
 #include "env/JitConfig.hpp"
 #include "env/ProcessorInfo.hpp"
+#include "infra/Flags.hpp"
 #include "x/runtime/X86Runtime.hpp"
 
 
@@ -111,4 +112,11 @@ bool
 OMR::X86::CPU::testOSForSSESupport()
    {
    return false;
+   }
+
+bool
+OMR::X86::CPU::supportsTransactionalMemoryInstructions()
+   {
+   flags32_t processorFeatureFlags8(self()->getX86ProcessorFeatureFlags8());
+   return processorFeatureFlags8.testAny(TR_RTM);
    }

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -64,6 +64,13 @@ public:
 
    bool testOSForSSESupport();
 
+
+   /** @brief Determines whether the Transactional Memory (TM) facility is available on the current processor.
+    *
+    *  @return true if TM is available, false otherwise.
+    */
+   bool supportsTransactionalMemoryInstructions();
+
    /**
     * @brief Answers whether the distance between a target and source address
     *        is within the reachable RIP displacement range.

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -207,6 +207,12 @@ OMR::Z::CPU::getSupportsTransactionalMemoryFacility()
    return _flags.testAny(S390SupportsTM);
    }
 
+bool
+OMR::Z::CPU::supportsTransactionalMemoryInstructions()
+   {
+   return self()->getSupportsTransactionalMemoryFacility();
+   }
+
 
 bool
 OMR::Z::CPU::setSupportsTransactionalMemoryFacility(bool value)

--- a/compiler/z/env/OMRCPU.cpp
+++ b/compiler/z/env/OMRCPU.cpp
@@ -27,7 +27,7 @@
 #pragma csect(STATIC,"OMRZCPUBase#S")
 #pragma csect(TEST,"OMRZCPUBase#T")
 
-#include "compiler/z/env/OMRCPU.hpp"
+#include "env/CPU.hpp"
 
 const char*
 OMR::Z::CPU::getProcessorName(int32_t machineId)

--- a/compiler/z/env/OMRCPU.hpp
+++ b/compiler/z/env/OMRCPU.hpp
@@ -122,6 +122,12 @@ class CPU : public OMR::CPU
     *     Determines whether the Transactional Memory (TM) facility is available on the current processor.
     */
    bool getSupportsTransactionalMemoryFacility();
+
+   /** \brief
+    *     Determines whether the Transactional Memory (TM) facility is available on the current processor.
+    *     Alias of getSupportsTransactionalMemoryFacility() as a platform agnostic query.
+    */
+   bool supportsTransactionalMemoryInstructions();
    
    /** \brief
     *     Determines whether the Transactional Memory (TM) facility is available on the current processor.


### PR DESCRIPTION
In Eclipse OpenJ9, I need to add an AOT feature flag for Transactional Memory (TM) in order to ensure consistency with regard to TM across the compile and load runs. However, as it turns out, the processor query for determining whether TM is enabled is different for each platform. If it was as simple as different names, I would've just `#ifdef`'d the different queries and moved on. However, on x86, the query isn't even in the `TR::CPU` class; it's initialized as a static member of the x86 codegen class, and the `initialize` method is private that can only be accessed by the x86 codegen class. 

This PR only contains changes that provide (for the most part) a wrapper around existing TM queries. The right thing to do would be to refactor all the code into the `TR::CPU` class, but that's a rabbit hole unto itself. I figure this change should suffice for now, until someone re-architects the code.