### PR TITLE
Remove the createOrFindClonedNode function in OMR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -159,7 +159,6 @@ OMR::CodeGenerator::CodeGenerator() :
       _implicitExceptionPoint(0),
       _localsThatAreStored(NULL),
       _numLocalsWhenStoreAnalysisWasDone(-1),
-      _uncommmonedNodes(self()->comp()->trMemory(), stackAlloc),
       _ialoadUnneeded(self()->comp()->trMemory()),
      _symRefTab(self()->comp()->getSymRefTab()),
      _vmThreadRegister(NULL),
@@ -1291,27 +1290,6 @@ bool OMR::CodeGenerator::areAssignableGPRsScarce()
    if (c1)
       threshold = atoi(c1);
       return (self()->getMaximumNumbersOfAssignableGPRs() <= threshold);
-   }
-
-// J9
-//
-TR::Node *
-OMR::CodeGenerator::createOrFindClonedNode(TR::Node *node, int32_t numChildren)
-   {
-   TR_HashId index;
-   if (!_uncommmonedNodes.locate(node->getGlobalIndex(), index))
-      {
-      // has not been uncommoned already, clone and store for later
-      TR::Node *clone = TR::Node::copy(node, numChildren);
-      _uncommmonedNodes.add(node->getGlobalIndex(), index, clone);
-      node = clone;
-      }
-   else
-      {
-      // found previously cloned node
-      node = (TR::Node *) _uncommmonedNodes.getData(index);
-      }
-   return node;
    }
 
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -266,7 +266,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR_BitVector *_localsThatAreStored;
    int32_t _numLocalsWhenStoreAnalysisWasDone;
-   TR_HashTabInt _uncommmonedNodes;               // uncommoned nodes keyed by the original nodes
    List<TR_Pair<TR::Node, int32_t> > _ialoadUnneeded;
 
    public:
@@ -1389,9 +1388,7 @@ class OMR_EXTENSIBLE CodeGenerator
       return true;
       }
 
-   // --------------------------------------------------------------------------
-
-   TR::Node *createOrFindClonedNode(TR::Node *node, int32_t numChildren);
+   // --------------------------------------------------------------------------	
 
    bool constantAddressesCanChangeSize(TR::Node *node);
    bool profiledPointersRequireRelocation();


### PR DESCRIPTION
`TR::Node *createOrFindClonedNode` function in `OMR::CodeGenerator` has only relevance to the OpenJ9 project. Therefore, remove it from OMR and relocate it to the `J9::CodeGenerator` instead. In addition, fix the spelling mistake on `_uncommonedNodes` and relocate it from OMR to J9.

Closes: #2068
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>