### PR TITLE
Overload function void incRefCountForOpaquePseudoRegister in OMR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -468,7 +468,10 @@ class OMR_EXTENSIBLE CodeGenerator
    rcount_t recursivelyDecReferenceCount(TR::Node*node);
    void evaluateChildrenWithMultipleRefCount(TR::Node*node);
 
+   
    void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp) {}
+   //OVERLOAD THE ABOVE FUNCTION:
+   void incRefCountForOpaquePseudoRegister(TR::Node * node) {}
 
    void startUsingRegister(TR::Register *reg);
    void stopUsingRegister(TR::Register *reg);


### PR DESCRIPTION
This patch adds an overload function of
`incRefCountForOpaquePseudoRegister` but without parameters `cg` and `comp`. This is the
first out 6 steps to simpify function
`incRefCountForOpaquePseudoRegister` by using less parameters.

Issue: #1855
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>