### PR TITLE
Fix _GNU_SOURCE redefinition

### DIFF
--- a/port/linux/omrosbacktrace_impl.c
+++ b/port/linux/omrosbacktrace_impl.c
@@ -25,8 +25,9 @@
  * @ingroup Port
  * @brief Stack backtracing support
  */
-
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "omrport.h"
 #include "omrportpriv.h"

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -27,7 +27,9 @@
  */
 
 /* for syscall */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "omrport.h"
 #include "omrportpriv.h"

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -28,7 +28,9 @@
 
 #if defined(LINUX)
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #endif /* defined(LINUX) */
 
 #include <pthread.h>

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -29,7 +29,9 @@
 #if defined(LINUX) && !defined(OMRZTPF)
 
 /* defining _GNU_SOURCE allows the use of dladdr() in dlfcn.h */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #elif defined(OSX)
 #define _XOPEN_SOURCE
 #endif /* defined(LINUX)  && !defined(OMRZTPF) */

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -31,7 +31,9 @@
 #endif
 
 #if defined(LINUX) && !defined(OMRZTPF)
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #elif defined(OSX)
 #define _XOPEN_SOURCE
 #include <libproc.h>


### PR DESCRIPTION
defining `_GNU_SOURCE` feature macro only if not defined to avoid redefinition error.

Signed-off-by: bharathappali <bharath.appali@gmail.com>