### PR TITLE
Add UTF-8 case when reading locale from LC_CTYPE

### DIFF
--- a/port/unix/j9nlshelpers.c
+++ b/port/unix/j9nlshelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,8 +117,8 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	}
 #endif /* defined (J9ZOS390) */
 #endif  /* defined(LINUX) || defined(OSX) */
-	if (lang != NULL && strcmp(lang, "POSIX") && strcmp(lang, "C"))
-		if (lang != NULL && (langlen = strlen(lang)) >= 2) {
+	if ((NULL != lang) && strcmp(lang, "POSIX") && strcmp(lang, "C") && strcmp(lang, "UTF-8")) {
+		if ((NULL != lang) && ((langlen = strlen(lang)) >= 2)) {
 			/* copy the language, stopping at '_'
 			 * CMVC 145188 - language locale must be lowercase
 			 */
@@ -129,6 +129,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 				countryStart++;
 			}
 		}
+	}
 	if (!strcmp(languageProp, "jp")) {
 		languageProp[1] = 'a';
 	}


### PR DESCRIPTION
OSX considers 'UTF-8' as a valid LC_CTYPE, and we never considered this
case, so we blindly copy that as the language name when we get it from
the LC_CTYPE env variable. 'UTF-8' is more like 'C' or 'POSIX' locale,
so just go with default language and region.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse/openj9/issues/5705

fyi: @DanHeidinga 