### PR TITLE
Delete _compressedRefs from OMR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -205,7 +205,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _simulatedNodeStates(NULL),
      _availableSpillTemps(getTypedAllocator<TR::SymbolReference*>(TR::comp()->allocator())),
      _counterBlocks(getTypedAllocator<TR::Block*>(TR::comp()->allocator())),
-     _compressedRefs(getTypedAllocator<TR::Node*>(TR::comp()->allocator())),
      _liveReferenceList(getTypedAllocator<TR_LiveReference*>(TR::comp()->allocator())),
      _snippetList(getTypedAllocator<TR::Snippet*>(TR::comp()->allocator())),
      _registerArray(self()->comp()->trMemory()),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1892,8 +1892,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR_Array<void *> _monitorMapping;
 
-   TR::list<TR::Node*> _compressedRefs;
-
    uint32_t _largestOutgoingArgSize;
 
    uint32_t _estimatedCodeLength;


### PR DESCRIPTION
`OMR::CodeGenerator` has field `compressedRefs` that does not appear to do anything useful in OpenJ9. Therefore, remove the field by first deleting the references in OpenJ9. Then remove the initialization in OMR.

Closes: #1896
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>