### PR TITLE
Remove expensive CS assert

### DIFF
--- a/gc/base/MarkingScheme.cpp
+++ b/gc/base/MarkingScheme.cpp
@@ -22,7 +22,6 @@
 
 #include "omrcfg.h"
 #include "omr.h"
-#include "ModronAssertions.h"
 #include "GlobalCollector.hpp"
 
 #include <string.h>
@@ -409,23 +408,6 @@ MM_MarkingScheme::createWorkPackets(MM_EnvironmentBase *env)
 	}
 
 	return workPackets;
-}
-
-void
-MM_MarkingScheme::assertNotForwardedPointer(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
-{
-	/* This is an expensive assert - fetching class slot during marking operation, thus invalidating benefits of leaf optimization.
-	 * TODO: after some soaking remove it!
-	 */
-	if (_extensions->isConcurrentScavengerEnabled()) {
-		MM_ForwardedHeader forwardHeader(objectPtr);
-		omrobjectptr_t forwardPtr = forwardHeader.getNonStrictForwardedObject();
-		/* It is ok to encounter a forwarded object during overlapped concurrent scavenger/marking (or even root scanning),
-		 * but we must do nothing about it (if in backout, STW global phase will recover them).
-		 */
-		Assert_GC_true_with_message3(env, ((NULL == forwardPtr) || (!_extensions->getGlobalCollector()->isStwCollectionInProgress() && _extensions->isConcurrentScavengerInProgress())),
-			"Encountered object %p forwarded to %p (header %p) while Concurrent Scavenger/Marking not in progress\n", objectPtr, forwardPtr, &forwardHeader);
-	}
 }
 
 void

--- a/gc/base/MarkingScheme.hpp
+++ b/gc/base/MarkingScheme.hpp
@@ -69,12 +69,8 @@ private:
 		Assert_GC_true_with_message(env, objectPtr != J9_INVALID_OBJECT, "Invalid object pointer %p\n", objectPtr);
 		Assert_MM_objectAligned(env, objectPtr);
 		Assert_GC_true_with_message3(env, isHeapObject(objectPtr), "Object %p not in heap range [%p,%p)\n", objectPtr, _heapBase, _heapTop);
-		
-		assertNotForwardedPointer(env, objectPtr);
 	}
 	
-	void assertNotForwardedPointer(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
-
 	/**
 	 * Private internal. Called exclusively from completeScan();
 	 */


### PR DESCRIPTION
The assert served its purpose. Removing it now, since it's defeating
leaf object optimization.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>