### PR TITLE
Remove OMR::ResolvedMethodSymbol NoTemps

### DIFF
--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -1107,10 +1107,9 @@ static bool blockIsMuchColderThanContainingLoop(TR::Block *block, TR::CodeGenera
 
 static bool blockIsIgnorablyCold(TR::Block *block, TR::CodeGenerator *cg)
    {
-   bool cannotSpillInBlock = cg->comp()->getJittedMethodSymbol()->isNoTemps();
    if (block->isCold() && cg->traceSimulateTreeEvaluation())
       traceMsg(cg->comp(), "            Block %d is cold\n", block->getNumber());
-   return !cannotSpillInBlock && (block->isCold() || blockIsMuchColderThanContainingLoop(block, cg));
+   return (block->isCold() || blockIsMuchColderThanContainingLoop(block, cg));
    }
 
 void

--- a/compiler/il/symbol/OMRMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRMethodSymbol.hpp
@@ -105,7 +105,7 @@ public:
       MayHaveLongOps               = 0x00040000, ///< this group is only used by resolved method symbols
       MayHaveLoops                 = 0x00080000,
       MayHaveNestedLoops           = 0x00100000,
-      NoTempsSet                   = 0x00200000,
+      // AVAILABLE                 = 0x00200000,
       MayHaveInlineableCall        = 0x00400000,
       IlGenSuccess                 = 0x00800000,
       MayContainMonitors           = 0x01000000,

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -2507,19 +2507,6 @@ OMR::ResolvedMethodSymbol::setUsesSinglePrecisionMode(bool b)
    _methodFlags.set(SinglePrecisionMode, b);
    }
 
-bool
-OMR::ResolvedMethodSymbol::isNoTemps()
-   {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
-   return _methodFlags.testAny(NoTempsSet);
-   }
-void
-OMR::ResolvedMethodSymbol::setNoTemps(bool b)
-   {
-   TR_ASSERT(self()->isJittedMethod(), "Should have been created as a jitted method.");
-   _methodFlags.set(NoTempsSet, b);
-   }
-
 /**
  * \brief Returns the bytecode that represents the start of the ilgen created basic block
  *

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -403,9 +403,6 @@ public:
    bool        usesSinglePrecisionMode();
    void        setUsesSinglePrecisionMode(bool b);
 
-   bool        isNoTemps();
-   void        setNoTemps(bool b=true);
-
 private:
    uint32_t                                  _localMappingCursor;
    uint32_t                                  _prologuePushSlots;

--- a/compiler/optimizer/CopyPropagation.cpp
+++ b/compiler/optimizer/CopyPropagation.cpp
@@ -840,17 +840,6 @@ int32_t TR_CopyPropagation::perform()
          bool baseAddrAvail = false;
          TR::Node * baseAddr = NULL;
 
-         // Bail out if we're in a NOTEMPS method and we're going to create a temp.  This conditional should match
-         // the conditional that covers the anchoring code below.
-         if (!isRegLoad &&
-                         (loadNode->getOpCodeValue() != TR::loadaddr) &&                   // loadaddr doesn't need to be anchored
-                         (loadNode->getOpCode().hasSymbolReference()) &&
-                         (loadNode->getSymbolReference() == copySymbolReference) &&
-                         (rhsOfStoreDefNode != loadNode) &&
-                         comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-                         comp()->getJittedMethodSymbol()->isNoTemps())
-            continue;
-
          if (performTransformation(comp(), "%s   Copy2 Propagation replacing Copy symRef #%d \n",OPT_DETAILS, copySymbolReference->getReferenceNumber()))
             {
             comp()->setOsrStateIsReliable(false); // could check if the propagation was done to a child of the OSR helper call here

--- a/compiler/optimizer/LoopCanonicalizer.cpp
+++ b/compiler/optimizer/LoopCanonicalizer.cpp
@@ -2535,16 +2535,6 @@ bool TR_LoopCanonicalizer::examineTreeForInductionVariableUse(TR::Block *loopInv
       }
 
    if (node->getOpCode().hasSymbolReference() &&
-       !node->getOpCode().isStore() &&
-       node->getSymbolReference() == _symRefBeingReplaced &&
-       comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-              comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(comp(), "Skipping transformation under NOTEMPS\n");
-      return false;
-      }
-
-   if (node->getOpCode().hasSymbolReference() &&
        !node->getOpCode().isStore())
       {
       if ((node->getSymbolReference() == _symRefBeingReplaced) &&

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -1999,13 +1999,6 @@ TR_LoopReducer::generateArraycmp(TR_RegionStructure * whileLoop, TR_InductionVar
       return false;
       }
 
-   if (comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-       comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(comp(), "arraycmp not safe to perform when NOTEMPS enabled\n");
-      return false;
-      }
-
    int32_t compNum = branchBlock ? branchBlock->getNumberOfRealTreeTops() : 0;
    int32_t incrNum = incrementBlock ? incrementBlock->getNumberOfRealTreeTops() : 0;
    if (compNum != 1 || incrNum != 2)
@@ -2614,13 +2607,6 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    //   <termination value>
    //
    //BBEnd <load/store-char>
-
-   if (comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-       comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(comp(), "arraytranslate not safe to perform when NOTEMPS enabled\n");
-      return false;
-      }
 
    if (!cg()->getSupportsArrayTranslateTRxx())
       {
@@ -3754,13 +3740,6 @@ TR_LoopReducer::generateArraytranslateAndTest(TR_RegionStructure * whileLoop, TR
 bool
 TR_LoopReducer::generateByteToCharArraycopy(TR_InductionVariable * byteIndVar, TR_InductionVariable * charIndVar, TR::Block * loopHeader)
    {
-   if (comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-       comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(comp(), "arraytranslate not safe to perform when NOTEMPS enabled\n");
-      return false;
-      }
-
    if (!comp()->cg()->getSupportsReferenceArrayCopy() && !comp()->cg()->getSupportsPrimitiveArrayCopy())
       {
       dumpOptDetails(comp(), "arraycopy not enabled for this platform\n");
@@ -4001,13 +3980,6 @@ TR_LoopReducer::generateByteToCharArraycopy(TR_InductionVariable * byteIndVar, T
 bool
 TR_LoopReducer::generateCharToByteArraycopy(TR_InductionVariable * byteIndVar, TR_InductionVariable * charIndVar, TR::Block * loopHeader)
    {
-   if (comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-         comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(comp(), "arraytranslate not safe to perform when NOTEMPS enabled\n");
-      return false;
-      }
-
    if (!comp()->cg()->getSupportsReferenceArrayCopy() && !comp()->cg()->getSupportsPrimitiveArrayCopy())
       {
       dumpOptDetails(comp(), "arraycopy not enabled for this platform\n");

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -3451,7 +3451,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
                   if (!comp()->fe()->isUnloadAssumptionRequired((TR_OpaqueClassBlock*)clazz, comp()->getCurrentMethod()))
                      {
                      checkCastTrees->add(currentTree);
-   
+
                      if (dupOfThisBlockAlreadyExecutedBeforeLoop)
                         _checksInDupHeader.add(currentTree);
                      }
@@ -4911,7 +4911,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
 
          for (auto changedSuccEdge = succNode->getSuccessors().begin(); changedSuccEdge != succNode->getSuccessors().end(); ++changedSuccEdge)
             {
-            // 
+            //
             // Watch for any edge from the original loop to the invariant
             // block - it will now refer to the proper region node, and
             // must be discarded from the list of predecessors of the
@@ -5448,13 +5448,6 @@ bool TR_LoopVersioner::buildLoopInvariantTree(List<TR::TreeTop> *nullCheckTrees,
                                                List<TR_NodeParentSymRefWeightTuple> *invariantTranslationNodesList,
                                                TR::Block *exitGotoBlock, TR::Block *loopInvariantBlock)
    {
-
-   if (comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-       comp()->getJittedMethodSymbol()->isNoTemps())
-       {
-       dumpOptDetails(comp(), "buildLoopInvariantTree not safe to perform when NOTEMPS enabled\n");
-       return false;
-       }
    TR::TreeTop *placeHolderTree = loopInvariantBlock->getLastRealTreeTop();
    TR::Node *placeHolderNode = placeHolderTree->getNode();
    int dumped = 0;
@@ -5654,13 +5647,6 @@ bool TR_LoopVersioner::buildSpecializationTree(List<TR::TreeTop> *nullCheckTrees
    {
    if (!comp()->getRecompilationInfo())
      return false;
-
-   if (comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-       comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(comp(), "buildSpecializationTree not safe to perform when NOTEMPS enabled\n");
-      return false;
-      }
 
    bool specializedLong = false;
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -8186,13 +8186,6 @@ void replaceWithSmallerType(OMR::ValuePropagation *vp, TR::Node *node)
    if (node->getReferenceCount() > 1)
       return;
 
-   if (vp->comp()->getJittedMethodSymbol() && // avoid NULL pointer on non-Wcode builds
-       vp->comp()->getJittedMethodSymbol()->isNoTemps())
-      {
-      dumpOptDetails(vp->comp(), "replaceWithSmallerType not safe to perform when NOTEMPS enabled\n");
-      return;
-      }
-
    TR::DataType newType = node->getDataType();
    TR::Node *load = node->getFirstChild();
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -850,13 +850,9 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
                else
                   {
                   // testing register pressure
-                  if (!comp->getJittedMethodSymbol()->isNoTemps())
-                     {
-                     if (!targetRegister)
-                        targetRegister = sourceRegister;
-                     break;
-                     }
-                  constReg = cg->allocateRegister();
+                  if (!targetRegister)
+                     targetRegister = sourceRegister;
+                  break;
                   }
 
                if (cond)


### PR DESCRIPTION
`isNoTemps` and `setNoTemps` are remants of a legacy project consuming
OMR and are no longer relevant.  Remove and fold code assuming `isNoTemps`
always returns false.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>