### PR TITLE
Fix cpu_set_t unknown type name error

### DIFF
--- a/port/common/j9nls.c
+++ b/port/common/j9nls.c
@@ -26,6 +26,9 @@
  * @brief Native language support
  * @deprecated NLS API is deprecated.
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include "omrcomp.h"
 #include "omrport.h"

--- a/port/common/omrerror.c
+++ b/port/common/omrerror.c
@@ -36,6 +36,9 @@
  * the error.  As a result the error message is not stored at time of the reported error, but can be looked
  * up at a later time.
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/port/common/omrheap.c
+++ b/port/common/omrheap.c
@@ -25,6 +25,10 @@
  * @ingroup Port
  * @brief Heap Utilities
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
+
 #include "omrport.h"
 #include "omrportpriv.h"
 #include "omrportpg.h"

--- a/port/common/omrmem32helpers.c
+++ b/port/common/omrmem32helpers.c
@@ -19,6 +19,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include "omrmem32helpers.h"
 #include "omrport.h"

--- a/port/common/omrmemcategories.c
+++ b/port/common/omrmemcategories.c
@@ -25,7 +25,9 @@
  * @ingroup Port
  * @brief Memory category management
  */
-
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 /*
  * This file contains the code for managing memory categories.

--- a/port/common/omrmemtag.c
+++ b/port/common/omrmemtag.c
@@ -25,7 +25,9 @@
  * @ingroup Port
  * @brief Memory Utilities
  */
-
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 /*
  * This file contains code for the portability library memory management.

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -25,6 +25,10 @@
  * @ingroup Port
  * @brief Port Library
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
+
 #include <string.h>
 #include "omrport.h"
 #include "omrportpriv.h"

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -19,6 +19,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <string.h>
 #include "omrport.h"

--- a/port/common/omrtlshelpers.c
+++ b/port/common/omrtlshelpers.c
@@ -35,6 +35,10 @@
  * Only the function @omrport_tls_free is available via the port library function table.  The rest of
  * the functions are helpers for the port library only.
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
+
 #include <string.h>
 #include "omrport.h"
 #include "omrportpriv.h"

--- a/port/linux/omrosdump_helpers.c
+++ b/port/linux/omrosdump_helpers.c
@@ -25,7 +25,9 @@
  * @ingroup Port
  * @brief Dump formatting
  */
-
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 
 #include <sys/mman.h>

--- a/port/unix/j9nlshelpers.c
+++ b/port/unix/j9nlshelpers.c
@@ -26,6 +26,9 @@
  * @brief Native language support helpers
  */
 
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <unistd.h>
 #include <sys/types.h>

--- a/port/unix/omrerrorhelpers.c
+++ b/port/unix/omrerrorhelpers.c
@@ -32,6 +32,9 @@
  * These functions are not accessible via the port library function table.
  */
 
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <string.h>
 #include <errno.h>

--- a/port/unix/omrfile.c
+++ b/port/unix/omrfile.c
@@ -26,6 +26,9 @@
  * @brief file
  */
 
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/port/unix/omrfiletext.c
+++ b/port/unix/omrfiletext.c
@@ -25,6 +25,9 @@
  * @ingroup Port
  * @brief file
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <nl_types.h>
 #include <langinfo.h>

--- a/port/unix/omriconvhelpers.c
+++ b/port/unix/omriconvhelpers.c
@@ -25,6 +25,9 @@
  * @ingroup Port
  * @brief iconv support helpers
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 /* Use the version of nl_langinfo() that returns an EBCDIC string */
 #define J9_USE_ORIG_EBCDIC_LANGINFO 1

--- a/port/unix/omrmem.c
+++ b/port/unix/omrmem.c
@@ -25,7 +25,9 @@
  * @ingroup Port
  * @brief Memory Utilities
  */
-
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 /*
  * This file contains code for the portability library memory management.

--- a/port/unix/omrmmap.c
+++ b/port/unix/omrmmap.c
@@ -33,7 +33,9 @@
  * memory mapping facilites do not exist at all. On these platforms the API will
  * still be available, but will simply read the file into allocated memory.
  */
-
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/port/unix/omrosdump.c
+++ b/port/unix/omrosdump.c
@@ -25,6 +25,9 @@
  * @ingroup Port
  * @brief Dump formatting
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include <sys/types.h>
 #if defined(AIXPPC)

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -25,6 +25,10 @@
  * @ingroup Port
  * @brief Signal handling
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
+
 #include "omrcfg.h"
 #include "omrport.h"
 #include "omrutil.h"

--- a/port/unix/omrsyslog.c
+++ b/port/unix/omrsyslog.c
@@ -25,6 +25,10 @@
  * @ingroup Port
  * @brief System logging support
  */
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
+
 #include <string.h>
 #include <syslog.h>
 #include "omrportpriv.h"

--- a/port/unix/protect_helpers.c
+++ b/port/unix/protect_helpers.c
@@ -19,6 +19,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+#if defined(OMR_MUSL_CLIB)
+#define _GNU_SOURCE
+#endif
 
 #include "omrcomp.h"
 #include "omrport.h"


### PR DESCRIPTION
This PR is a part of the group of PR's that were/will be raised as a fix for issue #3774

In musl environment the OMR build fails with :
```
error: unknown type name 'cpu_set_t'
  cpu_set_t process_affinity;
  ^~~~~~~~~
```

**Note:**
I have added the code in a view that `-DMUSL` is added to the complier flags.

**Build System Changes**
Flags to be added : `-DMUSL`

This item is still **Work In Progress** as only compile error are being resolved as of now, Will be ready to be reviewed after checking if no runtime errors are found as well after completing musl support

Signed-off-by: bharathappali <bharath.appali@gmail.com>