### PR TITLE
z/TPF Root VPATH Rename

### DIFF
--- a/omrmakefiles/rules.ztpf.mk
+++ b/omrmakefiles/rules.ztpf.mk
@@ -108,7 +108,7 @@ ifneq (,$(findstring executable,$(ARTIFACT_TYPE)))
     GLOBAL_LDFLAGS+=$(DEFAULT_LIBS)
 endif
 
-TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /ztpf/svtcur/gnu/all /ztpf/commit
+TPF_ROOT ?= /ztpf/java/bld/jvm/userfiles /zbld/svtcur/gnu/all /ztpf/commit
 
 ###
 ### Shared Libraries


### PR DESCRIPTION
Very minor update for one of the vpaths used during z/TPF only builds.
The directory path change and we didn't correctly update the path to
reflect the correct name.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>