### PR TITLE
Remove references to `linux/prctl.h`

### DIFF
--- a/port/linux/omrosdump_helpers.c
+++ b/port/linux/omrosdump_helpers.c
@@ -33,7 +33,6 @@
 #include <sys/stat.h>
 #if defined(LINUX)
 #include <sys/prctl.h>
-#include <linux/prctl.h>
 #include <sys/resource.h>
 #endif
 #include <elf.h>

--- a/thread/unix/thrdsup.c
+++ b/thread/unix/thrdsup.c
@@ -31,7 +31,6 @@
 
 #if defined(LINUX) && !defined(OMRZTPF)
 #include <sys/prctl.h>
-#include <linux/prctl.h>
 #endif /* defined(LINUX) */
 
 #if defined(OMRZTPF)


### PR DESCRIPTION
This header is unneccisary. Linux documentation indicated only
`sys/prctl.h` is required
(http://man7.org/linux/man-pages/man2/prctl.2.html)


Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>