### PR TITLE
Correct API comment for OMRSymbol constructor

### DIFF
--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -96,7 +96,8 @@ public:
 protected:
 
    /**
-    * Generic constructor, sets size to 0
+    * @brief Generic constructor for the creation of a new symbol.  The
+    *        size is set to 0.
     */
    Symbol() :
       _size(0),
@@ -107,14 +108,17 @@ protected:
    { }
 
    /**
-    * Create symbol of specified data type, inferring size
-    * from type.
+    * @brief Create symbol of specified data type, inferring the size
+    *        from the type.
+    * @param[in] d : TR::DataType of the new symbol
     */
    Symbol(TR::DataType d);
 
    /**
-    * Create symbol of specified data type, inferring size
-    * from type.
+    * @brief Create symbol of specified data type and specified size.
+    *
+    * @param[in] d : TR::DataType of the new symbol
+    * @param[in] size : size of new symbol
     */
    Symbol(TR::DataType d, uint32_t size);
 


### PR DESCRIPTION
The comment describing the API for the `Symbol(TR::DataType d, uint32_t size)`
constructor was incorrectly stating the size is inferred from the type.

Correct the text, and add Doxygen headers to all the OMRSymbol constructors.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>