### PR TITLE
Concurrent Mark kickoff with Concurrent Scavenger

### DIFF
--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1824,7 +1824,7 @@ MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentBase *env, MM_AllocateDescript
 		MM_ScavengerStats *scavengerStats = &_extensions->scavengerStats;
 
 		/* Have we done at least 1 scavenge ? If not no statistics available so return high values */
-		if (0 == scavengerStats->_gcCount) {
+		if (!scavengerStats->isAvailable(env)) {
 			return (uintptr_t)-1;
 		}
 #if defined(OMR_GC_LARGE_OBJECT_AREA)

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -195,3 +195,13 @@ MM_ScavengerStats::clear(bool firstIncrement)
 	memset(_copy_distance_counts, 0, sizeof(_copy_distance_counts));
 	memset(_copy_cachesize_counts, 0, sizeof(_copy_cachesize_counts));
 }
+
+bool
+MM_ScavengerStats::isAvailable(MM_EnvironmentBase *env) {
+	if (env->getExtensions()->isConcurrentScavengerEnabled()) {
+		/* with CS, we count STW increments (2 per each cycle) */
+		return (_gcCount > 1);
+	} else {
+		return (_gcCount > 0);
+	}
+}

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -224,6 +224,12 @@ public:
 	}
 
 	void clear(bool firstIncrement);
+	
+	/**
+	 * @return true if at least one full Scavenge cycle is complete (stats are calculated once, at the end of each cycle)
+	 */
+	bool isAvailable(MM_EnvironmentBase *env);
+	
 	MM_ScavengerStats();
 
 	struct FlipHistory* getFlipHistory(uintptr_t lookback);


### PR DESCRIPTION
Normally, we prevent CM kickoff logic before Scavenge Stat info is
available (survival rate, allocate space size....). In presence of CS,
we incorrectly conclude that first Scavenge cycle is complete (while
only the first STW increment is complete) and proceed with incomplete
data to kickoff math. This indirectly may lead to premature and too
frequent kickoff.

This problem is only visible when CM concurrentSlack option is provided
with high values.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>