### PR TITLE
Merge FreeEntryAllocateStats after compaction

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -478,6 +478,9 @@ MM_ParallelGlobalGC::masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_Allo
 
 		masterThreadCompact(env, allocDescription, rebuildMarkBits);
 		_collectionStatistics._tenureFragmentation = NO_FRAGMENTATION;
+		if (_extensions->processLargeAllocateStats) {
+			processLargeAllocateStatsAfterCompact(env);
+		}
 	} else {
 		/* If a compaction was prevented, report the reason */
 		CompactPreventedReason compactPreventedReason = (CompactPreventedReason)(_extensions->globalGCStats.compactStats._compactPreventedReason);
@@ -1114,6 +1117,13 @@ MM_ParallelGlobalGC::processLargeAllocateStatsBeforeGC(MM_EnvironmentBase *env)
 		defaultMemorySubspace->getTopLevelMemorySubSpace(MEMORY_TYPE_NEW)->mergeLargeObjectAllocateStats(env);
 	}
 }
+
+void
+MM_ParallelGlobalGC::processLargeAllocateStatsAfterCompact(MM_EnvironmentBase *env)
+{
+	processLargeAllocateStatsAfterSweep(env);
+}
+
 
 void
 MM_ParallelGlobalGC::processLargeAllocateStatsAfterSweep(MM_EnvironmentBase *env)

--- a/gc/base/standard/ParallelGlobalGC.hpp
+++ b/gc/base/standard/ParallelGlobalGC.hpp
@@ -240,6 +240,12 @@ protected:
 	 */
 	virtual void processLargeAllocateStatsAfterSweep(MM_EnvironmentBase *env);
 
+	/**
+	 * compaction would change freeEntries stats, merge FreeEntryAllocateStats after compaction.
+	 * currently processLargeAllocateStatsAfterCompact() is same as processLargeAllocateStatsAfterSweep()
+	 */
+	void processLargeAllocateStatsAfterCompact(MM_EnvironmentBase *env);
+
 	virtual void postMark(MM_EnvironmentBase *env);
 
 	MM_ParallelSweepScheme*


### PR DESCRIPTION
	- FreeEntryAllocateStats has been updated after sweep,
	  but compaction would change freeEntries stats,
	  update FreeEntryAllocateStats after compaction.
       - the change would keep FreeEntryAllocateStats up to date,
          avoid potential trace error later.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>