### PR TITLE
Disable on stack replacement (OSR) for AArch64

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1995,8 +1995,8 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
    if (_sampleInterval == 0) // sampleInterval==0 does make much sense
       _sampleInterval = 1;
 
-#if defined(TR_HOST_ARM)
-   // OSR is not available for ARM yet
+#if defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)
+   // OSR is not available for ARM or AArch64 yet
    self()->setOption(TR_DisableOSR);
    self()->setOption(TR_EnableOSR, false);
    self()->setOption(TR_EnableOSROnGuardFailure, false);


### PR DESCRIPTION
Complete support isn't ready yet.  Disabling until it is.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>