### PR TITLE
Generate entry breakpoints for methods compiled with system linkage

### DIFF
--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -625,6 +625,13 @@ TR::PPCSystemLinkage::mapSingleAutomatic(
 void
 TR::PPCSystemLinkage::createPrologue(TR::Instruction *cursor)
    {
+   TR::Node *firstNode = comp()->getStartTree()->getNode();
+
+   if (comp()->getOption(TR_EntryBreakPoints))
+      {
+      cursor = generateInstruction(cg(), TR::InstOpCode::bad, firstNode, cursor);
+      }
+
    createPrologue(cursor, comp()->getJittedMethodSymbol()->getParameterList());
    }
 


### PR DESCRIPTION
Implemented breakOnEntry debugging option on Power for methods compiled using system linkage.
