### PR TITLE
Deep Structure Scan Optimization

### DIFF
--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -148,6 +148,8 @@ public:
 
 	uintptr_t _oolTraceAllocationBytes; /**< Tracks the bytes allocated since the last ool object trace */
 
+	uintptr_t approxScanCacheCount; /**< Local copy of approximate entries in global Cache Scan List. Updated upon allocation of new cache. */
+
 	MM_Validator *_activeValidator; /**< Used to identify and report crashes inside Validators */
 
 	MM_MarkStats _markStats;
@@ -640,6 +642,7 @@ public:
 		,_slaveThreadCpuTimeNanos(0)
 		,_freeEntrySizeClassStats()
 		,_oolTraceAllocationBytes(0)
+		,approxScanCacheCount(0)
 		,_activeValidator(NULL)
 		,_lastSyncPointReached(NULL)
 #if defined(OMR_GC_SEGREGATED_HEAP)
@@ -691,6 +694,7 @@ public:
 		,_slaveThreadCpuTimeNanos(0)
 		,_freeEntrySizeClassStats()
 		,_oolTraceAllocationBytes(0)
+		,approxScanCacheCount(0)
 		,_activeValidator(NULL)
 		,_lastSyncPointReached(NULL)
 #if defined(OMR_GC_SEGREGATED_HEAP)


### PR DESCRIPTION
See https://github.com/eclipse/openj9/issues/6060 for background and results

* deepScan routine introduced to "special treat" objects with self referencing fields (fast traversal of deep structure nodes)
    * Split into two functions `deepScan` and `deepScanOutline`. Frequently called checks _(see lazy start check below)_ must be inlined
    * `deepScanOutline` scans self referencing field of an object follows it and repeats. If it can't follow through in one direction, it will attempt to use the second self referencing field (e.g., the next and previous pointes of double linked lists)
* Lazy Start condition used for gatekeeping - inhibit the special treatment routine with relatively high probability to skip over most false positives (shorter lists), while only marginally delay detection of very deep structures
    *  Lazy Start check (`(uintptr_t)objectPtr & 0xF0) == 0`) for probability 1/16 to special treat
* `approxScanCacheCount` added to Environment to have a thread local copy which is required for checking throttling condition, optimization to avoid overflow of the free list
    * If free list is utilized more than 50% deep scan is terminated