### PR TITLE
Group warmCodeAlloc/coldCodeAlloc into a struct

### DIFF
--- a/include_core/j9nongenerated.h
+++ b/include_core/j9nongenerated.h
@@ -212,6 +212,12 @@ typedef struct J9MemorySegmentList {
 	uintptr_t flags;
 } J9MemorySegmentList;
 
+
+typedef struct CodeCacheHeader {
+	uint8_t *warmCodeAlloc;
+	uint8_t *coldCodeAlloc;
+} CodeCacheHeader;
+
 #if defined(OMR_GC_REALTIME)
 
 typedef struct MM_GCRememberedSet {


### PR DESCRIPTION
This commit is supposed to slightly improve the readability of the code.
The VM code is 'blindly' fetching the first two words from a code cache
knowing that they represent `warmCodeAlloc` and `coldCodeAlloc`.
With this commit, the VM will define a CodeCacheHeader containing the
two words while the code cache will include this header.
Moreover, the code has been changed to replace all direct accesses of
`warmCodeAlloc` and `coldCodeAlloc` with getters/setters.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>