### PR TITLE
Remove all uses of the ILOpcode: bucmpeq

### DIFF
--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -107,7 +107,6 @@ OMR::ILOpCode::compareOpCode(TR::DataType dt,
             {
             switch(ct)
                {
-               case TR_cmpEQ: return TR::bucmpeq;
                case TR_cmpNE: return TR::bucmpne;
                case TR_cmpLT: return TR::bucmplt;
                case TR_cmpLE: return TR::bucmple;

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -14011,7 +14011,6 @@ TR::Node *ifCmpWithEqualitySimplifier(TR::Node * node, TR::Block * block, TR::Si
       switch (opCode)
          {
          case TR::ifbcmpeq:
-         case TR::ifbucmpeq:
          case TR::ifscmpeq:
          case TR::ifsucmpeq:
             takeBranch = firstChild->get64bitIntegralValue() == secondChild->get64bitIntegralValue();

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -964,7 +964,6 @@ static TR::InstOpCode::Mnemonic cmp2branch(TR::ILOpCodes op, TR::CodeGenerator *
        case TR::dcmpeq:
        case TR::fcmpequ:
        case TR::dcmpequ:
-       case TR::bucmpeq:
        case TR::bcmpeq:
           return TR::InstOpCode::beq;
        case TR::icmpne:
@@ -1058,7 +1057,6 @@ static TR::InstOpCode::Mnemonic cmp2cmp(TR::ILOpCodes op, TR::CodeGenerator *cg)
        case TR::iucmpge:
        case TR::iucmpgt:
        case TR::iucmple:
-       case TR::bucmpeq:
        case TR::bucmpne:
        case TR::bucmplt:
        case TR::bucmpge:
@@ -1115,7 +1113,6 @@ static TR::InstOpCode::Mnemonic cmp2cmpi(TR::ILOpCodes op, TR::CodeGenerator *cg
        case TR::iucmpge:
        case TR::iucmpgt:
        case TR::iucmple:
-       case TR::bucmpeq:
        case TR::bucmpne:
        case TR::bucmplt:
        case TR::bucmpge:
@@ -1432,7 +1429,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
 
       TR::InstOpCode::Mnemonic opCode = (node->getOpCodeValue() == TR::ificmpeq || node->getOpCodeValue() == TR::ifiucmpeq ||
                               node->getOpCodeValue() == TR::ifscmpeq || node->getOpCodeValue() == TR::ifsucmpeq ||
-                              node->getOpCodeValue() == TR::ifbcmpeq || node->getOpCodeValue() == TR::ifbucmpeq)
+                              node->getOpCodeValue() == TR::ifbcmpeq)
          ? TR::InstOpCode::beq : TR::InstOpCode::bne;
       TR::LabelSymbol *label = node->getBranchDestination()->getNode()->getLabel();
 
@@ -1530,7 +1527,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
              bool newReg = false;
              uint64_t value = secondChild->get64bitIntegralValue();
 
-             if (node->getOpCodeValue() == TR::ifbucmpne || node->getOpCodeValue() == TR::ifbucmpeq)
+             if (node->getOpCodeValue() == TR::ifbucmpne)
                 {
                 tReg = cg->allocateRegister();
                 newReg = true;
@@ -1559,7 +1556,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
              TR::Register *tReg = NULL;
              bool newReg = false;
              TR::Register *secondReg = NULL;
-             if (node->getOpCodeValue() == TR::ifbucmpne || node->getOpCodeValue() == TR::ifbucmpeq)
+             if (node->getOpCodeValue() == TR::ifbucmpne)
                 {
                 tReg = cg->allocateRegister();
                 newReg = true;
@@ -1994,7 +1991,7 @@ TR::Register *handleSkipCompare(TR::Node * node, TR::InstOpCode::Mnemonic opcode
 
 
 // also handles acmpeq in 32-bit mode
-// and also: bcmpeq, bucmpeq, scmpeq, sucmpeq, iucmpeq
+// and also: bcmpeq, scmpeq, sucmpeq, iucmpeq
 TR::Register *OMR::Power::TreeEvaluator::icmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (skipCompare(node))

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1670,7 +1670,7 @@ TR::Register *OMR::X86::TreeEvaluator::unsignedIntegerIfCmpleEvaluator(TR::Node 
    }
 
 
-// also handles ifbcmpne, ifbucmpeq, ifbucmpne
+// also handles ifbcmpne, ifbucmpne
 TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 
@@ -1754,7 +1754,7 @@ TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::Cod
       }
 
    TR_X86OpCodes opCode;
-   if (node->getOpCodeValue() == TR::ifbcmpeq || node->getOpCodeValue() == TR::ifbucmpeq)
+   if (node->getOpCodeValue() == TR::ifbcmpeq)
       opCode = reverseBranch ? JNE4 : JE4;
    else
       opCode = reverseBranch ? JE4 : JNE4;
@@ -1765,7 +1765,6 @@ TR::Register *OMR::X86::TreeEvaluator::ifbcmpeqEvaluator(TR::Node *node, TR::Cod
 
 // ifbcmpneEvaluator handled by ifbcmpeqEvaluator
 // ifbucmpneEvaluator handled by ifbcmpeqEvaluator
-// ifbucmpeqEvaluator handled by ifbcmpeqEvaluator
 
 TR::Register *OMR::X86::TreeEvaluator::ifbcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
@@ -2072,7 +2071,7 @@ TR::Register *OMR::X86::TreeEvaluator::bcmpeqEvaluator(TR::Node *node, TR::CodeG
       TR_X86CompareAnalyser  temp(cg);
       temp.integerCompareAnalyser(node, CMP1RegReg, CMP1RegMem, CMP1MemReg);
       }
-   bool isEq = node->getOpCodeValue() == TR::bcmpeq || node->getOpCodeValue() == TR::bucmpeq;
+   bool isEq = node->getOpCodeValue() == TR::bcmpeq;
    generateRegInstruction(isEq ? SETE1Reg : SETNE1Reg,
                           node, targetRegister, cg);
    generateRegRegInstruction(MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1155,7 +1155,7 @@ OMR::Z::TreeEvaluator::ifacmpneEvaluator(TR::Node * node, TR::CodeGenerator * cg
 TR::Register *
 OMR::Z::TreeEvaluator::ifbcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (node->getOpCodeValue() == TR::ifbcmpeq || node->getOpCodeValue() == TR::ifbucmpeq)
+   if (node->getOpCodeValue() == TR::ifbcmpeq)
       {
       return generateS390CompareBranch(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
       }
@@ -1523,7 +1523,7 @@ OMR::Z::TreeEvaluator::acmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 TR::Register *
 OMR::Z::TreeEvaluator::bcmpeqEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
-   if (node->getOpCodeValue() == TR::bcmpeq || node->getOpCodeValue() == TR::bucmpeq)
+   if (node->getOpCodeValue() == TR::bcmpeq)
       {
       return generateS390CompareBool(node, cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, TR::InstOpCode::COND_BE);
       }

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -398,7 +398,6 @@ unsignedCompareSignatureCharJJ_I_testMethodType  * OpCodesTest::_luCmplt = 0;
 unsignedCompareSignatureCharJJ_I_testMethodType  * OpCodesTest::_luCmpge = 0;
 unsignedCompareSignatureCharJJ_I_testMethodType  * OpCodesTest::_luCmpgt = 0;
 unsignedCompareSignatureCharJJ_I_testMethodType  * OpCodesTest::_luCmple = 0;
-unsignedCompareSignatureCharBB_I_testMethodType  * OpCodesTest::_buCmpeq = 0;
 unsignedCompareSignatureCharBB_I_testMethodType  * OpCodesTest::_buCmpne = 0;
 unsignedCompareSignatureCharBB_I_testMethodType  * OpCodesTest::_buCmplt = 0;
 unsignedCompareSignatureCharBB_I_testMethodType  * OpCodesTest::_buCmpge = 0;
@@ -466,7 +465,6 @@ unsignedCompareSignatureCharJJ_I_testMethodType * OpCodesTest::_ifLuCmplt = 0;
 unsignedCompareSignatureCharJJ_I_testMethodType * OpCodesTest::_ifLuCmpge = 0;
 unsignedCompareSignatureCharJJ_I_testMethodType * OpCodesTest::_ifLuCmpgt = 0;
 unsignedCompareSignatureCharJJ_I_testMethodType * OpCodesTest::_ifLuCmple = 0;
-unsignedCompareSignatureCharBB_I_testMethodType * OpCodesTest::_ifBuCmpeq = 0;
 unsignedCompareSignatureCharBB_I_testMethodType * OpCodesTest::_ifBuCmpne = 0;
 unsignedCompareSignatureCharBB_I_testMethodType * OpCodesTest::_ifBuCmplt = 0;
 unsignedCompareSignatureCharBB_I_testMethodType * OpCodesTest::_ifBuCmpge = 0;

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -724,7 +724,6 @@ class OpCodesTest : public TestDriver
    static unsignedCompareSignatureCharJJ_I_testMethodType *_luCmpge;
    static unsignedCompareSignatureCharJJ_I_testMethodType *_luCmpgt;
    static unsignedCompareSignatureCharJJ_I_testMethodType *_luCmple;
-   static unsignedCompareSignatureCharBB_I_testMethodType *_buCmpeq;
    static unsignedCompareSignatureCharBB_I_testMethodType *_buCmpne;
    static unsignedCompareSignatureCharBB_I_testMethodType *_buCmplt;
    static unsignedCompareSignatureCharBB_I_testMethodType *_buCmpge;
@@ -792,7 +791,6 @@ class OpCodesTest : public TestDriver
    static unsignedCompareSignatureCharJJ_I_testMethodType *_ifLuCmpge;
    static unsignedCompareSignatureCharJJ_I_testMethodType *_ifLuCmpgt;
    static unsignedCompareSignatureCharJJ_I_testMethodType *_ifLuCmple;
-   static unsignedCompareSignatureCharBB_I_testMethodType *_ifBuCmpeq;
    static unsignedCompareSignatureCharBB_I_testMethodType *_ifBuCmpne;
    static unsignedCompareSignatureCharBB_I_testMethodType *_ifBuCmplt;
    static unsignedCompareSignatureCharBB_I_testMethodType *_ifBuCmpge;

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -123,7 +123,6 @@ PPCOpCodesTest::compileCompareTestMethods()
    compileOpCodeMethod(_ifBcmpeq, _numberOfBinaryArgs, TR::ifbcmpeq, "ifBcmpeq", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBcmpgt, _numberOfBinaryArgs, TR::ifbcmpgt, "ifBcmpgt", _argTypesBinaryByte, TR::Int32, rc);
 
-   compileOpCodeMethod(_ifBuCmpeq, _numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmpne, _numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmplt, _numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmpge, _numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc);
@@ -698,14 +697,6 @@ PPCOpCodesTest::invokeCompareTests()
          UINT_MAXIMUM, UINT_MAXIMUM,
          UINT_POS, UINT_MINIMUM,
          UINT_MINIMUM, UINT_POS
-         };
-   uint8_t ifBuCmpeqDataArr[][2] =
-         {
-         UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_POS,
-         UBYTE_MAXIMUM, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_MAXIMUM,
-         UBYTE_MAXIMUM, UBYTE_MAXIMUM
          };
    uint8_t ifBuCmpneDataArr[][2] =
          {
@@ -1342,28 +1333,7 @@ PPCOpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
       }
 
-   //ifBuCompare equal and not equal
-   testCaseNum = sizeof(ifBuCmpeqDataArr) / sizeof(ifBuCmpeqDataArr[0]);
-   for(uint32_t i = 0; i < testCaseNum; ++i)
-      {
-      OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
-      }
-
+   //ifBuCompare not equal
    testCaseNum = sizeof(ifBuCmpneDataArr) / sizeof(ifBuCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
@@ -2661,7 +2631,6 @@ PPCOpCodesTest::compileDisabledCompareTestMethods()
    compileOpCodeMethod(_bCmplt, _numberOfBinaryArgs, TR::bcmplt, "bCmplt", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_bCmpge, _numberOfBinaryArgs, TR::bcmpge, "bCmpge", _argTypesBinaryByte, TR::Int32, rc);
 
-   compileOpCodeMethod(_buCmpeq, _numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_buCmpne, _numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc);
 
    compileOpCodeMethod(_lCmp, _numberOfBinaryArgs, TR::lcmp, "lCmp", _argTypesBinaryLong, TR::Int32, rc);
@@ -2953,14 +2922,6 @@ PPCOpCodesTest::invokeDisabledCompareTests()
          {
          BYTE_POS, BYTE_MAXIMUM,
          BYTE_MAXIMUM, BYTE_POS
-         };
-   uint8_t buCmpeqDataArr[][2] =
-         {
-         UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_POS,
-         UBYTE_MAXIMUM, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_MAXIMUM,
-         UBYTE_MAXIMUM, UBYTE_MAXIMUM
          };
    uint8_t buCmpneDataArr[][2] =
          {
@@ -3893,28 +3854,7 @@ PPCOpCodesTest::invokeDisabledCompareTests()
       OMR_CT_EXPECT_EQ(bCompareConst, compareGE(ifBcmpgeDataArr[i][0], ifBcmpgeDataArr[i][1]), bCompareConst(ifBcmpgeDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
-   //buCompare equal and not-equal
-   testCaseNum = sizeof(buCmpeqDataArr) / sizeof(buCmpeqDataArr[0]);
-   for(uint32_t i = 0; i < testCaseNum; ++i)
-      {
-      OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
-      }
-
+   //buCompare not-equal
    testCaseNum = sizeof(buCmpneDataArr) / sizeof(buCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2301,7 +2301,6 @@ S390OpCodesTest::compileDisabledCompareOpCodesTestMethods()
    compileOpCodeMethod(_iuCmpne, _numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc);
    compileOpCodeMethod(_iuCmpge, _numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc);
 
-   compileOpCodeMethod(_buCmpeq, _numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_buCmpne, _numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc);
 
    compileOpCodeMethod(_suCmpeq, _numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc);
@@ -2327,7 +2326,7 @@ S390OpCodesTest::compileDisabledCompareOpCodesTestMethods()
    compileOpCodeMethod(_ifBcmpge, _numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBcmple, _numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc);
 
-   compileOpCodeMethod(_ifBuCmpeq, _numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc);
+
    compileOpCodeMethod(_ifBuCmpne, _numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmplt, _numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmpge, _numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc);
@@ -2429,14 +2428,6 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
          UINT_POS, UINT_MINIMUM,
          UINT_MINIMUM, UINT_POS
          };
-   uint8_t buCmpeqDataArr[][2] =
-         {
-         UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_POS,
-         UBYTE_MAXIMUM, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_MAXIMUM,
-         UBYTE_MAXIMUM, UBYTE_MAXIMUM
-         };
    uint8_t buCmpneDataArr[][2] =
          {
          UBYTE_MAXIMUM, UBYTE_POS,
@@ -2504,14 +2495,6 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
          {
          BYTE_MINIMUM, BYTE_NEG,
          BYTE_NEG, BYTE_MINIMUM
-         };
-   uint8_t ifBuCmpeqDataArr[][2] =
-         {
-         UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_POS,
-         UBYTE_MAXIMUM, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_MAXIMUM,
-         UBYTE_MAXIMUM, UBYTE_MAXIMUM
          };
    uint8_t ifBuCmpneDataArr[][2] =
          {
@@ -2939,28 +2922,6 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
-   //buCompare
-   testCaseNum = sizeof(buCmpeqDataArr) / sizeof(buCmpeqDataArr[0]);
-   for(uint32_t i = 0; i < testCaseNum; ++i)
-      {
-      OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
-      }
-
    testCaseNum = sizeof(buCmpneDataArr) / sizeof(buCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
@@ -3361,28 +3322,6 @@ S390OpCodesTest::invokeDisabledCompareOpCodesTests()
       compileOpCodeMethod(bCompareConst, 
             _numberOfBinaryArgs, TR::ifbcmple, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBcmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(bCompareConst, compareLE(ifBcmpleDataArr[i][0], ifBcmpleDataArr[i][1]), bCompareConst(ifBcmpleDataArr[i][0], BYTE_PLACEHOLDER_2));
-      }
-
-   //ifBuCompare
-   testCaseNum = sizeof(ifBuCmpeqDataArr) / sizeof(ifBuCmpeqDataArr[0]);
-   for(uint32_t i = 0; i < testCaseNum; ++i)
-      {
-      OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst, 
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpneDataArr) / sizeof(ifBuCmpneDataArr[0]);

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -218,7 +218,6 @@ X86OpCodesTest::compileCompareTestMethods()
    compileOpCodeMethod(_iuCmpne, _numberOfBinaryArgs, TR::iucmpne, "iuCmpne", _argTypesBinaryInt, TR::Int32, rc);
    compileOpCodeMethod(_iuCmpge, _numberOfBinaryArgs, TR::iucmpge, "iuCmpge", _argTypesBinaryInt, TR::Int32, rc);
 
-   compileOpCodeMethod(_buCmpeq, _numberOfBinaryArgs, TR::bucmpeq, "buCmpeq", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_buCmpne, _numberOfBinaryArgs, TR::bucmpne, "buCmpne", _argTypesBinaryByte, TR::Int32, rc);
 
    compileOpCodeMethod(_suCmpeq, _numberOfBinaryArgs, TR::sucmpeq, "suCmpeq", _argTypesBinaryShort, TR::Int32, rc);
@@ -268,8 +267,6 @@ X86OpCodesTest::compileCompareTestMethods()
    compileOpCodeMethod(_ifBcmpge, _numberOfBinaryArgs, TR::ifbcmpge, "ifBcmpge", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBcmple, _numberOfBinaryArgs, TR::ifbcmple, "ifBcmple", _argTypesBinaryByte, TR::Int32, rc);
 
-
-   compileOpCodeMethod(_ifBuCmpeq, _numberOfBinaryArgs, TR::ifbucmpeq, "ifBuCmpeq", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmpne, _numberOfBinaryArgs, TR::ifbucmpne, "ifBuCmpne", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmplt, _numberOfBinaryArgs, TR::ifbucmplt, "ifBuCmplt", _argTypesBinaryByte, TR::Int32, rc);
    compileOpCodeMethod(_ifBuCmpge, _numberOfBinaryArgs, TR::ifbucmpge, "ifBuCmpge", _argTypesBinaryByte, TR::Int32, rc);
@@ -2247,28 +2244,12 @@ X86OpCodesTest::invokeCompareTests()
          UINT_MINIMUM, UINT_POS
          };
 
-   uint8_t buCmpeqDataArr[][2] =
-         {
-         UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_POS,
-         UBYTE_MAXIMUM, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_MAXIMUM,
-         UBYTE_MAXIMUM, UBYTE_MAXIMUM
-         };
    uint8_t buCmpneDataArr[][2] =
          {
          UBYTE_MAXIMUM, UBYTE_POS,
          UBYTE_POS, UBYTE_MAXIMUM,
          UBYTE_MINIMUM, UBYTE_POS,
          UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MAXIMUM, UBYTE_MAXIMUM
-         };
-   uint8_t ifBuCmpeqDataArr[][2] =
-         {
-         UBYTE_POS, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_POS,
-         UBYTE_MAXIMUM, UBYTE_MINIMUM,
-         UBYTE_MINIMUM, UBYTE_MAXIMUM,
          UBYTE_MAXIMUM, UBYTE_MAXIMUM
          };
    uint8_t ifBuCmpneDataArr[][2] =
@@ -3692,28 +3673,7 @@ X86OpCodesTest::invokeCompareTests()
       OMR_CT_EXPECT_EQ(iuCompareConst, compareGE(iuCmpgeDataArr[i][0], iuCmpgeDataArr[i][1]), iuCompareConst(iuCmpgeDataArr[i][0], INT_PLACEHOLDER_2));
       }
 
-   //buCompare equal and not-equal
-   testCaseNum = sizeof(buCmpeqDataArr) / sizeof(buCmpeqDataArr[0]);
-   for(uint32_t i = 0; i < testCaseNum; ++i)
-      {
-      OMR_CT_EXPECT_EQ(_buCmpeq, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), _buCmpeq(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "buCmpeqConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst,
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(buCmpeqDataArr[i][0]), 2, &(buCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "buCmpeqConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst,
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(buCmpeqDataArr[i][0]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, buCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "buCmpeqConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst,
-            _numberOfBinaryArgs, TR::bucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(buCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(buCmpeqDataArr[i][0], buCmpeqDataArr[i][1]), buCompareConst(buCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
-      }
-
+   //buCompare not-equal
    testCaseNum = sizeof(buCmpneDataArr) / sizeof(buCmpneDataArr[0]);
    for(uint32_t i = 0; i < testCaseNum; ++i)
       {
@@ -3860,28 +3820,6 @@ X86OpCodesTest::invokeCompareTests()
       compileOpCodeMethod(suCompareConst,
             _numberOfBinaryArgs, TR::sucmple, resolvedMethodName, _argTypesBinaryShort, TR::Int32, rc, 2, 2, &(suCmpleDataArr[i][1]));
       OMR_CT_EXPECT_EQ(suCompareConst, compareLE(suCmpleDataArr[i][0], suCmpleDataArr[i][1]), suCompareConst(suCmpleDataArr[i][0], SHORT_PLACEHOLDER_2)) << suCmpleDataArr[i][0] << " : " << suCmpleDataArr[i][1];
-      }
-
-   //ifBuCompare
-   testCaseNum = sizeof(ifBuCmpeqDataArr) / sizeof(ifBuCmpeqDataArr[0]);
-   for(uint32_t i = 0; i < testCaseNum; ++i)
-      {
-      OMR_CT_EXPECT_EQ(_ifBuCmpeq, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), _ifBuCmpeq(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst,
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 4, 1, &(ifBuCmpeqDataArr[i][0]), 2, &(ifBuCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst,
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 1, &(ifBuCmpeqDataArr[i][0]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(BYTE_PLACEHOLDER_1, ifBuCmpeqDataArr[i][1]));
-
-      sprintf(resolvedMethodName, "ifBuCmpeqConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(buCompareConst,
-            _numberOfBinaryArgs, TR::ifbucmpeq, resolvedMethodName, _argTypesBinaryByte, TR::Int32, rc, 2, 2, &(ifBuCmpeqDataArr[i][1]));
-      OMR_CT_EXPECT_EQ(buCompareConst, compareEQ(ifBuCmpeqDataArr[i][0], ifBuCmpeqDataArr[i][1]), buCompareConst(ifBuCmpeqDataArr[i][0], BYTE_PLACEHOLDER_2));
       }
 
    testCaseNum = sizeof(ifBuCmpneDataArr) / sizeof(ifBuCmpneDataArr[0]);

--- a/fvtest/compilertest/tests/injectors/OpIlInjector.cpp
+++ b/fvtest/compilertest/tests/injectors/OpIlInjector.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -192,7 +192,6 @@ OpIlInjector::setDataType()
          case TR::bcmpge:
          case TR::bcmpgt:
          case TR::bcmple:
-         case TR::bucmpeq:
          case TR::bucmpne:
          case TR::bucmplt:
          case TR::bucmpge:
@@ -204,7 +203,6 @@ OpIlInjector::setDataType()
          case TR::ifbcmpge:
          case TR::ifbcmpgt:
          case TR::ifbcmple:
-         case TR::ifbucmpeq:
          case TR::ifbucmpne:
          case TR::ifbucmplt:
          case TR::ifbucmpge:


### PR DESCRIPTION
Removes all uses to the ILOpcode: `bucmpeq`. The definitions and initializations in the lists remains. If this commit merges successfully, then we can remove the uses of all the Opcodes in `Equality compare` category at the same time. 

Issue:#2657
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>