### PR TITLE
Replace ResolvedMethodSymbol::getLogicalParameterList

### DIFF
--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -327,11 +327,6 @@ OMR::ResolvedMethodSymbol::getThisTempForObjectCtorIndex()
    return self()->getFirstJitTempIndex() - delta;
    }
 
-List<TR::ParameterSymbol>&
-OMR::ResolvedMethodSymbol::getLogicalParameterList(TR::Compilation *comp)
-   {
-      return self()->getParameterList();
-   }
 
 template <typename AllocatorType>
 TR::ResolvedMethodSymbol *

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -90,9 +90,6 @@ public:
    void setParameterList()                                                    { _resolvedMethod->makeParameterList(self()); }
    List<TR::ParameterSymbol>& getParameterList()                               { return _parameterList; }
 
-   /// With zOS type 1 linkage, the parameters in the parameter list
-   /// don't look at all like the source level (logical) parameters.
-   List<TR::ParameterSymbol>& getLogicalParameterList(TR::Compilation *comp);
    ListBase<TR::AutomaticSymbol>& getAutomaticList()                           { return _automaticList;}
    void setAutomaticList(List<TR::AutomaticSymbol> list)                       { _automaticList = list; };
 

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -684,7 +684,7 @@ TR_InlinerBase::exceedsSizeThreshold(TR_CallSite *callsite, int bytecodeSize, TR
 void
 TR_InlinerBase::createParmMap(TR::ResolvedMethodSymbol *calleeSymbol, TR_LinkHead<TR_ParameterMapping> &map)
    {
-   ListIterator<TR::ParameterSymbol> parms(&calleeSymbol->getLogicalParameterList(comp()));
+   ListIterator<TR::ParameterSymbol> parms(&calleeSymbol->getParameterList());
 
    for (TR::ParameterSymbol * p = parms.getFirst(); p; p = parms.getNext())
       {


### PR DESCRIPTION
This method is a remnant of a legacy project consuming OMR.  It is
no longer relevant, and simply returns `getParameterList`.  Replace
all references with `getParameterList` and remove the `TR::Compilation *`
argument.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>