### PR TITLE
CMake: Link ddrgen against thread library

### DIFF
--- a/ddr/tools/ddrgen/CMakeLists.txt
+++ b/ddr/tools/ddrgen/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(omr_ddrgen
 	omr_ddr_macros
 	omr_ddr_scanner
 	${OMR_PORT_LIB}
+	${OMR_THREAD_LIB}
 )
 
 if(OMRPORT_OMRSIG_SUPPORT)


### PR DESCRIPTION
ddrgen uses the thread library. It works in current builds because the
port library is a static lib and has a dependency on the thread library

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>