### PR TITLE
Simplifying function calls of TR_S390Peephole in OMR

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2039,14 +2039,14 @@ OMR::Z::CodeGenerator::deleteInst(TR::Instruction* old)
 void
 OMR::Z::CodeGenerator::doPreRAPeephole()
    {
-   TR_S390PreRAPeephole ph(self()->comp(), self());
+   TR_S390PreRAPeephole ph(self()->comp());
    ph.perform();
    }
 
 void
 OMR::Z::CodeGenerator::doPostRAPeephole()
    {
-   TR_S390PostRAPeephole ph(self()->comp(), self());
+   TR_S390PostRAPeephole ph(self()->comp());
    ph.perform();
    }
 

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -52,16 +52,16 @@
 #include "z/codegen/S390OutOfLineCodeSection.hpp"
 #include "z/codegen/SystemLinkage.hpp"
 
-TR_S390Peephole::TR_S390Peephole(TR::Compilation* comp, TR::CodeGenerator *cg)
+TR_S390Peephole::TR_S390Peephole(TR::Compilation* comp)
    : _fe(comp->fe()),
      _outFile(comp->getOutFile()),
-     _cursor(cg->getFirstInstruction()),
-     _cg(cg)
+     _cursor(comp->cg()->getFirstInstruction()),
+     _cg(comp->cg())
    {
    }
 
-TR_S390PreRAPeephole::TR_S390PreRAPeephole(TR::Compilation* comp, TR::CodeGenerator *cg)
-   : TR_S390Peephole(comp, cg)
+TR_S390PreRAPeephole::TR_S390PreRAPeephole(TR::Compilation* comp)
+   : TR_S390Peephole(comp)
    {
    }
 
@@ -261,8 +261,8 @@ TR::Instruction* realInstructionWithLabelsAndRET(TR::Instruction* inst, bool for
 
 ///////////////////////////////////////////////////////////////////////////////
 
-TR_S390PostRAPeephole::TR_S390PostRAPeephole(TR::Compilation* comp, TR::CodeGenerator *cg)
-   : TR_S390Peephole(comp, cg)
+TR_S390PostRAPeephole::TR_S390PostRAPeephole(TR::Compilation* comp)
+   : TR_S390Peephole(comp)
    {
    }
 

--- a/compiler/z/codegen/S390Peephole.hpp
+++ b/compiler/z/codegen/S390Peephole.hpp
@@ -31,7 +31,7 @@
 class TR_S390Peephole
    {
 public:
-   TR_S390Peephole(TR::Compilation* comp, TR::CodeGenerator *cg);
+   TR_S390Peephole(TR::Compilation* comp);
 
 protected:
    void printInfo(const char* info)
@@ -68,7 +68,7 @@ protected:
 class TR_S390PreRAPeephole : private TR_S390Peephole
    {
 public:
-   TR_S390PreRAPeephole(TR::Compilation* comp, TR::CodeGenerator *cg);
+   TR_S390PreRAPeephole(TR::Compilation* comp);
 
    void perform();
 
@@ -92,7 +92,7 @@ private:
 class TR_S390PostRAPeephole : private TR_S390Peephole
    {
 public:
-   TR_S390PostRAPeephole(TR::Compilation* , TR::CodeGenerator *);
+   TR_S390PostRAPeephole(TR::Compilation* comp);
 
    void perform();
 


### PR DESCRIPTION
Simplifying function calls of `TR_S390Peephole`, `TR_S390PostRAPeephole` and
`TR_S390RreRAPeephole`. They now require `TR::Compilation* comp` as the only 1 argument. This will close #1855 as there is no more function that passes both `cg` and `comp` at the same time.

Closes: #1855
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>