### PR TITLE
Rename compiler OMR_OSX macro to OMR_MACOS

### DIFF
--- a/compiler/env/OMRCompilerEnv.cpp
+++ b/compiler/env/OMRCompilerEnv.cpp
@@ -84,7 +84,7 @@ OMR::CompilerEnv::initializeHostEnvironment()
    host.setMajorOS(TR::os_windows);
 #elif HOST_OS == OMR_ZOS
    host.setMajorOS(TR::os_zos);
-#elif HOST_OS == OMR_OSX
+#elif HOST_OS == OMR_MACOS
    host.setMajorOS(TR::os_osx);
 #else
    host.setMajorOS(TR::os_unknown);
@@ -127,7 +127,7 @@ OMR::CompilerEnv::initializeTargetEnvironment()
    target.setMajorOS(TR::os_windows);
 #elif HOST_OS == OMR_ZOS
    target.setMajorOS(TR::os_zos);
-#elif HOST_OS == OMR_OSX
+#elif HOST_OS == OMR_MACOS
    target.setMajorOS(TR::os_osx);
 #else
    target.setMajorOS(TR::os_unknown);

--- a/compiler/env/defines.h
+++ b/compiler/env/defines.h
@@ -50,8 +50,8 @@
 #ifndef OMR_ZOS
 #  define OMR_ZOS     204
 #endif
-#ifndef OMR_OSX
-#  define OMR_OSX     205
+#ifndef OMR_MACOS
+#  define OMR_MACOS     205
 #endif
 
 /* Architectures */
@@ -103,7 +103,7 @@
 #elif defined(__MVS__)
 #  define HOST_OS OMR_ZOS
 #elif defined(__APPLE__) && defined(__MACH__)
-#  define HOST_OS OMR_OSX
+#  define HOST_OS OMR_MACOS
 #else
 #  error "defines.h: unknown OS"
 #endif


### PR DESCRIPTION
Fixes #2258

Signed-off-by: Rounak Agarwal <rounakr.ag73@gmail.com>