### PR TITLE
Apply consistent use of OS macros in compiler

### DIFF
--- a/compiler/codegen/ELFGenerator.cpp
+++ b/compiler/codegen/ELFGenerator.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 #include "codegen/ELFGenerator.hpp"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include <stdio.h>
 #include <string.h>

--- a/compiler/codegen/ELFGenerator.hpp
+++ b/compiler/codegen/ELFGenerator.hpp
@@ -22,7 +22,7 @@
 #ifndef ELFGENERATOR_HPP
 #define ELFGENERATOR_HPP
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include <elf.h>
 #include <string>

--- a/compiler/codegen/ELFRelocationResolver.hpp
+++ b/compiler/codegen/ELFRelocationResolver.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include "codegen/OMRELFRelocationResolver.hpp"
 
@@ -39,6 +39,6 @@ class OMR_EXTENSIBLE ELFRelocationResolver : public ::OMR::ELFRelocationResolver
 
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif

--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -35,7 +35,7 @@
 #include "env/jittypes.h"
 #include "env/PersistentInfo.hpp"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h>
 #endif
 
@@ -145,7 +145,7 @@ TR_FrontEnd::getFormattedName(
       bool suffix)
    {
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
    // FIXME: TODO: This is a temporary implementation -- we ignore the suffix format and
    // use the pid only
 

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -107,7 +107,7 @@ namespace TR
 #else /* (_MSC_VER < 1800) */
    #define va_copy_end(x) va_end(x)
 #endif /* (_MSC_VER < 1800) */
-#elif defined(J9ZOS390) && !defined(__C99)  // zOS defines it only if __C99 is defined
+#elif (HOST_OS == OMR_ZOS) && !defined(__C99)  // zOS defines it only if __C99 is defined
    #define va_copy(d,s) (memcpy((d),(s),sizeof(va_list)))
    #define va_copy_end(x)
 #else                                       // other platforms support va_copy properly

--- a/compiler/codegen/OMRELFRelocationResolver.cpp
+++ b/compiler/codegen/OMRELFRelocationResolver.cpp
@@ -22,7 +22,7 @@
 #include "codegen/OMRELFRelocationResolver.hpp"
 #include "infra/Assert.hpp"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 uint32_t
 OMR::ELFRelocationResolver::resolveRelocationType(const TR::StaticRelocation &relocation)
@@ -31,4 +31,4 @@ OMR::ELFRelocationResolver::resolveRelocationType(const TR::StaticRelocation &re
    return static_cast<uint32_t>(-1);
    }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */

--- a/compiler/codegen/OMRELFRelocationResolver.hpp
+++ b/compiler/codegen/OMRELFRelocationResolver.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #ifndef OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
 #define OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
@@ -60,6 +60,6 @@ private:
 
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif // OMR_ELF_RELOCATION_RESOLVER_HPP

--- a/compiler/compile/CompilationTypes.hpp
+++ b/compiler/compile/CompilationTypes.hpp
@@ -36,7 +36,7 @@ namespace TR { class Node; }
 namespace TR { class TreeTop; }
 
 enum TR_Hotness
-#if !defined(LINUXPPC) || defined(__LITTLE_ENDIAN__)
+#if !(HOST_OS == OMR_LINUX) || defined(__LITTLE_ENDIAN__)
    : int8_t // use only 8 bits to save space; The ifdef is needed because xlC BE compiler does not accept the syntax
 #endif
    {

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -910,7 +910,7 @@ OMR::Compilation::isJProfilingCompilation()
    return false;
    }
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS)
 static void stopBeforeCompile()
    {
    static int first = 1;
@@ -921,7 +921,7 @@ static void stopBeforeCompile()
       first = 0;
       }
    }
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS) */
 
 static int32_t strHash(const char *str)
    {
@@ -971,13 +971,13 @@ int32_t OMR::Compilation::compile()
       TR::Compiler->debug.breakPoint();
       }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    if (self()->getOption(TR_DebugBeforeCompile))
       {
       self()->getDebug()->setupDebugger((void *) *((long*)&(stopBeforeCompile)));
       stopBeforeCompile();
       }
-#elif defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS)
    if (self()->getOption(TR_DebugBeforeCompile))
       {
 #if defined(LINUXPPC64)
@@ -987,7 +987,7 @@ int32_t OMR::Compilation::compile()
 #endif /* defined(LINUXPPC64) */
       stopBeforeCompile();
       }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
    if (self()->getOutFile() != NULL && (self()->getOption(TR_TraceAll) || debug("traceStartCompile") || self()->getOptions()->getAnyTraceCGOption() || self()->getOption(TR_Timing)))
       {
@@ -1232,23 +1232,23 @@ int32_t OMR::Compilation::compile()
       }
 #endif /* ifdef(J9_PROJECT_SPECIFIC) */
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
    if (self()->getOption(TR_DebugOnEntry))
       {
       intptrj_t jitTojitStart = (intptrj_t) self()->cg()->getCodeStart();
       jitTojitStart += ((*(int32_t *)(jitTojitStart - 4)) >> 16) & 0x0000ffff;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
       self()->getDebug()->setupDebugger((void *)jitTojitStart);
 #else
       self()->getDebug()->setupDebugger((void *)jitTojitStart, self()->cg()->getCodeEnd(), false);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
       }
-#elif defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS)
    if (self()->getOption(TR_DebugOnEntry))
       {
       self()->getDebug()->setupDebugger(self()->cg()->getCodeStart(),self()->cg()->getCodeEnd(),false);
       }
-#endif /* defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS) */
 
    return COMPILATION_SUCCEEDED;
    }

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -21,7 +21,7 @@
 
 #include "control/CompileMethod.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <process.h>
 #else
 #include <unistd.h>
@@ -73,7 +73,7 @@ writePerfToolEntry(void *start, uint32_t size, const char *name)
    if (firstAttempt)
       {
       firstAttempt = false;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
       int jvmPid = _getpid();
 #else
       pid_t jvmPid = getpid();
@@ -448,7 +448,7 @@ compileMethodFromDetails(
    catch (const TR::ILValidationFailure &exception)
       {
       rc = COMPILATION_IL_VALIDATION_FAILURE;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
       // Compiling with -Wc,lp64 results in a crash on z/OS when trying
       // to call the what() virtual method of the exception.
       printCompFailureInfo(jitConfig, &compiler, "");
@@ -460,7 +460,7 @@ compileMethodFromDetails(
       {
       // failed! :-(
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
       // Compiling with -Wc,lp64 results in a crash on z/OS when trying
       // to call the what() virtual method of the exception.
       printCompFailureInfo(jitConfig, &compiler, "");

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -868,7 +868,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
                                  SET_OPTION_BIT(TR_IProfilerPerformTimestampCheck), "F"},
    {"iprofilerVerbose",          "O\tEnable Interpreter Profiling output messages",           SET_OPTION_BIT(TR_VerboseInterpreterProfiling), "F"},
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    {"j2prof",             "D\tenable profiling",
         SET_OPTION_BIT(TR_CreatePCMaps), "F" },
 #endif
@@ -2167,7 +2167,7 @@ OMR::Options::jitLatePostProcess(TR::OptionSet *optionSet, void * jitConfig)
          self()->setOption(TR_ConservativeCompilation, true);
 
       if (TR::Options::isQuickstartDetected()
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
          || sharedClassCache()  // Disable GCR for zOS if SharedClasses/AOT is used
 #endif
          )
@@ -2655,16 +2655,16 @@ OMR::Options::jitPreProcess()
    #endif
 
    #if defined(TR_TARGET_32BIT) && defined(PROD_WITH_ASSUMES)
-      #if defined(LINUX)
+      #if (HOST_OS == OMR_LINUX)
          #if defined(S390)
             _userSpaceVirtualMemoryMB = 2048; // 2 GB = 2048 MB
          #else
             _userSpaceVirtualMemoryMB = 3072; // 3 GB = 3072 MB
          #endif //#if defined(S390)
-      #elif defined(J9ZOS390)
+      #elif (HOST_OS == OMR_ZOS)
          _userSpaceVirtualMemoryMB = -1; // Compute userspace dynamically on z/OS
-      #endif //#if defined(LINUX)
-   #elif !defined(OMR_OS_WINDOWS)
+      #endif //#if (HOST_OS == OMR_LINUX)
+   #elif !(HOST_OS == OMR_WINDOWS)
       _userSpaceVirtualMemoryMB = 0; // Disabled for 64 bit or non-windows production
    #endif //#if defined(TR_TARGET_32BIT) && defined(PROD_WITH_ASSUMES)
 
@@ -2720,7 +2720,7 @@ OMR::Options::jitPreProcess()
 
       // Enable upgrade hints only if we have an SMP
       if (TR::Compiler->target.numberOfProcessors() > 1
-   #if defined(J9ZOS390) // do not enable upgrade hints, hot/scorching hints on zOS because of compilation costs
+   #if (HOST_OS == OMR_ZOS) // do not enable upgrade hints, hot/scorching hints on zOS because of compilation costs
           && _quickstartDetected
    #endif
           )
@@ -3696,7 +3696,7 @@ OMR::Options::jitPostProcess()
       self()->setOption(TR_EnableLargeCodePages);
       }
 
-#if defined(TR_TARGET_64BIT) && defined(J9ZOS390)
+#if defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS)
    // We allocate code cache memory on z/OS by asking the port library for typically small (~2MB) code cache chunks.
    // This is done because the port library can typically only allocate executable memory (code caches) below the
    // 2GB bar. When RMODE(64) is enabled however we are able to allocate executable memory above the 2GB bar. This

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1214,7 +1214,7 @@ enum TR_ProcessOptionsFlags
 
 #define TRIVIAL_INLINER_MAX_SIZE           25
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define DEFAULT_WAIT_TIME_TO_EXIT_STARTUP_MODE 5500 // ms
 #else
 #define DEFAULT_WAIT_TIME_TO_EXIT_STARTUP_MODE 2500 // ms
@@ -1234,7 +1234,7 @@ enum TR_ProcessOptionsFlags
 #define DEFAULT_SCRATCH_SPACE_LIMIT_KB (256*1024)
 #define DEFAULT_SCRATCH_SPACE_LOWER_BOUND_KB (32*1024)
 
-#if defined(J9ZOS390) && defined(TR_TARGET_32BIT)
+#if (HOST_OS == OMR_ZOS) && defined(TR_TARGET_32BIT)
 #define JSR292_SCRATCH_SPACE_FACTOR 1 // 1.5GB on 31-bit z/OS is too much
 #elif defined(TR_HOST_ARM)
 #define JSR292_SCRATCH_SPACE_FACTOR 2 // 1.5GB on 32-bit ARM is too much

--- a/compiler/cs2/timer.h
+++ b/compiler/cs2/timer.h
@@ -36,12 +36,12 @@
 #include "cs2/listof.h"
 #include "cs2/hashtab.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <time.h>
 #include "windows_api.h"
 #else
 #include <sys/time.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 #ifdef CS2_ALLOCINFO
@@ -52,7 +52,7 @@
 
 namespace CS2 {
 
-#if defined(_AIX)
+#if (HOST_OS == OMR_AIX)
 
 /**
  * \brief AIX-specific timer class.
@@ -81,7 +81,7 @@ class AIXTimer {
 };
 
 typedef AIXTimer PlatformTimer;
-#elif defined(LINUX) || defined(OSX) || (defined (__MVS__) && defined (_XOPEN_SOURCE_EXTENDED))
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) || (defined (__MVS__) && defined (_XOPEN_SOURCE_EXTENDED))
 /**
  * \brief Linux-specific timer class.
  *
@@ -110,7 +110,7 @@ private:
 };
 
 typedef BSDTimer PlatformTimer;
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 /**
  * \brief Windows-specific timer class.
  *
@@ -166,7 +166,7 @@ class BaseTimer {
 };
 
 typedef BaseTimer PlatformTimer;
-#endif /* defined(_AIX) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 /**
  * \brief A general purpose timer class.

--- a/compiler/cs2/windows_api.h
+++ b/compiler/cs2/windows_api.h
@@ -19,13 +19,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 #ifdef BOOLEAN
 /* There is a collision between J9's definition of BOOLEAN and Windows headers */
 #define BOOLEAN_COLLISION_DETECTED BOOLEAN
 #undef BOOLEAN
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #ifdef boolean
 /* There is a collision between J9's definition of boolean and Windows headers */

--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
 #include <sys/wait.h>
 #include <sys/types.h>

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -176,7 +176,7 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInit
 #endif
 
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* Hack - to satisfy the runtime linker we need a definition of the following functions.
    Should never be called.  This code can be removed when we permit the JIT to be linked
    against libstdc++ on Linux.

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -39,7 +39,7 @@ namespace TR
 // We should be relying on the port library to allocate memory, but this connection
 // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9,
 // where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
    #if !defined(MAP_ANONYMOUS)
       #define NO_MAP_ANONYMOUS
       #if defined(MAP_ANON)
@@ -59,7 +59,7 @@ FEBase<Derived>::allocateRelocationData(TR::Compilation* comp, uint32_t size)
    if (size == 0) return 0;
    TR_ASSERT(size >= 2048, "allocateRelocationData should be used for whole-sale memory allocation only");
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    return reinterpret_cast<uint8_t *>(
          VirtualAlloc(NULL,
             size,

--- a/compiler/env/OMRDebugEnv.cpp
+++ b/compiler/env/OMRDebugEnv.cpp
@@ -26,14 +26,14 @@
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"
 
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 #include <signal.h>
 #endif
 
 void
 OMR::DebugEnv::breakPoint()
    {
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
    raise(SIGTRAP);
 #else
    TR_UNIMPLEMENTED();

--- a/compiler/env/OMRIO.hpp
+++ b/compiler/env/OMRIO.hpp
@@ -52,7 +52,7 @@ namespace OMR { typedef OMR::IO IOConnector; }
 #ifdef _MSC_VER
    #define POINTER_PRINTF_FORMAT "0x%p"
 #else
-   #if defined(LINUX) || defined(OSX)
+   #if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
       #ifdef TR_HOST_64BIT
          #ifdef TR_TARGET_X86
             #define POINTER_PRINTF_FORMAT "%12p"

--- a/compiler/env/OMRVMEnv.cpp
+++ b/compiler/env/OMRVMEnv.cpp
@@ -65,7 +65,7 @@ OMR::VMEnv::heapTailPaddingSizeInBytes()
 uint64_t
 OMR::VMEnv::getUSecClock()
    {
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
    struct timeval tp;
    struct timezone tzp;
 

--- a/compiler/env/defines.h
+++ b/compiler/env/defines.h
@@ -22,17 +22,17 @@
 #ifndef OMR_DEFINES_H
 #define OMR_DEFINES_H
 
-/* 
+/*
    This is the first file that the OMR code should be including.
    The idea is the define a standard set of C macros based on the
    system configuration. This is the only file (hopefully) needs to
    use system specific macros (e.g. __linux__).
-   
+
    In addition, if there are system-configuration specific feature
    test macros that you want to define, this is probably the file you
    want to define them in. You should also provide documentation of
    what your macro does. As an example see SUPPORTS_THREAD_LOCAL
-   
+
    Note that this file is included is asm code as well. Apart from C
    pre-processor macros, it shouldn't contain anything else.
 */
@@ -92,17 +92,17 @@
   ways of checking for a particular host os.  As a reference, see
   http://sourceforge.net/p/predef/wiki/OperatingSystems/
 */
-#if defined(__linux__)
+#if (HOST_OS == OMR_LINUX)
 #  define HOST_OS OMR_LINUX
 #elif defined(_TPF_SOURCE)
 #  define HOST_OS OMR_LINUX
-#elif defined(_AIX)
+#elif (HOST_OS == OMR_AIX)
 #  define HOST_OS OMR_AIX
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #  define HOST_OS OMR_WINDOWS
-#elif defined(__MVS__)
+#elif (HOST_OS == OMR_ZOS)
 #  define HOST_OS OMR_ZOS
-#elif defined(__APPLE__) && defined(__MACH__)
+#elif (HOST_OS == OMR_OSX)
 #  define HOST_OS OMR_OSX
 #else
 #  error "defines.h: unknown OS"
@@ -158,7 +158,7 @@
 #  error "defines.h: unknown compiler"
 #endif
 
-/* FIXME: we need to deprecate TR_HOST_* macros and replace them with 
+/* FIXME: we need to deprecate TR_HOST_* macros and replace them with
    code of the form: #if (HOST_ARCH == ARCH_X86) */
 #if (HOST_ARCH == ARCH_X86)
 #  define TR_HOST_X86    1

--- a/compiler/env/jittypes.h
+++ b/compiler/env/jittypes.h
@@ -163,7 +163,7 @@ typedef struct TR_InlinedCallSite
       #include <builtins.h>
       #endif /* __cplusplus */
       #define FLUSH_MEMORY(smp) if( smp ) __lwsync();
-   #elif defined(LINUX)
+   #elif (HOST_OS == OMR_LINUX)
       #define FLUSH_MEMORY(smp) if( smp ) __asm__("lwsync");
    #endif
 #endif

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -772,7 +772,7 @@ OMR::Node::createWithSymRef(TR::ILOpCodes op, uint16_t numChildren, TR::SymbolRe
  * These are defined for compilers that do not support variadic templates
  * Otherwise the definitions are in il/OMRNode_inlines.hpp
  */
-#if defined(_MSC_VER) || defined(LINUXPPC)
+#if defined(_MSC_VER) || (HOST_OS == OMR_LINUX)
 TR::Node *
 OMR::Node::recreateWithoutSymRef_va_args(TR::Node *originalNode, TR::ILOpCodes op,
                                               uint16_t numChildren, uint16_t numChildArgs,

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -191,7 +191,7 @@ public:
    static TR::Node *createWithSymRef(TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef);
    static TR::Node *createWithSymRef(TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef, uintptr_t extraChildrenForFixup);
 
-#if defined(_MSC_VER) || defined(LINUXPPC)
+#if defined(_MSC_VER) || (HOST_OS == OMR_LINUX)
 private:
    static TR::Node *recreateWithoutSymRef_va_args(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, va_list &args);
    static TR::Node *createWithoutSymRef(TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, ...);

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -56,7 +56,7 @@ OMR::Node::self()
  * Node constructors
  */
 
-#if !defined(_MSC_VER) && !defined(LINUXPPC)
+#if !defined(_MSC_VER) && !(HOST_OS == OMR_LINUX)
 /*
  * These are defined for compilers that support variadic templates
  * XLC (but not on LINUX PPC) and GCC support C++11 variadic templates

--- a/compiler/infra/Annotations.hpp
+++ b/compiler/infra/Annotations.hpp
@@ -81,12 +81,12 @@
 // OMR_LIKELY and OMR_UNLIKELY
 // TODO: check if the definition of these macros is too broad,
 //       __builtin_expect() may not have any effect on xlC
-#if defined(TR_HOST_X86) && defined(OMR_OS_WINDOWS)
+#if defined(TR_HOST_X86) && (HOST_OS == OMR_WINDOWS)
    #define OMR_LIKELY(expr) (expr)
    #define OMR_UNLIKELY(expr) (expr)
 #else
    #define OMR_LIKELY(expr)   __builtin_expect((expr), 1)
    #define OMR_UNLIKELY(expr) __builtin_expect((expr), 0)
-#endif /* defined(TR_HOST_X86) && defined(OMR_OS_WINDOWS) */
+#endif /* defined(TR_HOST_X86) && (HOST_OS == OMR_WINDOWS) */
 
 #endif

--- a/compiler/infra/Bit.hpp
+++ b/compiler/infra/Bit.hpp
@@ -30,11 +30,11 @@
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 
-#if defined(TR_TARGET_X86) && defined(OMR_OS_WINDOWS)
+#if defined(TR_TARGET_X86) && (HOST_OS == OMR_WINDOWS)
    #define abs64 _abs64
 #else
    #define abs64 labs
-#endif /* defined(TR_TARGET_X86) && defined(OMR_OS_WINDOWS) */
+#endif /* defined(TR_TARGET_X86) && (HOST_OS == OMR_WINDOWS) */
 
 // For getting at different parts of a 32 bit integer
 class intParts  {
@@ -405,7 +405,7 @@ static inline bool isPowerOf2(int64_t input)
    return (input & -input) == input;
    }
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 // On OSX, intptrj_t isn't int32_t nor int64_t
 
 static inline int32_t leadingZeroes (intptrj_t input)

--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -66,12 +66,12 @@ bool
 OMR::Monitor::init(char *name)
    {
    _name = name;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_INIT(_monitor);
 #else
    bool rc = MUTEX_INIT(_monitor);
    TR_ASSERT(rc == true, "error initializing monitor\n");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    return true;
    }
 
@@ -84,36 +84,36 @@ OMR::Monitor::destroy(TR::Monitor *monitor)
 void
 OMR::Monitor::destroy()
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_DESTROY(_monitor);
 #else
    int32_t rc = MUTEX_DESTROY(_monitor);
    TR_ASSERT(rc == 0, "error destroying monitor\n");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 void
 OMR::Monitor::enter()
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_ENTER(_monitor);
 #else
    int32_t rc = MUTEX_ENTER(_monitor);
    TR_ASSERT(rc == 0, "error locking monitor\n");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 int32_t
 OMR::Monitor::exit()
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_EXIT(_monitor);
    return 0;
 #else
    int32_t rc = MUTEX_EXIT(_monitor);
    TR_ASSERT(rc == 0, "error unlocking monitor\n");
    return rc;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 char const *

--- a/compiler/infra/ThreadLocal.h
+++ b/compiler/infra/ThreadLocal.h
@@ -34,8 +34,8 @@
 
 #if defined(SUPPORTS_THREAD_LOCAL)
 
-#if defined(OMR_OS_WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)
- #if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX)
+ #if (HOST_OS == OMR_WINDOWS)
   #include "windows.h"
   #define tlsDeclare(type, variable) extern DWORD variable
   #define tlsDefine(type, variable) DWORD variable = TLS_OUT_OF_INDEXES
@@ -43,15 +43,15 @@
   #define tlsFree(variable)  (TlsFree(variable))
   #define tlsSet(variable, value) TlsSetValue((variable), value)
   #define tlsGet(variable, type) ((type)TlsGetValue(variable))
- #else /* if defined(LINUX) || defined(AIXPPC) */
+ #else /* if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
   #define tlsDeclare(type, variable) extern __thread type variable
   #define tlsDefine(type, variable) __thread type variable = NULL
   #define tlsAlloc(variable) // not required on win, linux or AIX
   #define tlsFree(variable)  // not required on win, linux or AIX
   #define tlsSet(variable, value) variable = value
   #define tlsGet(variable, type) (variable)
- #endif /* defined(OMR_OS_WINDOWS) */
-#else /* !(defined(OMR_OS_WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)) */  /* Mainly for defined(OMRZTPF) or defined(J9ZOS390) */
+ #endif /* (HOST_OS == OMR_WINDOWS) */
+#else /* !((HOST_OS == OMR_WINDOWS) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX)) */  /* Mainly for defined(OMRZTPF) or (HOST_OS == OMR_ZOS) */
  #include <pthread.h>
 
  #define tlsDeclare(type, variable) extern pthread_key_t variable
@@ -59,12 +59,12 @@
  #define tlsAlloc(variable) pthread_key_create(&variable, NULL)   // allocates a new key, which will have initial value NULL for all threads
  #define tlsFree(variable) pthread_key_delete(variable)
  #define tlsSet(variable, value) pthread_setspecific(variable, value)
- #if defined(J9ZOS390)
+ #if (HOST_OS == OMR_ZOS)
   #define tlsGet(variable, type) ((type) pthread_getspecific_d8_np(variable))
  #else
   #define tlsGet(variable, type) ((type) pthread_getspecific(variable))
  #endif
-#endif /* defined(OMR_OS_WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_WINDOWS) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX) */
 
 #else /* !defined(SUPPORTS_THREAD_LOCAL) */
  #define tlsDeclare(type, variable) extern type variable

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -912,7 +912,7 @@ TR_CallStack::~TR_CallStack()
    {
    //::commit is supposed to clear up the lists after everything has been propagated to a caller
    //if there are still some residual symRefs left it means that we missed a call to commit somewhere
-#if !defined(AIXPPC)
+#if !(HOST_OS == OMR_AIX)
    TR_ASSERT(std::uncaught_exception() || (_autos.isEmpty() && _temps.isEmpty() && _injectedBasicBlockTemps.isEmpty()), "lists should have been emptied by TR_CallStack::commit");
 #endif
    }

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -1230,7 +1230,7 @@ TR::VPClassType *TR::VPClassType::create(OMR::ValuePropagation *vp, const char *
    }
 
 //Workaround for zOS V1R11 bug
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma noinline(TR::VPResolvedClass::VPResolvedClass(TR_OpaqueClassBlock *,TR::Compilation *))
 #pragma noinline(TR::VPResolvedClass::VPResolvedClass(TR_OpaqueClassBlock *, TR::Compilation *, int32_t))
 #endif

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -102,7 +102,7 @@
 #include "ras/DebugCounter.hpp"
 #include "runtime/Runtime.hpp"
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/debug.h>
 #endif
 
@@ -1559,7 +1559,7 @@ void OMR::Power::CodeGenerator::doPeephole()
 
       if ((TR::Compiler->target.cpu.id() == TR_PPCp6) && instructionCursor->isTrap())
          {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
          trapPeephole(self(),instructionCursor);
 #endif
          }
@@ -2572,7 +2572,7 @@ void OMR::Power::CodeGenerator::addRealRegisterInterference(TR::Register    *reg
    reg->getLiveRegisterInfo()->addInterference(realReg->getRealRegisterMask());
    }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <unistd.h>
 class  TR_Method;
 FILE                     *j2Profile;

--- a/compiler/p/runtime/PPCArrayCopy.inc
+++ b/compiler/p/runtime/PPCArrayCopy.inc
@@ -137,7 +137,7 @@
    .globl    FUNC_LABEL(__leArrayCopy)
    .type     FUNC_LABEL(__leArrayCopy),@function
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
    .globl    __arrayCopy
    .globl    __wordArrayCopy
    .globl    __halfWordArrayCopy
@@ -517,7 +517,7 @@ __forwardHalfWordArrayCopy:
 #elif defined(LINUXPPC64)
    .align   5
 FUNC_LABEL(__arrayCopy_dp):
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
    .align   5
 __arrayCopy_dp:
 #else
@@ -577,7 +577,7 @@ __arrayCopy_dp:
    stfd  fp8, 0(r9)
    addi  r9, r9, 8
    bc BO_IF, CR0_LT, .L.tableDispatch
-#if defined(AIXPPC) || defined(LINUX) || defined(LINUXPPC64)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(LINUXPPC64)
    .align   5     ! force 32-byte I-cache sector alignment here
 #endif
 .L.qWordAligned_dp:
@@ -756,7 +756,7 @@ __arrayCopy_dp:
    stfd  fp8, -8(r9)
    addi  r9, r9, -8
    bc BO_IF, CR0_LT, .L.reverseTableDispatch
-#if defined(AIXPPC) || defined(LINUX) || defined(LINUXPPC64)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(LINUXPPC64)
    .align   5     ! force 32-byte I-cache sector alignment here
 #endif
 .L.reverseQWordAligned_dp:
@@ -2632,9 +2632,9 @@ __leArrayCopy:
 #endif
 
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    .csect    ArrayCopy_DATA{RW}
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
    .data
 #elif defined (LINUXPPC64)
    .section ".data"

--- a/compiler/p/runtime/PPCAsmUtil.inc
+++ b/compiler/p/runtime/PPCAsmUtil.inc
@@ -79,7 +79,7 @@
 
 	.globl FUNC_LABEL(jitPPCDataCacheBlockZero)
 	.type  FUNC_LABEL(jitPPCDataCacheBlockZero),@function
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 	.globl _tr_try_lock
 	.globl _tr_unlock
 	.globl jitPPCDataCacheBlockZero

--- a/compiler/p/runtime/VirtualGuardRuntime.spp
+++ b/compiler/p/runtime/VirtualGuardRuntime.spp
@@ -30,7 +30,7 @@
 	.globl	FUNC_LABEL(_patchVirtualGuard)
 	.type	FUNC_LABEL(_patchVirtualGuard), @function
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 	.globl	_patchVirtualGuard
 #endif
 

--- a/compiler/p/runtime/ppcasmdefines.inc
+++ b/compiler/p/runtime/ppcasmdefines.inc
@@ -262,7 +262,7 @@
 	#define J9_BP r15
 	#define J9VM_STRUCT r13
 	#define J9SP r14
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	#define RTOC r12
 #else
 	#define RTOC r2

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -40,7 +40,7 @@ void TR_CallStackIterator::printStackBacktrace(TR::Compilation *comp)
       }
    }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <demangle.h>
 #include <sys/debug.h>
 
@@ -171,7 +171,7 @@ const char *TR_PPCCallStackIterator::getProcedureName()
       }
    }
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 #include <execinfo.h>
 #include <cxxabi.h>
 
@@ -230,7 +230,7 @@ void TR_LinuxCallStackIterator::printStackBacktrace(TR::Compilation *comp)
    free(symbols);
    }
 
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 #include <unistd.h>
 #include <ceeedcct.h>
@@ -300,7 +300,7 @@ bool TR_MvsCallStackIterator::callTraceback()
    // Null-terminate the string.
    _proc_name[_parms.__tf_entry_name.__tf_bufflen] = 0;
 
-#if defined(J9ZOS390) && defined(J9_PROJECT_SPECIFIC)
+#if (HOST_OS == OMR_ZOS) && defined(J9_PROJECT_SPECIFIC)
    // On Java zOS, we need to convert the ebcdic string to ascii
    __e2a_l( _proc_name, (int32_t) _parms.__tf_entry_name.__tf_bufflen);
 #endif
@@ -327,7 +327,7 @@ bool TR_MvsCallStackIterator::getNext ()
    return true;
    }
 
-#elif defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
+#elif (HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
 
 #include "ras/CallStack.hpp"
 #include <windows.h>
@@ -497,6 +497,6 @@ bool TR_WinCallStackIterator::getNext()
    return !_done;
    }
 
-#elif !(defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
+#elif !((HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
 
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */

--- a/compiler/ras/CallStackIterator.hpp
+++ b/compiler/ras/CallStackIterator.hpp
@@ -41,7 +41,7 @@ protected:
    virtual bool isDone() { return true; }
    };
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 struct tbtable;
 
 class TR_PPCCallStackIterator : public TR_CallStackIterator
@@ -65,7 +65,7 @@ private:
 
 typedef TR_PPCCallStackIterator TR_CallStackIteratorImpl;
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 
 class TR_LinuxCallStackIterator : public TR_CallStackIterator
    {
@@ -79,7 +79,7 @@ private:
 
 typedef TR_LinuxCallStackIterator TR_CallStackIteratorImpl;
 
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 #ifdef TR_HOST_64BIT
    #include <__le_api.h>
@@ -164,7 +164,7 @@ private:
 
 typedef TR_MvsCallStackIterator TR_CallStackIteratorImpl;
 
-#elif defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
+#elif (HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
 
 class TR_WinCallStackIterator : public TR_CallStackIterator
    {
@@ -188,10 +188,10 @@ public:
 
 typedef TR_WinCallStackIterator TR_CallStackIteratorImpl;
 
-#elif !(defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
+#elif !((HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
 
 typedef TR_CallStackIterator TR_CallStackIteratorImpl;
 
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 #endif

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -116,7 +116,7 @@
 #include <netdb.h>
 #endif
 
-#if defined(J9ZOS390) || defined(AIXPPC) || defined(LINUX)
+#if (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 #include <unistd.h>
 #endif
 
@@ -161,7 +161,7 @@ TR_Debug * createDebugObject(TR::Compilation * comp)
 
 
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS)
 static void stopOnCreate()
    {
    static int first = 1;
@@ -172,7 +172,7 @@ static void stopOnCreate()
       first = 0;
       }
    }
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS) */
 
 
 void
@@ -203,10 +203,10 @@ TR_Debug::debugOnCreate()
    {
 #if defined(TR_HOST_X86)
    TR::Compiler->debug.breakPoint();
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
    setupDebugger((void *) *((long*)&(stopOnCreate)));
    stopOnCreate();
-#elif defined(LINUX) || defined(J9ZOS390) || (defined(OMR_OS_WINDOWS))
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || ((HOST_OS == OMR_WINDOWS))
    setupDebugger((void *) &stopOnCreate,(void *) &stopOnCreate,true);
    stopOnCreate();
 #endif /* defined(TR_HOST_X86) */
@@ -4884,7 +4884,7 @@ TR_Debug::traceRegisterWeight(TR::Register *realReg, uint32_t weight)
    trfflush(_file);
    }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #if !defined(J9OS_I5)
 #include <unistd.h>
 extern "C" void yield(void);
@@ -4954,7 +4954,7 @@ void TR_Debug::setupDebugger(void *addr)
 
 #endif
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
    {
    static bool started = false;
@@ -5027,7 +5027,7 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
    started = true;
    }
 
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 #include <spawn.h>
 #include <unistd.h>
 void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
@@ -5122,7 +5122,7 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
          else printf("Could not open %s, skipping break !\n",cfname);
          }
    }
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #ifndef WINDOWS_API_INCLUDED
 extern "C"
    {
@@ -5187,7 +5187,7 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
       started = true;
       }
    }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 void TR_Debug::setSingleAllocMetaData(bool usesSingleAllocMetaData)
    {

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -611,11 +611,11 @@ public:
    const char * getName(TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
 #endif
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    virtual void setupDebugger(void *);
-#elif defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_WINDOWS)
    virtual void setupDebugger(void *, void *, bool);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
    virtual void setSingleAllocMetaData(bool usesSingleAllocMetaData);
 

--- a/compiler/ras/IgnoreLocale.hpp
+++ b/compiler/ras/IgnoreLocale.hpp
@@ -34,7 +34,7 @@ int strnicmp_ignore_locale(const char *s1, const char *s2, size_t n);
 #include <strings.h>
    #define STRICMP strcasecmp
    #define STRNICMP strncasecmp
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
    #define STRICMP _stricmp
    #define STRNICMP _strnicmp
 #elif PILOT

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -997,7 +997,7 @@ TR_Debug::formattedString(char *buf, uint32_t bufLen, const char *format, va_lis
    va_list args_copy;
    va_copy(args_copy, args);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
    // vsnprintf returns -1 on zos when buffer is too small
    char s[VSNPRINTF_BUFFER_SIZE];
    int resultLen = vsnprintf(s, VSNPRINTF_BUFFER_SIZE, format, args_copy);

--- a/compiler/runtime/OMRCodeCacheConfig.hpp
+++ b/compiler/runtime/OMRCodeCacheConfig.hpp
@@ -108,7 +108,7 @@ class OMR_EXTENSIBLE CodeCacheConfig
          _emitExecutableELF(false),
          _emitRelocatableELF(false)
       {
-      #if defined(J9ZOS390)     // EBCDIC
+      #if (HOST_OS == OMR_ZOS)     // EBCDIC
       _warmEyeCatcher[0] = '\xD1';
       _warmEyeCatcher[1] = '\xC9';
       _warmEyeCatcher[2] = '\xE3';

--- a/compiler/runtime/OMRRuntimeAssumptions.cpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.cpp
@@ -22,7 +22,7 @@
 #include "runtime/OMRRuntimeAssumptions.hpp"
 #include "env/jittypes.h"
 
-#if defined(__IBMCPP__) && !defined(AIXPPC) && !defined(LINUXPPC)
+#if defined(__IBMCPP__) && !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_LINUX)
 #define ASM_CALL __cdecl
 #else
 #define ASM_CALL

--- a/compiler/runtime/Runtime.cpp
+++ b/compiler/runtime/Runtime.cpp
@@ -23,8 +23,8 @@
 
 TR_RuntimeHelperTable runtimeHelpers;
 
-#if (defined(__IBMCPP__) || defined(__IBMC__) && !defined(MVS)) && !defined(LINUXPPC64)
- #if defined(AIXPPC)
+#if (defined(__IBMCPP__) || defined(__IBMC__) && !(HOST_OS == OMR_ZOS)) && !defined(LINUXPPC64)
+ #if (HOST_OS == OMR_AIX)
   #define JIT_HELPER(x) extern "C" void *x
  #else
   #define JIT_HELPER(x) extern "C" __cdecl x()
@@ -32,7 +32,7 @@ TR_RuntimeHelperTable runtimeHelpers;
 #else
  #if defined(LINUXPPC64)
   #define JIT_HELPER(x) extern "C" void *x
- #elif defined(LINUX)
+ #elif (HOST_OS == OMR_LINUX)
   #define JIT_HELPER(x) extern "C" void x()
  #else
   #define JIT_HELPER(x) extern "C" x()

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -379,7 +379,7 @@ void arm64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int32_t
 #endif /* TR_TARGET_ARM64 */
 
 
-#if defined(J9ZOS390) && defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT)
+#if (HOST_OS == OMR_ZOS) && defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT)
 
 //-----------------------------------------------------------------------------
 //   zOS 31 Bit - "plain" Multi Code Cache Support
@@ -398,7 +398,7 @@ void s390zOS31CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int
    *numHelpers = 0;
    }
 
-#elif defined(J9ZOS390) && defined(TR_TARGET_64BIT) && defined(TR_TARGET_S390)
+#elif (HOST_OS == OMR_ZOS) && defined(TR_TARGET_64BIT) && defined(TR_TARGET_S390)
 
 //-----------------------------------------------------------------------------
 //   zOS 64 Bit - "plain" Multi Code Cache Support
@@ -419,7 +419,7 @@ void s390zOS64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, int
    }
 
 
-#elif !defined(J9ZOS390) && defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT)
+#elif !(HOST_OS == OMR_ZOS) && defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT)
 
 //-----------------------------------------------------------------------------
 //   zLinux 31 Bit - "plain" Multi Code Cache Support
@@ -438,7 +438,7 @@ void s390zLinux31CodeCacheParameters(int32_t *trampolineSize, void **callBacks, 
    *numHelpers = 0;
    }
 
-#elif defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
+#elif defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && !(HOST_OS == OMR_ZOS)
 
 // Size of a Trampoline (Padded to be 8-byte aligned)
 #define TRAMPOLINE_SIZE 24
@@ -572,7 +572,7 @@ void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
       }
 #endif
 
-#if defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && defined(J9ZOS390)
+#if defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS)
    // zOS 31 code cache support.
    if (TR::Compiler->target.cpu.isZ())
       {
@@ -580,7 +580,7 @@ void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
       }
 #endif
 
-#if defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && defined(J9ZOS390)
+#if defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS)
    // zOS 64 code cache support.
    if (TR::Compiler->target.cpu.isZ())
       {
@@ -588,7 +588,7 @@ void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
       }
 #endif
 
-#if defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
+#if defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && !(HOST_OS == OMR_ZOS)
    // zLinux 31 code cache support.
    if (TR::Compiler->target.cpu.isZ())
       {
@@ -596,7 +596,7 @@ void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCall
       }
 #endif
 
-#if defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
+#if defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && !(HOST_OS == OMR_ZOS)
    // zLinux 64 code cache support.
    if (TR::Compiler->target.cpu.isZ())
       {

--- a/compiler/x/amd64/codegen/OMRELFRelocationResolver.cpp
+++ b/compiler/x/amd64/codegen/OMRELFRelocationResolver.cpp
@@ -21,7 +21,7 @@
 
 #include "codegen/ELFRelocationResolver.hpp"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include <elf.h>
 #include "infra/Assert.hpp"
@@ -37,4 +37,4 @@ OMR::X86::AMD64::ELFRelocationResolver::resolveRelocationType(const TR::StaticRe
    return static_cast<uint32_t>(-1);
    }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */

--- a/compiler/x/amd64/codegen/OMRELFRelocationResolver.hpp
+++ b/compiler/x/amd64/codegen/OMRELFRelocationResolver.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #ifndef OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
 #define OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
@@ -61,6 +61,6 @@ private:
 }
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif // OMRELFRELOCATIONRESOLVER_HPP

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.hpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.hpp
@@ -35,7 +35,7 @@ namespace TR { class Register; }
 //
 // DOUBLE_EXPONENT_SCALE = -(16383-1023)
 //
-#if !defined(_LONG_LONG) && !defined(LINUX)
+#if !defined(_LONG_LONG) && !(HOST_OS == OMR_LINUX)
 #define DOUBLE_EXPONENT_SCALE 0xc0ce000000000000L
 #else
 #define DOUBLE_EXPONENT_SCALE 0xc0ce000000000000LL

--- a/compiler/x/codegen/FPTreeEvaluator.hpp
+++ b/compiler/x/codegen/FPTreeEvaluator.hpp
@@ -32,7 +32,7 @@
 
 // Binary representation of double 1.0
 //
-#if !defined(_LONG_LONG) && !defined(LINUX)
+#if !defined(_LONG_LONG) && !(HOST_OS == OMR_LINUX)
 #define IEEE_DOUBLE_1_0          0x3ff0000000000000L
 #define IEEE_DOUBLE_NEGATIVE_0_0 0x8000000000000000L
 #else

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1102,7 +1102,7 @@ OMR::X86::CodeGenerator::getNanoTimeTemp()
    if (_nanoTimeTemp == NULL)
       {
       TR::AutomaticSymbol *sym;
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
       sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,sizeof(struct timeval));
 #else
       sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,8);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -48,7 +48,7 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include "x/codegen/X86Register.hpp"
 #include "env/CompilerEnv.hpp"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <sys/time.h>
 #endif
 

--- a/compiler/x/runtime/X86Runtime.hpp
+++ b/compiler/x/runtime/X86Runtime.hpp
@@ -24,7 +24,7 @@
 
 #include "env/ProcessorInfo.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <intrin.h>
 #define cpuid(CPUInfo, EAXValue)             __cpuid(CPUInfo, EAXValue)
 #define cpuidex(CPUInfo, EAXValue, ECXValue) __cpuidex(CPUInfo, EAXValue, ECXValue)
@@ -39,7 +39,7 @@ inline unsigned long long _xgetbv(unsigned int ecx)
    __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(ecx));
    return ((unsigned long long)edx << 32) | eax;
    }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 char* feGetEnv(const char*);
 inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
@@ -91,20 +91,20 @@ inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
 
 inline bool AtomicCompareAndSwap(volatile uint32_t* ptr, uint32_t old_val, uint32_t new_val)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    return old_val == (uint32_t)_InterlockedCompareExchange((volatile long*)ptr, (long)new_val, (long)old_val);
 #else
    return __sync_bool_compare_and_swap(ptr, old_val, new_val);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 inline bool AtomicCompareAndSwap(volatile uint16_t* ptr, uint16_t old_val, uint16_t new_val)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    return old_val == (uint16_t)_InterlockedCompareExchange16((volatile short*)ptr, (short)new_val, (short)old_val);
 #else
    return __sync_bool_compare_and_swap(ptr, old_val, new_val);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 inline void patchingFence16(void* addr)

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -137,7 +137,7 @@ OMR::Z::Snippet::generatePICBinary(TR::CodeGenerator * cg, uint8_t * cursor, TR:
       intptrj_t destAddr = (intptrj_t)(glueRef->getSymbol()->castToMethodSymbol()->getMethodAddress());
 
 #if defined(TR_TARGET_64BIT)
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
       if (cg->comp()->getOption(TR_EnableRMODE64))
 #endif
          {

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -2002,7 +2002,7 @@ static void intToString(int num, char *str, int len=10, bool padWithZeros=false)
    unsigned char c[16];
    int i=0,j=0,n=0;
 
-   #if !defined(LINUX) && !defined(TR_HOST_X86)
+   #if !(HOST_OS == OMR_LINUX) && !defined(TR_HOST_X86)
    __cvd(num, (char *)packedDecValue);
    __unpk(c, len-1, packedDecValue, 7 );
    c[len-1] = c[len-1] | 0xf0;
@@ -2028,7 +2028,7 @@ static void intToHex(uint32_t num, char *str, int len)
            0xC3, 0xC4, 0xC5, 0xC6
                      };
 
-   #if !defined(LINUX) && !defined(TR_HOST_X86)
+   #if !(HOST_OS == OMR_LINUX) && !defined(TR_HOST_X86)
    memcpy(temp, &num, 4);
    __unpk((unsigned char *)str, len, temp, 4);
    __tr((unsigned char *)str, ebcdic_translate-240, len);

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -2139,7 +2139,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
    // Direct calls on 64-bit systems may require a trampoline. As the trampoline will kill the EP register we should
    // always see the EP register defined in the post-dependencies of such calls.
 #if defined(TR_TARGET_64BIT)
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
    if (comp->getOption(TR_EnableRMODE64))
 #endif
       {
@@ -2179,7 +2179,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
       }
    else // address known
       {
-#if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
+#if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS))
       if (cg->canUseRelativeLongInstructions(imm) || isHelper || comp->getOption(TR_EnableRMODE64))
 #endif
          {
@@ -2206,8 +2206,8 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
             tempInst = (new (INSN_HEAP) TR::S390RILInstruction(TR::InstOpCode::BRASL, callNode, RegRA, reinterpret_cast<void*>(imm), callSymRef, cg));
             }
 #endif
-#if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
-#if (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
+#if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS))
+#if (defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS))
          if (!comp->getOption(TR_EnableRMODE64))
 #endif
 
@@ -2222,7 +2222,7 @@ generateDirectCall(TR::CodeGenerator * cg, TR::Node * callNode, bool myself, TR:
          AOTcgDiag1(comp, "\ntempInst=%x\n", tempInst);
          return tempInst;
          }
-#if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && defined(J9ZOS390))
+#if !defined(TR_TARGET_64BIT) || (defined(TR_TARGET_64BIT) && (HOST_OS == OMR_ZOS))
       else
          {
          genLoadAddressConstant(cg, callNode, imm, RegEP, preced, cond);

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -111,7 +111,7 @@ TR::S390HelperCallSnippet::emitSnippetBody()
    intptrj_t destAddr = (intptrj_t)(helperSymRef->getSymbol()->castToMethodSymbol()->getMethodAddress());
 
 #if defined(TR_TARGET_64BIT)
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
    if (cg()->comp()->getOption(TR_EnableRMODE64))
 #endif
       {

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2363,7 +2363,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
          i2 = (int32_t)((getTargetPtr() - (uintptrj_t)cursor) / 2);
 
 #if defined(TR_TARGET_64BIT)
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
         if (comp->getOption(TR_EnableRMODE64))
 #endif
             {
@@ -2387,7 +2387,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
       // zLinux 64 bit we only allow atomic patching on a 4 byte boundary as we use Multi-Code Caches and
       // require trampolines.
 
-#if defined(J9ZOS390) || !defined(TR_TARGET_64BIT)
+#if (HOST_OS == OMR_ZOS) || !defined(TR_TARGET_64BIT)
       // Address must not cross an 8 byte boundary for atomic patching
       int32_t padSize = ((uintptrj_t) (cursor + 4) % 8) == 0 ? 2 : 0;
 #else
@@ -2401,7 +2401,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
          cursor += 2;
          }
 #if defined(TR_TARGET_64BIT)
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
       if (comp->getOption(TR_EnableRMODE64))
 #endif
          {
@@ -2469,7 +2469,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
                i2 = (int32_t)(((uintptrj_t)(callSymbol->getMethodAddress()) - (uintptrj_t)cursor) / 2);
                }
 #if defined(TR_TARGET_64BIT)
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
             if (comp->getOption(TR_EnableRMODE64))
 #endif
                {

--- a/configure
+++ b/configure
@@ -4362,7 +4362,7 @@ fi
 	if test "x$OMR_TOOLCHAIN" = "x"; then :
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#if !(defined(__xlC__) || (defined(__MVS__) && defined(__COMPILER_VER__)))
+#if !(defined(__xlC__) || ((HOST_OS == OMR_ZOS) && defined(__COMPILER_VER__)))
 #error not an xlc compiler
 #endif
 int

--- a/ddr/include/ddr/config.hpp
+++ b/ddr/include/ddr/config.hpp
@@ -27,20 +27,20 @@
 
 /* Enable standard limit macros on z/OS. */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* We need to define these for the limit macros to get defined in z/OS */
 #define _ISOC99_SOURCE 1
 #define __STDC_LIMIT_MACROS 1
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 /* C++ TR1 support */
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 #define __IBMCPP_TR1__ 1
 #define OMR_HAVE_TR1 1
 #else
 #define OMR_HAVE_CXX11 1
-#endif /* !defined(AIXPPC) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_ZOS) */
 
 /* Why is this disabled? */
 

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -32,11 +32,11 @@
 #include <vector>
 #include <errno.h>
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <sys/fcntl.h>
 #endif /* OSX */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/errno.h>
@@ -175,7 +175,7 @@ struct Dwarf_Die_s
 	Dwarf_Half _tag;
 	Dwarf_Die_s *_parent;
 	Dwarf_Die_s *_sibling;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	Dwarf_Die_s *_previous;
 #endif /* defined (AIXPPC) */
 	Dwarf_Die_s *_child;

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -27,9 +27,9 @@
 #include "ddr/std/unordered_map.hpp"
 #include <map>
 
-#if defined(OSX) || defined(AIXPPC)
+#if (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX)
 #include "ddr/scanner/dwarf/DwarfFunctions.hpp"
-#else /* defined(OSX) || defined(AIXPPC) */
+#else /* (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX) */
 
 #if defined(HAVE_DWARF_H)
 #include <dwarf.h>
@@ -47,7 +47,7 @@
 #error "Need libdwarf.h or libdwarf/libdwarf.h"
 #endif /* defined(HAVE_LIBDWARF_H) */
 
-#endif /* defined(OSX) || defined(AIXPPX) */
+#endif /* (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX) */
 
 #include "ddr/ir/ClassUDT.hpp"
 #include "ddr/ir/EnumUDT.hpp"

--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -27,12 +27,12 @@
 #include <utility>
 #include <vector>
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined uintptr_t.  Ignore its definition */
 #define UDATA UDATA_win_
 #include "dia2.h"
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "ddr/ir/ClassUDT.hpp"
 #include "ddr/ir/EnumUDT.hpp"

--- a/ddr/include/ddr/std/sstream.hpp
+++ b/ddr/include/ddr/std/sstream.hpp
@@ -24,7 +24,7 @@
 
 #include "ddr/config.hpp"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 
 #include <ctype.h>
 #undef toupper
@@ -35,8 +35,8 @@
 #define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
 #define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
 
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 #include <sstream>
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #endif /* SSTREAM_HPP */

--- a/ddr/include/ddr/std/string.hpp
+++ b/ddr/include/ddr/std/string.hpp
@@ -24,7 +24,7 @@
 
 #include "ddr/config.hpp"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 
 #include <ctype.h>
 #undef toupper
@@ -35,8 +35,8 @@
 #define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
 #define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
 
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 #include <string>
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #endif /* STRING_HPP */

--- a/ddr/include/ddr/std/unordered_map.hpp
+++ b/ddr/include/ddr/std/unordered_map.hpp
@@ -24,11 +24,11 @@
 
 #include "ddr/config.hpp"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include <ctype.h>
 #undef toupper
 #undef tolower
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #if defined(OMR_HAVE_CXX11)
 #include <unordered_map>
@@ -41,9 +41,9 @@ using std::tr1::unordered_map;
 #error "Need std::unordered_map defined in TR1 or C++11."
 #endif /* defined(OMR_HAVE_CXX11) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
 #define tolower(c)     (isupper(c) ? (c | _XLOWER_ASCII) : c)
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #endif /* DDR_UNORDERED_MAP */

--- a/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
@@ -19,9 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 #define __IBMCPP_TR1__ 1
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
 
 #include "ddr/blobgen/genBlob.hpp"
 #include "ddr/blobgen/java/genBinaryBlob.hpp"

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -321,11 +321,11 @@ DwarfScanner::getName(Dwarf_Die die, string *name, Dwarf_Off *dieOffset)
 				}
 				Dwarf_Die spec = NULL;
 				if (
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 					DW_DLV_ERROR == dwarf_offdie(_debug, offset, &spec, &err)
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 					DW_DLV_ERROR == dwarf_offdie_b(_debug, offset, 1, &spec, &err)
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 				) {
 					ERRMSG("Getting die from specification offset: %s\n", dwarf_errmsg(err));
 					rc = DDR_RC_ERROR;
@@ -337,9 +337,9 @@ DwarfScanner::getName(Dwarf_Die die, string *name, Dwarf_Off *dieOffset)
 			}
 		}
 		if ((NULL == dieName)
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 			|| ((0 == strncmp(dieName, "__", 2)) && (strlen(dieName + 2) == strspn(dieName + 2, "0123456789")))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 			|| (0 == strncmp(dieName, "<anonymous", 10)))
 		{
 			*name = "";
@@ -577,12 +577,12 @@ DwarfScanner::getTypeTag(Dwarf_Die die, Dwarf_Die *typeDie, Dwarf_Half *tag)
 		/* Use the offset to get the Die containing the type tag. */
 		Dwarf_Die newDie = NULL;
 		if (
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			/* z/OS dwarf library doesn't have dwarf_offdie_b, only dwarf_offdie. */
 			DW_DLV_ERROR == dwarf_offdie(_debug, offset, &newDie, &err)
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 			DW_DLV_ERROR == dwarf_offdie_b(_debug, offset, 1, &newDie, &err)
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 		) {
 			ERRMSG("Getting typedie from type offset: %s\n", dwarf_errmsg(err));
 			goto getTypeDone;
@@ -818,9 +818,9 @@ DwarfScanner::createNewType(Dwarf_Die die, Dwarf_Half tag, const char *dieName, 
 	default:
 		{
 			const char *tagName = NULL;
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 			dwarf_get_TAG_name(tag, &tagName);
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 			ERRMSG("Symbol with name '%s' has unknown symbol type: %s (%d)\n", dieName, tagName, tag);
 			rc = DDR_RC_ERROR;
 		}
@@ -940,7 +940,7 @@ isVtablePointer(const char *fieldName)
 {
 #if defined(__GNUC__)
 	return 0 == strncmp(fieldName, "_vptr.", 6);
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 	return 0 == strcmp(fieldName, "__vfp");
 #else
 	return false;

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -24,9 +24,9 @@
 #include <algorithm>
 #include <assert.h>
 #include <comdef.h>
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <inttypes.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 #include <stdio.h>
 
 #include "ddr/std/sstream.hpp"

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -19,17 +19,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 #define __IBMCPP_TR1__ 1
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
 
 #include <stdlib.h>
 #include <string.h>
 #include <vector>
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #include "omrport.h"
 #include "thread_api.h"
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
 
 	DDR_RC rc = DDR_RC_OK;
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* Convert EBCDIC to UTF-8 (ASCII) */
 	if (-1 != iconv_init()) {
 		/* translate argv strings to ASCII */
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
 		fprintf(stderr, "failed to initialize iconv\n");
 		rc = DDR_RC_ERROR;
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	/* Get options. */
 	Options options;

--- a/doc/CodingStandard.md
+++ b/doc/CodingStandard.md
@@ -1550,9 +1550,9 @@ TODO: in the future, we would like to have OMR_OS_xxx flags for operating system
 
 Correct
 ```c
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
-#if defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 
 #if defined( _AMD64_)
 ```

--- a/example/glue/UtilGlue.c
+++ b/example/glue/UtilGlue.c
@@ -25,7 +25,7 @@
  * it can be used without requiring all the dependencies of LanguageVMGlue.
  * (Since LanguageVMGlue interacts with OMR_VM initialization, it prereqs all GC/RAS/OMR core modules.)
  */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 omr_error_t
 OMR_Glue_GetVMDirectoryToken(void **token)
 {
@@ -33,7 +33,7 @@ OMR_Glue_GetVMDirectoryToken(void **token)
 	*token = NULL;
 	return OMR_ERROR_NONE;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Provides the thread name to be used when no name is given.

--- a/example/glue/VerboseManagerImpl.cpp
+++ b/example/glue/VerboseManagerImpl.cpp
@@ -29,9 +29,9 @@
 
 #include "VerboseHandlerOutputStandard.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define snprintf _snprintf
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 MM_VerboseManagerImpl *
 MM_VerboseManagerImpl::newInstance(MM_EnvironmentBase *env, OMR_VM* vm)

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -18,7 +18,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -61,7 +61,7 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    if (segmentSize < config.codeCachePadKB() << 10)
       codeCacheSizeToAllocate = config.codeCachePadKB() << 10;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    auto memorySlab = reinterpret_cast<uint8_t *>(
          VirtualAlloc(NULL,
             codeCacheSizeToAllocate,
@@ -84,7 +84,7 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
 void
 TestCompiler::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
 #else
    munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));

--- a/fvtest/compilertest/tests/FooBarTest.cpp
+++ b/fvtest/compilertest/tests/FooBarTest.cpp
@@ -131,7 +131,7 @@ FooBarTest::invokeTests()
 // "test/env/FrontEnd.cpp"  TestCompiler::FrontEnd::methodTrampolineLookup is "methodTrampolineLookup not implemented yet".
 // This test also failed intermittent (segfault) on PPCLE, temporarily disabled this test on PPCLE, under track of Work Item
 // Please remove this #ifdef after those functions are implemented.
-#if defined(TR_TARGET_X86) || defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
+#if defined(TR_TARGET_X86) || defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && !(HOST_OS == OMR_ZOS)
 TEST(JITTest, FooBarTest)
    {
    ::TestCompiler::FooBarTest _fooBarTest;

--- a/fvtest/compilertest/tests/OMRTestEnv.cpp
+++ b/fvtest/compilertest/tests/OMRTestEnv.cpp
@@ -19,13 +19,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #undef BYTE
 #include "windows.h"
 #define PATH_MAX MAXPATHLEN
 #else
 #include <dlfcn.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <errno.h>
 #include "OMRTestEnv.hpp"
 

--- a/fvtest/compilertest/tests/main.cpp
+++ b/fvtest/compilertest/tests/main.cpp
@@ -27,13 +27,13 @@
 #include "gtest/gtest.h"
 #include "OMRTestEnv.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #undef BYTE
 #include "windows.h"
 #define PATH_MAX MAXPATHLEN
 #else
 #include <dlfcn.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 int main(int argc, char **argv)
    {

--- a/fvtest/gctest/gcTestHelpers.cpp
+++ b/fvtest/gctest/gcTestHelpers.cpp
@@ -20,13 +20,13 @@
  *******************************************************************************/
 
 #include "gcTestHelpers.hpp"
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined uintptr_t.  Ignore its definition */
 #define UDATA UDATA_win_
 #include <windows.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
 #include <psapi.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 void
 GCTestEnvironment::initParams()
@@ -96,13 +96,13 @@ GCTestEnvironment::GCTestTearDown()
 void
 printMemUsed(const char *where, OMRPortLibrary *portLib)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 	PROCESS_MEMORY_COUNTERS_EX pmc;
 	GetProcessMemoryInfo(GetCurrentProcess(), (PPROCESS_MEMORY_COUNTERS)&pmc, sizeof(pmc));
 	/* result in bytes */
 	gcTestEnv->log(LEVEL_VERBOSE, "%s: phys: %ld; virt: %ld\n", where, pmc.WorkingSetSize, pmc.PrivateUsage);
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 	const char *statm_path = "/proc/self/statm";
 	intptr_t fileDescriptor = omrfile_open(statm_path, EsOpenRead, 0444);
@@ -129,5 +129,5 @@ printMemUsed(const char *where, OMRPortLibrary *portLib)
 	omrfile_close(fileDescriptor);
 #else
 	/* memory info not supported */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/fvtest/omrGtestGlue/argmain.cpp
+++ b/fvtest/omrGtestGlue/argmain.cpp
@@ -28,29 +28,29 @@
  * correctly when it is located in a library.
  */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 /* Define a macro for the name of the main function that takes char args */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CHARMAIN translated_main
 #else
 #define CHARMAIN main
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 extern "C" int omr_main_entry(int argc, char **argv, char **envp);
 
 int
 CHARMAIN(int argc, char **argv, char **envp)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* translate argv strings to ascii */
 	iconv_init();
 	{
@@ -59,12 +59,12 @@ CHARMAIN(int argc, char **argv, char **envp)
 			argv[i] = e2a_string(argv[i]);
 		}
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	return omr_main_entry(argc, argv, envp);
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -127,4 +127,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/fvtest/omrGtestGlue/iconvInitialization.cpp
+++ b/fvtest/omrGtestGlue/iconvInitialization.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
 
 extern "C" int iconv_init(void);

--- a/fvtest/omrGtestGlue/omrGtest.cpp
+++ b/fvtest/omrGtestGlue/omrGtest.cpp
@@ -21,7 +21,7 @@
 
 #include "iconvInitialization.cpp"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* Gtest invokes xlocale, which has function definition for tolower and toupper.
  * This causes compilation issue since the a2e macros (tolower and toupper) automatically replace the function definitions.
  * So we explicitly include <ctype.h> and undefine the macros for gtest, after gtest we then define back the macros.

--- a/fvtest/omrGtestGlue/omrTest.h
+++ b/fvtest/omrGtestGlue/omrTest.h
@@ -22,7 +22,7 @@
 #ifndef OMR_TEST_FRAMEWORK_H_
 #define OMR_TEST_FRAMEWORK_H_
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* Gtest invokes some functions (e.g., getcwd() ) before main() is invoked.
  * We need to invoke iconv_init() before gtest to ensure a2e is initialized.
  */
@@ -31,7 +31,7 @@ static int iconv_init_static_variable = iconv_initialization();
 #endif
 
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /*  Gtest invokes xlocale, which has function definition for tolower and toupper.
  * This causes compilation issue since the a2e macros (tolower and toupper) automatically replace the function definitions.
  * So we explicitly include <ctype.h> and undefine the macros for gtest, after gtest we then define back the macros.

--- a/fvtest/porttest/fileTest.cpp
+++ b/fvtest/porttest/fileTest.cpp
@@ -22,13 +22,13 @@
 #include "omrcfg.h"
 
 #include <limits.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* Undefine the winsockapi because winsock2 defines it.  Removes warnings. */
 #if defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
 #undef _WINSOCKAPI_
 #endif
 #include <winsock2.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include "omrTest.h"
 #include "omrport.h"
 #include "portTestHelpers.hpp"
@@ -40,13 +40,13 @@ protected:
 	SetUp()
 	{
 		::testing::Test::SetUp();
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		/* initialize sockets so that we can use gethostname() */
 		WORD wsaVersionRequested = MAKEWORD(2, 2);
 		WSADATA wsaData;
 		int wsaErr = WSAStartup(wsaVersionRequested, &wsaData);
 		ASSERT_EQ(0, wsaErr);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 		/* generate machine specific file name to prevent conflict between multiple tests running on shared drive */
 		OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
@@ -65,9 +65,9 @@ protected:
 		omrfile_unlink(fileName);
 		delete[] fileName;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		WSACleanup();
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		::testing::Test::TearDown();
 	}
 

--- a/fvtest/porttest/main.cpp
+++ b/fvtest/porttest/main.cpp
@@ -63,10 +63,10 @@ omr_main_entry(int argc, char **argv, char **envp)
 		portTestEnv->initPort();
 		if (startsWith(testName, "omrfile")) {
 			return omrfile_runTests(portTestEnv->getPortLibrary(), argv[0], testName, FALSE);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		} else if (startsWith(testName, "omrfile_blockingasync")) {
 			return omrfile_runTests(portTestEnv->getPortLibrary(), argv[0], testName, TRUE);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		} else if (startsWith(testName, "omrmmap")) {
 			return omrmmap_runTests(portTestEnv->getPortLibrary(), argv[0], testName);
 		} else if (startsWith(testName, "omrsig")) {

--- a/fvtest/porttest/omrdumpTest.cpp
+++ b/fvtest/porttest/omrdumpTest.cpp
@@ -33,18 +33,18 @@
 #include <string.h>
 #include <stdio.h>
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/types.h>
 #include <sys/var.h>
 #endif
 
 #include <signal.h>
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* for getcwd() */
 #include <direct.h>
 #define getcwd _getcwd
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "omrport.h"
@@ -67,7 +67,7 @@ removeDump(OMRPortLibrary *portLib, const char *filename, const char *testName)
 	portTestEnv->changeIndent(1);
 
 	/* Delete the file if possible. */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	char deleteCore[EsMaxPath] = {0};
 	sprintf(deleteCore, "tso delete %s", (strstr(filename, ".") + 1));
 
@@ -78,11 +78,11 @@ removeDump(OMRPortLibrary *portLib, const char *filename, const char *testName)
 	if (-1 == system(deleteCore)) {
 		removeDumpSucceeded = false;
 	}
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	if (0 != remove(filename)) {
 		removeDumpSucceeded = false;
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	if (removeDumpSucceeded) {
 		portTestEnv->log("removed: %s\n", filename);
 	} else {
@@ -121,7 +121,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 	uintptr_t rc = 99;
 	char coreFileName[EsMaxPath];
 	BOOLEAN doFileVerification = FALSE;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct vario myvar;
 	int sys_parmRC;
 #endif
@@ -138,7 +138,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 	/* try out a more sane NULL test */
 	portTestEnv->log("calling omrdump_create with empty filename\n");
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	rc = omrdump_create(coreFileName, "IEATDUMP", NULL);
 #else
 	rc = omrdump_create(coreFileName, NULL, NULL);
@@ -150,7 +150,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 		portTestEnv->log("omrdump_create claims to have written a core file to: %s\n", coreFileName);
 
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		/* We defer to fork abort on AIX machines that don't have "Enable full CORE dump" enabled in smit,
 		 * in which case omrdump_create will not return the filename.
 		 * So, only check for a specific filename if we are getting full core dumps */
@@ -160,9 +160,9 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 
 			doFileVerification = TRUE;
 		}
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 		doFileVerification = TRUE;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		if (doFileVerification) {
 			verifyFileRC = verifyFileExists(PORTTEST_ERROR_ARGS, coreFileName);
 			if (verifyFileRC == 0) {
@@ -192,7 +192,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_name)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	coreFileName = atoe_getcwd(buff, EsMaxPath);
 #else
 	coreFileName = getcwd(buff, EsMaxPath);
@@ -202,7 +202,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_name)
 	strncat(coreFileName, testName, EsMaxPath);
 
 	portTestEnv->log("calling omrdump_create with filename: %s\n", coreFileName);
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 	rc = omrdump_create(coreFileName, NULL, NULL);
 #else
 	rc = omrdump_create(coreFileName, "IEATDUMP", NULL);
@@ -240,7 +240,7 @@ TEST(PortDumpTest, dump_test_create_dump_from_signal_handler)
 	simpleHandlerInfo handlerInfo;
 	uint32_t sig_protectFlags;
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	coreFileName = atoe_getcwd(buff, EsMaxPath);
 #else
 	coreFileName = getcwd(buff, EsMaxPath);
@@ -282,7 +282,7 @@ simpleHandlerFunction(struct OMRPortLibrary *portLibrary, uint32_t gpType, void 
 
 	portTestEnv->log("calling omrdump_create with filename: %s\n", info->coreFileName);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	rc = omrdump_create(info->coreFileName, "IEATDUMP", NULL);
 #else
 	rc = omrdump_create(info->coreFileName, NULL, NULL);

--- a/fvtest/porttest/omrfileTest.cpp
+++ b/fvtest/porttest/omrfileTest.cpp
@@ -34,10 +34,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
 #include <windows.h> /* for MAX_PATH */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "testProcessHelpers.hpp"
@@ -1029,7 +1029,7 @@ TEST_F(PortFileTest2, file_test8)
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, fileName, EsOpenWrite | EsOpenAppend, 0666);
 
 	prevFilePtr = omrfile_seek(fd, 0, EsSeekCur);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Windows sets the file pointer to the end of file as soon as it is opened in append mode. */
 	if (5 != prevFilePtr) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "File pointer location is wrong after opening the file. Expected = 5, Got = %lld", prevFilePtr);
@@ -1039,7 +1039,7 @@ TEST_F(PortFileTest2, file_test8)
 	if (0 != prevFilePtr) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "File pointer location is wrong after opening the file. Expected = 0, Got = %lld", prevFilePtr);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (-1 == fd) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "%s() returned %d expected valid file handle\n", FILE_OPEN_FUNCTION_NAME, -1);
@@ -3262,7 +3262,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 
 	SleepFor(1);
 
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, length);
 
 	if (0 != unlockRc) {
@@ -3272,7 +3272,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 	portTestEnv->log("Child 1: Released read lock on bytes %lld for %lld\n", offset, length);
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 
 
 	lockRc = FILE_LOCK_BYTES_FUNCTION(OMRPORTLIB, fd, OMRPORT_FILE_WRITE_LOCK | OMRPORT_FILE_WAIT_FOR_LOCK, (offset + 2), length);
@@ -3285,7 +3285,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 	}
 	portTestEnv->log("Child 1: Got write lock on bytes %lld for %lld\n", (offset + 2), length);
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, (length - 2));
 
 	if (0 != unlockRc) {
@@ -3295,7 +3295,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 	portTestEnv->log("Child 1: Released read lock on bytes %lld for %lld\n", offset, (length - 2));
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, (offset + 2), length);
 
@@ -3445,10 +3445,10 @@ TEST_F(PortFileTest2, file_test27)
 	const char *localFilename = "omrfile_test27.tst";
 	intptr_t fd1, fd2;
 	int32_t expectedMode;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const int32_t allWrite = 0222;
 	const int32_t allRead = 0444;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	const int32_t ownerWritable = 0200;
 	const int32_t ownerReadable = 0400;
 	int32_t m;
@@ -3469,16 +3469,16 @@ TEST_F(PortFileTest2, file_test27)
 	} else {
 		(void)FILE_CLOSE_FUNCTION(OMRPORTLIB, fd1);
 		for (m = 0; m < nModes; ++m) {
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 			if (0 != (testModes[m] & J9S_ISGID)) {
 				continue; /* sgid not support on some versions of AIX */
 			}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 			if (0 != (testModes[m] & (J9S_ISUID | J9S_ISGID))) {
 				continue; /* sgid/suid sometimes ignored on OSX */
 			}
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
-#if defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
+#if (HOST_OS == OMR_WINDOWS)
 			if (allWrite == (testModes[m] & allWrite)) {
 				expectedMode = allRead + allWrite;
 			} else {
@@ -3486,7 +3486,7 @@ TEST_F(PortFileTest2, file_test27)
 			}
 #else
 			expectedMode = testModes[m];
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			rc = omrfile_chmod(localFilename, testModes[m]);
 			if (expectedMode != rc) {
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_chmod() returned %d expected %d\n", rc, expectedMode);
@@ -3542,10 +3542,10 @@ TEST_F(PortFileTest2, file_test28)
 	const char *testName = APPEND_ASYNC(omrfile_test28);
 	const char *localDirectoryName = "omrfile_test28_dir";
 	int32_t expectedMode;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const int32_t allWrite = 0222;
 	const int32_t allRead = 0444;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	int32_t m;
 	int32_t rc;
 #define nModes 22
@@ -3560,16 +3560,16 @@ TEST_F(PortFileTest2, file_test28)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "%s() failed for %s: could not create\n", FILE_OPEN_FUNCTION_NAME, localDirectoryName);
 	} else {
 		for (m = 0; m < nModes; ++m) {
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 			if (0 != (testModes[m] & J9S_ISGID)) {
 				continue; /* sgid not support on some versions of AIX */
 			}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 			if (0 != (testModes[m] & (J9S_ISUID | J9S_ISGID))) {
 				continue; /* sgid/suid sometimes ignored on OSX */
 			}
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
-#if defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
+#if (HOST_OS == OMR_WINDOWS)
 			if (allWrite == (testModes[m] & allWrite)) {
 				expectedMode = allRead + allWrite;
 			} else {
@@ -3577,7 +3577,7 @@ TEST_F(PortFileTest2, file_test28)
 			}
 #else
 			expectedMode = testModes[m];
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			rc = omrfile_chmod(localDirectoryName, testModes[m]);
 			if (expectedMode != rc) {
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_chmod() returned %d expected %d\n", rc, expectedMode);
@@ -3602,13 +3602,13 @@ TEST_F(PortFileTest2, file_test29)
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = APPEND_ASYNC(omrfile_test29);
 	const char *testFile = "omrfile_test29_file";
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	uintptr_t gid, uid;
 	intptr_t rc;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	reportTestEntry(OMRPORTLIB, testName);
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	omrfile_unlink(testFile);
 	(void)omrfile_create_file(OMRPORTLIB, testFile, 0, testName);
 	gid = omrsysinfo_get_egid();
@@ -3626,7 +3626,7 @@ TEST_F(PortFileTest2, file_test29)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_chown() to root succeeded, should have failed\n");
 	}
 	omrfile_unlink(testFile);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	reportTestExit(OMRPORTLIB, testName);
 }
@@ -3795,10 +3795,10 @@ TEST_F(PortFileTest2, file_test32)
 		goto done;
 	}
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(localFilename, 0666);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(localFilename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
@@ -3807,7 +3807,7 @@ TEST_F(PortFileTest2, file_test32)
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isGroupWriteable != 1'\n");
 	}
@@ -3822,7 +3822,7 @@ TEST_F(PortFileTest2, file_test32)
 	}
 #else
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	omrfile_unlink(localFilename);
 
@@ -3838,10 +3838,10 @@ TEST_F(PortFileTest2, file_test32)
 		goto done;
 	}
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(localFilename, 0444);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(localFilename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 0) {
@@ -3850,7 +3850,7 @@ TEST_F(PortFileTest2, file_test32)
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isGroupWriteable != 0'\n");
 	}
@@ -3865,7 +3865,7 @@ TEST_F(PortFileTest2, file_test32)
 	}
 #else
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	omrfile_unlink(localFilename);
 
@@ -3880,16 +3880,16 @@ TEST_F(PortFileTest2, file_test32)
 		goto done;
 	}
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(localFilename, 0222);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(localFilename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserWriteable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*On windows if a file is write-able, then it is also read-able*/
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 1'\n");
@@ -3898,9 +3898,9 @@ TEST_F(PortFileTest2, file_test32)
 	if (stat.perm.isUserReadable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 0'\n");
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isGroupWriteable != 1'\n");
 	}
@@ -3917,7 +3917,7 @@ TEST_F(PortFileTest2, file_test32)
 	}
 #else
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 done:
@@ -3962,7 +3962,7 @@ const char *testName = APPEND_ASYNC(omrfile_test33: test UTF - 8 encoding);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * Test a very long file name
  *
@@ -4098,7 +4098,7 @@ exit:
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 /**
@@ -4110,7 +4110,7 @@ exit:
  *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 int
 omrfile_test34(struct OMRPortLibrary *portLibrary)
 {
@@ -4139,9 +4139,9 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	sync();
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	rc = omrfile_stat_filesystem(fileName, 0, &buf_before);
 	if (0 != rc) {
 		portTestEnv->log(LEVEL_ERROR, "first omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
@@ -4173,9 +4173,9 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 	omrfile_printf(fd, "%s", stringToWrite);
 	omrfile_sync(fd); /* flush data written to disk */
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	sync();
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	rc = omrfile_stat_filesystem(fileName, 0, &buf_after);
 	if (0 != rc) {
 		portTestEnv->log(LEVEL_ERROR, "second omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
@@ -4250,7 +4250,7 @@ const char *testName = APPEND_ASYNC(omrfile_test34_multiple_tries: _test_omrfile
 exit:
 	return reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * Test omrfile_test35
@@ -4337,16 +4337,16 @@ TEST_F(PortFileTest2, file_test36)
 
 	omrfileFD = omrfile_convert_native_fd_to_omrfile_fd(nativeFD);
 
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 	if (omrfileFD != nativeFD) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfileFD != nativeFD, they should be the same. omrfileFD: %x, nativeFD: %x\n", omrfileFD, nativeFD);
 	}
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	if (omrfileFD == nativeFD) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfileFD == nativeFD, they should be different. omrfileFD: %x, nativeFD: %x\n", omrfileFD, nativeFD);
 	}
 
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	/* go back and forth with a standard stream.  */
 	nativeFD = omrfile_convert_omrfile_fd_to_native_fd(OMRPORT_TTY_OUT);
@@ -4365,7 +4365,7 @@ TEST_F(PortFileTest2, file_test36)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /**
  * Verify port file system.
  *
@@ -4716,7 +4716,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 

--- a/fvtest/porttest/omrfilestreamTest.cpp
+++ b/fvtest/porttest/omrfilestreamTest.cpp
@@ -35,10 +35,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
 #include <windows.h> /* for MAX_PATH */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrcfg.h"
 #include "omrport.h"
@@ -49,9 +49,9 @@
  * CRLFNEWLINES will be defined when we require changing newlines from '\n' to '\r\n'
  */
 #undef CRLFNEWLINES
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CRLFNEWLINES
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Write all data in the buffer. Will write in a loop until all data is sent. If an error occurs,
@@ -759,10 +759,10 @@ TEST(PortFileStreamTest, omrfilestream_test_open_permission_flags)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_close() returned %d expected %d\n", rc, 0);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfilestream_open, so omrfile_chmod() is called*/
 	omrfile_chmod(filename, 0666);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(filename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
@@ -771,7 +771,7 @@ TEST(PortFileStreamTest, omrfilestream_test_open_permission_flags)
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isGroupWriteable != 1'\n");
 	}
@@ -784,9 +784,9 @@ TEST(PortFileStreamTest, omrfilestream_test_open_permission_flags)
 	if (stat.perm.isOtherReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isOtherReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlink(filename);
 	if (0 != rc) {
@@ -816,10 +816,10 @@ readOnlyTest:
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_close() returned %d expected %d\n", rc, 0);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(filename, 0444);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(filename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 0) {
@@ -828,7 +828,7 @@ readOnlyTest:
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isGroupWriteable != 0'\n");
 	}
@@ -841,9 +841,9 @@ readOnlyTest:
 	if (stat.perm.isOtherReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isOtherReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlink(filename);
 	if (0 != rc) {
@@ -865,27 +865,27 @@ writeOnlyTest:
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_close() returned %d expected %d\n", rc, 0);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(filename, 0222);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(filename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserWriteable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*On windows if a file is write-able, then it is also read-able*/
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	if (stat.perm.isUserReadable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 0'\n");
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isGroupWriteable != 1'\n");
 	}
@@ -900,9 +900,9 @@ writeOnlyTest:
 	if (stat.perm.isOtherReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isOtherReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	/*umask vary so we can't test 'isGroupWritable', 'isGroupReadable', 'isOtherWritable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlink(filename);
 	if (0 != rc) {
@@ -915,7 +915,7 @@ exit:
 }
 
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * Test a very long file name. For both relative and absolute paths, build up a directory hierarchy
  * that is greater than the system defined MAX_PATH.
@@ -1054,7 +1054,7 @@ unlinkFile:
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Verify flush.  Check to make sure that a flush will write all data to the file.
@@ -2415,7 +2415,7 @@ TEST(PortFileStreamTest, omrfilestream_test_invalid_filestream_access)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfilestream_close() returned negative error code %d\n", rc);
 		goto unlinkFiles;
 	}
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	/* This test has different behavior on windows, and it will allow you to open files even if you
 	 * do not have the correct permissions.
 	 */
@@ -2423,7 +2423,7 @@ TEST(PortFileStreamTest, omrfilestream_test_invalid_filestream_access)
 	if (NULL != noAccessStream) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfilestream_open() returned valid file handle, expected NULL\n");
 	}
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 
 	/*

--- a/fvtest/porttest/omrintrospectTest.cpp
+++ b/fvtest/porttest/omrintrospectTest.cpp
@@ -29,9 +29,9 @@
  */
 
 #include "omrport.h"
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include <signal.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include "testHelpers.hpp"
 
 /**

--- a/fvtest/porttest/omrmemTest.cpp
+++ b/fvtest/porttest/omrmemTest.cpp
@@ -49,7 +49,7 @@ extern PortTestEnvironment *portTestEnv;
 
 #define allocNameSize 64 /**< @internal buffer size for name function */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define MEM32_LIMIT 0X7FFFFFFF
 #else
 #define MEM32_LIMIT 0xFFFFFFFF

--- a/fvtest/porttest/omrsignalExtendedTest.cpp
+++ b/fvtest/porttest/omrsignalExtendedTest.cpp
@@ -29,10 +29,10 @@
  *
  */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <signal.h>
 #include <pthread.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include <errno.h>
 #include <string.h>
@@ -42,7 +42,7 @@
 #include "omrthread.h"
 #include "testHelpers.hpp"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 typedef enum SignalEvent {
 	INVALID,
 	READY,
@@ -560,4 +560,4 @@ cleanup:
 	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */

--- a/fvtest/porttest/omrsignalTest.cpp
+++ b/fvtest/porttest/omrsignalTest.cpp
@@ -35,11 +35,11 @@
  *
  */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <signal.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
 #endif
 
@@ -54,9 +54,9 @@
 #include "testProcessHelpers.hpp"
 #include "omrport.h"
 
-#if !defined(OMR_OS_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER)
+#if !(HOST_OS == OMR_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER)
 #define J9SIGNAL_TEST_RUN_ASYNC_UNIX_TESTS
-#endif /* !defined(OMR_OS_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER) */
 
 #define SIG_TEST_SIZE_EXENAME 1024
 
@@ -74,7 +74,7 @@ struct PortSigMap testSignalMap[] = {
 	{OMRPORT_SIG_FLAG_SIGQUIT, "OMRPORT_SIG_FLAG_SIGQUIT", SIGQUIT, "SIGQUIT"}
 	, {OMRPORT_SIG_FLAG_SIGABRT, "OMRPORT_SIG_FLAG_SIGABRT", SIGABRT, "SIGABRT"}
 	, {OMRPORT_SIG_FLAG_SIGTERM, "OMRPORT_SIG_FLAG_SIGTERM", SIGTERM, "SIGTERM"}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	, {OMRPORT_SIG_FLAG_SIGRECONFIG, "OMRPORT_SIG_FLAG_SIGRECONFIG", SIGRECONFIG, "SIGRECONFIG"}
 #endif
 	/* {OMRPORT_SIG_FLAG_SIGINT, "OMRPORT_SIG_FLAG_SIGINT", SIGINT, "SIGINT"} */
@@ -608,7 +608,7 @@ TEST(PortSigTest, sig_test0)
 
 	if (!omrsig_can_protect(OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION)) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->can_protect() must always support 0 | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION\n");
-# if defined(J9ZOS390)
+# if (HOST_OS == OMR_ZOS)
 		/* z/OS does not always support this, however, pltest should never be run under a configuration that does not support it.
 		 * See implementation of omrsig_can_proctect() and omrsig_startup()
 		 */
@@ -619,7 +619,7 @@ TEST(PortSigTest, sig_test0)
 
 	if (!omrsig_can_protect(OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION)) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->can_protect() must always support 0 | OMRPORT_SIG_FLAG_MAY_RETURN | OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION\n");
-# if defined(J9ZOS390)
+# if (HOST_OS == OMR_ZOS)
 		portTestEnv->log("OMRPORT_SIG_FLAG_MAY_CONTINUE_EXECUTION is not supported if the default settings for TRAP(ON,SPIE) have been changed. The should both be set to 1\n");
 #endif
 
@@ -931,7 +931,7 @@ TEST(PortSigTest, sig_test6)
 		 * to run this test you need to port/unix/omrsignal.c (remove static from declaration of tlsKeyCurrentSignal)
 		 * and add "<export name="tlsKeyCurrentSignal" />" to port/module.xml, to export tlsKeyCurrentSignal.
 		 */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		{
 			extern omrthread_tls_key_t tlsKeyCurrentSignal;
 			int signo = (int)(uintptr_t)omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
@@ -942,7 +942,7 @@ TEST(PortSigTest, sig_test6)
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "currentSignal corrupt -- got: %d expected: %d\n", signo, expectedSigno);
 			}
 		}
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 #endif
 
 	}
@@ -1065,7 +1065,7 @@ TEST(PortSigTest, sig_test8)
 							flags,
 							&result);
 		portTestEnv->log("omrsig_test8 protectResult=%d\n", protectResult);
-#if defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 		if (protectResult != OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH in protectResult\n");
 		}
@@ -1073,7 +1073,7 @@ TEST(PortSigTest, sig_test8)
 		if (protectResult != OMRPORT_SIG_EXCEPTION_OCCURRED) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH in protectResult\n");
 		}
-#endif /* defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64) */
 		if (result != 0) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected 0 in *result\n");
 		}
@@ -1126,7 +1126,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 		goto exit;
 	}
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	setAsyncRC = omrsig_set_async_signal_handler(asyncTestHandler, &handlerInfo, OMRPORT_SIG_FLAG_SIGRECONFIG);
 	if (setAsyncRC == OMRPORT_SIG_ERROR) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsig_set_async_signal_handler returned: OMRPORT_SIG_ERROR\n");
@@ -1155,7 +1155,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 		/* test that we handle the signal when it is raise()'d */
 		portTestOptionsGlobal = omrsig_get_options();
 		if (0 != (OMRPORT_SIG_OPTIONS_ZOS_USE_CEEHDLR & portTestOptionsGlobal)) {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			/* This prevents LE from sending the corresponding LE condition to our thread */
 			sighold(signum);
 			raise(signum);
@@ -1202,7 +1202,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 
 		j9process_close(OMRPORTLIB, &childProcess, 0);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		/*
 		 * Verify that async signals can't be received by the asyncSignalReporter thread.
 		 * pltest runs with 2 threads only, this thread and the asyncSignalReporter thread.

--- a/fvtest/porttest/omrslTest.cpp
+++ b/fvtest/porttest/omrslTest.cpp
@@ -107,11 +107,11 @@ TEST(PortSlTest, sl_testOpenPathLengths)
 	const char *testName = "omrsl_testOpenPathLengths";
 	uintptr_t handle = 0;
 	uintptr_t rc = 0;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const char *fakeName = "\\temp";
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	const char *fakeName = "/temp";
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	size_t fakeNameLength = strlen(fakeName);
 	char sharedLibName[2*EsMaxPath] = "temp";
 	size_t pathLength = strlen(sharedLibName);
@@ -123,21 +123,21 @@ TEST(PortSlTest, sl_testOpenPathLengths)
 	 * AIX - "lib.so", "lib.a" and ".srvpgm" are added to the input path consecutively
 	 */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const char *extension = ".dll";
-#elif defined(AIXPPC) /* defined(OMR_OS_WINDOWS) */
+#elif (HOST_OS == OMR_AIX) /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9OS_I5)
 	const char *extension = ".srvpgm";
 #else /* defined(J9OS_I5) */
 	const char *extension = "lib.so";
 #endif /* defined(J9OS_I5) */
-#else /* defined(AIXPPC) */
-#if defined(OSX)
+#else /* (HOST_OS == OMR_AIX) */
+#if (HOST_OS == OMR_OSX)
 	const char *extension = "lib.dylib";
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	const char *extension = "lib.so";
-#endif /* defined(OSX) */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	size_t extensionLength = strlen(extension);
 
@@ -177,7 +177,7 @@ exit:
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 
 /**
  * CMVC 197740
@@ -269,4 +269,4 @@ exit:
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */

--- a/fvtest/porttest/omrstrTest.cpp
+++ b/fvtest/porttest/omrstrTest.cpp
@@ -36,9 +36,9 @@
  * @note port library string operations are not optional in the port library table.
  *
  */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -646,7 +646,7 @@ TEST(PortStrTest, str_test4)
 			char expected[J9STR_BUFFER_SIZE];
 			const char *default_tokens[] = { " %pid", " %home", " %last", " %seq"
 									   , " %uid"
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 									   , "%job"
 #endif
 									 };
@@ -809,7 +809,7 @@ static const U_16 utf16Data[] = {
 };
 static const char *utf16String = (const char *)utf16Data;
 static const uint32_t utf16StringLength = sizeof(utf16Data);
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma convlit(suspend)
 #endif
 static const char platformString[] = {
@@ -819,7 +819,7 @@ static const char platformString[] = {
 };
 
 static const uint32_t platformStringLength = sizeof(platformString) - 1;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma convlit(resume)
 #endif
 
@@ -1416,22 +1416,22 @@ TEST(PortStrTest, str_WinacpToMutf8)
 		'\x1', '\x2', '\x3', '\x4', '\x5', '\x6', '\x7', '\x8',
 		'\x81', '\x91', '\xa1', '\xb1', '\xc1', '\xd1', '\xe1', '\xf1'
 	};
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	char expectedMutf8[] = {
 		'\x1', '\x2', '\x3', '\x4', '\x5', '\x6', '\x7', '\x8',
 		'\xc2', '\x81', '\xe2', '\x80', '\x98', '\xc2', '\xa1', '\xc2', '\xb1', '\xc3', '\x81', '\xc3', '\x91', '\xc3', '\xa1', '\xc3', '\xb1'
 	};
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	const char *testName = "omrstr_WinacpToMutf8";
 	char outBuff[TEST_BUF_LEN];
 	int32_t originalStringLength = sizeof(winacpData);
 	int32_t convertedStringLength = 0;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	int32_t expectedStringLength = sizeof(expectedMutf8);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	reportTestEntry(OMRPORTLIB, testName);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	{
 		uint32_t defaultACP = GetACP();
 		if (1252 != defaultACP) {
@@ -1439,11 +1439,11 @@ TEST(PortStrTest, str_WinacpToMutf8)
 			reportTestExit(OMRPORTLIB, testName);
 		}
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	memset(outBuff, 0, sizeof(outBuff));
 	convertedStringLength = omrstr_convert(J9STR_CODE_WINDEFAULTACP, J9STR_CODE_MUTF8,
 										   winacpData, originalStringLength,  outBuff, sizeof(outBuff));
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (convertedStringLength != expectedStringLength) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "buffer length wrong.  Expected %d actual %d\n", expectedStringLength, convertedStringLength);
 	}
@@ -1454,11 +1454,11 @@ TEST(PortStrTest, str_WinacpToMutf8)
 	if (OMRPORT_ERROR_STRING_UNSUPPORTED_ENCODING != convertedStringLength) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Failed to detect invalid conversion");
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * Check whether a null/non-null terminated string is properly handled by fstring().
  * It calls atoe_vsnprintf() to verify the functionalities.
@@ -1569,4 +1569,4 @@ TEST(PortStrTest, str_test_atoe_vsnprintf)
 	portTestEnv->log("\n");
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */

--- a/fvtest/porttest/omrtimeTest.cpp
+++ b/fvtest/porttest/omrtimeTest.cpp
@@ -38,9 +38,9 @@
  */
 #include <stdlib.h>
 #include <string.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "omrport.h"
@@ -526,7 +526,7 @@ TEST(PortTimeTest, time_nano_time_direction)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/**
 	 * On Windows, if QueryPerformanceCounter is used on a multiprocessor computer,
 	 * time might be different accross CPUs. Therefore skip this test and only
@@ -539,7 +539,7 @@ TEST(PortTimeTest, time_nano_time_direction)
 			reportTestExit(OMRPORTLIB, testName);
 		}
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (0 == omrthread_attach_ex(&self, J9THREAD_ATTR_DEFAULT)) {
 		/* success in starting up thread library and attaching */

--- a/fvtest/porttest/omrttyExtendedTest.cpp
+++ b/fvtest/porttest/omrttyExtendedTest.cpp
@@ -30,9 +30,9 @@
  */
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "omrport.h"
@@ -42,7 +42,7 @@
  *
  * Call omrtty_daemonize, then call omrtty_printf/omrtty_vprintf. If we crash or print anything, then the test has failed.
  */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 TEST(PortTtyTest, tty_daemonize_test)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
@@ -90,4 +90,4 @@ TEST(PortTtyTest, tty_daemonize_test)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -39,9 +39,9 @@
 #include "omrmemcategories.h"
 #include "omrformatconsts.h"
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/vminfo.h>
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 #define TWO_GIG_BAR 0x7FFFFFFF
 #define ONE_MB (1*1024*1024)
@@ -64,9 +64,9 @@
 
 #define allocNameSize 64 /**< @internal buffer size for name function */
 
-#if defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX)
 #define ENABLE_RESERVE_MEMORY_EX_TESTS
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX) */
 
 #if defined(ENABLE_RESERVE_MEMORY_EX_TESTS)
 static int omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *, const char *, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
@@ -242,7 +242,7 @@ exit:
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * Returns TRUE if the given page size and flags corresponds to new page sizes added in z/OS.
  * z/OS traditionally supports 4K and 1M fixed pages.
@@ -289,7 +289,7 @@ TEST(PortVmemTest, vmem_test1)
 	const char *testName = "omrvmem_test1";
 	char *memPtr = NULL;
 	uintptr_t *pageSizes = NULL;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	uintptr_t *pageFlags = NULL;
 #endif /* J9ZOS390 */
 	int i = 0;
@@ -303,7 +303,7 @@ TEST(PortVmemTest, vmem_test1)
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	pageFlags =
 #endif /* J9ZOS390 */
 		omrvmem_supported_page_flags();
@@ -317,7 +317,7 @@ TEST(PortVmemTest, vmem_test1)
 		getPortLibraryMemoryCategoryData(OMRPORTLIB, &initialBlocks, &initialBytes);
 
 		/* reserve and commit */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
 		if (isNewPageSize(pageSizes[i], pageFlags[i])) {
 			continue;
@@ -409,7 +409,7 @@ TEST(PortVmemTest, vmem_test_free_memory)
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = "omrvmem_test_free_memory";
 	uintptr_t *pageSizes = NULL;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	uintptr_t *pageFlags = NULL;
 #endif /* J9ZOS390 */
 	int i = 0;
@@ -422,14 +422,14 @@ TEST(PortVmemTest, vmem_test_free_memory)
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	pageFlags = omrvmem_supported_page_flags();
 #endif /* J9ZOS390 */
 
 	/* reserve and commit memory for each page size */
 	for (i = 0 ; pageSizes[i] != 0 ; i++) {
 		/* reserve and commit */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
 		if (isNewPageSize(pageSizes[i], pageFlags[i])) {
 			continue;
@@ -501,7 +501,7 @@ TEST(PortVmemTest, vmem_test_shared_file_handle)
 	const char *testName = "omrvmem_test_shared_file_handle";
 	char *memPtr = NULL;
 	uintptr_t *pageSizes = NULL;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	uintptr_t *pageFlags = NULL;
 #endif /* J9ZOS390 */
 	int i = 0;
@@ -515,7 +515,7 @@ TEST(PortVmemTest, vmem_test_shared_file_handle)
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	pageFlags = omrvmem_supported_page_flags();
 #endif /* J9ZOS390 */
 
@@ -528,7 +528,7 @@ TEST(PortVmemTest, vmem_test_shared_file_handle)
 		getPortLibraryMemoryCategoryData(OMRPORTLIB, &initialBlocks, &initialBytes);
 
 		/* reserve and commit */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
 		if (isNewPageSize(pageSizes[i], pageFlags[i])) {
 			continue;
@@ -710,7 +710,7 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 	const char *testName = "vmem_test_double_mapping";
 	char *memPtr = NULL;
 	uintptr_t *pageSizes = NULL;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	uintptr_t *pageFlags = NULL;
 #endif /* J9ZOS390 */
 	struct J9PortVmemIdentifier vmemID;
@@ -730,7 +730,7 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
 	uintptr_t pageSize = pageSizes[0];
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	pageFlags = omrvmem_supported_page_flags();
 #endif /* J9ZOS390 */
 
@@ -752,7 +752,7 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 		getPortLibraryMemoryCategoryData(OMRPORTLIB, &initialBlocks, &initialBytes);
 
 		/* reserve and commit */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
 		if (isNewPageSize(pageSizes[0], pageFlags[0])) {
 			goto J9ZOS390_exit;
@@ -893,7 +893,7 @@ TEST(PortVmemTest, vmem_test_double_mapping)
 			}
 		}
 	}
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 J9ZOS390_exit:
 #endif /* J9ZOS390 */
 	portTestEnv->changeIndent(-1);
@@ -1315,7 +1315,7 @@ TEST(PortVmemTest, vmem_decommit_memory_test)
 	const char *testName = "omrvmem_decommit_memory_test";
 	char *memPtr = NULL;
 	uintptr_t *pageSizes = NULL;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	uintptr_t *pageFlags = NULL;
 #endif /* J9ZOS390 */
 	int i = 0;
@@ -1329,7 +1329,7 @@ TEST(PortVmemTest, vmem_decommit_memory_test)
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	pageFlags =
 #endif /* J9ZOS390 */
 		omrvmem_supported_page_flags();
@@ -1337,7 +1337,7 @@ TEST(PortVmemTest, vmem_decommit_memory_test)
 	/* reserve, commit, decommit, and memory for each page size */
 	for (i = 0 ; pageSizes[i] != 0 ; i++) {
 		/* reserve and commit */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
 		if (isNewPageSize(pageSizes[i], pageFlags[i])) {
 			continue;
@@ -1523,11 +1523,11 @@ omrvmem_testReserveMemoryEx_StandardAndQuickMode(struct OMRPortLibrary *portLibr
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	int rc = omrvmem_testReserveMemoryEx_impl(OMRPORTLIB, testName, topDown, FALSE, strictAddress, strictPageSize, use2To32G);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	if (TEST_PASS == rc) {
 		rc |= omrvmem_testReserveMemoryEx_impl(OMRPORTLIB, testName, topDown, TRUE, strictAddress, strictPageSize, use2To32G);
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	return rc;
 }
 
@@ -1585,15 +1585,15 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 				params[j].endAddress = (void *)(SIXTY_FOUR_GB - 1);
 			} else {
 				params[j].startAddress = (void *)(pageSizes[i] * 2);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 				params[j].endAddress = (void *)(pageSizes[i] * 100);
-#elif defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 				params[j].endAddress = (void *)0x7FFFFFFFFFF;
 #elif defined(OMR_ENV_DATA64)
 				params[j].endAddress = (void *)0xffffffffffffffff;
 #else /* defined(OMR_ENV_DATA64) */
 				params[j].endAddress = (void *)TWO_GIG_BAR;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 			}
 			params[j].byteAmount = pageSizes[i];
 			params[j].mode |= OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT;
@@ -1782,11 +1782,11 @@ memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 		for (j = 0; j < NUM_SEGMENTS; j++) {
 			omrvmem_vmem_params_init(&params[j]);
 			params[j].startAddress = (void *)(pageSizes[i] * 2);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 			params[j].endAddress = (void *)(pageSizes[i] * 100);
-#elif defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 			params[j].endAddress = (void *) 0x7FFFFFFFFFF;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 			params[j].byteAmount = pageSizes[i];
 			params[j].mode |= OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT;
 			params[j].pageSize = pageSizes[i];
@@ -1827,7 +1827,7 @@ memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 	return isMemoryAvailable;
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * Test request for pages below the 2G bar on z/OS
  */
@@ -2245,11 +2245,11 @@ TEST(PortVmemTest, vmem_testReserveLargePagesAboveBar)
 	reportTestExit(OMRPORTLIB, testName);
 }
 #endif /* defined(OMR_ENV_DATA64) */
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #endif /* ENABLE_RESERVE_MEMORY_EX_TESTS */
 
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 /**
  * Verify port library memory management.
  *
@@ -2325,7 +2325,7 @@ TEST(PortVmemTest, vmem_test_commitOutsideOfReservedRange)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 
 #if defined(ENABLE_RESERVE_MEMORY_EX_TESTS)
 /**
@@ -2370,7 +2370,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			intptr_t rc;
 			void (*function)();
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 
 			*((unsigned int *)memPtr) = (unsigned int)0x4e800020; /* blr instruction (equivalent to RET on x86)*/
 			__lwsync();
@@ -2388,7 +2388,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			function();
 			portTestEnv->log("Dynamically created function returned successfully\n");
 
-#elif defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(J9ZOS390) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX)
 			size_t length;
 
 #if defined(J9ZOS39064)
@@ -2427,7 +2427,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			}
 #endif /* J9ZOS39064 */
 
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 			rc = omrvmem_free_memory(memPtr, params.byteAmount, &vmemID);
 			if (rc != 0) {
@@ -2455,9 +2455,9 @@ TEST(PortVmemTest, vmem_test_numa)
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = "omrvmem_test_numa";
 	uintptr_t *pageSizes = NULL;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	uintptr_t *pageFlags = NULL;
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	uintptr_t totalNumaNodeCount = 0;
 	intptr_t detailReturnCode = 0;
 
@@ -2466,9 +2466,9 @@ TEST(PortVmemTest, vmem_test_numa)
 
 	/* First get all the supported page sizes */
 	pageSizes = omrvmem_supported_page_sizes();
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	pageFlags = omrvmem_supported_page_flags();
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	/* Find out how many NUMA nodes are available */
 	detailReturnCode = omrvmem_numa_get_node_details(NULL, &totalNumaNodeCount);
@@ -2530,7 +2530,7 @@ TEST(PortVmemTest, vmem_test_numa)
 			uintptr_t reserveSizeInBytes = pageSize * nodesWithMemoryCount;
 
 			/* reserve and commit */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			/* On z/OS skip this test for newly added large pages as obsolete omrvmem_reserve_memory() does not support them */
 			if (isNewPageSize(pageSizes[i], pageFlags[i])) {
 				continue;
@@ -2638,7 +2638,7 @@ verifyFindValidPageSizeOutput(struct OMRPortLibrary *portLibrary,
 	}
 }
 
-#if (defined(LINUX) && !defined(LINUXPPC)) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_LINUX)) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 
 static int
 omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const char *testName)
@@ -2750,11 +2750,11 @@ TEST(PortVmemTest, vmem_testFindValidPageSize)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	portTestEnv->changeIndent(1);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define OMRPORT_VMEM_PAGESIZE_COUNT 5	/* This should be same as defined in port/unix_include/j9portpg.h */
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #define OMRPORT_VMEM_PAGESIZE_COUNT 3	/* This should be same as defined in port/win32_include/j9portpg.h */
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	uintptr_t *pageSizes = NULL;
 	uintptr_t *pageFlags = NULL;
@@ -2806,7 +2806,7 @@ _exit:
 	EXPECT_EQ(0, rc) << "Test Failed!";
 }
 
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 static int
 omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const char *testName)
@@ -3014,7 +3014,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	/* Test -Xlp:codecache options */
 
 	/* First get the page size of the data segment. This is the page size used by the JIT code cache if 16M Code Pages are not being used */
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #define SAMPLE_BLOCK_SIZE 4
 	/* Allocate a memory block using omrmem_allocate_memory, and use the address to get the page size of data segment */
 	address = omrmem_allocate_memory(SAMPLE_BLOCK_SIZE, OMRMEM_CATEGORY_PORT_LIBRARY);
@@ -3034,7 +3034,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	omrmem_free_memory(address);
 #else
 	dataSegmentPageSize = getpagesize();
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	portTestEnv->log("Page size of data segment: 0x%zx\n", dataSegmentPageSize);
 
@@ -3339,7 +3339,7 @@ _exit:
 	return rc;
 }
 
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 static int
 omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const char *testName)
@@ -3913,7 +3913,7 @@ _exit:
 	return rc;
 }
 
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 uintptr_t
 getSizeFromString(struct OMRPortLibrary *portLibrary, char *sizeString)
@@ -4163,7 +4163,7 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	const char *testName = "vmem_testGetProcessMemorySize";
 
 	reportTestEntry(OMRPORTLIB, testName);
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PRIVATE, &size);
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_PRIVATE did not fail";
 	EXPECT_EQ(0u, size) << "value updated when query invalid";
@@ -4176,14 +4176,14 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL did not fail";
 	EXPECT_EQ(0u, size) << "value updated when query invalid";
 #else
-#if !defined(OSX)
+#if !(HOST_OS == OMR_OSX)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PRIVATE, &size);
 	EXPECT_EQ(0, result) << "OMRPORT_VMEM_PROCESS_PRIVATE failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_PRIVATE returned 0";
 	portTestEnv->log("OMRPORT_VMEM_PROCESS_PRIVATE = %lu.\n", size);
-#endif /* !defined(OSX) */
+#endif /* !(HOST_OS == OMR_OSX) */
 
-#if defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PHYSICAL, &size);
 	EXPECT_EQ(0, result) << "OMRPORT_VMEM_PROCESS_PHYSICAL failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_PHYSICAL returned 0";
@@ -4193,7 +4193,7 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	EXPECT_EQ(0, result) << "OMRPORT_VMEM_PROCESS_VIRTUAL failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL returned 0";
 	portTestEnv->log("OMRPORT_VMEM_PROCESS_VIRTUAL = %lu.\n", size);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	size = 0;
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PHYSICAL, &size);
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_PHYSICAL did not fail";
@@ -4202,8 +4202,8 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_VIRTUAL, &size);
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL did not fail";
 	EXPECT_EQ(0u, size) << "value updated when query invalid";
-#endif /* defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX) */
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	size = 0;
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_EnsureWideEnum, &size);
 	EXPECT_TRUE(result < 0) << "Invalid query not detected";
@@ -4219,12 +4219,12 @@ TEST(PortVmemTest, omrvmem_get_available_physical_memory)
 	uint64_t freePhysicalMemorySize = 0;
 	int32_t status = omrvmem_get_available_physical_memory(&freePhysicalMemorySize);
 	/* omrvmem_get_available_physical_memory is not supported on zos */
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 	ASSERT_EQ(0, status) << "Non-zero status from omrvmem_get_available_physical_memory";
 	portTestEnv->log("freePhysicalMemorySize = %" OMR_PRIu64 "\n", freePhysicalMemorySize);
-#else /* !defined(J9ZOS390) */
+#else /* !(HOST_OS == OMR_ZOS) */
 	ASSERT_EQ(OMRPORT_ERROR_VMEM_NOT_SUPPORTED, status) << "omrvmem_get_available_physical_memory should not be supported";
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 
 }
 

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -27,42 +27,42 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
-#endif /* defined(OMR_OS_WINDOWS) */
-#if !defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_WINDOWS) */
+#if !(HOST_OS == OMR_WINDOWS)
 #include <grp.h>
 #include <errno.h>
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include <limits.h>
 #else
 #define __STDC_LIMIT_MACROS
 #include <stdint.h> /* For INT64_MAX. */
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 #include <sys/resource.h> /* For RLIM_INFINITY */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define _UNIX03_SOURCE
 #include "atoe.h"
 #endif
 
 #include "testHelpers.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define J9DIRECTORY_SEPARATOR_CHARACTER '\\'
 #define J9FILE_EXTENSION ".exe"
 #define J9FILE_EXTENSION_LENGTH (sizeof(J9FILE_EXTENSION) - 1)
 #else
 #define J9DIRECTORY_SEPARATOR_CHARACTER '/'
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /* Under the standard compiler configuration, INT64_MAX is
  * not available; instead, LONGLONG_MAX is defined by xLC.
  */
-#if defined(J9ZOS390) && !defined(INT64_MAX)
+#if (HOST_OS == OMR_ZOS) && !defined(INT64_MAX)
 #define INT64_MAX LONGLONG_MAX
-#endif /* defined(J9ZOS390) && !defined(INT64_MAX) */
+#endif /* (HOST_OS == OMR_ZOS) && !defined(INT64_MAX) */
 
 /**
  * @brief Function takes an expected name for an executable and also the name that was actually
@@ -104,7 +104,7 @@ validate_executable_name(const char *expected, const char *found)
 	/* On Windows, disregard comparing the extension, should this be dropped on the command
 	 * line (API always returns executable name including the extension (.exe).
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Check whether argv0 ends with the extension ".exe".  If not, we need to reduce
 	 * the number of characters to compare (against the executable name found by API).
 	 */
@@ -113,7 +113,7 @@ validate_executable_name(const char *expected, const char *found)
 				J9FILE_EXTENSION_LENGTH) != 0) {
 		length -= J9FILE_EXTENSION_LENGTH;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	if (length == expected_length) {
 		if (strncmp(found_base_path, expected_base_path, length) == 0) {
 			return TRUE;
@@ -132,12 +132,12 @@ TEST(PortSysinfoTest, sysinfo_test0)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Remove extra "./" from the front of executable name. */
 	if (0 == strncmp(argv0, "./", 2)) {
 		argv0 = &argv0[2];
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrsysinfo_get_executable_name(NULL, &executable_name);
 	if (-1 == rc) {
@@ -336,7 +336,7 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 		portTestEnv->log(msg);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (NULL == strstr(osName, "Windows")) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_get_OS_version does not contain \"Windows\".\n", 0, 1);
 		reportTestExit(OMRPORTLIB, testName);
@@ -350,7 +350,7 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -615,8 +615,8 @@ done:
 
 
 /* sysinfo_set_limit and sysinfo_get_limit tests will not work on windows */
-#if !defined(OMR_OS_WINDOWS)
-#if !(defined(AIXPPC) || defined(J9ZOS390))
+#if !(HOST_OS == OMR_WINDOWS)
+#if !((HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS))
 /**
  *
  * Test omrsysinfo_test_sysinfo_set_limit and omrsysinfo_test_sysinfo_get_limit
@@ -718,7 +718,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !(defined(AIXPPC) || defined(J9ZOS390)) */
+#endif /* !((HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)) */
 
 /**
  *
@@ -997,7 +997,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /**
  *
  * Test omrsysinfo_test_sysinfo_set_limit and omrsysinfo_test_sysinfo_get_limit
@@ -1089,7 +1089,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FLAGS)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 /**
  * Test omrsysinfo_test_sysinfo_get_limit for resource OMRPORT_RESOURCE_FILE_DESCRIPTORS.
@@ -1179,14 +1179,14 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_get_limit_FILE_DESCRIPTORS)
 	}
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /* Since the processor and memory usage port library APIs are not available on zOS (neither
  * 31-bit not 64-bit) yet, so we exclude these tests from running on zOS. When the zOS
  * implementation is available, we must remove these guards so that they are built and
  * executed on the z as well. Remove this comment too.
  */
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 /**
  * Test for omrsysinfo_get_memory_info() port library API. Check that we are indeed
  * able to retrieve memory statistics on all supported platforms and also, perform
@@ -1213,31 +1213,31 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.availPhysical)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.totalSwap)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.availSwap)
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.totalVirtual)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.availVirtual)
-#else /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#else /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			/* We do not check totalVirtual since it may be set to some value or -1, depending
 			 * on whether there is a limit set for this or not on the box.
 			 */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.availVirtual)
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
-#if defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 			/* Size of the file buffer area is not available on Windows, AIX and OSX. Therefore,
 			 * it must be set to OMRPORT_MEMINFO_NOT_AVAILABLE.
 			 */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.buffered)
-#else /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			/* On platforms where buffer area is defined, OMRPORT_MEMINFO_NOT_AVAILABLE is
 			 * surely a failure!
 			 */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.buffered)
-#endif /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 #if defined (OSX)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.cached)
 #else /* defined (OSX) */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.cached)
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 		) {
 
 			/* Fail pltest if one of these memory usage parameters were found inconsistent. */
@@ -1249,13 +1249,13 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 		/* Validate the statistics that we obtained. */
 		if ((memInfo.totalPhysical > 0) &&
 			(memInfo.availPhysical <= memInfo.totalPhysical) &&
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			/* Again, it does not make sense to do checks and comparisons on Virtual Memory
 			 * on places other than Windows.
 			 */
 			(memInfo.totalVirtual > 0) &&
 			(memInfo.availVirtual <= memInfo.totalVirtual) &&
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			(memInfo.availSwap <= memInfo.totalSwap) &&
 			(memInfo.timestamp > 0)) {
 
@@ -1263,10 +1263,10 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			portTestEnv->log("Retrieved memory usage statistics.\n");
 			portTestEnv->log("Total physical memory: %llu bytes.\n", memInfo.totalPhysical);
 			portTestEnv->log("Available physical memory: %llu bytes.\n", memInfo.availPhysical);
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 			portTestEnv->log("Total virtual memory: %llu bytes.\n", memInfo.totalVirtual);
 			portTestEnv->log("Available virtual memory: %llu bytes.\n", memInfo.availVirtual);
-#else /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#else /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			/* This may or may not be available depending on whether a limit is set. Print out if this
 			 * is available or else, call this parameter "undefined".
 			 */
@@ -1277,19 +1277,19 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			}
 			/* Leave Available Virtual memory parameter as it is on non-Windows Platforms. */
 			portTestEnv->log("Available virtual memory: <undefined>.\n");
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			portTestEnv->log("Total swap memory: %llu bytes.\n", memInfo.totalSwap);
 			portTestEnv->log("Swap memory free: %llu bytes.\n", memInfo.availSwap);
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 			portTestEnv->log("Cache memory: <undefined>.\n");
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 			portTestEnv->log("Cache memory: %llu bytes.\n", memInfo.cached);
-#endif /* defined(OSX) */
-#if defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined (OSX)
+#endif /* (HOST_OS == OMR_OSX) */
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined (OSX)
 			portTestEnv->log("Buffers memory: <undefined>.\n");
-#else /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined (OSX) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined (OSX) */
 			portTestEnv->log("Buffers memory: %llu bytes.\n", memInfo.buffered);
-#endif /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined (OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined (OSX) */
 			portTestEnv->log("Timestamp: %llu.\n", memInfo.timestamp);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid memory usage statistics retrieved.\n");
@@ -1421,11 +1421,11 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 	portTestEnv->log("User time:   %lld.\n", currInfo.procInfoArray[0].userTime);
 	portTestEnv->log("System time: %lld.\n", currInfo.procInfoArray[0].systemTime);
 	portTestEnv->log("Idle time:   %lld.\n", currInfo.procInfoArray[0].idleTime);
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	portTestEnv->log("Wait time:   <undefined>.\n");
 #else /* Non-windows/OSX platforms */
 	portTestEnv->log("tWait time:   %lld.\n", currInfo.procInfoArray[0].waitTime);
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 	portTestEnv->log("Busy time:   %lld.\n", currInfo.procInfoArray[0].busyTime);
 	portTestEnv->changeIndent(-1);
 
@@ -1439,12 +1439,12 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 			if ((OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].userTime) &&
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].systemTime) &&
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].idleTime) &&
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 				/* Windows and OSX do not have the notion of Wait times. */
 				(OMRPORT_PROCINFO_NOT_AVAILABLE == currInfo.procInfoArray[cntr].waitTime) &&
 #else /* Non-windows/OSX platforms */
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].waitTime) &&
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].busyTime)) {
 
 				/* Print out processor times in each mode for each CPU that is online. */
@@ -1453,11 +1453,11 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 				portTestEnv->log("User time:   %lld.\n", currInfo.procInfoArray[cntr].userTime);
 				portTestEnv->log("System time: %lld.\n", currInfo.procInfoArray[cntr].systemTime);
 				portTestEnv->log("Idle time:   %lld.\n", currInfo.procInfoArray[cntr].idleTime);
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 				portTestEnv->log("Wait time:   <undefined>.\n");
 #else /* Non-windows/OSX platforms */
 				portTestEnv->log("Wait time:   %lld.\n", currInfo.procInfoArray[cntr].waitTime);
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 				portTestEnv->log("Busy time:   %lld.\n", currInfo.procInfoArray[cntr].busyTime);
 				portTestEnv->changeIndent(-1);
 			} else {
@@ -1639,7 +1639,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_CPU_utilization)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 
 
 /*
@@ -1716,7 +1716,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	const char *data = "Hello World!";
 	intptr_t tmpFile = 0;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	wchar_t *origEnv = NULL;
 	const unsigned char utf8[]       = {0x63, 0x3A, 0x5C, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB1, 0xD0, 0xB0, 0x5C, 0x00};
 	const unsigned char utf8_file[]  = {0x63, 0x3A, 0x5C, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB1, 0xD0, 0xB0, 0x5C, 0x74, 0x65, 0x73, 0x74, 0x2E, 0x74, 0x78, 0x74, 0x00};
@@ -1727,16 +1727,16 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	origEnv = (wchar_t *)omrmem_allocate_memory(EsMaxPath, OMRMEM_CATEGORY_PORT_LIBRARY);
 	wcscpy(origEnv, _wgetenv(L"TMP"));
 	rc = _wputenv_s(L"TMP", unicode);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	char *origEnv = NULL;
 	const char *utf8 = "/tmp/test/";
 	const char *utf8_file = "/tmp/test/test.txt";
 	char *origEnvRef = getenv("TMPDIR");
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	char *envVarInEbcdic = a2e_string("TMPDIR");
 	char *origEnvInEbcdic = NULL;
 	char *utf8InEbcdic = a2e_string(utf8);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 
@@ -1744,19 +1744,19 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 		origEnv = (char *)omrmem_allocate_memory(strlen(origEnvRef) + 1, OMRMEM_CATEGORY_PORT_LIBRARY);
 		if (NULL != origEnv) {
 			strcpy(origEnv, origEnvRef);
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			origEnvInEbcdic = a2e_string(origEnv);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 		}
 	}
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	rc = setenv(envVarInEbcdic, utf8InEbcdic, 1);
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	rc = setenv("TMPDIR", (const char *)utf8, 1);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error to update environment variable rc: %d\n", rc);
@@ -1806,23 +1806,23 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	}
 
 	if (NULL != origEnv) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		_wputenv_s(L"TMP", origEnv);
-#elif defined(J9ZOS390) /* defined(OMR_OS_WINDOWS) */
+#elif (HOST_OS == OMR_ZOS) /* (HOST_OS == OMR_WINDOWS) */
 		setenv(envVarInEbcdic, origEnvInEbcdic, 1);
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 		setenv("TMPDIR", origEnv, 1);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		omrmem_free_memory(origEnv);
 	} else {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		_wputenv_s(L"TMP", L"");
-#elif !defined(J9ZOS390) /* defined(OMR_OS_WINDOWS) */
+#elif !(HOST_OS == OMR_ZOS) /* (HOST_OS == OMR_WINDOWS) */
 		unsetenv("TMPDIR");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	}
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	if (NULL != envVarInEbcdic) {
 		free(envVarInEbcdic);
 	}
@@ -1832,7 +1832,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	if (NULL != utf8InEbcdic) {
 		free(utf8InEbcdic);
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	if (NULL != buffer) {
 		omrmem_free_memory(buffer);
@@ -1840,7 +1840,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /*
  * Test omrsysinfo_get_tmp when ignoreEnvVariable is FALSE/TRUE
  * Expected result size of buffer required
@@ -1854,11 +1854,11 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 	char *oldTmpDir = NULL;
 	char *oldTmpDirValue = NULL;
 	const char *modifiedTmpDir = "omrsysinfo_test_get_tmp4_dir";
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	char *envVarInEbcdic = a2e_string(envVar);
 	char *oldTmpDirValueInEbcdic = NULL;
 	char *modifiedTmpDirInEbcdic = a2e_string(modifiedTmpDir);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 
@@ -1867,17 +1867,17 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 		oldTmpDirValue = (char *)omrmem_allocate_memory(strlen(oldTmpDir) + 1, OMRMEM_CATEGORY_PORT_LIBRARY);
 		if (NULL != oldTmpDirValue) {
 			strcpy(oldTmpDirValue, oldTmpDir);
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			oldTmpDirValueInEbcdic = a2e_string(oldTmpDirValue);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 		}
 	}
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	rc = setenv(envVarInEbcdic, modifiedTmpDirInEbcdic, 1);
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	rc = setenv(envVar, modifiedTmpDir, 1);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error in updating environment variable TMPDIR, rc: %zd\n", rc);
 	}
@@ -1923,7 +1923,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 	}
 
 	/* restore TMPDIR */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	if (NULL != oldTmpDirValue) {
 		setenv(envVarInEbcdic, oldTmpDirValueInEbcdic, 1);
 		omrmem_free_memory(oldTmpDirValue);
@@ -1937,18 +1937,18 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 	if (NULL != modifiedTmpDirInEbcdic) {
 		free(modifiedTmpDirInEbcdic);
 	}
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	if (NULL != oldTmpDirValue) {
 		setenv(envVar, oldTmpDirValue, 1);
 		omrmem_free_memory(oldTmpDirValue);
 	} else {
 		unsetenv(envVar);
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /*
  * Test omrsysinfo_get_cwd when the buffer size == 0, then allocate required ammount of bites and try again.
@@ -2022,7 +2022,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	char *buffer = NULL;
 	char *orig_cwd = NULL;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* c:\U+6211 U+7684 U+7236 U+4EB2 U+662F U+6536 U+68D2 U+5B50 U+7684 */
 	const wchar_t unicode[] = {0x0063, 0x003A, 0x005C, 0x6211, 0x7684, 0x7236, 0x4EB2, 0x662F, 0x6536, 0x68D2, 0x5B50, 0x7684, 0x005C, 0x00};
 	const unsigned char utf8[]       = {0x63, 0x3A, 0x5C, 0xE6, 0x88, 0x91, 0xE7, 0x9A, 0x84, 0xE7, 0x88, 0xB6, 0xE4, 0xBA, 0xB2, 0xE6, 0x98, 0xAF, 0xE6, 0x94, 0xB6, 0xE6, 0xA3, 0x92, 0xE5, 0xAD, 0x90, 0xE7, 0x9A, 0x84, 0x5C, 0x00};
@@ -2041,12 +2041,12 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error failed to change current directory rc: %d\n", rc);
 	}
 #else
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	/* On OSX, /tmp is a symbolic link to /private/tmp. For the cwd to match after chdir, use /private/tmp. */
 	const char *utf8 = "/private/tmp/omrsysinfo_test_get_cwd3/";
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	const char *utf8 = "/tmp/omrsysinfo_test_get_cwd3/";
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 
@@ -2059,7 +2059,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	} else {
 		portTestEnv->log("mkdir %s\n", utf8);
 	}
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	rc = atoe_chdir(utf8);
 #else
 	rc = chdir(utf8);
@@ -2069,7 +2069,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	} else {
 		portTestEnv->log("cd %s\n", utf8);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	buffer = (char *)omrmem_allocate_memory(EsMaxPath, OMRMEM_CATEGORY_PORT_LIBRARY);
 	rc = omrsysinfo_get_cwd(buffer, EsMaxPath);
@@ -2085,16 +2085,16 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "invalid directory rc: %d\n", rc);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	_chdir(orig_cwd); /* we need to exit current directory before deleting it*/
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	atoe_chdir(orig_cwd);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	rc = chdir(orig_cwd);
 	if (-1 == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error: failed to change to directory %s, errno: %d\n", (const char *)orig_cwd, errno);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlinkdir((const char *)utf8);
 	if (-1 == rc) {
@@ -2106,7 +2106,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /**
  * Test omrsysinfo_get_groups.
  */
@@ -2167,7 +2167,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_groups)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 /**
  * Test omrsysinfo_test_get_open_file_count.
  * Available only on Linux and AIX.
@@ -2236,8 +2236,8 @@ TEST(PortSysinfoTest, sysinfo_test_get_open_file_count)
 	reportTestExit(OMRPORTLIB, testName);
 	return;
 }
-#endif /* defined(LINUX) || defined(AIXPPC) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * Test omrsysinfo_test_get_os_description.
@@ -2277,7 +2277,7 @@ TEST(PortSysinfoTest, sysinfo_test_os_kernel_info)
 
 	rc = omrsysinfo_os_kernel_info(&kernelInfo);
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	/* Throw an error if failure happens on Linux */
 	if (FALSE == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS,
@@ -2290,13 +2290,13 @@ TEST(PortSysinfoTest, sysinfo_test_os_kernel_info)
 			goto exit;
 		}
 	}
-#else /* defined(LINUX) */
+#else /* (HOST_OS == OMR_LINUX) */
 	if (TRUE == rc) {
 		/* Throw an error if omrsysinfo_os_kernel_info passes on an unsupported platform */
 		outputErrorMessage(PORTTEST_ERROR_ARGS,	"omrsysinfo_os_kernel_info passed on an unsupported platform\n");
 		goto exit;
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 exit:
 	reportTestExit(OMRPORTLIB, testName);
@@ -2318,7 +2318,7 @@ TEST(PortSysinfoTest, sysinfo_cgroup_get_memlimit)
 
 	rc = omrsysinfo_cgroup_get_memlimit(&cgroupMemLimit);
 
-#if !defined(LINUX)
+#if !(HOST_OS == OMR_LINUX)
 	if (OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_cgroup_get_memlimit returned %d, expected %d on platform that does not support cgroups\n", rc, OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM);
 	}

--- a/fvtest/porttest/si_numcpusTest.cpp
+++ b/fvtest/porttest/si_numcpusTest.cpp
@@ -240,7 +240,7 @@ TEST(PortSysinfoTest, sysinfo_numcpus_runTime)
 	EXPECT_TRUE(TEST_PASS == omrsysinfo_numcpus_runTime(OMRPORTLIB, OMRPORT_CPU_BOUND)) << "Test failed.";
 }
 
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 /**
  * @internal
  * Internal function: Counts up the number of processors that are online as per the
@@ -369,4 +369,4 @@ _cleanup:
 	omrsysinfo_destroy_processor_info(&procInfo);
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */

--- a/fvtest/porttest/testHelpers.cpp
+++ b/fvtest/porttest/testHelpers.cpp
@@ -295,7 +295,7 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	portTestEnv->changeIndent(1);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	char dumpName[EsMaxPath] = {0};
 
 	/* Replace trailing ".X&DS" on 64bit and add required "//" prefix */
@@ -315,7 +315,7 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 		fclose(file);
 		rc = 0;
 	}
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	J9FileStat fileStat;
 	int32_t fileStatRC = 99;
 
@@ -333,7 +333,7 @@ verifyFileExists(struct OMRPortLibrary *portLibrary, const char *pltestFileName,
 		/* error in file_stat */
 		outputErrorMessage(OMRPORTLIB, pltestFileName, lineNumber, testName, "\nomrfile_stat call in verifyFileExists() returned %i: %s\n", fileStatRC, omrerror_last_error_message());
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	portTestEnv->changeIndent(-1);
 	return rc;
@@ -449,7 +449,7 @@ raiseSEGV(OMRPortLibrary *portLibrary, void *arg)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	const char *testName = (const char *)arg;
 
-#if defined(OMR_OS_WINDOWS) || defined (J9ZOS390)
+#if (HOST_OS == OMR_WINDOWS) || defined (J9ZOS390)
 	/*
 	 * - Windows structured exception handling doesn't interact with raise().
 	 * - z/OS doesn't provide a value for the psw1 (PC) register when you use raise()
@@ -459,7 +459,7 @@ raiseSEGV(OMRPortLibrary *portLibrary, void *arg)
 	*ptr = -1;
 #else
 	raise(SIGSEGV);
-#endif /* defined(OMR_OS_WINDOWS) || defined (J9ZOS390) */
+#endif /* (HOST_OS == OMR_WINDOWS) || defined (J9ZOS390) */
 
 	outputErrorMessage(PORTTEST_ERROR_ARGS, "unexpectedly continued execution");
 

--- a/fvtest/porttest/testProcessHelpers.cpp
+++ b/fvtest/porttest/testProcessHelpers.cpp
@@ -20,15 +20,15 @@
  *******************************************************************************/
 
 /* These headers are required for ChildrenTest */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <process.h>
 #include <Windows.h>
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <fcntl.h>
 #include <stdlib.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -36,9 +36,9 @@
 #include <sys/sem.h>
 #include <errno.h>
 #define PROCESS_HELPER_SEM_KEY 0x05CAC8E /* Reads OSCACHE */
-#endif /* defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include <spawn.h>
 #include <stdlib.h> /* for malloc for atoe */
 #include "atoe.h"
@@ -54,9 +54,9 @@
 #define PORTTEST_PROCESS_HELPERS_DEBUG
 #endif
 
-#if defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 
-#if (defined(__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)) || defined(OSX)
+#if (defined(__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)) || (HOST_OS == OMR_OSX)
 /* union semun is defined by including <sys/sem.h> */
 #else
 /* according to X/OPEN we have to define it ourselves */
@@ -68,12 +68,12 @@ union semun {
 };
 #endif
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static int setFdCloexec(int fd);
-#if !defined(OSX)
+#if !(HOST_OS == OMR_OSX)
 static intptr_t translateModifiedUtf8ToPlatform(OMRPortLibrary *portLibrary, const char *inBuffer, uintptr_t inBufferSize, char **outBuffer);
-#endif /* !defined(OSX) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_OSX) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 intptr_t
 openLaunchSemaphore(OMRPortLibrary *portLibrary, const char *name, uintptr_t nProcess)
@@ -139,7 +139,7 @@ CloseLaunchSemaphore(OMRPortLibrary *portLibrary, intptr_t semaphore)
 	return semctl(semaphore, 0, IPC_RMID, 0);
 }
 
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 intptr_t
 openLaunchSemaphore(OMRPortLibrary *portLibrary, const char *name, uintptr_t nProcess)
 {
@@ -199,7 +199,7 @@ CloseLaunchSemaphore(OMRPortLibrary *portLibrary, intptr_t semaphore)
 	}
 	return -1;
 }
-#else /* defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 /* Not supported on anything else */
 intptr_t
 openLaunchSemaphore(OMRPortLibrary *portLibrary, const char *name, uintptr_t nProcess)
@@ -222,7 +222,7 @@ CloseLaunchSemaphore(OMRPortLibrary *portLibrary, intptr_t semaphore)
 	return -1;
 }
 
-#endif /* defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 OMRProcessHandle
 launchChildProcess(OMRPortLibrary *portLibrary, const char *testname, const char *argv0, const char *options)
@@ -332,14 +332,14 @@ done:
 void
 SleepFor(intptr_t second)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	Sleep((DWORD)second * 1000);
-#elif defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	sleep(second);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static int
 setFdCloexec(int fd)
 {
@@ -354,7 +354,7 @@ setFdCloexec(int fd)
 	return rc;
 }
 
-#if !defined(OSX)
+#if !(HOST_OS == OMR_OSX)
 static intptr_t
 translateModifiedUtf8ToPlatform(OMRPortLibrary *portLibrary, const char *inBuffer, uintptr_t inBufferSize, char **outBuffer)
 {
@@ -393,8 +393,8 @@ translateModifiedUtf8ToPlatform(OMRPortLibrary *portLibrary, const char *inBuffe
 		return 0;
 	}
 }
-#endif /* !defined(OSX) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_OSX) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 intptr_t
 j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, uint32_t options)
@@ -403,7 +403,7 @@ j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, ui
 	int32_t rc = 0;
 	OMRProcessHandleStruct *processHandleStruct = (OMRProcessHandleStruct *)*processHandle;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (!CloseHandle((HANDLE)processHandleStruct->procHandle)) {
 		rc = OMRPROCESS_ERROR;
 	}
@@ -423,7 +423,7 @@ j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, ui
 			rc = OMRPROCESS_ERROR;
 		}
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	if (OMRPROCESS_INVALID_FD != processHandleStruct->inHandle) {
 		if (0 != close((int) processHandleStruct->inHandle)) {
 			rc = OMRPROCESS_ERROR;
@@ -439,7 +439,7 @@ j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, ui
 			rc = OMRPROCESS_ERROR;
 		}
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrmem_free_memory(processHandleStruct);
 	processHandleStruct = *processHandle = NULL;
 
@@ -450,7 +450,7 @@ intptr_t j9process_waitfor(OMRPortLibrary *portLibrary, OMRProcessHandle process
 {
 	OMRProcessHandleStruct *processHandleStruct = (OMRProcessHandleStruct *) processHandle;
 	intptr_t rc = OMRPROCESS_ERROR;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (WAIT_OBJECT_0 == WaitForSingleObject((HANDLE) processHandleStruct->procHandle, INFINITE)) {
 		DWORD procstat = 0;
 
@@ -461,7 +461,7 @@ intptr_t j9process_waitfor(OMRPortLibrary *portLibrary, OMRProcessHandle process
 	}
 
 	return rc;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	int statusLocation = -1;
 	pid_t retVal = waitpid((pid_t)processHandleStruct->procHandle, &statusLocation, 0);
 
@@ -473,7 +473,7 @@ intptr_t j9process_waitfor(OMRPortLibrary *portLibrary, OMRProcessHandle process
 	} else {
 		rc = OMRPROCESS_ERROR;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	return rc;
 }
 
@@ -484,7 +484,7 @@ j9process_get_exitCode(OMRPortLibrary *portLibrary, OMRProcessHandle processHand
 	return processHandleStruct->exitCode;
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 typedef struct OMRProcessWin32Pipes {
 	HANDLE inR;
 	HANDLE inW;
@@ -644,7 +644,7 @@ getUnicodeCmdline(struct OMRPortLibrary *portLibrary, const char *command[], uin
 	return rc;
 }
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 intptr_t
 j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t commandLength, const char *dir, uint32_t options, OMRProcessHandle *processHandle)
@@ -653,7 +653,7 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	intptr_t rc = 0;
 	OMRProcessHandleStruct *processHandleStruct = NULL;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	STARTUPINFOW sinfo;
 	PROCESS_INFORMATION pinfo;
 	SECURITY_ATTRIBUTES sAttrib;
@@ -813,7 +813,7 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	}
 
 	return rc;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	const char *cmd = NULL;
 	int grdpid;
 	unsigned int i;
@@ -891,10 +891,10 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	memset(newCommand, 0, newCommandSize);
 
 	for (i = 0 ; i < commandLength; i += 1) {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		newCommand[i] = (char *)omrmem_allocate_memory(strlen(command[i]) + 1, OMRMEM_CATEGORY_PORT_LIBRARY);
 		omrstr_printf(newCommand[i], strlen(command[i]) + 1, command[i]);
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 		intptr_t translateStatus = translateModifiedUtf8ToPlatform(OMRPORTLIB, command[i], strlen(command[i]), &(newCommand[i]));
 		if (0 != translateStatus) {
 			unsigned int j = 0;
@@ -906,7 +906,7 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 			}
 			return translateStatus;
 		}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	}
 	cmd = newCommand[0];
 
@@ -1033,5 +1033,5 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	}
 
 	return OMRPROCESS_ERROR;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/fvtest/rastest/agentNegativeTest.cpp
+++ b/fvtest/rastest/agentNegativeTest.cpp
@@ -21,13 +21,13 @@
 
 #include "omrcfg.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* Undefine the winsockapi because winsock2 defines it.  Removes warnings. */
 #if defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
 #undef _WINSOCKAPI_
 #endif
 #include <winsock2.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrport.h"
 #include "omr.h"
@@ -44,21 +44,21 @@ protected:
 	SetUp()
 	{
 		OMRTEST_ASSERT_ERROR_NONE(omrTestVMInit(&testVM, rasTestEnv->getPortLibrary()));
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		/* initialize sockets so that we can use gethostname() */
 		WORD wsaVersionRequested = MAKEWORD(2, 2);
 		WSADATA wsaData;
 		int wsaErr = WSAStartup(wsaVersionRequested, &wsaData);
 		ASSERT_EQ(0, wsaErr);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	}
 
 	virtual void
 	TearDown()
 	{
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		WSACleanup();
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		OMRTEST_ASSERT_ERROR_NONE(omrTestVMFini(&testVM));
 	}
 
@@ -170,13 +170,13 @@ TEST_F(RASAgentNegativeTest, CorruptedAgent)
 	 *  for Unix, fileName = libcorruptedAgent_<hostname>.so
 	 *  for OSX, fileName = libcorruptedAgent_<hostname>.dylib
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	omrstr_printf(fileName, sizeof(fileName), "%s.dll", agentName);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	omrstr_printf(fileName, sizeof(fileName), "lib%s.dylib", agentName);
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	omrstr_printf(fileName, sizeof(fileName), "lib%s.so", agentName);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	/* create the empty agent file with permission 751*/
 	fileDescriptor = omrfile_open(fileName, EsOpenCreate | EsOpenWrite, 0751);

--- a/fvtest/rastest/bindthreadagent.c
+++ b/fvtest/rastest/bindthreadagent.c
@@ -140,11 +140,11 @@ waitForTestChildThread(OMR_TI const *ti, OMR_VM *testVM, omrthread_t childThead,
 	 * Sleep for 0.2 sec to avoid unloading the agent library before the child thread has completed.
 	 * For more detail, please see JAZZ103 74016
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	Sleep(200);
 #else
 	usleep(200000);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	return childRc;
 }

--- a/fvtest/rastest/cpuLoadAgent.c
+++ b/fvtest/rastest/cpuLoadAgent.c
@@ -69,7 +69,7 @@ OMRAgent_OnLoad(OMR_TI const *ti, OMR_VM *vm, char const *options, OMR_AgentCall
 			omrtty_printf("%s: BindCurrentThread passed, vmThread=0x%p\n", agentName, vmThread);
 		}
 	}
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 	/**
 	 * Exclude z/OS when testing GetProcessCpuLoad() and GetSystemCpuLoad(). Existing implementation of
 	 * omrsysinfo_get_CPU_utilization(), which the two APIs rely on, is problematic on z/OS. (details see JAZZ103 53507)
@@ -77,7 +77,7 @@ OMRAgent_OnLoad(OMR_TI const *ti, OMR_VM *vm, char const *options, OMR_AgentCall
 	if (OMR_ERROR_NONE == rc) {
 		rc = OMRTEST_PRINT_ERROR(testTICpuLoad(vmThread, ti));
 	}
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 	if (OMR_ERROR_NONE == rc) {
 		rc = ti->UnbindCurrentThread(vmThread);
 		if (OMR_ERROR_NONE != rc) {
@@ -441,11 +441,11 @@ systemTimeCPUBurn(void)
 	FILE *tempFile = NULL;
 
 	for (j = 0; j < NUM_ITERATIONS_SYSTEM_CPU_BURN; j++) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		tempFile = fopen("nul", "w");
 #else
 		tempFile = fopen("/dev/null", "w");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		fwrite("garbage", 1, sizeof("garbage"), tempFile);
 		fclose(tempFile);
 	}

--- a/fvtest/rastest/traceTest.cpp
+++ b/fvtest/rastest/traceTest.cpp
@@ -110,11 +110,11 @@ TEST(RASTraceTest, TraceAgent)
 #endif /* TEST_TRACEAGENT */
 
 	/* Load sampleSubscriber agent */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	agent = omr_agent_create(&testVM.omrVM, "sampleSubscriber=NUL");
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	agent = omr_agent_create(&testVM.omrVM, "sampleSubscriber=/dev/null");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	ASSERT_FALSE(NULL == agent) << "testAgent: createAgent() sampleSubscriber failed";
 
 	OMRTEST_ASSERT_ERROR_NONE(omr_agent_openLibrary(agent));

--- a/fvtest/rastest/traceagent.c
+++ b/fvtest/rastest/traceagent.c
@@ -252,7 +252,7 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 	omr_error_t rc = OMR_ERROR_NONE;
 	omr_error_t testRc = OMR_ERROR_NONE;
 	uint64_t memorySize = 0;
-#if defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_ERROR(ti->GetFreePhysicalMemorySize(vmThread, &memorySize));
 		if (OMR_ERROR_NONE != rc) {
@@ -262,7 +262,7 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 			omrtty_printf("%s:%d Free physical memory size (in bytes): %llu, rc = %d (%s), the function call is successful !\n", __FILE__, __LINE__, memorySize, rc, omrErrorToString(rc));
 		}
 	}
-#if defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_ERROR(ti->GetProcessVirtualMemorySize(vmThread, &memorySize));
 		if (OMR_ERROR_NONE != rc) {
@@ -281,8 +281,8 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 			omrtty_printf("%s:%d Process physical memory size (in bytes): %llu, rc = %d (%s), the function call is successful !\n", __FILE__, __LINE__, memorySize, rc, omrErrorToString(rc));
 		}
 	}
-#endif /* defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX) */
-#if defined(LINUX) || defined(AIXPPC)|| defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)|| (HOST_OS == OMR_WINDOWS)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_ERROR(ti->GetProcessPrivateMemorySize(vmThread, &memorySize));
 		if (OMR_ERROR_NONE != rc) {
@@ -292,8 +292,8 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 			omrtty_printf("%s:%d Process private memory size (in bytes): %llu, rc = %d (%s), the function call is successful !\n", __FILE__, __LINE__, memorySize, rc, omrErrorToString(rc));
 		}
 	}
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) */
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 	return testRc;
 }
 
@@ -307,9 +307,9 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 	int32_t traceMetaLength = 0;
 	UtSubscription *subscriptionID = NULL;
 	uint64_t *invalidMemorySizePtr = NULL;
-#if !defined(LINUX) && !defined(OMR_OS_WINDOWS) && !defined(OSX)
+#if !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX)
 	uint64_t memorySize = -1;
-#endif /* !defined(LINUX) && !defined(OMR_OS_WINDOWS) && !defined(OSX) */
+#endif /* !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX) */
 
 	rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetTraceMetadata(vmThread, NULL, &traceMetaLength), OMR_ERROR_ILLEGAL_ARGUMENT);
 	if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
@@ -350,7 +350,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 	}
 
 	/* Test with invalidMemorySizePtr, OMR_ERROR_ILLEGAL_ARGUMENT is expected */
-#if defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetFreePhysicalMemorySize(vmThread, invalidMemorySizePtr), OMR_ERROR_ILLEGAL_ARGUMENT);
 		if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
@@ -364,7 +364,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 			testRc = OMR_ERROR_INTERNAL;
 		}
 	}
-#if defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetProcessVirtualMemorySize(vmThread, invalidMemorySizePtr), OMR_ERROR_ILLEGAL_ARGUMENT);
 		if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
@@ -378,11 +378,11 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 			testRc = OMR_ERROR_INTERNAL;
 		}
 	}
-#endif /* defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX) */
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 
 	/* Test GetFreePhysicalMemorySize and GetProcessPrivateMemorySize on platforms other than LINUX, AIXPPC and WIN, OMR_ERROR_NOT_AVAILABLE is expected */
-#if !defined(LINUX) && !defined(AIXPPC) && !defined(OMR_OS_WINDOWS)  && !defined(OSX)
+#if !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_WINDOWS)  && !(HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetFreePhysicalMemorySize(vmThread, &memorySize), OMR_ERROR_NOT_AVAILABLE);
 		if (OMR_ERROR_NOT_AVAILABLE != rc) {
@@ -398,7 +398,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 	}
 
 	/* Test GetProcessVirtualMemorySize and GetProcessPhysicalMemorySize on platforms other than LINUX and WIN, OMR_ERROR_NOT_AVAILABLE is expected */
-#elif !defined(LINUX) && !defined(OMR_OS_WINDOWS) && !defined(OSX)
+#elif !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetProcessVirtualMemorySize(vmThread, &memorySize), OMR_ERROR_NOT_AVAILABLE);
 		if (OMR_ERROR_NOT_AVAILABLE != rc) {
@@ -413,7 +413,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 		}
 	}
 
-#endif /* !defined(LINUX) && !defined(AIXPPC) && !defined(OMR_OS_WINDOWS) && !defined(OSX) */
+#endif /* !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX) */
 
 	return testRc;
 }

--- a/fvtest/sigtest/sigTest.cpp
+++ b/fvtest/sigtest/sigTest.cpp
@@ -19,26 +19,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define _OPEN_THREADS 2
 #define _UNIX03_SOURCE
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #define __STDC_FORMAT_MACROS
 #include <stdint.h>
 #include <inttypes.h>
 #include <pthread.h>
 #include <dlfcn.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 #include <errno.h>
 #include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <unistd.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include "omrthread.h"
 #include "omrTest.h"
@@ -50,23 +50,23 @@
 #include "sigTestHelpers.hpp"
 
 enum TestAction {
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	test_sigaction,
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 	test_signal,
 	test_omrsig_handler,
 	test_omrsig_primary_signal,
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	test_omrsig_primary_sigaction
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 };
 
 #if !defined(PRId64)
-#if defined(OMR_OS_WINDOWS) || defined(J9ZOS390)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS)
 #define PRId64 "I64d"
 #else
 #error no value for PRId64
-#endif /* defined(OMR_OS_WINDOWS) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS) */
 #endif
 
 static jmp_buf env;
@@ -76,24 +76,24 @@ static void handlerPrimaryInstaller(int sig);
 static void handlerSecondary(int sig);
 static void handlerSecondaryInstaller(int sig);
 static void handlerTertiaryInstaller(int sig);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define sigsetjmp(env, savesigs) setjmp(env)
 #define siglongjmp(env, val) longjmp(env, val)
 static int signumOptions[] = {SIGABRT, 10000};
 #define NUM_TEST_CONDITIONS (2*2*4*2)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 static int signalRaisingThread(void *entryArg);
 static volatile bool primaryMasked;
 static volatile bool secondaryMasked;
 static int signumOptions[] = {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* On AIX, calls to sigaltstack() fail after siglongjmp out of a handler,
 	 * so cannot test SIGABRT effectively.
 	 */
 	SIGURG,
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	SIGABRT,
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	10000, SIGCHLD, SIGCONT
 };
 #define THREADING_TEST_ITERATIONS 200
@@ -102,22 +102,22 @@ static void handlerPrimaryInfo(int sig, siginfo_t *siginfo, void *uc);
 static void handlerSecondaryInfo(int sig, siginfo_t *siginfo, void *uc);
 static unsigned int flagOptions[] = {SA_SIGINFO, SA_RESETHAND, SA_NODEFER, SA_ONSTACK};
 typedef int (*SIGACTION)(int signum, const struct sigaction *act, struct sigaction *oldact);
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma map (sigactionOS, "\174\174SIGACT")
 extern int sigactionOS(int, const struct sigaction *, struct sigaction *);
 #else
 static SIGACTION sigactionOS = NULL;
-#endif /* defined(J9ZOS390) */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_ZOS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 static sighandler_t handlerOptions[] = {SIG_DFL, SIG_IGN, NULL, handlerPrimary, handlerSecondary};
 
 static omr_error_t test(TestAction testFunc);
 static omr_error_t setupExistingHandlerConditions(bool existingPrimary, bool existingSecondary, bool onStack, int signum);
 static bool checkPreviousHandler(int signum, TestAction testFunc, sighandler_t expectedPreviousHandler, sighandler_t previousHandler);
 static omr_error_t performTestAndCheck(int expectedHandlerCalls, bool onStackCondition, bool testingSecondaryHandler, int signum);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 static omr_error_t runTest(bool existingPrimary, bool existingSecondary, sighandler_t action, int signum, TestAction testFunc);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 static void checkSignalMask(int signum, bool expected, bool checkingPrimary);
 typedef void (*sigaction_t)(int sig, siginfo_t *siginfo, void *uc);
 static omr_error_t runTest(bool existingPrimary, bool existingSecondary, struct sigaction *action, bool onStack, int signum, TestAction testFunc);
@@ -125,7 +125,7 @@ static omr_error_t runSigactionTest(int *expectedHandlerCalls, bool existingPrim
 									int signum, struct sigaction *act, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler);
 static omr_error_t runPrimarySigactionTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
 		int signum, struct sigaction *act, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 static omr_error_t runSignalTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
 								 int signum, sighandler_t action, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler);
 static omr_error_t runHandlerTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
@@ -133,12 +133,12 @@ static omr_error_t runHandlerTest(int *expectedHandlerCalls, bool existingPrimar
 static omr_error_t runPrimarySignalTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
 										int signum, sighandler_t action, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler);
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 TEST(OmrSigTest, sigactionTest)
 {
 	EXPECT_TRUE(OMR_ERROR_NONE == test(test_sigaction)) << "sigaction() test failed.";
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 TEST(OmrSigTest, signalTest)
 {
@@ -155,7 +155,7 @@ TEST(OmrSigTest, omrsig_primary_signalTest)
 	EXPECT_TRUE(OMR_ERROR_NONE == test(test_omrsig_primary_signal)) << "omrsig_primary_signal() test failed.";
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 TEST(OmrSigTest, omrsig_primary_sigactionTest)
 {
 	EXPECT_TRUE(OMR_ERROR_NONE == test(test_omrsig_primary_sigaction)) << "omrsig_primary_sigaction() test failed.";
@@ -208,16 +208,16 @@ TEST(OmrSigTest, omrsigReentrancyTest)
 	}
 }
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 TEST(OmrSigTest, handlerInstallingHandlerTest)
 {
 	/* Test using a signal handler which installs a handler and raises a signal. */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	sigset_t mask;
 	sigemptyset(&mask);
 	pthread_sigmask(SIG_SETMASK, &mask, NULL);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	omrsig_primary_signal(SIGABRT, handlerPrimaryInstaller);
 	signal(SIGABRT, handlerSecondaryInstaller);
@@ -231,7 +231,7 @@ TEST(OmrSigTest, handlerInstallingHandlerTest)
 			<< "Expected 4 handler calls, got " << handlerCalls << ".";
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static int
 signalRaisingThread(void *entryArg)
 {
@@ -256,7 +256,7 @@ signalRaisingThread(void *entryArg)
 	}
 	return 0;
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /* Iterate through all possible test conditions and run the tests. */
 static omr_error_t
@@ -277,14 +277,14 @@ test(TestAction testFunc)
 		/* Select handler function. */
 		int handlerIndex = ((i & 12) >> 2);
 		if ((3 == handlerIndex)
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 			&& (testFunc != test_omrsig_primary_sigaction)
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 			&& (testFunc != test_omrsig_primary_signal)) {
 			handlerIndex += 1;
 		}
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		struct sigaction act = {{0}};
 		act.sa_flags = 0;
 		if ((test_sigaction == testFunc) || (test_omrsig_primary_sigaction == testFunc)) {
@@ -305,7 +305,7 @@ test(TestAction testFunc)
 			act.sa_handler = handlerOptions[handlerIndex];
 		}
 		sigemptyset(&act.sa_mask);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 		int signum = signumOptions[(i & 48) >> 4];
 		bool onStack = (i & 64) != 0;
@@ -315,19 +315,19 @@ test(TestAction testFunc)
 		if (OMR_ERROR_NONE != runTest(
 				existingPrimary,
 				existingSecondary,
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 				handlerOptions[handlerIndex],
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 				&act,
 				onStack,
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 				signum,
 				testFunc)) {
 
 			int64_t flags = 0;
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 			flags = act.sa_flags;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 			rc = OMR_ERROR_INTERNAL;
 
 			printf("Test %d:%d failed at %s:%d. Conditions: %sexisting primary, %sexisting secondary, flags = %" PRId64 ", signum is %d, handler is 0x%p, %salt signal stack.\n",
@@ -345,27 +345,27 @@ test(TestAction testFunc)
 }
 
 /* Setup the specified test conditions, run the test, and check the result. */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 static omr_error_t
 runTest(bool existingPrimary, bool existingSecondary, sighandler_t act, int signum, TestAction testFunc)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 static omr_error_t
 runTest(bool existingPrimary, bool existingSecondary, struct sigaction *act, bool onStack, int signum, TestAction testFunc)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	omr_error_t rc = OMR_ERROR_NONE;
 	int expectedHandlerCalls = 0;
 	handlerCalls = 0;
 	sighandler_t expectedPreviousHandler = SIG_DFL;
 	sighandler_t previousHandler = SIG_DFL;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	sighandler_t action = act;
 	bool onStack = false;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	sighandler_t action = act->sa_handler;
 	primaryMasked = false;
 	secondaryMasked = false;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (signum != signumOptions[1]) {
 		rc = setupExistingHandlerConditions(existingPrimary, existingSecondary, onStack, signum);
@@ -374,11 +374,11 @@ runTest(bool existingPrimary, bool existingSecondary, struct sigaction *act, boo
 	/* Calculate the expected number of signal handler calls and call the test function. */
 	if (OMR_ERROR_NONE == rc) {
 		switch (testFunc) {
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		case test_sigaction:
 			rc = runSigactionTest(&expectedHandlerCalls, existingPrimary, existingSecondary, signum, act, &expectedPreviousHandler, &previousHandler);
 			break;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 		case test_signal:
 			rc = runSignalTest(&expectedHandlerCalls, existingPrimary, existingSecondary, signum, action, &expectedPreviousHandler, &previousHandler);
 			break;
@@ -388,11 +388,11 @@ runTest(bool existingPrimary, bool existingSecondary, struct sigaction *act, boo
 		case test_omrsig_primary_signal:
 			rc = runPrimarySignalTest(&expectedHandlerCalls, existingPrimary, existingSecondary, signum, action, &expectedPreviousHandler, &previousHandler);
 			break;
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		case test_omrsig_primary_sigaction:
 			rc = runPrimarySigactionTest(&expectedHandlerCalls, existingPrimary, existingSecondary, signum, act, &expectedPreviousHandler, &previousHandler);
 			break;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 		}
 	}
 	if (OMR_ERROR_NONE == rc) {
@@ -409,25 +409,25 @@ runTest(bool existingPrimary, bool existingSecondary, struct sigaction *act, boo
 		}
 		rc = performTestAndCheck(
 				 expectedHandlerCalls,
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 				 false,
 				 false,
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 				 onStack && (SA_ONSTACK & act->sa_flags) && handlerIsFunction(action)
 				 && ((testFunc == test_sigaction) || (testFunc == test_omrsig_primary_sigaction)),
 				 testFunc == test_sigaction,
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 				 signum);
 	}
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	/* Cleanup alternate stack if it exists. */
 	if (onStack && (signum != signumOptions[1])) {
 		stack_t stack;
 		sigaltstack(NULL, &stack);
 		free(stack.ss_sp);
 	}
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	return rc;
 }
@@ -455,7 +455,7 @@ setupExistingHandlerConditions(bool existingPrimary, bool existingSecondary, boo
 	/* Setup existing primary handler condition. */
 	if (OMR_ERROR_NONE == rc) {
 		if (existingPrimary) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			if (SIG_ERR == omrsig_primary_signal(signum, handlerPrimary)) {
 				rc = OMR_ERROR_INTERNAL;
 			}
@@ -467,7 +467,7 @@ setupExistingHandlerConditions(bool existingPrimary, bool existingSecondary, boo
 			if (0 != omrsig_primary_sigaction(signum, &act, NULL)) {
 				rc = OMR_ERROR_INTERNAL;
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		} else {
 			if (SIG_ERR == omrsig_primary_signal(signum, SIG_IGN)) {
 				rc = OMR_ERROR_INTERNAL;
@@ -494,7 +494,7 @@ setupExistingHandlerConditions(bool existingPrimary, bool existingSecondary, boo
 		}
 	}
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	/* Setup signal stack condition. */
 	if (OMR_ERROR_NONE == rc) {
 		stack_t stack;
@@ -513,14 +513,14 @@ setupExistingHandlerConditions(bool existingPrimary, bool existingSecondary, boo
 			printf("sigaltstack() failed with error code %d in setting test conditions at %s:%d.\n", errno, __FILE__, __LINE__);
 		}
 	}
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	handlerCalls = 0;
 
 	return rc;
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static omr_error_t
 runPrimarySigactionTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
 						int signum, struct sigaction *act, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler)
@@ -553,17 +553,17 @@ runPrimarySigactionTest(int *expectedHandlerCalls, bool existingPrimary, bool ex
 	secondaryMasked = false;
 	return rc;
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 static omr_error_t
 runPrimarySignalTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
 					 int signum, sighandler_t action, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	*expectedHandlerCalls = 1;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	*expectedHandlerCalls = 2;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	if (existingSecondary) {
 		*expectedHandlerCalls += 1;
 	}
@@ -587,7 +587,7 @@ runHandlerTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSec
 {
 	omr_error_t rc = OMR_ERROR_NONE;
 	*expectedHandlerCalls = 0;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* On Windows, primary is reset after first signal, but jump from handler prevents the
 	 * reset of the secondary when it is called here.
 	 */
@@ -597,14 +597,14 @@ runHandlerTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSec
 	if (existingSecondary) {
 		*expectedHandlerCalls += 2;
 	}
-#else /* !defined(OMR_OS_WINDOWS) */
+#else /* !(HOST_OS == OMR_WINDOWS) */
 	if (existingPrimary) {
 		*expectedHandlerCalls = 2;
 	}
 	if (existingSecondary) {
 		*expectedHandlerCalls += 1;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	if (0 == setjmp(env) && (signum != signumOptions[1])) {
 		int ret = omrsig_handler(signum, NULL, NULL);
 		if ((OMRSIG_RC_SIGNAL_HANDLED != ret)
@@ -617,13 +617,13 @@ runHandlerTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSec
 		}
 	}
 	*previousHandler = SIG_DFL;
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	primaryMasked = existingPrimary;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 	return rc;
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static omr_error_t
 runSigactionTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
 				 int signum, struct sigaction *act, sighandler_t *expectedPreviousHandler, sighandler_t *previousHandler)
@@ -656,13 +656,13 @@ runSigactionTest(int *expectedHandlerCalls, bool existingPrimary, bool existingS
 	}
 	primaryMasked = existingPrimary;
 	secondaryMasked = (!(act->sa_flags & SA_NODEFER)
-#if (defined(AIXPPC) || defined(J9ZOS390))
+#if ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS))
 					   && !(act->sa_flags & SA_RESETHAND)
-#endif /* (defined(AIXPPC) || defined(J9ZOS390)) */
+#endif /* ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)) */
 					   && handlerIsFunction(act));
 	return rc;
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 static omr_error_t
 runSignalTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSecondary,
@@ -670,18 +670,18 @@ runSignalTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSeco
 {
 	*expectedHandlerCalls = 1;
 	if (existingPrimary) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		*expectedHandlerCalls = 2;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 		*expectedHandlerCalls = 3;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	}
 	if (!handlerIsFunction(action)) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		*expectedHandlerCalls = existingPrimary ? 1 : 0;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 		*expectedHandlerCalls = existingPrimary ? 2 : 0;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	}
 	*previousHandler = signal(signum, action);
 	if (existingSecondary) {
@@ -691,10 +691,10 @@ runSignalTest(int *expectedHandlerCalls, bool existingPrimary, bool existingSeco
 	} else {
 		*expectedPreviousHandler = SIG_IGN;
 	}
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	primaryMasked = existingPrimary;
 	secondaryMasked = false;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 	return OMR_ERROR_NONE;
 }
 
@@ -717,9 +717,9 @@ performTestAndCheck(int expectedHandlerCalls, bool onStackCondition, bool testin
 {
 	omr_error_t rc = OMR_ERROR_NONE;
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	if (signum != signumOptions[1]) {
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 		/* Find the system implementation of sigaction on first call. */
 		if (NULL == sigactionOS) {
 			sigactionOS = (SIGACTION)dlsym(RTLD_NEXT, "sigaction");
@@ -732,7 +732,7 @@ performTestAndCheck(int expectedHandlerCalls, bool onStackCondition, bool testin
 			rc = OMR_ERROR_INTERNAL;
 			printf("dlsym() for sigaction failed at %s:%d.\n", __FILE__, __LINE__);
 		}
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 
 		if (OMR_ERROR_INTERNAL == rc) {
 			struct sigaction actprimary = {{0}};
@@ -764,7 +764,7 @@ performTestAndCheck(int expectedHandlerCalls, bool onStackCondition, bool testin
 	sigset_t mask;
 	sigemptyset(&mask);
 	pthread_sigmask(SIG_SETMASK, &mask, NULL);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	/* Perform the signal test and check the expected number of calls. */
 	for (int i = 0; i < 2; i += 1) {
@@ -790,7 +790,7 @@ performTestAndCheck(int expectedHandlerCalls, bool onStackCondition, bool testin
 	return rc;
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static void
 checkSignalMask(int signum, bool expected, bool checkingPrimary)
 {
@@ -804,15 +804,15 @@ checkSignalMask(int signum, bool expected, bool checkingPrimary)
 			   __FILE__, __LINE__);
 	}
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 static void
 handlerPrimary(int sig)
 {
 	handlerCalls += 1;
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	checkSignalMask(sig, primaryMasked, true);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 	if ((OMRSIG_RC_SIGNAL_HANDLED != omrsig_handler(sig, NULL, NULL)) && (SIGABRT == sig)) {
 		siglongjmp(env, handlerCalls);
 	}
@@ -822,15 +822,15 @@ static void
 handlerSecondary(int sig)
 {
 	handlerCalls += 1;
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	checkSignalMask(sig, secondaryMasked, false);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 	if (SIGABRT == sig) {
 		siglongjmp(env, handlerCalls);
 	}
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static void
 handlerPrimaryInfo(int sig, siginfo_t *siginfo, void *uc)
 {
@@ -850,7 +850,7 @@ handlerSecondaryInfo(int sig, siginfo_t *siginfo, void *uc)
 		siglongjmp(env, handlerCalls);
 	}
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 static void
 handlerPrimaryInstaller(int sig)

--- a/fvtest/sigtest/sigTestHelpers.cpp
+++ b/fvtest/sigtest/sigTestHelpers.cpp
@@ -27,7 +27,7 @@ handlerIsFunction(sighandler_t handler)
 	return (SIG_DFL != handler) && (SIG_IGN != handler) && (NULL != handler);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 bool
 handlerIsFunction(const struct sigaction *act)
 {
@@ -36,7 +36,7 @@ handlerIsFunction(const struct sigaction *act)
 			   && (SIG_DFL != (sighandler_t)act->sa_sigaction)
 			   && (SIG_IGN != (sighandler_t)act->sa_sigaction));
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 void
 createThread(omrthread_t *newThread, uintptr_t suspend, omrthread_detachstate_t detachstate,

--- a/fvtest/sigtest/sigTestHelpers.hpp
+++ b/fvtest/sigtest/sigTestHelpers.hpp
@@ -33,8 +33,8 @@ void createThread(omrthread_t *newThread, uintptr_t suspend, omrthread_detachsta
 				  omrthread_entrypoint_t entryProc, void *entryArg);
 intptr_t joinThread(omrthread_t threadToJoin);
 bool handlerIsFunction(sighandler_t handler);
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 bool handlerIsFunction(const struct sigaction *act);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #endif /* OMRSIGTESTHELPERS_H_INCLUDED */

--- a/fvtest/threadextendedtest/processTimeTest.cpp
+++ b/fvtest/threadextendedtest/processTimeTest.cpp
@@ -37,11 +37,11 @@ systemTimeCpuBurn(void)
 	FILE * tempFile = NULL;
 
 	for (j = 0; j < 100; j++) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		tempFile = fopen("nul", "w");
 #else
 		tempFile = fopen("/dev/null", "w");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		fwrite("garbage", 1, sizeof("garbage"), tempFile);
 		fclose(tempFile);
 	}

--- a/fvtest/threadtest/createTest.cpp
+++ b/fvtest/threadtest/createTest.cpp
@@ -19,18 +19,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <pthread.h>
 #include <limits.h>	/* for PTHREAD_STACK_MIN */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h> /* required for the _SC_PAGESIZE  constant */
-#endif /* defined(LINUX) || defined(OSX) */
-#endif /* defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 #include "createTestHelper.h"
 #include "common/omrthreadattr.h"
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX)
 #include "unix/unixthreadattr.h"
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX) */
 #include "thread_api.h"
 #include "thrdsup.h"
 #include "omrTest.h"
@@ -53,7 +53,7 @@ omrthread_verboseCall(const char *func, intptr_t retVal)
         if (retVal != J9THREAD_SUCCESS) {
                 intptr_t errnoSet = retVal & J9THREAD_ERR_OS_ERRNO_SET;
                 omrthread_os_errno_t os_errno = J9THREAD_INVALID_OS_ERRNO;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
                 omrthread_os_errno_t os_errno2 = omrthread_get_os_errno2();
 #endif /* J9ZOS390 */
 
@@ -64,7 +64,7 @@ omrthread_verboseCall(const char *func, intptr_t retVal)
 
                 if (retVal == J9THREAD_ERR_UNSUPPORTED_ATTR) {
                         if (errnoSet) {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
                                 omrTestEnv->log(LEVEL_ERROR, "%s unsupported: retVal %zd (%zx) : errno %zd (%zx) %s, errno2 %zd (%zx)\n", func, retVal, retVal, os_errno, os_errno, strerror((int)os_errno), os_errno2, os_errno2);
 #else /* !J9ZOS390 */
                                 omrTestEnv->log(LEVEL_ERROR, "%s unsupported: retVal %zd (%zx) : errno %zd %s\n", func, retVal, retVal, os_errno, strerror((int)os_errno));
@@ -74,7 +74,7 @@ omrthread_verboseCall(const char *func, intptr_t retVal)
                         }
                 } else {
                         if (errnoSet) {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
                                 omrTestEnv->log(LEVEL_ERROR, "%s failed: retVal %zd (%zx) : errno %zd (%zx) %s, errno2 %zd (%zx)\n", func, retVal, retVal, os_errno, os_errno, strerror((int)os_errno), os_errno2, os_errno2);
 #else /* !J9ZOS390 */
                                 omrTestEnv->log(LEVEL_ERROR, "%s failed: retVal %zd (%zx) : errno %zd %s\n", func, retVal, retVal, os_errno, strerror((int)os_errno));
@@ -110,7 +110,7 @@ protected:
 	SetUpTestCase()
 	{
 		portLib = omrTestEnv->getPortLibrary();
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		if (omrTestEnv->realtime) {
 			omrthread_lib_control(J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING, J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_ENABLED);
 		}
@@ -121,7 +121,7 @@ protected:
 		}
 #else
 		initPrioMap();
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	}
 };
 
@@ -203,7 +203,7 @@ mapOSInherit(intptr_t policy)
 static int
 threadmain(void *arg)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* Threads are detached. It isn't safe to access data in this thread. */
 	return 0;
 #else
@@ -231,7 +231,7 @@ threadmain(void *arg)
 
 		if (osPolicy != expected->osPolicy) {
 			printMismatchS("child thread policy", mapOSPolicy(expected->osPolicy), mapOSPolicy(osPolicy));
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 			/* bug? Some Linux PPC versions create the thread with the wrong policy.
 			 * Warn, but don't flag this as an error. The parent thread has already
 			 * checked for errors in the pthread_attr_t.
@@ -270,7 +270,7 @@ canCreateThread(const create_attr_t *expected, const omrthread_attr_t attr)
 		omrthread_resume(handle);
 
 #if defined(SPEC_PTHREAD_API)
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		/* bug? Linux can return a success code, but still fail to create the thread.
 		 * NOTE: It is not guaranteed that tid 0 is invalid in all pthread implementations.
 		 */
@@ -279,13 +279,13 @@ canCreateThread(const create_attr_t *expected, const omrthread_attr_t attr)
 			status |= CREATE_FAILED;
 			return status;
 		}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		/* this may fail because omrthreads detach themselves upon exiting */
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		/* OSX TODO: Why do the tests segfault in child thread when accessing &data on OSX without a 1ms sleep? */
 		omrthread_sleep(10);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 		PTHREAD_VERBOSE(pthread_join(tid, NULL));
 		status |= data.status;
 
@@ -351,9 +351,9 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 		int osPolicy;
 		int osInheritsched;
 #endif
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		int osScope;
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #ifdef J9ZOS390
 		int osThreadweight;
 		int osDetachstate;
@@ -368,7 +368,7 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 #ifndef J9ZOS390
 
 		PTHREAD_VERBOSE(pthread_attr_getschedpolicy(attr, &osPolicy));
-#if (defined(AIXPPC) || defined(LINUX) || defined(OSX))
+#if ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX))
 		/* aix and linux bug - need to set the schedpolicy to OTHER if inheritsched used */
 		if (J9THREAD_SCHEDPOLICY_INHERIT == expected->policy) {
 			if (osPolicy != OS_SCHED_OTHER) {
@@ -377,7 +377,7 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 			}
 		}
 		else
-#endif /* (defined(AIXPPC) || defined(LINUX) || defined(OSX)) */
+#endif /* ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) */
 		{
 			if (osPolicy != expected->osPolicy) {
 				printMismatchS("os schedpolicy", mapOSPolicy(expected->osPolicy), mapOSPolicy(osPolicy));
@@ -398,13 +398,13 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 		}
 #endif /* not J9ZOS390 */
 
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		PTHREAD_VERBOSE(pthread_attr_getscope(attr, &osScope));
 		if (osScope != expected->osScope) {
 			printMismatchI("os scope", expected->osScope, osScope);
 			status |= WRONG_OS_SCOPE;
 		}
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #ifdef J9ZOS390
 		osThreadweight = pthread_attr_getweight_np(attr);
@@ -431,7 +431,7 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 static void
 getCurrentOsSched(int *priority, int *policy)
 {
-#if defined(SPEC_PTHREAD_API) && !defined(J9ZOS390)
+#if defined(SPEC_PTHREAD_API) && !(HOST_OS == OMR_ZOS)
 	OSTHREAD tid = pthread_self();
 	struct sched_param param;
 
@@ -472,12 +472,12 @@ getOsPolicy(omrthread_schedpolicy_t policy, omrthread_prio_t priority)
 	}
 #endif /* defined(SPEC_PTHREAD_API) */
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	/* overwrite the ospolicy on LINUX if we're using realtime scheduling */
 	if (omrthread_lib_use_realtime_scheduling()) {
 		ospolicy = getRTPolicy(priority);
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return ospolicy;
 }
@@ -489,7 +489,7 @@ getOsStacksize(size_t stacksize)
 		stacksize = STACK_DEFAULT_SIZE;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	/* Linux allocates 2MB if you ask for a stack smaller than STACK_MIN */
 	{
 		size_t pageSafeMinimumStack = 2 * sysconf(_SC_PAGESIZE);
@@ -501,7 +501,7 @@ getOsStacksize(size_t stacksize)
 			stacksize = pageSafeMinimumStack;
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return stacksize;
 }
@@ -732,10 +732,10 @@ TEST_F(ThreadCreateTest, SetAttrPolicy)
 		status |= EXPECTED_VALID;
 	}
 	status |= isAttrOk(&expected, attr);
-#if (defined(LINUX) || defined(AIXPPC))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX))
 	omrTestEnv->log(LEVEL_ERROR, "  ignoring omrthread_create failure\n");
 	status &= ~CREATE_FAILED;
-#endif /* (defined(LINUX) || defined(AIXPPC)) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)) */
 	END_IF_FAILED(status);
 
 	expected.policy = J9THREAD_SCHEDPOLICY_FIFO;
@@ -747,10 +747,10 @@ TEST_F(ThreadCreateTest, SetAttrPolicy)
 		status |= EXPECTED_VALID;
 	}
 	status |= isAttrOk(&expected, attr);
-#if (defined(LINUX) || defined(AIXPPC))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX))
 	omrTestEnv->log(LEVEL_ERROR, "  ignoring omrthread_create failure\n");
 	status &= ~CREATE_FAILED;
-#endif /* (defined(LINUX) || defined(AIXPPC)) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)) */
 	END_IF_FAILED(status);
 
 	expected.policy = J9THREAD_SCHEDPOLICY_INHERIT;

--- a/fvtest/threadtest/createTestHelper.h
+++ b/fvtest/threadtest/createTestHelper.h
@@ -24,7 +24,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
 #endif
 #include <stdio.h>
@@ -34,13 +34,13 @@
 #include "omrthread.h"
 #include "omrport.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define SPEC_WIN_API
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX)
 #define SPEC_PTHREAD_API
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX) */
 
 #ifndef ASSERT
 #define ASSERT(x) assert(x)
@@ -50,7 +50,7 @@
 #define PTHREAD_VERBOSE(x) pthread_verboseCall(#x, (x))
 
 /* OS-specific values */
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define OS_PTHREAD_INHERIT_SCHED PTHREAD_INHERIT_SCHED
 #define OS_PTHREAD_EXPLICIT_SCHED PTHREAD_EXPLICIT_SCHED
 #define OS_PTHREAD_SCOPE_SYSTEM PTHREAD_SCOPE_SYSTEM
@@ -58,7 +58,7 @@
 #define OS_SCHED_RR SCHED_RR
 #define OS_SCHED_FIFO SCHED_FIFO
 
-#else /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #define OS_PTHREAD_INHERIT_SCHED (-1)
 #define OS_PTHREAD_EXPLICIT_SCHED (-2)
@@ -66,9 +66,9 @@
 #define OS_SCHED_OTHER (-1)
 #define OS_SCHED_RR (-2)
 #define OS_SCHED_FIFO (-3)
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define OS_MEDIUM_WEIGHT __MEDIUM_WEIGHT
 #define OS_HEAVY_WEIGHT __HEAVY_WEIGHT
 #else
@@ -101,13 +101,13 @@
 /* ospriority.c */
 extern void initPrioMap(void);
 extern const char *mapOSPolicy(intptr_t policy);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 extern void initRealtimePrioMap(void);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 extern int getRTPolicy(omrthread_prio_t priority);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 typedef int osprio_t;
 extern osprio_t getOsPriority(omrthread_prio_t priority);

--- a/fvtest/threadtest/keyDestructorTest.cpp
+++ b/fvtest/threadtest/keyDestructorTest.cpp
@@ -24,22 +24,22 @@
 #include "omrTest.h"
 #include "testHelper.hpp"
 
-#if !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390)
+#if !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_ZOS)
 #include <pthread.h>
 #include <stdlib.h>
-#endif /* !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_ZOS) */
 
 extern ThreadTestEnvironment *omrTestEnv;
 
 class KeyDestructorTest: public ::testing::Test {
 public:
 	static bool completed;
-#if !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390)
+#if !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_ZOS)
 	static pthread_key_t key;
 
 	static void detachThread(void *p);
 	static void *threadproc(void *p);
-#endif /* !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_ZOS) */
 protected:
 
 	static void
@@ -50,7 +50,7 @@ protected:
 
 bool KeyDestructorTest::completed = false;
 
-#if !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390)
+#if !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_ZOS)
 pthread_key_t KeyDestructorTest::key;
 
 void
@@ -94,11 +94,11 @@ KeyDestructorTest::threadproc(void *p)
 	/* will never get here.  Just to stop compiler warning */
 	return NULL;
 }
-#endif /* !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_ZOS) */
 
 TEST_F(KeyDestructorTest, KeyDestructor)
 {
-#if defined(OMR_OS_WINDOWS) || defined(J9ZOS390)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS)
 	completed = true;
 #else
 	pthread_t thread;
@@ -114,6 +114,6 @@ TEST_F(KeyDestructorTest, KeyDestructor)
 
 	rc = pthread_key_delete(key);
 	ASSERT_EQ(0, rc);
-#endif /* defined(OMR_OS_WINDOWS) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_ZOS) */
 	ASSERT_TRUE(completed);
 }

--- a/fvtest/threadtest/ospriority.cpp
+++ b/fvtest/threadtest/ospriority.cpp
@@ -19,15 +19,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
-#if defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#endif /* (HOST_OS == OMR_WINDOWS) */
+#if (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <pthread.h>
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <mach/mach_host.h>
-#endif /* defined(OSX) */
-#endif /* defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 #include "createTestHelper.h"
 #include "omrutil.h"
 #include "omrutilbase.h"
@@ -75,7 +75,7 @@ mapOSPolicy(intptr_t policy)
 	}
 }
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 
 void
 initPrioMap(void)
@@ -83,13 +83,13 @@ initPrioMap(void)
 	uintptr_t i;
 	osprio_t defaultPriority = 0;
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	host_priority_info_data_t priorityInfoData;
 	mach_msg_type_number_t msgTypeNumber = HOST_PRIORITY_INFO_COUNT;
 	host_flavor_t flavor = HOST_PRIORITY_INFO;
 	host_info(mach_host_self(), flavor, (host_info_t)&priorityInfoData, &msgTypeNumber);
 	defaultPriority = priorityInfoData.user_priority;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	for (i = 0; i <= VM_PRIO_MAX; i++) {
 		VMToOSPrioMap[i] = defaultPriority;
@@ -238,7 +238,7 @@ initRealtimePrioMap(void)
 	printMap();
 }
 
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 
 #if defined(J9OS_I5)
 
@@ -263,7 +263,7 @@ initPrioMap(void)
 }
 #endif /* defined(J9OS_I5) */
 
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 
 void
 initPrioMap(void)
@@ -285,7 +285,7 @@ initPrioMap(void)
 	memcpy(VMToOSPrioMap, tmpMap, sizeof(osprio_t) * (VM_PRIO_MAX + 1));
 }
 
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 void
 initPrioMap(void)
@@ -298,4 +298,4 @@ initPrioMap(void)
 
 #else
 #error "unsupported platform"
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */

--- a/fvtest/utiltest/main.cpp
+++ b/fvtest/utiltest/main.cpp
@@ -36,7 +36,7 @@ main(int argc, char **argv, char **envp)
 
 TEST(UtilTest, detectVMDirectory)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	void *token = NULL;
 	ASSERT_EQ(OMR_ERROR_NONE, OMR_Glue_GetVMDirectoryToken(&token));
 
@@ -52,5 +52,5 @@ TEST(UtilTest, detectVMDirectory)
 		_snwprintf(pathEnd, length, L"\\abc");
 		wprintf(L"Mangled VM Directory: '%s'\n", path);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/gc/base/Bits.hpp
+++ b/gc/base/Bits.hpp
@@ -120,14 +120,14 @@ public:
 #endif /* !defined(OMR_ENV_DATA64) */
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64)
 	/**
 	 * Return the number of bits set to 0 before the first bit set to one starting at the lowest
 	 * significant bit.
 	 * @note If the input is 0, the result is undefined.
 	 * @return Number of non-zero bits starting at the lowest significant bit.
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Implicit return in eax, not seen by compiler.  Disable compile warning C4035: no return value */
 #pragma warning(disable:4035)
 	MMINLINE static uintptr_t leadingZeroes(uintptr_t input)
@@ -137,7 +137,7 @@ public:
 		}
 	}
 #pragma warning(default:4035) /* re-enable warning */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	/**
 	 * Return the number of bits set to 0 before the first bit set to one starting at the highest
@@ -145,7 +145,7 @@ public:
 	 * @note If the input is 0, the result is undefined.
 	 * @return Number of non-zero bits starting at the highest significant bit.
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Implicit return in eax, not seen by compiler.  Disable compile warning C4035: no return value */
 #pragma warning(disable:4035)
 	MMINLINE static uintptr_t trailingZeroes(uintptr_t input)
@@ -157,9 +157,9 @@ public:
 		}
 	}
 #pragma warning(default:4035) /* re-enable warning */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#elif defined(LINUX) && defined(J9HAMMER)
+#elif (HOST_OS == OMR_LINUX) && defined(J9HAMMER)
 	/**
 	 * Return the number of bits set to 0 before the first bit set to one starting at the lowest
 	 * significant bit.
@@ -191,7 +191,7 @@ public:
 		return result;
 	}
 
-#else /* defined(LINUX) && defined(J9HAMMER) */
+#else /* (HOST_OS == OMR_LINUX) && defined(J9HAMMER) */
 
 
 	/**
@@ -246,7 +246,7 @@ public:
 
 		return J9BITS_BITS_IN_SLOT - 1 - result;
 	}
-#endif /* defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64) */
 };
 
 #endif /*BITS_HPP_*/

--- a/gc/base/ConcurrentSafepointCallback.hpp
+++ b/gc/base/ConcurrentSafepointCallback.hpp
@@ -46,11 +46,11 @@ private:
 protected:
 
 public:
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 	virtual void registerCallback(MM_EnvironmentBase *env, SafepointCallbackHandler handler, void *userData, bool cancelAfterGC = false);
 #else
 	virtual void registerCallback(MM_EnvironmentBase *env,  SafepointCallbackHandler handler, void *userData);
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 
 	virtual void requestCallback(MM_EnvironmentBase *env);
 

--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -295,7 +295,7 @@ MM_Configuration::initializeRunTimeObjectAlignmentAndCRShift(MM_EnvironmentBase*
 			Assert_MM_unreachable();
 			return false;
 		}
-#if !defined(S390) && !defined(J9ZOS390)
+#if !defined(S390) && !(HOST_OS == OMR_ZOS)
 		/* s390 benefits from smaller shift values but other platforms don't so just force the shift to 3 if it was not 0 to save
 		 * on testing resources.
 		 * (still honour the "canChangeShift" flag, though, since we want our testing options to still work)

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -130,16 +130,16 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 #define ONE_MB			((uintptr_t)1 * 1024 * 1024)
 #define TWO_MB			((uintptr_t)2 * 1024 * 1024)
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	requestedPageSize = SIXTY_FOUR_KB; /* Use 64K pages for AIX-32 and AIX-64 */
-#elif ((defined(LINUX) || defined(OSX)) && (defined(J9X86) || defined(J9HAMMER)))
+#elif (((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && (defined(J9X86) || defined(J9HAMMER)))
 	requestedPageSize = TWO_MB; /* Use 2M pages for Linux/OSX x86-64 */
-#elif (defined(LINUX) && defined(S390))
+#elif ((HOST_OS == OMR_LINUX) && defined(S390))
 	requestedPageSize = ONE_MB; /* Use 1M pages for zLinux-31 and zLinux-64 */
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	requestedPageSize = ONE_MB; /* Use 1M PAGEABLE for ZOS-31 and ZOS-64 */
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	if (!validateDefaultPageParameters(requestedPageSize, requestedPageFlags, pageSizes, pageFlags)) {
 		requestedPageSize = pageSizes[0];

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -87,7 +87,7 @@ MM_HeapVirtualMemory::initialize(MM_EnvironmentBase* env, uintptr_t size)
 
 	/* Under -Xaggressive ensure a full page of padding -- see JAZZ103 45254 */
 	if (extensions->padToPageSize) {
-#if (defined(AIXPPC) && !defined(PPC64))
+#if ((HOST_OS == OMR_AIX) && !defined(PPC64))
 		/*
 		 * An attempt to allocate heap with top at 0xffffffff
 		 * In this case extra padding is not required because of overflow protection padding can be used instead
@@ -100,7 +100,7 @@ MM_HeapVirtualMemory::initialize(MM_EnvironmentBase* env, uintptr_t size)
 			/* overflow protection must be there to play role of padding even top is not so close to the end of the memory */
 			forcedOverflowProtection = true;
 		} else
-#endif /* (defined(AIXPPC) && !defined(PPC64)) */
+#endif /* ((HOST_OS == OMR_AIX) && !defined(PPC64)) */
 		{
 			/* Ignore extra full page padding if page size is too large (hard coded here for 1G or larger) */
 #define ONE_GB ((uintptr_t)1 * 1024 * 1024 * 1024)

--- a/gc/base/MemoryManager.cpp
+++ b/gc/base/MemoryManager.cpp
@@ -213,13 +213,13 @@ MM_MemoryManager::createVirtualMemoryForHeap(MM_EnvironmentBase* env, MM_MemoryH
 				if (requestedTopAddress <= ceiling) {
 					bool allocationTopDown = true;
 					/* define the scan direction when reserving the GC heap in the range of (4G, 32G) */
-#if defined(S390) || defined(J9ZOS390)
+#if defined(S390) || (HOST_OS == OMR_ZOS)
 					/* s390 benefits from smaller shift values so allocate direction is bottom up */
 					options |= OMRPORT_VMEM_ALLOC_DIR_BOTTOM_UP;
 					allocationTopDown = false;
-#else /* defined(S390) || defined(J9ZOS390) */
+#else /* defined(S390) || (HOST_OS == OMR_ZOS) */
 					options |= OMRPORT_VMEM_ALLOC_DIR_TOP_DOWN;
-#endif /* defined(S390) || defined(J9ZOS390) */
+#endif /* defined(S390) || (HOST_OS == OMR_ZOS) */
 
 					if (allocationTopDown && extensions->shouldForceSpecifiedShiftingCompression) {
 						/* force to allocate heap top-down from correspondent to shift address */

--- a/gc/base/MemoryManager.hpp
+++ b/gc/base/MemoryManager.hpp
@@ -58,16 +58,16 @@ private:
 	{
 		bool result = true;
 
-#if (defined(AIXPPC) && !defined(PPC64))
+#if ((HOST_OS == OMR_AIX) && !defined(PPC64))
 		result = false;
-#elif(defined(AIXPPC) && defined(OMR_GC_REALTIME))
+#elif((HOST_OS == OMR_AIX) && defined(OMR_GC_REALTIME))
 		MM_GCExtensionsBase* extensions = env->getExtensions();
 		if (extensions->isMetronomeGC()) {
 			result = false;
 		}
 #elif defined(J9ZOS39064)
 		result = false;
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) */
 
 		return result;
 	}
@@ -84,12 +84,12 @@ private:
 	{
 		uintptr_t result = 0;
 
-#if (defined(AIXPPC) && defined(PPC64))
+#if ((HOST_OS == OMR_AIX) && defined(PPC64))
 		/*
 		 * AIX-64 memory segment size is 256M
 		 */
 		result = (uintptr_t)256 * 1024 * 1024;
-#endif /* (defined(AIXPPC) && defined(PPC64)) */
+#endif /* ((HOST_OS == OMR_AIX) && defined(PPC64)) */
 
 		return result;
 	}

--- a/gc/base/MemoryPoolLargeObjects.hpp
+++ b/gc/base/MemoryPoolLargeObjects.hpp
@@ -63,15 +63,15 @@ class MM_MemorySubSpace;
 #define LOA_EXPAND_TRIGGER2 ((double)0.50)
 #define LOA_EXPAND_TRGGER3 5
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #if defined(OMR_ENV_DATA64)
 #define LOA_EMPTY ((void*)0x7FFFFFFFFFFFFFFF)
 #else /* !OMR_ENV_DATA64 */
 #define LOA_EMPTY ((void*)0x7FFFFFFF)
 #endif /* OMR_ENV_DATA64 */
-#else /* !defined(J9ZOS390)*/
+#else /* !(HOST_OS == OMR_ZOS)*/
 #define LOA_EMPTY ((void*)-1)
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 
 /**
  * @todo Provide class documentation

--- a/gc/base/NonVirtualMemory.cpp
+++ b/gc/base/NonVirtualMemory.cpp
@@ -53,7 +53,7 @@ MM_NonVirtualMemory::newInstance(MM_EnvironmentBase* env, uintptr_t heapAlignmen
 	return vmem;
 }
 
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 /**
  * Allocate a chunk of memory.
  * @param size The number of bytes to allocate.
@@ -114,4 +114,4 @@ MM_NonVirtualMemory::setNumaAffinity(uintptr_t numaNode, void* address, uintptr_
 	return true;
 }
 
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */

--- a/gc/base/NonVirtualMemory.hpp
+++ b/gc/base/NonVirtualMemory.hpp
@@ -64,16 +64,16 @@ protected:
 	{
 		_typeId = __FUNCTION__;
 	};
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 	virtual void tearDown(MM_EnvironmentBase* env);
 	virtual void* reserveMemory(J9PortVmemParams* params);
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
 public:
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 	virtual bool commitMemory(void* address, uintptr_t size);
 	virtual bool decommitMemory(void* address, uintptr_t size, void* lowValidAddress, void* highValidAddress);
 	virtual bool setNumaAffinity(uintptr_t numaNode, void* address, uintptr_t byteAmount);
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
 
 public:
 /*

--- a/gc/base/standard/ConcurrentCardTableForWC.cpp
+++ b/gc/base/standard/ConcurrentCardTableForWC.cpp
@@ -22,7 +22,7 @@
 
 #include "omrcfg.h"
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
@@ -177,7 +177,7 @@ MM_ConcurrentGCIncrementalUpdate::createCardTable(MM_EnvironmentBase *env)
 	Assert_MM_true(NULL == _cardTable);
 	Assert_MM_true(NULL == _extensions->cardTable);
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
 	if ((uintptr_t)omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) > 1 ) {

--- a/gc/base/standard/ConcurrentPrepareCardTableTask.cpp
+++ b/gc/base/standard/ConcurrentPrepareCardTableTask.cpp
@@ -22,7 +22,7 @@
 
 #include "omrcfg.h"
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 

--- a/gc/base/standard/ConcurrentSafepointCallback.cpp
+++ b/gc/base/standard/ConcurrentSafepointCallback.cpp
@@ -46,11 +46,11 @@ MM_ConcurrentSafepointCallback::kill(MM_EnvironmentBase *env)
 }
 
 void
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 MM_ConcurrentSafepointCallback::registerCallback(MM_EnvironmentBase *env, SafepointCallbackHandler handler, void *userData, bool cancelAfterGC)
 #else
 MM_ConcurrentSafepointCallback::registerCallback(MM_EnvironmentBase *env, SafepointCallbackHandler handler, void *userData)
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 {
 	/* To facilitate simple Card Table logic treat registerCallback as a no-op */
 }

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -108,9 +108,9 @@
 /* VM Design 1774: Ideally we would pull these cache line values from the port library but this will suffice for
  * a quick implementation
  */
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 #define CACHE_LINE_SIZE 128
-#elif defined(J9ZOS390) || (defined(LINUX) && defined(S390))
+#elif (HOST_OS == OMR_ZOS) || ((HOST_OS == OMR_LINUX) && defined(S390))
 #define CACHE_LINE_SIZE 256
 #else
 #define CACHE_LINE_SIZE 64

--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -40,7 +40,7 @@
 #include <builtins.h>
 #endif
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #if defined(__xlC__)
 #include <builtins.h>
 /* 
@@ -62,9 +62,9 @@
 /* Bytecode for: nop */
 #pragma mc_func __ppc_nop  {"60000000"}
 #endif /* #if defined(__xlC__) */
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 #if defined(__xlC__)
 #include <builtins.h>
 /* 
@@ -86,7 +86,7 @@
 /* Bytecode for: nop */
 #pragma mc_func __ppc_nop  {"60000000"}
 #endif /* #if defined(__xlC__) */
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -103,7 +103,7 @@
  * Do not call directly, use the methods from VM_AtomicSupport.
  */
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* The default hardware priorities on AIX is MEDIUM(4).
  * For AIX, dropSMT should drop to LOW(2) and 
  * restoreSMT should raise back to MEDIUM(4)
@@ -115,7 +115,7 @@
 		inline void __dropSMT() {  __asm__ volatile ("or 1,1,1"); }
 		inline void __restoreSMT() {  __asm__ volatile ("or 2,2,2"); }
 #endif
-#elif defined(LINUXPPC) /* defined(AIXPPC) */
+#elif (HOST_OS == OMR_LINUX) /* (HOST_OS == OMR_AIX) */
 /* The default hardware priorities on LINUXPPC is MEDIUM-LOW(3).
  * For LINUXPPC, dropSMT should drop to VERY-LOW(1) and 
  * restoreSMT should raise back to MEDIUM-LOW(3)
@@ -138,7 +138,7 @@
 
 #if defined(_MSC_VER)
 		/* use compiler intrinsic */
-#elif defined(LINUXPPC) || defined(AIXPPC)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 #if defined(__xlC__)
 		/* XL compiler complained about generated assembly, use machine code instead. */
 		inline void __nop() { __ppc_nop(); }
@@ -147,7 +147,7 @@
 		inline void __nop() { __asm__ volatile ("nop"); }
 		inline void __yield() { __asm__ volatile ("or 27,27,27"); }
 #endif
-#elif defined(LINUX) && (defined(S390) || defined(S39064))
+#elif (HOST_OS == OMR_LINUX) && (defined(S390) || defined(S39064))
 		/*
 		 * nop instruction requires operand https://bugzilla.redhat.com/show_bug.cgi?id=506417
 		 */
@@ -156,7 +156,7 @@
 		inline void __nop() { __asm__ volatile ("nop"); }
 #endif
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 #if defined(__GNUC__) && !defined(__clang__)
 	/* GCC compiler does not provide the same intrinsics. */
 
@@ -232,7 +232,7 @@ public:
 		asm volatile("":::"memory");
 #elif defined(_MSC_VER) /* __GNUC__ */
 		_ReadWriteBarrier();
-#elif defined(J9ZOS390) /* _MSC_VER */
+#elif (HOST_OS == OMR_ZOS) /* _MSC_VER */
 		__fence();
 #elif defined(__xlC__) /* J9ZOS390 */
 		asm volatile("");
@@ -252,7 +252,7 @@ public:
 	readWriteBarrier()
 	{
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__sync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
@@ -276,12 +276,12 @@ public:
 #else /* defined(S390) */
 		asm volatile("":::"memory");
 #endif /* defined(J9X86) */
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		/* Replace this with an inline "bcr 15,0" whenever possible */
 		__fence();
 		J9ZOSRWB();
 		__fence();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -297,7 +297,7 @@ public:
 	{
 	/* Neither x86 nor S390 require a write barrier - the compiler fence is sufficient */
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__lwsync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
@@ -309,9 +309,9 @@ public:
 #else /* defined(AARCH64) */
 		asm volatile("":::"memory");
 #endif /* defined(ARM) */
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		__fence();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -327,7 +327,7 @@ public:
 	{
 	/* Neither x86 nor S390 require a read barrier - the compiler fence is sufficient */
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__isync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
@@ -339,9 +339,9 @@ public:
 #else /* defined(AARCH64) */
 		asm volatile("":::"memory");
 #endif /* defined(ARM) */
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		__fence();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -359,11 +359,11 @@ public:
 	VMINLINE static void
 	monitorEnterBarrier()
 	{
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		readWriteBarrier();
-#else /* defined(AIXPPC) || defined(LINUXPPC) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 		readBarrier();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 	}
 
 	/**
@@ -401,13 +401,13 @@ public:
 		return __sync_val_compare_and_swap(address, oldValue, newValue);
 #elif defined(_MSC_VER) /* defined(__GNUC__) */
 		return (uint32_t)_InterlockedCompareExchange((volatile long *)address, (long)newValue, (long)oldValue);
-#elif defined(J9ZOS390) /* defined(_MSC_VER) */
+#elif (HOST_OS == OMR_ZOS) /* defined(_MSC_VER) */
 		/* V1.R13 has a compiler bug and if you pass a constant as oldValue it will cause c-stack corruption */
 		volatile uint32_t old = oldValue;
 		/* 390 cs() function defined in <stdlib.h>, doesn't expand properly to __cs1() which correctly deals with aliasing */
 		__cs1((uint32_t *)&old, (uint32_t *)address, (uint32_t *)&newValue);
 		return old;
-#elif defined(__xlC__) /* defined(J9ZOS390) */
+#elif defined(__xlC__) /* (HOST_OS == OMR_ZOS) */
 		__compare_and_swap((volatile int*)address, (int*)&oldValue, (int)newValue);
 		return oldValue;
 #else /* defined(__xlC__) */
@@ -458,7 +458,7 @@ public:
 		return __sync_val_compare_and_swap(address, oldValue, newValue);
 #elif defined(_MSC_VER) /* defined(__GNUC__) */
 		return (uint64_t)_InterlockedCompareExchange64((volatile __int64 *)address, (__int64)newValue, (__int64)oldValue);
-#elif defined(J9ZOS390) /* defined(_MSC_VER) */
+#elif (HOST_OS == OMR_ZOS) /* defined(_MSC_VER) */
 		 /* V1.R13 has a compiler bug and if you pass a constant as oldValue it will cause c-stack corruption */
 		 volatile uint64_t old = oldValue;
 #if defined(OMR_ENV_DATA64)
@@ -470,7 +470,7 @@ public:
 		cds((cds_t*)&old, (cds_t*)address, *(cds_t*)&newValue);
 		return old;
 #endif /* defined(OMR_ENV_DATA64) */
-#elif defined(__xlC__) /* defined(J9ZOS390) */
+#elif defined(__xlC__) /* (HOST_OS == OMR_ZOS) */
 		__compare_and_swaplp((volatile long*)address, (long*)&oldValue, (long)newValue);
 		return oldValue;
 #else /* defined(__xlC__) */
@@ -858,9 +858,9 @@ public:
 	dropSMTThreadPriority()
 	{
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__dropSMT();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -871,9 +871,9 @@ public:
 	restoreSMTThreadPriority()
 	{
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__restoreSMT();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 

--- a/include_core/edcwccwi.h
+++ b/include_core/edcwccwi.h
@@ -28,7 +28,7 @@
 
 #include "omrcomp.h"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "unix/zos/edcwccwi.h"
 #else
 #error Only legal on ZOS

--- a/include_core/leconditionhandler.h
+++ b/include_core/leconditionhandler.h
@@ -24,7 +24,7 @@
 
 #include "omrcomp.h"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "unix/zos/leconditionhandler.h"
 #else
 #error Only legal on ZOS

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -33,7 +33,7 @@
 #define OMRPORT_ACCESS_FROM_OMRVM(omrVM) OMRPORT_ACCESS_FROM_OMRRUNTIME((omrVM)->_runtime)
 #define OMRPORT_ACCESS_FROM_OMRVMTHREAD(omrVMThread) OMRPORT_ACCESS_FROM_OMRVM((omrVMThread)->_vm)
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "edcwccwi.h"
 /* Convert function pointer to XPLINK calling convention */
 #define OMR_COMPATIBLE_FUNCTION_POINTER(fp) ((void*)__bldxfd(fp))
@@ -509,7 +509,7 @@ omr_error_t OMR_Glue_FreeLanguageThread(void *languageThread);
  */
 omr_error_t OMR_Glue_LinkLanguageThreadToOMRThread(void *languageThread, OMR_VMThread *omrVMThread);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * @brief Get a platform-dependent token that can be used to locate the VM directory.
  *
@@ -527,7 +527,7 @@ omr_error_t OMR_Glue_LinkLanguageThreadToOMRThread(void *languageThread, OMR_VMT
  * @return an OMR error code
  */
 omr_error_t OMR_Glue_GetVMDirectoryToken(void **token);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 char *OMR_Glue_GetThreadNameForUnamedThread(OMR_VMThread *vmThread);
 

--- a/include_core/omragent_internal.h
+++ b/include_core/omragent_internal.h
@@ -32,12 +32,12 @@
  * The structures defined in this file may be changed without notice.
  */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* pdh.h include windows.h which defined uintptr_t.  Ignore its definition */
 #define UDATA UDATA_win32_
 #include <pdh.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrcomp.h"
 #include "omragent.h"

--- a/include_core/omrceetbck.h
+++ b/include_core/omrceetbck.h
@@ -24,7 +24,7 @@
 
 #include "omrcomp.h"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "unix/zos/omrceetbck.h"
 #else
 #error Only legal on ZOS

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -260,11 +260,11 @@
  * Note: these are determined at configure time with cmake.
  * For the autoconf builds, we just hard code them based on platform
  */
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 #define OMR_USE_POSIX_SEMAPHORES
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define OMR_USE_OSX_SEMAPHORES
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 #define OMR_USE_ZOS_SEMAPHORES
 #endif
 

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -38,7 +38,7 @@
 
 #include <stdint.h>
 #include "omrcfg.h"
-#if defined(__cplusplus) && (defined(__xlC__) || defined(J9ZOS390))
+#if defined(__cplusplus) && (defined(__xlC__) || (HOST_OS == OMR_ZOS))
 #include <builtins.h>
 #endif
 
@@ -62,9 +62,9 @@ typedef int32_t					I_32;
 typedef int16_t					I_16;
 typedef int8_t					I_8;
 
-#if defined(MVS)
+#if (HOST_OS == OMR_ZOS)
 typedef int32_t					BOOLEAN;
-#elif defined(LINUX) || defined(RS6000) || defined(J9ZOS390) || defined(OSX) || defined(OMRZTPF) /* MVS */
+#elif (HOST_OS == OMR_LINUX) || defined(RS6000) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX) || defined(OMRZTPF) /* MVS */
 typedef uint32_t					BOOLEAN;
 #else /* MVS */
 /* Don't typedef BOOLEAN since it's already defined on Windows */
@@ -110,7 +110,7 @@ EXE_EXTENSION_CHAR: the executable has a delimiter that we want to stop at as pa
 
 
 /* Linux ANSI compiler (gcc) and OSX (clang). */
-#if defined(LINUX) || defined (OSX)
+#if (HOST_OS == OMR_LINUX) || defined (OSX)
 
 /* NOTE: Linux supports different processors -- do not assume 386 */
 
@@ -147,7 +147,7 @@ typedef double SYS_FLOAT;
 #define J9_PRIORITY_MAP {0,0,0,0,0,0,0,0,0,0,0,0}
 
 
-#if (defined(LINUXPPC) && !defined(LINUXPPC64)) || defined(S390) || defined(J9HAMMER)
+#if ((HOST_OS == OMR_LINUX) && !defined(LINUXPPC64)) || defined(S390) || defined(J9HAMMER)
 #define VA_PTR(valist) ((va_list*)&valist[0])
 #endif
 
@@ -174,7 +174,7 @@ typedef double SYS_FLOAT;
 
 #define HAS_BUILTIN_EXPECT
 
-#endif /* defined(LINUX) || defined (OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || defined (OSX) */
 
 
 /* MVS compiler */
@@ -255,7 +255,7 @@ typedef double SYS_FLOAT;
 #define HAS_BUILTIN_EXPECT
 #endif /* RS6000 */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 typedef double 					SYS_FLOAT;
 
 #define NO_LVALUE_CASTING
@@ -294,9 +294,9 @@ typedef double 					SYS_FLOAT;
 /* Only for use on static functions */
 #define VMINLINE_ALWAYS __forceinline
 #endif /* __GNUC__ */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 typedef double				SYS_FLOAT;
 
 #define J9CONST64(x) x##LL
@@ -327,7 +327,7 @@ typedef struct {
 
 #if defined(__cplusplus)
 
-#if defined(__MVS__) && defined(__COMPILER_VER__)
+#if (HOST_OS == OMR_ZOS) && defined(__COMPILER_VER__)
 #if (__COMPILER_VER__ >= 0x410D0000)
 #define VMINLINE_ALWAYS inline __attribute__((always_inline))
 #endif

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -203,7 +203,7 @@ struct ModronLnrlOptions {
 #if defined(DEBUG)
 #define MMINLINE
 #else /* DEBUG */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define MMINLINE __forceinline
 #elif (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
 #define MMINLINE inline __attribute((always_inline))
@@ -212,7 +212,7 @@ struct ModronLnrlOptions {
 #endif /* OMR_OS_WINDOWS */
 #endif /* DEBUG */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define MMINLINE_DEBUG __forceinline
 #elif ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #define MMINLINE_DEBUG inline __attribute((always_inline))
@@ -226,7 +226,7 @@ struct ModronLnrlOptions {
  * Also, spinlocks can't provide realtime locking.
  * Do not use the custom spinlocks on AIX as yield calls create performance issues.
  */
-#if defined(OMR_INTERP_HAS_SEMAPHORES) && !defined(AIXPPC)
+#if defined(OMR_INTERP_HAS_SEMAPHORES) && !(HOST_OS == OMR_AIX)
 #define J9MODRON_USE_CUSTOM_SPINLOCKS
 #endif
 
@@ -501,7 +501,7 @@ typedef enum {
 /* Because SLES zLinux/31 never allocates mmap()ed memory below the 1GB line unless you ask it to, we
  * always request that the heap is allocated low in the address range. This leaves the space above
  * 2GB free for other mmap() allocations (e.g. pthread stacks).*/
-#if defined(S390) && defined(LINUX) && !defined(OMR_ENV_DATA64)
+#if defined(S390) && (HOST_OS == OMR_LINUX) && !defined(OMR_ENV_DATA64)
 #define PREFERRED_HEAP_BASE 0x10000000
 #else
 #define PREFERRED_HEAP_BASE 0x0
@@ -509,12 +509,12 @@ typedef enum {
 
 #define SUBALLOCATOR_INITIAL_SIZE (200*1024*1024)
 #define SUBALLOCATOR_COMMIT_SIZE (50*1024*1024)
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* virtual memory is assigned in segment of 256M, so grab the entire segment */
 #define SUBALLOCATOR_ALIGNMENT (256*1024*1024)
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 #define SUBALLOCATOR_ALIGNMENT (8*1024*1024)
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 #if defined(OMR_GC_REALTIME)
 #define METRONOME_DEFAULT_HRT_PERIOD_MICRO 1000 /* This gives vanilla linux a chance to use the HRT */

--- a/include_core/omrmutex.h
+++ b/include_core/omrmutex.h
@@ -24,8 +24,8 @@
 
 #include "omrcomp.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include "win/omrmutex.h"
 #else
 #include "unix/omrmutex.h"
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -32,7 +32,7 @@
 /* NOTE:  omrportlib.h include is at the bottom of this file until its dependencies on this file can be relaxed */
 
 /* fix for linux s390 32bit stdint vs unistd.h definition of intptr_t (see CMVC 73850) */
-#if defined(LINUX) && defined(S390)
+#if (HOST_OS == OMR_LINUX) && defined(S390)
 #include <stdint.h>
 #endif
 
@@ -50,11 +50,11 @@
 #include "omrgcconsts.h"
 #endif /* defined(OMRZTPF) */
 
-#if (defined(LINUX) || defined(RS6000) || defined (OSX))
+#if ((HOST_OS == OMR_LINUX) || defined(RS6000) || defined (OSX))
 #include <unistd.h>
-#endif /* (defined(LINUX) || defined(RS6000) || defined (OSX)) */
+#endif /* ((HOST_OS == OMR_LINUX) || defined(RS6000) || defined (OSX)) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define PORT_ABEND_CODE	0xDED
 #define PORT_ABEND_REASON_CODE 20
 #define PORT_ABEND_CLEANUP_CODE 1 	/* allow for normal enclave termination/cleanup processing */
@@ -240,7 +240,7 @@
 #define OMRPORT_TIME_DELTA_IN_NANOSECONDS ((uint64_t) 1000000000)
 /** @} */
 
-#if defined(S390) || defined(J9ZOS390)
+#if defined(S390) || (HOST_OS == OMR_ZOS)
 /**
  * @name Constants to calculate time from high-resolution timer
  * @anchor hiresConstants
@@ -258,19 +258,19 @@
 #define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 2048000)
 #define OMRTIME_HIRES_CLOCK_FREQUENCY ((uint64_t) 2048000000) /* Frequency is microseconds / second */
 
-#else /* defined(S390) || defined(J9ZOS390) */
+#else /* defined(S390) || (HOST_OS == OMR_ZOS) */
 
 #define OMRPORT_TIME_HIRES_NANOTIME_NUMERATOR ((uint64_t) 0)
 #define OMRPORT_TIME_HIRES_NANOTIME_DENOMINATOR ((uint64_t) 0)
 #define OMRPORT_TIME_HIRES_MICROTIME_DIVISOR ((uint64_t) 0)
 #define OMRPORT_TIME_HIRES_MILLITIME_DIVISOR ((uint64_t) 0)
 
-#endif /* defined(S390) || defined(J9ZOS390) */
+#endif /* defined(S390) || (HOST_OS == OMR_ZOS) */
 /** @} */
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #define OMR_CONFIGURABLE_SUSPEND_SIGNAL
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 /**
  * @name Time Unit Conversion
@@ -398,7 +398,7 @@ typedef enum J9VMemMemoryQuery {
 	OMRPORT_VMEM_PROCESS_EnsureWideEnum = 0x1000000
 } J9VMemMemoryQuery;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 typedef struct OMRCgroupEntry {
 	int32_t hierarchyId; /**< cgroup hierarch ID*/
@@ -408,7 +408,7 @@ typedef struct OMRCgroupEntry {
 	struct OMRCgroupEntry *next; /**< pointer to next OMRCgroupEntry*/
 } OMRCgroupEntry;
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 typedef struct OMRCgroupMetricElement {
 	const char *units;
@@ -445,12 +445,12 @@ typedef struct OMRCgroupMetricIteratorState {
  * highest memory address on platform
  *
  */
-#if defined(J9ZOS390) && !defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_ENV_DATA64)
 /* z/OS 31-bit uses signed pointer comparison so this UDATA_MAX maximum address becomes -1 which is less than the minimum address of 0 so use IDATA_MAX instead */
 #define OMRPORT_VMEM_MAX_ADDRESS ((void *) IDATA_MAX)
-#else /* defined(J9ZOS390) && !defined(OMR_ENV_DATA64) */
+#else /* (HOST_OS == OMR_ZOS) && !defined(OMR_ENV_DATA64) */
 #define OMRPORT_VMEM_MAX_ADDRESS ((void *) UDATA_MAX)
-#endif /* defined(J9ZOS390) && !defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_ZOS) && !defined(OMR_ENV_DATA64) */
 
 /**
  * @name Memory Tagging
@@ -480,7 +480,7 @@ typedef struct J9MemTag {
 #endif
 } J9MemTag;
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 /**
  * @name Linux OS Dump Eyecatcher
  *
@@ -492,7 +492,7 @@ typedef struct J9MemTag {
 #else
 #define J9OSDUMP_SIZE	(128 * 1024)
 #endif
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /* omrfile_chown takes unsigned arguments for user/group IDs, but uses -1 to indicate that group/user id are not to be changed */
 #define OMRPORT_FILE_IGNORE_ID UDATA_MAX
@@ -758,11 +758,11 @@ typedef struct J9ProcessorInfos {
 #define OMRPORT_SIG_FLAG_SIGABEND  0x80
 #define OMRPORT_SIG_FLAG_SIGPIPE  0x100
 #define OMRPORT_SIG_FLAG_SIGALRM  0x200
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define OMRPORT_SIG_FLAG_SIGALLSYNC  (OMRPORT_SIG_FLAG_SIGSEGV | OMRPORT_SIG_FLAG_SIGBUS | OMRPORT_SIG_FLAG_SIGILL | OMRPORT_SIG_FLAG_SIGFPE | OMRPORT_SIG_FLAG_SIGTRAP | OMRPORT_SIG_FLAG_SIGABEND)
 #else
 #define OMRPORT_SIG_FLAG_SIGALLSYNC  (OMRPORT_SIG_FLAG_SIGSEGV | OMRPORT_SIG_FLAG_SIGBUS | OMRPORT_SIG_FLAG_SIGILL | OMRPORT_SIG_FLAG_SIGFPE | OMRPORT_SIG_FLAG_SIGTRAP)
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 #define OMRPORT_SIG_FLAG_SIGQUIT  0x400
 #define OMRPORT_SIG_FLAG_SIGABRT  0x800
 #define OMRPORT_SIG_FLAG_SIGTERM  0x1000
@@ -932,21 +932,21 @@ typedef struct J9ProcessorInfos {
 /* Windows current thread ANSI code page */
 #define J9STR_CODE_WINTHREADACP 8
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /*
  * OMR on z/OS translates the output of certain system calls such as getenv to ASCII using functions in atoe.c; see stdlib.h for a list.
  * Use J9STR_CODE_PLATFORM_OMR_INTERNAL to when processing the output of these calls.  Otherwise, use J9STR_CODE_PLATFORM_RAW.
  */
 #define J9STR_CODE_PLATFORM_OMR_INTERNAL J9STR_CODE_LATIN1
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 /*
  * Most system calls on Windows use the "wide" versions which return UTF-16, which OMR then converts to UTF-8.
  */
 #define J9STR_CODE_PLATFORM_OMR_INTERNAL J9STR_CODE_UTF8
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 /* on other platforms the internal encoding is the actual operating system encoding */
 #define J9STR_CODE_PLATFORM_OMR_INTERNAL J9STR_CODE_PLATFORM_RAW
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #define UNICODE_REPLACEMENT_CHARACTER 0xFFFD
 #define MAX_STRING_TERMINATOR_LENGTH 4
@@ -989,17 +989,17 @@ typedef struct J9MmapHandle {
 #include "omrcuda.h"
 #endif /* OMR_OPT_CUDA */
 
-#if !defined(OMR_OS_WINDOWS)
-#if defined(OSX)
+#if !(HOST_OS == OMR_WINDOWS)
+#if (HOST_OS == OMR_OSX)
 #define _XOPEN_SOURCE
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 #include <ucontext.h>
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #undef _XOPEN_SOURCE
 #endif /* OSX */
 #endif /* !OMR_OS_WINDOWS */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 struct __mcontext;
 #endif /* J9ZOS390 */
 
@@ -1020,9 +1020,9 @@ typedef struct J9PlatformThread {
 	uintptr_t stack_base;
 	uintptr_t stack_end;
 	uintptr_t priority;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	void *context;
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	/* This should really be 'struct __mcontext*' however DDR cannot parse the zos system header
 	 * that we carry as part of portlib. DDR runs on a linux machine and the defines required by the edcwccwi.h
 	 * header are set by both VAC and other zos system headers that DDR has no access to.
@@ -1032,7 +1032,7 @@ typedef struct J9PlatformThread {
 	ucontext_t *context;
 #endif
 	struct J9PlatformStackFrame *callstack;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	void *sigmask;
 #else /* OMR_OS_WINDOWS */
 	sigset_t *sigmask;

--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -21,34 +21,34 @@
  *******************************************************************************/
 
 #include <signal.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined UDATA.  Ignore its definition */
 #define UDATA UDATA_win32_
 #include <windows.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #define __THROW
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 typedef __sighandler_t sighandler_t;
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 typedef void (*sighandler_t)(int sig);
-#elif defined(J9ZOS390) || defined(AIXPPC)
+#elif (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_AIX)
 typedef void (*sighandler_t)(int sig);
 #define __THROW
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 /* Use sig_handler_t instead of sighandler_t for Windows. Define it for compatibility. */
 #define sig_handler_t sighandler_t
 typedef void (__cdecl *sighandler_t)(int signum);
 #define __THROW
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #define OMRSIG_RC_ERROR -1
 #define OMRSIG_RC_SIGNAL_HANDLED 0
@@ -80,11 +80,11 @@ int omrsig_handler(int sig, void *siginfo, void *uc);
  */
 sighandler_t omrsig_primary_signal(int signum, sighandler_t handler);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 _CRTIMP void (__cdecl * __cdecl signal(_In_ int _SigNum, _In_opt_ void (__cdecl * _Func)(int)))(int);
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Register a primary signal handler function, emulating the behavior, parameters, and return of sigaction().
@@ -105,20 +105,20 @@ sighandler_t signal(int signum, sighandler_t handler) __THROW;
 sighandler_t sigset(int sig, sighandler_t disp) __THROW;
 int sigignore(int sig) __THROW;
 sighandler_t bsd_signal(int signum, sighandler_t handler) __THROW;
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 sighandler_t sysv_signal(int signum, sighandler_t handler) __THROW;
-#endif /* !defined(J9ZOS390) */
-#if defined(LINUX)
+#endif /* !(HOST_OS == OMR_ZOS) */
+#if (HOST_OS == OMR_LINUX)
 __sighandler_t __sysv_signal(int sig, __sighandler_t handler) __THROW;
 sighandler_t ssignal(int sig, sighandler_t handler) __THROW;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 int __sigactionset(size_t newct, const __sigactionset_t newsets[], size_t *oldct, __sigactionset_t oldsets[], int options);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #ifdef __cplusplus
 } /* extern "C" { */

--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -31,7 +31,7 @@
 /* Reducing the TLS slots from 127 to 123 on ZOS and from 128 to 124 on the rest
  * to compensate for adding thread category related functionality
  */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define J9THREAD_MAX_TLS_KEYS 123   /* One of the TLS slots is replaced by os_errno2 on ZOS */
 #else /* !J9ZOS390 */
 #define J9THREAD_MAX_TLS_KEYS 124

--- a/include_core/omrutil.h
+++ b/include_core/omrutil.h
@@ -42,7 +42,7 @@
 extern "C" {
 #endif
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma map(getdsa, "GETDSA")
 /* ----------------- omrgetdsa.s ---------------- */
 /**
@@ -143,7 +143,7 @@ uintptr_t findSmallestPrimeGreaterThanOrEqualTo(uintptr_t number);
  */
 uintptr_t getSupportedBiggestNumberByPrimeNumberHelper(void);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* ---------------- omrgetdbghelp.c ---------------- */
 
 /**
@@ -165,7 +165,7 @@ uintptr_t omrgetdbghelp_getDLL(void);
 */
 void omrgetdbghelp_freeDLL(uintptr_t dbgHelpDLL);
 
-#endif  /* defined(OMR_OS_WINDOWS) */
+#endif  /* (HOST_OS == OMR_WINDOWS) */
 
 /* ---------------- stricmp.c ---------------- */
 
@@ -265,7 +265,7 @@ uintptr_t try_scan(char **scan_start, const char *search_string);
 
 
 /* ---------------- detectVMDirectory.c ---------------- */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * @brief Detect the directory where the VM library or executable resides.
  *
@@ -279,9 +279,9 @@ uintptr_t try_scan(char **scan_start, const char *search_string);
  * @return OMR_ERROR_NONE on success, an OMR error code otherwise.
  */
 omr_error_t detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDirectoryEnd);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* ---------------- getstoragekey.c ---------------- */
 
 /**
@@ -293,7 +293,7 @@ omr_error_t detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wc
 
 uintptr_t getStorageKey(void);
 
-#endif /*if defined(J9ZOS390)*/
+#endif /*if (HOST_OS == OMR_ZOS)*/
 
 /**
  * Returns a string representing the type of page indicated by the given pageFlags.

--- a/include_core/omrutilbase.h
+++ b/include_core/omrutilbase.h
@@ -140,7 +140,7 @@ subtractAtomic(volatile uintptr_t *address, uintptr_t value);
 uintptr_t setAtomic(volatile uintptr_t *address, uintptr_t value);
 
 /* ---------------- cas8help.s ---------------- */
-#if !defined(OMR_ENV_DATA64) && (defined(AIXPPC) || defined(LINUXPPC))
+#if !defined(OMR_ENV_DATA64) && ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX))
 
 /**
  * @brief Perform a compare and swap of a 64-bit value on a 32-bit system.
@@ -172,7 +172,7 @@ uint64_t
 getTimebase(void);
 
 /* ---------------- zbarrier.s ---------------- */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * @brief zOS Read-write barrier.
  *
@@ -182,7 +182,7 @@ getTimebase(void);
  */
 void
 J9ZOSRWB(void);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -629,11 +629,11 @@ omrthread_lib_clear_flags(uintptr_t flags);
 
 #define J9THREAD_LIB_CONTROL_GET_MEM_CATEGORIES "get_mem_categories"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING "use_realtime_scheduling"
 #define J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_ENABLED ((uintptr_t) J9THREAD_LIB_FLAG_REALTIME_SCHEDULING_ENABLED)
 #define J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_DISABLED ((uintptr_t) 0)
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /**
 * @brief Control the thread library.
@@ -1358,7 +1358,7 @@ omrthread_get_errordesc(intptr_t err);
 omrthread_os_errno_t
 omrthread_get_os_errno(void);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * @brief
  * @return omrthread_os_errno_t

--- a/include_core/thrtypes.h
+++ b/include_core/thrtypes.h
@@ -37,10 +37,10 @@ typedef struct J9Thread {
 	J9OSCond condition;
 	J9OSMutex mutex;
 	uintptr_t stacksize;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	uintptr_t *tos;
 #endif /* OMR_OS_WINDOWS */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	void *jumpBuffer;
 #endif /* LINUX */
 #if defined(OMR_PORT_NUMA_SUPPORT)
@@ -48,10 +48,10 @@ typedef struct J9Thread {
 #endif /* OMR_PORT_NUMA_SUPPORT */
 	struct J9ThreadMonitor *destroyed_monitor_head;
 	struct J9ThreadMonitor *destroyed_monitor_tail;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	omrthread_os_errno_t os_errno2;
 #endif   /* J9ZOS390 */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	uintptr_t key_deletion_attempts;
 #endif /* !OMR_OS_WINDOWS */
 } J9Thread;
@@ -94,7 +94,7 @@ typedef struct J9ThreadLibrary {
 	struct J9ThreadMonitorPool *monitor_pool;
 	struct J9Pool *thread_pool;
 	uintptr_t threadCount;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	uintptr_t stack_usage;
 #endif /* OMR_OS_WINDOWS */
 	intptr_t initStatus;
@@ -148,9 +148,9 @@ typedef struct J9ThreadLibrary {
 	struct J9Pool *rwmutexPool;
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
 	omrthread_attr_t systemThreadAttr;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	clock_serv_t clockService;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 } J9ThreadLibrary;
 
 /*

--- a/include_core/unix/thrdsup.h
+++ b/include_core/unix/thrdsup.h
@@ -24,7 +24,7 @@
 
 #include "omrcfg.h"
 
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 #define J9_POSIX_THREADS
 #endif
 
@@ -37,13 +37,13 @@
 #include "omrcomp.h"
 #include "omrutilbase.h"
 
-#if (defined(LINUX) || defined(OSX) || defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_ZOS) || defined(OMRZTPF))
 #include <sys/time.h>
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <mach/clock.h>
 #include <mach/mach.h>
-#endif /* defined(OSX) */
-#endif /* defined(LINUX) || defined(OSX) || defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_ZOS) || defined(OMRZTPF) */
 
 
 #include "omrmutex.h"
@@ -80,7 +80,7 @@ typedef struct zos_sem_t {
 	struct J9ThreadMonitor *monitor;
 } zos_sem_t;
 typedef zos_sem_t OSSEMAPHORE;
-#endif /* defined(LINUX) || defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
 
 
 #include "thrtypes.h"
@@ -127,11 +127,11 @@ extern int priority_map[];
  *
  * CMVC 199234 - use CLOCK_MONOTONIC also on Linux
  */
-#if (defined(AIXPPC) && !defined(J9OS_I5)) || (defined(LINUX) && !defined(OMRZTPF))
+#if ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF))
 #define J9THREAD_USE_MONOTONIC_COND_CLOCK 1
-#else /* (defined(AIXPPC) && !defined(J9OS_I5)) || (defined(LINUX) && !defined(OMRZTPF) */
+#else /* ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 #define J9THREAD_USE_MONOTONIC_COND_CLOCK 0
-#endif /* (defined(AIXPPC) && !defined(J9OS_I5)) || (defined(LINUX) && !defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 #if J9THREAD_USE_MONOTONIC_COND_CLOCK
 #define TIMEOUT_CLOCK timeoutClock
@@ -141,7 +141,7 @@ extern pthread_condattr_t *defaultCondAttr;
 #define TIMEOUT_CLOCK CLOCK_REALTIME
 #endif /* J9THREAD_USE_MONOTONIC_COND_CLOCK */
 
-#if (defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF))
+#if ((HOST_OS == OMR_ZOS) || (HOST_OS == OMR_ZOS) || defined(OMRZTPF))
 #define SETUP_TIMEOUT(ts_, millis, nanos) {								\
 		struct timeval tv_;											\
 		J9DIV_T secs_ = J9DIV(millis, 1000);					\
@@ -155,7 +155,7 @@ extern pthread_condattr_t *defaultCondAttr;
 			ts_.tv_sec = tv_.tv_sec + secs_.quot;			\
 			ts_.tv_nsec = nanos_;								\
 		} }
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define SETUP_TIMEOUT(ts_, millis, nanos) {						\
 		J9DIV_T secs_ = J9DIV(millis, 1000);					\
 		int nanos_ = secs_.rem * 1000000 + nanos;				\
@@ -166,7 +166,7 @@ extern pthread_condattr_t *defaultCondAttr;
 			ts_.tv_sec = secs_.quot;							\
 			ts_.tv_nsec = nanos_;								\
 		} }
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define SETUP_TIMEOUT(ts_, millis, nanos) {								\
 		J9DIV_T secs_ = J9DIV(millis, 1000);					\
 		int nanos_ = secs_.rem * 1000000 + nanos;				\
@@ -179,7 +179,7 @@ extern pthread_condattr_t *defaultCondAttr;
 			ts_.tv_sec += secs_.quot;							\
 			ts_.tv_nsec = nanos_;								\
 		} }
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 /* COND_DESTROY */
 
 #define COND_DESTROY(cond) pthread_cond_destroy(&(cond))
@@ -201,7 +201,7 @@ extern pthread_condattr_t *defaultCondAttr;
 
 /* THREAD_YIELD */
 
-#if (defined(LINUX) || defined(AIXPPC) || defined(OSX))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX))
 #define THREAD_YIELD() (sched_yield())
 
 #ifdef OMR_THR_YIELD_ALG
@@ -228,13 +228,13 @@ extern pthread_condattr_t *defaultCondAttr;
 	}\
 }
 #endif
-#else /* (defined(LINUX) || defined(AIXPPC) || defined(OSX)) */
+#else /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)) */
 #ifdef OMR_THR_YIELD_ALG
 #error 'OMR_THR_YIELD_ALG' is not supported on this platform
 #endif
-#endif /* (defined(LINUX) || defined(AIXPPC) || defined(OSX)) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)) */
 
-#if defined(MVS) || defined (J9ZOS390)
+#if (HOST_OS == OMR_ZOS) || defined (J9ZOS390)
 #define THREAD_YIELD() (pthread_yield(0))
 #endif
 
@@ -264,15 +264,15 @@ extern pthread_condattr_t *defaultCondAttr;
 
 /* NOTE: the calling thread must already own the mutex! */
 
-#if defined(LINUX) && defined(J9X86)
+#if (HOST_OS == OMR_LINUX) && defined(J9X86)
 #define PTHREAD_COND_TIMEDWAIT(x,y,z) linux_pthread_cond_timedwait(x,y,z)
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define PTHREAD_COND_TIMEDWAIT(x,y,z) pthread_cond_timedwait_relative_np(x,y,z)
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define PTHREAD_COND_TIMEDWAIT(x,y,z) pthread_cond_timedwait(x,y,z)
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define COND_WAIT_RC_TIMEDOUT -1
 #else
 #define COND_WAIT_RC_TIMEDOUT ETIMEDOUT
@@ -301,18 +301,18 @@ extern pthread_condattr_t *defaultCondAttr;
 
 /* THREAD_DETACH */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define THREAD_DETACH(thread) pthread_detach(&(thread))
 #else
 #define THREAD_DETACH(thread) pthread_detach(thread)
 #endif
 
 /* THREAD_SET_NAME */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define THREAD_SET_NAME(self, thread, name) set_pthread_name((self), (thread), (name))
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #define THREAD_SET_NAME(self, thread, name) 0 /* not implemented */
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /* THREAD_SET_PRIORITY */
 #define THREAD_SET_PRIORITY(thread, priority) set_pthread_priority((thread), (priority))
@@ -322,7 +322,7 @@ extern pthread_condattr_t *defaultCondAttr;
 #define TLS_ALLOC_WITH_DESTRUCTOR(key, destructor) (pthread_key_create(&(key), (destructor)))
 #define TLS_DESTROY(key) (pthread_key_delete(key))
 #define TLS_SET(key, value) (pthread_setspecific(key, value))
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define TLS_GET(key) (pthread_getspecific_d8_np(key))
 #else
 #define TLS_GET(key) (pthread_getspecific(key))

--- a/include_core/ute_module.h
+++ b/include_core/ute_module.h
@@ -35,9 +35,9 @@
 
 #include <stdio.h>
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h>
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #include "omrcomp.h"
 

--- a/jitbuilder/control/Jit.cpp
+++ b/jitbuilder/control/Jit.cpp
@@ -185,7 +185,7 @@ internal_compileMethodBuilder(TR::MethodBuilder *m, void **entry)
    {
    auto rc = m->Compile(entry);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
    struct FunctionDescriptor
    {
       uint64_t environment;

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -62,7 +62,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    // We should really rely on the port library to allocate memory, but this connection
    // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9
    // where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
-   #if !defined(OMR_OS_WINDOWS)
+   #if !(HOST_OS == OMR_WINDOWS)
       #if !defined(MAP_ANONYMOUS)
          #define NO_MAP_ANONYMOUS
          #if defined(MAP_ANON)
@@ -80,7 +80,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    if (segmentSize < config.codeCachePadKB() << 10)
       codeCacheSizeToAllocate = config.codeCachePadKB() << 10;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    auto memorySlab = reinterpret_cast<uint8_t *>(
          VirtualAlloc(NULL,
             codeCacheSizeToAllocate,
@@ -108,7 +108,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
 void
 JitBuilder::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
 #else
    munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));

--- a/omrmakefiles/confighelpers.m4
+++ b/omrmakefiles/confighelpers.m4
@@ -72,7 +72,7 @@ AC_DEFUN([OMRCFG_CATEGORIZE_TOOLCHAIN],
 #error not an msvc compiler
 #endif]])], [$1=msvc]))
 	AS_IF([test "x$$1" = "x"],
-		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if !(defined(__xlC__) || (defined(__MVS__) && defined(__COMPILER_VER__)))
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if !(defined(__xlC__) || ((HOST_OS == OMR_ZOS) && defined(__COMPILER_VER__)))
 #error not an xlc compiler
 #endif]])], [$1=xlc]))
 	AS_IF([test "x$$1" = "x"],

--- a/omrsigcompat/omrsig.cpp
+++ b/omrsigcompat/omrsig.cpp
@@ -20,23 +20,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define _OPEN_THREADS 2
 #define _UNIX03_SOURCE
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined UDATA.  Ignore its definition */
 #define UDATA UDATA_win32_
 #include <windows.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <dlfcn.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <errno.h>
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <pthread.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 #include <string.h>
 
 #include "omrsig.h"
@@ -52,12 +52,12 @@ static int omrsig_sigaction_internal(int signum, const struct sigaction *act, st
 static bool validSignalNum(int signum, bool nullAction);
 static bool handlerIsFunction(const struct sigaction *act);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 typedef void (__cdecl * (__cdecl *SIGNAL)(_In_ int _SigNum, _In_opt_ void (__cdecl * _Func)(int)))(int);
 static SIGNAL signalOS = NULL;
 
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 #pragma map (sigactionOS, "\174\174SIGACT")
 extern int sigactionOS(int, const struct sigaction*, struct sigaction*);
@@ -93,15 +93,15 @@ handlerIsFunction(const struct sigaction *act)
 static bool
 validSignalNum(int signum, bool nullAction)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	return (SIGABRT == signum) || (SIGFPE == signum) || (SIGILL == signum) || (SIGINT == signum)
 		|| (SIGSEGV == signum) || (SIGTERM == signum) || (SIGBREAK == signum);
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	return (signum >= 0) && (signum < NSIG) && (((signum != SIGKILL) && (signum != SIGSTOP)
 		&& (signum != SIGTHCONT) && (signum != SIGTHSTOP)) || nullAction);
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	return (signum >= 0) && (signum < NSIG) && (((signum != SIGKILL) && (signum != SIGSTOP)) || nullAction);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 }
 
 /**
@@ -120,11 +120,11 @@ omrsig_handler(int sig, void *siginfo, void *uc)
 
 		if (handlerIsFunction(&handlerSlot.secondaryAction)) {
 #if defined(POSIX_SIGNAL)
-#if defined(OSX) || defined(OMRZTPF)
+#if (HOST_OS == OMR_OSX) || defined(OMRZTPF)
 			sigset_t oldMask = {0};
-#else /* defined(OSX) || defined(OMRZTPF)  */
+#else /* (HOST_OS == OMR_OSX) || defined(OMRZTPF)  */
 			sigset_t oldMask = {{0}};
-#endif /* defined(OSX) || defined(OMRZTPF)  */
+#endif /* (HOST_OS == OMR_OSX) || defined(OMRZTPF)  */
 			sigset_t usedMask = handlerSlot.secondaryAction.sa_mask;
 			sigaddset(&usedMask, sig);
 			int ec = pthread_sigmask(SIG_BLOCK, &usedMask, &oldMask);
@@ -134,16 +134,16 @@ omrsig_handler(int sig, void *siginfo, void *uc)
 			 * entry to the signal handler.
 			 */
 			if ((0 == ec) && ((handlerSlot.secondaryAction.sa_flags & SA_NODEFER)
-#if (defined(AIXPPC) || defined(J9ZOS390))
+#if ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS))
 				/* Only AIX and zos respects that SA_RESETHAND behaves like SA_NODEFER by POSIX spec. */
 				|| (handlerSlot.secondaryAction.sa_flags & SA_RESETHAND)
-#endif /* (defined(AIXPPC) || defined(J9ZOS390)) */
+#endif /* ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)) */
 				)) {
-#if defined(OSX) || defined(OMRZTPF)
+#if (HOST_OS == OMR_OSX) || defined(OMRZTPF)
 				sigset_t mask = {0};
-#else /* defined(OSX) || defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_OSX) || defined(OMRZTPF) */
 				sigset_t mask = {{0}};
-#endif /* defined(OSX) || defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_OSX) || defined(OMRZTPF) */
 				sigemptyset(&mask);
 				sigaddset(&mask, sig);
 				ec = pthread_sigmask(SIG_UNBLOCK, &mask, NULL);
@@ -226,7 +226,7 @@ omrsig_primary_sigaction(int signum, const struct sigaction *act, struct sigacti
 }
 #endif /* defined(POSIX_SIGNAL) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-dllimport"
@@ -236,20 +236,20 @@ omrsig_primary_sigaction(int signum, const struct sigaction *act, struct sigacti
 #endif /* defined (__clang__) */
 void (__cdecl * __cdecl
 signal(_In_ int signum, _In_opt_ void (__cdecl * handler)(int)))(int)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 sighandler_t
 signal(int signum, sighandler_t handler) __THROW
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	return omrsig_signal_internal(signum, handler);
 }
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #else
 #pragma warning(pop)
 #endif /* defined (__clang__) */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 static sighandler_t
 omrsig_signal_internal(int signum, sighandler_t handler)
@@ -268,7 +268,7 @@ omrsig_signal_internal(int signum, sighandler_t handler)
 #endif /* defined(POSIX_SIGNAL) */
 
 	sighandler_t ret = SIG_DFL;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (SIG_GET == handler) {
 		if (0 == omrsig_sigaction_internal(signum, NULL, &oldact, false)) {
 			ret = oldact.sa_handler;
@@ -276,15 +276,15 @@ omrsig_signal_internal(int signum, sighandler_t handler)
 			ret = SIG_ERR;
 		}
 	} else {
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		if (0 == omrsig_sigaction_internal(signum, &act, &oldact, false)) {
 			ret = oldact.sa_handler;
 		} else {
 			ret = SIG_ERR;
 		}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	return ret;
 }
 
@@ -300,7 +300,7 @@ int
 omrsig_signalOS_internal(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
 	int rc = 0;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* zos does not seem to allow dlopen with NULL and no dll name. Use pragma map to SIGACT instead.*/
 	rc = sigactionOS(signum, act, oldact);
 #elif defined(OMRZTPF)
@@ -325,16 +325,16 @@ omrsig_signalOS_internal(int signum, const struct sigaction *act, struct sigacti
 		sigactionOS = (SIGACTION)dlsym(RTLD_NEXT, "sigaction");
 		if (NULL == sigactionOS) {
 			char *lib = NULL;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #if defined(OMR_ENV_DATA64)
 			lib = "/usr/lib/libc.a(shr_64.o)";
 #else /* defined(OMR_ENV_DATA64) */
 			lib = "/usr/lib/libc.a(shr.o)";
 #endif /* defined(OMR_ENV_DATA64) */
 			void *handle = dlopen(lib, RTLD_LAZY | RTLD_MEMBER);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 			void *handle = dlopen(lib, RTLD_LAZY);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 			sigactionOS = (SIGACTION)dlsym(handle, "sigaction");
 		}
 	}
@@ -446,12 +446,12 @@ omrsig_sigaction_internal(int signum, const struct sigaction *act, struct sigact
 			} else {
 				newRegisteringHandler = sigData[signum].secondaryAction;
 			}
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			/* On zos, when an alt signal stack is set, the second call to pthread_sigmask() or
 			 * sigprocmask() within a signal handler will cause the program to sig kill itself.
 			 */
 			newRegisteringHandler.sa_flags &= ~SA_ONSTACK;
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 			rc = omrsig_signalOS_internal(signum, &newRegisteringHandler, NULL);
 		}
 		SIGUNLOCK(sigMutex);
@@ -459,7 +459,7 @@ omrsig_sigaction_internal(int signum, const struct sigaction *act, struct sigact
 	return rc;
 }
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 __sighandler_t
 __sysv_signal(int sig, __sighandler_t handler) __THROW
@@ -473,9 +473,9 @@ ssignal(int sig, sighandler_t handler) __THROW
 	return omrsig_signal_internal(sig, handler);
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 
 static bool
 checkMaskEquality(int signum, const sigset_t *mask, const sigset_t *otherMask)
@@ -567,21 +567,21 @@ failed:
 	return -1;
 }
 
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 
 sighandler_t
 sigset(int sig, sighandler_t disp) __THROW
 {
 	sighandler_t ret = SIG_ERR;
-#if defined(OSX) || defined(OMRZTPF)
+#if (HOST_OS == OMR_OSX) || defined(OMRZTPF)
 	sigset_t mask = {0};
 	sigset_t oldmask = {0};
-#else /* defined(OSX) || defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_OSX) || defined(OMRZTPF) */
 	sigset_t mask = {{0}};
 	sigset_t oldmask = {{0}};
-#endif /* defined(OSX) || defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_OSX) || defined(OMRZTPF) */
 	struct sigaction oldact = {{0}};
 
 	if (SIG_HOLD == disp) {
@@ -649,7 +649,7 @@ bsd_signal(int signum, sighandler_t handler) __THROW
 	return ret;
 }
 
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 
 sighandler_t
 sysv_signal(int signum, sighandler_t handler) __THROW
@@ -657,7 +657,7 @@ sysv_signal(int signum, sighandler_t handler) __THROW
 	return omrsig_signal_internal(signum, handler);
 }
 
-#endif /* !defined(J9ZOS390) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_ZOS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 } /* extern "C" { */

--- a/omrtrace/omrtrace_internal.h
+++ b/omrtrace/omrtrace_internal.h
@@ -97,7 +97,7 @@ extern "C" {
 /* assert() and abort() are a bit useless on Windows - they
  * just print a message. Force a GPF instead.
  */
-#if defined(OMR_OS_WINDOWS) && !defined(__clang__)
+#if (HOST_OS == OMR_WINDOWS) && !defined(__clang__)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -109,12 +109,12 @@ extern "C" {
 		} \
 	} while (0)
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 #include <assert.h>
 #define UT_ASSERT(expr) assert(expr)
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #define DBG_ASSERT(expr) \
 	if (OMR_TRACEGLOBAL(traceDebug) > 0) { \

--- a/omrtrace/omrtracewrappers.cpp
+++ b/omrtrace/omrtracewrappers.cpp
@@ -23,15 +23,15 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include <stdlib.h> /* for abs */
 #include <string.h> /* for strlen, strcpy */
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 #include "omrtrace_internal.h"
 #include "thread_api.h"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
 #endif
 
@@ -56,7 +56,7 @@ twThreadSelf(void)
 omr_error_t
 twE2A(char *str)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	long length = (long)strlen(str);
 	if (length > 0) {
 		char *abuf;
@@ -66,6 +66,6 @@ twE2A(char *str)
 			free(abuf);
 		}
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	return OMR_ERROR_NONE;
 }

--- a/port/common/omrcuda.cpp
+++ b/port/common/omrcuda.cpp
@@ -748,13 +748,13 @@ enum J9CudaGlobalState {
 uint32_t
 openDriver(OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	const char *driverLibrary = "libcuda.so";
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	const char *driverLibrary = "libcuda.dylib";
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 	const char *driverLibrary = "nvcuda.dll";
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	J9CudaGlobalData *globals = &portLibrary->portGlobals->cudaGlobals;
 	int deviceCount = 0;
 	int version = 0;
@@ -978,21 +978,21 @@ const J9CudaLibraryDescriptor runtimeLibraries[] = {
 	 * This special entry must appear first for forward compatiblity. In normal
 	 * installations, it is a link to the newest version available.
 	 */
-#if defined(LINUX) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_LINUX) && defined(OMR_ENV_DATA64)
 	{ 5050, "libcudart.so" },
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	{ 5050, "libcudart.dylib" },
 #endif /* LINUX && OMR_ENV_DATA64 */
 
-#if defined(LINUX) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_LINUX) && defined(OMR_ENV_DATA64)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("libcudart.so." #major "." #minor)
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("libcudart." #major "." #minor ".dylib")
-#elif defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("cudart64_" #major #minor ".dll")
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("cudart32_" #major #minor ".dll")
-#endif /* defined(LINUX) && defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_LINUX) && defined(OMR_ENV_DATA64) */
 
 #define OMRCUDA_LIBRARY_ENTRY(major, minor) { ((major) * 1000) + ((minor) * 10), OMRCUDA_LIBRARY_NAME(major, minor) }
 

--- a/port/common/omrexit.c
+++ b/port/common/omrexit.c
@@ -29,11 +29,11 @@
 
 #include "omrport.h"
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #if defined(OMRPORT_OMRSIG_SUPPORT)
 extern void omrsig_chain_at_shutdown_and_exit(struct OMRPortLibrary *portLibrary);
 #endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 
 /**
@@ -72,11 +72,11 @@ omrexit_shutdown_and_exit(struct OMRPortLibrary *portLibrary, int32_t exitCode)
 	portLibrary->cuda_shutdown(portLibrary);
 #endif /* defined(OMR_OPT_CUDA) */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #if defined(OMRPORT_OMRSIG_SUPPORT)
 	omrsig_chain_at_shutdown_and_exit(portLibrary);
 #endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	exit((int)exitCode);
 }

--- a/port/common/omrfilestream.c
+++ b/port/common/omrfilestream.c
@@ -41,7 +41,7 @@
 #include "ut_omrport.h"
 
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* Needed for a translation table from ascii -> ebcdic */
 #include "atoe.h"
 
@@ -56,7 +56,7 @@
 #undef fread
 #endif
 
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 /**
  * @internal
@@ -94,12 +94,12 @@ EsTranslateOpenFlags(int32_t flags)
 	/* Ignore all other flags: they are taken care of earlier */
 	flags &= (EsOpenWrite | EsOpenRead | EsOpenAppend);
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* On Z/OS, stdio functions are shadowed to take ASCII strings, and turn them into EBCDIC.
 	 * Since fdopen is a POSIX function, it needs EBCDIC strings.
 	 */
 #pragma convlit(suspend)
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	switch (flags) {
 	case (EsOpenWrite):
@@ -118,9 +118,9 @@ EsTranslateOpenFlags(int32_t flags)
 		return NULL;
 	}
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma convlit(resume)
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 }
 

--- a/port/common/omrfilestreamtext.c
+++ b/port/common/omrfilestreamtext.c
@@ -39,7 +39,7 @@
 #include "portnls.h"
 #include "ut_omrport.h"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* Needed for a translation table from ascii -> ebcdic */
 #include "atoe.h"
 
@@ -50,16 +50,16 @@
 #undef nl_langinfo
 #endif
 
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 
 /**
  * CRLFNEWLINES will be defined when we require changing newlines from '\n' to '\r\n'
  */
 #undef CRLFNEWLINES
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CRLFNEWLINES
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 static intptr_t
 write_all(struct OMRPortLibrary *portLibrary, OMRFileStream *fileStream, const char *buf, intptr_t nbytes);

--- a/port/common/omrmem32helpers.c
+++ b/port/common/omrmem32helpers.c
@@ -51,7 +51,7 @@ struct {
  * We use a 8MB heap to give us more room in case an application loads a larger amount of classes than usual.
  * For testing purposes, this value is mirrored in port library test. If we tune this value, we should also adjust it in omrmemTest.cpp
  */
-#if defined(AIXPPC) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_AIX) && defined(OMR_GC_COMPRESSED_POINTERS)
 /* virtual memory is allocated in 256M segments on AIX, so grab the whole segment */
 #define HEAP_SIZE_BYTES 256*1024*1024
 #else
@@ -418,7 +418,7 @@ void *
 allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, const char *callSite)
 {
 	void *returnPtr = NULL;
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	BOOLEAN useMalloc31 = FALSE;
 #elif defined(OMRZTPF)
 	/* malloc on z/TPF is 32 bits */
@@ -426,7 +426,7 @@ allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, cons
 #endif
 
 	Trc_PRT_mem_allocate_memory32_Entry(byteAmount);
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (OMRPORT_DISABLE_ENSURE_CAP32 == portLibrary->portGlobals->disableEnsureCap32) {
 		useMalloc31 = TRUE;
 	}
@@ -453,7 +453,7 @@ allocate_memory32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, cons
 		}
 
 		omrthread_monitor_exit(PPG_mem_mem32_subAllocHeapMem32.monitor);
-#if (defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)) || defined(OMRZTPF)
 	}
 #endif
 
@@ -477,7 +477,7 @@ ensure_capacity32(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount)
 
 	Trc_PRT_mem_ensure_capacity32_Entry(byteAmount);
 
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (OMRPORT_DISABLE_ENSURE_CAP32 == portLibrary->portGlobals->disableEnsureCap32) {
 		Trc_PRT_mem_ensure_capacity32_NotRequired_Exit();
 		return OMRPORT_ENSURE_CAPACITY_NOT_REQUIRED;
@@ -670,7 +670,7 @@ free_memory32(struct OMRPortLibrary *portLibrary, void *memoryPointer)
 #endif
 	Trc_PRT_mem_free_memory32_Entry(memoryPointer);
 
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (OMRPORT_DISABLE_ENSURE_CAP32 == portLibrary->portGlobals->disableEnsureCap32) {
 		free(memoryPointer);
 	} else {
@@ -720,7 +720,7 @@ free_memory32(struct OMRPortLibrary *portLibrary, void *memoryPointer)
 
 		omrthread_monitor_exit(PPG_mem_mem32_subAllocHeapMem32.monitor);
 
-#if (defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)) || defined(OMRZTPF)
 	}
 #endif
 

--- a/port/common/omrmemtag.c
+++ b/port/common/omrmemtag.c
@@ -224,7 +224,7 @@ omrmem_advise_and_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPo
 	Trc_PRT_mem_omrmem_advise_and_free_memory_Entry(memoryPointer);
 
 	if (memoryPointer != NULL) {
-#if (defined(LINUX) || defined (AIXPPC) || defined(J9ZOS390) || defined(OSX))
+#if ((HOST_OS == OMR_LINUX) || defined (AIXPPC) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX))
 
 		J9MemTag *headerTag = NULL;
 		headerTag = omrmem_get_header_tag(memoryPointer);
@@ -237,7 +237,7 @@ omrmem_advise_and_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPo
 		} else {
 			memorySize = 0;
 		}
-#endif /* (defined(LINUX) || defined (AIXPPC) || defined(J9ZOS390) || defined(OSX)) */
+#endif /* ((HOST_OS == OMR_LINUX) || defined (AIXPPC) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX)) */
 		memoryPointer = unwrapBlockAndCheckTags(portLibrary, memoryPointer);
 		adviseAndFreeFunction(portLibrary, memoryPointer, memorySize);
 	}

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -104,14 +104,14 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		return 0;
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64)
 	if (!strcmp("SIG_INTERNAL_HANDLER", key)) {
 		/* used by optimized code to implement fast signal handling on Windows */
 		extern int structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, EXCEPTION_POINTERS *exceptionInfo);
 		*(int (**)(struct OMRPortLibrary *, omrsig_handler_fn, void *, uint32_t, EXCEPTION_POINTERS *))value = structuredExceptionHandler;
 		return 0;
 	}
-#endif /* defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64) */
 
 #if defined(OMR_PORT_ZOS_CEEHDLRSUPPORT)
 	if (!strcmp("SIG_INTERNAL_HANDLER", key)) {
@@ -265,14 +265,14 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		}
 	}
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* OMRPORT_CTLDATA_AIX_PROC_ATTR key is used only on AIX systems */
 	if (0 == strcmp(OMRPORT_CTLDATA_AIX_PROC_ATTR, key)) {
 		return (int32_t)portLibrary->portGlobals->control.aix_proc_attr;
 	}
 #endif
 
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	if (0 == strcmp(OMRPORT_CTLDATA_NOSUBALLOC32BITMEM, key)) {
 		portLibrary->portGlobals->disableEnsureCap32 = value;
 		return 0;

--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -20,30 +20,30 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <time.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrportasserts.h"
 
 #include <stdarg.h>
 #include <string.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <malloc.h>
-#elif defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <alloca.h>
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 #include <stdlib.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <errno.h>
 
 /*
 #define J9STR_DEBUG
 */
 
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX)
 #include <iconv.h>
 typedef iconv_t  charconvState_t;
 #define J9STR_USE_ICONV
@@ -51,9 +51,9 @@ typedef iconv_t  charconvState_t;
 #define J9_USE_ORIG_EBCDIC_LANGINFO 1
 
 #include "omriconvhelpers.h"
-#else /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX) */
 typedef void *charconvState_t; /*dummy type */
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) || (HOST_OS == OMR_OSX) */
 
 /* for sprintf, which is used for printing floats */
 #include <stdio.h>
@@ -172,12 +172,12 @@ static int32_t convertWideToPlatform(struct OMRPortLibrary *portLibrary, charcon
 static int32_t convertLatin1ToMutf8(struct OMRPortLibrary *portLibrary, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize);
 static int32_t convertMutf8ToLatin1(struct OMRPortLibrary *portLibrary, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 static void convertJ9TimeToSYSTEMTIME(J9TimeInfo *j9TimeInfo, SYSTEMTIME *systemTime);
 static void convertTimeMillisToJ9Time(int64_t timeMillis, J9TimeInfo *tm);
 static void convertSYSTEMTIMEToJ9Time(SYSTEMTIME *systemTime, J9TimeInfo *j9TimeInfo);
 static BOOLEAN firstDateComesBeforeSecondDate(J9TimeInfo *firstDate, J9TimeInfo *secondDate);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Write characters to a string as specified by format.
@@ -275,7 +275,7 @@ omrstr_convert(struct OMRPortLibrary *portLibrary, int32_t fromCode, int32_t toC
 		}
 	}
 	break;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	case J9STR_CODE_WINTHREADACP:
 	case J9STR_CODE_WINDEFAULTACP: {
 		switch (toCode) {
@@ -288,7 +288,7 @@ omrstr_convert(struct OMRPortLibrary *portLibrary, int32_t fromCode, int32_t toC
 		}
 	}
 	break;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	case J9STR_CODE_MUTF8: {
 		switch (toCode) {
 		case J9STR_CODE_PLATFORM_RAW:
@@ -1267,7 +1267,7 @@ setJ9TimeToEpoch(struct J9TimeInfo *tm)
  */
 static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *omrtimeInfo)
 {
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 
 	time_t secondsUTC;
 	struct tm localTime;
@@ -1295,7 +1295,7 @@ static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *
 
 	return;
 
-#else /* !defined(OMR_OS_WINDOWS) */
+#else /* !(HOST_OS == OMR_WINDOWS) */
 
 	TIME_ZONE_INFORMATION timeZoneInformation;
 	J9TimeInfo daylightDateAsJ9TimeInfo, standardDateAsJ9TimeInfo;
@@ -1330,7 +1330,7 @@ static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *
 
 	/* Get the TimeZone Information needed to convert to local time */
 	rc = GetTimeZoneInformation(&timeZoneInformation);
-#if ( defined(OMR_OS_WINDOWS) || (_WIN32_WCE>=420) )
+#if ( (HOST_OS == OMR_WINDOWS) || (_WIN32_WCE>=420) )
 	if (rc == TIME_ZONE_ID_INVALID) {
 		return;
 	}
@@ -1412,11 +1412,11 @@ static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *
 
 	return;
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /*
  * @internal
  *
@@ -1700,7 +1700,7 @@ convertTimeMillisToJ9Time(int64_t timeMillis, J9TimeInfo *tm)
 
 }
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * @internal
@@ -2487,7 +2487,7 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 	uintptr_t mutf8Limit = outBufferSize;
 	BOOLEAN firstConversion = TRUE;
 	/* set up buffers and convertors */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	uintptr_t requiredBufferSize = 0;
 	encodingState = NULL;
 	/* MultiByteToWideChar is not resumable, so we need a buffer large enough to hold the entire intermediate result */
@@ -2501,7 +2501,7 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		wideBufferSize = requiredBufferSize;
 	}
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9STR_USE_ICONV)
 	/* use the EBCDIC string for UTF-16 on z/OS */
@@ -2519,12 +2519,12 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		uintptr_t tempWideBufferSize = wideBufferPartialSize;
 
 		if (wideBufferPartialSize < 0) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			/* the working buffer is dynamically allocated only on Windows */
 			if (wideBuffer != onStackBuffer) {
 				portLibrary->mem_free_memory(portLibrary, wideBuffer);
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 			iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2540,12 +2540,12 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		}
 		/* updates platformCursor to character after the last translated character */
 		if (wideBufferPartialSize < 0) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			/* the working buffer is dynamically allocated only on Windows */
 			if (wideBuffer != onStackBuffer) {
 				portLibrary->mem_free_memory(portLibrary, wideBuffer);
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 			iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2554,11 +2554,11 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		/* Now convert the result to modified UTF-8 */
 		mutf8PartialSize = convertWideToMutf8(&tempWideBuffer, &tempWideBufferSize, mutf8Cursor, mutf8Limit);
 		if (0 != tempWideBufferSize) { /* should have consumed all the data */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			if (wideBuffer != onStackBuffer) {
 				portLibrary->mem_free_memory(portLibrary, wideBuffer);
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 			iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2571,11 +2571,11 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 			}
 		}
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (wideBuffer != onStackBuffer) {
 		portLibrary->mem_free_memory(portLibrary, wideBuffer);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 	iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2609,9 +2609,9 @@ convertMutf8ToPlatform(struct OMRPortLibrary *portLibrary, const uint8_t *inBuff
 		/* wideBuffer is always on stack - no need to free it */
 		return OMRPORT_ERROR_STRING_ICONV_OPEN_FAILED;
 	}
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 	encodingState = NULL;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	while (mutf8Remaining > 0) { /* translated section by section as dictated by the size of wideBuffer */
 		uint8_t wideBuffer[CONVERSION_BUFFER_SIZE];
 		const uint8_t *wideBufferCursor = wideBuffer;
@@ -3089,7 +3089,7 @@ static int32_t
 convertPlatformToWide(struct OMRPortLibrary *portLibrary, charconvState_t encodingState, uint32_t codePage, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize)
 {
 	int32_t resultSize = -1;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	int32_t mbChars = (int32_t)MultiByteToWideChar(codePage, OS_ENCODING_MB_FLAGS, (LPCSTR)*inBuffer, (int)*inBufferSize, (LPWSTR)outBuffer, (int)outBufferSize);
 	if ((outBufferSize > 0) && (0 == mbChars)) {
 		resultSize = OMRPORT_ERROR_STRING_BUFFER_TOO_SMALL; /* should not happen: caller should have allocated a sufficiently large buffer */
@@ -3116,7 +3116,7 @@ convertPlatformToWide(struct OMRPortLibrary *portLibrary, charconvState_t encodi
 	} else {
 		resultSize = (outBufferSize - wideBufferLimit); /* number of bytes written */
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	if ((outBufferSize > 0) && ((outBufferSize - resultSize) >= 2)) {
 		uint16_t *terminator = (uint16_t *) &outBuffer[resultSize];
 		*terminator = 0;
@@ -3182,7 +3182,7 @@ convertWideToPlatform(struct OMRPortLibrary *portLibrary, charconvState_t encodi
 		*inBuffer = platformCursor;
 		*inBufferSize = platformLimit;
 	}
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 	LPCWSTR wideCursor = (LPCWSTR)*inBuffer;
 	uintptr_t wideRemaining = *inBufferSize / WIDE_CHAR_SIZE;
 	resultSize = WideCharToMultiByte(OS_ENCODING_CODE_PAGE, OS_ENCODING_MB_FLAGS, wideCursor,

--- a/port/linux/omrosdump_helpers.c
+++ b/port/linux/omrosdump_helpers.c
@@ -31,7 +31,7 @@
 #include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include <sys/prctl.h>
 #include <linux/prctl.h>
 #include <sys/resource.h>
@@ -372,7 +372,7 @@ deriveCoreFileName(struct OMRPortLibrary *portLibrary, char *corePatterFormat, B
 				/* literal '%' */
 				charsPrinted = portLibrary->str_printf(portLibrary, outCursor, bytesLeft, "%%");
 				break;
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 			case 'c':
 				{
 					struct rlimit limit = {0};
@@ -448,7 +448,7 @@ deriveCoreFileName(struct OMRPortLibrary *portLibrary, char *corePatterFormat, B
 					return -1;
 				}
 			case 'e':
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #ifndef PR_GET_NAME
 #define PR_GET_NAME 16
 #endif

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -1271,9 +1271,9 @@ port_numa_interleave_memory(struct OMRPortLibrary *portLibrary, void  *start, ui
 void
 omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t mode, uintptr_t *pageSize, uintptr_t *pageFlags)
 {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	{
 		/* Note that the PPG_vmem_pageSize is a null-terminated list of page sizes.
 		 * There will always be the 0 element (default page size),
@@ -1287,7 +1287,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t
 			*pageFlags = PPG_vmem_pageFlags[1];
 		}
 	}
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	else {
 		if (NULL != pageSize) {
 			/* Return the same page size as used by JIT code cache */
@@ -1302,7 +1302,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t
 			}
 		}
 	}
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	return;
 }
@@ -1318,7 +1318,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 	Assert_PRT_true_wrapper(OMRPORT_VMEM_PAGE_FLAG_NOT_USED == validPageFlags);
 
 	if (0 != validPageSize) {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		/* On Linux PPC, for executable pages, search through the list of supported page sizes only if
 		 * - request is for 16M pages, and
 		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
@@ -1341,7 +1341,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
 			(codeCacheConsolidationEnabled && (SIXTEEN_M == validPageSize)))
 #endif /* defined(OMR_ENV_DATA64) */
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			uintptr_t pageIndex = 0;
 			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(portLibrary);
@@ -1362,12 +1362,12 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		validPageSize = defaultLargePageSize;
 		validPageFlags = defaultLargePageFlags;
 	} else {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
 			validPageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
 			validPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
 		} else
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			validPageSize = PPG_vmem_pageSize[0];
 			validPageFlags = PPG_vmem_pageFlags[0];

--- a/port/linuxppc64/omrtime.c
+++ b/port/linuxppc64/omrtime.c
@@ -27,9 +27,9 @@
  */
 
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #define _GNU_SOURCE
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #include <stdio.h>
 #include <time.h>

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -53,7 +53,7 @@ typedef struct J9PortControlData {
 	uintptr_t sig_flags;
 	OMRMemCategorySet language_memory_categories;
 	OMRMemCategorySet omr_memory_categories;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	uintptr_t aix_proc_attr;
 #endif
 } J9PortControlData;

--- a/port/unix/j9nlshelpers.c
+++ b/port/unix/j9nlshelpers.c
@@ -49,7 +49,7 @@ nls_tolower(char toConvert)
 {
 	char lower;
 
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 	lower = j9_ascii_tolower(toConvert);
 #else
 	/* check to see if it is an uppercase character, and if so, return the corresponding lowercase char */
@@ -78,10 +78,10 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	char regionProp[4] = "US";
 	char *lang = NULL;
 	int langlen = 0;
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	intptr_t result;
 	char langProp[24];
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	intptr_t countryStart = 2;
 
 	/* Get the language */
@@ -90,7 +90,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	 * that the locale is not installed OR not selected & generated (see /etc/locale.gen) */
 	setlocale(LC_ALL, "");
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	lang = setlocale(LC_CTYPE, NULL);
 	/* set lang for later usage, we cannot use the return of setlocale(LC_ALL, "") as its not
 	 * the correct interface to retrieve it (lang/region) */
@@ -103,7 +103,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 			lang = langProp;
 		}
 	}
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	/* Query locale data */
 	lang = setlocale(LC_CTYPE, NULL);
 #if defined (J9ZOS390)
@@ -116,7 +116,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 		}
 	}
 #endif /* defined (J9ZOS390) */
-#endif  /* defined(LINUX) || defined(OSX) */
+#endif  /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (lang != NULL && strcmp(lang, "POSIX") && strcmp(lang, "C"))
 		if (lang != NULL && (langlen = strlen(lang)) >= 2) {
 			/* copy the language, stopping at '_'

--- a/port/unix/omrcpu.c
+++ b/port/unix/omrcpu.c
@@ -39,7 +39,7 @@
 #include "omrportpg.h"
 #endif
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
@@ -94,7 +94,7 @@ omrcpu_startup(struct OMRPortLibrary *portLibrary)
 
 #if (__IBMC__ || __IBMCPP__)
 	dcbz((void *) &buf[512]);
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	__asm__(
 		"dcbz 0, %0"
 		: /* no outputs */
@@ -155,7 +155,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if (__IBMC__ || __IBMCPP__)
 		dcbst(addr);
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		__asm__(
 			"dcbst 0,%0"
 			: /* no outputs */
@@ -165,7 +165,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if (__IBMC__ || __IBMCPP__)
 	sync();
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	__asm__("sync");
 #endif
 
@@ -174,7 +174,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if (__IBMC__ || __IBMCPP__)
 		icbi(addr);
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		__asm__(
 			"icbi 0,%0"
 			: /* no outputs */
@@ -185,7 +185,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 #if (__IBMC__ || __IBMCPP__)
 	sync();
 	isync();
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	__asm__("sync");
 	__asm__("isync");
 #endif
@@ -214,7 +214,7 @@ omrcpu_get_cache_line_size(struct OMRPortLibrary *portLibrary, int32_t *lineSize
 			*lineSize = (int32_t) result;
 			rc = 0;
 		}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	}
 	return rc;
 }

--- a/port/unix/omrerrorhelpers.c
+++ b/port/unix/omrerrorhelpers.c
@@ -68,7 +68,7 @@ errorMessage(struct OMRPortLibrary *portLibrary, int32_t errorCode)
 		ptBuffers->errorMessageBufferSize = J9ERROR_DEFAULT_BUFFER_SIZE;
 	}
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* On AIX, strerror() returns an error string based on current locale encoding. When printing out the error message in file_write_using_iconv(),
 	 * The NLS message (UTF-8) + the error string is converted from UTF-8 to locale encoding. So non-UTF-8 error string needs to be converted to UTF-8 here.
 	 */
@@ -81,7 +81,7 @@ errorMessage(struct OMRPortLibrary *portLibrary, int32_t errorCode)
 			errString = stackBuf;
 		}
 	}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	/* Copy from OS to ptBuffers */
 	portLibrary->str_printf(portLibrary, ptBuffers->errorMessageBuffer, ptBuffers->errorMessageBufferSize, "%s", errString);

--- a/port/unix/omrfile.c
+++ b/port/unix/omrfile.c
@@ -31,12 +31,12 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <sys/vfs.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <sys/param.h>
 #include <sys/mount.h>
-#endif /*  defined(LINUX)  && !defined(OMRZTPF) */
+#endif /*  (HOST_OS == OMR_LINUX)  && !defined(OMRZTPF) */
 #if !defined(OMRZTPF)
 #include <sys/statvfs.h>
 #endif /* !defined(OMRZTPF) */
@@ -57,27 +57,27 @@
 #undef fread
 #endif
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 typedef struct statfs PlatformStatfs;
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 typedef struct statvfs PlatformStatfs;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 
 static const char *const fileFStatErrorMsgPrefix = "fstat : ";
 static const char *const fileFStatFSErrorMsgPrefix = "fstatfs : ";
-#if defined(AIXPPC) && !defined(J9OS_I5)
+#if (HOST_OS == OMR_AIX) && !defined(J9OS_I5)
 static const char *const fileFStatVFSErrorMsgPrefix = "fstatvfs : ";
-#endif /* defined(AIXPPC) && !defined(J9OS_I5) */
+#endif /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 
 static int32_t EsTranslateOpenFlags(int32_t flags);
 static void setPortableError(OMRPortLibrary *portLibrary, const char *funcName, int32_t portlibErrno, int systemErrno);
 static int32_t findError(int32_t errorCode);
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5))
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5))
 static void updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf, PlatformStatfs *statfsBuf);
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#else /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 static void updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf);
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 
 static int32_t
 EsTranslateOpenFlags(int32_t flags)
@@ -212,13 +212,13 @@ findError(int32_t errorCode)
  *
  * @return void
  */
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5))
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5))
 static void
 updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf, PlatformStatfs *statfsBuf)
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#else /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 static void
 updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf)
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 {
 	if (S_ISDIR(statBuf->st_mode)) {
 		j9statBuf->isDir = 1;
@@ -248,7 +248,7 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 	j9statBuf->ownerUid = statBuf->st_uid;
 	j9statBuf->ownerGid = statBuf->st_gid;
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	if (NULL != statfsBuf) {
 		switch (statfsBuf->f_type) {
 		/* Detect remote filesystem types */
@@ -262,7 +262,7 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 			break;
 		}
 	}
-#elif defined(AIXPPC) && !defined(J9OS_I5) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (NULL != statfsBuf) {
 		/* Detect NFS filesystem */
 		if (NULL != strstr(statfsBuf->f_basetype, "nfs")) {
@@ -271,9 +271,9 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 			j9statBuf->isFixed = 1;
 		}
 	}
-#else /* defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 	j9statBuf->isFixed = 1;
-#endif /* defined(AIXPPC) && !defined(J9OS_I5) */
+#endif /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 
 }
 
@@ -607,7 +607,7 @@ omrfile_chown(struct OMRPortLibrary *portLibrary, const char *path, uintptr_t ow
 {
 	int rc;
 	Trc_PRT_file_chown_entry(path, owner, group);
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	if ((OMRPORT_FILE_IGNORE_ID == owner) || (OMRPORT_FILE_IGNORE_ID == group)) {
 		struct stat st;
 		if (0 != stat(path, &st)) {
@@ -634,7 +634,7 @@ omrfile_chown(struct OMRPortLibrary *portLibrary, const char *path, uintptr_t ow
 void
 omrfile_findclose(struct OMRPortLibrary *portLibrary, uintptr_t findhandle)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	closedir64((DIR64 *)findhandle);
 #else
 	closedir((DIR *)findhandle);
@@ -644,13 +644,13 @@ omrfile_findclose(struct OMRPortLibrary *portLibrary, uintptr_t findhandle)
 uintptr_t
 omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *resultbuf)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	DIR64 *dirp = NULL;
 #else
 	DIR *dirp = NULL;
 #endif
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
 #else
 	struct dirent *entry;
@@ -658,7 +658,7 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 
 	Trc_PRT_file_findfirst_Entry2(path, resultbuf);
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	dirp = opendir64(path);
 #else
 	dirp = opendir(path);
@@ -667,13 +667,13 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 		Trc_PRT_file_findfirst_ExitFail(-1);
 		return (uintptr_t)-1;
 	}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64(dirp);
 #else
 	entry = readdir(dirp);
 #endif
 	if (entry == NULL) {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		closedir64(dirp);
 #else
 		closedir(dirp);
@@ -698,7 +698,7 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 int32_t
 omrfile_findnext(struct OMRPortLibrary *portLibrary, uintptr_t findhandle, char *resultbuf)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
 #else
 	struct dirent *entry;
@@ -706,7 +706,7 @@ omrfile_findnext(struct OMRPortLibrary *portLibrary, uintptr_t findhandle, char 
 
 	Trc_PRT_file_findnext_Entry2(findhandle, resultbuf);
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64((DIR64 *)findhandle);
 #else
 	entry = readdir((DIR *)findhandle);
@@ -1139,9 +1139,9 @@ int32_t
 omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if (!defined(OMRZTPF) && defined(LINUX)) || defined(AIXPPC) || defined(OSX)
+#if (!defined(OMRZTPF) && (HOST_OS == OMR_LINUX)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	PlatformStatfs statfsbuf;
-#endif /* (!defined(OMRZTPF) && defined(LINUX)) || defined(AIXPPC) || defined(OSX) */
+#endif /* (!defined(OMRZTPF) && (HOST_OS == OMR_LINUX)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 	int32_t rc = 0;
 	int localfd = (int)fd;
 
@@ -1159,7 +1159,7 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	if (0 != fstatfs(localfd - FD_BIAS, &statfsbuf)) {
 		intptr_t myerror = errno;
 		Trc_PRT_file_fstat_fstatfsFailed(myerror);
@@ -1168,7 +1168,7 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#elif defined(AIXPPC) && !defined(J9OS_I5) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (0 != fstatvfs(localfd - FD_BIAS, &statfsbuf)) {
 		intptr_t myerror = errno;
 		Trc_PRT_file_fstat_fstatvfsFailed(myerror);
@@ -1177,9 +1177,9 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#else /* defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 	updateJ9FileStat(portLibrary, buf, &statbuf);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 _end:
 	Trc_PRT_file_fstat_Exit(rc);
@@ -1191,9 +1191,9 @@ int32_t
 omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flags, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	PlatformStatfs statfsbuf;
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 	memset(buf, 0, sizeof(J9FileStat));
 
@@ -1202,19 +1202,19 @@ omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flag
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	if (statfs(path, &statfsbuf)) {
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#elif defined(AIXPPC) && !defined(J9OS_I5) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (statvfs(path, &statfsbuf)) {
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#else /* defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 	updateJ9FileStat(portLibrary, buf, &statbuf);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return 0;
 }

--- a/port/unix/omrfiletext.c
+++ b/port/unix/omrfiletext.c
@@ -38,11 +38,11 @@
 
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if (defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)) && !defined(OMRZTPF)
+#if (defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF)
 #define J9VM_USE_WCTOMB
-#else /* (defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)) && !defined(OMRZTPF) */
+#else /* (defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF) */
 #include "omriconvhelpers.h"
-#endif /* (defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)) && !defined(OMRZTPF) */
+#endif /* (defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF) */
 
 /* Some older platforms (Netwinder) don't declare CODESET */
 #ifndef CODESET
@@ -50,7 +50,7 @@
 #endif
 
 /* a2e overrides nl_langinfo to return ASCII strings. We need the native EBCDIC string */
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
 #if defined (nl_langinfo)
 #undef nl_langinfo
@@ -83,7 +83,7 @@ omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *
 #pragma convlit(resume)
 #endif
 
-#if defined(J9ZOS390) || defined(OMRZTPF)
+#if (HOST_OS == OMR_ZOS) || defined(OMRZTPF)
 	/* z/OS and z/TPF always needs to translate to EBCDIC */
 	requiresTranslation = 1;
 #else
@@ -404,12 +404,12 @@ file_write_using_iconv(struct OMRPortLibrary *portLibrary, intptr_t fd, const ch
 char *
 omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, intptr_t nbytes)
 {
-#if (defined(J9ZOS390))
+#if ((HOST_OS == OMR_ZOS))
 	const char eol = a2e_tab['\n'];
 	char *tempStr = NULL;
 #else
 	const static char eol = '\n';
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	char temp[64];
 	char *cursor = buf;
 	BOOLEAN foundEOL = FALSE;
@@ -451,7 +451,7 @@ omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 	}
 
 	*cursor = '\0';
-#if (defined(J9ZOS390))
+#if ((HOST_OS == OMR_ZOS))
 	tempStr = e2a_string(buf);
 	if (NULL == tempStr) {
 		return NULL;
@@ -459,7 +459,7 @@ omrfile_read_text(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 
 	memcpy(buf, tempStr, strlen(buf));
 	free(tempStr);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	return buf;
 }
 

--- a/port/unix/omriconvhelpers.c
+++ b/port/unix/omriconvhelpers.c
@@ -35,23 +35,23 @@
 #include "omrportptb.h"
 #include "omrportpriv.h"
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma convlit(suspend)
 #endif
 const char *utf8 = "UTF-8";
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 const char *utf16 = "01200"; /* z/OS does not accept "UTF-16" */
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 const char *utf16 = "UTF-16LE";
 #else
 const char *utf16 = "UTF-16";
 #endif
 const char *ebcdic = "IBM-1047";
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #pragma convlit(resume)
 #endif
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /*
  * Open a convertor object and update the table if successful.
  * @note use only the const strings above to denote UTF-8, UTF-16, and EBCDIC
@@ -105,7 +105,7 @@ int32_t
 iconv_global_init(struct OMRPortLibrary *portLibrary)
 {
 	int32_t rc = 0;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	iconv_t *globalConverter = PPG_global_converter;
 	MUTEX *globalConverterMutex = PPG_global_converter_mutex;
 	uint32_t initializedConvertors = 0;
@@ -146,7 +146,7 @@ iconv_global_init(struct OMRPortLibrary *portLibrary)
 void
 iconv_global_destroy(struct OMRPortLibrary *portLibrary)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	if (PPG_global_converter_enabled) {
 		iconv_t *globalConverter = PPG_global_converter;
 		MUTEX *globalConverterMutex = PPG_global_converter_mutex;
@@ -182,7 +182,7 @@ iconv_get(struct OMRPortLibrary *portLibrary, J9IconvName converterName, const c
 	 */
 	PortlibPTBuffers_t ptBuffer = NULL;
 	iconv_t converter = J9VM_INVALID_ICONV_DESCRIPTOR;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 
 	if (PPG_global_converter_enabled) {
 		/* NOTE: using original nl_langinfo implementation that returns an EBCDIC string
@@ -249,7 +249,7 @@ iconv_get(struct OMRPortLibrary *portLibrary, J9IconvName converterName, const c
 void
 iconv_free(struct OMRPortLibrary *portLibrary, J9IconvName converterName, iconv_t converter)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 
 	if (PPG_global_converter_enabled) {
 		iconv_t *globalConverter = PPG_global_converter;

--- a/port/unix/omrmem.c
+++ b/port/unix/omrmem.c
@@ -41,16 +41,16 @@
 #include "omrportasserts.h"
 #include "ut_omrport.h"
 #include "protect_helpers.h"
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <sys/mman.h>
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/shm.h>
 #include <sys/vminfo.h>
 #endif/*AIXPPC*/
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 
 #include "omrvmem.h"
 #include <sys/types.h>
@@ -73,9 +73,9 @@ int omrdiscard_data(void *address, int numFrames);
 void *
 omrmem_allocate_memory_basic(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount)
 {
-#if (defined(S390) || defined(J9ZOS390)) && !defined(OMR_ENV_DATA64)
+#if (defined(S390) || (HOST_OS == OMR_ZOS)) && !defined(OMR_ENV_DATA64)
 	return (void *)(((uintptr_t) malloc(byteAmount)) & 0x7FFFFFFF);
-#elif defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#elif (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	void *retval = NULL;
 	retval = malloc(byteAmount);
 	Assert_AddressAbove4GBBar((NULL == retval) || (0x100000000 <= ((uintptr_t)retval)));
@@ -98,9 +98,9 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 {
 	uintptr_t pageSize = 0;
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	pageSize = sysconf(_SC_PAGESIZE);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	struct vm_page_info pageInfo;
 	pageInfo.addr = (uint64_t) portLibrary->portGlobals;
 	/*  retrieve size of the page backing portLibrary->portGlobals which is allocated
@@ -115,7 +115,7 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 		Trc_PRT_mem_advise_and_free_memory_basic_vmgetinfo_failed(errno);
 		Assert_PRT_ShouldNeverHappen_wrapper();
 	}
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	pageSize = FOUR_K;
 #endif /* J9ZOS390 */
 
@@ -135,16 +135,16 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 
 			Trc_PRT_mem_advise_and_free_memory_basic_oscall(memPtrPageRounded, memPtrSizePageRounded);
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 			if (-1 == madvise((void *)memPtrPageRounded, memPtrSizePageRounded, MADV_DONTNEED)) {
 				Trc_PRT_mem_advise_and_free_memory_basic_madvise_failed((void *)memPtrPageRounded, memPtrSizePageRounded, errno);
 			}
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 			if (-1 == disclaim64((void *)memPtrPageRounded, memPtrSizePageRounded, DISCLAIM_ZEROMEM)) {
 				Trc_PRT_mem_advise_and_free_memory_basic_disclaim64_failed((void *)memPtrPageRounded, memPtrSizePageRounded, errno);
 				Assert_PRT_ShouldNeverHappen_wrapper();
 			}
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 #if defined(OMR_ENV_DATA64)
 			if (omrdiscard_data((void *)memPtrPageRounded, memPtrSizePageRounded >> ZOS_REAL_FRAME_SIZE_SHIFT) != 0) {
@@ -158,7 +158,7 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 			}
 #endif /* defined(OMR_ENV_DATA64) */
 
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 		}
 	}
 
@@ -168,7 +168,7 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 void *
 omrmem_reallocate_memory_basic(struct OMRPortLibrary *portLibrary, void *memoryPointer, uintptr_t byteAmount)
 {
-#if (defined(S390) || defined(J9ZOS390)) && !defined(OMR_ENV_DATA64)
+#if (defined(S390) || (HOST_OS == OMR_ZOS)) && !defined(OMR_ENV_DATA64)
 	return (void *)(((uintptr_t) realloc(memoryPointer, byteAmount)) & 0x7FFFFFFF);
 #elif defined(OMRZTPF)
     return realloc64(memoryPointer, byteAmount);
@@ -180,16 +180,16 @@ omrmem_reallocate_memory_basic(struct OMRPortLibrary *portLibrary, void *memoryP
 void
 omrmem_shutdown_basic(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	omrmem_free_memory_basic(portLibrary, portLibrary->portGlobals->procSelfMap);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	omrmem_free_memory_basic(portLibrary, portLibrary->portGlobals);
 }
 
 void
 omrmem_startup_basic(struct OMRPortLibrary *portLibrary, uintptr_t portGlobalSize)
 {
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	char tmpbuff[256];
 #endif
 
@@ -199,11 +199,11 @@ omrmem_startup_basic(struct OMRPortLibrary *portLibrary, uintptr_t portGlobalSiz
 		return;
 	}
 	memset(portLibrary->portGlobals, 0, portGlobalSize);
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	portLibrary->portGlobals->procSelfMap = omrmem_allocate_memory_basic(portLibrary, J9OSDUMP_SIZE);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_GC_COMPRESSED_POINTERS)
 	/* 'disableEnsureCap32' is set using omrport_control(OMRPORT_CTLDATA_NOSUBALLOC32BITMEM,...),
 	 * or by setting the J9_SUBALLOC_FOR_32 environment variable before starting the JVM.
 	 *

--- a/port/unix/omrmmap.c
+++ b/port/unix/omrmmap.c
@@ -50,7 +50,7 @@
 #include "protect_helpers.h"
 #include "omrportpriv.h"
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/shm.h>
 #include <sys/vminfo.h>
 #endif/*AIXPPC*/
@@ -299,14 +299,14 @@ omrmmap_capabilities(struct OMRPortLibrary *portLibrary)
 			| OMRPORT_MMAP_CAPABILITY_READ
 			| OMRPORT_MMAP_CAPABILITY_PROTECT
 			/* If JSE platforms include WRITE and MSYNC - ZOS included, but currently has own omrmmap.c */
-#if ((defined(LINUX) && defined(J9X86)) \
-  || (defined(LINUXPPC)) \
-  || (defined(LINUX) && defined(S390)) \
-  || (defined(LINUX) && defined(J9HAMMER)) \
-  || (defined(LINUX) && defined(ARM)) \
-  || (defined(LINUX) && defined(AARCH64)) \
-  || (defined(AIXPPC)) \
-  || (defined(OSX)))
+#if (((HOST_OS == OMR_LINUX) && defined(J9X86)) \
+  || ((HOST_OS == OMR_LINUX)) \
+  || ((HOST_OS == OMR_LINUX) && defined(S390)) \
+  || ((HOST_OS == OMR_LINUX) && defined(J9HAMMER)) \
+  || ((HOST_OS == OMR_LINUX) && defined(ARM)) \
+  || ((HOST_OS == OMR_LINUX) && defined(AARCH64)) \
+  || ((HOST_OS == OMR_AIX)) \
+  || ((HOST_OS == OMR_OSX)))
 			| OMRPORT_MMAP_CAPABILITY_WRITE
 			| OMRPORT_MMAP_CAPABILITY_MSYNC
 #endif
@@ -344,16 +344,16 @@ omrmmap_dont_need(struct OMRPortLibrary *portLibrary, const void *startAddress, 
 
 			Trc_PRT_mmap_dont_need_oscall(roundedStart, roundedLength);
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 			if (-1 == madvise((void *)roundedStart, roundedLength, MADV_DONTNEED)) {
 				Trc_PRT_mmap_dont_need_madvise_failed((void *)roundedStart, roundedLength, errno);
 			}
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 			/* madvise is not supported on AIX.  disclaim64() fails on virtual memory mapped to a file */
 			if (-1 == disclaim64((void *)roundedStart, roundedLength, DISCLAIM_ZEROMEM)) {
 				Trc_PRT_mmap_dont_need_disclaim64_failed((void *)roundedStart, roundedLength, errno);
 			}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		}
 	}
 }

--- a/port/unix/omrosdump.c
+++ b/port/unix/omrosdump.c
@@ -27,7 +27,7 @@
  */
 
 #include <sys/types.h>
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/proc.h>
 #endif
 #include <unistd.h>
@@ -54,7 +54,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* **********
 These definitions were copied from /usr/include/sys/proc.h in AIX 6.1, because this functionality does not
 exist on AIX 5.3. The code that uses these definitions does a runtime lookup to see if the
@@ -105,7 +105,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 	char *lastSep = NULL;
 	intptr_t pid = 0;
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct vario myvar;
 
 	/* check to see if full core dumps are enabled */
@@ -140,15 +140,15 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 	if (0 == pid) {
 		/* in the child process */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		/*
 		 * on Linux, shared library pages don't appear in core files by default.
 		 * Mark all pages writable to force these pages to appear
 		 */
 		markAllPagesWritable(portLibrary);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		/* On AIX we need to ask sigaction for full dumps */
 		{
 			struct sigaction act;
@@ -157,16 +157,16 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 			sigfillset(&act.sa_mask);
 			sigaction(SIGIOT, &act, 0);
 		}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 		/*
 		 * CMVC 95748: don't use abort() after fork() on Linux as this seems to upset certain levels of glibc
 		 */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define J9_DUMP_SIGNAL  SIGSEGV
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #define J9_DUMP_SIGNAL  SIGABRT
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 		/* Ensure we get default action (core) - reset primary&app handlers */
 		OMRSIG_SIGNAL(J9_DUMP_SIGNAL, SIG_DFL);
@@ -184,9 +184,9 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 			}
 		}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		pthread_kill(pthread_self(), J9_DUMP_SIGNAL);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 		abort();
 	} /* end of child process */
@@ -197,7 +197,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 		return 1;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 
 	if (NULL != filename) {
 		/* Wait for child process that is generating core file to finish */
@@ -208,7 +208,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 		return 1;
 	}
 
-#elif defined(AIXPPC) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	if (filename && filename[0] != '\0') {
 		char corepath[EsMaxPath] = "";
@@ -258,11 +258,11 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 
 	return 0;
 
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #error "This platform doesn't have an implementation of omrdump_create"
 
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #else /* J9OS_I5 */
 
@@ -320,7 +320,7 @@ unlimitCoreFileSize(struct OMRPortLibrary *portLibrary)
 int32_t
 omrdump_startup(struct OMRPortLibrary *portLibrary)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	uintptr_t handle = 0;
 
 	portLibrary->error_set_last_error(portLibrary, 0, 0);
@@ -360,7 +360,7 @@ omrdump_startup(struct OMRPortLibrary *portLibrary)
 		}
 		portLibrary->sl_close_shared_library(portLibrary, handle);
 	}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	/* We can only get here omrdump_startup completed successfully */
 

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -26,13 +26,13 @@
  * @brief shared library
  */
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
 /* defining _GNU_SOURCE allows the use of dladdr() in dlfcn.h */
 #define _GNU_SOURCE
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define _XOPEN_SOURCE
-#endif /* defined(LINUX)  && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX)  && !defined(OMRZTPF) */
 
 /*
  *	Standard unix shared libraries
@@ -51,11 +51,11 @@
 /* Start copy from omrfiletext.c */
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)
+#if defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define J9VM_USE_MBTOWC
-#else /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#else /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #include "omriconvhelpers.h"
-#endif /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#endif /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 
 #if defined(J9VM_USE_MBTOWC) || defined(J9VM_USE_ICONV)
@@ -73,11 +73,11 @@
 #include "omrport.h"
 #include "portnls.h"
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #define PLATFORM_DLL_EXTENSION ".dylib"
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define PLATFORM_DLL_EXTENSION ".so"
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #if (defined(J9VM_USE_MBTOWC)) /* priv. proto (autogen) */
 
@@ -160,7 +160,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 	/* dlopen(2) called with NULL filename opens a handle to current executable. */
 	handle = dlopen(openExec ? NULL : openName, lazyOrNow);
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	if ((NULL == handle) && !openExec) {
 		/* last ditch, try dir port lib DLL is in */
 		char portLibDir[MAX_STRING_LENGTH];
@@ -195,7 +195,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 			}
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	if (NULL == handle) {
 		getDLError(portLibrary, errBuf, sizeof(errBuf));

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -30,9 +30,9 @@
 #define ENV_DEBUG
 #endif
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #define _GNU_SOURCE
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define _XOPEN_SOURCE
 #include <libproc.h>
 #include <mach/mach.h>
@@ -44,7 +44,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -70,37 +70,37 @@
 #define USER_HZ HZ
 #endif /* !defined(USER_HZ) && !defined(OMRZTPF) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "omrsimap.h"
 #include "omrsysinfo_helpers.h"
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 #include "auxv.h"
 #include <strings.h>
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <fcntl.h>
 #include <sys/procfs.h>
 #include <sys/systemcfg.h>
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 /* Start copy from omrfiletext.c */
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if defined(__STDC_ISO_10646__) || defined(LINUX) ||defined(OSX)
+#if defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) ||(HOST_OS == OMR_OSX)
 #define J9VM_USE_MBTOWC
-#else /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#else /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #include "omriconvhelpers.h"
-#endif /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#endif /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /* a2e overrides nl_langinfo to return ASCII strings. We need the native EBCDIC string */
-#if defined(J9ZOS390) && defined (nl_langinfo)
+#if (HOST_OS == OMR_ZOS) && defined (nl_langinfo)
 #undef nl_langinfo
 #endif
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "omrgetuserid.h"
 #endif
 
@@ -131,20 +131,20 @@
 #endif
 #endif
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <linux/magic.h>
 #include <sys/sysinfo.h>
 #include <sys/vfs.h>
 #include <sched.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <sys/sysctl.h>
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 #include <unistd.h>
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include "omrcgroup.h"
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include "omrportpriv.h"
 #include "omrportpg.h"
 #include "omrportptb.h"
@@ -158,7 +158,7 @@
 #include <tpf/sysapi.h>
 #endif /* defined(OMRZTPF) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include <sys/ps.h>
 #include <sys/types.h>
 #include "atoe.h"
@@ -257,7 +257,7 @@ struct  {
 #endif
 };
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #define OMR_CGROUP_V1_MOUNT_POINT "/sys/fs/cgroup"
 #define ROOT_CGROUP "/"
@@ -372,35 +372,35 @@ static struct OMRCgroupSubsystemMetricMap omrCgroupCpusetMetricMap[] = {
 
 static uint32_t attachedPortLibraries;
 static omrthread_monitor_t cgroupEntryListMonitor;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 static intptr_t cwdname(struct OMRPortLibrary *portLibrary, char **result);
 static uint32_t getLimitSharedMemory(struct OMRPortLibrary *portLibrary, uint64_t *limit);
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 static intptr_t readSymbolicLink(struct OMRPortLibrary *portLibrary, char *linkFilename, char **result);
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) */
-#if defined(AIXPPC) || defined(J9ZOS390)
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 static BOOLEAN isSymbolicLink(struct OMRPortLibrary *portLibrary, char *filename);
 static intptr_t searchSystemPath(struct OMRPortLibrary *portLibrary, char *filename, char **result);
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 static void setOSFeature(struct OMROSDesc *desc, uint32_t feature);
 static intptr_t getZOSDescription(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
-#if !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF)
+#if !defined(RS6000) && !(HOST_OS == OMR_ZOS) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF)
 static uint64_t getPhysicalMemory(struct OMRPortLibrary *portLibrary);
-#elif defined(OMRZTPF) /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX)  && !defined(OMRZTPF) */
+#elif defined(OMRZTPF) /* !defined(RS6000) && !(HOST_OS == OMR_ZOS) && !(HOST_OS == OMR_OSX)  && !defined(OMRZTPF) */
 static uint64_t getPhysicalMemory();
-#endif /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF) */
+#endif /* !defined(RS6000) && !(HOST_OS == OMR_ZOS) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF) */
 
 #if defined(OMRZTPF)
 	uintptr_t get_IPL_IstreamCount();
 	uintptr_t get_Dispatch_IstreamCount();
 #endif /* defined(OMRZTPF) */
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 static BOOLEAN isCgroupV1Available(struct OMRPortLibrary *portLibrary);
 static void freeCgroupEntries(struct OMRPortLibrary *portLibrary, OMRCgroupEntry *cgEntryList);
 static char * getCgroupNameForSubsystem(struct OMRPortLibrary *portLibrary, OMRCgroupEntry *cgEntryList, const char *subsystem);
@@ -413,17 +413,17 @@ static int32_t readCgroupMetricFromFile(struct OMRPortLibrary *portLibrary, uint
 static int32_t readCgroupSubsystemFile(struct OMRPortLibrary *portLibrary, uint64_t subsystemFlag, const char *fileName, int32_t numItemsToRead, const char *format, ...);
 static int32_t isRunningInContainer(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer);
 static int32_t getCgroupMemoryLimit(struct OMRPortLibrary *portLibrary, uint64_t *limit);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 static int32_t retrieveLinuxMemoryStatsFromProcFS(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 static int32_t retrieveLinuxCgroupMemoryStats(struct OMRPortLibrary *portLibrary, struct OMRCgroupMemoryInfo *cgroupMemInfo);
 static int32_t retrieveLinuxMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 static int32_t retrieveOSXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 static int32_t retrieveAIXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 static int32_t retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 #endif
 
@@ -503,7 +503,7 @@ omrsysinfo_process_exists(struct OMRPortLibrary *portLibrary, uintptr_t pid)
 const char *
 omrsysinfo_get_CPU_architecture(struct OMRPortLibrary *portLibrary)
 {
-#if defined(RS6000) || defined(LINUXPPC)
+#if defined(RS6000) || (HOST_OS == OMR_LINUX)
 #ifdef PPC64
 #ifdef OMR_ENV_LITTLE_ENDIAN
 	return OMRPORT_ARCH_PPC64LE;
@@ -515,7 +515,7 @@ omrsysinfo_get_CPU_architecture(struct OMRPortLibrary *portLibrary)
 #endif /* PPC64*/
 #elif defined(J9X86)
 	return OMRPORT_ARCH_X86;
-#elif defined(S390) || defined(J9ZOS390)
+#elif defined(S390) || (HOST_OS == OMR_ZOS)
 #if defined(S39064) || defined(J9ZOS39064)
 	return OMRPORT_ARCH_S390X;
 #else
@@ -556,7 +556,7 @@ omrsysinfo_get_OS_type(struct OMRPortLibrary *portLibrary)
 #if defined(J9OS_I5)
 	/* JCL on IBM i expects to see "OS/400" */
 	return "OS/400";
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	return "Mac OS X";
 #else
 	if (NULL == PPG_si_osType) {
@@ -682,12 +682,12 @@ omrsysinfo_get_OS_version(struct OMRPortLibrary *portLibrary)
 		}
 #else
 		rc = uname(&sysinfo);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 		if (rc >= 0) {
 			int len;
 			char *buffer = NULL;
-#if defined(RS6000) || defined(J9ZOS390)
+#if defined(RS6000) || (HOST_OS == OMR_ZOS)
 			len = strlen(sysinfo.version) + strlen(sysinfo.release) + RELEASE_OVERHEAD;
 			buffer = portLibrary->mem_allocate_memory(portLibrary, len, OMR_GET_CALLSITE(), OMRMEM_CATEGORY_PORT_LIBRARY);
 			if (NULL != buffer) {
@@ -794,7 +794,7 @@ omrsysinfo_get_groups(struct OMRPortLibrary *portLibrary, uint32_t **gidList, ui
 static intptr_t
 find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 {
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	intptr_t retval = readSymbolicLink(portLibrary, "/proc/self/exe", result);
 	if (NULL != *result) {
 		/* The code in this block is a work around for a linux bug. If /proc/self/exe is read after a
@@ -817,7 +817,7 @@ find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 		}
 	}
 	return retval;
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	intptr_t rc = -1;
 	uint32_t size = 0;
 
@@ -829,7 +829,7 @@ find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 		rc = 0;
 	}
 	return rc;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 
 	intptr_t retval = -1;
 	intptr_t length;
@@ -871,7 +871,7 @@ find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 #else
 	char *execName = NULL;
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* On AIX, "/proc" provides a way of determining argument vector (not just using
 	 * argv[0] from within main()).
 	 */
@@ -1046,7 +1046,7 @@ cleanup:
 	}
 
 	return retval;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 
 /**
@@ -1110,7 +1110,7 @@ doAlloc:
 	return 0;
 }
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 /**
  * @internal  Examines the named file to determine if it is a symbolic link.  On platforms which don't have
  * symbolic links (or where we can't tell) or if an unexpected error occurs, just answer FALSE.
@@ -1136,7 +1136,7 @@ isSymbolicLink(struct OMRPortLibrary *portLibrary, char *filename)
 
 	return FALSE;
 }
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
 
 /**
  * @internal  Attempts to read the contents of a symbolic link.  (The contents are the relative pathname of
@@ -1145,11 +1145,11 @@ isSymbolicLink(struct OMRPortLibrary *portLibrary, char *filename)
  * portLibrary->mem_free_memory when it is no longer needed.
  * On success, returns 0.  On error, returns -1.
  */
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 static intptr_t
 readSymbolicLink(struct OMRPortLibrary *portLibrary, char *linkFilename, char **result)
 {
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 	char fixedBuffer[PATH_MAX + 1];
 	int size = readlink(linkFilename, fixedBuffer, sizeof(fixedBuffer) - 1);
 #ifdef DEBUG
@@ -1166,13 +1166,13 @@ readSymbolicLink(struct OMRPortLibrary *portLibrary, char *linkFilename, char **
 	strcpy(*result, fixedBuffer);
 	return 0;
 
-#else /* defined(LINUX) || defined(AIXPPC) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
 	return -1;
-#endif /* defined(LINUX) || defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
 }
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS)
 /**
  * @internal  Searches through the system PATH for the named file.  If found, it returns the path entry
  * which matched the file.  A buffer large enough to hold the proper path entry (without a
@@ -1241,7 +1241,7 @@ searchSystemPath(struct OMRPortLibrary *portLibrary, char *filename, char **resu
 	return -1;
 }
 
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_ZOS) */
 
 uintptr_t
 omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t type)
@@ -1252,13 +1252,13 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 
 	switch (type) {
 	case OMRPORT_CPU_PHYSICAL:
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 		toReturn = sysconf(_SC_NPROCESSORS_CONF);
 
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedPhysical("errno: ", errno);
 		}
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		/* Temporarily using ONLINE for PHYSICAL on z/OS */
 		toReturn = portLibrary->sysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_ONLINE);
 
@@ -1284,7 +1284,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedOnline("(no errno) ", 0);
 		}
-#elif (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#elif ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 		/* returns number of online(_SC_NPROCESSORS_ONLN) processors, number configured(_SC_NPROCESSORS_CONF) may  be more than online */
 		toReturn = sysconf(_SC_NPROCESSORS_ONLN);
 
@@ -1298,7 +1298,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedOnline("(no errno) ", 0);
 		}
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		toReturn = Get_Number_Of_CPUs();
 
 		if (0 == toReturn) {
@@ -1315,7 +1315,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 #if defined(J9OS_I5)
 		toReturn = 0;
 		Trc_PRT_sysinfo_get_number_CPUs_by_type_invalidType();
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 		rsid_t who = { .at_tid = thread_self() };
 		rsethandle_t rset = rs_alloc(RS_EMPTY);
 		ra_getrset(R_THREAD, who, 0, rset);
@@ -1325,7 +1325,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 >= toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedBound("errno: ", errno);
 		}
-#elif defined(LINUX) && !defined(OMRZTPF)
+#elif (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 		cpu_set_t cpuSet;
 		int32_t size = sizeof(cpuSet); /* Size in bytes */
 		pid_t mainProcess = getpid();
@@ -1382,7 +1382,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedBound("(no errno) ", 0);
 		}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 		/* OS X does not export interfaces that identify processors or control thread
 		 * placement--explicit thread to processor binding is not supported. Thus, this
 		 * just returns number of CPUs.
@@ -1391,7 +1391,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedBound("errno: ", errno);
 		}
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		toReturn = Get_Number_Of_CPUs();
 
 		if (0 == toReturn) {
@@ -1441,7 +1441,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 /* Base for the decimal number system is 10. */
 #define COMPUTATION_BASE	10
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #define MEMSTATPATH			"/proc/meminfo"
 
 #define MEMTOTAL_PREFIX		"MemTotal:"
@@ -1794,7 +1794,7 @@ _exit:
 	return rc;
 }
 
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 
 /**
  * Function collects memory usage statistics on OSX and returns the same.
@@ -1869,7 +1869,7 @@ retrieveOSXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *
 	return ret;
 }
 
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 
 /**
  * Function collects memory usage statistics on AIX and returns the same.
@@ -1949,13 +1949,13 @@ omrsysinfo_get_memory_info(struct OMRPortLibrary *portLibrary, struct J9MemoryIn
 	memInfo->hostCached = OMRPORT_MEMINFO_NOT_AVAILABLE;
 	memInfo->hostBuffered = OMRPORT_MEMINFO_NOT_AVAILABLE;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	rc = retrieveLinuxMemoryStats(portLibrary, memInfo);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	rc = retrieveOSXMemoryStats(portLibrary, memInfo);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	rc = retrieveAIXMemoryStats(portLibrary, memInfo);
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	rc = retrieveZOSMemoryStats(portLibrary, memInfo);
 #endif
 
@@ -1988,7 +1988,7 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 {
 	uint64_t result = 0;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	if (portLibrary->sysinfo_cgroup_are_subsystems_enabled(portLibrary, OMR_CGROUP_SUBSYSTEM_MEMORY)) {
 		int32_t rc = portLibrary->sysinfo_cgroup_get_memlimit(portLibrary, &result);
 
@@ -1996,17 +1996,17 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 			return result;
 		}
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined (RS6000)
 	/* physmem is not a field in the system_configuration struct */
 	/* on systems with 43K headers. However, this is not an issue as we only support AIX 5.2 and above only */
 	result = (uint64_t) _system_configuration.physmem;
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	J9CVT * __ptr32 cvtp = ((J9PSA * __ptr32)0)->flccvt;
 	J9RCE * __ptr32 rcep = cvtp->cvtrcep;
 	result = ((U_64)rcep->rcepool * J9BYTES_PER_PAGE);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	{
 		int name[2] = {CTL_HW, HW_MEMSIZE};
 		size_t len = sizeof(result);
@@ -2023,7 +2023,7 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 	return result;
 }
 
-#if !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF)
+#if !defined(RS6000) && !(HOST_OS == OMR_ZOS) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF)
 
 /**
  * Returns physical memory available on the system
@@ -2046,7 +2046,7 @@ getPhysicalMemory(struct OMRPortLibrary *portLibrary)
 		return (uint64_t) pagesize * num_pages;
 	}
 }
-#elif defined(OMRZTPF) /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF) */
+#elif defined(OMRZTPF) /* !defined(RS6000) && !(HOST_OS == OMR_ZOS) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF) */
 
 static uint64_t
 getPhysicalMemory( void ) {
@@ -2074,7 +2074,7 @@ getPhysicalMemory( void ) {
 	return physMemory;
 }
 
-#endif /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF) */
+#endif /* !defined(RS6000) && !(HOST_OS == OMR_ZOS) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF) */
 
 void
 omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
@@ -2093,7 +2093,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 			portLibrary->mem_free_memory(portLibrary, PPG_si_executableName);
 			PPG_si_executableName = NULL;
 		}
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 		omrthread_monitor_enter(cgroupEntryListMonitor);
 		freeCgroupEntries(portLibrary, PPG_cgroupEntryList);
 		PPG_cgroupEntryList = NULL;
@@ -2103,7 +2103,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 			omrthread_monitor_destroy(cgroupEntryListMonitor);
 			cgroupEntryListMonitor = NULL;
 		}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	}
 }
 
@@ -2118,7 +2118,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	 */
 	(void) find_executable_name(portLibrary, &PPG_si_executableName);
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	PPG_cgroupEntryList = NULL;
 	/* To handle the case where multiple port libraries are started and shutdown,
 	 * as done by some fvtests (eg fvtest/porttest/j9portTest.cpp) that create fake portlibrary
@@ -2132,7 +2132,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	}
 	attachedPortLibraries += 1;
 	isRunningInContainer(portLibrary, &PPG_isRunningInContainer);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	return 0;
 }
 
@@ -2144,7 +2144,7 @@ omrsysinfo_get_username(struct OMRPortLibrary *portLibrary, char *buffer, uintpt
 	size_t nameLen = 0;
 	struct passwd *pwent = NULL;
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* CMVC 182664 */
 #define USERID_BUF_LEN 16
 	char loginID[USERID_BUF_LEN];
@@ -2302,7 +2302,7 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 	}
 	break;
 	case OMRPORT_RESOURCE_CORE_FLAGS: {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		struct vario myvar;
 
 		if (0 == sys_parm(SYSP_GET, SYSP_V_FULLCORE, &myvar)) {
@@ -2331,7 +2331,7 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 	 * must match "ulimit -n".
 	 */
 	case OMRPORT_RESOURCE_FILE_DESCRIPTORS: {
-#if defined(AIXPPC) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_ZOS)
 		/* getrlimit(2) is a POSIX routine. */
 		if (0 == getrlimit(RLIMIT_NOFILE, &lim)) {
 			*limit = (uint64_t) (hardLimitRequested ? lim.rlim_max : lim.rlim_cur);
@@ -2346,11 +2346,11 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 			Trc_PRT_sysinfo_getrlimit_error(resource, findError(errno));
 			rc = OMRPORT_LIMIT_UNKNOWN;
 		}
-#else /* defined(AIXPPC) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_AIX) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_ZOS) */
 		/* unsupported on other platforms (just in case). */
 		*limit = OMRPORT_LIMIT_UNKNOWN_VALUE;
 		rc = OMRPORT_LIMIT_UNKNOWN;
-#endif /* defined(AIXPPC) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_ZOS) */
 	}
 	break;
 	default:
@@ -2415,7 +2415,7 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 			if (hardLimitRequested) {
 				lim.rlim_max = limit;
 			} else {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 				/* MacOS doesn't allow the soft file limit to be unlimited */
 				if ((OMRPORT_RESOURCE_FILE_DESCRIPTORS == resourceRequested)
 						&& (RLIM_INFINITY == limit)) {
@@ -2446,7 +2446,7 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 		}
 
 		case OMRPORT_RESOURCE_CORE_FLAGS: {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 			struct vario myvar;
 
 			myvar.v.v_fullcore.value = limit;
@@ -2476,7 +2476,7 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 static uint32_t
 getLimitSharedMemory(struct OMRPortLibrary *portLibrary, uint64_t *limit)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	int fd = 0;
 	int64_t shmmax = -1;
 	int bytesRead = 0;
@@ -2516,18 +2516,18 @@ errorReturn:
 	Trc_PRT_sysinfo_getLimitSharedMemory_ErrorExit(OMRPORT_LIMIT_UNKNOWN, OMRPORT_LIMIT_UNKNOWN_VALUE);
 	*limit = OMRPORT_LIMIT_UNKNOWN_VALUE;
 	return OMRPORT_LIMIT_UNKNOWN;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	Trc_PRT_sysinfo_getLimitSharedMemory_notImplemented(OMRPORT_LIMIT_UNKNOWN);
 	*limit = OMRPORT_LIMIT_UNKNOWN_VALUE;
 	return OMRPORT_LIMIT_UNKNOWN;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 
 intptr_t
 omrsysinfo_get_load_average(struct OMRPortLibrary *portLibrary, struct J9PortSysInfoLoadData *loadAverageData)
 {
-#if (defined(LINUX) || defined(OSX)) && !defined(OMRZTPF)
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF)
 	double loadavg[3];
 	int returnValue = getloadavg(loadavg, 3);
 	if (returnValue == 3) {
@@ -2539,7 +2539,7 @@ omrsysinfo_get_load_average(struct OMRPortLibrary *portLibrary, struct J9PortSys
 	return -1;
 #elif defined(J9OS_I5)
 	return -1;
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	perfstat_cpu_total_t perfstats;
 	int returnValue = perfstat_cpu_total(NULL, &perfstats, sizeof(perfstat_cpu_total_t), 1);
 	if ((returnValue != EINVAL) && (returnValue != EFAULT) && (returnValue != ENOMEM)) {
@@ -2558,14 +2558,14 @@ intptr_t
 omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9SysinfoCPUTime *cpuTime)
 {
 	intptr_t status = OMRPORT_ERROR_SYSINFO_OPFAILED;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	/* omrtime_nano_time() gives monotonically increasing times as against omrtime_hires_clock() that
 	 * returns times that can (and does) decrease. Use this to compute timestamps.
 	 */
 	uint64_t preTimestamp = portLibrary->time_nano_time(portLibrary); /* ticks */
 	uint64_t postTimestamp; /* ticks */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	intptr_t bytesRead = -1;
 	/*
 	 * Read the first line of /proc/stat, which takes the form:
@@ -2605,7 +2605,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 		cpuTime->numberOfCpus = portLibrary->sysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_ONLINE);
 		status = 0;
 	}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	processor_cpu_load_info_t cpuLoadInfo;
 	mach_msg_type_number_t msgTypeNumber;
 	natural_t processorCount;
@@ -2637,7 +2637,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	/*Xj9GetSysCPUTime() is newly added to retrieve System CPU Time fromILE.*/
 	cpuTime->cpuTime = Xj9GetSysCPUTime();
 	status = 0;	
-#elif defined(AIXPPC) /* AIX */
+#elif (HOST_OS == OMR_AIX) /* AIX */
 	perfstat_cpu_total_t stats;
 	const uintptr_t NS_PER_CPU_TICK = 10000000L;
 
@@ -2660,7 +2660,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	/* Use the average of the timestamps before and after reading processor times to reduce bias. */
 	cpuTime->timestamp = (preTimestamp + postTimestamp) / 2;
 	return status;
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) */
+#else /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 	/* Support on z/OS being temporarily removed to avoid wrong CPU stats being passed. */
 	return OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED;
 #endif
@@ -3075,7 +3075,7 @@ omrsysinfo_env_iterator_next(struct OMRPortLibrary *portLibrary, J9SysinfoEnvIte
 
 }
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #define PROCSTATPATH	"/proc/stat"
 #define PROCSTATPREFIX	"cpu"
@@ -3222,7 +3222,7 @@ retrieveLinuxProcessorStats(struct OMRPortLibrary *portLibrary, struct J9Process
 	return 0;
 }
 
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 
 /**
  * Function collects processor usage statistics on OSX and returns the same.
@@ -3271,7 +3271,7 @@ retrieveOSXProcessorStats(struct OMRPortLibrary *portLibrary, struct J9Processor
 	return ret;
 }
 
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 
 /**
  * Function collects processor usage statistics on AIX and returns the same.
@@ -3403,7 +3403,7 @@ omrsysinfo_get_processor_info(struct OMRPortLibrary *portLibrary, struct J9Proce
 
 	Trc_PRT_sysinfo_get_processor_info_Entered();
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* Support on z/OS being temporarily removed to avoid wrong CPU stats being passed. */
 	Trc_PRT_sysinfo_get_processor_info_Exit(OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED);
 	return OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED;
@@ -3460,13 +3460,13 @@ omrsysinfo_get_processor_info(struct OMRPortLibrary *portLibrary, struct J9Proce
 		/* online field for the aggregate record needs to be -1 */
 		procInfo->procInfoArray[0].online = -1;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		rc = retrieveLinuxProcessorStats(portLibrary, procInfo);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 		rc = retrieveOSXProcessorStats(portLibrary, procInfo);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 		rc = retrieveAIXProcessorStats(portLibrary, procInfo);
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		rc = retrieveZOSProcessorStats(portLibrary, procInfo);
 #endif
 		retries++;
@@ -3620,7 +3620,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 		portLibrary->error_set_last_error(portLibrary, EINVAL, findError(EINVAL));
 		Trc_PRT_sysinfo_get_open_file_count_invalidArgRecvd("count");
 	} else {
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 		char buffer[PATH_MAX] = {0};
 		const char *procDirectory = "/proc/%d/fd/";
 		DIR *dir = NULL;
@@ -3663,7 +3663,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 			}
 			closedir(dir); /* Done reading the /proc file-system. */
 		}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 		pid_t pid = getpid();
 		/* First call with null to get the size of the buffer required */
 		int32_t bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, 0, 0);
@@ -3699,7 +3699,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 				portLibrary->mem_free_memory(portLibrary, procFDInfo);
 			}
 		}
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 		/* TODO: stub where z/OS code goes in. */
 		ret = OMRPORT_ERROR_SYSINFO_GET_OPEN_FILES_NOT_SUPPORTED;
 #endif
@@ -3709,7 +3709,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 	return ret;
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * @internal
  * Helper to set appropriate feature field in a OMROSDesc struct
@@ -3752,7 +3752,7 @@ getZOSDescription(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc)
 
 	return rc;
 }
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 intptr_t
 omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc)
@@ -3763,9 +3763,9 @@ omrsysinfo_get_os_description(struct OMRPortLibrary *portLibrary, struct OMROSDe
 	if (NULL != desc) {
 		memset(desc, 0, sizeof(OMROSDesc));
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		rc = getZOSDescription(portLibrary, desc);
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	}
 
 	Trc_PRT_sysinfo_get_os_description_Exit(rc);
@@ -3794,19 +3794,19 @@ omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernel
 {
 	BOOLEAN success = FALSE;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	struct utsname name = {{0}};
 	if (0 == uname(&name)) {
 		if (3 == sscanf(name.release, "%u.%u.%u", &kernelInfo->kernelVersion, &kernelInfo->majorRevision, &kernelInfo->minorRevision)) {
 			success = TRUE;
 		}
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	return success;
 }
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
 /**
  * @internal
@@ -4408,13 +4408,13 @@ _end:
 	return rc;
 }
 
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 BOOLEAN
 omrsysinfo_cgroup_is_system_available(struct OMRPortLibrary *portLibrary)
 {
 	BOOLEAN result = FALSE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 
 	Trc_PRT_sysinfo_cgroup_is_system_available_Entry();
@@ -4446,29 +4446,29 @@ _end:
 		PPG_cgroupSubsystemsAvailable = 0;
 	}
 	Trc_PRT_sysinfo_cgroup_is_system_available_Exit((uintptr_t)result);
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return result;
 }
 
 uint64_t
 omrsysinfo_cgroup_get_available_subsystems(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	Trc_PRT_sysinfo_cgroup_get_available_subsystems_Entry();
 	if (NULL == PPG_cgroupEntryList) {
 		portLibrary->sysinfo_cgroup_is_system_available(portLibrary);
 	}
 	Trc_PRT_sysinfo_cgroup_get_available_subsystems_Exit(PPG_cgroupSubsystemsAvailable);
 	return PPG_cgroupSubsystemsAvailable;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_are_subsystems_available(struct OMRPortLibrary *portLibrary, uint64_t subsystemFlags)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	uint64_t available = 0;
 	uint64_t rc = 0;
 
@@ -4480,25 +4480,25 @@ omrsysinfo_cgroup_are_subsystems_available(struct OMRPortLibrary *portLibrary, u
 	Trc_PRT_sysinfo_cgroup_are_subsystems_available_Exit(rc);
 
 	return rc;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_get_enabled_subsystems(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	return PPG_cgroupSubsystemsEnabled;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_enable_subsystems(struct OMRPortLibrary *portLibrary, uint64_t requestedSubsystems)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	uint64_t available = 0;
 
 	Trc_PRT_sysinfo_cgroup_enable_subsystems_Entry(requestedSubsystems);
@@ -4509,19 +4509,19 @@ omrsysinfo_cgroup_enable_subsystems(struct OMRPortLibrary *portLibrary, uint64_t
 	Trc_PRT_sysinfo_cgroup_enable_subsystems_Exit(PPG_cgroupSubsystemsEnabled);
 
 	return PPG_cgroupSubsystemsEnabled;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_are_subsystems_enabled(struct OMRPortLibrary *portLibrary, uint64_t subsystemsFlags)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	return (PPG_cgroupSubsystemsEnabled & subsystemsFlags);
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 int32_t
@@ -4531,9 +4531,9 @@ omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *lim
 
 	Assert_PRT_true(NULL != limit);
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	rc = getCgroupMemoryLimit(portLibrary, limit);
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 	return rc;
 }
@@ -4542,16 +4542,16 @@ omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *lim
 BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	int32_t rc = getCgroupMemoryLimit(portLibrary, NULL);
 	if (0 == rc) {
 		return TRUE;
 	} else {
 		return FALSE;
 	}
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return FALSE;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 /*
@@ -4560,7 +4560,7 @@ omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 struct OMRCgroupEntry *
 omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	return PPG_cgroupEntryList;
 #else
 	return NULL;
@@ -4582,7 +4582,7 @@ omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, ui
 {
 	Assert_PRT_true(NULL != state);
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	state->count = 0;
 	state->subsystemid = subsystem;
 	state->fileMetricCounter = 0;
@@ -4602,7 +4602,7 @@ omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, ui
 	rc = 0;
 
 _end:
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return rc;
 }
 
@@ -4610,9 +4610,9 @@ BOOLEAN
 omrsysinfo_cgroup_subsystem_iterator_hasNext(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state)
 {
 	BOOLEAN check = FALSE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	check = state->count < state->numElements;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return check;
 }
 
@@ -4620,7 +4620,7 @@ int32_t
 omrsysinfo_cgroup_subsystem_iterator_metricKey(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state, const char **metricKey)
 {
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_METRIC_NOT_AVAILABLE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	if (NULL != metricKey) {
 		const struct OMRCgroupSubsystemMetricMap *subsystemMetricMap = NULL;
 		switch (state->subsystemid) {
@@ -4653,7 +4653,7 @@ int32_t
 omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement)
 {
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	struct OMRCgroupMetricInfoElement *currentElement = NULL;
 	const struct OMRCgroupSubsystemMetricMap *subsystemMetricMap = NULL;
 	const struct OMRCgroupSubsystemMetricMap *subsystemMetricMapElement = NULL;
@@ -4755,7 +4755,7 @@ _end:
 		}
 	}
 	
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return rc;	
 }
 

--- a/port/unix/omrtime.c
+++ b/port/unix/omrtime.c
@@ -26,10 +26,10 @@
  * @brief Timer utilities
  */
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <mach/clock.h>
 #include <mach/mach.h>
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 #include <time.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -40,11 +40,11 @@
 
 #define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_I64(1000000000)
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 static clock_serv_t cs_t;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 static const clockid_t OMRTIME_NANO_CLOCK = CLOCK_MONOTONIC;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 
 /**
@@ -88,21 +88,21 @@ uint64_t
 omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *success)
 {
 	uint64_t nsec = 0;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	struct timeval ts;
 	*success = 0;
 	if (0 == gettimeofday(&ts, NULL)) {
 		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)(ts.tv_usec * 1000);
 		*success = 1;
 	}
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	struct timespec ts;
 	*success = 0;
 	if (0 == clock_gettime(CLOCK_REALTIME, &ts)) {
 		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
 		*success = 1;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	return nsec;
 }
 
@@ -110,18 +110,18 @@ int64_t
 omrtime_nano_time(struct OMRPortLibrary *portLibrary)
 {
 	int64_t hiresTime = 0;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	mach_timespec_t mt;
 	if (KERN_SUCCESS == clock_get_time(cs_t, &mt)) {
 		hiresTime = ((int64_t)mt.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)mt.tv_nsec;
 	}
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	struct timespec ts;
 
 	if (0 == clock_gettime(OMRTIME_NANO_CLOCK, &ts)) {
 		hiresTime = ((int64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)ts.tv_nsec;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	return hiresTime;
 }
@@ -224,9 +224,9 @@ omrtime_hires_delta(struct OMRPortLibrary *portLibrary, uint64_t startTime, uint
 void
 omrtime_shutdown(struct OMRPortLibrary *portLibrary)
 {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	mach_port_deallocate(mach_task_self(), cs_t);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 /**
  * PortLibrary startup.
@@ -246,20 +246,18 @@ int32_t
 omrtime_startup(struct OMRPortLibrary *portLibrary)
 {
 	int32_t rc = 0;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	if (KERN_SUCCESS != host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cs_t)) {
 		rc = OMRPORT_ERROR_STARTUP_TIME;
 	}
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	struct timespec ts;
 
 	/* check if the clock is available */
 	if (0 != clock_getres(OMRTIME_NANO_CLOCK, &ts)) {
 		rc = OMRPORT_ERROR_STARTUP_TIME;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	return rc;
 }
-
-

--- a/port/unix_include/omrcgroup.h
+++ b/port/unix_include/omrcgroup.h
@@ -22,7 +22,7 @@
 #ifndef omrcgroup_h
 #define omrcgroup_h
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 /**
  * Stores memory usage statistics of the cgroup. These stats are collected from the files present
@@ -39,6 +39,6 @@ typedef struct OMRCgroupMemoryInfo {
 	uint64_t cached; /**< page cache memory (as in memory.stat file)*/
 } OMRCgroupMemoryInfo;
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif /* omrcgroup_h */

--- a/port/unix_include/omriconvhelpers.h
+++ b/port/unix_include/omriconvhelpers.h
@@ -29,11 +29,11 @@
 
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if (!defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX)) || defined(OMRZTPF)
+#if (!defined(__STDC_ISO_10646__) && !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_OSX)) || defined(OMRZTPF)
 #define J9VM_USE_ICONV
-#endif /* !defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX) */
+#endif /* !defined(__STDC_ISO_10646__) && !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_OSX) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define J9VM_CACHE_ICONV_DESC
 #include "atoe.h"
 #endif
@@ -53,7 +53,7 @@
  */
 
 typedef enum {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	J9NLS_ICONV_DESCRIPTOR,
 #endif /* J9ZOS390 */
 	J9FILETEXT_ICONV_DESCRIPTOR,

--- a/port/unix_include/omrintrospect.h
+++ b/port/unix_include/omrintrospect.h
@@ -30,14 +30,14 @@
 
 #include "omrintrospect_common.h"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /*
  * CMVC 194846.
  * NOTE: When we use pthread_sigmask on other platforms, we can remove this macro.
  */
 #define sigprocmask pthread_sigmask
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 typedef ucontext_t thread_context;
 

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -28,9 +28,9 @@
  */
 
 #include "omrcfg.h"
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include "omrcgroup.h"
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include "omrport.h"
 #if defined(OMR_ENV_DATA64)
 #include "omrportpriv.h"
@@ -70,7 +70,7 @@ typedef struct OMRPortPlatformGlobals {
 	uintptr_t vmem_pageSize[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of supported page sizes */
 	uintptr_t vmem_pageFlags[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of flags describing type of the supported page sizes */
 	BOOLEAN isRunningInContainer;	
-#if defined(LINUX) && defined(S390)
+#if (HOST_OS == OMR_LINUX) && defined(S390)
 	int64_t last_clock_delta_update;  /** hw clock microsecond timestamp of last clock delta adjustment */
 	int64_t software_msec_clock_delta; /** signed difference between hw and sw clocks in milliseconds */
 #endif
@@ -84,12 +84,12 @@ typedef struct OMRPortPlatformGlobals {
 #if defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL)
 	int32_t introspect_threadSuspendSignal;
 #endif /* defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL) */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	uint64_t cgroupSubsystemsAvailable; /**< cgroup subsystems available for port library to use; it is valid only when cgroupEntryList is non-null */
 	uint64_t cgroupSubsystemsEnabled; /**< cgroup subsystems enabled in port library; it is valid only when cgroupEntryList is non-null */
 	OMRCgroupEntry *cgroupEntryList; /**< head of the circular linked list, each element contains information about cgroup of the process for a subsystem */
 	BOOLEAN syscallNotAllowed; /**< Assigned True if the mempolicy syscall is failed due to security opts (Can be seen in case of docker) */
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 } OMRPortPlatformGlobals;
 
 
@@ -111,7 +111,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_vmem_pageSize (portLibrary->portGlobals->platformGlobals.vmem_pageSize)
 #define PPG_vmem_pageFlags (portLibrary->portGlobals->platformGlobals.vmem_pageFlags)
 #define PPG_isRunningInContainer (portLibrary->portGlobals->platformGlobals.isRunningInContainer)
-#if defined(LINUX) && defined(S390)
+#if (HOST_OS == OMR_LINUX) && defined(S390)
 #define PPG_last_clock_delta_update  (portLibrary->portGlobals->platformGlobals.last_clock_delta_update)
 #define PPG_software_msec_clock_delta (portLibrary->portGlobals->platformGlobals.software_msec_clock_delta)
 #endif
@@ -130,13 +130,13 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_introspect_threadSuspendSignal (portLibrary->portGlobals->platformGlobals.introspect_threadSuspendSignal)
 #endif
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* Note that PPG_cgroupSubsystemsAvailable and PPG_cgroupSubsystemsEnabled are valid only if PPG_cgroupEntryList is not NULL */
 #define PPG_cgroupSubsystemsAvailable (portLibrary->portGlobals->platformGlobals.cgroupSubsystemsAvailable)
 #define PPG_cgroupSubsystemsEnabled (portLibrary->portGlobals->platformGlobals.cgroupSubsystemsEnabled)
 #define PPG_cgroupEntryList (portLibrary->portGlobals->platformGlobals.cgroupEntryList)
 #define PPG_numaSyscallNotAllowed (portLibrary->portGlobals->platformGlobals.syscallNotAllowed)
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif /* omrportpg_h */
 

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1236,9 +1236,9 @@ void
 omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
 		uintptr_t mode, uintptr_t *pageSize, uintptr_t *pageFlags)
 {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	{
 		/* Note that the PPG_vmem_pageSize is a null-terminated list of page sizes.
 		 * There will always be the 0 element (default page size),
@@ -1252,7 +1252,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
 			*pageFlags = PPG_vmem_pageFlags[1];
 		}
 	}
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	else {
 		if (NULL != pageSize) {
 			/* Return the same page size as used by JIT code cache */
@@ -1267,7 +1267,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
 			}
 		}
 	}
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	return;
 }
@@ -1284,7 +1284,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 	Assert_PRT_true_wrapper(OMRPORT_VMEM_PAGE_FLAG_NOT_USED == validPageFlags);
 
 	if (0 != validPageSize) {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		/* On Linux PPC, for executable pages, search through the list of supported page sizes only if
 		 * - request is for 16M pages, and
 		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
@@ -1307,7 +1307,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
 				((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize)))
 #endif /* defined(J9VM_ENV_DATA64) */
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			uintptr_t pageIndex = 0;
 			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(
@@ -1331,12 +1331,12 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		validPageSize = defaultLargePageSize;
 		validPageFlags = defaultLargePageFlags;
 	} else {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
 			validPageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
 			validPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
 		} else
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			validPageSize = PPG_vmem_pageSize[0];
 			validPageFlags = PPG_vmem_pageFlags[0];

--- a/third_party/gtest-1.8.0/include/gtest/internal/gtest-port-arch.h
+++ b/third_party/gtest-1.8.0/include/gtest/internal/gtest-port-arch.h
@@ -78,7 +78,7 @@
 # define GTEST_OS_ZOS 1
 #elif defined(__sun) && defined(__SVR4)
 # define GTEST_OS_SOLARIS 1
-#elif defined(_AIX)
+#elif (HOST_OS == OMR_AIX)
 # define GTEST_OS_AIX 1
 #elif defined(__hpux)
 # define GTEST_OS_HPUX 1

--- a/third_party/gtest-1.8.0/include/gtest/internal/gtest-port.h
+++ b/third_party/gtest-1.8.0/include/gtest/internal/gtest-port.h
@@ -2274,7 +2274,7 @@ inline bool IsXDigit(wchar_t ch) {
   return ch == low_byte && isxdigit(low_byte) != 0;
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* We need to define tolower and toupper macros for ToLower/ToUpper to use a2e tolower/toupper.
  */
 #define toupper(c)     (islower(c) ? (c & _XUPPER_ASCII) : c)
@@ -2288,7 +2288,7 @@ inline char ToUpper(char ch) {
   return static_cast<char>(toupper(static_cast<unsigned char>(ch)));
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* We need to undefine the macros in order to avoid function definitions for tolower and toupper in xlocale.
  */
 #undef toupper

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -96,9 +96,9 @@ static uintptr_t monitor_on_notify_all_wait_list(omrthread_t self, omrthread_mon
 static void monitor_notify_all_migration(omrthread_monitor_t monitor);
 
 static intptr_t failedToSetAttr(intptr_t rc);
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 static intptr_t copyAttr(omrthread_attr_t *attrTo, const omrthread_attr_t *attrFrom);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 static intptr_t fixupThreadAccounting(omrthread_t thread, uintptr_t type);
 static void storeExitCpuUsage(omrthread_t thread);
@@ -135,7 +135,7 @@ omrthread_t global_lock_owner = UNOWNED;
 #endif
 
 #ifdef OMR_ENV_DATA64
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* See CMVC 87602 - Problems on AIX 5.2 with very long wait times */
 #define BOUNDED_I64_TO_IDATA(longValue) ((longValue) > 0x7FFFFFFFLL ? (intptr_t)0x7FFFFFFF : (intptr_t)(longValue))
 #else /* AIXPPC */
@@ -166,9 +166,9 @@ omrthread_t global_lock_owner = UNOWNED;
 #define J9THR_WAIT_INTERRUPTED(flags) (((flags) & J9THREAD_FLAG_INTERRUPTED) != 0)
 #define J9THR_WAIT_PRI_INTERRUPTED(flags) (((flags) & (J9THREAD_FLAG_PRIORITY_INTERRUPTED | J9THREAD_FLAG_ABORTED)) != 0)
 
-#if defined(OMR_OS_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL)
+#if (HOST_OS == OMR_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL)
 #define NOTIFY_WRAPPER(thread) OMROSCOND_NOTIFY_ALL((thread)->condition);
-#else /* defined(OMR_OS_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
+#else /* (HOST_OS == OMR_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
 #define NOTIFY_WRAPPER(thread) \
 	do { \
 		if (OMR_ARE_ALL_BITS_SET((thread)->library->flags, J9THREAD_LIB_FLAG_NOTIFY_POLICY_BROADCAST)) { \
@@ -177,13 +177,13 @@ omrthread_t global_lock_owner = UNOWNED;
 			OMROSCOND_NOTIFY((thread)->condition); \
 		} \
 	} while (0)
-#endif /* defined(OMR_OS_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
+#endif /* (HOST_OS == OMR_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
 
 /*
  * Thread Library
  */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 
 /**
  * pthread TLS key destructor for self_ptr
@@ -216,7 +216,7 @@ self_key_destructor(void *current_omr_thread)
 
 #undef OMR_MAX_KEY_DELETION_ATTEMPTS
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * Initialize a J9 threading library.
@@ -240,9 +240,9 @@ omrthread_init(omrthread_library_t lib)
 	lib->spinlock = 0;
 	lib->threadCount = 0;
 	lib->globals = NULL;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	lib->stack_usage = 0;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	lib->flags = 0;
 
 	omrthread_mem_init(lib);
@@ -254,11 +254,11 @@ omrthread_init(omrthread_library_t lib)
 #error "CALLER_LAST_INDEX must be <= MAX_CALLER_INDEX"
 #endif
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (TLS_ALLOC(lib->self_ptr))
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	if (TLS_ALLOC_WITH_DESTRUCTOR(lib->self_ptr, self_key_destructor))
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	{
 		goto init_cleanup1;
 	}
@@ -314,19 +314,19 @@ omrthread_init(omrthread_library_t lib)
 	lib->gc_lock_tracing = NULL;
 #endif
 
-#if	defined(OMR_OS_WINDOWS)
+#if	(HOST_OS == OMR_WINDOWS)
 	lib->flags |= J9THREAD_LIB_FLAG_DESTROY_MUTEX_ON_MONITOR_FREE;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (omrthread_attr_init(&lib->systemThreadAttr) != J9THREAD_SUCCESS) {
 		goto init_cleanup10;
 	}
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	if (KERN_SUCCESS != host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &lib->clockService)) {
 		goto init_cleanup11;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #if defined(OMR_PORT_NUMA_SUPPORT)
 	/* Load the numa library from the dll */
@@ -337,11 +337,11 @@ omrthread_init(omrthread_library_t lib)
 	lib->initStatus = 1;
 	return;
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 /* Unused cleanup label for future error handling. */
 /* init_cleanup12:		mach_port_deallocate(mach_task_self(), lib->clockService); */
 init_cleanup11:		omrthread_attr_destroy(&lib->systemThreadAttr);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 init_cleanup10:		pool_kill(lib->global_pool);
 init_cleanup9:		pool_kill(lib->thread_pool);
 init_cleanup8:		OMROSMUTEX_DESTROY(lib->resourceUsageMutex);
@@ -429,7 +429,7 @@ omrthread_lib_control(const char *key, uintptr_t value)
 		}
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	if (0 == strcmp(J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING, key)) {
 		if ((J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_DISABLED == value)
 		 || (J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_ENABLED == value)
@@ -468,7 +468,7 @@ omrthread_lib_control(const char *key, uintptr_t value)
 			}
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return rc;
 }
@@ -476,12 +476,12 @@ omrthread_lib_control(const char *key, uintptr_t value)
 BOOLEAN
 omrthread_lib_use_realtime_scheduling(void)
 {
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	omrthread_library_t lib = GLOBAL_DATA(default_library);
 	return OMR_ARE_ALL_BITS_SET(lib->flags, J9THREAD_LIB_FLAG_REALTIME_SCHEDULING_ENABLED);
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	return FALSE;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 }
 
 /**
@@ -564,7 +564,7 @@ init_spinCounts(omrthread_library_t lib)
 
 	lib->defaultMonitorSpinCount1 = 256;
 	lib->defaultMonitorSpinCount2 = 32;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/*
 	 * z/OS has exponentially increasing yield times
 	 * if you call it back to back within a short period
@@ -709,9 +709,9 @@ omrthread_shutdown(void)
 #if defined(OMR_THR_FORK_SUPPORT)
 	pool_kill(lib->rwmutexPool);
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	mach_port_deallocate(mach_task_self(), lib->clockService);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 
 
@@ -860,9 +860,9 @@ postForkResetThreads(omrthread_t self)
 			OMROSCOND_INIT(threadIterator->condition);
 			OMROSMUTEX_INIT(threadIterator->mutex);
 			threadIterator->tid = omrthread_get_ras_tid();
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #error "The implementation of postForkResetThreads() is not complete in WIN32."
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			threadIterator->handle = THREAD_SELF();
 		} else {
 			omrthread_tls_finalizeNoLock(threadIterator);
@@ -1227,11 +1227,11 @@ omrthread_attach_ex(omrthread_t *handle, omrthread_attr_t *attr)
 		goto cleanup2;
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(BREW)
+#if (HOST_OS == OMR_WINDOWS) && !defined(BREW)
 	DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &thread->handle, 0, TRUE, DUPLICATE_SAME_ACCESS);
 #else
 	thread->handle = THREAD_SELF();
-#endif /* defined(OMR_OS_WINDOWS) && !defined(BREW) */
+#endif /* (HOST_OS == OMR_WINDOWS) && !defined(BREW) */
 
 	initialize_thread_priority(thread);
 
@@ -1529,11 +1529,11 @@ thread_wrapper(WRAPPER_ARG arg)
 
 	TLS_SET(lib->self_ptr, thread);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (lib->stack_usage) {
 		paint_stack(thread);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 	if (thread->flags & J9THREAD_FLAG_CANCELED) {
@@ -1595,7 +1595,7 @@ thread_wrapper(WRAPPER_ARG arg)
 
 	threadEnableCpuMonitor(thread);
 
-#if defined(LINUX)  && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX)  && !defined(OMRZTPF)
 	/* Workaround for NPTL bug on Linux. See omrthread_exit() */
 	{
 		jmp_buf jumpBuffer;
@@ -1610,10 +1610,10 @@ thread_wrapper(WRAPPER_ARG arg)
 		}
 		thread->jumpBuffer = NULL;
 	}
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	thread->entrypoint(thread->entryarg);
 	/* omrthread_exit not called */
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 	threadInternalExit(globalAlreadyLocked);
 	/* UNREACHABLE */
@@ -1717,7 +1717,7 @@ omrthread_exit(omrthread_monitor_t monitor)
 		}
 	}
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	/* NPTL calls __pthread_unwind() from pthread_exit(). That walks the stack.
 	 * We can't allow that to happen, since our caller might have already been
 	 * unloaded. Walking the calling frame could cause a crash. Instead, we
@@ -1728,7 +1728,7 @@ omrthread_exit(omrthread_monitor_t monitor)
 	if (self->jumpBuffer) {
 		longjmp(*(jmp_buf *)self->jumpBuffer, 1);
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	threadInternalExit(GLOBAL_IS_LOCKED);
 
@@ -1766,7 +1766,7 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 
 	/* create a default attr if none was supplied */
 	if (NULL != attr) {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		/* OSX threads ignore policy inheritance. Create a new attr and do inheritance manually as needed. */
 		if (J9THREAD_SCHEDPOLICY_INHERIT == (*attr)->schedpolicy) {
 			if (J9THREAD_SUCCESS != copyAttr(&tempAttr, attr)) {
@@ -1775,7 +1775,7 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 			}
 			tempAttrAllocated = TRUE;
 		} else
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 		{
 			tempAttr = *attr;
 		}
@@ -1800,12 +1800,12 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 
 	if (self && (J9THREAD_SCHEDPOLICY_INHERIT == tempAttr->schedpolicy)) {
 		thread->priority = self->priority;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		if (J9THREAD_SUCCESS != omrthread_attr_set_priority(&tempAttr, self->priority)) {
 			retVal = J9THREAD_ERR_INVALID_SCHEDPOLICY;
 			goto cleanup1;
 		}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	} else {
 		thread->priority = tempAttr->priority;
 	}
@@ -1838,9 +1838,9 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 	/* Ignore errors, the thead cpu monitor should not cause thread creation failure */
 	omrthread_set_category(thread, tempAttr->category, J9THREAD_TYPE_SET_CREATE);
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	thread->jumpBuffer = NULL;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(OMR_PORT_NUMA_SUPPORT)
 	memset(&(thread->numaAffinity), 0x0, sizeof(thread->numaAffinity));
@@ -1872,7 +1872,7 @@ threadCreateDone:
 	return retVal;
 }
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 static intptr_t
 copyAttr(omrthread_attr_t *attrTo, const omrthread_attr_t *attrFrom)
 {
@@ -1933,7 +1933,7 @@ destroyAttr:
 copyAttrDone:
 	return rc;
 }
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 /**
  * Allocate a omrthread_t from the omrthread_t pool.
@@ -1963,7 +1963,7 @@ threadAllocate(omrthread_library_t lib, int globalIsLocked)
 		lib->threadCount++;
 		newThread->library = lib;
 		newThread->os_errno = J9THREAD_INVALID_OS_ERRNO;
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 		newThread->os_errno2 = 0;
 #endif /* J9ZOS390 */
 #if defined(OMR_THR_JLM)
@@ -2001,13 +2001,13 @@ threadAllocate(omrthread_library_t lib, int globalIsLocked)
 static intptr_t
 threadDestroy(omrthread_t thread, int globalAlreadyLocked)
 {
-#if defined(OMR_OS_WINDOWS) || defined(THREAD_ASSERTS)
+#if (HOST_OS == OMR_WINDOWS) || defined(THREAD_ASSERTS)
 	omrthread_library_t lib;
 
 	ASSERT(thread);
 	lib = thread->library;
 	ASSERT(lib);
-#endif /* defined(OMR_OS_WINDOWS) || defined(THREAD_ASSERTS) */
+#endif /* (HOST_OS == OMR_WINDOWS) || defined(THREAD_ASSERTS) */
 
 	THREAD_LOCK(thread, CALLER_DESTROY);
 	if ((thread->flags & J9THREAD_FLAG_DEAD) == 0) {
@@ -2024,7 +2024,7 @@ threadDestroy(omrthread_t thread, int globalAlreadyLocked)
 	omrthread_dump_trace(thread);
 #endif
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Acquire the global monitor mutex (if needed) while performing handle closing and freeing. */
 	if (!globalAlreadyLocked) {
 		GLOBAL_LOCK_SIMPLE(lib);
@@ -2041,14 +2041,14 @@ threadDestroy(omrthread_t thread, int globalAlreadyLocked)
 		GLOBAL_UNLOCK_SIMPLE(lib);
 	}
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 	/* On z/OS, we cannot call GLOBAL_LOCK_SIMPLE(lib) before calling threadFree(), since this leads to
 	 * seg faults in the JVM. See PR 82332: [zOS S390] 80 VM_Extended.TestJvmCpuMonitorMXBeanLocal : crash
 	 */
 	threadFree(thread, globalAlreadyLocked);
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	return 0;
 }
@@ -2138,12 +2138,12 @@ threadInternalExit(int globalAlreadyLocked)
 	storeExitCpuUsage(self);
 
 	if (0 == (self->flags & J9THREAD_FLAG_JOINABLE)) {
-#if !defined(J9ZOS390)
+#if !(HOST_OS == OMR_ZOS)
 		/* On z/OS we create the thread in the detached state, so the
 		 * call to pthread_detach is not required.
 		 */
 		THREAD_DETACH(self->handle);
-#endif /* !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_ZOS) */
 
 		if (detached) {
 			threadDestroy(self, GLOBAL_IS_LOCKED);
@@ -3235,7 +3235,7 @@ omrthread_unpark(omrthread_t thread)
 uintptr_t
 omrthread_current_stack_free(void)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	MEMORY_BASIC_INFORMATION memInfo;
 	SYSTEM_INFO sysInfo;
 	uintptr_t stackFree;
@@ -3251,7 +3251,7 @@ omrthread_current_stack_free(void)
 	return (stackFree < guardPageSize) ? 0 : stackFree - guardPageSize;
 #else
 	return 0;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }
 
 

--- a/thread/common/omrthreaderror.c
+++ b/thread/common/omrthreaderror.c
@@ -47,7 +47,7 @@ omrthread_get_os_errno(void)
 	return os_errno;
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * Retrieve the os_errno2 saved in the current omrthread_t.
  * @return ZOS-specific error code. Default value is 0.

--- a/thread/common/omrthreadinspect.c
+++ b/thread/common/omrthreadinspect.c
@@ -31,16 +31,16 @@
  * The APIs in this file are only used for inspecting threads -- not for modifying them
  */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* Allowing the use of pthread_attr_getstack in omrthread_get_stack_range */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 #include <features.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <pthread.h>
 #define _XOPEN_SOURCE
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #include "threaddef.h"
 #include "omrthreadinspect.h"
@@ -300,7 +300,7 @@ uintptr_t
 omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd)
 {
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	pthread_attr_t attr;
 	OSTHREAD osTid = thread->handle;
 	uintptr_t rc = 0;
@@ -338,7 +338,7 @@ omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd
 	/* On Linux, native stack grows from high to low memory */
 	*stackEnd = (void *)((uintptr_t)*stackStart + stackSize);
 	return J9THREAD_SUCCESS;
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	OSTHREAD osTid = thread->handle;
 	size_t stackSize = 0;
 
@@ -346,9 +346,9 @@ omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd
 	stackSize = pthread_get_stacksize_np(osTid);
 	*stackEnd = (void *)((uintptr_t)*stackStart + stackSize);
 	return J9THREAD_SUCCESS;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	return J9THREAD_ERR_UNSUPPORTED_PLAT;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 }
 
 #if (defined(OMR_THR_JLM))

--- a/thread/common/thread_internal.h
+++ b/thread/common/thread_internal.h
@@ -237,14 +237,14 @@ omrthread_get_mapped_priority(omrthread_prio_t omrthreadPriority);
 
 /* ------------- priority.c ------------ */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /**
  * @brief
  * @return intptr_t
  */
 intptr_t
 initialize_priority_map(void);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * @brief

--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -289,7 +289,7 @@ omrthread_numa_init(omrthread_library_t threadLibrary)
 	}
 	/* find our current affinity mask since we will need it when removing any affinity binding from threads, later (since we still want to honour restrictions we inherited from the environment) */
 	CPU_ZERO(&defaultAffinityMask);
-#if __GLIBC_PREREQ(2,4) || defined(LINUXPPC)
+#if __GLIBC_PREREQ(2,4) || (HOST_OS == OMR_LINUX)
 	/*
 	 * LIR 902 : On Linux PPC, rolling up tool chain level to VAC 8 on RHEL 4.
 	 * The libc version on RHEL 4 requires 3 arg to sched_setaffinity.
@@ -388,7 +388,7 @@ omrthread_numa_set_node_affinity_nolock(omrthread_t thread, const uintptr_t *nod
 			memcpy(&affinityCPUs, &defaultAffinityMask, sizeof(cpu_set_t));
 		}
 		if ((threadIsStarted) && (0 == result)) {
-#if __GLIBC_PREREQ(2,4) || defined(LINUXPPC)
+#if __GLIBC_PREREQ(2,4) || (HOST_OS == OMR_LINUX)
 			/*
 			 * LIR 902 : On Linux PPC, rolling up tool chain level to VAC 8 on RHEL 4.
 			 * The libc version on RHEL 4 requires 3 arg to sched_setaffinity.
@@ -457,16 +457,16 @@ omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintp
 			 * by an external program (see: http://www.linuxjournal.com/article/6799)
 			 */
 
-#if __GLIBC_PREREQ(2,4) || defined(LINUXPPC)
+#if __GLIBC_PREREQ(2,4) || (HOST_OS == OMR_LINUX)
 			/*
 			 * LIR 902 : On Linux PPC, rolling up tool chain level to VAC 8 on RHEL 4.
 			 * The libc version on RHEL 4 requires 3 arg to sched_getaffinity.
 			 * Note: this will not compile/run properly on RHEL 3.
 			 */
 			if (0 == sched_getaffinity(thread->tid, sizeof(cpu_set_t), &affinityCPUs))
-#else /* defined(LINUXPPC) */
+#else /* (HOST_OS == OMR_LINUX) */
 			if (0 == sched_getaffinity(thread->tid, &affinityCPUs))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 			{
 				/* Now try matching it up with CPUs from known NUMA nodes */
 				uintptr_t node = 1;

--- a/thread/unix/omrthreadattr.c
+++ b/thread/unix/omrthreadattr.c
@@ -28,9 +28,9 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <limits.h>	/* for PTHREAD_STACK_MIN */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h> /* required for the _SC_PAGESIZE  constant */
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #include "omrcfg.h"
 #include "omrcomp.h"
 #include "omrthread.h"
@@ -356,7 +356,7 @@ setSchedpolicy(pthread_attr_t *pattr, omrthread_schedpolicy_t policy)
 	intptr_t pret = 0;
 
 	if (J9THREAD_SCHEDPOLICY_INHERIT == policy) {
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		/*
 		 * Non-root users are frequently not allowed to create threads
 		 * using SCHED_RR or SCHED_FIFO.
@@ -374,7 +374,7 @@ setSchedpolicy(pthread_attr_t *pattr, omrthread_schedpolicy_t policy)
 		if (pret != 0) {
 			return J9THREAD_ERR_INVALID_VALUE;
 		}
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 		pret = DEBUG_SYSCALL(pthread_attr_setinheritsched(pattr, PTHREAD_INHERIT_SCHED));
 		if (pret != 0) {
 			return J9THREAD_ERR_INVALID_VALUE;
@@ -463,7 +463,7 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 	/* stacksize may be adjusted to satisfy platform-specific quirks */
 
 #if !defined(OMRZTPF)
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	/* Linux allocates 2MB if you ask for a stack smaller than STACK_MIN */
 	{
 		long pageSafeMinimumStack = 2 * sysconf(_SC_PAGESIZE);
@@ -475,7 +475,7 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 			stacksize = pageSafeMinimumStack;
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	if (DEBUG_SYSCALL(pthread_attr_setstacksize(pattr, stacksize)) != 0) {
 		return J9THREAD_ERR_INVALID_VALUE;

--- a/thread/unix/rasthrsup.c
+++ b/thread/unix/rasthrsup.c
@@ -26,16 +26,16 @@
 /* this #include defines the buildspec flags */
 #include "omrthread.h"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #if __GLIBC_PREREQ(2,4)
 #include <sys/syscall.h>
 #endif /* __GLIBC_PREREQ(2,4) */
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <pthread.h>
 #include <sys/syscall.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /**
  * This is required to pick up correct thread IDs on Linux
  */
@@ -53,14 +53,14 @@
 /* this line is needed to build the syscall macro which is called (as gettid) within the function */
 _syscall0(pid_t, gettid);
 #endif /* !__GLIBC_PREREQ(2,4) && !defined(OMRZTPF) */
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 uintptr_t
 omrthread_get_ras_tid(void)
 {
 	uintptr_t threadID = 0;
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #if __GLIBC_PREREQ(2,4)
 	/* Want thread id that shows up in /proc etc.  gettid() does not cut it */
 	threadID = syscall(SYS_gettid);
@@ -71,11 +71,11 @@ omrthread_get_ras_tid(void)
 	 */
 	threadID = (uintptr_t) gettid();
 #endif /* __GLIBC_PREREQ(2,4) */
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
     uint64_t tid64;
     pthread_threadid_np(NULL, &tid64);
     threadID = (pid_t)tid64;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	pthread_t myThread = pthread_self();
 
 	/*
@@ -89,7 +89,7 @@ omrthread_get_ras_tid(void)
 	} else {
 		threadID = 0;
 	}
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return threadID;
 }
 

--- a/thread/unix/thrcreate.c
+++ b/thread/unix/thrcreate.c
@@ -41,7 +41,7 @@ osthread_create(struct J9Thread *self, OSTHREAD *handle, const omrthread_attr_t 
 	retCode = DEBUG_SYSCALL(pthread_create(handle, &ux->pattr, entrypoint, entryarg));
 	if (retCode != 0) {
 		if (self) {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 			/* z stores the error code in errno and errno2, not in the return value from pthread_create() */
 			self->os_errno = errno;
 			self->os_errno2 = __errno2();

--- a/thread/unix/thrdsup.c
+++ b/thread/unix/thrdsup.c
@@ -29,10 +29,10 @@
 #include "threaddef.h"
 #include "thread_internal.h"
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <sys/prctl.h>
 #include <linux/prctl.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(OMRZTPF)
 #include <tpf/c_eb0eb.h>
@@ -40,9 +40,9 @@
 #include <tpf/tpfapi.h>
 #endif /* if defined(OMRZTPF) */
 
-#if (defined(LINUX) || defined(OSX)) && defined(J9X86)
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && defined(J9X86)
 #include <fpu_control.h>
-#endif /* (defined(LINUX) || defined(OSX)) && defined(J9X86) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && defined(J9X86) */
 
 #if J9THREAD_USE_MONOTONIC_COND_CLOCK
 /*
@@ -87,11 +87,11 @@ call_omrthread_init(void)
 {
 	omrthread_library_t lib = GLOBAL_DATA(default_library);
 
-#if defined(LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || (HOST_OS == OMR_OSX)
 	if (initialize_priority_map()) {
 		goto thread_init_error;
 	}
-#endif /* defined(LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || (HOST_OS == OMR_OSX) */
 
 #ifdef J9ZOS390
 	zos_init_yielding();
@@ -120,7 +120,7 @@ init_thread_library(void)
 	return lib->initStatus != 1;
 }
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 intptr_t
 set_pthread_name(pthread_t self, pthread_t thread, const char *name)
 {
@@ -128,7 +128,7 @@ set_pthread_name(pthread_t self, pthread_t thread, const char *name)
 		/* for Linux and OSX, the thread being named must be the current thread */
 		return -1;
 	}
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #ifndef PR_SET_NAME
 #define PR_SET_NAME 15
 #endif
@@ -136,24 +136,24 @@ set_pthread_name(pthread_t self, pthread_t thread, const char *name)
 	prctl(PR_SET_NAME, name);
 #endif
 	/* we ignore the return value of prctl, since naming is not supported on some older linux distributions */
-#else /* defined(LINUX) */
+#else /* (HOST_OS == OMR_LINUX) */
 	pthread_setname_np(name);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	return 0;
 }
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 intptr_t
 osthread_join(omrthread_t self, omrthread_t threadToJoin)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	intptr_t j9thrRc = J9THREAD_SUCCESS;
 	if (0 != pthread_join(threadToJoin->handle, NULL)) {
 		self->os_errno = errno;
 		j9thrRc = J9THREAD_ERR | J9THREAD_ERR_OS_ERRNO_SET;
 	}
 	return j9thrRc;
-#else /* defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_ZOS) */
 	intptr_t j9thrRc = J9THREAD_SUCCESS;
 	int rc = pthread_join(threadToJoin->handle, NULL);
 	if (0 != rc) {
@@ -161,10 +161,10 @@ osthread_join(omrthread_t self, omrthread_t threadToJoin)
 		j9thrRc = J9THREAD_ERR | J9THREAD_ERR_OS_ERRNO_SET;
 	}
 	return j9thrRc;
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 }
 
-#if defined(LINUX) && defined(J9X86)
+#if (HOST_OS == OMR_LINUX) && defined(J9X86)
 int
 linux_pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime)
 {
@@ -182,7 +182,7 @@ linux_pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const
 }
 #endif
 
-#if defined(J9ZOS390) && defined(OMR_INTERP_HAS_SEMAPHORES)
+#if (HOST_OS == OMR_ZOS) && defined(OMR_INTERP_HAS_SEMAPHORES)
 
 intptr_t
 sem_init_zos(j9sem_t s, int pShared, int initValue)
@@ -318,7 +318,7 @@ ztpf_init_proc()
 }
 #endif /* defined(OMRZTPF) */
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /**
  * We have to tell the z/OS LE that we want a specific kind of yielding threshold,
  * not the default kind.

--- a/tools/configure
+++ b/tools/configure
@@ -3831,7 +3831,7 @@ fi
 	if test "x$OMR_BUILD_TOOLCHAIN" = "x"; then :
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#if !(defined(__xlC__) || (defined(__MVS__) && defined(__COMPILER_VER__)))
+#if !(defined(__xlC__) || ((HOST_OS == OMR_ZOS) && defined(__COMPILER_VER__)))
 #error not an xlc compiler
 #endif
 int

--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -25,10 +25,10 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #define strdup _strdup
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "HookGen.hpp"
 #include "pugixml.hpp"
@@ -335,7 +335,7 @@ char *
 HookGen::getAbsolutePath(const char *filename)
 {
 	char *absolutePath = NULL;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	char PATH_SEPARATOR = '\\';
 	char resolved_path[MAX_PATH];
 	DWORD retval = 0;
@@ -344,7 +344,7 @@ HookGen::getAbsolutePath(const char *filename)
 		return absolutePath;
 	}
 #else
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #define PATH_MAX 1024
 #endif /* J9ZOS390 */
 	char PATH_SEPARATOR = '/';
@@ -352,7 +352,7 @@ HookGen::getAbsolutePath(const char *filename)
 	if (NULL == realpath(filename, resolved_path)) {
 		return absolutePath;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	char *chopped = strrchr(resolved_path, PATH_SEPARATOR);
 	if (NULL != chopped) {

--- a/tools/hookgen/main.cpp
+++ b/tools/hookgen/main.cpp
@@ -23,25 +23,25 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC)
 #include "atoe.h"
-#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
-#if defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC) */
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "HookGen.hpp"
 
 /* On all platforms operate on UTF-8 encoding */
 int
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 translated_main(int argc, char **argv, char **envp)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 main(int argc, char **argv, char **envp)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	RCType rc = RC_OK;
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC)
 	/* Convert EBCDIC to UTF-8 (ASCII) */
 	if (-1 != iconv_init()) {
 		/* translate argv strings to ascii */
@@ -57,7 +57,7 @@ main(int argc, char **argv, char **envp)
 		fprintf(stderr, "failed to initialize iconv\n");
 		rc = RC_FAILED;
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	if (RC_OK == rc) {
 		rc = startHookGen(argc, argv);
 	}
@@ -65,7 +65,7 @@ main(int argc, char **argv, char **envp)
 }
 
 /* Convert Windows wide character encoding to UTF-8 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -129,4 +129,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/tools/tracegen/FileUtils.cpp
+++ b/tools/tracegen/FileUtils.cpp
@@ -19,7 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* needed to expose snprintf() */
 #define _ISOC99_SOURCE
 #endif

--- a/tools/tracegen/Port.cpp
+++ b/tools/tracegen/Port.cpp
@@ -20,29 +20,29 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <sys/vfs.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <sys/param.h>
 #include <sys/mount.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include <string.h>
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
 #define J9FILE_UNC_EXTENDED_LENGTH_PREFIX (L"\\\\?\\")
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <sys/types.h>
 #if !defined(OMRZTPF)
 #include <sys/statvfs.h>
 #endif
 #include <dirent.h>
-#endif /* defined(OMR_OS_WINDOWS)*/
+#endif /* (HOST_OS == OMR_WINDOWS)*/
 
 #include "Port.hpp"
 
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 RCType
 Port::omrfile_findfirst(const char *path, char **resultbuf, intptr_t *handle)
 {
@@ -499,7 +499,7 @@ cleanup:
 
 	return resolved_path;
 }
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 FILE *
 Port::fopen(const char *path, const char *mode)
@@ -511,37 +511,37 @@ RCType
 Port::omrfile_findfirst(const char *path, char **resultbuf, intptr_t *handle)
 {
 	RCType rc = RC_FAILED;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	DIR64 *dirp = NULL;
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	DIR *dirp = NULL;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	struct dirent *entry;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	dirp = opendir64(path);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	dirp = opendir(path);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	if (NULL == dirp) {
 		return RC_FAILED;
 	}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64(dirp);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	entry = readdir(dirp);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	if (NULL == entry) {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		closedir64(dirp);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 		closedir(dirp);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		return RC_FAILED;
 	}
 
@@ -557,17 +557,17 @@ RCType
 Port::omrfile_findnext(intptr_t findhandle, char **resultbuf)
 {
 	RCType rc = RC_FAILED;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	struct dirent *entry;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64((DIR64 *)findhandle);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	entry = readdir((DIR *)findhandle);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	if (entry == NULL) {
 		return RC_FAILED;
 	}
@@ -582,11 +582,11 @@ RCType
 Port::omrfile_findclose(intptr_t findhandle)
 {
 	RCType rc = RC_FAILED;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	if (0 == closedir64((DIR64 *)findhandle)) {
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	if (0 == closedir((DIR *)findhandle)) {
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		rc = RC_OK;
 	}
 	return rc;
@@ -640,11 +640,11 @@ RCType
 Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	struct statfs statfsbuf;
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	struct statvfs statvfsbuf;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	memset(buf, 0, sizeof(*buf));
 
@@ -680,7 +680,7 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 	buf->ownerUid = statbuf.st_uid;
 	buf->ownerGid = statbuf.st_gid;
 
-#if (defined(LINUX) && !defined(J9ZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(J9ZTPF)) || (HOST_OS == OMR_OSX)
 	if (statfs(path, &statfsbuf)) {
 		return RC_FAILED;
 	}
@@ -695,7 +695,7 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 		buf->isFixed = 1;
 		break;
 	}
-#elif defined(AIXPPC) && !defined(J9OS_I5)
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5)
 	if (statvfs(path, &statvfsbuf)) {
 		return RC_FAILED;
 	}
@@ -705,10 +705,10 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 	} else {
 		buf->isFixed = 1;
 	}
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	/* Assume we have a fixed file unless the platform can be more specific */
 	buf->isFixed = 1;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return RC_OK;
 }
@@ -723,16 +723,16 @@ Port::omrfile_realpath(const char *path)
 	}
 	return result;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 int
 Port::strncasecmp(const char *s1, const char *s2, size_t n)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	return ::_strnicmp(s1, s2, n);
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	return ::strncasecmp(s1, s2, (int) n);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	return ::strncasecmp(s1, s2, n);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/tools/tracegen/Port.hpp
+++ b/tools/tracegen/Port.hpp
@@ -31,19 +31,19 @@
 #include <sys/stat.h>
 #include <time.h>
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include <strings.h>
 #endif
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #include <sys/utime.h>
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <limits.h>
 #include <unistd.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define strdup _strdup
 #define stat _stat
 #define snprintf _snprintf
@@ -55,7 +55,7 @@
 #define OS_ENCODING_MB_FLAGS 0
 #define OS_ENCODING_WC_FLAGS 0
 #define UNICODE_BUFFER_SIZE EsMaxPath
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #define PATH_SEP  "/"
 #define dirstat struct stat
 #define PORT_INVALID_FIND_FILE_HANDLE ((intptr_t) 0)
@@ -65,7 +65,7 @@
 /* EsMaxPath was chosen from unix MAXPATHLEN. */
 #define EsMaxPath 	1024
 #endif /* defined(PATH_MAX) */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 typedef enum RCType {
 	RC_OK 		= 0,
@@ -116,7 +116,7 @@ private:
 protected:
 public:
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/**
 	 * Uses convertFromUTF8 and if the resulting unicode path is longer than the Windows defined MAX_PATH,
 	 * the path is converted to an absolute path and prepended with //?/
@@ -165,7 +165,7 @@ public:
 	 * @return RC_OK on success, RC_FAILED on failure.
 	 */
 	static RCType convertToUTF8(const wchar_t *unicodeString, char **utf8Buffer);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	static RCType omrfile_findfirst(const char *path, char **resultbuf, intptr_t *handle);
 

--- a/tools/tracegen/TraceGen.cpp
+++ b/tools/tracegen/TraceGen.cpp
@@ -24,13 +24,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/types.h>
 #include <unistd.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include "ArgParser.hpp"
 #include "CFileWriter.hpp"

--- a/tools/tracegen/main.cpp
+++ b/tools/tracegen/main.cpp
@@ -23,9 +23,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC)
 #include "atoe.h"
-#endif /* defined(J9ZOS390)  && !defined(OMR_EBCDIC) */
+#endif /* (HOST_OS == OMR_ZOS)  && !defined(OMR_EBCDIC) */
 
 #include "FileUtils.hpp"
 #include "Port.hpp"
@@ -33,14 +33,14 @@
 
 /* On all platforms operate on UTF-8 encoding */
 int
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 translated_main(int argc, char **argv, char **envp)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 main(int argc, char **argv, char **envp)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	RCType rc = RC_OK;
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC)
 	/* Convert EBCDIC to UTF-8 (ASCII) */
 	if (-1 != iconv_init()) {
 		/* translate argv strings to ascii */
@@ -56,7 +56,7 @@ main(int argc, char **argv, char **envp)
 		eprintf("failed to initialize iconv");
 		rc = RC_FAILED;
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 	if (RC_OK == rc) {
 		rc = startTraceGen(argc, argv);
 	}
@@ -64,7 +64,7 @@ main(int argc, char **argv, char **envp)
 }
 
 /* Convert Windows wide character encoding to UTF-8 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -128,4 +128,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/tools/tracemerge/DATMerge.cpp
+++ b/tools/tracemerge/DATMerge.cpp
@@ -24,12 +24,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <fcntl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include "DATMerge.hpp"
 #include "ArgParser.hpp"

--- a/tools/tracemerge/main.cpp
+++ b/tools/tracemerge/main.cpp
@@ -23,23 +23,23 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC)
 #include "atoe.h"
-#endif /* defined(J9ZOS390)  && !defined(OMR_EBCDIC) */
+#endif /* (HOST_OS == OMR_ZOS)  && !defined(OMR_EBCDIC) */
 
 #include "DATMerge.hpp"
 #include "FileUtils.hpp"
 #include "Port.hpp"
 
 int
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 translated_main(int argc, char **argv, char **envp)
 #else
 main(int argc, char **argv, char **envp)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	RCType rc = RC_OK;
-#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
+#if (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC)
 	int i = 0;
 	if (-1 != iconv_init()) {
 		/* translate argv strings to ascii */
@@ -55,14 +55,14 @@ main(int argc, char **argv, char **envp)
 		FileUtils::printError("failed to initialize iconv\n");
 		rc = RC_FAILED;
 	}
-#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
+#endif /* (HOST_OS == OMR_ZOS) && !defined(OMR_EBCDIC) */
 	if (RC_OK == rc) {
 		rc = startTraceMerge(argc, argv);
 	}
 	return (RC_OK == rc) ? 0 : -1;
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -125,4 +125,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/util/main_function/main_function.cpp
+++ b/util/main_function/main_function.cpp
@@ -30,18 +30,18 @@
  * correctly when it is located in a library.
  */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #endif
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 #include "atoe.h"
 #endif
 
 /* Define a macro for the name of the main function that takes char args */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CHARMAIN translated_main
 #else
 #define CHARMAIN main
@@ -52,7 +52,7 @@ extern "C" int omr_main_entry(int argc, char **argv, char **envp);
 int
 CHARMAIN(int argc, char **argv, char **envp)
 {
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 	/* translate argv strings to ascii */
 	iconv_init();
 	{
@@ -61,12 +61,12 @@ CHARMAIN(int argc, char **argv, char **envp)
 			argv[i] = e2a_string(argv[i]);
 		}
 	}
-#endif /* defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_ZOS) */
 
 	return omr_main_entry(argc, argv, envp);
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -129,4 +129,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/util/omrutil/detectVMDirectory.c
+++ b/util/omrutil/detectVMDirectory.c
@@ -22,13 +22,13 @@
 
 #include "omrcfg.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrutil.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 omr_error_t
 detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDirectoryEnd)
 {
@@ -53,4 +53,4 @@ detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDi
 	}
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/util/omrutil/gettimebase.c
+++ b/util/omrutil/gettimebase.c
@@ -26,7 +26,7 @@
 #include "omrcomp.h"
 #include "omrutilbase.h"
 
-#if defined(LINUX) && defined(OMR_ARCH_ARM)
+#if (HOST_OS == OMR_LINUX) && defined(OMR_ARCH_ARM)
 #include <time.h>
 #endif
 
@@ -43,7 +43,7 @@ getTimebase(void)
 	uint32_t upper;
 	asm volatile("rdtsc" : "=a" (lower), "=d" (upper));
 	tsc = ((uint64_t)upper << 32) | lower;
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 	tsc = __builtin_ppc_get_timebase();
@@ -77,11 +77,11 @@ getTimebase(void)
 #endif /* OMR_ENV_DATA64 */
 #endif /* GCC 4.8 */
 
-#elif defined(LINUX) && defined(S390)
+#elif (HOST_OS == OMR_LINUX) && defined(S390)
 	asm("stck %0" : "=m" (tsc));
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 	__stck(&tsc);
-#elif defined(LINUX) && defined(OMR_ARCH_ARM)
+#elif (HOST_OS == OMR_LINUX) && defined(OMR_ARCH_ARM)
 	/* For now, use the system nano clock */
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)
 	struct timespec ts;

--- a/util/omrutil/j9memclr.c
+++ b/util/omrutil/j9memclr.c
@@ -32,12 +32,12 @@ void dcbz(char *);
 #pragma reg_killed_by dcbz
 #endif
 
-#if (defined(LINUX) && defined(S390))
+#if ((HOST_OS == OMR_LINUX) && defined(S390))
 /* _j9Z10Zero() is defined in j9memclrz10_31.s and j9memclrz10_64.s */
 extern void _j9Z10Zero(void *ptr, uintptr_t length);
 #endif
 
-#if defined(AIXPPC) || defined (LINUXPPC)
+#if (HOST_OS == OMR_AIX) || defined (LINUXPPC)
 static uintptr_t cacheLineSize = 0;
 #endif
 
@@ -57,17 +57,17 @@ static int isZ10orGreater = -1;
 void
 OMRZeroMemory(void *ptr, uintptr_t length)
 {
-#if defined(AIXPPC) || defined (LINUXPPC)
+#if (HOST_OS == OMR_AIX) || defined (LINUXPPC)
 	char *addr = ptr;
 	char *limit;
 	uintptr_t localCacheLineSize;
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	if (length < 2048) {
 		memset(ptr, 0, (size_t)length);
 		return;
 	}
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	/* one-time-only calculation of cache line size */
 	if (0 == cacheLineSize) {
@@ -116,7 +116,7 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 		*((uintptr_t *)addr) = 0;
 	}
 
-#elif defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64)
 #if defined(REENABLE_WHEN_THIS_WORKS)
 	/* NOTE: memset on WIN64 (AMD64) seems to do a fine job all on its own,
 	 * so we don't use our own SSE2 code there
@@ -153,7 +153,7 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 #else
 	memset(ptr, 0, (size_t)length);
 #endif
-#elif defined(J9ZOS390)
+#elif (HOST_OS == OMR_ZOS)
 
 	if (((struct IHAPSA *)0)->FLCFGIEF) {
 		J9ZERZ10(ptr, length);
@@ -186,7 +186,7 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 uintptr_t
 getCacheLineSize(void)
 {
-#if defined(AIXPPC) || defined (LINUXPPC)
+#if (HOST_OS == OMR_AIX) || defined (LINUXPPC)
 	char buf[1024];
 	uintptr_t i, ppcCacheLineSize;
 

--- a/util/omrutil/unix/linux/s390/archinfo.c
+++ b/util/omrutil/unix/linux/s390/archinfo.c
@@ -21,9 +21,9 @@
  *******************************************************************************/
 
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #define _GNU_SOURCE
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 #if defined(OMRZTPF)
 #include <tpf/c_cinfc.h>   /* for access to cinfc */
 #include <tpf/c_pi1dt.h>   /* for access to machine type. */

--- a/util/pool/pool.c
+++ b/util/pool/pool.c
@@ -917,7 +917,7 @@ pool_includesElement(J9Pool *pool, void *anElement)
 	return FALSE;
 }
 
-#if defined(J9ZOS390)
+#if (HOST_OS == OMR_ZOS)
 /* Temporary hack to resolve ZOS linking problems.
  * Functions in pool_cap.c are not getting short-names properly without this fix.  */
 void


### PR DESCRIPTION
OS macros defines were standardized
#2257 
Signed-off-by: Avinash Pydimarri <pydavina@in.ibm.com>