### PR TITLE
Total regions count for metronome regions lists

### DIFF
--- a/gc/base/segregated/FreeHeapRegionList.hpp
+++ b/gc/base/segregated/FreeHeapRegionList.hpp
@@ -94,8 +94,6 @@ public:
 		}
 		return region;
 	}
-
-	virtual uintptr_t getMaxRegions() = 0;
 		
 	/* Methods inherited from HeapRegionList */
 	virtual bool isEmpty() { return 0 == _length; }

--- a/gc/base/segregated/LockingFreeHeapRegionList.cpp
+++ b/gc/base/segregated/LockingFreeHeapRegionList.cpp
@@ -71,26 +71,9 @@ MM_LockingFreeHeapRegionList::tearDown(MM_EnvironmentBase *env)
 uintptr_t
 MM_LockingFreeHeapRegionList::getTotalRegions()
 {
-	uintptr_t count = 0;
-	lock();
-	for (MM_HeapRegionDescriptorSegregated *cur = _head; cur != NULL; cur = cur->getNext()) {
-		count += cur->getRange();		
-	}
-	unlock();
-	return count;
+	return _totalRegionsCount;
 }
 
-uintptr_t
-MM_LockingFreeHeapRegionList::getMaxRegions()
-{
-	uintptr_t max = 0;
-	lock();
-	for (MM_HeapRegionDescriptorSegregated *cur = _head; cur != NULL; cur = cur->getNext()) {
-		max = (max > cur->getRange()) ? max : cur->getRange();
-	}
-	unlock();
-	return max;
-}
 
 void
 MM_LockingFreeHeapRegionList::showList(MM_EnvironmentBase *env)

--- a/gc/base/segregated/MemoryPoolSegregated.cpp
+++ b/gc/base/segregated/MemoryPoolSegregated.cpp
@@ -329,10 +329,9 @@ MM_MemoryPoolSegregated::getActualFreeMemorySize()
 {
 	uintptr_t single = 0;
 	uintptr_t multi = 0;
-	uintptr_t maxMulti = 0;
 	uintptr_t coalesce = 0;
 	
-	_regionPool->countFreeRegions(&single, &multi, &maxMulti, &coalesce);
+	_regionPool->countFreeRegions(&single, &multi, &coalesce);
 	
 	return (single + multi + coalesce) * _extensions->getHeap()->getHeapRegionManager()->getRegionSize();
 }

--- a/gc/base/segregated/RegionPoolSegregated.cpp
+++ b/gc/base/segregated/RegionPoolSegregated.cpp
@@ -237,11 +237,10 @@ MM_RegionPoolSegregated::moveInUseToSweep(MM_EnvironmentBase *env)
 }
 
 void
-MM_RegionPoolSegregated::countFreeRegions(uintptr_t *singleFree, uintptr_t *multiFree, uintptr_t *maxMultiFree, uintptr_t *coalesceFree)
+MM_RegionPoolSegregated::countFreeRegions(uintptr_t *singleFree, uintptr_t *multiFree, uintptr_t *coalesceFree)
 {
 	*singleFree = _singleFreeList->getTotalRegions();
 	*multiFree = _multiFreeList->getTotalRegions();
-	*maxMultiFree = _multiFreeList->getMaxRegions();
 	*coalesceFree = _coalesceFreeList->getTotalRegions();
 }
 

--- a/gc/base/segregated/RegionPoolSegregated.hpp
+++ b/gc/base/segregated/RegionPoolSegregated.hpp
@@ -181,7 +181,7 @@ public:
  	 * region lists to "sweep" region lists.
  	 */
 	void moveInUseToSweep(MM_EnvironmentBase *env);
-	void countFreeRegions(uintptr_t *singleFree, uintptr_t *multiFree, uintptr_t *maxMultiFree, uintptr_t *coalesceFree);
+	void countFreeRegions(uintptr_t *singleFree, uintptr_t *multiFree, uintptr_t *coalesceFree);
 	void addFreeRange(void *lowAddress, void *highAddress);
 	void addFreeRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region, bool alreadyFree = false);
 	void addSingleFree(MM_EnvironmentBase *env, MM_HeapRegionQueue *regionQueue);


### PR DESCRIPTION
Main issue was that using metronome gc, a long pause occured when using large heap sizes. These changes address that issue.

- Added counters in both `LockingFreeHeapRegionList` and `LockingHeadRegionQueue`
- Counter is incremented by number of regions being added
- `LockingFreeHeapRegionList.cpp::getTotalRegions()` no longer has to iterate through a list to find count, as it just returns the count
- Reduces pause to only a few microseconds
- Removed a paramater in `RegionPoolSegregated::countFreeRegions` which unnecessarily traversed a list, whose value was not used
- addresses issue eclipse/openj9#4769

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>