### PR TITLE
Move _afterRA to OMR::Z::CodeGenerator class

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -239,7 +239,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _internalControlFlowSafeNestingDepth(0),
      _stackOfArtificiallyInflatedNodes(self()->comp() ? self()->comp()->trMemory() : 0, 16),
      _stackOfMemoryReferencesCreatedDuringEvaluation(self()->comp() ? self()->comp()->trMemory() : 0, 16),
-     _afterRA(false),
      randomizer(self()->comp()),
      _outOfLineColdPathNestedDepth(0),
      _codeGenPhase(self()),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -419,7 +419,6 @@ class OMR_EXTENSIBLE CodeGenerator
    void identifyUnneededByteConvNodes(TR::Node*, TR::TreeTop *, vcount_t, TR::DataType);
    void identifyUnneededByteConvNodes();
 
-   bool afterRA() { return _afterRA; }
    TR::CodeGenPhase& getCodeGeneratorPhase() {return _codeGenPhase;}
 
    void prepareNodeForInstructionSelection(TR::Node*node);
@@ -1935,8 +1934,6 @@ class OMR_EXTENSIBLE CodeGenerator
    uint8_t _globalGPRPartitionLimit;
    uint8_t _globalFPRPartitionLimit;
    flags16_t _enabledFlags;
-
-   bool _afterRA;
 
    // MOVE TO J9 Z CodeGenerator
    // isTemporaryBased storageReferences just have a symRef but some other routines expect a node so use the below to fill in this symRef on this node

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -423,7 +423,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _ccInstruction(NULL),
      _previouslyAssignedTo(self()->comp()->allocator("LocalRA")),
      _methodBegin(NULL),
-     _methodEnd(NULL)
+     _methodEnd(NULL),
+     _afterRA(false)
    {
    TR::Compilation *comp = self()->comp();
    _cgFlags = 0;

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -542,6 +542,8 @@ public:
 
    virtual bool isAddMemoryUpdate(TR::Node * node, TR::Node * valueChild);
 
+   bool afterRA() { return _afterRA; }
+
 #ifdef DEBUG
    void dumpPreGPRegisterAssignment(TR::Instruction *);
    void dumpPostGPRegisterAssignment(TR::Instruction *, TR::Instruction *);
@@ -871,6 +873,8 @@ private:
    CS2::HashTable<ncount_t, bool, TR::Allocator> _nodesToBeEvaluatedInRegPairs;
 
 protected:
+
+   bool _afterRA;
    flags32_t  _cgFlags;
 
    /** Miscellaneous S390CG boolean flags. */


### PR DESCRIPTION
The variable bool _afterRA was defined in OMR::CodeGenerator but was
only used in the Z CodeGenerator. The variable is therefore moved into
OMR::Z::CodeGenerator. However, I believe the
field is attempting to track that local register assignment (RA) has
already run. There is probably a better way to accomplish this using the
code generator phase enum.

Closes: #1898
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>