### PR TITLE
Move firstTimeLiveOOLRegisterList to Z CodeGenerator

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -214,7 +214,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _spill16FreeList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
      _internalPointerSpillFreeList(getTypedAllocator<TR_BackingStore*>(TR::comp()->allocator())),
      _spilledRegisterList(NULL),
-     _firstTimeLiveOOLRegisterList(NULL),
      _referencedRegistersList(NULL),
      _variableSizeSymRefPendingFreeList(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),
      _variableSizeSymRefFreeList(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1059,9 +1059,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR::list<TR::Register*> *getSpilledRegisterList() {return _spilledRegisterList;}
    TR::list<TR::Register*> *setSpilledRegisterList(TR::list<TR::Register*> *r) {return _spilledRegisterList = r;}
-   TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
-   TR::list<TR::Register*> *setFirstTimeLiveOOLRegisterList(TR::list<TR::Register*> *r) {return _firstTimeLiveOOLRegisterList = r;}
-
+   
    TR_BackingStore *allocateSpill(bool containsCollectedReference, int32_t *offset, bool reuse=true);
    TR_BackingStore *allocateSpill(int32_t size, bool containsCollectedReference, int32_t *offset, bool reuse=true);
    TR_BackingStore *allocateInternalPointerSpill(TR::AutomaticSymbol *pinningArrayPointer);
@@ -1886,7 +1884,6 @@ class OMR_EXTENSIBLE CodeGenerator
    int32_t _accumulatorNodeUsage;
 
    TR::list<TR::Register*> *_spilledRegisterList;
-   TR::list<TR::Register*> *_firstTimeLiveOOLRegisterList;
    TR::list<OMR::RegisterUsage*> *_referencedRegistersList;
    int32_t _currentPathDepth;
    TR::list<TR::Node*> _nodesSpineCheckedList;

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -422,6 +422,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
      _nodesToBeEvaluatedInRegPairs(self()->comp()->allocator()),
      _ccInstruction(NULL),
      _previouslyAssignedTo(self()->comp()->allocator("LocalRA")),
+     _firstTimeLiveOOLRegisterList(NULL),
      _methodBegin(NULL),
      _methodEnd(NULL)
    {

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -203,6 +203,9 @@ public:
    TR_BranchPreloadCallData _outlineCall;
    TR_BranchPreloadCallData _outlineArrayCall;
 
+   TR::list<TR::Register*> *getFirstTimeLiveOOLRegisterList() {return _firstTimeLiveOOLRegisterList;}
+   TR::list<TR::Register*> *setFirstTimeLiveOOLRegisterList(TR::list<TR::Register*> *r) {return _firstTimeLiveOOLRegisterList = r;}
+
    TR::list<TR_BranchPreloadCallData*> *_callsForPreloadList;
 
    TR::list<TR_BranchPreloadCallData*> * getCallsForPreloadList() { return _callsForPreloadList; }
@@ -817,6 +820,8 @@ public:
 protected:
    TR::list<TR::S390ConstantDataSnippet*>  _constantList;
    TR::list<TR::S390ConstantDataSnippet*>  _snippetDataList;
+
+   TR::list<TR::Register*> *_firstTimeLiveOOLRegisterList;
 
 private:
 


### PR DESCRIPTION
The _firstTimeLiveOOLRegisterList is only used in the the
OMR::Z::CodeGenerator class, but is defined and declared in the
OMR::CodeGenerator class. Thus, move the variable and its accessor
funcitons to Z CodeGenerator

Closes: #1893
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>