### PR TITLE
Remove unused unkilledTemp property from ResolvedMethodSymbol

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1283,11 +1283,6 @@ void OMR::Compilation::performOptimizations()
       ((TR::Optimizer*)(_optimizer))->setRequestOptimization(OMR::trivialDeadTreeRemoval, true, block);
       }
 
-   if (_methodSymbol->hasUnkilledTemps())
-      {
-      ((TR::Optimizer*)(_optimizer))->setRequestOptimization(OMR::globalDeadStoreElimination);
-      }
-
    if (_optimizer)
       _optimizer->optimize();
    }

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -270,9 +270,6 @@ public:
    bool hasSnapshots()                       { return _properties.testAny(HasSnapshots); }
    void setHasSnapshots(bool v=true)         { _properties.set(HasSnapshots,v); }
 
-   bool hasUnkilledTemps()                   { return _properties.testAny(HasUnkilledTemps); }
-   void setHasUnkilledTemps(bool v=true)     { _properties.set(HasUnkilledTemps,v); }
-
    bool detectInternalCycles(TR::CFG *cfg, TR::Compilation *comp);
    bool catchBlocksHaveRealPredecessors(TR::CFG *cfg, TR::Compilation *comp);
 
@@ -316,7 +313,7 @@ protected:
       CanSkipZeroInitializationOnNewarrays      = 1 << 5,
       CanSkipArrayStoreChecks                   = 1 << 6,
       HasSnapshots                              = 1 << 7,
-      HasUnkilledTemps                          = 1 << 8,
+      // AVAILABLE                              = 1 << 8,
       CanDirectNativeCall                       = 1 << 9,
       CanReplaceWithHWInstr                     = 1 << 10,
       IsSideEffectFree                          = 1 << 12,


### PR DESCRIPTION
Not useful in OMR nor any known downstream project.  Since the
property is never set, remove guarded code assuming it is set.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>