### PR TITLE
Remove and cleanup MetaDataList from ResolvedMethodSymbol

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -126,7 +126,6 @@ OMR::ResolvedMethodSymbol::ResolvedMethodSymbol(TR_ResolvedMethod * method, TR::
      _automaticList(comp->trMemory()),
      _parameterList(comp->trMemory()),
      _variableSizeSymbolList(comp->trMemory()),
-     _methodMetaDataList(comp->trMemory()),
      _comp(comp),
      _firstJitTempIndex(-1),
      _cannotAttemptOSR(NULL),
@@ -1929,13 +1928,6 @@ OMR::ResolvedMethodSymbol::addVariableSizeSymbol(TR::AutomaticSymbol *s)
       _variableSizeSymbolList.add(s);
    }
 
-void
-OMR::ResolvedMethodSymbol::addMethodMetaDataSymbol(TR::RegisterMappedSymbol *s)
-   {
-   TR_ASSERT(!s || s->isMethodMetaData(), "should be method metadata");
-   if (!_methodMetaDataList.find(s))
-      _methodMetaDataList.add(s);
-   }
 
 // get/setTempIndex is called from TR_ResolvedMethod::makeParameterList
 int32_t

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -94,7 +94,6 @@ public:
    void setAutomaticList(List<TR::AutomaticSymbol> list)                       { _automaticList = list; };
 
    List<TR::AutomaticSymbol>& getVariableSizeSymbolList()                      { return _variableSizeSymbolList;}
-   ListBase<TR::RegisterMappedSymbol>& getMethodMetaDataList()                 { return _methodMetaDataList;}
 
    void removeUnusedLocals();
 
@@ -130,7 +129,6 @@ public:
    void addAutomatic(TR::AutomaticSymbol *p);
 
    void addVariableSizeSymbol(TR::AutomaticSymbol *s);
-   void addMethodMetaDataSymbol(TR::RegisterMappedSymbol*s);
 
    mcount_t            getResolvedMethodIndex() { return _methodIndex; }
    TR_ResolvedMethod * getResolvedMethod()      { return _resolvedMethod; }
@@ -329,7 +327,6 @@ private:
    List<TR::AutomaticSymbol>                  _automaticList;
    List<TR::ParameterSymbol>                  _parameterList;
    List<TR::AutomaticSymbol>                  _variableSizeSymbolList;
-   List<TR::RegisterMappedSymbol>             _methodMetaDataList;
    TR_Array<List<TR::SymbolReference> >     * _autoSymRefs;
    TR_Array<List<TR::SymbolReference> >     * _pendingPushSymRefs;
    TR_Array<TR::SymbolReference*>           * _parmSymRefs;

--- a/compiler/optimizer/DataFlowAnalysis.hpp
+++ b/compiler/optimizer/DataFlowAnalysis.hpp
@@ -744,7 +744,6 @@ class TR_LiveVariableInformation
                               TR_Structure *,
                               bool splitLongs = false,
                               bool includeParms = false,
-                              bool includeMethodMetaDataSymbols = false,
                               bool ignoreOSRUses = false);
 
    bool traceLiveVarInfo()           { return _traceLiveVariableInfo; }
@@ -758,7 +757,6 @@ class TR_LiveVariableInformation
    int32_t numLocals()                 { return _numLocals; }
    bool includeParms()                 { return _includeParms; }
    bool splitLongs()                   { return _splitLongs; }
-   bool includeMethodMetaDataSymbols() { return _includeMethodMetaDataSymbols; }
 
    int32_t numNodes()                { return _numNodes; }
 
@@ -790,7 +788,6 @@ class TR_LiveVariableInformation
    TR_Memory *     _trMemory;
    int32_t         _numLocals;
    bool            _includeParms;
-   bool            _includeMethodMetaDataSymbols;
    bool            _splitLongs;
    bool            _traceLiveVariableInfo;
    bool            _ignoreOSRUses;
@@ -824,7 +821,6 @@ class TR_OSRLiveVariableInformation : public TR_LiveVariableInformation
                               TR_Structure *,
                               bool splitLongs = false,
                               bool includeParms = false,
-                              bool includeMethodMetaDataSymbols = false,
                               bool ignoreOSRUses = false);
 
    private:

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -423,16 +423,6 @@ TR_GlobalRegisterAllocator::perform()
                ++numLocals;
             }
 
-         ListIterator<TR::RegisterMappedSymbol> methodMetaDataSymbols(&comp()->getMethodSymbol()->getMethodMetaDataList());
-         if (comp()->allocateAtThisOptLevel())
-            {
-            for (auto mds = methodMetaDataSymbols.getFirst(); mds != NULL; mds = methodMetaDataSymbols.getNext())
-               {
-               TR_ASSERT(mds->isMethodMetaData(), "Should be method meta data");
-               ++numLocals;
-               }
-            }
-
          const uint64_t MAX_BITVECTOR_MEMORY_USAGE = 1000000000;
          uint64_t bitvectorMemoryUsage = numLocals * comp()->getFlowGraph()->getNextNodeNumber();
 

--- a/compiler/optimizer/Liveness.cpp
+++ b/compiler/optimizer/Liveness.cpp
@@ -76,7 +76,6 @@ TR_Liveness::TR_Liveness(TR::Compilation           *comp,
    if (liveVariableInfo == NULL)
       // can be re-used by the caller because it's allocated in caller's stack
       _liveVariableInfo = new (trStackMemory()) TR_LiveVariableInformation(comp, optimizer, rootStructure, splitLongs, includeParms,
-                                                                           false,
                                                                            ignoreOSRUses);
    else
       _liveVariableInfo = liveVariableInfo;

--- a/compiler/optimizer/SinkStores.cpp
+++ b/compiler/optimizer/SinkStores.cpp
@@ -797,20 +797,6 @@ int32_t TR_SinkStores::performStoreSinking()
       return 1;
       }
 
-   if (trace() && sinkMethodMetaDataStores())
-      {
-      ListIterator<TR::RegisterMappedSymbol> methodMetaDataSymbols(&comp()->getMethodSymbol()->getMethodMetaDataList());
-      int32_t localCount = 0;
-      for (auto *m = methodMetaDataSymbols.getFirst(); m != NULL; m = methodMetaDataSymbols.getNext())
-         {
-         TR_ASSERT(m->isMethodMetaData(), "should be method meta data");
-         // If this assume fires than the order the method meta symbols were added in LiveVariableInformation has changed and
-         // the mapping of live index to symbol name given below is wrong
-         TR_ASSERT(m->getLiveLocalIndex() == localCount,"Index mismatch for MethodMetaDataSymbol therefore this tracing output is wrong\n");
-         traceMsg(comp(), "Local #%2d is MethodMetaData symbol at %p : %s\n",localCount++,m,m->getName());
-         }
-      }
-
    _liveVarInfo->createGenAndKillSetCaches();
    if (!enablePreciseSymbolTracking())
       _liveVarInfo->trackLiveCommonedLoads();


### PR DESCRIPTION
The `OMR::ResolvedMethodSymbol` maintains a list of method metadata
symbols that are a remnant of a legacy project consuming OMR.  They
are not used in OMR nor any known downstream project.

Remove and fold code that referenced this list (it was never populated
with anything).

Signed-off-by: Daryl Maier <maier@ca.ibm.com>