### PR TITLE
Allocation deviation boost in CS

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -453,6 +453,7 @@ public:
 	uintptr_t concurrentScavengerBackgroundThreads; /**< number of background GC threads during concurrent phase of Scavenge */
 	bool concurrentScavengerBackgroundThreadsForced; /**< true if concurrentScavengerBackgroundThreads set via command line option */
 	uintptr_t concurrentScavengerSlack; /**< amount of bytes added on top of avearge allocated bytes during concurrent cycle, in calcualtion for survivor size */
+	float concurrentScavengerAllocDeviationBoost; /**< boost factor for allocate rate and its deviation, used for tilt calcuation in Concurrent Scavenger */
 #endif	/* OMR_GC_CONCURRENT_SCAVENGER */
 	uintptr_t scavengerFailedTenureThreshold;
 	uintptr_t maxScavengeBeforeGlobal;
@@ -1460,6 +1461,7 @@ public:
 		, concurrentScavengerBackgroundThreads(1)
 		, concurrentScavengerBackgroundThreadsForced(false)
 		, concurrentScavengerSlack(0)
+		, concurrentScavengerAllocDeviationBoost(2.0)
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 		, scavengerFailedTenureThreshold(0)
 		, maxScavengeBeforeGlobal(0)

--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -81,6 +81,8 @@ private:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	uintptr_t _bytesAllocatedDuringConcurrent;
 	uintptr_t _avgBytesAllocatedDuringConcurrent;
+	float _deviationBytesAllocatedDuringConcurrent;
+	float _avgDeviationBytesAllocatedDuringConcurrent;
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
 	MM_LargeObjectAllocateStats *_largeObjectAllocateStats; /**< Approximate allocation profile for large objects. Struct to keep merged stats from two allocate pools */
@@ -192,6 +194,8 @@ public:
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)		
 		,_bytesAllocatedDuringConcurrent(0)
 		,_avgBytesAllocatedDuringConcurrent(0)
+		,_deviationBytesAllocatedDuringConcurrent(0)
+		,_avgDeviationBytesAllocatedDuringConcurrent(0)
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */ 		
 	{
 		_typeId = __FUNCTION__;


### PR DESCRIPTION
When calculating tilt ratio in Concurrent Scavenger, allocation rate is
taken into account (beside Nursery flipping rate), since during active
CS cycle allocation is fed from common allocate/survivor space.

Allocate rate can vary a lot (more than flipping rate). So far, we
compensated the variability by boosting the average allocate rate by
fixed 20%. Real life variability could be much larger.

We now track deviations in allocation rate from the average, and use
this parameter to more precisely boost the allocation rate provided to
the tilt math.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>