### PR TITLE
Enable DDR on z/OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ OMRTraceFormat.dat
 /tracegen
 /tracemerge
 *.pdat
+*.tracesentinel
 ut_*.c
 ut_*.h
 ut_*.inc

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,66 +1,82 @@
 ###############################################################################
-# Copyright (c) 2015, 2018 IBM Corp. and others
-# 
+# Copyright (c) 2015, 2019 IBM Corp. and others
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#    
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 ###############################################################################
 
-top_srcdir:=.
+top_srcdir := .
+
 include $(top_srcdir)/omrmakefiles/configure.mk
 
 ###
 ### Global targets
 ###
 
-all: postbuild
-.DEFAULT: all
-clean:
-.PHONY: all clean
+all : postbuild
+.DEFAULT : all
+clean :
+.PHONY : all clean
 
-help:
+help :
 	@echo "help   Display this help message."
 	@echo "all    Build OMR."
 	@echo "clean  Clean OMR build artifacts."
 	@echo "test   Run functional verification tests."
 	@echo "lint   Run the OMR linter."
-.PHONY: help
+.PHONY : help
+
+# recursively find files in directory $1 matching the pattern $2
+FindAllFiles = \
+	$(wildcard $1/$2) \
+	$(foreach i,$(wildcard $1/*),$(call FindAllFiles,$i,$2))
 
 ###
 ### Tracegen
 ###
 ifeq (yes,$(ENABLE_TRACEGEN))
-define TRACEGEN_COMMAND
-cd $(exe_output_dir) && ./tracegen -treatWarningAsError -generatecfiles -threshold 1 -root $(top_srcdir)
-endef
 
-define TRACEMERGE_COMMAND
-cd $(exe_output_dir) && ./tracemerge -majorversion 5 -minorversion 1 -root $(top_srcdir)
-endef
-else
-define TRACEGEN_COMMAND
-@echo Skipping tracegen
-endef
+TRACEGEN_DEFINITION_TDF_FILES := $(patsubst ./%,%,$(call FindAllFiles,$(top_srcdir),*.tdf))
 
-define TRACEMERGE_COMMAND
-@echo Skipping tracemerge
-endef
-endif
+tracegen.sentinel : $(TRACEGEN_DEFINITION_TDF_FILES)
+	cd $(exe_output_dir) && ./tracegen -treatWarningAsError -generatecfiles -threshold 1 -root $(top_srcdir)
+	touch $@
 
+# re-run tracegen if the executable has changed
+tracegen.sentinel : $(exe_output_dir)/tracegen$(EXEEXT)
+
+TRACEGEN_COMMAND := $(MAKE) -f GNUmakefile tracegen.sentinel
+
+tracemerge.sentinel : tracegen.sentinel
+	cd $(exe_output_dir) && ./tracemerge -majorversion 5 -minorversion 1 -root $(top_srcdir)
+	touch $@
+
+# re-run tracemerge if the executable has changed
+tracemerge.sentinel : $(exe_output_dir)/tracemerge$(EXEEXT)
+
+TRACEMERGE_COMMAND := $(MAKE) -f GNUmakefile tracemerge.sentinel
+
+else # ENABLE_TRACEGEN
+
+TRACEGEN_COMMAND :=
+TRACEMERGE_COMMAND :=
+
+endif # ENABLE_TRACEGEN
 
 # ASCII To EBCDIC Targets
 ifeq (zos,$(OMR_HOST_OS))
@@ -77,15 +93,12 @@ convertPath = $1
 endif
 
 HOOK_DEFINITION_FILES = $(call convertPath,$(abspath ./gc/base/omrmmprivate.hdf ./gc/include/omrmm.hdf ./fvtest/algotest/hooksample.hdf))
-HOOK_DEFINITION_SENTINEL = $(patsubst %.hdf,%.sentinel, $(HOOK_DEFINITION_FILES))
-define HOOKGEN_COMMAND
-cd $(exe_output_dir) && ./hookgen $<
-endef
+HOOK_DEFINITION_SENTINELS = $(patsubst %.hdf,%.sentinel, $(HOOK_DEFINITION_FILES))
 
 # Trace Build Tools
 ifeq (yes,$(ENABLE_TRACEGEN))
 tool_targets += tools/tracegen
-main_targets += tools/tracemerge
+tool_targets += tools/tracemerge
 endif
 
 # FVTest Helper Libraries
@@ -93,7 +106,7 @@ test_prereqs := third_party/pugixml-1.5 fvtest/util fvtest/omrGtestGlue
 test_targets += $(test_prereqs)
 
 # Utility Libraries
-main_targets +=  util/omrutil util/pool util/avl util/hashtable util/hookable
+main_targets += util/omrutil util/pool util/avl util/hashtable util/hookable
 test_targets += \
   fvtest/algotest \
   fvtest/utiltest
@@ -173,7 +186,10 @@ endif
 
 ifeq (yes,$(ENABLE_DDR))
   postbuild_targets += ddr
-  ddr:: staticlib
+  ddr :: staticlib
+ifeq (zos,$(OMR_HOST_OS))
+  ddr :: util/a2e
+endif
 endif
 
 DO_TEST_TARGET := yes
@@ -193,7 +209,7 @@ postbuild_targets += tests
 main_targets := $(sort $(main_targets))
 test_targets := $(sort $(test_targets))
 
-targets += $(tool_targets) $(prebuild_targets) $(main_targets) omr_static_lib $(test_targets) ddr
+targets += $(tool_targets) $(main_targets) omr_static_lib $(test_targets) ddr
 targets_clean := $(addsuffix _clean,$(targets))
 targets_ddrgen := $(addsuffix _ddrgen,$(filter-out omr_static_lib jitbuilder/% fvtest/% perftest/% third_party/% tools/% ddr ddr/% example/%,$(targets)))
 
@@ -201,130 +217,132 @@ targets_ddrgen := $(addsuffix _ddrgen,$(filter-out omr_static_lib jitbuilder/% f
 ### Rules
 ###
 
-postbuild: $(postbuild_targets)
+postbuild : $(postbuild_targets)
 	$(TRACEMERGE_COMMAND)
 
-tests: staticlib
+tests : staticlib
 ifeq (yes,$(DO_TEST_TARGET))
 	@$(MAKE) -f GNUmakefile $(test_targets)
 endif
 
-staticlib: mainbuild
+staticlib : mainbuild
 	@$(MAKE) -f GNUmakefile omr_static_lib
 
-mainbuild: prebuild
+mainbuild : prebuild
 	@$(MAKE) -f GNUmakefile $(main_targets)
 
-prebuild: tools
-	@$(MAKE) -f GNUmakefile $(prebuild_targets) $(HOOK_DEFINITION_SENTINEL)
+prebuild : tools
+	@$(MAKE) -f GNUmakefile hook_definition_sentinel_all
 	$(TRACEGEN_COMMAND)
 
-tools:
+tools :
 	@$(MAKE) -f GNUmakefile $(tool_targets)
 
-.PHONY: tools prebuild mainbuild staticlib tests postbuild
+.PHONY : hook_definition_sentinel_all tools prebuild mainbuild staticlib tests postbuild
 
 ###
 ### Inter-target Dependencies
 ###
 
-# These rules must be specified before $(targets)::
+# These rules must be specified before $(targets) ::
 
 # If a prereq directory is not also defined in $(targets),
 # then we won't execute 'make' in the prereq directory.
 
 ifeq (zos,$(OMR_HOST_OS))
-tools/tracegen:: util/a2e
-tools/tracemerge:: util/a2e
-tools/hookgen:: util/a2e
+tools/hookgen :: util/a2e
+tools/tracegen :: util/a2e
+tools/tracemerge :: util/a2e
 endif
 
-$(HOOK_DEFINITION_SENTINEL): $(exe_output_dir)/hookgen$(EXEEXT)
-%.sentinel: %.hdf
-	$(HOOKGEN_COMMAND)
+hook_definition_sentinel_all : $(HOOK_DEFINITION_SENTINELS)
+
+# re-run hookgen if the executable has changed
+$(HOOK_DEFINITION_SENTINELS) : $(exe_output_dir)/hookgen$(EXEEXT)
+
+%.sentinel : %.hdf
+	cd $(exe_output_dir) && ./hookgen $<
 	touch $@
 
-hook_definition_sentinel_clean:
-	rm -f $(HOOK_DEFINITION_SENTINEL)
+hook_definition_sentinel_clean :
+	rm -f $(HOOK_DEFINITION_SENTINELS)
 
-omrsigcompat:: util/omrutil
+omrsigcompat :: util/omrutil
 
-example:: $(test_prereqs)
+example :: $(test_prereqs)
 
-fvtest/algotest::$(test_prereqs)
-fvtest/gctest:: $(test_prereqs)
-fvtest/jitbuildertest:: $(test_prereqs)
-fvtest/porttest:: $(test_prereqs)
-fvtest/rastest:: $(test_prereqs)
-fvtest/sigtest:: $(test_prereqs)
-fvtest/threadextendedtest:: $(test_prereqs)
-fvtest/threadtest:: $(test_prereqs)
-fvtest/utiltest:: $(test_prereqs)
-fvtest/vmtest:: $(test_prereqs)
+fvtest/algotest ::$(test_prereqs)
+fvtest/gctest :: $(test_prereqs)
+fvtest/jitbuildertest :: $(test_prereqs)
+fvtest/porttest :: $(test_prereqs)
+fvtest/rastest :: $(test_prereqs)
+fvtest/sigtest :: $(test_prereqs)
+fvtest/threadextendedtest :: $(test_prereqs)
+fvtest/threadtest :: $(test_prereqs)
+fvtest/utiltest :: $(test_prereqs)
+fvtest/vmtest :: $(test_prereqs)
 
-perftest/gctest:: $(test_prereqs)
+perftest/gctest :: $(test_prereqs)
 
 # Test Compiler dependencies
 ifeq (1,$(OMR_TEST_COMPILER))
-  fvtest/compilertest:: $(compiler_prereqs)
+  fvtest/compilertest :: $(compiler_prereqs)
 endif
 
 # JitBuilder dependencies
 ifeq (1,$(OMR_JITBUILDER))
-  fvtest/jitbuildertest:: $(compiler_prereqs)
-  jitbuilder:: $(compiler_prereqs)
-  jitbuilder/release/cpp:: $(compiler_prereqs)
+  fvtest/jitbuildertest :: $(compiler_prereqs)
+  jitbuilder :: $(compiler_prereqs)
+  jitbuilder/release/cpp :: $(compiler_prereqs)
 endif
 
 ###
 ### Targets
 ###
 
-$(targets)::
+$(targets) ::
 	$(MAKE) -C $@ all
-.PHONY: $(targets)
+.PHONY : $(targets)
 
-%:
+% :
 	@echo Error, No rule to build target $@
 	@exit -1
 
-clean: $(targets_clean) hook_definition_sentinel_clean
-$(targets_clean)::
+clean : $(targets_clean) hook_definition_sentinel_clean
+$(targets_clean) ::
 	$(MAKE) -C $(patsubst %_clean,%,$@) clean
-.PHONY: $(targets_clean)
+.PHONY : $(targets_clean)
 
-lint:
+lint :
 	$(MAKE) -C fvtest/compilertest -f linter.mk
-.PHONY: lint
+.PHONY : lint
 
-test:
+test :
 ifeq (yes,$(ENABLE_FVTEST))
 	$(MAKE) -f fvtest/omrtest.mk test
 else
 	@echo Functional verification tests are disabled.
 	@echo Enable by configuring with --enable-fvtest
 endif
-.PHONY: test
-
+.PHONY : test
 
 # preprocess ddrgen-annotated source code
 
-ddrgen:
+ddrgen :
 	$(MAKE) -f GNUmakefile $(targets_ddrgen)
 
-$(targets_ddrgen):
+$(targets_ddrgen) :
 	$(MAKE) -C $(patsubst %_ddrgen,%,$@) ddrgen
 
-.PHONY: ddrgen $(targets_ddrgen)
-
+.PHONY : ddrgen $(targets_ddrgen)
 
 # Rerunning configure
 
-configure.mk: config.status configure.mk.in
+configure.mk : config.status configure.mk.in
 	config.status
 
-config.status: $(top_srcdir)/configure
+config.status : $(top_srcdir)/configure
 	$(top_srcdir)/configure -C
 
-$(top_srcdir)/configure: $(top_srcdir)/configure.ac
+$(top_srcdir)/configure : $(top_srcdir)/configure.ac
 	cd $(top_srcdir) && autoconf

--- a/ddr/include/ddr/ir/TextFile.hpp
+++ b/ddr/include/ddr/ir/TextFile.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,42 +19,29 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef SCANNER_HPP
-#define SCANNER_HPP
+#ifndef TEXTFILE_HPP
+#define TEXTFILE_HPP
 
-#include "ddr/error.hpp"
 #include "ddr/std/string.hpp"
 
-#include "omrport.h"
+struct OMRPortLibrary;
 
-#include <set>
-#include <vector>
-
-class ClassUDT;
-class EnumUDT;
-class NamespaceUDT;
-class Symbol_IR;
-class Type;
-class TypedefUDT;
-class UnionUDT;
-
-using std::set;
-using std::string;
-using std::vector;
-
-class Scanner
+class TextFile
 {
+private:
+	OMRPortLibrary * const _portLibrary;
+	intptr_t _file;
+
 public:
-	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir,
-			vector<string> *debugFiles, const char *blacklistPath) = 0;
+	explicit TextFile(OMRPortLibrary *portLibrary)
+		: _portLibrary(portLibrary)
+		, _file(-1)
+	{
+	}
 
-protected:
-	set<string> _blacklistedFiles;
-	set<string> _blacklistedTypes;
-
-	bool checkBlacklistedType(const string &name) const;
-	bool checkBlacklistedFile(const string &name) const;
-	DDR_RC loadBlacklist(OMRPortLibrary *portLibrary, const char *file);
+	bool openRead(const char *filename);
+	bool readLine(std::string &line);
+	void close();
 };
 
-#endif /* SCANNER_HPP */
+#endif /* TEXTFILE_HPP */

--- a/ddr/include/ddr/macros/MacroTool.hpp
+++ b/ddr/include/ddr/macros/MacroTool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -27,6 +27,7 @@
 
 #include <vector>
 
+struct OMRPortLibrary;
 class Symbol_IR;
 
 class MacroTool
@@ -35,7 +36,7 @@ private:
 	std::vector<MacroInfo> macroList;
 
 public:
-	DDR_RC getMacros(const std::string &fname);
+	DDR_RC getMacros(OMRPortLibrary *portLibrary, const char *filename);
 	DDR_RC addMacrosToIR(Symbol_IR *ir) const;
 };
 

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,18 +59,29 @@ using std::runtime_error;
 using std::tuple;
 #endif /* OMR_HAVE_TR1 */
 
-typedef /*struct Dwarf_Debug_s*/ void *Dwarf_Debug;
+struct Dwarf_Attribute_s;
+struct Dwarf_Debug_s;
+struct Dwarf_Die_s;
+struct Dwarf_Error_s;
+
+typedef struct Dwarf_Debug_s *Dwarf_Debug;
 typedef struct Dwarf_Die_s *Dwarf_Die;
 typedef struct Dwarf_Error_s *Dwarf_Error;
 typedef struct Dwarf_Attribute_s *Dwarf_Attribute;
 
+typedef unsigned char Dwarf_Small;
 typedef int Dwarf_Bool;
 typedef unsigned long long Dwarf_Off;
 typedef unsigned long long Dwarf_Unsigned;
 typedef unsigned short Dwarf_Half;
 typedef signed long long Dwarf_Signed;
 typedef unsigned long long Dwarf_Addr;
-typedef signed long Dwarf_Sword;
+
+struct Dwarf_Block
+{
+	Dwarf_Small *bl_data;
+	Dwarf_Unsigned bl_len;
+};
 
 typedef void *Dwarf_Ptr;
 typedef void (*Dwarf_Handler)(Dwarf_Error error, Dwarf_Ptr errarg);
@@ -109,12 +120,14 @@ typedef vector<string> str_vect;
 #define DW_AT_external 0x0c
 #define DW_AT_data_member_location 0xd
 #define DW_AT_data_bit_offset 0x0e
+#define DW_AT_declaration 0x0f
 
 #define DW_DLA_ATTR 0x01
 #define DW_DLA_DIE 0x02
 #define DW_DLA_ERROR 0x03
 #define DW_DLA_LIST 0x04
 #define DW_DLA_STRING 0x05
+#define DW_DLA_BLOCK 0x06
 
 #define DW_FORM_unknown 0x00
 #define DW_FORM_ref1 0x01
@@ -125,6 +138,41 @@ typedef vector<string> str_vect;
 #define DW_FORM_sdata 0x06
 #define DW_FORM_string 0x07
 #define DW_FORM_flag 0x0c
+#define DW_FORM_exprloc 0x18
+
+#define DW_OP_plus_uconst 0x23
+#define DW_OP_lit0 0x30
+#define DW_OP_lit1 0x31
+#define DW_OP_lit2 0x32
+#define DW_OP_lit3 0x33
+#define DW_OP_lit4 0x34
+#define DW_OP_lit5 0x35
+#define DW_OP_lit6 0x36
+#define DW_OP_lit7 0x37
+#define DW_OP_lit8 0x38
+#define DW_OP_lit9 0x39
+#define DW_OP_lit10 0x3a
+#define DW_OP_lit11 0x3b
+#define DW_OP_lit12 0x3c
+#define DW_OP_lit13 0x3d
+#define DW_OP_lit14 0x3e
+#define DW_OP_lit15 0x3f
+#define DW_OP_lit16 0x40
+#define DW_OP_lit17 0x41
+#define DW_OP_lit18 0x42
+#define DW_OP_lit19 0x43
+#define DW_OP_lit20 0x44
+#define DW_OP_lit21 0x45
+#define DW_OP_lit22 0x46
+#define DW_OP_lit23 0x47
+#define DW_OP_lit24 0x48
+#define DW_OP_lit25 0x49
+#define DW_OP_lit26 0x4a
+#define DW_OP_lit27 0x4b
+#define DW_OP_lit28 0x4c
+#define DW_OP_lit29 0x4d
+#define DW_OP_lit30 0x4e
+#define DW_OP_lit31 0x4f
 
 #define DW_TAG_unknown 0x00
 #define DW_TAG_array_type 0x01
@@ -149,6 +197,7 @@ typedef vector<string> str_vect;
 #define DW_TAG_typedef 0x14
 #define DW_TAG_union_type 0x15
 #define DW_TAG_volatile_type 0x16
+#define DW_TAG_unspecified_type 0x17
 
 struct Dwarf_Error_s
 {
@@ -226,6 +275,8 @@ int dwarf_formstring(Dwarf_Attribute attr, char **returned_string, Dwarf_Error *
 void dwarf_dealloc(Dwarf_Debug dbg, void *space, Dwarf_Unsigned type);
 
 int dwarf_hasattr(Dwarf_Die die, Dwarf_Half attr, Dwarf_Bool *returned_bool, Dwarf_Error *error);
+
+int dwarf_formblock(Dwarf_Attribute attr, Dwarf_Block **returned_block, Dwarf_Error *error);
 
 int dwarf_formflag(Dwarf_Attribute attr, Dwarf_Bool *returned_flag, Dwarf_Error *error);
 

--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -40,7 +40,6 @@
 #include "ddr/ir/Symbol_IR.hpp"
 
 using std::hash;
-using std::ifstream;
 using std::map;
 using std::pair;
 using std::set;

--- a/ddr/lib/ddr-ir/CMakeLists.txt
+++ b/ddr/lib/ddr-ir/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(omr_ddr_ir
 	Modifiers.cpp
 	NamespaceUDT.cpp
 	Symbol_IR.cpp
+	TextFile.cpp
 	Type.cpp
 	TypedefUDT.cpp
 	UDT.cpp

--- a/ddr/lib/ddr-ir/Makefile
+++ b/ddr/lib/ddr-ir/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2018 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -48,6 +48,7 @@ OBJECTS = \
   EnumMember$(OBJEXT) \
   Symbol_IR$(OBJEXT) \
   EnumUDT$(OBJEXT) \
+  TextFile$(OBJEXT) \
   Type$(OBJEXT) \
   TypedefUDT$(OBJEXT) \
   TypePrinter$(OBJEXT) \

--- a/ddr/lib/ddr-ir/TextFile.cpp
+++ b/ddr/lib/ddr-ir/TextFile.cpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "ddr/ir/TextFile.hpp"
+
+#include "omrport.h"
+
+/*
+ * Open the named file for reading.
+ * Returns true if the file was newly opened; false otherwise.
+ */
+bool
+TextFile::openRead(const char *filename)
+{
+	if (_file < 0) {
+		OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+
+		_file = omrfile_open(filename, EsOpenRead, 0);
+
+		if (_file >= 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Read a line of text from this file into 'line'; excluding any line terminators.
+ * Returns true if any text was read (even a blank line); false otherwise.
+ */
+bool
+TextFile::readLine(std::string &line)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+	char buffer[200];
+
+	line.clear();
+
+	while (NULL != omrfile_read_text(_file, buffer, sizeof(buffer))) {
+		for (size_t index = 0;; ++index) {
+			char ch = buffer[index];
+
+			if (('\0' == ch) || ('\n' == ch) || ('\r' == ch)) {
+				if (0 != index) {
+					line.append(buffer, index);
+				}
+				if ('\0' == ch) {
+					break;
+				} else {
+					return true;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Close this file. This has no effect if the file was not opened
+ * or has already been closed.
+ */
+void
+TextFile::close()
+{
+	if (_file >= 0) {
+		OMRPORT_ACCESS_FROM_OMRPORT(_portLibrary);
+
+		omrfile_close(_file);
+		_file = -1;
+	}
+}

--- a/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -173,6 +173,18 @@ dwarf_hasattr(Dwarf_Die die, Dwarf_Half attr, Dwarf_Bool *returned_bool, Dwarf_E
 		}
 	}
 	return ret;
+}
+
+int
+dwarf_formblock(Dwarf_Attribute attr, Dwarf_Block **returned_block, Dwarf_Error *error)
+{
+	/* No attributes are generated with block forms on OSX. */
+	if ((NULL == attr) || (NULL == returned_block)) {
+		setError(error, DW_DLE_IA);
+	} else {
+		setError(error, DW_DLE_ATTR_FORM_BAD);
+	}
+	return DW_DLV_ERROR;
 }
 
 int

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <functional>
+#include <stack>
 #include <utility>
 
 class DwarfVisitor : public TypeVisitor
@@ -78,8 +79,9 @@ DwarfScanner::getSourcelist(Dwarf_Die die)
 		}
 		free(_fileNamesTable);
 		_fileNamesTable = NULL;
-		_fileNameCount = 0;
 	}
+
+	_fileNameCount = 0;
 
 	char **fileNamesTableConcat = NULL;
 	char *compDir = NULL;
@@ -92,8 +94,24 @@ DwarfScanner::getSourcelist(Dwarf_Die die)
 		goto Failed;
 	}
 
-	_fileNamesTable = NULL;
-	_fileNameCount = 0;
+	if (!hasAttr) {
+		/* The DIE doesn't have a compilation directory attribute so we can skip
+		 * over getting the absolute paths from the relative paths. AIX does
+		 * not provide this attribute.
+		 */
+		goto Done;
+	}
+
+	/* Get the CU directory. */
+	if (DW_DLV_ERROR == dwarf_attr(die, DW_AT_comp_dir, &attr, &error)) {
+		ERRMSG("Getting compilation directory attribute: %s\n", dwarf_errmsg(error));
+		goto Failed;
+	}
+
+	if (DW_DLV_ERROR == dwarf_formstring(attr, &compDir, &error)) {
+		ERRMSG("Getting compilation directory string: %s\n", dwarf_errmsg(error));
+		goto Failed;
+	}
 
 	/* Get the dwarf source file names. */
 	if (DW_DLV_ERROR == dwarf_srcfiles(die, &_fileNamesTable, &_fileNameCount, &error)) {
@@ -104,32 +122,16 @@ DwarfScanner::getSourcelist(Dwarf_Die die)
 		goto Done;
 	}
 
-	if (!hasAttr) {
-		/* The DIE didn't have a compilationDirectory attribute so we can skip
-		 * over getting the absolute paths from the relative paths.  AIX does
-		 * not provide this attribute.
-		 */
-		goto Done;
-	} else {
-		/* Get the CU directory. */
-		if (DW_DLV_ERROR == dwarf_attr(die, DW_AT_comp_dir, &attr, &error)) {
-			ERRMSG("Getting compilation directory attribute: %s\n", dwarf_errmsg(error));
+	if (0 != _fileNameCount) {
+		/* Allocate a new file name table to hold the concatenated absolute paths. */
+		fileNamesTableConcat = (char **)malloc(sizeof(char *) * _fileNameCount);
+		if (NULL == fileNamesTableConcat) {
+			ERRMSG("Failed to allocate file name table.\n");
 			goto Failed;
 		}
-
-		if (DW_DLV_ERROR == dwarf_formstring(attr, &compDir, &error)) {
-			ERRMSG("Getting compilation directory string: %s\n", dwarf_errmsg(error));
-			goto Failed;
-		}
+		memset(fileNamesTableConcat, 0, sizeof(char *) * _fileNameCount);
 	}
 
-	/* Allocate a new file name table to hold the concatenated absolute paths. */
-	fileNamesTableConcat = (char **)malloc(sizeof(char *) * _fileNameCount);
-	if (NULL == fileNamesTableConcat) {
-		ERRMSG("Failed to allocate file name table.\n");
-		goto Failed;
-	}
-	memset(fileNamesTableConcat, 0, sizeof(char *) * _fileNameCount);
 	for (Dwarf_Signed i = 0; i < _fileNameCount; ++i) {
 		char *path = _fileNamesTable[i];
 		if (0 == strncmp(path, "../", 3)) {
@@ -237,20 +239,15 @@ DwarfScanner::blackListedDie(Dwarf_Die die, bool *dieBlackListed)
 				goto Done;
 			}
 
-			/* If the decl_file matches an entry in the file table not beginning with "/usr/",
-			 * then we are interested in it. Also filter out decl file "<built-in>".
-			 * Futhermore, don't filter out entries that have an unspecified declaring file.
-			 */
 			if (0 == declFile) {
-				/* declFile can be 0 when no declaring file is specified */
+				/* no declaring file is specified */
 				blacklistedFile = false;
 			} else if (declFile <= (Dwarf_Unsigned)_fileNameCount) {
 				const string fileName(_fileNamesTable[declFile - 1]);
 				blacklistedFile = checkBlacklistedFile(fileName);
 			} else {
-				ERRMSG("Invalid decl_file value: %llu\n", declFile);
-				rc = DDR_RC_ERROR;
-				goto Done;
+				/* declFile refers to a file for which we don't have a name */
+				blacklistedFile = false;
 			}
 		}
 	}
@@ -271,6 +268,30 @@ Done:
 		dwarf_dealloc(_debug, err, DW_DLA_ERROR);
 	}
 	return rc;
+}
+
+static bool
+isUnnamed(const char *name)
+{
+	if (NULL == name) {
+		return true;
+	}
+
+	if (0 == strncmp(name, "<anonymous", 10)) {
+		return true;
+	}
+
+#if defined(J9ZOS390) || defined(LINUXPPC)
+	if (0 == strncmp(name, "__", 2)) {
+		size_t digitCount = strspn(name + 2, "0123456789");
+
+		if ('\0' == name[digitCount + 2]) {
+			return true;
+		}
+	}
+#endif /* defined(J9ZOS390) || defined(LINUXPPC) */
+
+	return false;
 }
 
 DDR_RC
@@ -334,12 +355,7 @@ DwarfScanner::getName(Dwarf_Die die, string *name, Dwarf_Off *dieOffset)
 				goto NameDone;
 			}
 		}
-		if ((NULL == dieName)
-#if defined(LINUXPPC)
-			|| ((0 == strncmp(dieName, "__", 2)) && (strlen(dieName + 2) == strspn(dieName + 2, "0123456789")))
-#endif /* defined(LINUXPPC) */
-			|| (0 == strncmp(dieName, "<anonymous", 10)))
-		{
+		if (isUnnamed(dieName)) {
 			*name = "";
 		} else {
 			*name = string(dieName);
@@ -431,43 +447,47 @@ DwarfScanner::getTypeInfo(Dwarf_Die die, Dwarf_Die *dieOut, string *typeName, Mo
 			} else if (DW_TAG_array_type == tag && !foundTypedef) {
 				Dwarf_Die child = NULL;
 				Dwarf_Unsigned upperBound = 0;
+				int ret = dwarf_child(typeDie, &child, &err);
 
 				/* Get the array size if it is an array. */
-				if (DW_DLV_ERROR == dwarf_child(typeDie, &child, &err)) {
+				if (DW_DLV_ERROR == ret) {
 					ERRMSG("Error getting child Die of array type: %s\n", dwarf_errmsg(err));
 					rc = DDR_RC_ERROR;
 					break;
+				} else if (DW_DLV_NO_ENTRY == ret) {
+					/* There is no child; assume the array type has an unspecified length. */
+					modifiers->addArrayDimension(0);
+				} else {
+					do {
+						Dwarf_Bool hasAttr = false;
+						if (DW_DLV_ERROR == dwarf_hasattr(child, DW_AT_upper_bound, &hasAttr, &err)) {
+							ERRMSG("Checking array for upper bound attribute: %s\n", dwarf_errmsg(err));
+							rc = DDR_RC_ERROR;
+							break;
+						}
+						if (hasAttr) {
+							Dwarf_Attribute attr = NULL;
+							if (DW_DLV_ERROR == dwarf_attr(child, DW_AT_upper_bound, &attr, &err)) {
+								ERRMSG("Array upper bound attribute: %s\n", dwarf_errmsg(err));
+								rc = DDR_RC_ERROR;
+								break;
+							}
+							ret = dwarf_formudata(attr, &upperBound, &err);
+							dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
+							if (DW_DLV_ERROR == ret) {
+								ERRMSG("Getting array upper bound value: %s\n", dwarf_errmsg(err));
+								rc = DDR_RC_ERROR;
+								break;
+							}
+							/* New array length is upperBound + 1. */
+							modifiers->addArrayDimension(upperBound + 1);
+						} else {
+							/* Arrays declared as "[]" have no size attributes. */
+							modifiers->addArrayDimension(0);
+						}
+					} while (DDR_RC_OK == getNextSibling(&child));
+					dwarf_dealloc(_debug, child, DW_DLA_DIE);
 				}
-
-				do {
-					Dwarf_Bool hasAttr = false;
-					if (DW_DLV_ERROR == dwarf_hasattr(child, DW_AT_upper_bound, &hasAttr, &err)) {
-						ERRMSG("Checking array for upper bound attribute: %s\n", dwarf_errmsg(err));
-						rc = DDR_RC_ERROR;
-						break;
-					}
-					if (hasAttr) {
-						Dwarf_Attribute attr = NULL;
-						if (DW_DLV_ERROR == dwarf_attr(child, DW_AT_upper_bound, &attr, &err)) {
-							ERRMSG("Array upper bound attribute: %s\n", dwarf_errmsg(err));
-							rc = DDR_RC_ERROR;
-							break;
-						}
-						int ret = dwarf_formudata(attr, &upperBound, &err);
-						dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
-						if (DW_DLV_ERROR == ret) {
-							ERRMSG("Getting array upper bound value: %s\n", dwarf_errmsg(err));
-							rc = DDR_RC_ERROR;
-							break;
-						}
-						/* New array length is upperBound + 1. */
-						modifiers->addArrayDimension(upperBound + 1);
-					} else {
-						/* Arrays declared as "[]" have no size attributes. */
-						modifiers->addArrayDimension(0);
-					}
-				} while (DDR_RC_OK == getNextSibling(&child));
-				dwarf_dealloc(_debug, child, DW_DLA_DIE);
 				if (NULL != err) {
 					break;
 				}
@@ -804,22 +824,27 @@ DwarfScanner::createNewType(Dwarf_Die die, Dwarf_Half tag, const char *dieName, 
 		if (DDR_RC_OK != rc) {
 			break;
 		}
+		/* correct xlc on z/OS: boolean -> bool */
+		if (0 == strcmp(dieName, "boolean")) {
+			dieName = "bool";
+		}
 		*newType = new Type(typeSize);
 		break;
 	/* Void types and function pointers: */
-	case DW_TAG_subroutine_type:
 	case DW_TAG_pointer_type:
 	case DW_TAG_ptr_to_member_type:
+	case DW_TAG_subroutine_type:
+	case DW_TAG_unspecified_type:
 		*newType = new Type(0);
 		dieName = "void";
 		break;
 	default:
 		{
-			const char *tagName = NULL;
+			const char *tagName = "";
 #if !defined(J9ZOS390)
 			dwarf_get_TAG_name(tag, &tagName);
 #endif /* !defined(J9ZOS390) */
-			ERRMSG("Symbol with name '%s' has unknown symbol type: %s (%d)\n", dieName, tagName, tag);
+			ERRMSG("Symbol with name '%s' has unknown symbol tag: %s (%d)\n", dieName, tagName, tag);
 			rc = DDR_RC_ERROR;
 		}
 		break;
@@ -938,11 +963,11 @@ isVtablePointer(const char *fieldName)
 {
 #if defined(__GNUC__)
 	return 0 == strncmp(fieldName, "_vptr.", 6);
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC)
 	return 0 == strcmp(fieldName, "__vfp");
-#else
+#else /* defined(__GNUC__) */
 	return false;
-#endif /* __GNUC__ */
+#endif /* defined(__GNUC__) */
 }
 
 /* A Die for a class/struct/union has children Die's for all of its properties,
@@ -1005,7 +1030,7 @@ DwarfScanner::scanClassChildren(NamespaceUDT *newClass, Dwarf_Die die)
 				/* The child is a member field. */
 				string fieldName = "";
 				rc = getName(childDie, &fieldName);
-				if (!isVtablePointer(fieldName.c_str())) {
+				if (!fieldName.empty() && !isVtablePointer(fieldName.c_str())) {
 					DEBUGPRINTF("fieldName: %s", fieldName.c_str());
 					if (DDR_RC_OK != addClassField(childDie, (ClassType *)newClass, fieldName)) {
 						rc = DDR_RC_ERROR;
@@ -1056,8 +1081,10 @@ DwarfVisitor::visitUnion(UnionUDT *newType) const
 DDR_RC
 DwarfScanner::addEnumMember(Dwarf_Die die, NamespaceUDT *outerUDT, EnumUDT *newEnum)
 {
+	Dwarf_Attribute attr = NULL;
+	string enumName = "";
+	int enumValue = 0;
 	Dwarf_Error error = NULL;
-	DDR_RC rc = DDR_RC_OK;
 	vector<EnumMember *> *members = NULL;
 
 	/* literals of a nested anonymous enum are collected in the enclosing namespace */
@@ -1067,51 +1094,144 @@ DwarfScanner::addEnumMember(Dwarf_Die die, NamespaceUDT *outerUDT, EnumUDT *newE
 		members = &newEnum->_enumMembers;
 	}
 
-	/* Check if an enum member with this name is already present. */
-	string enumName = "";
-	rc = getName(die, &enumName);
+	DDR_RC rc = getName(die, &enumName);
 
-	bool memberAlreadyExists = false;
+	if (DDR_RC_OK != rc) {
+		goto AddEnumMemberDone;
+	}
+
+	/* Check if an enum member with this name is already present. */
 	for (vector<EnumMember *>::iterator m = members->begin(); m != members->end(); ++m) {
 		if ((*m)->_name == enumName) {
-			memberAlreadyExists = true;
-			break;
+			/* member already exists */
+			goto AddEnumMemberDone;
 		}
 	}
 
-	if (!memberAlreadyExists) {
+	/* Get the value attribute of the enum. */
+	if (DW_DLV_ERROR == dwarf_attr(die, DW_AT_const_value, &attr, &error)) {
+		ERRMSG("Getting value attribute of enum: %s\n", dwarf_errmsg(error));
+		goto AddEnumMemberError;
+	}
+
+	if (NULL != attr) {
+		Dwarf_Half form = 0;
+
+		/* Get the literal value form. */
+		if (DW_DLV_ERROR == dwarf_whatform(attr, &form, &error)) {
+			ERRMSG("Getting form of const_value attribute: %s\n", dwarf_errmsg(error));
+			goto AddEnumMemberError;
+		}
+
+		/* Get the literal value. */
+		if (DW_FORM_udata == form) {
+			Dwarf_Unsigned value = 0;
+
+			if (DW_DLV_ERROR == dwarf_formudata(attr, &value, &error)) {
+				ERRMSG("Getting const value of enum: %s\n", dwarf_errmsg(error));
+				goto AddEnumMemberError;
+			}
+			enumValue = (int)value;
+		} else {
+			Dwarf_Signed value = 0;
+
+			if (DW_DLV_ERROR == dwarf_formsdata(attr, &value, &error)) {
+				ERRMSG("Getting const value of enum: %s\n", dwarf_errmsg(error));
+				goto AddEnumMemberError;
+			}
+			enumValue = (int)value;
+		}
+	}
+
+	{
 		/* Create new enum member. */
 		EnumMember *newEnumMember = new EnumMember;
 
-		if (DDR_RC_OK != rc) {
-			goto AddEnumMemberDone;
-		}
 		newEnumMember->_name = enumName;
+		newEnumMember->_value = enumValue;
 
-		/* Get the value attribute of the enum. */
-		Dwarf_Attribute attr = NULL;
-		if (DW_DLV_ERROR == dwarf_attr(die, DW_AT_const_value, &attr, &error)) {
-			ERRMSG("Getting value attribute of enum: %s\n", dwarf_errmsg(error));
-			rc = DDR_RC_ERROR;
-			goto AddEnumMemberDone;
-		}
-
-		/* Get the enum const value. */
-		Dwarf_Signed value = 0;
-		if ((NULL != attr) && (DW_DLV_ERROR == dwarf_formsdata(attr, &value, &error))) {
-			ERRMSG("Getting const value of enum: %s\n", dwarf_errmsg(error));
-			rc = DDR_RC_ERROR;
-			goto AddEnumMemberDone;
-		}
-		newEnumMember->_value = value;
 		members->push_back(newEnumMember);
 	}
 
 AddEnumMemberDone:
+	if (NULL != attr) {
+		dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
+	}
 	if (NULL != error) {
 		dwarf_dealloc(_debug, error, DW_DLA_ERROR);
 	}
 	return rc;
+
+AddEnumMemberError:
+	rc = DDR_RC_ERROR;
+	goto AddEnumMemberDone;
+}
+
+static bool
+getUdata(Dwarf_Small **value, Dwarf_Unsigned *len, Dwarf_Unsigned *result)
+{
+	Dwarf_Unsigned answer = 0;
+
+	for (int shift = 0; 0 != *len; shift += 7) {
+		Dwarf_Small digit = **value;
+
+		*value += 1;
+		*len -= 1;
+
+		answer |= ((Dwarf_Unsigned)(digit & 0x7F)) << shift;
+
+		if (0 == (digit & 0x80)) {
+			*result = answer;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool
+evaluateOffset(Dwarf_Ptr expr, Dwarf_Unsigned len, Dwarf_Unsigned *offset)
+{
+	if (0 != len) {
+		Dwarf_Small *pc = (Dwarf_Small *)expr;
+		std::stack<Dwarf_Unsigned> values;
+
+		/*
+		 * Push the implicit base pointer for the structure.
+		 * Because we seek the offset, use zero.
+		 */
+		values.push(0);
+
+		do {
+			Dwarf_Small opcode = *pc;
+
+			pc += 1;
+			len -= 1;
+
+			if (DW_OP_plus_uconst == opcode) {
+				Dwarf_Unsigned value = 0;
+
+				if (getUdata(&pc, &len, &value)) {
+					values.top() += value;
+				} else {
+					printf("Missing or malformed operand for opcode(%d)\n", opcode);
+					return false;
+				}
+			} else if ((DW_OP_lit0 <= opcode) && (opcode <= DW_OP_lit31)) {
+				values.push((Dwarf_Unsigned)(opcode - DW_OP_lit0));
+			} else  {
+				printf("Unsupported opcode(%d) in exprloc\n", opcode);
+				return false;
+			}
+		} while (0 != len);
+
+		if (1 == values.size()) {
+			*offset = values.top();
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /* Add a field to a class UDT from a Die. */
@@ -1129,8 +1249,7 @@ DwarfScanner::addClassField(Dwarf_Die die, ClassType *newClass, const string &fi
 	/* Follow the die through any type modifiers (pointer, volatile, etc) to
 	 * get the field type.
 	 */
-	if (DDR_RC_OK == getTypeInfo(die, &baseDie, &typeName, &fieldModifiers, &typeSize, &bitField)
-			&& ((NULL != baseDie) || !fieldName.empty())) {
+	if (DDR_RC_OK == getTypeInfo(die, &baseDie, &typeName, &fieldModifiers, &typeSize, &bitField)) {
 		/* Get the field UDT. */
 		Dwarf_Half tag = 0;
 		if (NULL == baseDie) {
@@ -1150,7 +1269,7 @@ DwarfScanner::addClassField(Dwarf_Die die, ClassType *newClass, const string &fi
 		newField->_modifiers = fieldModifiers;
 		newField->_bitField = bitField;
 
-		/* check if field is static (DW_AT_external=yes) */
+		/* check if field is static (DW_AT_external=yes) or (DW_AT_declaration=yes) */
 		{
 			Dwarf_Bool hasAttr = false;
 
@@ -1176,6 +1295,33 @@ DwarfScanner::addClassField(Dwarf_Die die, ClassType *newClass, const string &fi
 					newField->_isStatic = true;
 				}
 			}
+
+			if (!newField->_isStatic) {
+				hasAttr = false;
+
+				/* Get the declaration attribute from a member Die if it exists. */
+				if (DW_DLV_ERROR == dwarf_hasattr(die, DW_AT_declaration, &hasAttr, &error)) {
+					ERRMSG("Checking if die has declaration attribute: %s\n", dwarf_errmsg(error));
+					goto AddUDTFieldDone;
+				}
+				if (hasAttr) {
+					Dwarf_Attribute attr = NULL;
+					if (DW_DLV_ERROR == dwarf_attr(die, DW_AT_declaration, &attr, &error)) {
+						ERRMSG("Getting declaration attribute: %s\n", dwarf_errmsg(error));
+						goto AddUDTFieldDone;
+					}
+					Dwarf_Bool isDeclaration = false;
+					int ret = dwarf_formflag(attr, &isDeclaration, &error);
+					dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
+					if (DW_DLV_ERROR == ret) {
+						ERRMSG("Getting formflag of declaration attribute: %s\n", dwarf_errmsg(error));
+						goto AddUDTFieldDone;
+					}
+					if (isDeclaration) {
+						newField->_isStatic = true;
+					}
+				}
+			}
 		}
 
 		if (!newField->_isStatic) {
@@ -1198,12 +1344,31 @@ DwarfScanner::addClassField(Dwarf_Die die, ClassType *newClass, const string &fi
 					ERRMSG("Getting offset attribute: %s\n", dwarf_errmsg(error));
 					goto AddUDTFieldDone;
 				}
-				int ret = dwarf_formudata(attr, &offset, &error);
-				dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
-				if (DW_DLV_ERROR == ret) {
+				Dwarf_Half form = 0;
+				if (DW_DLV_ERROR == dwarf_whatform(attr, &form, &error)) {
+					ERRMSG("Getting form of offset attribute: %s\n", dwarf_errmsg(error));
+					goto FreeAttrThenDone;
+				}
+				if (DW_FORM_exprloc == form) {
+					Dwarf_Block *block = NULL;
+					if (DW_DLV_ERROR == dwarf_formblock(attr, &block, &error)) {
+						ERRMSG("Getting block/exprloc of offset attribute: %s\n", dwarf_errmsg(error));
+						goto FreeAttrThenDone;
+					}
+					bool ok = evaluateOffset(block->bl_data, block->bl_len, &offset);
+					dwarf_dealloc(_debug, block, DW_DLA_BLOCK);
+					if (!ok) {
+						ERRMSG("Cannot evalue offset expression for %s.%s\n",
+								newClass->_name.c_str(), fieldName.c_str());
+						goto FreeAttrThenDone;
+					}
+				} else if (DW_DLV_ERROR == dwarf_formudata(attr, &offset, &error)) {
 					ERRMSG("Getting value of offset attribute: %s\n", dwarf_errmsg(error));
+FreeAttrThenDone:
+					dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
 					goto AddUDTFieldDone;
 				}
+				dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
 				newField->_offset = hasAttrBytes ? offset : (offset / 8);
 			} else if ("union" != newClass->getSymbolKindName()) {
 				ERRMSG("Missing offset attribute for %s.%s\n", newClass->_name.c_str(), fieldName.c_str());
@@ -1305,7 +1470,7 @@ DwarfScanner::traverse_cu_in_debug_section(Symbol_IR *ir)
 			rc = DDR_RC_ERROR;
 			break;
 		}
-		if (NULL == childDie) {
+		if (DW_DLV_NO_ENTRY == ret) {
 			continue;
 		}
 
@@ -1350,7 +1515,7 @@ DwarfScanner::startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir, vector<strin
 {
 	DEBUGPRINTF("Initializing libDwarf:");
 
-	DDR_RC rc = loadBlacklist(blacklistPath);
+	DDR_RC rc = loadBlacklist(portLibrary, blacklistPath);
 
 	if (DDR_RC_OK == rc) {
 		/* Read list of debug files to scan from the input file. */
@@ -1358,6 +1523,7 @@ DwarfScanner::startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir, vector<strin
 			Symbol_IR newIR(ir);
 			rc = scanFile(portLibrary, &newIR, it->c_str());
 			if (DDR_RC_OK != rc) {
+				ERRMSG("Failure scanning %s\n", it->c_str());
 				break;
 			}
 			ir->mergeIR(&newIR);
@@ -1384,15 +1550,10 @@ DwarfScanner::scanFile(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *f
 		Dwarf_Unsigned access = DW_DLC_READ;
 		Dwarf_Handler errhand = 0;
 		Dwarf_Ptr errarg = NULL;
-		res = dwarf_init(fd, access, errhand, errarg, &_debug, &error);
+		intptr_t native_fd = omrfile_convert_omrfile_fd_to_native_fd(fd);
+		res = dwarf_init((int)native_fd, access, errhand, errarg, &_debug, &error);
 		if (DW_DLV_OK != res) {
-			if (DW_DLV_ERROR == res) {
-				ERRMSG("Failed to Initialize libDwarf scanning %s! DW_DLV_ERROR: res: %s\nExiting...\n", filepath, dwarf_errmsg(error));
-			} else if (DW_DLV_NO_ENTRY == res) {
-				ERRMSG("Failed to Initialize libDwarf scanning %s! DW_DLV_ERROR: res: %s\nExiting...\n", filepath, dwarf_errmsg(error));
-			} else {
-				ERRMSG("Failed to Initialize libDwarf scanning %s! DW_DLV_ERROR: res: %s\nExiting...\n", filepath, dwarf_errmsg(error));
-			}
+			ERRMSG("Failed to initialize libDwarf scanning %s: %s\nExiting...\n", filepath, dwarf_errmsg(error));
 			if (NULL != error) {
 				dwarf_dealloc(_debug, error, DW_DLA_ERROR);
 			}
@@ -1401,19 +1562,16 @@ DwarfScanner::scanFile(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *f
 	}
 
 	if (DDR_RC_OK == rc) {
-		DEBUGPRINTF("Initialized libDwarf: Continuing...");
+		DEBUGPRINTF("Initialized libDwarf; scanning %s...", filepath);
 
-		DEBUGPRINTF("%s", filepath);
 		/* Get info from dbg - Dwarf Info structure.*/
 		rc = traverse_cu_in_debug_section(ir);
-	}
 
-	if (DDR_RC_OK == rc) {
 		DEBUGPRINTF("Unloading libDwarf");
 
 		res = dwarf_finish(_debug, &error);
 		if (DW_DLV_OK != res) {
-			ERRMSG("Failed to Unload libDwarf! res: %s\nExiting...\n", dwarf_errmsg(error));
+			ERRMSG("Failed to Unload libDwarf: %s\nExiting...\n", dwarf_errmsg(error));
 			if (NULL != error) {
 				dwarf_dealloc(_debug, error, DW_DLA_ERROR);
 			}

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,11 +33,9 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstdio>
-#include <fstream>
-#include <iostream>
 #include "ddr/std/sstream.hpp"
 #include <stdio.h>
-#include <stdlib.h> /* for exit() */
+#include <stdlib.h>
 #include <string.h>
 #include <functional>
 #include <utility>
@@ -325,7 +323,7 @@ DwarfScanner::getName(Dwarf_Die die, string *name, Dwarf_Off *dieOffset)
 					DW_DLV_ERROR == dwarf_offdie(_debug, offset, &spec, &err)
 #else /* defined(J9ZOS390) */
 					DW_DLV_ERROR == dwarf_offdie_b(_debug, offset, 1, &spec, &err)
-#endif /* !defined(J9ZOS390) */
+#endif /* defined(J9ZOS390) */
 				) {
 					ERRMSG("Getting die from specification offset: %s\n", dwarf_errmsg(err));
 					rc = DDR_RC_ERROR;
@@ -1350,96 +1348,19 @@ DwarfScanner::traverse_cu_in_debug_section(Symbol_IR *ir)
 DDR_RC
 DwarfScanner::startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir, vector<string> *debugFiles, const char *blacklistPath)
 {
-	DEBUGPRINTF("Init:");
 	DEBUGPRINTF("Initializing libDwarf:");
 
 	DDR_RC rc = loadBlacklist(blacklistPath);
 
-	map<Type *, set<string> > typeToContainingFiles;
-	map<string, set<Type *> > fileToContainedTypes;
-
-	/* Read list of debug files to scan from the input file. */
-	for (vector<string>::iterator it = debugFiles->begin(); it != debugFiles->end(); ++it) {
-		const string & debugFile = *it;
-		Symbol_IR newIR(ir);
-		rc = scanFile(portLibrary, &newIR, debugFile.c_str());
-		if (DDR_RC_OK != rc) {
-			break;
-		}
-		for (vector<Type *>::iterator it2 = newIR._types.begin(); it2 != newIR._types.end(); ++it2) {
-			Type *type = *it2;
-			typeToContainingFiles[type].insert(debugFile);
-			fileToContainedTypes[debugFile].insert(type);
-			vector<UDT *> *subTypes = type->getSubUDTS();
-			if (NULL != subTypes) {
-				for (vector<UDT *>::iterator it3 = subTypes->begin(); it3 != subTypes->end(); ++it3) {
-					UDT *subType = *it3;
-					typeToContainingFiles[subType].insert(debugFile);
-					fileToContainedTypes[debugFile].insert(subType);
-				}
-			}
-		}
-		ir->mergeIR(&newIR);
-	}
-
 	if (DDR_RC_OK == rc) {
-		/* Create a set of all files and remove from that set any files that are necessary. */
-		set<string> unnecessaryFiles;
-		unnecessaryFiles.insert(debugFiles->begin(), debugFiles->end());
-
-		/* Any type scanned in only one file is necessary, so remove them first. */
-		for (map<Type *, set<string> >::iterator it = typeToContainingFiles.begin(); it != typeToContainingFiles.end() && !unnecessaryFiles.empty();) {
-			if (1 == it->second.size()) {
-				string fileName = *it->second.begin();
-				set<string>::iterator uselessFile = unnecessaryFiles.find(fileName);
-				if (unnecessaryFiles.end() != uselessFile) {
-					unnecessaryFiles.erase(uselessFile);
-				}
-				fileToContainedTypes[fileName].erase(fileToContainedTypes[fileName].find(it->first));
-				map<Type *, set<string> >::iterator previous = it;
-				++it;
-				typeToContainingFiles.erase(previous);
-			} else {
-				++it;
-			}
-		}
-
-		while (!typeToContainingFiles.empty()) {
-			/* Next, count how many unmarked types are contained in each file.
-			 * Keep the file which contains the most until no unmarked types remain.
-			 */
-			string fileWithMostTypes = "";
-			size_t greatestNumberOfTypes = 0;
-			for (map<string, set<Type *> >::iterator it = fileToContainedTypes.begin(); it != fileToContainedTypes.end(); ++it) {
-				if ((it->second.size() > greatestNumberOfTypes) && (unnecessaryFiles.end() != unnecessaryFiles.find(it->first))) {
-					greatestNumberOfTypes = it->second.size();
-					fileWithMostTypes = it->first;
-				}
-			}
-			if (greatestNumberOfTypes > 0) {
-				/* Consider the file that adds the most new types necessary and remove its types from the maps. */
-				unnecessaryFiles.erase(unnecessaryFiles.find(fileWithMostTypes));
-				for (set<Type *>::iterator it = fileToContainedTypes[fileWithMostTypes].begin(); it != fileToContainedTypes[fileWithMostTypes].end(); ++ it) {
-					Type *typeFromFile = *it;
-					/* For each type contained in the file, remove it from the type set of each file it is in. */
-					for (set<string>::iterator it2 = typeToContainingFiles[typeFromFile].begin(); it2 != typeToContainingFiles[typeFromFile].end(); ++ it2) {
-						string fileContainingType = *it2;
-						fileToContainedTypes[fileContainingType].erase(fileToContainedTypes[fileContainingType].find(typeFromFile));
-					}
-					typeToContainingFiles.erase(typeToContainingFiles.find(typeFromFile));
-				}
-				fileToContainedTypes.erase(fileToContainedTypes.find(fileWithMostTypes));
-			} else {
+		/* Read list of debug files to scan from the input file. */
+		for (vector<string>::iterator it = debugFiles->begin(); it != debugFiles->end(); ++it) {
+			Symbol_IR newIR(ir);
+			rc = scanFile(portLibrary, &newIR, it->c_str());
+			if (DDR_RC_OK != rc) {
 				break;
 			}
-		}
-
-		/* Afterwards, print the files that are found to be uneccessary for a complete superset. */
-		if (!unnecessaryFiles.empty()) {
-			printf("These files can be ommited from scanning without missing any data:\n");
-			for (set<string>::iterator it = unnecessaryFiles.begin(); it != unnecessaryFiles.end(); ++ it) {
-				printf("%s,\n", it->c_str());
-			}
+			ir->mergeIR(&newIR);
 		}
 	}
 

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -126,7 +126,7 @@ PdbScanner::startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir, vector<string>
 	}
 
 	if (DDR_RC_OK == rc) {
-		rc = loadBlacklist(blacklistPath);
+		rc = loadBlacklist(portLibrary, blacklistPath);
 	}
 
 	if (DDR_RC_OK == rc) {

--- a/ddr/test/makefile
+++ b/ddr/test/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -36,6 +36,8 @@ ifeq (gcc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += -g3 -Wno-error -frtti -std=c++0x
 else ifeq (msvc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += /Zi /EHsc
+else ifeq (zos,$(OMR_HOST_OS))
+  # no extra flags for z/OS
 else
   MODULE_CXXFLAGS += -qdbgfmt=stabstring
 endif

--- a/ddr/test/makefile
+++ b/ddr/test/makefile
@@ -24,6 +24,7 @@ include $(top_srcdir)/omrmakefiles/configure.mk
 
 MODULE_NAME := ddrgentest
 ARTIFACT_TYPE := cxx_executable
+USE_NATIVE_ENCODING := 1
 
 OBJECTS += $(patsubst %.cpp,%$(OBJEXT),$(wildcard *.cpp))
 OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))

--- a/ddr/tools/blob_reader/CMakeLists.txt
+++ b/ddr/tools/blob_reader/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2017 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,4 +32,9 @@ target_link_libraries(omr_blob_reader
 	omr_ddr_macros
 	omr_ddr_scanner
 	omrutil
+	${OMR_PORT_LIB}
 )
+
+if(OMRPORT_OMRSIG_SUPPORT)
+	target_link_libraries(omr_blob_reader omrsig)
+endif()

--- a/ddr/tools/blob_reader/Makefile
+++ b/ddr/tools/blob_reader/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2017 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -39,5 +39,11 @@ endif
 
 OBJECTS = \
   blob_reader$(OBJEXT)
+
+MODULE_STATIC_LIBS += omrstatic
+
+ifeq (1,$(OMRPORT_OMRSIG_SUPPORT))
+  MODULE_SHARED_LIBS += omrsig
+endif
 
 include $(top_srcdir)/omrmakefiles/rules.mk

--- a/ddr/tools/blob_reader/Makefile
+++ b/ddr/tools/blob_reader/Makefile
@@ -42,7 +42,11 @@ OBJECTS = \
 
 MODULE_STATIC_LIBS += omrstatic
 
-ifeq (win,$(OMR_HOST_OS))
+ifeq (aix,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += iconv perfstat
+else ifeq (osx,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += iconv
+else ifeq (win,$(OMR_HOST_OS))
   MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
 endif
 

--- a/ddr/tools/blob_reader/Makefile
+++ b/ddr/tools/blob_reader/Makefile
@@ -42,6 +42,10 @@ OBJECTS = \
 
 MODULE_STATIC_LIBS += omrstatic
 
+ifeq (win,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
+endif
+
 ifeq (1,$(OMRPORT_OMRSIG_SUPPORT))
   MODULE_SHARED_LIBS += omrsig
 endif

--- a/ddr/tools/blob_reader/blob_reader.cpp
+++ b/ddr/tools/blob_reader/blob_reader.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -29,7 +29,12 @@
 #include <string.h>
 #include <vector>
 
-#include "ddr/error.hpp"
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#include "atoe.h"
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
+
+#include "omrport.h"
+#include "thread_api.h"
 
 using std::vector;
 
@@ -137,13 +142,24 @@ struct BlobConstant {
 	}
 };
 
-struct Field;
-struct Constant;
+struct Constant {
+	const char *name;
+	uint32_t nameLength;
+	uint64_t value;
+};
+
+struct Field {
+	const char *name;
+	uint32_t nameLength;
+	const char *type;
+	uint32_t typeLength;
+	uint32_t offset;
+};
 
 struct Structure {
-	char *name;
+	const char *name;
 	uint32_t nameLength;
-	char *superName;
+	const char *superName;
 	uint32_t superNameLength;
 	uint32_t size;
 	vector<Field *> fields;
@@ -161,258 +177,271 @@ struct Structure {
 	}
 };
 
-bool
+static bool
 compareStructs(const Structure *first, const Structure *second)
 {
 	return strcmp(first->name, second->name) < 0;
 }
 
-struct Field {
-	char *name;
-	uint32_t nameLength;
-	char *type;
-	uint32_t typeLength;
-	uint32_t offset;
-};
-
-struct Constant {
-	char *name;
-	uint32_t nameLength;
-	uint64_t value;
-};
-
 int
 main(int argc, char *argv[])
 {
-	if (argc < 2) {
-		ERRMSG("Please specify a blob filename.\n");
-		ERRMSG("Usage: %s <blobfile>\n", argv[0]);
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+	/* Convert EBCDIC to UTF-8 (ASCII) */
+	if (-1 == iconv_init()) {
+		fprintf(stderr, "failed to initialize iconv\n");
 		return -1;
 	}
 
-	FILE *fd = fopen(argv[1], "rb");
-	if (NULL == fd) {
-		ERRMSG("fopen failed: %s", strerror(errno));
+	/* translate argv strings to ASCII */
+	for (int i = 0; i < argc; ++i) {
+		argv[i] = e2a_string(argv[i]);
+		if (NULL == argv[i]) {
+			fprintf(stderr, "failed to convert argument #%d from EBCDIC to ASCII\n", i);
+			return -1;
+		}
+	}
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
+
+	omrthread_attach(NULL);
+
+	OMRPortLibrary portLibrary;
+
+	if (0 != omrport_init_library(&portLibrary, sizeof(portLibrary))) {
+		fprintf(stderr, "failed to initalize port library\n");
 		return -1;
 	}
 
-	/* Read header */
+	OMRPORT_ACCESS_FROM_OMRPORT(&portLibrary);
+	int rc = -1;
+	intptr_t fd = -1;
+	size_t rb = 0;
+	uint8_t *blobBuffer = NULL;
 	BlobHeaderV1 blobHdrV1;
+
 	memset(&blobHdrV1, 0, sizeof(blobHdrV1));
 
-	size_t rb = fread(&blobHdrV1, 1, sizeof(blobHdrV1), fd);
+	if (argc < 2) {
+		omrfile_printf(OMRPORT_TTY_ERR, "Please specify a blob filename.\n");
+		omrfile_printf(OMRPORT_TTY_ERR, "Usage: %s <blobfile>\n", argv[0]);
+		goto done;
+	}
+
+	fd = omrfile_open(argv[1], EsOpenRead, 0);
+	if (fd < 0) {
+		omrfile_printf(OMRPORT_TTY_ERR, "fopen failed: %s\n", strerror(errno));
+		goto done;
+	}
+
+	/* read header */
+	rb = omrfile_read(fd, &blobHdrV1, sizeof(blobHdrV1));
 	if (sizeof(blobHdrV1) != rb) {
-		ERRMSG("read blob header returned %lu, expected %lu\n", (unsigned long)rb, (unsigned long)sizeof(blobHdrV1));
-		fclose(fd);
-		return -1;
-	}
+		omrfile_printf(OMRPORT_TTY_ERR, "read blob header returned %zu, expected %zu\n", rb, sizeof(blobHdrV1));
+	} else {
+		/* Data is written in the blob in the natural byte order of the originating system.
+		 * All version numbers thus far are small: a large version number is interpreted as
+		 * a mismatch between the byte order of this system and the originating system.
+		 */
+		const bool swapsNeeded = blobHdrV1.coreVersion > (uint32_t) 0xFFFF;
 
-	/* Data is written in the blob in the natural byte order of the originating system.
-	 * All version numbers thus far are small: a large version number is interpreted as
-	 * a mismatch between the byte order of this system and the originating system.
-	 */
-	const bool swapsNeeded = blobHdrV1.coreVersion > (uint32_t) 0xFFFF;
-
-	if (swapsNeeded) {
-		blobHdrV1.endian_swap();
-	}
-
-	printf("Blob Header:\n"
-		   " coreVersion: %u\n"
-		   " sizeofBool: %u\n"
-		   " sizeofUDATA: %u\n"
-		   " bitfieldFormat: %u\n" /* see initializeBitfieldEncoding in j9ddr.c */
-		   " structDataSize: %u\n"
-		   " stringTableDataSize: %u\n"
-		   " structureCount: %u\n",
-		   blobHdrV1.coreVersion,
-		   blobHdrV1.sizeofBool,
-		   blobHdrV1.sizeofUDATA,
-		   blobHdrV1.bitfieldFormat,
-		   blobHdrV1.structDataSize,
-		   blobHdrV1.stringTableDataSize,
-		   blobHdrV1.structureCount);
-
-	/* Copy the file into memory */
-	size_t blobLength = sizeof(blobHdrV1) + blobHdrV1.structDataSize + blobHdrV1.stringTableDataSize;
-	uint8_t *blobBuffer = (uint8_t *)malloc(blobLength);
-	if (NULL == blobBuffer) {
-		ERRMSG("malloc blobBuffer failed\n");
-		fclose(fd);
-		return -1;
-	}
-
-	rewind(fd);
-	rb = fread(blobBuffer, 1, blobLength, fd);
-	fclose(fd);
-	if (blobLength != rb) {
-		ERRMSG("read blob data returned %lu, expected %lu\n", (unsigned long)rb, (unsigned long)blobLength);
-		return -1;
-	}
-
-	/* Read strings */
-	{
-		printf("\n== STRINGS ==\n");
-
-		const uint8_t * const stringDataStart = blobBuffer + sizeof(blobHdrV1) + blobHdrV1.structDataSize;
-		const uint8_t * const stringDataEnd = stringDataStart + blobHdrV1.stringTableDataSize;
-		const uint8_t *currentString = stringDataStart;
-		unsigned int stringNum = 1; /* Numbers the strings in the printed list */
-
-		while (currentString < stringDataEnd) {
-			BlobString *blobString = (BlobString *)currentString;
-
-			if (swapsNeeded) {
-				blobString->endian_swap();
-			}
-
-			/* NOTE string lengths appear to be padded to an even length */
-			const uint16_t padding = blobString->length & 1;
-
-			/* The format of the printed list is:
-			 * #: <offset in string data> [<string length>] <string data>
-			 */
-			printf("%5u: %8lx [%u] %.*s\n", stringNum, (long unsigned int)(currentString - stringDataStart), blobString->length, blobString->length, blobString->data);
-
-			/* NOTE stringTableDataSize includes the space for the lengths */
-			currentString += blobString->length + sizeof(blobString->length) + padding;
-			stringNum += 1;
+		if (swapsNeeded) {
+			blobHdrV1.endian_swap();
 		}
-	}
 
-	/* NOTE DDRGen uses a hash table to uniquify the string data while building
-	 * the structure information.
-	 */
+		omrfile_printf(OMRPORT_TTY_OUT, "Blob Header:\n"
+				" coreVersion: %u\n"
+				" sizeofBool: %u\n"
+				" sizeofUDATA: %u\n"
+				" bitfieldFormat: %u\n" /* see initializeBitfieldEncoding in j9ddr.c */
+				" structDataSize: %u\n"
+				" stringTableDataSize: %u\n"
+				" structureCount: %u\n",
+				blobHdrV1.coreVersion,
+				blobHdrV1.sizeofBool,
+				blobHdrV1.sizeofUDATA,
+				blobHdrV1.bitfieldFormat,
+				blobHdrV1.structDataSize,
+				blobHdrV1.stringTableDataSize,
+				blobHdrV1.structureCount);
 
-	/* Read structs */
-	{
-		const uint8_t *const stringDataStart = blobBuffer + sizeof(blobHdrV1) + blobHdrV1.structDataSize;
-#define BLOBSTRING_AT(offset) \
-		((BlobString *)(stringDataStart + (offset)))
+		/* read the file into memory */
+		const size_t blobLength = blobHdrV1.structDataSize + blobHdrV1.stringTableDataSize;
+		blobBuffer = (uint8_t *)malloc(blobLength);
+		if (NULL == blobBuffer) {
+			omrfile_printf(OMRPORT_TTY_ERR, "malloc blobBuffer failed\n");
+			goto done;
+		}
 
-		/* set offset to start of struct data */
-		const uint8_t *currentStruct = blobBuffer + sizeof(blobHdrV1);
+		rb = omrfile_read(fd, blobBuffer, blobLength);
+		if (blobLength != rb) {
+			omrfile_printf(OMRPORT_TTY_ERR, "read blob data returned %zu, expected %zu\n", rb, blobLength);
+			goto done;
+		}
 
-		uint32_t structCount = 1;
-		vector<Structure *> structs;
-		while (structCount <= blobHdrV1.structureCount) {
-			BlobStruct *blobStruct = (BlobStruct *)currentStruct;
+		/* read strings */
+		{
+			omrfile_printf(OMRPORT_TTY_OUT, "\n== STRINGS ==\n");
 
-			if (swapsNeeded) {
-				blobStruct->endian_swap();
-			}
+			const uint8_t * const stringDataStart = blobBuffer + blobHdrV1.structDataSize;
+			const uint8_t * const stringDataEnd = stringDataStart + blobHdrV1.stringTableDataSize;
+			const uint8_t *currentString = stringDataStart;
 
-			currentStruct += sizeof(BlobStruct);
-
-			Structure *builtStruct = new Structure;
-
-			builtStruct->name = BLOBSTRING_AT(blobStruct->nameOffset)->data;
-			builtStruct->nameLength = BLOBSTRING_AT(blobStruct->nameOffset)->length;
-			if ((uint32_t)-1 == blobStruct->superName) {
-				builtStruct->superName = NULL;
-				builtStruct->superNameLength = 0;
-			} else {
-				builtStruct->superName = BLOBSTRING_AT(blobStruct->superName)->data;
-				builtStruct->superNameLength = BLOBSTRING_AT(blobStruct->superName)->length;
-			}
-			builtStruct->size = blobStruct->sizeOf;
-
-			uint32_t fieldCount = 1;
-			while (fieldCount <= blobStruct->fieldCount) {
-				BlobField *blobField = (BlobField *)currentStruct;
+			for (uint32_t stringNum = 1; currentString < stringDataEnd; ++stringNum) {
+				BlobString *blobString = (BlobString *)currentString;
 
 				if (swapsNeeded) {
-					blobField->endian_swap();
+					blobString->endian_swap();
 				}
 
-				currentStruct += sizeof(BlobField);
+				/* NOTE string lengths appear to be padded to an even length */
+				const uint16_t padding = blobString->length & 1;
 
-				Field *field = (Field *)malloc(sizeof(Field));
-				field->name = BLOBSTRING_AT(blobField->declaredName)->data;
-				field->nameLength = BLOBSTRING_AT(blobField->declaredName)->length;
-				field->type = BLOBSTRING_AT(blobField->declaredType)->data;
-				field->typeLength = BLOBSTRING_AT(blobField->declaredType)->length;
-				field->offset = blobField->offset;
+				/* The format of the printed list is:
+				 * #: <offset in string data> [<string length>] <string data>
+				 */
+				omrfile_printf(OMRPORT_TTY_OUT, "%5u: %8zx [%zu] %.*s\n", stringNum, (uintptr_t)(currentString - stringDataStart), blobString->length, blobString->length, blobString->data);
 
-				builtStruct->fields.push_back(field);
-				fieldCount += 1;
+				/* NOTE stringTableDataSize includes the space for the lengths */
+				currentString += blobString->length + sizeof(blobString->length) + padding;
 			}
+		}
 
-			uint32_t constCount = 1;
-			while (constCount <= blobStruct->constCount) {
-				BlobConstant *blobConst = (BlobConstant *)currentStruct;
+		/* read structuress */
+		{
+			const uint8_t * const stringDataStart = blobBuffer + blobHdrV1.structDataSize;
+	#define BLOBSTRING_AT(offset) \
+			((const BlobString *)(stringDataStart + (offset)))
+
+			/* set offset to start of struct data */
+			const uint8_t *currentStruct = blobBuffer;
+
+			vector<Structure *> structs;
+			for (uint32_t structCount = 1; structCount <= blobHdrV1.structureCount; ++structCount) {
+				BlobStruct *blobStruct = (BlobStruct *)currentStruct;
 
 				if (swapsNeeded) {
-					blobConst->endian_swap();
+					blobStruct->endian_swap();
 				}
 
-				currentStruct += sizeof(BlobConstant);
+				currentStruct += sizeof(BlobStruct);
 
-				Constant *constant = (Constant *)malloc(sizeof(Constant));
-				constant->name = BLOBSTRING_AT(blobConst->name)->data;
-				constant->nameLength = BLOBSTRING_AT(blobConst->name)->length;
-				constant->value = *(uint64_t *)blobConst->value;
+				Structure *builtStruct = new Structure;
 
-				builtStruct->constants.push_back(constant);
-				constCount += 1;
+				builtStruct->name = BLOBSTRING_AT(blobStruct->nameOffset)->data;
+				builtStruct->nameLength = BLOBSTRING_AT(blobStruct->nameOffset)->length;
+				if ((uint32_t)-1 == blobStruct->superName) {
+					builtStruct->superName = NULL;
+					builtStruct->superNameLength = 0;
+				} else {
+					builtStruct->superName = BLOBSTRING_AT(blobStruct->superName)->data;
+					builtStruct->superNameLength = BLOBSTRING_AT(blobStruct->superName)->length;
+				}
+				builtStruct->size = blobStruct->sizeOf;
+
+				for (uint32_t fieldCount = 1; fieldCount <= blobStruct->fieldCount; ++fieldCount) {
+					BlobField *blobField = (BlobField *)currentStruct;
+
+					if (swapsNeeded) {
+						blobField->endian_swap();
+					}
+
+					currentStruct += sizeof(BlobField);
+
+					Field *field = new Field;
+
+					field->name = BLOBSTRING_AT(blobField->declaredName)->data;
+					field->nameLength = BLOBSTRING_AT(blobField->declaredName)->length;
+					field->type = BLOBSTRING_AT(blobField->declaredType)->data;
+					field->typeLength = BLOBSTRING_AT(blobField->declaredType)->length;
+					field->offset = blobField->offset;
+
+					builtStruct->fields.push_back(field);
+				}
+
+				for (uint32_t constCount = 1; constCount <= blobStruct->constCount; ++constCount) {
+					BlobConstant *blobConst = (BlobConstant *)currentStruct;
+
+					if (swapsNeeded) {
+						blobConst->endian_swap();
+					}
+
+					currentStruct += sizeof(BlobConstant);
+
+					Constant *constant = new Constant;
+
+					constant->name = BLOBSTRING_AT(blobConst->name)->data;
+					constant->nameLength = BLOBSTRING_AT(blobConst->name)->length;
+					constant->value = *(uint64_t *)blobConst->value;
+
+					builtStruct->constants.push_back(constant);
+				}
+
+				structs.push_back(builtStruct);
 			}
+			sort(structs.begin(), structs.end(), compareStructs);
 
-			structs.push_back(builtStruct);
-			structCount += 1;
+			omrfile_printf(OMRPORT_TTY_OUT, "\n== STRUCTS ==\n");
+			for (size_t i = 0; i < structs.size(); ++i) {
+				Structure *builtStruct = structs[i];
+				omrfile_printf(OMRPORT_TTY_OUT, "\nStruct name: %.*s\n",
+						builtStruct->nameLength,
+						builtStruct->name);
+				if (NULL == builtStruct->superName) {
+					omrfile_printf(OMRPORT_TTY_OUT, " no superName\n");
+				} else {
+					omrfile_printf(OMRPORT_TTY_OUT, " superName: %.*s\n",
+							builtStruct->superNameLength,
+							builtStruct->superName);
+				}
+				omrfile_printf(OMRPORT_TTY_OUT, " sizeOf: %zu\n"
+						" fieldCount: %zu\n"
+						" constCount: %zu\n",
+						builtStruct->size,
+						builtStruct->fields.size(),
+						builtStruct->constants.size());
+
+				/* print fields in the structure */
+				for (size_t j = 0; j < builtStruct->fields.size(); ++j) {
+					Field *field = builtStruct->fields[j];
+
+					omrfile_printf(OMRPORT_TTY_OUT, " Field declaredName: %.*s\n",
+							field->nameLength,
+							field->name);
+					omrfile_printf(OMRPORT_TTY_OUT, "  declaredType: %.*s\n",
+							field->typeLength,
+							field->type);
+					omrfile_printf(OMRPORT_TTY_OUT, "  offset: %u\n", field->offset);
+					delete field;
+				}
+
+				/* print constants in the structure */
+				for (size_t j = 0; j < builtStruct->constants.size(); ++j) {
+					Constant *constant = builtStruct->constants[j];
+
+					omrfile_printf(OMRPORT_TTY_OUT, " Constant name: %.*s\n",
+							constant->nameLength,
+							constant->name);
+					omrfile_printf(OMRPORT_TTY_OUT, "  value: %llu\n", constant->value);
+					delete constant;
+				}
+				delete builtStruct;
+			}
+	#undef BLOBSTRING_AT
 		}
-		sort(structs.begin(), structs.end(), compareStructs);
-
-		printf("\n== STRUCTS ==\n");
-		for (size_t i = 0; i < structs.size(); ++i) {
-			Structure *builtStruct = structs[i];
-			printf("\nStruct name: %.*s\n",
-				   builtStruct->nameLength,
-				   builtStruct->name);
-			if (NULL == builtStruct->superName) {
-				printf(" no superName\n");
-			} else {
-				printf(" superName: %.*s\n",
-					   builtStruct->superNameLength,
-					   builtStruct->superName);
-			}
-			printf(" sizeOf: %u\n"
-				   " fieldCount: %lu\n"
-				   " constCount: %lu\n",
-				   builtStruct->size,
-				   (unsigned long int)builtStruct->fields.size(),
-				   (unsigned long int)builtStruct->constants.size());
-
-			/* Print fields in the struct */
-			for (size_t j = 0; j < builtStruct->fields.size(); ++j) {
-				Field *field = builtStruct->fields[j];
-
-				printf(" Field declaredName: %.*s\n",
-					   field->nameLength,
-					   field->name);
-				printf("  declaredType: %.*s\n",
-					   field->typeLength,
-					   field->type);
-				printf("  offset: %u\n", field->offset);
-				free(field);
-			}
-
-			/* Print consts in the struct */
-			for (size_t j = 0; j < builtStruct->constants.size(); ++j) {
-				Constant *constant = builtStruct->constants[j];
-
-				printf(" Constant name: %.*s\n",
-					   constant->nameLength,
-					   constant->name);
-				printf("  value: %llu\n", (long long unsigned int)constant->value);
-				free(constant);
-			}
-			delete builtStruct;
-		}
-#undef BLOBSTRING_AT
 	}
 
-	/* free the blob buffer */
-	free(blobBuffer);
-	blobBuffer = NULL;
-	return 0;
+	rc = 0;
+
+done:
+	if (fd >= 0) {
+		omrfile_close(fd);
+		fd = -1;
+	}
+
+	if (NULL != blobBuffer) {
+		free(blobBuffer);
+		blobBuffer = NULL;
+	}
+
+	return rc;
 }

--- a/ddr/tools/ddrgen/Makefile
+++ b/ddr/tools/ddrgen/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 IBM Corp. and others
+# Copyright (c) 2016, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,21 +49,15 @@ endif
 
 ifeq (aix,$(OMR_HOST_OS))
   MODULE_SHARED_LIBS += iconv perfstat
-endif
-
-ifeq (win,$(OMR_HOST_OS))
-  MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
-endif
-
-ifeq (osx,$(OMR_HOST_OS))
+else ifeq (osx,$(OMR_HOST_OS))
   MODULE_SHARED_LIBS += iconv
+else ifeq (win,$(OMR_HOST_OS))
+  MODULE_SHARED_LIBS += ws2_32 shell32 Iphlpapi psapi pdh
 endif
 
 ifeq (gcc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += -frtti -D__STDC_LIMIT_MACROS -std=c++0x
-endif
-
-ifeq (msvc,$(OMR_TOOLCHAIN))
+else ifeq (msvc,$(OMR_TOOLCHAIN))
   MODULE_CXXFLAGS += /EHsc
 endif
 
@@ -71,7 +65,7 @@ ifeq (1,$(OMRPORT_OMRSIG_SUPPORT))
   MODULE_SHARED_LIBS += omrsig
 endif
 
-DDRGEN_STATIC_LIBS = \
+DDRGEN_STATIC_LIBS := \
   ddr-scanner \
   ddr-ir \
   ddr-blobgen \
@@ -84,3 +78,12 @@ OBJECTS = \
   ddrgen$(OBJEXT)
 
 include $(top_srcdir)/omrmakefiles/rules.mk
+
+# This must follow the include above because we want to append to LD_STATIC_LIBS.
+ifeq (zos,$(OMR_HOST_OS))
+  ifeq (1,$(OMR_ENV_DATA64))
+    LD_STATIC_LIBS += /usr/lpp/cbclib/lib/libelfdwarf64.x
+  else
+    LD_STATIC_LIBS += /usr/lpp/cbclib/lib/libelfdwarf32.x
+  endif
+endif

--- a/ddr/tools/getmacros
+++ b/ddr/tools/getmacros
@@ -34,6 +34,14 @@ flag_undef_regex_comment="^/\* #undef (${id}) \*/"
 value_define_regex="^ *# *define +(${id}) +[^ /].*($|//|/\*)"
 include_guard_regex=".*_[Hh]([Pp][Pp])?_? *($|//|/\*)"
 
+# Detect if we're running on z/OS, in which case we'll
+# need to use iconv to produce EBCDIC output.
+if [ "$(uname -s)" = "OS/390" ]; then
+	zos390=yes
+else
+	zos390=no
+fi
+
 ##
 # Create a list of all c, h, cpp and hpp files that have simple (non function) macros within them.
 ##
@@ -146,7 +154,6 @@ define_value_macro() {
 
 process_one_policy_file() {
 	# Inject repeated include guard and file delimiter
-	(( filenum++ ))
 	echo ""
 	echo "#ifndef DDRGEN_F${filenum}_GUARD_H"
 	echo "#define DDRGEN_F${filenum}_GUARD_H"
@@ -202,7 +209,6 @@ parse_namespace_policy_files() {
 	local filenum=0
 
 	for f in "${annotated_files[@]}"; do
-
 		# Find ddr_options or use the default.
 		get_ddr_options
 
@@ -215,8 +221,17 @@ parse_namespace_policy_files() {
 			mv ${f} ${f}.orig
 			cp ${f}.orig ${f}
 
+			# Increment the sequence number embedded in generated include guard names.
+			(( filenum++ ))
+
 			# read from the backup, rather than the file to which we're appending
-			process_one_policy_file < ${f}.orig >> ${f}
+			if [ $zos390 = yes ] ; then
+				# On z/OS, all source files are in EBCDIC: we must retain that
+				# property as we append to header files.
+				process_one_policy_file < ${f}.orig | iconv -f ISO8859-1 -t IBM-1047 >> ${f}
+			else
+				process_one_policy_file < ${f}.orig >> ${f}
+			fi
 		fi
 	done
 }

--- a/omrmakefiles/rules.zos.mk
+++ b/omrmakefiles/rules.zos.mk
@@ -1,19 +1,19 @@
 ###############################################################################
 # Copyright (c) 2015, 2019 IBM Corp. and others
-# 
+#
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
 # distribution and is available at https://www.eclipse.org/legal/epl-2.0/
 # or the Apache License, Version 2.0 which accompanies this distribution and
 # is available at https://www.apache.org/licenses/LICENSE-2.0.
-#      
+#
 # This Source Code may also be made available under the following
 # Secondary Licenses when the conditions for such availability set
 # forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
 # General Public License, version 2 with the GNU Classpath
 # Exception [1] and GNU General Public License, version 2 with the
 # OpenJDK Assembly Exception [2].
-#    
+#
 # [1] https://www.gnu.org/software/classpath/license.html
 # [2] http://openjdk.java.net/legal/assembly-exception.html
 #
@@ -26,13 +26,13 @@ ifneq ($(OMR_ALLOW_NATIVE_ENCODING),1)
   USE_NATIVE_ENCODING := 0
 endif
 
-ifneq ($(USE_NATIVE_ENCODING), 1)
+ifneq ($(USE_NATIVE_ENCODING),1)
   GLOBAL_CPPFLAGS+=-I$(top_srcdir)/util/a2e/headers
 endif
 
 # Specify the minimum arch for 64-bit programs
-GLOBAL_CFLAGS+=-Wc,ARCH\(7\)
-GLOBAL_CXXFLAGS+=-Wc,ARCH\(7\)
+GLOBAL_CFLAGS+=-Wc,"ARCH(7)"
+GLOBAL_CXXFLAGS+=-Wc,"ARCH(7)"
 
 # Enable Warnings as Errors
 ifeq ($(OMR_WARNINGS_AS_ERRORS),1)
@@ -43,12 +43,15 @@ ifeq ($(OMR_ENHANCED_WARNINGS),1)
 endif
 
 # Enable Debugging Symbols
-ifeq ($(OMR_DEBUG),1)
+ifeq ($(ENABLE_DDR),yes)
+  GLOBAL_CFLAGS   += -Wc,debug
+  GLOBAL_CXXFLAGS += -Wc,debug
+else ifeq ($(OMR_DEBUG),1)
 endif
 
 # Enable Optimizations
 ifeq ($(OMR_OPTIMIZE),1)
-    COPTFLAGS=-O3 -Wc,TUNE\(10\) -Wc,inline\(auto,noreport,600,5000\)
+    COPTFLAGS=-O3 -Wc,"TUNE(10)" -Wc,"inline(auto,noreport,600,5000)"
 
     # OMRTODO: The COMPAT=ZOSV1R13 option does not appear to be related to
     # optimizations.  This linker option is supplied only on the compile line,
@@ -58,8 +61,7 @@ ifeq ($(OMR_OPTIMIZE),1)
     # option means: "COMPAT=ZOSV1R13 is the minimum level that supports conditional sequential RLDs"
     # http://www-01.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieab100/compat.htm
     COPTFLAGS+=-Wl,compat=ZOSV1R13
-endif
-ifneq ($(OMR_OPTIMIZE),1)
+else
     COPTFLAGS=-0
 endif
 GLOBAL_CFLAGS+=$(COPTFLAGS)
@@ -77,18 +79,18 @@ GLOBAL_CPPFLAGS+=-DJ9ZOS390 -DLONGLONG -DJ9VM_TIERED_CODE_CACHE -D_ALL_SOURCE -D
 # a,goff   Assemble into GOFF object files
 # NOANSIALIAS Do not generate ALIAS binder control statements
 # TARGET   Generate code for the target operating system
-GLOBAL_FLAGS+=-Wc,xplink,rostring,FLOAT\(IEEE,FOLD,AFP\),enum\(4\) -Wa,goff -Wc,NOANSIALIAS -Wc,TARGET\(zOSV1R13\)
+GLOBAL_FLAGS+=-Wc,"xplink,rostring,FLOAT(IEEE,FOLD,AFP),enum(4)" -Wa,goff -Wc,NOANSIALIAS -Wc,"TARGET(zOSV1R13)"
 
-ifneq (1,$(USE_NATIVE_ENCODING))
-  GLOBAL_CPPFLAGS+=-DIBM_ATOE
-  GLOBAL_FLAGS+=-Wc,convlit\(ISO8859-1\)
-else
+ifeq (1,$(USE_NATIVE_ENCODING))
   GLOBAL_CPPFLAGS+=-DOMR_EBCDIC
+else
+  GLOBAL_CPPFLAGS+=-DIBM_ATOE
+  GLOBAL_FLAGS+=-Wc,"convlit(ISO8859-1)"
 endif
 
 ifeq (1,$(OMR_ENV_DATA64))
   GLOBAL_CPPFLAGS+=-DJ9ZOS39064
-  GLOBAL_FLAGS+=-Wc,lp64 -Wa,SYSPARM\(BIT64\)
+  GLOBAL_FLAGS+=-Wc,lp64 -Wa,"SYSPARM(BIT64)"
 else
   GLOBAL_CPPFLAGS+=-D_LARGE_FILES
 endif
@@ -108,7 +110,7 @@ ifeq (1,$(DO_LINK))
 
   # This is the first option applied to the C++ linking command.
   # It is not applied to the C linking command.
-  OMR_MK_CXXLINKFLAGS=-Wc,"langlvl(extended0x)" -+ 
+  OMR_MK_CXXLINKFLAGS=-Wc,"langlvl(extended0x)" -+
 
   ifneq (,$(findstring shared,$(ARTIFACT_TYPE)))
     GLOBAL_LDFLAGS+=-Wl,xplink,dll
@@ -158,14 +160,14 @@ define LINK_C_SHARED_COMMAND
 $(CCLINKSHARED) -o $($(MODULE_NAME)_shared) \
   $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS) \
   $(LD_SHARED_LIBS) $(OBJECTS) $(LD_STATIC_LIBS)
-mv $(LIBPREFIX)$(MODULE_NAME).x $(lib_output_dir)
+cp -f $(LIBPREFIX)$(MODULE_NAME).x $(lib_output_dir)
 endef
 
 define LINK_CXX_SHARED_COMMAND
 $(CXXLINKSHARED) $(OMR_MK_CXXLINKFLAGS) -o $($(MODULE_NAME)_shared) \
   $(LDFLAGS) $(MODULE_LDFLAGS) $(GLOBAL_LDFLAGS) \
   $(LD_SHARED_LIBS) $(OBJECTS) $(LD_STATIC_LIBS)
-mv $(LIBPREFIX)$(MODULE_NAME).x $(lib_output_dir)
+cp -f $(LIBPREFIX)$(MODULE_NAME).x $(lib_output_dir)
 endef
 
 ifneq (,$(findstring shared,$(ARTIFACT_TYPE)))
@@ -173,5 +175,5 @@ CLEAN_FILES+=$(LIBPREFIX)$(MODULE_NAME).x
 CLEAN_FILES+=$(lib_output_dir)/$(LIBPREFIX)$(MODULE_NAME).x
 endif
 define CLEAN_COMMAND
--$(RM) $(OBJECTS) $(OBJECTS:$(OBJEXT)=.d) $(CLEAN_FILES) 
+-$(RM) $(OBJECTS) $(OBJECTS:$(OBJEXT)=.d) $(CLEAN_FILES)
 endef

--- a/util/a2e/atoe_utils.c
+++ b/util/a2e/atoe_utils.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,6 +38,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>   /* for malloc() via e2a_string()/a2e_string() */
+#include <string.h>
+
 /*
  * ======================================================================
  * Define ae2,e2a,a2e_string, e2a_string

--- a/util/a2e/sysTranslate.c
+++ b/util/a2e/sysTranslate.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2015 IBM Corp. and others
+ * Copyright (c) 2001, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 #pragma map(sysTranslate, "SYSXLATE")
 #include <builtins.h>
+#include <string.h>
 
 char *
 sysTranslate(const char *source, int length, char *trtable, char *xlate_buf)


### PR DESCRIPTION
* Add ddrgen dependency on j9a2e.
* Build hook and trace artifacts incrementally.
* Don't compile ddr/test with '-qdbgfmt=stabstring'.
* Enable generation of debug information.
* Ignore *.tracesentinel.
* Link ddrgen with elfdwarf.
* Simplify host-specific conditionals.
* Copy .x files instead of moving them.
* Use quotes instead of multiple escape sequences in compiler options.

* Add required includes of <string.h>.

* Make hookgen more robust - print a message if an XML child is missing instead of crashing with a segmentation fault.

* Read text files consistently - add TextFile class for reading text files consistently (using the port library instead of 'FILE *' or stl streams).

* Fix getmacros to use iconv to work with EBCDIC-encoded files.

* Remove checking for redundant input to ddrgen.

  - It's possible that ddrgen was invoked with some input files that don't contribute any additional debugging information. There was code to check for that and provide feedback, however, it had several problems:
  - It operated on 'Type *' many (most?) of which will be stale pointers after the call to `mergeIR()`.
  - The algorithm didn't scale well; on most platforms openj9 only provides a few input files but on z/OS ddrgen must process more than a thousand files - the result being it didn't terminate even after 15 minutes. It has never reported any unnecessary input so that was time spent with no benefit.

* Multiple enhancements to DwarfScanner:

  - add correction for base type: boolean -> bool
  - handle DW_AT_data_member_location expressions
  - handle DW_TAG_array_type with no children
  - ignore anonymous fields
  - refactor check for anonymous types
  - treat fields marked with DW_AT_declaration as static
  - use native file descriptor in call to dwarf_init()
  - 'void' may be tagged DW_TAG_unspecified_type
  - don't trigger a segfault encountering an unknown tag
  - handle enum literal value forms sdata & udata
  - don't call dwarf_srcfiles() if a CU doesn't have DW_AT_comp_dir
  - don't call malloc(0)
  - don't blacklist types with DW_AT_decl_file out of range

* Use native encoding for ddrgen sample code.

  - avoids difficulties with using ctype.h in C++ code
  - DWARF uses ASCII anyways even if the source is EBCDIC

* Fix blob_reader tool.

  - use iconv to handle EBCDIC <-> ASCII conversions
  - use port library for file I/O
