### PR TITLE
Improve compactNULLCHKs

### DIFF
--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -2025,7 +2025,15 @@ void TR_CompactNullChecks::compactNullChecks(TR::Block *block, TR_BitVector *wri
       if (prevNode->getOpCodeValue() == TR::BBStart)
          {
          block = prevNode->getBlock();
-              exitTree = block->getExit();
+         exitTree = block->getExit();
+         TR::Block *blockItr = block->getNextBlock();
+         while (blockItr && blockItr->isExtensionOfPreviousBlock())
+            {
+            if (blockItr->getPrevBlock()->getSuccessors().size() != 1)
+               break;
+            exitTree = blockItr->getExit();
+            blockItr = blockItr->getNextBlock();
+            }
          }
       if (block->isOSRInduceBlock() || block->isOSRCatchBlock() || block->isOSRCodeBlock())
          return;
@@ -2095,7 +2103,7 @@ void TR_CompactNullChecks::compactNullChecks(TR::Block *block, TR_BitVector *wri
          writtenSymbols->empty();
          bool replacedNullCheck = false;
          bool compactionDone = false;
-         while (cursorTreeTop != exitTree)
+         while (cursorTreeTop != exitTree && cursorTreeTop->getNode()->getOpCodeValue() != TR::BBEnd)
             {
             TR::Node *cursorNode = cursorTreeTop->getNode();
             replacedNullCheck = replaceNullCheckIfPossible(cursorNode, objectRef, prevNode,
@@ -2138,6 +2146,9 @@ bool TR_CompactNullChecks::replacePassThroughIfPossible(TR::Node *currentNode, T
       return false;
 
    currentNode->setVisitCount(visitCount);
+
+   if (currentNode->isNopableInlineGuard())
+      return false;
 
    int32_t i = 0;
    for (i = 0; i < currentNode->getNumChildren(); ++i)

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -16423,6 +16423,15 @@ TR::Node *nullchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
                 s->_blockRemoved |= cfg->removeEdge(*edge);
              }
           }
+       else if (node->getOpCodeValue() == TR::NULLCHK
+                && !node->getFirstChild()->getOpCode().isLikeDef()
+                && node->getFirstChild()->exceptionsRaised() == 0
+                && node->getFirstChild()->getReferenceCount() == 1
+                && node->getFirstChild()->getNumChildren() == 1
+                && performTransformation(s->comp(), "%sNULLCHK passthrough simplification on n%dn\n", s->optDetailString(), node->getGlobalIndex()))
+          {
+          TR::Node::recreate(node->getFirstChild(), TR::PassThrough);
+          }
        }
    return node;
    }


### PR DESCRIPTION
This change does two things: (1) when we find a NULLCHK with a first
child that has reference count 1 - turn that node into a PassThrough to
provide an opportunity for something more useful to move up under the
NULLCHK and (2) allow compactNULLCKs to cross block boundaries when the
two blocks are in treetop order and are in a single predecessor to
single successor relationship (eg the break is due to exception edges or
similar.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>