### PR TITLE
AArch64: Fix comment for OMRMemoryReference

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -403,7 +403,7 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
     * @param[in] ci : current instruction
     * @param[in] cursor : instruction cursor
     * @param[in] cg : CodeGenerator
-    * @return estimated binary length
+    * @return instruction cursor after encoding
     */
    uint8_t *generateBinaryEncoding(TR::Instruction *ci, uint8_t *cursor, TR::CodeGenerator *cg);
    };


### PR DESCRIPTION
This commit fixes the doxygen comment for
OMRMemoryReference::generateBinaryEncoding() for AArch64.

Signed-off-by: knn-k <konno@jp.ibm.com>