### PR TITLE
Remove supportsTrapsInTMRegion from OMR

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1399,9 +1399,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    bool supportsLengthMinusOneForMemoryOpts() {return false;}
 
-   // Java, likely Z
-   bool supportsTrapsInTMRegion() { return true; }
-
    // Allows a platform code generator to assert that a particular node operation will use 64 bit values
    // that are not explicitly present in the node datatype.
    bool usesImplicit64BitGPRs(TR::Node *node) { return false; }

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -299,11 +299,6 @@ public:
 
    bool supportsLengthMinusOneForMemoryOpts() {return true;}
 
-   bool supportsTrapsInTMRegion()
-      {
-      return TR::Compiler->target.isZOS();
-      }
-
    bool inlineNDmemcpyWithPad(TR::Node * node, int64_t * maxLengthPtr = NULL);
    bool codegenSupportsLoadlessBNDCheck() {return TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12);}
    TR::Register *evaluateLengthMinusOneForMemoryOps(TR::Node *,  bool , bool &lenMinusOne);


### PR DESCRIPTION
Remove all the references to `supportsTrapsInTMRegion` from OMR as the
field has already been transferred to  OpenJ9.

Closes: #1868
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>