### PR TITLE
CMake: blobreader needs to link against the thread library

### DIFF
--- a/ddr/tools/blob_reader/CMakeLists.txt
+++ b/ddr/tools/blob_reader/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(omr_blob_reader
 	omr_ddr_scanner
 	omrutil
 	${OMR_PORT_LIB}
+	${OMR_THREAD_LIB}
 )
 
 if(OMRPORT_OMRSIG_SUPPORT)


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>