### PR TITLE
Fix broken links in OMR README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Presentations about Eclipse OMR
 Blog Posts about OMR technologies
 ---------------------------------
 
-* [Introducing Eclipse OMR: Building Language Runtimes](https://developer.ibm.com/open/2016/03/08/introducing-omr-building-language-runtimes/)
-* [JitBuilder Library and Eclipse OMR: Just-In-Time Compilers made easy](https://developer.ibm.com/open/2016/07/19/jitbuilder-library-and-eclipse-omr-just-in-time-compilers-made-easy/)
+* [Introducing Eclipse OMR: Building Language Runtimes](https://developer.ibm.com/code/2016/03/08/introducing-omr-building-language-runtimes/)
+* [JitBuilder Library and Eclipse OMR: Just-In-Time Compilers made easy](https://developer.ibm.com/code/2016/07/19/jitbuilder-library-and-eclipse-omr-just-in-time-compilers-made-easy/)
 
-(c) Copyright IBM Corp. 2016, 2018
+(c) Copyright IBM Corp. 2016, 2019


### PR DESCRIPTION
Fix broken links for "Blog Posts about OMR technologies"

Signed-off-by: Igor Braga <higorb1@gmail.com>