### PR TITLE
Remove getInternalPtrMapBit from OMR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -681,9 +681,6 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsTenuredObjectAlignment() { return false; }
    bool isObjectOfSizeWorthAligning(uint32_t size) { return false; }
 
-   // J9
-   int32_t getInternalPtrMapBit() { return 31;}
-
    uint32_t getMaxObjectSizeGuaranteedNotToOverflow() { return _maxObjectSizeGuaranteedNotToOverflow; }
 
    // --------------------------------------------------------------------------

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -413,8 +413,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    static uint32_t registerBitMask(int32_t reg);
 
-   int32_t getInternalPtrMapBit() { return 18;}
-
    int32_t getMaximumNumbersOfAssignableGPRs();
    int32_t getMaximumNumbersOfAssignableFPRs();
    int32_t getMaximumNumbersOfAssignableVRs();


### PR DESCRIPTION
This commit removes field `getInternalPtrMapBit` from OMR.

Closes: #1877
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>