### PR TITLE
Remove old version of incRefCountForOpaquePseudoRegister

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -468,9 +468,6 @@ class OMR_EXTENSIBLE CodeGenerator
    rcount_t recursivelyDecReferenceCount(TR::Node*node);
    void evaluateChildrenWithMultipleRefCount(TR::Node*node);
 
-   
-   void incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp) {}
-   //OVERLOAD THE ABOVE FUNCTION:
    void incRefCountForOpaquePseudoRegister(TR::Node * node) {}
 
    void startUsingRegister(TR::Register *reg);


### PR DESCRIPTION
Removes the old version of the function `incRefCountForOpaquePseudoRegister` from OMR. This is the last commit to simpify `incRefCountForOpaquePseudoRegister(TR::Node * node, TR::CodeGenerator * cg, TR::Compilation * comp)`  to `void incRefCountForOpaquePseudoRegister(TR::Node * node)` . 

Issue:#1855
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>