### PR TITLE
Use symRef with known obj index for known parms

### DIFF
--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -597,7 +597,8 @@ void TR_ResolvedMethod::makeParameterList(TR::ResolvedMethodSymbol *methodSym)
       }
    else
       {
-      parmSymbol = methodSym->comp()->getSymRefTab()->createParameterSymbol(methodSym, 0, TR::Address);
+      TR::KnownObjectTable::Index knownObjectIndex = methodSym->getKnownObjectIndexForParm(0);
+      parmSymbol = methodSym->comp()->getSymRefTab()->createParameterSymbol(methodSym, 0, TR::Address, knownObjectIndex);
       parmSymbol->setOrdinal(ordinal++);
 
       int32_t len = classNameLen; // len is passed by reference and changes during the call

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.cpp
@@ -2488,6 +2488,13 @@ void OMR::ResolvedMethodSymbol::clearProfilingOffsetInfo()
    _bytecodeProfilingOffsets.clear();
    }
 
+
+TR::KnownObjectTable::Index
+OMR::ResolvedMethodSymbol::getKnownObjectIndexForParm(int32_t ordinal)
+   {
+   return TR::KnownObjectTable::UNKNOWN;
+   }
+
 //Explicit instantiations
 
 template TR::ResolvedMethodSymbol * OMR::ResolvedMethodSymbol::create(TR_StackMemory m, TR_ResolvedMethod * rm, TR::Compilation * comp);

--- a/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/symbol/OMRResolvedMethodSymbol.hpp
@@ -130,6 +130,14 @@ public:
 
    void addVariableSizeSymbol(TR::AutomaticSymbol *s);
 
+   /*
+    * \brief Get known object index of a parameter if there is any known object information available
+    *
+    * \parm ordinal
+    *     the ordinal of a parameter including the receiver if the method is a virtual method
+    */
+   TR::KnownObjectTable::Index getKnownObjectIndexForParm(int32_t ordinal);
+
    mcount_t            getResolvedMethodIndex() { return _methodIndex; }
    TR_ResolvedMethod * getResolvedMethod()      { return _resolvedMethod; }
 


### PR DESCRIPTION
If known object information is avaible for the method receiver, use
known object index to create the parm symbol reference. Optimizations
can make use of the info without running global VP which is very
expensive and doesn't kick in at warm.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>