### PR TITLE
Revert "Avoid looking up the NLS catalog in en locale's with default msg"

### DIFF
--- a/port/common/j9nls.c
+++ b/port/common/j9nls.c
@@ -385,15 +385,6 @@ j9nls_lookup_message(struct OMRPortLibrary *portLibrary, uintptr_t flags, uint32
 	omrthread_monitor_enter(nls->monitor);
 
 	if (!nls->catalog) {
-		/* Don't load the catalog if VM is running in an
-		 * english locale and there is a default message
-		 */
-		if (NULL != default_string) {
-			if (0 == strncmp(nls->language, "en", sizeof(nls->language))) {
-				message = default_string;
-				goto done;
-			}
-		}
 		open_catalog(portLibrary);
 	}
 
@@ -404,7 +395,7 @@ j9nls_lookup_message(struct OMRPortLibrary *portLibrary, uintptr_t flags, uint32
 			message = J9NLS_ERROR_MESSAGE(J9NLS_PORT_NLS_FAILURE, "NLS Failure\n");
 		}
 	}
-done:
+
 	omrthread_monitor_exit(nls->monitor);
 	return message;
 }


### PR DESCRIPTION
Reverts eclipse/omr#3912

I'd like to revert this change as it's causing problems for OpenJ9.  There seems to be an issue with OpenJ9's use of NLS default messages that is preventing new versions of OMR from being consumed.

I haven't been able to track down the root cause and would like to revert this while I continue to investigate.

Given NLS is a deprecated component in OMR, I'd appreciate willingness from the OMR community to temporarily revert this change.