### PR TITLE
Re-apply "Avoid looking up the NLS catalog in en locale's with default msg"

### DIFF
--- a/port/common/j9nls.c
+++ b/port/common/j9nls.c
@@ -385,6 +385,15 @@ j9nls_lookup_message(struct OMRPortLibrary *portLibrary, uintptr_t flags, uint32
 	omrthread_monitor_enter(nls->monitor);
 
 	if (!nls->catalog) {
+		/* Don't load the catalog if VM is running in an
+		 * english locale and there is a default message
+		 */
+		if (NULL != default_string) {
+			if (0 == strncmp(nls->language, "en", sizeof(nls->language))) {
+				message = default_string;
+				goto done;
+			}
+		}
 		open_catalog(portLibrary);
 	}
 
@@ -395,7 +404,7 @@ j9nls_lookup_message(struct OMRPortLibrary *portLibrary, uintptr_t flags, uint32
 			message = J9NLS_ERROR_MESSAGE(J9NLS_PORT_NLS_FAILURE, "NLS Failure\n");
 		}
 	}
-
+done:
 	omrthread_monitor_exit(nls->monitor);
 	return message;
 }


### PR DESCRIPTION
Reverts eclipse/omr#3926 so that eclipse/omr#3912 is re-applied.

Issue with NLS users is fixed: https://github.com/eclipse/openj9/pull/5962