### PR TITLE
Reorder defines so xlC16 finds the xlc before gnu

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -396,7 +396,10 @@ public:
 #if defined(OMRZTPF)
         cs((cs_t *)&oldValue, (cs_t *)address, (cs_t)newValue);
         return oldValue;
-#elif defined(__GNUC__) /* defined(OMRZTPF) */ 
+#elif defined(__xlC__) /* defined(OMRZTPF) */
+		__compare_and_swap((volatile int*)address, (int*)&oldValue, (int)newValue);
+		return oldValue;
+#elif defined(__GNUC__)  /* defined(__xlC__) */
 		/* Assume GCC >= 4.2 */
 		return __sync_val_compare_and_swap(address, oldValue, newValue);
 #elif defined(_MSC_VER) /* defined(__GNUC__) */
@@ -410,7 +413,7 @@ public:
 #elif defined(__xlC__) /* defined(J9ZOS390) */
 		__compare_and_swap((volatile int*)address, (int*)&oldValue, (int)newValue);
 		return oldValue;
-#else /* defined(__xlC__) */
+#else /* defined(J9ZOS390) */
 #error "lockCompareExchangeU32(): unsupported platform!"
 #endif /* defined(__xlC__) */
 #endif /* defined(ATOMIC_SUPPORT_STUB) */
@@ -453,7 +456,10 @@ public:
 #elif defined(OMRZTPF) /* defined(OMR_ARCH_POWER) && !defined(OMR_ENV_DATA64) */
 		csg((csg_t *)&oldValue, (csg_t *)address, (csg_t)newValue);
 		return oldValue;
-#elif defined(__GNUC__) /* defined(OMRZTPF) */
+#elif defined(__xlC__) /* defined(OMRZTPF) */
+		__compare_and_swaplp((volatile long*)address, (long*)&oldValue, (long)newValue);
+		return oldValue;
+#elif defined(__GNUC__) /* defined(__xlC__) */
 		/* Assume GCC >= 4.2 */
 		return __sync_val_compare_and_swap(address, oldValue, newValue);
 #elif defined(_MSC_VER) /* defined(__GNUC__) */
@@ -470,10 +476,7 @@ public:
 		cds((cds_t*)&old, (cds_t*)address, *(cds_t*)&newValue);
 		return old;
 #endif /* defined(OMR_ENV_DATA64) */
-#elif defined(__xlC__) /* defined(J9ZOS390) */
-		__compare_and_swaplp((volatile long*)address, (long*)&oldValue, (long)newValue);
-		return oldValue;
-#else /* defined(__xlC__) */
+#else /* defined(J9ZOS390) */
 #error "lockCompareExchangeU64(): unsupported platform!"
 #endif /* defined(__xlC__) */
 #endif /* defined(ATOMIC_SUPPORT_STUB) */

--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -394,8 +394,8 @@ public:
 		}
 #endif /* defined(ATOMIC_ALLOW_PRE_READ) */
 #if defined(OMRZTPF)
-        cs((cs_t *)&oldValue, (cs_t *)address, (cs_t)newValue);
-        return oldValue;
+		cs((cs_t *)&oldValue, (cs_t *)address, (cs_t)newValue);
+		return oldValue;
 #elif defined(__xlC__) /* defined(OMRZTPF) */
 		__compare_and_swap((volatile int*)address, (int*)&oldValue, (int)newValue);
 		return oldValue;
@@ -410,9 +410,6 @@ public:
 		/* 390 cs() function defined in <stdlib.h>, doesn't expand properly to __cs1() which correctly deals with aliasing */
 		__cs1((uint32_t *)&old, (uint32_t *)address, (uint32_t *)&newValue);
 		return old;
-#elif defined(__xlC__) /* defined(J9ZOS390) */
-		__compare_and_swap((volatile int*)address, (int*)&oldValue, (int)newValue);
-		return oldValue;
 #else /* defined(J9ZOS390) */
 #error "lockCompareExchangeU32(): unsupported platform!"
 #endif /* defined(__xlC__) */

--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -108,7 +108,7 @@
  * For AIX, dropSMT should drop to LOW(2) and 
  * restoreSMT should raise back to MEDIUM(4)
  */
-#if defined(__xlC__)
+#if defined(__xlC__) && !defined(__GNUC__)
 		inline void __dropSMT() { __ppc_dropSMT(); }
 		inline void __restoreSMT() { __ppc_restoreSMT(); }
 #else
@@ -120,7 +120,7 @@
  * For LINUXPPC, dropSMT should drop to VERY-LOW(1) and 
  * restoreSMT should raise back to MEDIUM-LOW(3)
  */
-#if defined(__xlC__)
+#if defined(__xlC__) && !defined(__GNUC__)
 		inline void __dropSMT() { __ppc_dropSMT(); }
 		inline void __restoreSMT() { __ppc_restoreSMT(); }
 #else
@@ -139,7 +139,7 @@
 #if defined(_MSC_VER)
 		/* use compiler intrinsic */
 #elif defined(LINUXPPC) || defined(AIXPPC)
-#if defined(__xlC__)
+#if defined(__xlC__) && !defined(__GNUC__)
 		/* XL compiler complained about generated assembly, use machine code instead. */
 		inline void __nop() { __ppc_nop(); }
 		inline void __yield() { __ppc_yield(); }

--- a/port/aix/omrintrospect.h
+++ b/port/aix/omrintrospect.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -50,7 +50,7 @@ typedef ucontext_t thread_context;
 typedef struct AIXFunctionEpilogue {
 	uint32_t nullWord;
 	struct tbtable_short tracebackTable;
-};
+} AIXFunctionEpilogue;
 
 typedef struct AIXStackFrame {
 	struct AIXStackFrame *link;

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -223,7 +223,7 @@ barrier_block_until_poked(barrier_r *barrier, uintptr_t deadline)
 	struct timespec spec;
 
 	fds[0].fd = barrier->descriptor_pair[0];
-	fds[0].events = POLLHUP | POLLERR | POLLNVAL | POLLIN;
+	fds[0].events = (short)(POLLHUP | POLLERR | POLLNVAL | POLLIN);
 	fds[0].revents = 0;
 
 	if (deadline == 0) {
@@ -496,7 +496,7 @@ sem_timedwait_r(sem_t_r *sem, uintptr_t seconds)
 	int deadline = 0;
 	int interval = seconds;
 	fds[0].fd = sem->descriptor_pair[0];
-	fds[0].events = POLLHUP | POLLERR | POLLNVAL | POLLIN;
+	fds[0].events = (short)(POLLHUP | POLLERR | POLLNVAL | POLLIN);
 	fds[0].revents = 0;
 
 	if (seconds == 0) {


### PR DESCRIPTION
xlC16 appears to be based on clang and now recognizes the
__GNUC__ defines.  Reorder this code so that the compiler
sees the __xlC__-specific case first.

+ additional changes to support xlc16

issue: #3775

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>