### PR TITLE
Fix function calls of incRefCountForOpaquePseudoRegister in OpenJ9

### DIFF
--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1274,7 +1274,7 @@ void ArtificiallyInflateReferenceCountWhenNecessary(TR::MemoryReference * mr, co
             cg->incReferenceCount(nodeArray[i]);
 
             // Reference count is now 2.
-            cg->incRefCountForOpaquePseudoRegister(nodeArray[i], cg, comp);
+            cg->incRefCountForOpaquePseudoRegister(nodeArray[i]);
             }
          else
             {


### PR DESCRIPTION
This commit changes all `incRefCountForOpaquePseudoRegister`  function calls to the fewer parameter overload version, which was implemented in #3905 and eclipse/openJ9#5881. This commit is step 4 / 6.

Issue: #1855
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>