### PR TITLE
Stop using sigval_t

### DIFF
--- a/port/aix/omrintrospect.h
+++ b/port/aix/omrintrospect.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,8 +42,6 @@ extern int getthrds64(pid_t ProcessIdentifier, struct thrdentry64 *ThreadBuffer,
 
 
 extern int32_t __omrgetsp(void);
-
-typedef union sigval sigval_t;
 
 typedef ucontext_t thread_context;
 

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1044,7 +1044,7 @@ suspend_all_preemptive(struct PlatformWalkData *data)
 	 */
 	do {
 		int i = 0;
-		sigval_t val;
+		union sigval val;
 		val.sival_ptr = data;
 
 		/* fire off enough signals to pause all threads in the process barring us */
@@ -1742,7 +1742,7 @@ omrintrospect_threads_nextDo(J9ThreadWalkState *state)
 			} else if (timedOut(data->state->deadline1) || data->error) {
 				break;
 			} else {
-				sigval_t val;
+				union sigval val;
 				val.sival_ptr = data;
 
 				/*

--- a/port/zos390/omrintrospect.h
+++ b/port/zos390/omrintrospect.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -59,7 +59,6 @@
 
 typedef __mcontext_t_ thread_context;
 
-typedef union sigval sigval_t;
 
 #pragma pack(packed)
 

--- a/port/ztpf/omrintrospect.c
+++ b/port/ztpf/omrintrospect.c
@@ -1167,7 +1167,7 @@ omrintrospect_threads_nextDo(J9ThreadWalkState *state)
 			} else if (timedOut(data->state->deadline1) || data->error) {
 				break;
 			} else {
-				sigval_t val;
+				union sigval val;
 				val.sival_ptr = data;
 
 				/*


### PR DESCRIPTION
The POSIX standard the type is `union sigval`. sigval_t is only provided
as a typedef convinience on linux

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>