### PR TITLE
Apply consistent os macros in compiler

### DIFF
--- a/compiler/codegen/ELFGenerator.cpp
+++ b/compiler/codegen/ELFGenerator.cpp
@@ -20,7 +20,7 @@
  *******************************************************************************/
 #include "codegen/ELFGenerator.hpp"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include <stdio.h>
 #include <string.h>

--- a/compiler/codegen/ELFGenerator.hpp
+++ b/compiler/codegen/ELFGenerator.hpp
@@ -22,7 +22,7 @@
 #ifndef ELFGENERATOR_HPP
 #define ELFGENERATOR_HPP
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include <elf.h>
 #include <string>

--- a/compiler/codegen/ELFRelocationResolver.hpp
+++ b/compiler/codegen/ELFRelocationResolver.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include "codegen/OMRELFRelocationResolver.hpp"
 
@@ -39,6 +39,6 @@ class OMR_EXTENSIBLE ELFRelocationResolver : public ::OMR::ELFRelocationResolver
 
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif

--- a/compiler/codegen/FrontEnd.cpp
+++ b/compiler/codegen/FrontEnd.cpp
@@ -35,7 +35,7 @@
 #include "env/jittypes.h"
 #include "env/PersistentInfo.hpp"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h>
 #endif
 
@@ -145,7 +145,7 @@ TR_FrontEnd::getFormattedName(
       bool suffix)
    {
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
    // FIXME: TODO: This is a temporary implementation -- we ignore the suffix format and
    // use the pid only
 

--- a/compiler/codegen/OMRELFRelocationResolver.cpp
+++ b/compiler/codegen/OMRELFRelocationResolver.cpp
@@ -22,7 +22,7 @@
 #include "codegen/OMRELFRelocationResolver.hpp"
 #include "infra/Assert.hpp"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 uint32_t
 OMR::ELFRelocationResolver::resolveRelocationType(const TR::StaticRelocation &relocation)
@@ -31,4 +31,4 @@ OMR::ELFRelocationResolver::resolveRelocationType(const TR::StaticRelocation &re
    return static_cast<uint32_t>(-1);
    }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */

--- a/compiler/codegen/OMRELFRelocationResolver.hpp
+++ b/compiler/codegen/OMRELFRelocationResolver.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #ifndef OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
 #define OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
@@ -60,6 +60,6 @@ private:
 
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif // OMR_ELF_RELOCATION_RESOLVER_HPP

--- a/compiler/compile/CompilationTypes.hpp
+++ b/compiler/compile/CompilationTypes.hpp
@@ -36,7 +36,7 @@ namespace TR { class Node; }
 namespace TR { class TreeTop; }
 
 enum TR_Hotness
-#if !defined(LINUXPPC) || defined(__LITTLE_ENDIAN__)
+#if !(HOST_OS == OMR_LINUX) || defined(__LITTLE_ENDIAN__)
    : int8_t // use only 8 bits to save space; The ifdef is needed because xlC BE compiler does not accept the syntax
 #endif
    {

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -910,7 +910,7 @@ OMR::Compilation::isJProfilingCompilation()
    return false;
    }
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS)
 static void stopBeforeCompile()
    {
    static int first = 1;
@@ -921,7 +921,7 @@ static void stopBeforeCompile()
       first = 0;
       }
    }
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS) */
 
 static int32_t strHash(const char *str)
    {
@@ -971,13 +971,13 @@ int32_t OMR::Compilation::compile()
       TR::Compiler->debug.breakPoint();
       }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    if (self()->getOption(TR_DebugBeforeCompile))
       {
       self()->getDebug()->setupDebugger((void *) *((long*)&(stopBeforeCompile)));
       stopBeforeCompile();
       }
-#elif defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS)
    if (self()->getOption(TR_DebugBeforeCompile))
       {
 #if defined(LINUXPPC64)
@@ -987,7 +987,7 @@ int32_t OMR::Compilation::compile()
 #endif /* defined(LINUXPPC64) */
       stopBeforeCompile();
       }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
    if (self()->getOutFile() != NULL && (self()->getOption(TR_TraceAll) || debug("traceStartCompile") || self()->getOptions()->getAnyTraceCGOption() || self()->getOption(TR_Timing)))
       {
@@ -1232,23 +1232,23 @@ int32_t OMR::Compilation::compile()
       }
 #endif /* ifdef(J9_PROJECT_SPECIFIC) */
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
    if (self()->getOption(TR_DebugOnEntry))
       {
       intptrj_t jitTojitStart = (intptrj_t) self()->cg()->getCodeStart();
       jitTojitStart += ((*(int32_t *)(jitTojitStart - 4)) >> 16) & 0x0000ffff;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
       self()->getDebug()->setupDebugger((void *)jitTojitStart);
 #else
       self()->getDebug()->setupDebugger((void *)jitTojitStart, self()->cg()->getCodeEnd(), false);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
       }
-#elif defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS)
    if (self()->getOption(TR_DebugOnEntry))
       {
       self()->getDebug()->setupDebugger(self()->cg()->getCodeStart(),self()->cg()->getCodeEnd(),false);
       }
-#endif /* defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS) */
 
    return COMPILATION_SUCCEEDED;
    }

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -21,7 +21,7 @@
 
 #include "control/CompileMethod.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <process.h>
 #else
 #include <unistd.h>
@@ -73,7 +73,7 @@ writePerfToolEntry(void *start, uint32_t size, const char *name)
    if (firstAttempt)
       {
       firstAttempt = false;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
       int jvmPid = _getpid();
 #else
       pid_t jvmPid = getpid();

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -868,7 +868,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
                                  SET_OPTION_BIT(TR_IProfilerPerformTimestampCheck), "F"},
    {"iprofilerVerbose",          "O\tEnable Interpreter Profiling output messages",           SET_OPTION_BIT(TR_VerboseInterpreterProfiling), "F"},
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    {"j2prof",             "D\tenable profiling",
         SET_OPTION_BIT(TR_CreatePCMaps), "F" },
 #endif
@@ -2655,7 +2655,7 @@ OMR::Options::jitPreProcess()
    #endif
 
    #if defined(TR_TARGET_32BIT) && defined(PROD_WITH_ASSUMES)
-      #if defined(LINUX)
+      #if (HOST_OS == OMR_LINUX)
          #if defined(S390)
             _userSpaceVirtualMemoryMB = 2048; // 2 GB = 2048 MB
          #else
@@ -2663,8 +2663,8 @@ OMR::Options::jitPreProcess()
          #endif //#if defined(S390)
       #elif defined(J9ZOS390)
          _userSpaceVirtualMemoryMB = -1; // Compute userspace dynamically on z/OS
-      #endif //#if defined(LINUX)
-   #elif !defined(OMR_OS_WINDOWS)
+      #endif //#if (HOST_OS == OMR_LINUX)
+   #elif !(HOST_OS == OMR_WINDOWS)
       _userSpaceVirtualMemoryMB = 0; // Disabled for 64 bit or non-windows production
    #endif //#if defined(TR_TARGET_32BIT) && defined(PROD_WITH_ASSUMES)
 

--- a/compiler/cs2/timer.h
+++ b/compiler/cs2/timer.h
@@ -36,12 +36,12 @@
 #include "cs2/listof.h"
 #include "cs2/hashtab.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <time.h>
 #include "windows_api.h"
 #else
 #include <sys/time.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 #ifdef CS2_ALLOCINFO
@@ -52,7 +52,7 @@
 
 namespace CS2 {
 
-#if defined(_AIX)
+#if (HOST_OS == OMR_AIX)
 
 /**
  * \brief AIX-specific timer class.
@@ -81,7 +81,7 @@ class AIXTimer {
 };
 
 typedef AIXTimer PlatformTimer;
-#elif defined(LINUX) || defined(OSX) || (defined (__MVS__) && defined (_XOPEN_SOURCE_EXTENDED))
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) || (defined (__MVS__) && defined (_XOPEN_SOURCE_EXTENDED))
 /**
  * \brief Linux-specific timer class.
  *
@@ -110,7 +110,7 @@ private:
 };
 
 typedef BSDTimer PlatformTimer;
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 /**
  * \brief Windows-specific timer class.
  *
@@ -166,7 +166,7 @@ class BaseTimer {
 };
 
 typedef BaseTimer PlatformTimer;
-#endif /* defined(_AIX) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 /**
  * \brief A general purpose timer class.

--- a/compiler/cs2/windows_api.h
+++ b/compiler/cs2/windows_api.h
@@ -19,13 +19,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 #ifdef BOOLEAN
 /* There is a collision between J9's definition of BOOLEAN and Windows headers */
 #define BOOLEAN_COLLISION_DETECTED BOOLEAN
 #undef BOOLEAN
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #ifdef boolean
 /* There is a collision between J9's definition of boolean and Windows headers */

--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
 #include <sys/wait.h>
 #include <sys/types.h>

--- a/compiler/env/DebugSegmentProvider.cpp
+++ b/compiler/env/DebugSegmentProvider.cpp
@@ -19,17 +19,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX)
 #include <sys/mman.h>
 #if defined(__APPLE__) || !defined(MAP_ANONYMOUS)
 #define MAP_ANONYMOUS MAP_ANON
 #endif
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #else
 #include <string.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "env/MemorySegment.hpp"
 #include "env/DebugSegmentProvider.hpp"
@@ -45,13 +45,13 @@ TR::DebugSegmentProvider::~DebugSegmentProvider() throw()
    {
    for ( auto it = _segments.begin(); it != _segments.end(); it = _segments.begin() )
       {
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX)
       munmap(it->base(), it->size());
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
       VirtualFree(it->base(), 0, MEM_RELEASE);
 #else
       _rawAllocator.deallocate(it->base(), it->size());
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX) */
       _segments.erase(it);
       }
    }
@@ -60,15 +60,15 @@ TR::MemorySegment &
 TR::DebugSegmentProvider::request(size_t requiredSize)
    {
    size_t adjustedSize = ( ( requiredSize + (defaultSegmentSize() - 1) ) / defaultSegmentSize() ) * defaultSegmentSize();
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX)
    void *newSegmentArea = mmap(NULL, adjustedSize, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
    if (newSegmentArea == MAP_FAILED) throw std::bad_alloc();
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
    void *newSegmentArea = VirtualAlloc(NULL, adjustedSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
    if (!newSegmentArea) throw std::bad_alloc();
 #else
    void *newSegmentArea = _rawAllocator.allocate(requiredSize);
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX) */
    try
       {
       auto result = _segments.insert( TR::MemorySegment(newSegmentArea, adjustedSize) );
@@ -79,13 +79,13 @@ TR::DebugSegmentProvider::request(size_t requiredSize)
       }
    catch (...)
       {
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX)
       munmap(newSegmentArea, adjustedSize);
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
       VirtualFree(newSegmentArea, 0, MEM_RELEASE);
 #else
      _rawAllocator.deallocate(newSegmentArea, adjustedSize);
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX) */
       throw;
       }
    }
@@ -93,15 +93,15 @@ TR::DebugSegmentProvider::request(size_t requiredSize)
 void
 TR::DebugSegmentProvider::release(TR::MemorySegment &segment) throw()
    {
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX)
    void * remap = mmap(segment.base(), segment.size(), PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
    TR_ASSERT(remap == segment.base(), "Remapping of memory failed!");
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
    VirtualFree(segment.base(), segment.size(), MEM_DECOMMIT);
    VirtualAlloc(segment.base(), segment.size(), MEM_COMMIT, PAGE_NOACCESS);
 #else
    memset(segment.base(), 0xEF, segment.size());
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || defined(_AIX) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || defined(__APPLE__) || (HOST_OS == OMR_AIX) */
    }
 
 size_t

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -176,7 +176,7 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInit
 #endif
 
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* Hack - to satisfy the runtime linker we need a definition of the following functions.
    Should never be called.  This code can be removed when we permit the JIT to be linked
    against libstdc++ on Linux.

--- a/compiler/env/FEBase_t.hpp
+++ b/compiler/env/FEBase_t.hpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -39,7 +39,7 @@ namespace TR
 // We should be relying on the port library to allocate memory, but this connection
 // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9,
 // where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
    #if !defined(MAP_ANONYMOUS)
       #define NO_MAP_ANONYMOUS
       #if defined(MAP_ANON)
@@ -59,7 +59,7 @@ FEBase<Derived>::allocateRelocationData(TR::Compilation* comp, uint32_t size)
    if (size == 0) return 0;
    TR_ASSERT(size >= 2048, "allocateRelocationData should be used for whole-sale memory allocation only");
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    return reinterpret_cast<uint8_t *>(
          VirtualAlloc(NULL,
             size,

--- a/compiler/env/OMRDebugEnv.cpp
+++ b/compiler/env/OMRDebugEnv.cpp
@@ -26,14 +26,14 @@
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"
 
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 #include <signal.h>
 #endif
 
 void
 OMR::DebugEnv::breakPoint()
    {
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
    raise(SIGTRAP);
 #else
    TR_UNIMPLEMENTED();

--- a/compiler/env/OMRIO.hpp
+++ b/compiler/env/OMRIO.hpp
@@ -52,7 +52,7 @@ namespace OMR { typedef OMR::IO IOConnector; }
 #ifdef _MSC_VER
    #define POINTER_PRINTF_FORMAT "0x%p"
 #else
-   #if defined(LINUX) || defined(OSX)
+   #if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
       #ifdef TR_HOST_64BIT
          #ifdef TR_TARGET_X86
             #define POINTER_PRINTF_FORMAT "%12p"

--- a/compiler/env/OMRVMEnv.cpp
+++ b/compiler/env/OMRVMEnv.cpp
@@ -65,7 +65,7 @@ OMR::VMEnv::heapTailPaddingSizeInBytes()
 uint64_t
 OMR::VMEnv::getUSecClock()
    {
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
    struct timeval tp;
    struct timezone tzp;
 

--- a/compiler/env/defines.h
+++ b/compiler/env/defines.h
@@ -22,17 +22,17 @@
 #ifndef OMR_DEFINES_H
 #define OMR_DEFINES_H
 
-/* 
+/*
    This is the first file that the OMR code should be including.
    The idea is the define a standard set of C macros based on the
    system configuration. This is the only file (hopefully) needs to
    use system specific macros (e.g. __linux__).
-   
+
    In addition, if there are system-configuration specific feature
    test macros that you want to define, this is probably the file you
    want to define them in. You should also provide documentation of
    what your macro does. As an example see SUPPORTS_THREAD_LOCAL
-   
+
    Note that this file is included is asm code as well. Apart from C
    pre-processor macros, it shouldn't contain anything else.
 */
@@ -92,15 +92,15 @@
   ways of checking for a particular host os.  As a reference, see
   http://sourceforge.net/p/predef/wiki/OperatingSystems/
 */
-#if defined(__linux__)
+#if (HOST_OS == OMR_LINUX)
 #  define HOST_OS OMR_LINUX
 #elif defined(_TPF_SOURCE)
 #  define HOST_OS OMR_LINUX
-#elif defined(_AIX)
+#elif (HOST_OS == OMR_AIX)
 #  define HOST_OS OMR_AIX
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #  define HOST_OS OMR_WINDOWS
-#elif defined(__MVS__)
+#elif defined(__MVC__)
 #  define HOST_OS OMR_ZOS
 #elif defined(__APPLE__) && defined(__MACH__)
 #  define HOST_OS OMR_OSX
@@ -158,7 +158,7 @@
 #  error "defines.h: unknown compiler"
 #endif
 
-/* FIXME: we need to deprecate TR_HOST_* macros and replace them with 
+/* FIXME: we need to deprecate TR_HOST_* macros and replace them with
    code of the form: #if (HOST_ARCH == ARCH_X86) */
 #if (HOST_ARCH == ARCH_X86)
 #  define TR_HOST_X86    1

--- a/compiler/env/jittypes.h
+++ b/compiler/env/jittypes.h
@@ -163,7 +163,7 @@ typedef struct TR_InlinedCallSite
       #include <builtins.h>
       #endif /* __cplusplus */
       #define FLUSH_MEMORY(smp) if( smp ) __lwsync();
-   #elif defined(LINUX)
+   #elif (HOST_OS == OMR_LINUX)
       #define FLUSH_MEMORY(smp) if( smp ) __asm__("lwsync");
    #endif
 #endif

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -772,7 +772,7 @@ OMR::Node::createWithSymRef(TR::ILOpCodes op, uint16_t numChildren, TR::SymbolRe
  * These are defined for compilers that do not support variadic templates
  * Otherwise the definitions are in il/OMRNode_inlines.hpp
  */
-#if defined(_MSC_VER) || defined(LINUXPPC)
+#if defined(_MSC_VER) || (HOST_OS == OMR_LINUX)
 TR::Node *
 OMR::Node::recreateWithoutSymRef_va_args(TR::Node *originalNode, TR::ILOpCodes op,
                                               uint16_t numChildren, uint16_t numChildArgs,

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -191,7 +191,7 @@ public:
    static TR::Node *createWithSymRef(TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef);
    static TR::Node *createWithSymRef(TR::ILOpCodes op, uint16_t numChildren, TR::SymbolReference * symRef, uintptr_t extraChildrenForFixup);
 
-#if defined(_MSC_VER) || defined(LINUXPPC)
+#if defined(_MSC_VER) || (HOST_OS == OMR_LINUX)
 private:
    static TR::Node *recreateWithoutSymRef_va_args(TR::Node *originalNode, TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, va_list &args);
    static TR::Node *createWithoutSymRef(TR::ILOpCodes op, uint16_t numChildren, uint16_t numChildArgs, ...);

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -56,7 +56,7 @@ OMR::Node::self()
  * Node constructors
  */
 
-#if !defined(_MSC_VER) && !defined(LINUXPPC)
+#if !defined(_MSC_VER) && !(HOST_OS == OMR_LINUX)
 /*
  * These are defined for compilers that support variadic templates
  * XLC (but not on LINUX PPC) and GCC support C++11 variadic templates

--- a/compiler/infra/Annotations.hpp
+++ b/compiler/infra/Annotations.hpp
@@ -81,12 +81,12 @@
 // OMR_LIKELY and OMR_UNLIKELY
 // TODO: check if the definition of these macros is too broad,
 //       __builtin_expect() may not have any effect on xlC
-#if defined(TR_HOST_X86) && defined(OMR_OS_WINDOWS)
+#if defined(TR_HOST_X86) && (HOST_OS == OMR_WINDOWS)
    #define OMR_LIKELY(expr) (expr)
    #define OMR_UNLIKELY(expr) (expr)
 #else
    #define OMR_LIKELY(expr)   __builtin_expect((expr), 1)
    #define OMR_UNLIKELY(expr) __builtin_expect((expr), 0)
-#endif /* defined(TR_HOST_X86) && defined(OMR_OS_WINDOWS) */
+#endif /* defined(TR_HOST_X86) && (HOST_OS == OMR_WINDOWS) */
 
 #endif

--- a/compiler/infra/Bit.hpp
+++ b/compiler/infra/Bit.hpp
@@ -30,11 +30,11 @@
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 
-#if defined(TR_TARGET_X86) && defined(OMR_OS_WINDOWS)
+#if defined(TR_TARGET_X86) && (HOST_OS == OMR_WINDOWS)
    #define abs64 _abs64
 #else
    #define abs64 labs
-#endif /* defined(TR_TARGET_X86) && defined(OMR_OS_WINDOWS) */
+#endif /* defined(TR_TARGET_X86) && (HOST_OS == OMR_WINDOWS) */
 
 // For getting at different parts of a 32 bit integer
 class intParts  {
@@ -405,7 +405,7 @@ static inline bool isPowerOf2(int64_t input)
    return (input & -input) == input;
    }
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 // On OSX, intptrj_t isn't int32_t nor int64_t
 
 static inline int32_t leadingZeroes (intptrj_t input)

--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -66,12 +66,12 @@ bool
 OMR::Monitor::init(char *name)
    {
    _name = name;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_INIT(_monitor);
 #else
    bool rc = MUTEX_INIT(_monitor);
    TR_ASSERT(rc == true, "error initializing monitor\n");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    return true;
    }
 
@@ -84,36 +84,36 @@ OMR::Monitor::destroy(TR::Monitor *monitor)
 void
 OMR::Monitor::destroy()
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_DESTROY(_monitor);
 #else
    int32_t rc = MUTEX_DESTROY(_monitor);
    TR_ASSERT(rc == 0, "error destroying monitor\n");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 void
 OMR::Monitor::enter()
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_ENTER(_monitor);
 #else
    int32_t rc = MUTEX_ENTER(_monitor);
    TR_ASSERT(rc == 0, "error locking monitor\n");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 int32_t
 OMR::Monitor::exit()
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    MUTEX_EXIT(_monitor);
    return 0;
 #else
    int32_t rc = MUTEX_EXIT(_monitor);
    TR_ASSERT(rc == 0, "error unlocking monitor\n");
    return rc;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 char const *

--- a/compiler/infra/ThreadLocal.h
+++ b/compiler/infra/ThreadLocal.h
@@ -34,8 +34,8 @@
 
 #if defined(SUPPORTS_THREAD_LOCAL)
 
-#if defined(OMR_OS_WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)
- #if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX)
+ #if (HOST_OS == OMR_WINDOWS)
   #include "windows.h"
   #define tlsDeclare(type, variable) extern DWORD variable
   #define tlsDefine(type, variable) DWORD variable = TLS_OUT_OF_INDEXES
@@ -43,15 +43,15 @@
   #define tlsFree(variable)  (TlsFree(variable))
   #define tlsSet(variable, value) TlsSetValue((variable), value)
   #define tlsGet(variable, type) ((type)TlsGetValue(variable))
- #else /* if defined(LINUX) || defined(AIXPPC) */
+ #else /* if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
   #define tlsDeclare(type, variable) extern __thread type variable
   #define tlsDefine(type, variable) __thread type variable = NULL
   #define tlsAlloc(variable) // not required on win, linux or AIX
   #define tlsFree(variable)  // not required on win, linux or AIX
   #define tlsSet(variable, value) variable = value
   #define tlsGet(variable, type) (variable)
- #endif /* defined(OMR_OS_WINDOWS) */
-#else /* !(defined(OMR_OS_WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC)) */  /* Mainly for defined(OMRZTPF) or defined(J9ZOS390) */
+ #endif /* (HOST_OS == OMR_WINDOWS) */
+#else /* !((HOST_OS == OMR_WINDOWS) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX)) */  /* Mainly for defined(OMRZTPF) or defined(J9ZOS390) */
  #include <pthread.h>
 
  #define tlsDeclare(type, variable) extern pthread_key_t variable
@@ -64,7 +64,7 @@
  #else
   #define tlsGet(variable, type) ((type) pthread_getspecific(variable))
  #endif
-#endif /* defined(OMR_OS_WINDOWS) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_WINDOWS) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX) */
 
 #else /* !defined(SUPPORTS_THREAD_LOCAL) */
  #define tlsDeclare(type, variable) extern type variable

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -912,7 +912,7 @@ TR_CallStack::~TR_CallStack()
    {
    //::commit is supposed to clear up the lists after everything has been propagated to a caller
    //if there are still some residual symRefs left it means that we missed a call to commit somewhere
-#if !defined(AIXPPC)
+#if !(HOST_OS == OMR_AIX)
    TR_ASSERT(std::uncaught_exception() || (_autos.isEmpty() && _temps.isEmpty() && _injectedBasicBlockTemps.isEmpty()), "lists should have been emptied by TR_CallStack::commit");
 #endif
    }

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -102,7 +102,7 @@
 #include "ras/DebugCounter.hpp"
 #include "runtime/Runtime.hpp"
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/debug.h>
 #endif
 
@@ -1559,7 +1559,7 @@ void OMR::Power::CodeGenerator::doPeephole()
 
       if ((TR::Compiler->target.cpu.id() == TR_PPCp6) && instructionCursor->isTrap())
          {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
          trapPeephole(self(),instructionCursor);
 #endif
          }
@@ -2572,7 +2572,7 @@ void OMR::Power::CodeGenerator::addRealRegisterInterference(TR::Register    *reg
    reg->getLiveRegisterInfo()->addInterference(realReg->getRealRegisterMask());
    }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <unistd.h>
 class  TR_Method;
 FILE                     *j2Profile;

--- a/compiler/p/runtime/PPCArrayCopy.inc
+++ b/compiler/p/runtime/PPCArrayCopy.inc
@@ -137,7 +137,7 @@
    .globl    FUNC_LABEL(__leArrayCopy)
    .type     FUNC_LABEL(__leArrayCopy),@function
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
    .globl    __arrayCopy
    .globl    __wordArrayCopy
    .globl    __halfWordArrayCopy
@@ -517,7 +517,7 @@ __forwardHalfWordArrayCopy:
 #elif defined(LINUXPPC64)
    .align   5
 FUNC_LABEL(__arrayCopy_dp):
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
    .align   5
 __arrayCopy_dp:
 #else
@@ -577,7 +577,7 @@ __arrayCopy_dp:
    stfd  fp8, 0(r9)
    addi  r9, r9, 8
    bc BO_IF, CR0_LT, .L.tableDispatch
-#if defined(AIXPPC) || defined(LINUX) || defined(LINUXPPC64)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(LINUXPPC64)
    .align   5     ! force 32-byte I-cache sector alignment here
 #endif
 .L.qWordAligned_dp:
@@ -756,7 +756,7 @@ __arrayCopy_dp:
    stfd  fp8, -8(r9)
    addi  r9, r9, -8
    bc BO_IF, CR0_LT, .L.reverseTableDispatch
-#if defined(AIXPPC) || defined(LINUX) || defined(LINUXPPC64)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(LINUXPPC64)
    .align   5     ! force 32-byte I-cache sector alignment here
 #endif
 .L.reverseQWordAligned_dp:
@@ -2632,9 +2632,9 @@ __leArrayCopy:
 #endif
 
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    .csect    ArrayCopy_DATA{RW}
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
    .data
 #elif defined (LINUXPPC64)
    .section ".data"

--- a/compiler/p/runtime/PPCAsmUtil.inc
+++ b/compiler/p/runtime/PPCAsmUtil.inc
@@ -79,7 +79,7 @@
 
 	.globl FUNC_LABEL(jitPPCDataCacheBlockZero)
 	.type  FUNC_LABEL(jitPPCDataCacheBlockZero),@function
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 	.globl _tr_try_lock
 	.globl _tr_unlock
 	.globl jitPPCDataCacheBlockZero

--- a/compiler/p/runtime/VirtualGuardRuntime.spp
+++ b/compiler/p/runtime/VirtualGuardRuntime.spp
@@ -30,7 +30,7 @@
 	.globl	FUNC_LABEL(_patchVirtualGuard)
 	.type	FUNC_LABEL(_patchVirtualGuard), @function
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 	.globl	_patchVirtualGuard
 #endif
 

--- a/compiler/p/runtime/ppcasmdefines.inc
+++ b/compiler/p/runtime/ppcasmdefines.inc
@@ -262,7 +262,7 @@
 	#define J9_BP r15
 	#define J9VM_STRUCT r13
 	#define J9SP r14
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	#define RTOC r12
 #else
 	#define RTOC r2

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -40,7 +40,7 @@ void TR_CallStackIterator::printStackBacktrace(TR::Compilation *comp)
       }
    }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <demangle.h>
 #include <sys/debug.h>
 
@@ -171,7 +171,7 @@ const char *TR_PPCCallStackIterator::getProcedureName()
       }
    }
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 #include <execinfo.h>
 #include <cxxabi.h>
 
@@ -327,7 +327,7 @@ bool TR_MvsCallStackIterator::getNext ()
    return true;
    }
 
-#elif defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
+#elif (HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
 
 #include "ras/CallStack.hpp"
 #include <windows.h>
@@ -497,6 +497,6 @@ bool TR_WinCallStackIterator::getNext()
    return !_done;
    }
 
-#elif !(defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
+#elif !((HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
 
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */

--- a/compiler/ras/CallStackIterator.hpp
+++ b/compiler/ras/CallStackIterator.hpp
@@ -41,7 +41,7 @@ protected:
    virtual bool isDone() { return true; }
    };
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 struct tbtable;
 
 class TR_PPCCallStackIterator : public TR_CallStackIterator
@@ -65,7 +65,7 @@ private:
 
 typedef TR_PPCCallStackIterator TR_CallStackIteratorImpl;
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 
 class TR_LinuxCallStackIterator : public TR_CallStackIterator
    {
@@ -164,7 +164,7 @@ private:
 
 typedef TR_MvsCallStackIterator TR_CallStackIteratorImpl;
 
-#elif defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
+#elif (HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT)
 
 class TR_WinCallStackIterator : public TR_CallStackIterator
    {
@@ -188,10 +188,10 @@ public:
 
 typedef TR_WinCallStackIterator TR_CallStackIteratorImpl;
 
-#elif !(defined(OMR_OS_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
+#elif !((HOST_OS == OMR_WINDOWS) && defined(TR_HOST_X86) && defined(TR_HOST_32BIT))
 
 typedef TR_CallStackIterator TR_CallStackIteratorImpl;
 
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 #endif

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -116,7 +116,7 @@
 #include <netdb.h>
 #endif
 
-#if defined(J9ZOS390) || defined(AIXPPC) || defined(LINUX)
+#if defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 #include <unistd.h>
 #endif
 
@@ -161,7 +161,7 @@ TR_Debug * createDebugObject(TR::Compilation * comp)
 
 
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS)
 static void stopOnCreate()
    {
    static int first = 1;
@@ -172,7 +172,7 @@ static void stopOnCreate()
       first = 0;
       }
    }
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS) */
 
 
 void
@@ -203,10 +203,10 @@ TR_Debug::debugOnCreate()
    {
 #if defined(TR_HOST_X86)
    TR::Compiler->debug.breakPoint();
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
    setupDebugger((void *) *((long*)&(stopOnCreate)));
    stopOnCreate();
-#elif defined(LINUX) || defined(J9ZOS390) || (defined(OMR_OS_WINDOWS))
+#elif (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || ((HOST_OS == OMR_WINDOWS))
    setupDebugger((void *) &stopOnCreate,(void *) &stopOnCreate,true);
    stopOnCreate();
 #endif /* defined(TR_HOST_X86) */
@@ -4884,7 +4884,7 @@ TR_Debug::traceRegisterWeight(TR::Register *realReg, uint32_t weight)
    trfflush(_file);
    }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #if !defined(J9OS_I5)
 #include <unistd.h>
 extern "C" void yield(void);
@@ -4954,7 +4954,7 @@ void TR_Debug::setupDebugger(void *addr)
 
 #endif
 
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
    {
    static bool started = false;
@@ -5122,7 +5122,7 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
          else printf("Could not open %s, skipping break !\n",cfname);
          }
    }
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #ifndef WINDOWS_API_INCLUDED
 extern "C"
    {
@@ -5187,7 +5187,7 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
       started = true;
       }
    }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 void TR_Debug::setSingleAllocMetaData(bool usesSingleAllocMetaData)
    {

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -611,11 +611,11 @@ public:
    const char * getName(TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
 #endif
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
    virtual void setupDebugger(void *);
-#elif defined(LINUX) || defined(J9ZOS390) || defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_WINDOWS)
    virtual void setupDebugger(void *, void *, bool);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
    virtual void setSingleAllocMetaData(bool usesSingleAllocMetaData);
 

--- a/compiler/ras/IgnoreLocale.hpp
+++ b/compiler/ras/IgnoreLocale.hpp
@@ -34,7 +34,7 @@ int strnicmp_ignore_locale(const char *s1, const char *s2, size_t n);
 #include <strings.h>
    #define STRICMP strcasecmp
    #define STRNICMP strncasecmp
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
    #define STRICMP _stricmp
    #define STRNICMP _strnicmp
 #elif PILOT

--- a/compiler/runtime/OMRRuntimeAssumptions.cpp
+++ b/compiler/runtime/OMRRuntimeAssumptions.cpp
@@ -22,7 +22,7 @@
 #include "runtime/OMRRuntimeAssumptions.hpp"
 #include "env/jittypes.h"
 
-#if defined(__IBMCPP__) && !defined(AIXPPC) && !defined(LINUXPPC)
+#if defined(__IBMCPP__) && !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_LINUX)
 #define ASM_CALL __cdecl
 #else
 #define ASM_CALL

--- a/compiler/runtime/Runtime.cpp
+++ b/compiler/runtime/Runtime.cpp
@@ -24,7 +24,7 @@
 TR_RuntimeHelperTable runtimeHelpers;
 
 #if (defined(__IBMCPP__) || defined(__IBMC__) && !defined(MVS)) && !defined(LINUXPPC64)
- #if defined(AIXPPC)
+ #if (HOST_OS == OMR_AIX)
   #define JIT_HELPER(x) extern "C" void *x
  #else
   #define JIT_HELPER(x) extern "C" __cdecl x()
@@ -32,7 +32,7 @@ TR_RuntimeHelperTable runtimeHelpers;
 #else
  #if defined(LINUXPPC64)
   #define JIT_HELPER(x) extern "C" void *x
- #elif defined(LINUX)
+ #elif (HOST_OS == OMR_LINUX)
   #define JIT_HELPER(x) extern "C" void x()
  #else
   #define JIT_HELPER(x) extern "C" x()

--- a/compiler/x/amd64/codegen/OMRELFRelocationResolver.cpp
+++ b/compiler/x/amd64/codegen/OMRELFRelocationResolver.cpp
@@ -21,7 +21,7 @@
 
 #include "codegen/ELFRelocationResolver.hpp"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #include <elf.h>
 #include "infra/Assert.hpp"
@@ -37,4 +37,4 @@ OMR::X86::AMD64::ELFRelocationResolver::resolveRelocationType(const TR::StaticRe
    return static_cast<uint32_t>(-1);
    }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */

--- a/compiler/x/amd64/codegen/OMRELFRelocationResolver.hpp
+++ b/compiler/x/amd64/codegen/OMRELFRelocationResolver.hpp
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #ifndef OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
 #define OMR_ELF_RELOCATION_RESOLVER_CONNECTOR
@@ -61,6 +61,6 @@ private:
 }
 }
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif // OMRELFRELOCATIONRESOLVER_HPP

--- a/compiler/x/codegen/FPBinaryArithmeticAnalyser.hpp
+++ b/compiler/x/codegen/FPBinaryArithmeticAnalyser.hpp
@@ -35,7 +35,7 @@ namespace TR { class Register; }
 //
 // DOUBLE_EXPONENT_SCALE = -(16383-1023)
 //
-#if !defined(_LONG_LONG) && !defined(LINUX)
+#if !defined(_LONG_LONG) && !(HOST_OS == OMR_LINUX)
 #define DOUBLE_EXPONENT_SCALE 0xc0ce000000000000L
 #else
 #define DOUBLE_EXPONENT_SCALE 0xc0ce000000000000LL

--- a/compiler/x/codegen/FPTreeEvaluator.hpp
+++ b/compiler/x/codegen/FPTreeEvaluator.hpp
@@ -32,7 +32,7 @@
 
 // Binary representation of double 1.0
 //
-#if !defined(_LONG_LONG) && !defined(LINUX)
+#if !defined(_LONG_LONG) && !(HOST_OS == OMR_LINUX)
 #define IEEE_DOUBLE_1_0          0x3ff0000000000000L
 #define IEEE_DOUBLE_NEGATIVE_0_0 0x8000000000000000L
 #else

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1102,7 +1102,7 @@ OMR::X86::CodeGenerator::getNanoTimeTemp()
    if (_nanoTimeTemp == NULL)
       {
       TR::AutomaticSymbol *sym;
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
       sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,sizeof(struct timeval));
 #else
       sym = TR::AutomaticSymbol::create(self()->trHeapMemory(),TR::Aggregate,8);

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -48,7 +48,7 @@ namespace OMR { typedef OMR::X86::CodeGenerator CodeGeneratorConnector; }
 #include "x/codegen/X86Register.hpp"
 #include "env/CompilerEnv.hpp"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <sys/time.h>
 #endif
 

--- a/compiler/x/runtime/X86Runtime.hpp
+++ b/compiler/x/runtime/X86Runtime.hpp
@@ -24,7 +24,7 @@
 
 #include "env/ProcessorInfo.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <intrin.h>
 #define cpuid(CPUInfo, EAXValue)             __cpuid(CPUInfo, EAXValue)
 #define cpuidex(CPUInfo, EAXValue, ECXValue) __cpuidex(CPUInfo, EAXValue, ECXValue)
@@ -39,7 +39,7 @@ inline unsigned long long _xgetbv(unsigned int ecx)
    __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(ecx));
    return ((unsigned long long)edx << 32) | eax;
    }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 char* feGetEnv(const char*);
 inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
@@ -91,20 +91,20 @@ inline bool jitGetCPUID(TR_X86CPUIDBuffer* pBuffer)
 
 inline bool AtomicCompareAndSwap(volatile uint32_t* ptr, uint32_t old_val, uint32_t new_val)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    return old_val == (uint32_t)_InterlockedCompareExchange((volatile long*)ptr, (long)new_val, (long)old_val);
 #else
    return __sync_bool_compare_and_swap(ptr, old_val, new_val);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 inline bool AtomicCompareAndSwap(volatile uint16_t* ptr, uint16_t old_val, uint16_t new_val)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    return old_val == (uint16_t)_InterlockedCompareExchange16((volatile short*)ptr, (short)new_val, (short)old_val);
 #else
    return __sync_bool_compare_and_swap(ptr, old_val, new_val);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
    }
 
 inline void patchingFence16(void* addr)

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -2002,7 +2002,7 @@ static void intToString(int num, char *str, int len=10, bool padWithZeros=false)
    unsigned char c[16];
    int i=0,j=0,n=0;
 
-   #if !defined(LINUX) && !defined(TR_HOST_X86)
+   #if !(HOST_OS == OMR_LINUX) && !defined(TR_HOST_X86)
    __cvd(num, (char *)packedDecValue);
    __unpk(c, len-1, packedDecValue, 7 );
    c[len-1] = c[len-1] | 0xf0;
@@ -2028,7 +2028,7 @@ static void intToHex(uint32_t num, char *str, int len)
            0xC3, 0xC4, 0xC5, 0xC6
                      };
 
-   #if !defined(LINUX) && !defined(TR_HOST_X86)
+   #if !(HOST_OS == OMR_LINUX) && !defined(TR_HOST_X86)
    memcpy(temp, &num, 4);
    __unpk((unsigned char *)str, len, temp, 4);
    __tr((unsigned char *)str, ebcdic_translate-240, len);

--- a/configure
+++ b/configure
@@ -4362,7 +4362,7 @@ fi
 	if test "x$OMR_TOOLCHAIN" = "x"; then :
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#if !(defined(__xlC__) || (defined(__MVS__) && defined(__COMPILER_VER__)))
+#if !(defined(__xlC__) || (defined(__MVC__) && defined(__COMPILER_VER__)))
 #error not an xlc compiler
 #endif
 int

--- a/ddr/include/ddr/config.hpp
+++ b/ddr/include/ddr/config.hpp
@@ -35,12 +35,12 @@
 
 /* C++ TR1 support */
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 #define __IBMCPP_TR1__ 1
 #define OMR_HAVE_TR1 1
 #else
 #define OMR_HAVE_CXX11 1
-#endif /* !defined(AIXPPC) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_AIX) && !defined(J9ZOS390) */
 
 /* Why is this disabled? */
 

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -32,11 +32,11 @@
 #include <vector>
 #include <errno.h>
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <sys/fcntl.h>
 #endif /* OSX */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/errno.h>
@@ -175,7 +175,7 @@ struct Dwarf_Die_s
 	Dwarf_Half _tag;
 	Dwarf_Die_s *_parent;
 	Dwarf_Die_s *_sibling;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	Dwarf_Die_s *_previous;
 #endif /* defined (AIXPPC) */
 	Dwarf_Die_s *_child;

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -27,9 +27,9 @@
 #include "ddr/std/unordered_map.hpp"
 #include <map>
 
-#if defined(OSX) || defined(AIXPPC)
+#if (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX)
 #include "ddr/scanner/dwarf/DwarfFunctions.hpp"
-#else /* defined(OSX) || defined(AIXPPC) */
+#else /* (HOST_OS == OMR_OSX) || (HOST_OS == OMR_AIX) */
 
 #if defined(HAVE_DWARF_H)
 #include <dwarf.h>
@@ -47,7 +47,7 @@
 #error "Need libdwarf.h or libdwarf/libdwarf.h"
 #endif /* defined(HAVE_LIBDWARF_H) */
 
-#endif /* defined(OSX) || defined(AIXPPX) */
+#endif /* (HOST_OS == OMR_OSX) || defined(AIXPPX) */
 
 #include "ddr/ir/ClassUDT.hpp"
 #include "ddr/ir/EnumUDT.hpp"

--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -27,12 +27,12 @@
 #include <utility>
 #include <vector>
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined uintptr_t.  Ignore its definition */
 #define UDATA UDATA_win_
 #include "dia2.h"
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "ddr/ir/ClassUDT.hpp"
 #include "ddr/ir/EnumUDT.hpp"

--- a/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
@@ -19,9 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 #define __IBMCPP_TR1__ 1
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
 
 #include "ddr/blobgen/genBlob.hpp"
 #include "ddr/blobgen/java/genBinaryBlob.hpp"

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -337,9 +337,9 @@ DwarfScanner::getName(Dwarf_Die die, string *name, Dwarf_Off *dieOffset)
 			}
 		}
 		if ((NULL == dieName)
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 			|| ((0 == strncmp(dieName, "__", 2)) && (strlen(dieName + 2) == strspn(dieName + 2, "0123456789")))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 			|| (0 == strncmp(dieName, "<anonymous", 10)))
 		{
 			*name = "";
@@ -940,7 +940,7 @@ isVtablePointer(const char *fieldName)
 {
 #if defined(__GNUC__)
 	return 0 == strncmp(fieldName, "_vptr.", 6);
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 	return 0 == strcmp(fieldName, "__vfp");
 #else
 	return false;

--- a/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
+++ b/ddr/lib/ddr-scanner/pdb/PdbScanner.cpp
@@ -24,9 +24,9 @@
 #include <algorithm>
 #include <assert.h>
 #include <comdef.h>
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <inttypes.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 #include <stdio.h>
 
 #include "ddr/std/sstream.hpp"

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -19,9 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 #define __IBMCPP_TR1__ 1
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
 
 #include <stdlib.h>
 #include <string.h>

--- a/doc/CodingStandard.md
+++ b/doc/CodingStandard.md
@@ -1550,9 +1550,9 @@ TODO: in the future, we would like to have OMR_OS_xxx flags for operating system
 
 Correct
 ```c
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
-#if defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 
 #if defined( _AMD64_)
 ```

--- a/example/glue/UtilGlue.c
+++ b/example/glue/UtilGlue.c
@@ -25,7 +25,7 @@
  * it can be used without requiring all the dependencies of LanguageVMGlue.
  * (Since LanguageVMGlue interacts with OMR_VM initialization, it prereqs all GC/RAS/OMR core modules.)
  */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 omr_error_t
 OMR_Glue_GetVMDirectoryToken(void **token)
 {
@@ -33,7 +33,7 @@ OMR_Glue_GetVMDirectoryToken(void **token)
 	*token = NULL;
 	return OMR_ERROR_NONE;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Provides the thread name to be used when no name is given.

--- a/example/glue/VerboseManagerImpl.cpp
+++ b/example/glue/VerboseManagerImpl.cpp
@@ -29,9 +29,9 @@
 
 #include "VerboseHandlerOutputStandard.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define snprintf _snprintf
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 MM_VerboseManagerImpl *
 MM_VerboseManagerImpl::newInstance(MM_EnvironmentBase *env, OMR_VM* vm)

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -18,7 +18,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -61,7 +61,7 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    if (segmentSize < config.codeCachePadKB() << 10)
       codeCacheSizeToAllocate = config.codeCachePadKB() << 10;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    auto memorySlab = reinterpret_cast<uint8_t *>(
          VirtualAlloc(NULL,
             codeCacheSizeToAllocate,
@@ -84,7 +84,7 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
 void
 TestCompiler::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
 #else
    munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));

--- a/fvtest/compilertest/tests/OMRTestEnv.cpp
+++ b/fvtest/compilertest/tests/OMRTestEnv.cpp
@@ -19,13 +19,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #undef BYTE
 #include "windows.h"
 #define PATH_MAX MAXPATHLEN
 #else
 #include <dlfcn.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <errno.h>
 #include "OMRTestEnv.hpp"
 

--- a/fvtest/compilertest/tests/main.cpp
+++ b/fvtest/compilertest/tests/main.cpp
@@ -27,13 +27,13 @@
 #include "gtest/gtest.h"
 #include "OMRTestEnv.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #undef BYTE
 #include "windows.h"
 #define PATH_MAX MAXPATHLEN
 #else
 #include <dlfcn.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 int main(int argc, char **argv)
    {

--- a/fvtest/gctest/gcTestHelpers.cpp
+++ b/fvtest/gctest/gcTestHelpers.cpp
@@ -20,13 +20,13 @@
  *******************************************************************************/
 
 #include "gcTestHelpers.hpp"
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined uintptr_t.  Ignore its definition */
 #define UDATA UDATA_win_
 #include <windows.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
 #include <psapi.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 void
 GCTestEnvironment::initParams()
@@ -96,13 +96,13 @@ GCTestEnvironment::GCTestTearDown()
 void
 printMemUsed(const char *where, OMRPortLibrary *portLib)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 	PROCESS_MEMORY_COUNTERS_EX pmc;
 	GetProcessMemoryInfo(GetCurrentProcess(), (PPROCESS_MEMORY_COUNTERS)&pmc, sizeof(pmc));
 	/* result in bytes */
 	gcTestEnv->log(LEVEL_VERBOSE, "%s: phys: %ld; virt: %ld\n", where, pmc.WorkingSetSize, pmc.PrivateUsage);
-#elif defined(LINUX)
+#elif (HOST_OS == OMR_LINUX)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLib);
 	const char *statm_path = "/proc/self/statm";
 	intptr_t fileDescriptor = omrfile_open(statm_path, EsOpenRead, 0444);
@@ -129,5 +129,5 @@ printMemUsed(const char *where, OMRPortLibrary *portLib)
 	omrfile_close(fileDescriptor);
 #else
 	/* memory info not supported */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/fvtest/omrGtestGlue/argmain.cpp
+++ b/fvtest/omrGtestGlue/argmain.cpp
@@ -28,9 +28,9 @@
  * correctly when it is located in a library.
  */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <stdlib.h>
 #include <string.h>
 
@@ -39,11 +39,11 @@
 #endif /* defined(J9ZOS390) */
 
 /* Define a macro for the name of the main function that takes char args */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CHARMAIN translated_main
 #else
 #define CHARMAIN main
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 extern "C" int omr_main_entry(int argc, char **argv, char **envp);
 
@@ -64,7 +64,7 @@ CHARMAIN(int argc, char **argv, char **envp)
 	return omr_main_entry(argc, argv, envp);
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -127,4 +127,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/fvtest/porttest/fileTest.cpp
+++ b/fvtest/porttest/fileTest.cpp
@@ -22,13 +22,13 @@
 #include "omrcfg.h"
 
 #include <limits.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* Undefine the winsockapi because winsock2 defines it.  Removes warnings. */
 #if defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
 #undef _WINSOCKAPI_
 #endif
 #include <winsock2.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include "omrTest.h"
 #include "omrport.h"
 #include "portTestHelpers.hpp"
@@ -40,13 +40,13 @@ protected:
 	SetUp()
 	{
 		::testing::Test::SetUp();
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		/* initialize sockets so that we can use gethostname() */
 		WORD wsaVersionRequested = MAKEWORD(2, 2);
 		WSADATA wsaData;
 		int wsaErr = WSAStartup(wsaVersionRequested, &wsaData);
 		ASSERT_EQ(0, wsaErr);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 		/* generate machine specific file name to prevent conflict between multiple tests running on shared drive */
 		OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
@@ -65,9 +65,9 @@ protected:
 		omrfile_unlink(fileName);
 		delete[] fileName;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		WSACleanup();
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		::testing::Test::TearDown();
 	}
 

--- a/fvtest/porttest/main.cpp
+++ b/fvtest/porttest/main.cpp
@@ -63,10 +63,10 @@ omr_main_entry(int argc, char **argv, char **envp)
 		portTestEnv->initPort();
 		if (startsWith(testName, "omrfile")) {
 			return omrfile_runTests(portTestEnv->getPortLibrary(), argv[0], testName, FALSE);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		} else if (startsWith(testName, "omrfile_blockingasync")) {
 			return omrfile_runTests(portTestEnv->getPortLibrary(), argv[0], testName, TRUE);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		} else if (startsWith(testName, "omrmmap")) {
 			return omrmmap_runTests(portTestEnv->getPortLibrary(), argv[0], testName);
 		} else if (startsWith(testName, "omrsig")) {

--- a/fvtest/porttest/omrdumpTest.cpp
+++ b/fvtest/porttest/omrdumpTest.cpp
@@ -33,18 +33,18 @@
 #include <string.h>
 #include <stdio.h>
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/types.h>
 #include <sys/var.h>
 #endif
 
 #include <signal.h>
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* for getcwd() */
 #include <direct.h>
 #define getcwd _getcwd
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "omrport.h"
@@ -121,7 +121,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 	uintptr_t rc = 99;
 	char coreFileName[EsMaxPath];
 	BOOLEAN doFileVerification = FALSE;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct vario myvar;
 	int sys_parmRC;
 #endif
@@ -150,7 +150,7 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 		portTestEnv->log("omrdump_create claims to have written a core file to: %s\n", coreFileName);
 
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		/* We defer to fork abort on AIX machines that don't have "Enable full CORE dump" enabled in smit,
 		 * in which case omrdump_create will not return the filename.
 		 * So, only check for a specific filename if we are getting full core dumps */
@@ -160,9 +160,9 @@ TEST(PortDumpTest, dump_test_create_dump_with_NO_name)
 
 			doFileVerification = TRUE;
 		}
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 		doFileVerification = TRUE;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		if (doFileVerification) {
 			verifyFileRC = verifyFileExists(PORTTEST_ERROR_ARGS, coreFileName);
 			if (verifyFileRC == 0) {

--- a/fvtest/porttest/omrfileTest.cpp
+++ b/fvtest/porttest/omrfileTest.cpp
@@ -34,10 +34,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
 #include <windows.h> /* for MAX_PATH */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "testProcessHelpers.hpp"
@@ -1029,7 +1029,7 @@ TEST_F(PortFileTest2, file_test8)
 	fd = FILE_OPEN_FUNCTION(OMRPORTLIB, fileName, EsOpenWrite | EsOpenAppend, 0666);
 
 	prevFilePtr = omrfile_seek(fd, 0, EsSeekCur);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Windows sets the file pointer to the end of file as soon as it is opened in append mode. */
 	if (5 != prevFilePtr) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "File pointer location is wrong after opening the file. Expected = 5, Got = %lld", prevFilePtr);
@@ -1039,7 +1039,7 @@ TEST_F(PortFileTest2, file_test8)
 	if (0 != prevFilePtr) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "File pointer location is wrong after opening the file. Expected = 0, Got = %lld", prevFilePtr);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (-1 == fd) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "%s() returned %d expected valid file handle\n", FILE_OPEN_FUNCTION_NAME, -1);
@@ -3262,7 +3262,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 
 	SleepFor(1);
 
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, length);
 
 	if (0 != unlockRc) {
@@ -3272,7 +3272,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 	portTestEnv->log("Child 1: Released read lock on bytes %lld for %lld\n", offset, length);
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 
 
 	lockRc = FILE_LOCK_BYTES_FUNCTION(OMRPORTLIB, fd, OMRPORT_FILE_WRITE_LOCK | OMRPORT_FILE_WAIT_FOR_LOCK, (offset + 2), length);
@@ -3285,7 +3285,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 	}
 	portTestEnv->log("Child 1: Got write lock on bytes %lld for %lld\n", (offset + 2), length);
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, offset, (length - 2));
 
 	if (0 != unlockRc) {
@@ -3295,7 +3295,7 @@ omrfile_test25_child_1(OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 	portTestEnv->log("Child 1: Released read lock on bytes %lld for %lld\n", offset, (length - 2));
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	unlockRc = FILE_UNLOCK_BYTES_FUNCTION(OMRPORTLIB, fd, (offset + 2), length);
 
@@ -3445,10 +3445,10 @@ TEST_F(PortFileTest2, file_test27)
 	const char *localFilename = "omrfile_test27.tst";
 	intptr_t fd1, fd2;
 	int32_t expectedMode;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const int32_t allWrite = 0222;
 	const int32_t allRead = 0444;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	const int32_t ownerWritable = 0200;
 	const int32_t ownerReadable = 0400;
 	int32_t m;
@@ -3469,16 +3469,16 @@ TEST_F(PortFileTest2, file_test27)
 	} else {
 		(void)FILE_CLOSE_FUNCTION(OMRPORTLIB, fd1);
 		for (m = 0; m < nModes; ++m) {
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 			if (0 != (testModes[m] & J9S_ISGID)) {
 				continue; /* sgid not support on some versions of AIX */
 			}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 			if (0 != (testModes[m] & (J9S_ISUID | J9S_ISGID))) {
 				continue; /* sgid/suid sometimes ignored on OSX */
 			}
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
-#if defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
+#if (HOST_OS == OMR_WINDOWS)
 			if (allWrite == (testModes[m] & allWrite)) {
 				expectedMode = allRead + allWrite;
 			} else {
@@ -3486,7 +3486,7 @@ TEST_F(PortFileTest2, file_test27)
 			}
 #else
 			expectedMode = testModes[m];
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			rc = omrfile_chmod(localFilename, testModes[m]);
 			if (expectedMode != rc) {
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_chmod() returned %d expected %d\n", rc, expectedMode);
@@ -3542,10 +3542,10 @@ TEST_F(PortFileTest2, file_test28)
 	const char *testName = APPEND_ASYNC(omrfile_test28);
 	const char *localDirectoryName = "omrfile_test28_dir";
 	int32_t expectedMode;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const int32_t allWrite = 0222;
 	const int32_t allRead = 0444;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	int32_t m;
 	int32_t rc;
 #define nModes 22
@@ -3560,16 +3560,16 @@ TEST_F(PortFileTest2, file_test28)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "%s() failed for %s: could not create\n", FILE_OPEN_FUNCTION_NAME, localDirectoryName);
 	} else {
 		for (m = 0; m < nModes; ++m) {
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 			if (0 != (testModes[m] & J9S_ISGID)) {
 				continue; /* sgid not support on some versions of AIX */
 			}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 			if (0 != (testModes[m] & (J9S_ISUID | J9S_ISGID))) {
 				continue; /* sgid/suid sometimes ignored on OSX */
 			}
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
-#if defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
+#if (HOST_OS == OMR_WINDOWS)
 			if (allWrite == (testModes[m] & allWrite)) {
 				expectedMode = allRead + allWrite;
 			} else {
@@ -3577,7 +3577,7 @@ TEST_F(PortFileTest2, file_test28)
 			}
 #else
 			expectedMode = testModes[m];
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			rc = omrfile_chmod(localDirectoryName, testModes[m]);
 			if (expectedMode != rc) {
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_chmod() returned %d expected %d\n", rc, expectedMode);
@@ -3602,13 +3602,13 @@ TEST_F(PortFileTest2, file_test29)
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	const char *testName = APPEND_ASYNC(omrfile_test29);
 	const char *testFile = "omrfile_test29_file";
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	uintptr_t gid, uid;
 	intptr_t rc;
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	reportTestEntry(OMRPORTLIB, testName);
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	omrfile_unlink(testFile);
 	(void)omrfile_create_file(OMRPORTLIB, testFile, 0, testName);
 	gid = omrsysinfo_get_egid();
@@ -3626,7 +3626,7 @@ TEST_F(PortFileTest2, file_test29)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_chown() to root succeeded, should have failed\n");
 	}
 	omrfile_unlink(testFile);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	reportTestExit(OMRPORTLIB, testName);
 }
@@ -3795,10 +3795,10 @@ TEST_F(PortFileTest2, file_test32)
 		goto done;
 	}
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(localFilename, 0666);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(localFilename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
@@ -3807,7 +3807,7 @@ TEST_F(PortFileTest2, file_test32)
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isGroupWriteable != 1'\n");
 	}
@@ -3822,7 +3822,7 @@ TEST_F(PortFileTest2, file_test32)
 	}
 #else
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	omrfile_unlink(localFilename);
 
@@ -3838,10 +3838,10 @@ TEST_F(PortFileTest2, file_test32)
 		goto done;
 	}
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(localFilename, 0444);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(localFilename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 0) {
@@ -3850,7 +3850,7 @@ TEST_F(PortFileTest2, file_test32)
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isGroupWriteable != 0'\n");
 	}
@@ -3865,7 +3865,7 @@ TEST_F(PortFileTest2, file_test32)
 	}
 #else
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	omrfile_unlink(localFilename);
 
@@ -3880,16 +3880,16 @@ TEST_F(PortFileTest2, file_test32)
 		goto done;
 	}
 	FILE_CLOSE_FUNCTION(OMRPORTLIB, fd);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(localFilename, 0222);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(localFilename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserWriteable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*On windows if a file is write-able, then it is also read-able*/
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 1'\n");
@@ -3898,9 +3898,9 @@ TEST_F(PortFileTest2, file_test32)
 	if (stat.perm.isUserReadable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isUserReadable != 0'\n");
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.isGroupWriteable != 1'\n");
 	}
@@ -3917,7 +3917,7 @@ TEST_F(PortFileTest2, file_test32)
 	}
 #else
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 done:
@@ -3962,7 +3962,7 @@ const char *testName = APPEND_ASYNC(omrfile_test33: test UTF - 8 encoding);
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * Test a very long file name
  *
@@ -4098,7 +4098,7 @@ exit:
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 /**
@@ -4110,7 +4110,7 @@ exit:
  *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 int
 omrfile_test34(struct OMRPortLibrary *portLibrary)
 {
@@ -4139,9 +4139,9 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 		goto exit;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	sync();
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	rc = omrfile_stat_filesystem(fileName, 0, &buf_before);
 	if (0 != rc) {
 		portTestEnv->log(LEVEL_ERROR, "first omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
@@ -4173,9 +4173,9 @@ omrfile_test34(struct OMRPortLibrary *portLibrary)
 	omrfile_printf(fd, "%s", stringToWrite);
 	omrfile_sync(fd); /* flush data written to disk */
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	sync();
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	rc = omrfile_stat_filesystem(fileName, 0, &buf_after);
 	if (0 != rc) {
 		portTestEnv->log(LEVEL_ERROR, "second omrfile_stat_filesystem() returned %d, expected %d\n", rc, 0);
@@ -4250,7 +4250,7 @@ const char *testName = APPEND_ASYNC(omrfile_test34_multiple_tries: _test_omrfile
 exit:
 	return reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * Test omrfile_test35
@@ -4365,7 +4365,7 @@ TEST_F(PortFileTest2, file_test36)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /**
  * Verify port file system.
  *
@@ -4716,7 +4716,7 @@ const char *testName = APPEND_ASYNC(omrfile_test39: test file permission bits us
 	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 

--- a/fvtest/porttest/omrfilestreamTest.cpp
+++ b/fvtest/porttest/omrfilestreamTest.cpp
@@ -35,10 +35,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
 #include <windows.h> /* for MAX_PATH */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrcfg.h"
 #include "omrport.h"
@@ -49,9 +49,9 @@
  * CRLFNEWLINES will be defined when we require changing newlines from '\n' to '\r\n'
  */
 #undef CRLFNEWLINES
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CRLFNEWLINES
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Write all data in the buffer. Will write in a loop until all data is sent. If an error occurs,
@@ -759,10 +759,10 @@ TEST(PortFileStreamTest, omrfilestream_test_open_permission_flags)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_close() returned %d expected %d\n", rc, 0);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfilestream_open, so omrfile_chmod() is called*/
 	omrfile_chmod(filename, 0666);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(filename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
@@ -771,7 +771,7 @@ TEST(PortFileStreamTest, omrfilestream_test_open_permission_flags)
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isGroupWriteable != 1'\n");
 	}
@@ -784,9 +784,9 @@ TEST(PortFileStreamTest, omrfilestream_test_open_permission_flags)
 	if (stat.perm.isOtherReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isOtherReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlink(filename);
 	if (0 != rc) {
@@ -816,10 +816,10 @@ readOnlyTest:
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_close() returned %d expected %d\n", rc, 0);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(filename, 0444);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(filename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 0) {
@@ -828,7 +828,7 @@ readOnlyTest:
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isGroupWriteable != 0'\n");
 	}
@@ -841,9 +841,9 @@ readOnlyTest:
 	if (stat.perm.isOtherReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isOtherReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	/*umask vary so we can't test 'isGroupWriteable', 'isGroupReadable', 'isOtherWriteable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlink(filename);
 	if (0 != rc) {
@@ -865,27 +865,27 @@ writeOnlyTest:
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_close() returned %d expected %d\n", rc, 0);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*The mode param is ignored by omrfile_open, so omrfile_chmod() is called*/
 	omrfile_chmod(filename, 0222);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrfile_stat(filename, 0, &stat);
 
 	if (stat.perm.isUserWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserWriteable != 1'\n");
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/*On windows if a file is write-able, then it is also read-able*/
 	if (stat.perm.isUserReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	if (stat.perm.isUserReadable != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isUserReadable != 0'\n");
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (stat.perm.isGroupWriteable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isGroupWriteable != 1'\n");
 	}
@@ -900,9 +900,9 @@ writeOnlyTest:
 	if (stat.perm.isOtherReadable != 1) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfile_stat() error 'stat.perm.isOtherReadable != 1'\n");
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	/*umask vary so we can't test 'isGroupWritable', 'isGroupReadable', 'isOtherWritable', or 'isOtherReadable'*/
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlink(filename);
 	if (0 != rc) {
@@ -915,7 +915,7 @@ exit:
 }
 
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * Test a very long file name. For both relative and absolute paths, build up a directory hierarchy
  * that is greater than the system defined MAX_PATH.
@@ -1054,7 +1054,7 @@ unlinkFile:
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Verify flush.  Check to make sure that a flush will write all data to the file.
@@ -2415,7 +2415,7 @@ TEST(PortFileStreamTest, omrfilestream_test_invalid_filestream_access)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfilestream_close() returned negative error code %d\n", rc);
 		goto unlinkFiles;
 	}
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	/* This test has different behavior on windows, and it will allow you to open files even if you
 	 * do not have the correct permissions.
 	 */
@@ -2423,7 +2423,7 @@ TEST(PortFileStreamTest, omrfilestream_test_invalid_filestream_access)
 	if (NULL != noAccessStream) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrfilestream_open() returned valid file handle, expected NULL\n");
 	}
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 
 	/*

--- a/fvtest/porttest/omrintrospectTest.cpp
+++ b/fvtest/porttest/omrintrospectTest.cpp
@@ -29,9 +29,9 @@
  */
 
 #include "omrport.h"
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include <signal.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include "testHelpers.hpp"
 
 /**

--- a/fvtest/porttest/omrsignalExtendedTest.cpp
+++ b/fvtest/porttest/omrsignalExtendedTest.cpp
@@ -29,10 +29,10 @@
  *
  */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <signal.h>
 #include <pthread.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include <errno.h>
 #include <string.h>
@@ -42,7 +42,7 @@
 #include "omrthread.h"
 #include "testHelpers.hpp"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 typedef enum SignalEvent {
 	INVALID,
 	READY,
@@ -560,4 +560,4 @@ cleanup:
 	portTestEnv->changeIndent(-1);
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */

--- a/fvtest/porttest/omrsignalTest.cpp
+++ b/fvtest/porttest/omrsignalTest.cpp
@@ -35,9 +35,9 @@
  *
  */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <signal.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9ZOS390)
 #include "atoe.h"
@@ -54,9 +54,9 @@
 #include "testProcessHelpers.hpp"
 #include "omrport.h"
 
-#if !defined(OMR_OS_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER)
+#if !(HOST_OS == OMR_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER)
 #define J9SIGNAL_TEST_RUN_ASYNC_UNIX_TESTS
-#endif /* !defined(OMR_OS_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && defined(OMR_PORT_ASYNC_HANDLER) */
 
 #define SIG_TEST_SIZE_EXENAME 1024
 
@@ -74,7 +74,7 @@ struct PortSigMap testSignalMap[] = {
 	{OMRPORT_SIG_FLAG_SIGQUIT, "OMRPORT_SIG_FLAG_SIGQUIT", SIGQUIT, "SIGQUIT"}
 	, {OMRPORT_SIG_FLAG_SIGABRT, "OMRPORT_SIG_FLAG_SIGABRT", SIGABRT, "SIGABRT"}
 	, {OMRPORT_SIG_FLAG_SIGTERM, "OMRPORT_SIG_FLAG_SIGTERM", SIGTERM, "SIGTERM"}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	, {OMRPORT_SIG_FLAG_SIGRECONFIG, "OMRPORT_SIG_FLAG_SIGRECONFIG", SIGRECONFIG, "SIGRECONFIG"}
 #endif
 	/* {OMRPORT_SIG_FLAG_SIGINT, "OMRPORT_SIG_FLAG_SIGINT", SIGINT, "SIGINT"} */
@@ -931,7 +931,7 @@ TEST(PortSigTest, sig_test6)
 		 * to run this test you need to port/unix/omrsignal.c (remove static from declaration of tlsKeyCurrentSignal)
 		 * and add "<export name="tlsKeyCurrentSignal" />" to port/module.xml, to export tlsKeyCurrentSignal.
 		 */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		{
 			extern omrthread_tls_key_t tlsKeyCurrentSignal;
 			int signo = (int)(uintptr_t)omrthread_tls_get(omrthread_self(), tlsKeyCurrentSignal);
@@ -942,7 +942,7 @@ TEST(PortSigTest, sig_test6)
 				outputErrorMessage(PORTTEST_ERROR_ARGS, "currentSignal corrupt -- got: %d expected: %d\n", signo, expectedSigno);
 			}
 		}
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 #endif
 
 	}
@@ -1065,7 +1065,7 @@ TEST(PortSigTest, sig_test8)
 							flags,
 							&result);
 		portTestEnv->log("omrsig_test8 protectResult=%d\n", protectResult);
-#if defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 		if (protectResult != OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH in protectResult\n");
 		}
@@ -1073,7 +1073,7 @@ TEST(PortSigTest, sig_test8)
 		if (protectResult != OMRPORT_SIG_EXCEPTION_OCCURRED) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected OMRPORT_SIG_EXCEPTION_CONTINUE_SEARCH in protectResult\n");
 		}
-#endif /* defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64) */
 		if (result != 0) {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "portLibrary->sig_protect -- expected 0 in *result\n");
 		}
@@ -1126,7 +1126,7 @@ TEST(PortSigTest, sig_test_async_unix_handler)
 		goto exit;
 	}
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	setAsyncRC = omrsig_set_async_signal_handler(asyncTestHandler, &handlerInfo, OMRPORT_SIG_FLAG_SIGRECONFIG);
 	if (setAsyncRC == OMRPORT_SIG_ERROR) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsig_set_async_signal_handler returned: OMRPORT_SIG_ERROR\n");

--- a/fvtest/porttest/omrslTest.cpp
+++ b/fvtest/porttest/omrslTest.cpp
@@ -107,11 +107,11 @@ TEST(PortSlTest, sl_testOpenPathLengths)
 	const char *testName = "omrsl_testOpenPathLengths";
 	uintptr_t handle = 0;
 	uintptr_t rc = 0;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const char *fakeName = "\\temp";
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	const char *fakeName = "/temp";
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	size_t fakeNameLength = strlen(fakeName);
 	char sharedLibName[2*EsMaxPath] = "temp";
 	size_t pathLength = strlen(sharedLibName);
@@ -123,21 +123,21 @@ TEST(PortSlTest, sl_testOpenPathLengths)
 	 * AIX - "lib.so", "lib.a" and ".srvpgm" are added to the input path consecutively
 	 */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	const char *extension = ".dll";
-#elif defined(AIXPPC) /* defined(OMR_OS_WINDOWS) */
+#elif (HOST_OS == OMR_AIX) /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9OS_I5)
 	const char *extension = ".srvpgm";
 #else /* defined(J9OS_I5) */
 	const char *extension = "lib.so";
 #endif /* defined(J9OS_I5) */
-#else /* defined(AIXPPC) */
-#if defined(OSX)
+#else /* (HOST_OS == OMR_AIX) */
+#if (HOST_OS == OMR_OSX)
 	const char *extension = "lib.dylib";
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	const char *extension = "lib.so";
-#endif /* defined(OSX) */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	size_t extensionLength = strlen(extension);
 
@@ -177,7 +177,7 @@ exit:
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 
 /**
  * CMVC 197740
@@ -269,4 +269,4 @@ exit:
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */

--- a/fvtest/porttest/omrstrTest.cpp
+++ b/fvtest/porttest/omrstrTest.cpp
@@ -36,9 +36,9 @@
  * @note port library string operations are not optional in the port library table.
  *
  */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -1416,22 +1416,22 @@ TEST(PortStrTest, str_WinacpToMutf8)
 		'\x1', '\x2', '\x3', '\x4', '\x5', '\x6', '\x7', '\x8',
 		'\x81', '\x91', '\xa1', '\xb1', '\xc1', '\xd1', '\xe1', '\xf1'
 	};
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	char expectedMutf8[] = {
 		'\x1', '\x2', '\x3', '\x4', '\x5', '\x6', '\x7', '\x8',
 		'\xc2', '\x81', '\xe2', '\x80', '\x98', '\xc2', '\xa1', '\xc2', '\xb1', '\xc3', '\x81', '\xc3', '\x91', '\xc3', '\xa1', '\xc3', '\xb1'
 	};
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	const char *testName = "omrstr_WinacpToMutf8";
 	char outBuff[TEST_BUF_LEN];
 	int32_t originalStringLength = sizeof(winacpData);
 	int32_t convertedStringLength = 0;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	int32_t expectedStringLength = sizeof(expectedMutf8);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	reportTestEntry(OMRPORTLIB, testName);
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	{
 		uint32_t defaultACP = GetACP();
 		if (1252 != defaultACP) {
@@ -1439,11 +1439,11 @@ TEST(PortStrTest, str_WinacpToMutf8)
 			reportTestExit(OMRPORTLIB, testName);
 		}
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	memset(outBuff, 0, sizeof(outBuff));
 	convertedStringLength = omrstr_convert(J9STR_CODE_WINDEFAULTACP, J9STR_CODE_MUTF8,
 										   winacpData, originalStringLength,  outBuff, sizeof(outBuff));
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (convertedStringLength != expectedStringLength) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "buffer length wrong.  Expected %d actual %d\n", expectedStringLength, convertedStringLength);
 	}
@@ -1454,7 +1454,7 @@ TEST(PortStrTest, str_WinacpToMutf8)
 	if (OMRPORT_ERROR_STRING_UNSUPPORTED_ENCODING != convertedStringLength) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Failed to detect invalid conversion");
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	reportTestExit(OMRPORTLIB, testName);
 }
 

--- a/fvtest/porttest/omrtimeTest.cpp
+++ b/fvtest/porttest/omrtimeTest.cpp
@@ -38,9 +38,9 @@
  */
 #include <stdlib.h>
 #include <string.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "omrport.h"
@@ -526,7 +526,7 @@ TEST(PortTimeTest, time_nano_time_direction)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/**
 	 * On Windows, if QueryPerformanceCounter is used on a multiprocessor computer,
 	 * time might be different accross CPUs. Therefore skip this test and only
@@ -539,7 +539,7 @@ TEST(PortTimeTest, time_nano_time_direction)
 			reportTestExit(OMRPORTLIB, testName);
 		}
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (0 == omrthread_attach_ex(&self, J9THREAD_ATTR_DEFAULT)) {
 		/* success in starting up thread library and attaching */

--- a/fvtest/porttest/omrttyExtendedTest.cpp
+++ b/fvtest/porttest/omrttyExtendedTest.cpp
@@ -30,9 +30,9 @@
  */
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "testHelpers.hpp"
 #include "omrport.h"
@@ -42,7 +42,7 @@
  *
  * Call omrtty_daemonize, then call omrtty_printf/omrtty_vprintf. If we crash or print anything, then the test has failed.
  */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 TEST(PortTtyTest, tty_daemonize_test)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
@@ -90,4 +90,4 @@ TEST(PortTtyTest, tty_daemonize_test)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/fvtest/porttest/omrvmemTest.cpp
+++ b/fvtest/porttest/omrvmemTest.cpp
@@ -39,9 +39,9 @@
 #include "omrmemcategories.h"
 #include "omrformatconsts.h"
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/vminfo.h>
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 #define TWO_GIG_BAR 0x7FFFFFFF
 #define ONE_MB (1*1024*1024)
@@ -64,9 +64,9 @@
 
 #define allocNameSize 64 /**< @internal buffer size for name function */
 
-#if defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined(J9ZOS390) || (HOST_OS == OMR_OSX)
 #define ENABLE_RESERVE_MEMORY_EX_TESTS
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined(J9ZOS390) || (HOST_OS == OMR_OSX) */
 
 #if defined(ENABLE_RESERVE_MEMORY_EX_TESTS)
 static int omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *, const char *, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
@@ -1523,11 +1523,11 @@ omrvmem_testReserveMemoryEx_StandardAndQuickMode(struct OMRPortLibrary *portLibr
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	int rc = omrvmem_testReserveMemoryEx_impl(OMRPORTLIB, testName, topDown, FALSE, strictAddress, strictPageSize, use2To32G);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	if (TEST_PASS == rc) {
 		rc |= omrvmem_testReserveMemoryEx_impl(OMRPORTLIB, testName, topDown, TRUE, strictAddress, strictPageSize, use2To32G);
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	return rc;
 }
 
@@ -1585,15 +1585,15 @@ omrvmem_testReserveMemoryEx_impl(struct OMRPortLibrary *portLibrary, const char 
 				params[j].endAddress = (void *)(SIXTY_FOUR_GB - 1);
 			} else {
 				params[j].startAddress = (void *)(pageSizes[i] * 2);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 				params[j].endAddress = (void *)(pageSizes[i] * 100);
-#elif defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 				params[j].endAddress = (void *)0x7FFFFFFFFFF;
 #elif defined(OMR_ENV_DATA64)
 				params[j].endAddress = (void *)0xffffffffffffffff;
 #else /* defined(OMR_ENV_DATA64) */
 				params[j].endAddress = (void *)TWO_GIG_BAR;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 			}
 			params[j].byteAmount = pageSizes[i];
 			params[j].mode |= OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT;
@@ -1782,11 +1782,11 @@ memoryIsAvailable(struct OMRPortLibrary *portLibrary, BOOLEAN strictAddress)
 		for (j = 0; j < NUM_SEGMENTS; j++) {
 			omrvmem_vmem_params_init(&params[j]);
 			params[j].startAddress = (void *)(pageSizes[i] * 2);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 			params[j].endAddress = (void *)(pageSizes[i] * 100);
-#elif defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 			params[j].endAddress = (void *) 0x7FFFFFFFFFF;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 			params[j].byteAmount = pageSizes[i];
 			params[j].mode |= OMRPORT_VMEM_MEMORY_MODE_READ | OMRPORT_VMEM_MEMORY_MODE_WRITE | OMRPORT_VMEM_MEMORY_MODE_COMMIT;
 			params[j].pageSize = pageSizes[i];
@@ -2370,7 +2370,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			intptr_t rc;
 			void (*function)();
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 
 			*((unsigned int *)memPtr) = (unsigned int)0x4e800020; /* blr instruction (equivalent to RET on x86)*/
 			__lwsync();
@@ -2388,7 +2388,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			function();
 			portTestEnv->log("Dynamically created function returned successfully\n");
 
-#elif defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(J9ZOS390) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || defined(J9ZOS390) || (HOST_OS == OMR_OSX)
 			size_t length;
 
 #if defined(J9ZOS39064)
@@ -2427,7 +2427,7 @@ TEST(PortVmemTest, vmem_test_reserveExecutableMemory)
 			}
 #endif /* J9ZOS39064 */
 
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 			rc = omrvmem_free_memory(memPtr, params.byteAmount, &vmemID);
 			if (rc != 0) {
@@ -2638,7 +2638,7 @@ verifyFindValidPageSizeOutput(struct OMRPortLibrary *portLibrary,
 	}
 }
 
-#if (defined(LINUX) && !defined(LINUXPPC)) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_LINUX)) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 
 static int
 omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const char *testName)
@@ -2750,11 +2750,11 @@ TEST(PortVmemTest, vmem_testFindValidPageSize)
 {
 	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
 	portTestEnv->changeIndent(1);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define OMRPORT_VMEM_PAGESIZE_COUNT 5	/* This should be same as defined in port/unix_include/j9portpg.h */
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #define OMRPORT_VMEM_PAGESIZE_COUNT 3	/* This should be same as defined in port/win32_include/j9portpg.h */
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	uintptr_t *pageSizes = NULL;
 	uintptr_t *pageFlags = NULL;
@@ -2806,7 +2806,7 @@ _exit:
 	EXPECT_EQ(0, rc) << "Test Failed!";
 }
 
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 static int
 omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const char *testName)
@@ -3014,7 +3014,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	/* Test -Xlp:codecache options */
 
 	/* First get the page size of the data segment. This is the page size used by the JIT code cache if 16M Code Pages are not being used */
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #define SAMPLE_BLOCK_SIZE 4
 	/* Allocate a memory block using omrmem_allocate_memory, and use the address to get the page size of data segment */
 	address = omrmem_allocate_memory(SAMPLE_BLOCK_SIZE, OMRMEM_CATEGORY_PORT_LIBRARY);
@@ -3034,7 +3034,7 @@ omrvmem_testFindValidPageSize_impl(struct OMRPortLibrary *portLibrary, const cha
 	omrmem_free_memory(address);
 #else
 	dataSegmentPageSize = getpagesize();
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	portTestEnv->log("Page size of data segment: 0x%zx\n", dataSegmentPageSize);
 
@@ -4176,14 +4176,14 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL did not fail";
 	EXPECT_EQ(0u, size) << "value updated when query invalid";
 #else
-#if !defined(OSX)
+#if !(HOST_OS == OMR_OSX)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PRIVATE, &size);
 	EXPECT_EQ(0, result) << "OMRPORT_VMEM_PROCESS_PRIVATE failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_PRIVATE returned 0";
 	portTestEnv->log("OMRPORT_VMEM_PROCESS_PRIVATE = %lu.\n", size);
-#endif /* !defined(OSX) */
+#endif /* !(HOST_OS == OMR_OSX) */
 
-#if defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PHYSICAL, &size);
 	EXPECT_EQ(0, result) << "OMRPORT_VMEM_PROCESS_PHYSICAL failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_PHYSICAL returned 0";
@@ -4193,7 +4193,7 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	EXPECT_EQ(0, result) << "OMRPORT_VMEM_PROCESS_VIRTUAL failed";
 	EXPECT_TRUE(size > 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL returned 0";
 	portTestEnv->log("OMRPORT_VMEM_PROCESS_VIRTUAL = %lu.\n", size);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	size = 0;
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_PHYSICAL, &size);
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_PHYSICAL did not fail";
@@ -4202,7 +4202,7 @@ TEST(PortVmemTest, vmem_testGetProcessMemorySize)
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_VIRTUAL, &size);
 	EXPECT_TRUE(result < 0) << "OMRPORT_VMEM_PROCESS_VIRTUAL did not fail";
 	EXPECT_EQ(0u, size) << "value updated when query invalid";
-#endif /* defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 #endif /* defined(J9ZOS390) */
 	size = 0;
 	result = omrvmem_get_process_memory_size(OMRPORT_VMEM_PROCESS_EnsureWideEnum, &size);

--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -27,10 +27,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
-#endif /* defined(OMR_OS_WINDOWS) */
-#if !defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_WINDOWS) */
+#if !(HOST_OS == OMR_WINDOWS)
 #include <grp.h>
 #include <errno.h>
 #if defined(J9ZOS390)
@@ -40,7 +40,7 @@
 #include <stdint.h> /* For INT64_MAX. */
 #endif /* defined(J9ZOS390) */
 #include <sys/resource.h> /* For RLIM_INFINITY */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9ZOS390)
 #define _UNIX03_SOURCE
@@ -49,13 +49,13 @@
 
 #include "testHelpers.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define J9DIRECTORY_SEPARATOR_CHARACTER '\\'
 #define J9FILE_EXTENSION ".exe"
 #define J9FILE_EXTENSION_LENGTH (sizeof(J9FILE_EXTENSION) - 1)
 #else
 #define J9DIRECTORY_SEPARATOR_CHARACTER '/'
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /* Under the standard compiler configuration, INT64_MAX is
  * not available; instead, LONGLONG_MAX is defined by xLC.
@@ -104,7 +104,7 @@ validate_executable_name(const char *expected, const char *found)
 	/* On Windows, disregard comparing the extension, should this be dropped on the command
 	 * line (API always returns executable name including the extension (.exe).
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Check whether argv0 ends with the extension ".exe".  If not, we need to reduce
 	 * the number of characters to compare (against the executable name found by API).
 	 */
@@ -113,7 +113,7 @@ validate_executable_name(const char *expected, const char *found)
 				J9FILE_EXTENSION_LENGTH) != 0) {
 		length -= J9FILE_EXTENSION_LENGTH;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	if (length == expected_length) {
 		if (strncmp(found_base_path, expected_base_path, length) == 0) {
 			return TRUE;
@@ -132,12 +132,12 @@ TEST(PortSysinfoTest, sysinfo_test0)
 
 	reportTestEntry(OMRPORTLIB, testName);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Remove extra "./" from the front of executable name. */
 	if (0 == strncmp(argv0, "./", 2)) {
 		argv0 = &argv0[2];
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrsysinfo_get_executable_name(NULL, &executable_name);
 	if (-1 == rc) {
@@ -336,7 +336,7 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 		portTestEnv->log(msg);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (NULL == strstr(osName, "Windows")) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_get_OS_version does not contain \"Windows\".\n", 0, 1);
 		reportTestExit(OMRPORTLIB, testName);
@@ -350,7 +350,7 @@ TEST(PortSysinfoTest, sysinfo_get_OS_type_test)
 		reportTestExit(OMRPORTLIB, testName);
 		return;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	reportTestExit(OMRPORTLIB, testName);
 }
 
@@ -615,8 +615,8 @@ done:
 
 
 /* sysinfo_set_limit and sysinfo_get_limit tests will not work on windows */
-#if !defined(OMR_OS_WINDOWS)
-#if !(defined(AIXPPC) || defined(J9ZOS390))
+#if !(HOST_OS == OMR_WINDOWS)
+#if !((HOST_OS == OMR_AIX) || defined(J9ZOS390))
 /**
  *
  * Test omrsysinfo_test_sysinfo_set_limit and omrsysinfo_test_sysinfo_get_limit
@@ -718,7 +718,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_ADDRESS_SPACE)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !(defined(AIXPPC) || defined(J9ZOS390)) */
+#endif /* !((HOST_OS == OMR_AIX) || defined(J9ZOS390)) */
 
 /**
  *
@@ -997,7 +997,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FILE)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /**
  *
  * Test omrsysinfo_test_sysinfo_set_limit and omrsysinfo_test_sysinfo_get_limit
@@ -1089,7 +1089,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_set_limit_CORE_FLAGS)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 /**
  * Test omrsysinfo_test_sysinfo_get_limit for resource OMRPORT_RESOURCE_FILE_DESCRIPTORS.
@@ -1179,7 +1179,7 @@ TEST(PortSysinfoTest, sysinfo_test_sysinfo_get_limit_FILE_DESCRIPTORS)
 	}
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /* Since the processor and memory usage port library APIs are not available on zOS (neither
  * 31-bit not 64-bit) yet, so we exclude these tests from running on zOS. When the zOS
@@ -1213,31 +1213,31 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.availPhysical)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.totalSwap)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.availSwap)
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.totalVirtual)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.availVirtual)
-#else /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#else /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			/* We do not check totalVirtual since it may be set to some value or -1, depending
 			 * on whether there is a limit set for this or not on the box.
 			 */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.availVirtual)
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
-#if defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 			/* Size of the file buffer area is not available on Windows, AIX and OSX. Therefore,
 			 * it must be set to OMRPORT_MEMINFO_NOT_AVAILABLE.
 			 */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.buffered)
-#else /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			/* On platforms where buffer area is defined, OMRPORT_MEMINFO_NOT_AVAILABLE is
 			 * surely a failure!
 			 */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.buffered)
-#endif /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 #if defined (OSX)
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE != memInfo.cached)
 #else /* defined (OSX) */
 			|| (OMRPORT_MEMINFO_NOT_AVAILABLE == memInfo.cached)
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 		) {
 
 			/* Fail pltest if one of these memory usage parameters were found inconsistent. */
@@ -1249,13 +1249,13 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 		/* Validate the statistics that we obtained. */
 		if ((memInfo.totalPhysical > 0) &&
 			(memInfo.availPhysical <= memInfo.totalPhysical) &&
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			/* Again, it does not make sense to do checks and comparisons on Virtual Memory
 			 * on places other than Windows.
 			 */
 			(memInfo.totalVirtual > 0) &&
 			(memInfo.availVirtual <= memInfo.totalVirtual) &&
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			(memInfo.availSwap <= memInfo.totalSwap) &&
 			(memInfo.timestamp > 0)) {
 
@@ -1263,10 +1263,10 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			portTestEnv->log("Retrieved memory usage statistics.\n");
 			portTestEnv->log("Total physical memory: %llu bytes.\n", memInfo.totalPhysical);
 			portTestEnv->log("Available physical memory: %llu bytes.\n", memInfo.availPhysical);
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 			portTestEnv->log("Total virtual memory: %llu bytes.\n", memInfo.totalVirtual);
 			portTestEnv->log("Available virtual memory: %llu bytes.\n", memInfo.availVirtual);
-#else /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#else /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			/* This may or may not be available depending on whether a limit is set. Print out if this
 			 * is available or else, call this parameter "undefined".
 			 */
@@ -1277,19 +1277,19 @@ TEST(PortSysinfoTest, sysinfo_testMemoryInfo)
 			}
 			/* Leave Available Virtual memory parameter as it is on non-Windows Platforms. */
 			portTestEnv->log("Available virtual memory: <undefined>.\n");
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 			portTestEnv->log("Total swap memory: %llu bytes.\n", memInfo.totalSwap);
 			portTestEnv->log("Swap memory free: %llu bytes.\n", memInfo.availSwap);
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 			portTestEnv->log("Cache memory: <undefined>.\n");
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 			portTestEnv->log("Cache memory: %llu bytes.\n", memInfo.cached);
-#endif /* defined(OSX) */
-#if defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined (OSX)
+#endif /* (HOST_OS == OMR_OSX) */
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined (OSX)
 			portTestEnv->log("Buffers memory: <undefined>.\n");
-#else /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined (OSX) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined (OSX) */
 			portTestEnv->log("Buffers memory: %llu bytes.\n", memInfo.buffered);
-#endif /* defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined (OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || defined (OSX) */
 			portTestEnv->log("Timestamp: %llu.\n", memInfo.timestamp);
 		} else {
 			outputErrorMessage(PORTTEST_ERROR_ARGS, "Invalid memory usage statistics retrieved.\n");
@@ -1421,11 +1421,11 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 	portTestEnv->log("User time:   %lld.\n", currInfo.procInfoArray[0].userTime);
 	portTestEnv->log("System time: %lld.\n", currInfo.procInfoArray[0].systemTime);
 	portTestEnv->log("Idle time:   %lld.\n", currInfo.procInfoArray[0].idleTime);
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	portTestEnv->log("Wait time:   <undefined>.\n");
 #else /* Non-windows/OSX platforms */
 	portTestEnv->log("tWait time:   %lld.\n", currInfo.procInfoArray[0].waitTime);
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 	portTestEnv->log("Busy time:   %lld.\n", currInfo.procInfoArray[0].busyTime);
 	portTestEnv->changeIndent(-1);
 
@@ -1439,12 +1439,12 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 			if ((OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].userTime) &&
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].systemTime) &&
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].idleTime) &&
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 				/* Windows and OSX do not have the notion of Wait times. */
 				(OMRPORT_PROCINFO_NOT_AVAILABLE == currInfo.procInfoArray[cntr].waitTime) &&
 #else /* Non-windows/OSX platforms */
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].waitTime) &&
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 				(OMRPORT_PROCINFO_NOT_AVAILABLE != currInfo.procInfoArray[cntr].busyTime)) {
 
 				/* Print out processor times in each mode for each CPU that is online. */
@@ -1453,11 +1453,11 @@ TEST(PortSysinfoTest, sysinfo_testProcessorInfo)
 				portTestEnv->log("User time:   %lld.\n", currInfo.procInfoArray[cntr].userTime);
 				portTestEnv->log("System time: %lld.\n", currInfo.procInfoArray[cntr].systemTime);
 				portTestEnv->log("Idle time:   %lld.\n", currInfo.procInfoArray[cntr].idleTime);
-#if defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 				portTestEnv->log("Wait time:   <undefined>.\n");
 #else /* Non-windows/OSX platforms */
 				portTestEnv->log("Wait time:   %lld.\n", currInfo.procInfoArray[cntr].waitTime);
-#endif /* defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 				portTestEnv->log("Busy time:   %lld.\n", currInfo.procInfoArray[cntr].busyTime);
 				portTestEnv->changeIndent(-1);
 			} else {
@@ -1716,7 +1716,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	const char *data = "Hello World!";
 	intptr_t tmpFile = 0;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	wchar_t *origEnv = NULL;
 	const unsigned char utf8[]       = {0x63, 0x3A, 0x5C, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB1, 0xD0, 0xB0, 0x5C, 0x00};
 	const unsigned char utf8_file[]  = {0x63, 0x3A, 0x5C, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB1, 0xD0, 0xB0, 0x5C, 0x74, 0x65, 0x73, 0x74, 0x2E, 0x74, 0x78, 0x74, 0x00};
@@ -1727,7 +1727,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	origEnv = (wchar_t *)omrmem_allocate_memory(EsMaxPath, OMRMEM_CATEGORY_PORT_LIBRARY);
 	wcscpy(origEnv, _wgetenv(L"TMP"));
 	rc = _wputenv_s(L"TMP", unicode);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	char *origEnv = NULL;
 	const char *utf8 = "/tmp/test/";
 	const char *utf8_file = "/tmp/test/test.txt";
@@ -1756,7 +1756,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	rc = setenv("TMPDIR", (const char *)utf8, 1);
 #endif /* defined(J9ZOS390) */
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (0 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error to update environment variable rc: %d\n", rc);
@@ -1806,20 +1806,20 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	}
 
 	if (NULL != origEnv) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		_wputenv_s(L"TMP", origEnv);
-#elif defined(J9ZOS390) /* defined(OMR_OS_WINDOWS) */
+#elif defined(J9ZOS390) /* (HOST_OS == OMR_WINDOWS) */
 		setenv(envVarInEbcdic, origEnvInEbcdic, 1);
 #else /* defined(J9ZOS390) */
 		setenv("TMPDIR", origEnv, 1);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		omrmem_free_memory(origEnv);
 	} else {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		_wputenv_s(L"TMP", L"");
-#elif !defined(J9ZOS390) /* defined(OMR_OS_WINDOWS) */
+#elif !defined(J9ZOS390) /* (HOST_OS == OMR_WINDOWS) */
 		unsetenv("TMPDIR");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	}
 
 #if defined(J9ZOS390)
@@ -1840,7 +1840,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp3)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /*
  * Test omrsysinfo_get_tmp when ignoreEnvVariable is FALSE/TRUE
  * Expected result size of buffer required
@@ -1948,7 +1948,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_tmp4)
 
 	reportTestExit(OMRPORTLIB, testName);
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /*
  * Test omrsysinfo_get_cwd when the buffer size == 0, then allocate required ammount of bites and try again.
@@ -2022,7 +2022,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	char *buffer = NULL;
 	char *orig_cwd = NULL;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* c:\U+6211 U+7684 U+7236 U+4EB2 U+662F U+6536 U+68D2 U+5B50 U+7684 */
 	const wchar_t unicode[] = {0x0063, 0x003A, 0x005C, 0x6211, 0x7684, 0x7236, 0x4EB2, 0x662F, 0x6536, 0x68D2, 0x5B50, 0x7684, 0x005C, 0x00};
 	const unsigned char utf8[]       = {0x63, 0x3A, 0x5C, 0xE6, 0x88, 0x91, 0xE7, 0x9A, 0x84, 0xE7, 0x88, 0xB6, 0xE4, 0xBA, 0xB2, 0xE6, 0x98, 0xAF, 0xE6, 0x94, 0xB6, 0xE6, 0xA3, 0x92, 0xE5, 0xAD, 0x90, 0xE7, 0x9A, 0x84, 0x5C, 0x00};
@@ -2041,12 +2041,12 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error failed to change current directory rc: %d\n", rc);
 	}
 #else
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	/* On OSX, /tmp is a symbolic link to /private/tmp. For the cwd to match after chdir, use /private/tmp. */
 	const char *utf8 = "/private/tmp/omrsysinfo_test_get_cwd3/";
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	const char *utf8 = "/tmp/omrsysinfo_test_get_cwd3/";
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	reportTestEntry(OMRPORTLIB, testName);
 
@@ -2069,7 +2069,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	} else {
 		portTestEnv->log("cd %s\n", utf8);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	buffer = (char *)omrmem_allocate_memory(EsMaxPath, OMRMEM_CATEGORY_PORT_LIBRARY);
 	rc = omrsysinfo_get_cwd(buffer, EsMaxPath);
@@ -2085,16 +2085,16 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "invalid directory rc: %d\n", rc);
 	}
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	_chdir(orig_cwd); /* we need to exit current directory before deleting it*/
 #elif defined(J9ZOS390)
 	atoe_chdir(orig_cwd);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	rc = chdir(orig_cwd);
 	if (-1 == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "error: failed to change to directory %s, errno: %d\n", (const char *)orig_cwd, errno);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	rc = omrfile_unlinkdir((const char *)utf8);
 	if (-1 == rc) {
@@ -2106,7 +2106,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_cwd3)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /**
  * Test omrsysinfo_get_groups.
  */
@@ -2167,7 +2167,7 @@ TEST(PortSysinfoTest, sysinfo_test_get_groups)
 	reportTestExit(OMRPORTLIB, testName);
 }
 
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 /**
  * Test omrsysinfo_test_get_open_file_count.
  * Available only on Linux and AIX.
@@ -2236,8 +2236,8 @@ TEST(PortSysinfoTest, sysinfo_test_get_open_file_count)
 	reportTestExit(OMRPORTLIB, testName);
 	return;
 }
-#endif /* defined(LINUX) || defined(AIXPPC) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * Test omrsysinfo_test_get_os_description.
@@ -2277,7 +2277,7 @@ TEST(PortSysinfoTest, sysinfo_test_os_kernel_info)
 
 	rc = omrsysinfo_os_kernel_info(&kernelInfo);
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	/* Throw an error if failure happens on Linux */
 	if (FALSE == rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS,
@@ -2290,13 +2290,13 @@ TEST(PortSysinfoTest, sysinfo_test_os_kernel_info)
 			goto exit;
 		}
 	}
-#else /* defined(LINUX) */
+#else /* (HOST_OS == OMR_LINUX) */
 	if (TRUE == rc) {
 		/* Throw an error if omrsysinfo_os_kernel_info passes on an unsupported platform */
 		outputErrorMessage(PORTTEST_ERROR_ARGS,	"omrsysinfo_os_kernel_info passed on an unsupported platform\n");
 		goto exit;
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 exit:
 	reportTestExit(OMRPORTLIB, testName);
@@ -2318,7 +2318,7 @@ TEST(PortSysinfoTest, sysinfo_cgroup_get_memlimit)
 
 	rc = omrsysinfo_cgroup_get_memlimit(&cgroupMemLimit);
 
-#if !defined(LINUX)
+#if !(HOST_OS == OMR_LINUX)
 	if (OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "omrsysinfo_cgroup_get_memlimit returned %d, expected %d on platform that does not support cgroups\n", rc, OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM);
 	}

--- a/fvtest/porttest/testHelpers.cpp
+++ b/fvtest/porttest/testHelpers.cpp
@@ -449,7 +449,7 @@ raiseSEGV(OMRPortLibrary *portLibrary, void *arg)
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 	const char *testName = (const char *)arg;
 
-#if defined(OMR_OS_WINDOWS) || defined (J9ZOS390)
+#if (HOST_OS == OMR_WINDOWS) || defined (J9ZOS390)
 	/*
 	 * - Windows structured exception handling doesn't interact with raise().
 	 * - z/OS doesn't provide a value for the psw1 (PC) register when you use raise()
@@ -459,7 +459,7 @@ raiseSEGV(OMRPortLibrary *portLibrary, void *arg)
 	*ptr = -1;
 #else
 	raise(SIGSEGV);
-#endif /* defined(OMR_OS_WINDOWS) || defined (J9ZOS390) */
+#endif /* (HOST_OS == OMR_WINDOWS) || defined (J9ZOS390) */
 
 	outputErrorMessage(PORTTEST_ERROR_ARGS, "unexpectedly continued execution");
 

--- a/fvtest/porttest/testProcessHelpers.cpp
+++ b/fvtest/porttest/testProcessHelpers.cpp
@@ -20,15 +20,15 @@
  *******************************************************************************/
 
 /* These headers are required for ChildrenTest */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <process.h>
 #include <Windows.h>
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <fcntl.h>
 #include <stdlib.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -36,7 +36,7 @@
 #include <sys/sem.h>
 #include <errno.h>
 #define PROCESS_HELPER_SEM_KEY 0x05CAC8E /* Reads OSCACHE */
-#endif /* defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 #if defined(J9ZOS390)
 #include <spawn.h>
@@ -54,9 +54,9 @@
 #define PORTTEST_PROCESS_HELPERS_DEBUG
 #endif
 
-#if defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 
-#if (defined(__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)) || defined(OSX)
+#if (defined(__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)) || (HOST_OS == OMR_OSX)
 /* union semun is defined by including <sys/sem.h> */
 #else
 /* according to X/OPEN we have to define it ourselves */
@@ -68,12 +68,12 @@ union semun {
 };
 #endif
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static int setFdCloexec(int fd);
-#if !defined(OSX)
+#if !(HOST_OS == OMR_OSX)
 static intptr_t translateModifiedUtf8ToPlatform(OMRPortLibrary *portLibrary, const char *inBuffer, uintptr_t inBufferSize, char **outBuffer);
-#endif /* !defined(OSX) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_OSX) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 intptr_t
 openLaunchSemaphore(OMRPortLibrary *portLibrary, const char *name, uintptr_t nProcess)
@@ -139,7 +139,7 @@ CloseLaunchSemaphore(OMRPortLibrary *portLibrary, intptr_t semaphore)
 	return semctl(semaphore, 0, IPC_RMID, 0);
 }
 
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 intptr_t
 openLaunchSemaphore(OMRPortLibrary *portLibrary, const char *name, uintptr_t nProcess)
 {
@@ -199,7 +199,7 @@ CloseLaunchSemaphore(OMRPortLibrary *portLibrary, intptr_t semaphore)
 	}
 	return -1;
 }
-#else /* defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 /* Not supported on anything else */
 intptr_t
 openLaunchSemaphore(OMRPortLibrary *portLibrary, const char *name, uintptr_t nProcess)
@@ -222,7 +222,7 @@ CloseLaunchSemaphore(OMRPortLibrary *portLibrary, intptr_t semaphore)
 	return -1;
 }
 
-#endif /* defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 OMRProcessHandle
 launchChildProcess(OMRPortLibrary *portLibrary, const char *testname, const char *argv0, const char *options)
@@ -332,14 +332,14 @@ done:
 void
 SleepFor(intptr_t second)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	Sleep((DWORD)second * 1000);
-#elif defined(LINUX) || defined(J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	sleep(second);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 static int
 setFdCloexec(int fd)
 {
@@ -354,7 +354,7 @@ setFdCloexec(int fd)
 	return rc;
 }
 
-#if !defined(OSX)
+#if !(HOST_OS == OMR_OSX)
 static intptr_t
 translateModifiedUtf8ToPlatform(OMRPortLibrary *portLibrary, const char *inBuffer, uintptr_t inBufferSize, char **outBuffer)
 {
@@ -393,8 +393,8 @@ translateModifiedUtf8ToPlatform(OMRPortLibrary *portLibrary, const char *inBuffe
 		return 0;
 	}
 }
-#endif /* !defined(OSX) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_OSX) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 intptr_t
 j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, uint32_t options)
@@ -403,7 +403,7 @@ j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, ui
 	int32_t rc = 0;
 	OMRProcessHandleStruct *processHandleStruct = (OMRProcessHandleStruct *)*processHandle;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (!CloseHandle((HANDLE)processHandleStruct->procHandle)) {
 		rc = OMRPROCESS_ERROR;
 	}
@@ -423,7 +423,7 @@ j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, ui
 			rc = OMRPROCESS_ERROR;
 		}
 	}
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	if (OMRPROCESS_INVALID_FD != processHandleStruct->inHandle) {
 		if (0 != close((int) processHandleStruct->inHandle)) {
 			rc = OMRPROCESS_ERROR;
@@ -439,7 +439,7 @@ j9process_close(OMRPortLibrary *portLibrary, OMRProcessHandle *processHandle, ui
 			rc = OMRPROCESS_ERROR;
 		}
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	omrmem_free_memory(processHandleStruct);
 	processHandleStruct = *processHandle = NULL;
 
@@ -450,7 +450,7 @@ intptr_t j9process_waitfor(OMRPortLibrary *portLibrary, OMRProcessHandle process
 {
 	OMRProcessHandleStruct *processHandleStruct = (OMRProcessHandleStruct *) processHandle;
 	intptr_t rc = OMRPROCESS_ERROR;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (WAIT_OBJECT_0 == WaitForSingleObject((HANDLE) processHandleStruct->procHandle, INFINITE)) {
 		DWORD procstat = 0;
 
@@ -461,7 +461,7 @@ intptr_t j9process_waitfor(OMRPortLibrary *portLibrary, OMRProcessHandle process
 	}
 
 	return rc;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	int statusLocation = -1;
 	pid_t retVal = waitpid((pid_t)processHandleStruct->procHandle, &statusLocation, 0);
 
@@ -473,7 +473,7 @@ intptr_t j9process_waitfor(OMRPortLibrary *portLibrary, OMRProcessHandle process
 	} else {
 		rc = OMRPROCESS_ERROR;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	return rc;
 }
 
@@ -484,7 +484,7 @@ j9process_get_exitCode(OMRPortLibrary *portLibrary, OMRProcessHandle processHand
 	return processHandleStruct->exitCode;
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 typedef struct OMRProcessWin32Pipes {
 	HANDLE inR;
 	HANDLE inW;
@@ -644,7 +644,7 @@ getUnicodeCmdline(struct OMRPortLibrary *portLibrary, const char *command[], uin
 	return rc;
 }
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 intptr_t
 j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t commandLength, const char *dir, uint32_t options, OMRProcessHandle *processHandle)
@@ -653,7 +653,7 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	intptr_t rc = 0;
 	OMRProcessHandleStruct *processHandleStruct = NULL;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	STARTUPINFOW sinfo;
 	PROCESS_INFORMATION pinfo;
 	SECURITY_ATTRIBUTES sAttrib;
@@ -813,7 +813,7 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	}
 
 	return rc;
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	const char *cmd = NULL;
 	int grdpid;
 	unsigned int i;
@@ -891,10 +891,10 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	memset(newCommand, 0, newCommandSize);
 
 	for (i = 0 ; i < commandLength; i += 1) {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		newCommand[i] = (char *)omrmem_allocate_memory(strlen(command[i]) + 1, OMRMEM_CATEGORY_PORT_LIBRARY);
 		omrstr_printf(newCommand[i], strlen(command[i]) + 1, command[i]);
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 		intptr_t translateStatus = translateModifiedUtf8ToPlatform(OMRPORTLIB, command[i], strlen(command[i]), &(newCommand[i]));
 		if (0 != translateStatus) {
 			unsigned int j = 0;
@@ -906,7 +906,7 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 			}
 			return translateStatus;
 		}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	}
 	cmd = newCommand[0];
 
@@ -1033,5 +1033,5 @@ j9process_create(OMRPortLibrary *portLibrary, const char *command[], uintptr_t c
 	}
 
 	return OMRPROCESS_ERROR;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/fvtest/rastest/agentNegativeTest.cpp
+++ b/fvtest/rastest/agentNegativeTest.cpp
@@ -21,13 +21,13 @@
 
 #include "omrcfg.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* Undefine the winsockapi because winsock2 defines it.  Removes warnings. */
 #if defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
 #undef _WINSOCKAPI_
 #endif
 #include <winsock2.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrport.h"
 #include "omr.h"
@@ -44,21 +44,21 @@ protected:
 	SetUp()
 	{
 		OMRTEST_ASSERT_ERROR_NONE(omrTestVMInit(&testVM, rasTestEnv->getPortLibrary()));
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		/* initialize sockets so that we can use gethostname() */
 		WORD wsaVersionRequested = MAKEWORD(2, 2);
 		WSADATA wsaData;
 		int wsaErr = WSAStartup(wsaVersionRequested, &wsaData);
 		ASSERT_EQ(0, wsaErr);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	}
 
 	virtual void
 	TearDown()
 	{
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		WSACleanup();
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		OMRTEST_ASSERT_ERROR_NONE(omrTestVMFini(&testVM));
 	}
 
@@ -170,13 +170,13 @@ TEST_F(RASAgentNegativeTest, CorruptedAgent)
 	 *  for Unix, fileName = libcorruptedAgent_<hostname>.so
 	 *  for OSX, fileName = libcorruptedAgent_<hostname>.dylib
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	omrstr_printf(fileName, sizeof(fileName), "%s.dll", agentName);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	omrstr_printf(fileName, sizeof(fileName), "lib%s.dylib", agentName);
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	omrstr_printf(fileName, sizeof(fileName), "lib%s.so", agentName);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	/* create the empty agent file with permission 751*/
 	fileDescriptor = omrfile_open(fileName, EsOpenCreate | EsOpenWrite, 0751);

--- a/fvtest/rastest/bindthreadagent.c
+++ b/fvtest/rastest/bindthreadagent.c
@@ -140,11 +140,11 @@ waitForTestChildThread(OMR_TI const *ti, OMR_VM *testVM, omrthread_t childThead,
 	 * Sleep for 0.2 sec to avoid unloading the agent library before the child thread has completed.
 	 * For more detail, please see JAZZ103 74016
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	Sleep(200);
 #else
 	usleep(200000);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	return childRc;
 }

--- a/fvtest/rastest/cpuLoadAgent.c
+++ b/fvtest/rastest/cpuLoadAgent.c
@@ -441,11 +441,11 @@ systemTimeCPUBurn(void)
 	FILE *tempFile = NULL;
 
 	for (j = 0; j < NUM_ITERATIONS_SYSTEM_CPU_BURN; j++) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		tempFile = fopen("nul", "w");
 #else
 		tempFile = fopen("/dev/null", "w");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		fwrite("garbage", 1, sizeof("garbage"), tempFile);
 		fclose(tempFile);
 	}

--- a/fvtest/rastest/traceTest.cpp
+++ b/fvtest/rastest/traceTest.cpp
@@ -110,11 +110,11 @@ TEST(RASTraceTest, TraceAgent)
 #endif /* TEST_TRACEAGENT */
 
 	/* Load sampleSubscriber agent */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	agent = omr_agent_create(&testVM.omrVM, "sampleSubscriber=NUL");
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	agent = omr_agent_create(&testVM.omrVM, "sampleSubscriber=/dev/null");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	ASSERT_FALSE(NULL == agent) << "testAgent: createAgent() sampleSubscriber failed";
 
 	OMRTEST_ASSERT_ERROR_NONE(omr_agent_openLibrary(agent));

--- a/fvtest/rastest/traceagent.c
+++ b/fvtest/rastest/traceagent.c
@@ -252,7 +252,7 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 	omr_error_t rc = OMR_ERROR_NONE;
 	omr_error_t testRc = OMR_ERROR_NONE;
 	uint64_t memorySize = 0;
-#if defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_ERROR(ti->GetFreePhysicalMemorySize(vmThread, &memorySize));
 		if (OMR_ERROR_NONE != rc) {
@@ -262,7 +262,7 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 			omrtty_printf("%s:%d Free physical memory size (in bytes): %llu, rc = %d (%s), the function call is successful !\n", __FILE__, __LINE__, memorySize, rc, omrErrorToString(rc));
 		}
 	}
-#if defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_ERROR(ti->GetProcessVirtualMemorySize(vmThread, &memorySize));
 		if (OMR_ERROR_NONE != rc) {
@@ -281,8 +281,8 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 			omrtty_printf("%s:%d Process physical memory size (in bytes): %llu, rc = %d (%s), the function call is successful !\n", __FILE__, __LINE__, memorySize, rc, omrErrorToString(rc));
 		}
 	}
-#endif /* defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX) */
-#if defined(LINUX) || defined(AIXPPC)|| defined(OMR_OS_WINDOWS)
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)|| (HOST_OS == OMR_WINDOWS)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_ERROR(ti->GetProcessPrivateMemorySize(vmThread, &memorySize));
 		if (OMR_ERROR_NONE != rc) {
@@ -292,8 +292,8 @@ testTraceAgentGetMemorySize(OMR_VMThread *vmThread, OMR_TI const *ti)
 			omrtty_printf("%s:%d Process private memory size (in bytes): %llu, rc = %d (%s), the function call is successful !\n", __FILE__, __LINE__, memorySize, rc, omrErrorToString(rc));
 		}
 	}
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) */
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 	return testRc;
 }
 
@@ -307,9 +307,9 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 	int32_t traceMetaLength = 0;
 	UtSubscription *subscriptionID = NULL;
 	uint64_t *invalidMemorySizePtr = NULL;
-#if !defined(LINUX) && !defined(OMR_OS_WINDOWS) && !defined(OSX)
+#if !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX)
 	uint64_t memorySize = -1;
-#endif /* !defined(LINUX) && !defined(OMR_OS_WINDOWS) && !defined(OSX) */
+#endif /* !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX) */
 
 	rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetTraceMetadata(vmThread, NULL, &traceMetaLength), OMR_ERROR_ILLEGAL_ARGUMENT);
 	if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
@@ -350,7 +350,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 	}
 
 	/* Test with invalidMemorySizePtr, OMR_ERROR_ILLEGAL_ARGUMENT is expected */
-#if defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetFreePhysicalMemorySize(vmThread, invalidMemorySizePtr), OMR_ERROR_ILLEGAL_ARGUMENT);
 		if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
@@ -364,7 +364,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 			testRc = OMR_ERROR_INTERNAL;
 		}
 	}
-#if defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetProcessVirtualMemorySize(vmThread, invalidMemorySizePtr), OMR_ERROR_ILLEGAL_ARGUMENT);
 		if (OMR_ERROR_ILLEGAL_ARGUMENT != rc) {
@@ -378,11 +378,11 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 			testRc = OMR_ERROR_INTERNAL;
 		}
 	}
-#endif /* defined(LINUX) || defined(OMR_OS_WINDOWS) || defined(OSX) */
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OMR_OS_WINDOWS) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_WINDOWS) || (HOST_OS == OMR_OSX) */
 
 	/* Test GetFreePhysicalMemorySize and GetProcessPrivateMemorySize on platforms other than LINUX, AIXPPC and WIN, OMR_ERROR_NOT_AVAILABLE is expected */
-#if !defined(LINUX) && !defined(AIXPPC) && !defined(OMR_OS_WINDOWS)  && !defined(OSX)
+#if !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_WINDOWS)  && !(HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetFreePhysicalMemorySize(vmThread, &memorySize), OMR_ERROR_NOT_AVAILABLE);
 		if (OMR_ERROR_NOT_AVAILABLE != rc) {
@@ -398,7 +398,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 	}
 
 	/* Test GetProcessVirtualMemorySize and GetProcessPhysicalMemorySize on platforms other than LINUX and WIN, OMR_ERROR_NOT_AVAILABLE is expected */
-#elif !defined(LINUX) && !defined(OMR_OS_WINDOWS) && !defined(OSX)
+#elif !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX)
 	if (OMR_ERROR_NONE == testRc) {
 		rc = OMRTEST_PRINT_UNEXPECTED_RC(ti->GetProcessVirtualMemorySize(vmThread, &memorySize), OMR_ERROR_NOT_AVAILABLE);
 		if (OMR_ERROR_NOT_AVAILABLE != rc) {
@@ -413,7 +413,7 @@ testNegativeCases(OMR_VMThread *vmThread, OMR_TI const *ti)
 		}
 	}
 
-#endif /* !defined(LINUX) && !defined(AIXPPC) && !defined(OMR_OS_WINDOWS) && !defined(OSX) */
+#endif /* !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_AIX) && !(HOST_OS == OMR_WINDOWS) && !(HOST_OS == OMR_OSX) */
 
 	return testRc;
 }

--- a/fvtest/sigtest/sigTestHelpers.cpp
+++ b/fvtest/sigtest/sigTestHelpers.cpp
@@ -27,7 +27,7 @@ handlerIsFunction(sighandler_t handler)
 	return (SIG_DFL != handler) && (SIG_IGN != handler) && (NULL != handler);
 }
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 bool
 handlerIsFunction(const struct sigaction *act)
 {
@@ -36,7 +36,7 @@ handlerIsFunction(const struct sigaction *act)
 			   && (SIG_DFL != (sighandler_t)act->sa_sigaction)
 			   && (SIG_IGN != (sighandler_t)act->sa_sigaction));
 }
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 void
 createThread(omrthread_t *newThread, uintptr_t suspend, omrthread_detachstate_t detachstate,

--- a/fvtest/sigtest/sigTestHelpers.hpp
+++ b/fvtest/sigtest/sigTestHelpers.hpp
@@ -33,8 +33,8 @@ void createThread(omrthread_t *newThread, uintptr_t suspend, omrthread_detachsta
 				  omrthread_entrypoint_t entryProc, void *entryArg);
 intptr_t joinThread(omrthread_t threadToJoin);
 bool handlerIsFunction(sighandler_t handler);
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 bool handlerIsFunction(const struct sigaction *act);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #endif /* OMRSIGTESTHELPERS_H_INCLUDED */

--- a/fvtest/threadextendedtest/processTimeTest.cpp
+++ b/fvtest/threadextendedtest/processTimeTest.cpp
@@ -37,11 +37,11 @@ systemTimeCpuBurn(void)
 	FILE * tempFile = NULL;
 
 	for (j = 0; j < 100; j++) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 		tempFile = fopen("nul", "w");
 #else
 		tempFile = fopen("/dev/null", "w");
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 		fwrite("garbage", 1, sizeof("garbage"), tempFile);
 		fclose(tempFile);
 	}

--- a/fvtest/threadtest/createTest.cpp
+++ b/fvtest/threadtest/createTest.cpp
@@ -19,18 +19,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#if defined(J9ZOS390) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <pthread.h>
 #include <limits.h>	/* for PTHREAD_STACK_MIN */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h> /* required for the _SC_PAGESIZE  constant */
-#endif /* defined(LINUX) || defined(OSX) */
-#endif /* defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
+#endif /* defined(J9ZOS390) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 #include "createTestHelper.h"
 #include "common/omrthreadattr.h"
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX)
 #include "unix/unixthreadattr.h"
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX) */
 #include "thread_api.h"
 #include "thrdsup.h"
 #include "omrTest.h"
@@ -110,7 +110,7 @@ protected:
 	SetUpTestCase()
 	{
 		portLib = omrTestEnv->getPortLibrary();
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		if (omrTestEnv->realtime) {
 			omrthread_lib_control(J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING, J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_ENABLED);
 		}
@@ -121,7 +121,7 @@ protected:
 		}
 #else
 		initPrioMap();
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	}
 };
 
@@ -231,7 +231,7 @@ threadmain(void *arg)
 
 		if (osPolicy != expected->osPolicy) {
 			printMismatchS("child thread policy", mapOSPolicy(expected->osPolicy), mapOSPolicy(osPolicy));
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 			/* bug? Some Linux PPC versions create the thread with the wrong policy.
 			 * Warn, but don't flag this as an error. The parent thread has already
 			 * checked for errors in the pthread_attr_t.
@@ -270,7 +270,7 @@ canCreateThread(const create_attr_t *expected, const omrthread_attr_t attr)
 		omrthread_resume(handle);
 
 #if defined(SPEC_PTHREAD_API)
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		/* bug? Linux can return a success code, but still fail to create the thread.
 		 * NOTE: It is not guaranteed that tid 0 is invalid in all pthread implementations.
 		 */
@@ -279,13 +279,13 @@ canCreateThread(const create_attr_t *expected, const omrthread_attr_t attr)
 			status |= CREATE_FAILED;
 			return status;
 		}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		/* this may fail because omrthreads detach themselves upon exiting */
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		/* OSX TODO: Why do the tests segfault in child thread when accessing &data on OSX without a 1ms sleep? */
 		omrthread_sleep(10);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 		PTHREAD_VERBOSE(pthread_join(tid, NULL));
 		status |= data.status;
 
@@ -351,9 +351,9 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 		int osPolicy;
 		int osInheritsched;
 #endif
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		int osScope;
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #ifdef J9ZOS390
 		int osThreadweight;
 		int osDetachstate;
@@ -368,7 +368,7 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 #ifndef J9ZOS390
 
 		PTHREAD_VERBOSE(pthread_attr_getschedpolicy(attr, &osPolicy));
-#if (defined(AIXPPC) || defined(LINUX) || defined(OSX))
+#if ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX))
 		/* aix and linux bug - need to set the schedpolicy to OTHER if inheritsched used */
 		if (J9THREAD_SCHEDPOLICY_INHERIT == expected->policy) {
 			if (osPolicy != OS_SCHED_OTHER) {
@@ -377,7 +377,7 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 			}
 		}
 		else
-#endif /* (defined(AIXPPC) || defined(LINUX) || defined(OSX)) */
+#endif /* ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) */
 		{
 			if (osPolicy != expected->osPolicy) {
 				printMismatchS("os schedpolicy", mapOSPolicy(expected->osPolicy), mapOSPolicy(osPolicy));
@@ -398,13 +398,13 @@ isAttrOk(const create_attr_t *expected, const omrthread_attr_t actual)
 		}
 #endif /* not J9ZOS390 */
 
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		PTHREAD_VERBOSE(pthread_attr_getscope(attr, &osScope));
 		if (osScope != expected->osScope) {
 			printMismatchI("os scope", expected->osScope, osScope);
 			status |= WRONG_OS_SCOPE;
 		}
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #ifdef J9ZOS390
 		osThreadweight = pthread_attr_getweight_np(attr);
@@ -472,12 +472,12 @@ getOsPolicy(omrthread_schedpolicy_t policy, omrthread_prio_t priority)
 	}
 #endif /* defined(SPEC_PTHREAD_API) */
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	/* overwrite the ospolicy on LINUX if we're using realtime scheduling */
 	if (omrthread_lib_use_realtime_scheduling()) {
 		ospolicy = getRTPolicy(priority);
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return ospolicy;
 }
@@ -489,7 +489,7 @@ getOsStacksize(size_t stacksize)
 		stacksize = STACK_DEFAULT_SIZE;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	/* Linux allocates 2MB if you ask for a stack smaller than STACK_MIN */
 	{
 		size_t pageSafeMinimumStack = 2 * sysconf(_SC_PAGESIZE);
@@ -501,7 +501,7 @@ getOsStacksize(size_t stacksize)
 			stacksize = pageSafeMinimumStack;
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return stacksize;
 }
@@ -732,10 +732,10 @@ TEST_F(ThreadCreateTest, SetAttrPolicy)
 		status |= EXPECTED_VALID;
 	}
 	status |= isAttrOk(&expected, attr);
-#if (defined(LINUX) || defined(AIXPPC))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX))
 	omrTestEnv->log(LEVEL_ERROR, "  ignoring omrthread_create failure\n");
 	status &= ~CREATE_FAILED;
-#endif /* (defined(LINUX) || defined(AIXPPC)) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)) */
 	END_IF_FAILED(status);
 
 	expected.policy = J9THREAD_SCHEDPOLICY_FIFO;
@@ -747,10 +747,10 @@ TEST_F(ThreadCreateTest, SetAttrPolicy)
 		status |= EXPECTED_VALID;
 	}
 	status |= isAttrOk(&expected, attr);
-#if (defined(LINUX) || defined(AIXPPC))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX))
 	omrTestEnv->log(LEVEL_ERROR, "  ignoring omrthread_create failure\n");
 	status &= ~CREATE_FAILED;
-#endif /* (defined(LINUX) || defined(AIXPPC)) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)) */
 	END_IF_FAILED(status);
 
 	expected.policy = J9THREAD_SCHEDPOLICY_INHERIT;

--- a/fvtest/threadtest/createTestHelper.h
+++ b/fvtest/threadtest/createTestHelper.h
@@ -34,13 +34,13 @@
 #include "omrthread.h"
 #include "omrport.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define SPEC_WIN_API
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX)
 #define SPEC_PTHREAD_API
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX) */
 
 #ifndef ASSERT
 #define ASSERT(x) assert(x)
@@ -50,7 +50,7 @@
 #define PTHREAD_VERBOSE(x) pthread_verboseCall(#x, (x))
 
 /* OS-specific values */
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define OS_PTHREAD_INHERIT_SCHED PTHREAD_INHERIT_SCHED
 #define OS_PTHREAD_EXPLICIT_SCHED PTHREAD_EXPLICIT_SCHED
 #define OS_PTHREAD_SCOPE_SYSTEM PTHREAD_SCOPE_SYSTEM
@@ -58,7 +58,7 @@
 #define OS_SCHED_RR SCHED_RR
 #define OS_SCHED_FIFO SCHED_FIFO
 
-#else /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #define OS_PTHREAD_INHERIT_SCHED (-1)
 #define OS_PTHREAD_EXPLICIT_SCHED (-2)
@@ -66,7 +66,7 @@
 #define OS_SCHED_OTHER (-1)
 #define OS_SCHED_RR (-2)
 #define OS_SCHED_FIFO (-3)
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #if defined(J9ZOS390)
 #define OS_MEDIUM_WEIGHT __MEDIUM_WEIGHT
@@ -101,13 +101,13 @@
 /* ospriority.c */
 extern void initPrioMap(void);
 extern const char *mapOSPolicy(intptr_t policy);
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 extern void initRealtimePrioMap(void);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 extern int getRTPolicy(omrthread_prio_t priority);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 typedef int osprio_t;
 extern osprio_t getOsPriority(omrthread_prio_t priority);

--- a/fvtest/threadtest/keyDestructorTest.cpp
+++ b/fvtest/threadtest/keyDestructorTest.cpp
@@ -24,22 +24,22 @@
 #include "omrTest.h"
 #include "testHelper.hpp"
 
-#if !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390)
+#if !(HOST_OS == OMR_WINDOWS) && !defined(J9ZOS390)
 #include <pthread.h>
 #include <stdlib.h>
-#endif /* !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && !defined(J9ZOS390) */
 
 extern ThreadTestEnvironment *omrTestEnv;
 
 class KeyDestructorTest: public ::testing::Test {
 public:
 	static bool completed;
-#if !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390)
+#if !(HOST_OS == OMR_WINDOWS) && !defined(J9ZOS390)
 	static pthread_key_t key;
 
 	static void detachThread(void *p);
 	static void *threadproc(void *p);
-#endif /* !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && !defined(J9ZOS390) */
 protected:
 
 	static void
@@ -50,7 +50,7 @@ protected:
 
 bool KeyDestructorTest::completed = false;
 
-#if !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390)
+#if !(HOST_OS == OMR_WINDOWS) && !defined(J9ZOS390)
 pthread_key_t KeyDestructorTest::key;
 
 void
@@ -94,11 +94,11 @@ KeyDestructorTest::threadproc(void *p)
 	/* will never get here.  Just to stop compiler warning */
 	return NULL;
 }
-#endif /* !defined(OMR_OS_WINDOWS) && !defined(J9ZOS390) */
+#endif /* !(HOST_OS == OMR_WINDOWS) && !defined(J9ZOS390) */
 
 TEST_F(KeyDestructorTest, KeyDestructor)
 {
-#if defined(OMR_OS_WINDOWS) || defined(J9ZOS390)
+#if (HOST_OS == OMR_WINDOWS) || defined(J9ZOS390)
 	completed = true;
 #else
 	pthread_t thread;
@@ -114,6 +114,6 @@ TEST_F(KeyDestructorTest, KeyDestructor)
 
 	rc = pthread_key_delete(key);
 	ASSERT_EQ(0, rc);
-#endif /* defined(OMR_OS_WINDOWS) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_WINDOWS) || defined(J9ZOS390) */
 	ASSERT_TRUE(completed);
 }

--- a/fvtest/threadtest/ospriority.cpp
+++ b/fvtest/threadtest/ospriority.cpp
@@ -19,15 +19,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
-#if defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#endif /* (HOST_OS == OMR_WINDOWS) */
+#if defined(J9ZOS390) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <pthread.h>
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <mach/mach_host.h>
-#endif /* defined(OSX) */
-#endif /* defined(J9ZOS390) || defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
+#endif /* defined(J9ZOS390) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 #include "createTestHelper.h"
 #include "omrutil.h"
 #include "omrutilbase.h"
@@ -75,7 +75,7 @@ mapOSPolicy(intptr_t policy)
 	}
 }
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 
 void
 initPrioMap(void)
@@ -83,13 +83,13 @@ initPrioMap(void)
 	uintptr_t i;
 	osprio_t defaultPriority = 0;
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	host_priority_info_data_t priorityInfoData;
 	mach_msg_type_number_t msgTypeNumber = HOST_PRIORITY_INFO_COUNT;
 	host_flavor_t flavor = HOST_PRIORITY_INFO;
 	host_info(mach_host_self(), flavor, (host_info_t)&priorityInfoData, &msgTypeNumber);
 	defaultPriority = priorityInfoData.user_priority;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	for (i = 0; i <= VM_PRIO_MAX; i++) {
 		VMToOSPrioMap[i] = defaultPriority;
@@ -238,7 +238,7 @@ initRealtimePrioMap(void)
 	printMap();
 }
 
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 
 #if defined(J9OS_I5)
 
@@ -263,7 +263,7 @@ initPrioMap(void)
 }
 #endif /* defined(J9OS_I5) */
 
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 
 void
 initPrioMap(void)
@@ -298,4 +298,4 @@ initPrioMap(void)
 
 #else
 #error "unsupported platform"
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */

--- a/fvtest/utiltest/main.cpp
+++ b/fvtest/utiltest/main.cpp
@@ -36,7 +36,7 @@ main(int argc, char **argv, char **envp)
 
 TEST(UtilTest, detectVMDirectory)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	void *token = NULL;
 	ASSERT_EQ(OMR_ERROR_NONE, OMR_Glue_GetVMDirectoryToken(&token));
 
@@ -52,5 +52,5 @@ TEST(UtilTest, detectVMDirectory)
 		_snwprintf(pathEnd, length, L"\\abc");
 		wprintf(L"Mangled VM Directory: '%s'\n", path);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/gc/base/Bits.hpp
+++ b/gc/base/Bits.hpp
@@ -120,14 +120,14 @@ public:
 #endif /* !defined(OMR_ENV_DATA64) */
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64)
 	/**
 	 * Return the number of bits set to 0 before the first bit set to one starting at the lowest
 	 * significant bit.
 	 * @note If the input is 0, the result is undefined.
 	 * @return Number of non-zero bits starting at the lowest significant bit.
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Implicit return in eax, not seen by compiler.  Disable compile warning C4035: no return value */
 #pragma warning(disable:4035)
 	MMINLINE static uintptr_t leadingZeroes(uintptr_t input)
@@ -137,7 +137,7 @@ public:
 		}
 	}
 #pragma warning(default:4035) /* re-enable warning */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	/**
 	 * Return the number of bits set to 0 before the first bit set to one starting at the highest
@@ -145,7 +145,7 @@ public:
 	 * @note If the input is 0, the result is undefined.
 	 * @return Number of non-zero bits starting at the highest significant bit.
 	 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Implicit return in eax, not seen by compiler.  Disable compile warning C4035: no return value */
 #pragma warning(disable:4035)
 	MMINLINE static uintptr_t trailingZeroes(uintptr_t input)
@@ -157,9 +157,9 @@ public:
 		}
 	}
 #pragma warning(default:4035) /* re-enable warning */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#elif defined(LINUX) && defined(J9HAMMER)
+#elif (HOST_OS == OMR_LINUX) && defined(J9HAMMER)
 	/**
 	 * Return the number of bits set to 0 before the first bit set to one starting at the lowest
 	 * significant bit.
@@ -191,7 +191,7 @@ public:
 		return result;
 	}
 
-#else /* defined(LINUX) && defined(J9HAMMER) */
+#else /* (HOST_OS == OMR_LINUX) && defined(J9HAMMER) */
 
 
 	/**
@@ -246,7 +246,7 @@ public:
 
 		return J9BITS_BITS_IN_SLOT - 1 - result;
 	}
-#endif /* defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64) */
 };
 
 #endif /*BITS_HPP_*/

--- a/gc/base/ConcurrentSafepointCallback.hpp
+++ b/gc/base/ConcurrentSafepointCallback.hpp
@@ -46,11 +46,11 @@ private:
 protected:
 
 public:
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 	virtual void registerCallback(MM_EnvironmentBase *env, SafepointCallbackHandler handler, void *userData, bool cancelAfterGC = false);
 #else
 	virtual void registerCallback(MM_EnvironmentBase *env,  SafepointCallbackHandler handler, void *userData);
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 
 	virtual void requestCallback(MM_EnvironmentBase *env);
 

--- a/gc/base/GCExtensionsBase.cpp
+++ b/gc/base/GCExtensionsBase.cpp
@@ -130,16 +130,16 @@ MM_GCExtensionsBase::initialize(MM_EnvironmentBase* env)
 #define ONE_MB			((uintptr_t)1 * 1024 * 1024)
 #define TWO_MB			((uintptr_t)2 * 1024 * 1024)
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	requestedPageSize = SIXTY_FOUR_KB; /* Use 64K pages for AIX-32 and AIX-64 */
-#elif ((defined(LINUX) || defined(OSX)) && (defined(J9X86) || defined(J9HAMMER)))
+#elif (((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && (defined(J9X86) || defined(J9HAMMER)))
 	requestedPageSize = TWO_MB; /* Use 2M pages for Linux/OSX x86-64 */
-#elif (defined(LINUX) && defined(S390))
+#elif ((HOST_OS == OMR_LINUX) && defined(S390))
 	requestedPageSize = ONE_MB; /* Use 1M pages for zLinux-31 and zLinux-64 */
 #elif defined(J9ZOS390)
 	requestedPageSize = ONE_MB; /* Use 1M PAGEABLE for ZOS-31 and ZOS-64 */
 	requestedPageFlags = OMRPORT_VMEM_PAGE_FLAG_PAGEABLE;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	if (!validateDefaultPageParameters(requestedPageSize, requestedPageFlags, pageSizes, pageFlags)) {
 		requestedPageSize = pageSizes[0];

--- a/gc/base/HeapVirtualMemory.cpp
+++ b/gc/base/HeapVirtualMemory.cpp
@@ -87,7 +87,7 @@ MM_HeapVirtualMemory::initialize(MM_EnvironmentBase* env, uintptr_t size)
 
 	/* Under -Xaggressive ensure a full page of padding -- see JAZZ103 45254 */
 	if (extensions->padToPageSize) {
-#if (defined(AIXPPC) && !defined(PPC64))
+#if ((HOST_OS == OMR_AIX) && !defined(PPC64))
 		/*
 		 * An attempt to allocate heap with top at 0xffffffff
 		 * In this case extra padding is not required because of overflow protection padding can be used instead
@@ -100,7 +100,7 @@ MM_HeapVirtualMemory::initialize(MM_EnvironmentBase* env, uintptr_t size)
 			/* overflow protection must be there to play role of padding even top is not so close to the end of the memory */
 			forcedOverflowProtection = true;
 		} else
-#endif /* (defined(AIXPPC) && !defined(PPC64)) */
+#endif /* ((HOST_OS == OMR_AIX) && !defined(PPC64)) */
 		{
 			/* Ignore extra full page padding if page size is too large (hard coded here for 1G or larger) */
 #define ONE_GB ((uintptr_t)1 * 1024 * 1024 * 1024)

--- a/gc/base/MemoryManager.hpp
+++ b/gc/base/MemoryManager.hpp
@@ -58,16 +58,16 @@ private:
 	{
 		bool result = true;
 
-#if (defined(AIXPPC) && !defined(PPC64))
+#if ((HOST_OS == OMR_AIX) && !defined(PPC64))
 		result = false;
-#elif(defined(AIXPPC) && defined(OMR_GC_REALTIME))
+#elif((HOST_OS == OMR_AIX) && defined(OMR_GC_REALTIME))
 		MM_GCExtensionsBase* extensions = env->getExtensions();
 		if (extensions->isMetronomeGC()) {
 			result = false;
 		}
 #elif defined(J9ZOS39064)
 		result = false;
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) */
 
 		return result;
 	}
@@ -84,12 +84,12 @@ private:
 	{
 		uintptr_t result = 0;
 
-#if (defined(AIXPPC) && defined(PPC64))
+#if ((HOST_OS == OMR_AIX) && defined(PPC64))
 		/*
 		 * AIX-64 memory segment size is 256M
 		 */
 		result = (uintptr_t)256 * 1024 * 1024;
-#endif /* (defined(AIXPPC) && defined(PPC64)) */
+#endif /* ((HOST_OS == OMR_AIX) && defined(PPC64)) */
 
 		return result;
 	}

--- a/gc/base/NonVirtualMemory.cpp
+++ b/gc/base/NonVirtualMemory.cpp
@@ -53,7 +53,7 @@ MM_NonVirtualMemory::newInstance(MM_EnvironmentBase* env, uintptr_t heapAlignmen
 	return vmem;
 }
 
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 /**
  * Allocate a chunk of memory.
  * @param size The number of bytes to allocate.
@@ -114,4 +114,4 @@ MM_NonVirtualMemory::setNumaAffinity(uintptr_t numaNode, void* address, uintptr_
 	return true;
 }
 
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */

--- a/gc/base/NonVirtualMemory.hpp
+++ b/gc/base/NonVirtualMemory.hpp
@@ -64,16 +64,16 @@ protected:
 	{
 		_typeId = __FUNCTION__;
 	};
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 	virtual void tearDown(MM_EnvironmentBase* env);
 	virtual void* reserveMemory(J9PortVmemParams* params);
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
 public:
-#if (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
+#if ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF)
 	virtual bool commitMemory(void* address, uintptr_t size);
 	virtual bool decommitMemory(void* address, uintptr_t size, void* lowValidAddress, void* highValidAddress);
 	virtual bool setNumaAffinity(uintptr_t numaNode, void* address, uintptr_t byteAmount);
-#endif /* (defined(AIXPPC) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && (!defined(PPC64) || defined(OMR_GC_REALTIME))) || defined(J9ZOS39064) || defined(OMRZTPF) */
 
 public:
 /*

--- a/gc/base/standard/ConcurrentCardTableForWC.cpp
+++ b/gc/base/standard/ConcurrentCardTableForWC.cpp
@@ -22,7 +22,7 @@
 
 #include "omrcfg.h"
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 

--- a/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
+++ b/gc/base/standard/ConcurrentGCIncrementalUpdate.cpp
@@ -177,7 +177,7 @@ MM_ConcurrentGCIncrementalUpdate::createCardTable(MM_EnvironmentBase *env)
 	Assert_MM_true(NULL == _cardTable);
 	Assert_MM_true(NULL == _extensions->cardTable);
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 	OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 
 	if ((uintptr_t)omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) > 1 ) {

--- a/gc/base/standard/ConcurrentPrepareCardTableTask.cpp
+++ b/gc/base/standard/ConcurrentPrepareCardTableTask.cpp
@@ -22,7 +22,7 @@
 
 #include "omrcfg.h"
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 #if defined(OMR_GC_MODRON_CONCURRENT_MARK)
 

--- a/gc/base/standard/ConcurrentSafepointCallback.cpp
+++ b/gc/base/standard/ConcurrentSafepointCallback.cpp
@@ -46,11 +46,11 @@ MM_ConcurrentSafepointCallback::kill(MM_EnvironmentBase *env)
 }
 
 void
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 MM_ConcurrentSafepointCallback::registerCallback(MM_EnvironmentBase *env, SafepointCallbackHandler handler, void *userData, bool cancelAfterGC)
 #else
 MM_ConcurrentSafepointCallback::registerCallback(MM_EnvironmentBase *env, SafepointCallbackHandler handler, void *userData)
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 {
 	/* To facilitate simple Card Table logic treat registerCallback as a no-op */
 }

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -108,9 +108,9 @@
 /* VM Design 1774: Ideally we would pull these cache line values from the port library but this will suffice for
  * a quick implementation
  */
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 #define CACHE_LINE_SIZE 128
-#elif defined(J9ZOS390) || (defined(LINUX) && defined(S390))
+#elif defined(J9ZOS390) || ((HOST_OS == OMR_LINUX) && defined(S390))
 #define CACHE_LINE_SIZE 256
 #else
 #define CACHE_LINE_SIZE 64

--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -40,7 +40,7 @@
 #include <builtins.h>
 #endif
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #if defined(__xlC__)
 #include <builtins.h>
 /* 
@@ -62,9 +62,9 @@
 /* Bytecode for: nop */
 #pragma mc_func __ppc_nop  {"60000000"}
 #endif /* #if defined(__xlC__) */
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 #if defined(__xlC__)
 #include <builtins.h>
 /* 
@@ -86,7 +86,7 @@
 /* Bytecode for: nop */
 #pragma mc_func __ppc_nop  {"60000000"}
 #endif /* #if defined(__xlC__) */
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -103,7 +103,7 @@
  * Do not call directly, use the methods from VM_AtomicSupport.
  */
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* The default hardware priorities on AIX is MEDIUM(4).
  * For AIX, dropSMT should drop to LOW(2) and 
  * restoreSMT should raise back to MEDIUM(4)
@@ -115,7 +115,7 @@
 		inline void __dropSMT() {  __asm__ volatile ("or 1,1,1"); }
 		inline void __restoreSMT() {  __asm__ volatile ("or 2,2,2"); }
 #endif
-#elif defined(LINUXPPC) /* defined(AIXPPC) */
+#elif (HOST_OS == OMR_LINUX) /* (HOST_OS == OMR_AIX) */
 /* The default hardware priorities on LINUXPPC is MEDIUM-LOW(3).
  * For LINUXPPC, dropSMT should drop to VERY-LOW(1) and 
  * restoreSMT should raise back to MEDIUM-LOW(3)
@@ -138,7 +138,7 @@
 
 #if defined(_MSC_VER)
 		/* use compiler intrinsic */
-#elif defined(LINUXPPC) || defined(AIXPPC)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 #if defined(__xlC__)
 		/* XL compiler complained about generated assembly, use machine code instead. */
 		inline void __nop() { __ppc_nop(); }
@@ -147,7 +147,7 @@
 		inline void __nop() { __asm__ volatile ("nop"); }
 		inline void __yield() { __asm__ volatile ("or 27,27,27"); }
 #endif
-#elif defined(LINUX) && (defined(S390) || defined(S39064))
+#elif (HOST_OS == OMR_LINUX) && (defined(S390) || defined(S39064))
 		/*
 		 * nop instruction requires operand https://bugzilla.redhat.com/show_bug.cgi?id=506417
 		 */
@@ -156,7 +156,7 @@
 		inline void __nop() { __asm__ volatile ("nop"); }
 #endif
 
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 #if defined(__GNUC__) && !defined(__clang__)
 	/* GCC compiler does not provide the same intrinsics. */
 
@@ -252,7 +252,7 @@ public:
 	readWriteBarrier()
 	{
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__sync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
@@ -281,7 +281,7 @@ public:
 		__fence();
 		J9ZOSRWB();
 		__fence();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -297,7 +297,7 @@ public:
 	{
 	/* Neither x86 nor S390 require a write barrier - the compiler fence is sufficient */
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__lwsync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
@@ -311,7 +311,7 @@ public:
 #endif /* defined(ARM) */
 #elif defined(J9ZOS390)
 		__fence();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -327,7 +327,7 @@ public:
 	{
 	/* Neither x86 nor S390 require a read barrier - the compiler fence is sufficient */
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__isync();
 #elif defined(_MSC_VER)
 		_ReadWriteBarrier();
@@ -341,7 +341,7 @@ public:
 #endif /* defined(ARM) */
 #elif defined(J9ZOS390)
 		__fence();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -359,11 +359,11 @@ public:
 	VMINLINE static void
 	monitorEnterBarrier()
 	{
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		readWriteBarrier();
-#else /* defined(AIXPPC) || defined(LINUXPPC) */
+#else /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 		readBarrier();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 	}
 
 	/**
@@ -858,9 +858,9 @@ public:
 	dropSMTThreadPriority()
 	{
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__dropSMT();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 
@@ -871,9 +871,9 @@ public:
 	restoreSMTThreadPriority()
 	{
 #if !defined(ATOMIC_SUPPORT_STUB)
-#if defined(AIXPPC) || defined(LINUXPPC)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 		__restoreSMT();
-#endif /* defined(AIXPPC) || defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) */
 #endif /* !defined(ATOMIC_SUPPORT_STUB) */
 	}
 

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -509,7 +509,7 @@ omr_error_t OMR_Glue_FreeLanguageThread(void *languageThread);
  */
 omr_error_t OMR_Glue_LinkLanguageThreadToOMRThread(void *languageThread, OMR_VMThread *omrVMThread);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * @brief Get a platform-dependent token that can be used to locate the VM directory.
  *
@@ -527,7 +527,7 @@ omr_error_t OMR_Glue_LinkLanguageThreadToOMRThread(void *languageThread, OMR_VMT
  * @return an OMR error code
  */
 omr_error_t OMR_Glue_GetVMDirectoryToken(void **token);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 char *OMR_Glue_GetThreadNameForUnamedThread(OMR_VMThread *vmThread);
 

--- a/include_core/omragent_internal.h
+++ b/include_core/omragent_internal.h
@@ -32,12 +32,12 @@
  * The structures defined in this file may be changed without notice.
  */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* pdh.h include windows.h which defined uintptr_t.  Ignore its definition */
 #define UDATA UDATA_win32_
 #include <pdh.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrcomp.h"
 #include "omragent.h"

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -260,9 +260,9 @@
  * Note: these are determined at configure time with cmake.
  * For the autoconf builds, we just hard code them based on platform
  */
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 #define OMR_USE_POSIX_SEMAPHORES
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define OMR_USE_OSX_SEMAPHORES
 #elif defined(J9ZOS390)
 #define OMR_USE_ZOS_SEMAPHORES

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -64,7 +64,7 @@ typedef int8_t					I_8;
 
 #if defined(MVS)
 typedef int32_t					BOOLEAN;
-#elif defined(LINUX) || defined(RS6000) || defined(J9ZOS390) || defined(OSX) || defined(OMRZTPF) /* MVS */
+#elif (HOST_OS == OMR_LINUX) || defined(RS6000) || defined(J9ZOS390) || (HOST_OS == OMR_OSX) || defined(OMRZTPF) /* MVS */
 typedef uint32_t					BOOLEAN;
 #else /* MVS */
 /* Don't typedef BOOLEAN since it's already defined on Windows */
@@ -110,7 +110,7 @@ EXE_EXTENSION_CHAR: the executable has a delimiter that we want to stop at as pa
 
 
 /* Linux ANSI compiler (gcc) and OSX (clang). */
-#if defined(LINUX) || defined (OSX)
+#if (HOST_OS == OMR_LINUX) || defined (OSX)
 
 /* NOTE: Linux supports different processors -- do not assume 386 */
 
@@ -147,7 +147,7 @@ typedef double SYS_FLOAT;
 #define J9_PRIORITY_MAP {0,0,0,0,0,0,0,0,0,0,0,0}
 
 
-#if (defined(LINUXPPC) && !defined(LINUXPPC64)) || defined(S390) || defined(J9HAMMER)
+#if ((HOST_OS == OMR_LINUX) && !defined(LINUXPPC64)) || defined(S390) || defined(J9HAMMER)
 #define VA_PTR(valist) ((va_list*)&valist[0])
 #endif
 
@@ -174,7 +174,7 @@ typedef double SYS_FLOAT;
 
 #define HAS_BUILTIN_EXPECT
 
-#endif /* defined(LINUX) || defined (OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || defined (OSX) */
 
 
 /* MVS compiler */
@@ -255,7 +255,7 @@ typedef double SYS_FLOAT;
 #define HAS_BUILTIN_EXPECT
 #endif /* RS6000 */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 typedef double 					SYS_FLOAT;
 
 #define NO_LVALUE_CASTING
@@ -294,7 +294,7 @@ typedef double 					SYS_FLOAT;
 /* Only for use on static functions */
 #define VMINLINE_ALWAYS __forceinline
 #endif /* __GNUC__ */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9ZOS390)
 typedef double				SYS_FLOAT;
@@ -327,7 +327,7 @@ typedef struct {
 
 #if defined(__cplusplus)
 
-#if defined(__MVS__) && defined(__COMPILER_VER__)
+#if defined(__MVC__) && defined(__COMPILER_VER__)
 #if (__COMPILER_VER__ >= 0x410D0000)
 #define VMINLINE_ALWAYS inline __attribute__((always_inline))
 #endif

--- a/include_core/omrgcconsts.h
+++ b/include_core/omrgcconsts.h
@@ -203,7 +203,7 @@ struct ModronLnrlOptions {
 #if defined(DEBUG)
 #define MMINLINE
 #else /* DEBUG */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define MMINLINE __forceinline
 #elif (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
 #define MMINLINE inline __attribute((always_inline))
@@ -212,7 +212,7 @@ struct ModronLnrlOptions {
 #endif /* OMR_OS_WINDOWS */
 #endif /* DEBUG */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define MMINLINE_DEBUG __forceinline
 #elif ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #define MMINLINE_DEBUG inline __attribute((always_inline))
@@ -226,7 +226,7 @@ struct ModronLnrlOptions {
  * Also, spinlocks can't provide realtime locking.
  * Do not use the custom spinlocks on AIX as yield calls create performance issues.
  */
-#if defined(OMR_INTERP_HAS_SEMAPHORES) && !defined(AIXPPC)
+#if defined(OMR_INTERP_HAS_SEMAPHORES) && !(HOST_OS == OMR_AIX)
 #define J9MODRON_USE_CUSTOM_SPINLOCKS
 #endif
 
@@ -501,7 +501,7 @@ typedef enum {
 /* Because SLES zLinux/31 never allocates mmap()ed memory below the 1GB line unless you ask it to, we
  * always request that the heap is allocated low in the address range. This leaves the space above
  * 2GB free for other mmap() allocations (e.g. pthread stacks).*/
-#if defined(S390) && defined(LINUX) && !defined(OMR_ENV_DATA64)
+#if defined(S390) && (HOST_OS == OMR_LINUX) && !defined(OMR_ENV_DATA64)
 #define PREFERRED_HEAP_BASE 0x10000000
 #else
 #define PREFERRED_HEAP_BASE 0x0
@@ -509,12 +509,12 @@ typedef enum {
 
 #define SUBALLOCATOR_INITIAL_SIZE (200*1024*1024)
 #define SUBALLOCATOR_COMMIT_SIZE (50*1024*1024)
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* virtual memory is assigned in segment of 256M, so grab the entire segment */
 #define SUBALLOCATOR_ALIGNMENT (256*1024*1024)
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 #define SUBALLOCATOR_ALIGNMENT (8*1024*1024)
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 #if defined(OMR_GC_REALTIME)
 #define METRONOME_DEFAULT_HRT_PERIOD_MICRO 1000 /* This gives vanilla linux a chance to use the HRT */

--- a/include_core/omrmutex.h
+++ b/include_core/omrmutex.h
@@ -24,8 +24,8 @@
 
 #include "omrcomp.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include "win/omrmutex.h"
 #else
 #include "unix/omrmutex.h"
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -32,7 +32,7 @@
 /* NOTE:  omrportlib.h include is at the bottom of this file until its dependencies on this file can be relaxed */
 
 /* fix for linux s390 32bit stdint vs unistd.h definition of intptr_t (see CMVC 73850) */
-#if defined(LINUX) && defined(S390)
+#if (HOST_OS == OMR_LINUX) && defined(S390)
 #include <stdint.h>
 #endif
 
@@ -50,9 +50,9 @@
 #include "omrgcconsts.h"
 #endif /* defined(OMRZTPF) */
 
-#if (defined(LINUX) || defined(RS6000) || defined (OSX))
+#if ((HOST_OS == OMR_LINUX) || defined(RS6000) || defined (OSX))
 #include <unistd.h>
-#endif /* (defined(LINUX) || defined(RS6000) || defined (OSX)) */
+#endif /* ((HOST_OS == OMR_LINUX) || defined(RS6000) || defined (OSX)) */
 
 #if defined(J9ZOS390)
 #define PORT_ABEND_CODE	0xDED
@@ -268,9 +268,9 @@
 #endif /* defined(S390) || defined(J9ZOS390) */
 /** @} */
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #define OMR_CONFIGURABLE_SUSPEND_SIGNAL
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 /**
  * @name Time Unit Conversion
@@ -398,7 +398,7 @@ typedef enum J9VMemMemoryQuery {
 	OMRPORT_VMEM_PROCESS_EnsureWideEnum = 0x1000000
 } J9VMemMemoryQuery;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 typedef struct OMRCgroupEntry {
 	int32_t hierarchyId; /**< cgroup hierarch ID*/
@@ -408,7 +408,7 @@ typedef struct OMRCgroupEntry {
 	struct OMRCgroupEntry *next; /**< pointer to next OMRCgroupEntry*/
 } OMRCgroupEntry;
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 typedef struct OMRCgroupMetricElement {
 	const char *units;
@@ -480,7 +480,7 @@ typedef struct J9MemTag {
 #endif
 } J9MemTag;
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 /**
  * @name Linux OS Dump Eyecatcher
  *
@@ -492,7 +492,7 @@ typedef struct J9MemTag {
 #else
 #define J9OSDUMP_SIZE	(128 * 1024)
 #endif
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /* omrfile_chown takes unsigned arguments for user/group IDs, but uses -1 to indicate that group/user id are not to be changed */
 #define OMRPORT_FILE_IGNORE_ID UDATA_MAX
@@ -938,12 +938,12 @@ typedef struct J9ProcessorInfos {
  * Use J9STR_CODE_PLATFORM_OMR_INTERNAL to when processing the output of these calls.  Otherwise, use J9STR_CODE_PLATFORM_RAW.
  */
 #define J9STR_CODE_PLATFORM_OMR_INTERNAL J9STR_CODE_LATIN1
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 /*
  * Most system calls on Windows use the "wide" versions which return UTF-16, which OMR then converts to UTF-8.
  */
 #define J9STR_CODE_PLATFORM_OMR_INTERNAL J9STR_CODE_UTF8
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 /* on other platforms the internal encoding is the actual operating system encoding */
 #define J9STR_CODE_PLATFORM_OMR_INTERNAL J9STR_CODE_PLATFORM_RAW
 #endif /* defined(J9ZOS390) */
@@ -989,12 +989,12 @@ typedef struct J9MmapHandle {
 #include "omrcuda.h"
 #endif /* OMR_OPT_CUDA */
 
-#if !defined(OMR_OS_WINDOWS)
-#if defined(OSX)
+#if !(HOST_OS == OMR_WINDOWS)
+#if (HOST_OS == OMR_OSX)
 #define _XOPEN_SOURCE
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 #include <ucontext.h>
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #undef _XOPEN_SOURCE
 #endif /* OSX */
 #endif /* !OMR_OS_WINDOWS */
@@ -1020,7 +1020,7 @@ typedef struct J9PlatformThread {
 	uintptr_t stack_base;
 	uintptr_t stack_end;
 	uintptr_t priority;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	void *context;
 #elif defined(J9ZOS390)
 	/* This should really be 'struct __mcontext*' however DDR cannot parse the zos system header
@@ -1032,7 +1032,7 @@ typedef struct J9PlatformThread {
 	ucontext_t *context;
 #endif
 	struct J9PlatformStackFrame *callstack;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	void *sigmask;
 #else /* OMR_OS_WINDOWS */
 	sigset_t *sigmask;

--- a/include_core/omrsig.h
+++ b/include_core/omrsig.h
@@ -21,34 +21,34 @@
  *******************************************************************************/
 
 #include <signal.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined UDATA.  Ignore its definition */
 #define UDATA UDATA_win32_
 #include <windows.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #define __THROW
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 typedef __sighandler_t sighandler_t;
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 typedef void (*sighandler_t)(int sig);
-#elif defined(J9ZOS390) || defined(AIXPPC)
+#elif defined(J9ZOS390) || (HOST_OS == OMR_AIX)
 typedef void (*sighandler_t)(int sig);
 #define __THROW
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 /* Use sig_handler_t instead of sighandler_t for Windows. Define it for compatibility. */
 #define sig_handler_t sighandler_t
 typedef void (__cdecl *sighandler_t)(int signum);
 #define __THROW
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #define OMRSIG_RC_ERROR -1
 #define OMRSIG_RC_SIGNAL_HANDLED 0
@@ -80,11 +80,11 @@ int omrsig_handler(int sig, void *siginfo, void *uc);
  */
 sighandler_t omrsig_primary_signal(int signum, sighandler_t handler);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 _CRTIMP void (__cdecl * __cdecl signal(_In_ int _SigNum, _In_opt_ void (__cdecl * _Func)(int)))(int);
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Register a primary signal handler function, emulating the behavior, parameters, and return of sigaction().
@@ -108,13 +108,13 @@ sighandler_t bsd_signal(int signum, sighandler_t handler) __THROW;
 #if !defined(J9ZOS390)
 sighandler_t sysv_signal(int signum, sighandler_t handler) __THROW;
 #endif /* !defined(J9ZOS390) */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 __sighandler_t __sysv_signal(int sig, __sighandler_t handler) __THROW;
 sighandler_t ssignal(int sig, sighandler_t handler) __THROW;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9ZOS390)
 int __sigactionset(size_t newct, const __sigactionset_t newsets[], size_t *oldct, __sigactionset_t oldsets[], int options);

--- a/include_core/omrutil.h
+++ b/include_core/omrutil.h
@@ -143,7 +143,7 @@ uintptr_t findSmallestPrimeGreaterThanOrEqualTo(uintptr_t number);
  */
 uintptr_t getSupportedBiggestNumberByPrimeNumberHelper(void);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* ---------------- omrgetdbghelp.c ---------------- */
 
 /**
@@ -165,7 +165,7 @@ uintptr_t omrgetdbghelp_getDLL(void);
 */
 void omrgetdbghelp_freeDLL(uintptr_t dbgHelpDLL);
 
-#endif  /* defined(OMR_OS_WINDOWS) */
+#endif  /* (HOST_OS == OMR_WINDOWS) */
 
 /* ---------------- stricmp.c ---------------- */
 
@@ -265,7 +265,7 @@ uintptr_t try_scan(char **scan_start, const char *search_string);
 
 
 /* ---------------- detectVMDirectory.c ---------------- */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /**
  * @brief Detect the directory where the VM library or executable resides.
  *
@@ -279,7 +279,7 @@ uintptr_t try_scan(char **scan_start, const char *search_string);
  * @return OMR_ERROR_NONE on success, an OMR error code otherwise.
  */
 omr_error_t detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDirectoryEnd);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9ZOS390)
 /* ---------------- getstoragekey.c ---------------- */

--- a/include_core/omrutilbase.h
+++ b/include_core/omrutilbase.h
@@ -140,7 +140,7 @@ subtractAtomic(volatile uintptr_t *address, uintptr_t value);
 uintptr_t setAtomic(volatile uintptr_t *address, uintptr_t value);
 
 /* ---------------- cas8help.s ---------------- */
-#if !defined(OMR_ENV_DATA64) && (defined(AIXPPC) || defined(LINUXPPC))
+#if !defined(OMR_ENV_DATA64) && ((HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX))
 
 /**
  * @brief Perform a compare and swap of a 64-bit value on a 32-bit system.

--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -629,11 +629,11 @@ omrthread_lib_clear_flags(uintptr_t flags);
 
 #define J9THREAD_LIB_CONTROL_GET_MEM_CATEGORIES "get_mem_categories"
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING "use_realtime_scheduling"
 #define J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_ENABLED ((uintptr_t) J9THREAD_LIB_FLAG_REALTIME_SCHEDULING_ENABLED)
 #define J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_DISABLED ((uintptr_t) 0)
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /**
 * @brief Control the thread library.

--- a/include_core/thrtypes.h
+++ b/include_core/thrtypes.h
@@ -37,10 +37,10 @@ typedef struct J9Thread {
 	J9OSCond condition;
 	J9OSMutex mutex;
 	uintptr_t stacksize;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	uintptr_t *tos;
 #endif /* OMR_OS_WINDOWS */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	void *jumpBuffer;
 #endif /* LINUX */
 #if defined(OMR_PORT_NUMA_SUPPORT)
@@ -51,7 +51,7 @@ typedef struct J9Thread {
 #if defined(J9ZOS390)
 	omrthread_os_errno_t os_errno2;
 #endif   /* J9ZOS390 */
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 	uintptr_t key_deletion_attempts;
 #endif /* !OMR_OS_WINDOWS */
 } J9Thread;
@@ -94,7 +94,7 @@ typedef struct J9ThreadLibrary {
 	struct J9ThreadMonitorPool *monitor_pool;
 	struct J9Pool *thread_pool;
 	uintptr_t threadCount;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	uintptr_t stack_usage;
 #endif /* OMR_OS_WINDOWS */
 	intptr_t initStatus;
@@ -148,9 +148,9 @@ typedef struct J9ThreadLibrary {
 	struct J9Pool *rwmutexPool;
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
 	omrthread_attr_t systemThreadAttr;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	clock_serv_t clockService;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 } J9ThreadLibrary;
 
 /*

--- a/include_core/unix/thrdsup.h
+++ b/include_core/unix/thrdsup.h
@@ -37,13 +37,13 @@
 #include "omrcomp.h"
 #include "omrutilbase.h"
 
-#if (defined(LINUX) || defined(OSX) || defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) || defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF))
 #include <sys/time.h>
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <mach/clock.h>
 #include <mach/mach.h>
-#endif /* defined(OSX) */
-#endif /* defined(LINUX) || defined(OSX) || defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) || defined(MVS) || defined(J9ZOS390) || defined(OMRZTPF) */
 
 
 #include "omrmutex.h"
@@ -80,7 +80,7 @@ typedef struct zos_sem_t {
 	struct J9ThreadMonitor *monitor;
 } zos_sem_t;
 typedef zos_sem_t OSSEMAPHORE;
-#endif /* defined(LINUX) || defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
 
 
 #include "thrtypes.h"
@@ -127,11 +127,11 @@ extern int priority_map[];
  *
  * CMVC 199234 - use CLOCK_MONOTONIC also on Linux
  */
-#if (defined(AIXPPC) && !defined(J9OS_I5)) || (defined(LINUX) && !defined(OMRZTPF))
+#if ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF))
 #define J9THREAD_USE_MONOTONIC_COND_CLOCK 1
-#else /* (defined(AIXPPC) && !defined(J9OS_I5)) || (defined(LINUX) && !defined(OMRZTPF) */
+#else /* ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 #define J9THREAD_USE_MONOTONIC_COND_CLOCK 0
-#endif /* (defined(AIXPPC) && !defined(J9OS_I5)) || (defined(LINUX) && !defined(OMRZTPF) */
+#endif /* ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 #if J9THREAD_USE_MONOTONIC_COND_CLOCK
 #define TIMEOUT_CLOCK timeoutClock
@@ -155,7 +155,7 @@ extern pthread_condattr_t *defaultCondAttr;
 			ts_.tv_sec = tv_.tv_sec + secs_.quot;			\
 			ts_.tv_nsec = nanos_;								\
 		} }
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define SETUP_TIMEOUT(ts_, millis, nanos) {						\
 		J9DIV_T secs_ = J9DIV(millis, 1000);					\
 		int nanos_ = secs_.rem * 1000000 + nanos;				\
@@ -166,7 +166,7 @@ extern pthread_condattr_t *defaultCondAttr;
 			ts_.tv_sec = secs_.quot;							\
 			ts_.tv_nsec = nanos_;								\
 		} }
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define SETUP_TIMEOUT(ts_, millis, nanos) {								\
 		J9DIV_T secs_ = J9DIV(millis, 1000);					\
 		int nanos_ = secs_.rem * 1000000 + nanos;				\
@@ -179,7 +179,7 @@ extern pthread_condattr_t *defaultCondAttr;
 			ts_.tv_sec += secs_.quot;							\
 			ts_.tv_nsec = nanos_;								\
 		} }
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 /* COND_DESTROY */
 
 #define COND_DESTROY(cond) pthread_cond_destroy(&(cond))
@@ -201,7 +201,7 @@ extern pthread_condattr_t *defaultCondAttr;
 
 /* THREAD_YIELD */
 
-#if (defined(LINUX) || defined(AIXPPC) || defined(OSX))
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX))
 #define THREAD_YIELD() (sched_yield())
 
 #ifdef OMR_THR_YIELD_ALG
@@ -228,11 +228,11 @@ extern pthread_condattr_t *defaultCondAttr;
 	}\
 }
 #endif
-#else /* (defined(LINUX) || defined(AIXPPC) || defined(OSX)) */
+#else /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)) */
 #ifdef OMR_THR_YIELD_ALG
 #error 'OMR_THR_YIELD_ALG' is not supported on this platform
 #endif
-#endif /* (defined(LINUX) || defined(AIXPPC) || defined(OSX)) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)) */
 
 #if defined(MVS) || defined (J9ZOS390)
 #define THREAD_YIELD() (pthread_yield(0))
@@ -264,13 +264,13 @@ extern pthread_condattr_t *defaultCondAttr;
 
 /* NOTE: the calling thread must already own the mutex! */
 
-#if defined(LINUX) && defined(J9X86)
+#if (HOST_OS == OMR_LINUX) && defined(J9X86)
 #define PTHREAD_COND_TIMEDWAIT(x,y,z) linux_pthread_cond_timedwait(x,y,z)
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define PTHREAD_COND_TIMEDWAIT(x,y,z) pthread_cond_timedwait_relative_np(x,y,z)
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define PTHREAD_COND_TIMEDWAIT(x,y,z) pthread_cond_timedwait(x,y,z)
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #if defined(J9ZOS390)
 #define COND_WAIT_RC_TIMEDOUT -1
@@ -308,11 +308,11 @@ extern pthread_condattr_t *defaultCondAttr;
 #endif
 
 /* THREAD_SET_NAME */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define THREAD_SET_NAME(self, thread, name) set_pthread_name((self), (thread), (name))
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #define THREAD_SET_NAME(self, thread, name) 0 /* not implemented */
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /* THREAD_SET_PRIORITY */
 #define THREAD_SET_PRIORITY(thread, priority) set_pthread_priority((thread), (priority))

--- a/include_core/ute_module.h
+++ b/include_core/ute_module.h
@@ -35,9 +35,9 @@
 
 #include <stdio.h>
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h>
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #include "omrcomp.h"
 

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -20,7 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -62,7 +62,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    // We should really rely on the port library to allocate memory, but this connection
    // has not yet been made, so as a quick workaround for platforms like OS X <= 10.9
    // where MAP_ANONYMOUS is not defined, is to map MAP_ANON to MAP_ANONYMOUS ourselves
-   #if !defined(OMR_OS_WINDOWS)
+   #if !(HOST_OS == OMR_WINDOWS)
       #if !defined(MAP_ANONYMOUS)
          #define NO_MAP_ANONYMOUS
          #if defined(MAP_ANON)
@@ -80,7 +80,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    if (segmentSize < config.codeCachePadKB() << 10)
       codeCacheSizeToAllocate = config.codeCachePadKB() << 10;
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    auto memorySlab = reinterpret_cast<uint8_t *>(
          VirtualAlloc(NULL,
             codeCacheSizeToAllocate,
@@ -108,7 +108,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
 void
 JitBuilder::CodeCacheManager::freeCodeCacheSegment(TR::CodeCacheMemorySegment * memSegment)
    {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
    VirtualFree(memSegment->_base, 0, MEM_RELEASE); // second arg must be zero when calling with MEM_RELEASE
 #else
    munmap(memSegment->_base, memSegment->_top - memSegment->_base + sizeof(TR::CodeCacheMemorySegment));

--- a/omrmakefiles/confighelpers.m4
+++ b/omrmakefiles/confighelpers.m4
@@ -72,7 +72,7 @@ AC_DEFUN([OMRCFG_CATEGORIZE_TOOLCHAIN],
 #error not an msvc compiler
 #endif]])], [$1=msvc]))
 	AS_IF([test "x$$1" = "x"],
-		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if !(defined(__xlC__) || (defined(__MVS__) && defined(__COMPILER_VER__)))
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if !(defined(__xlC__) || (defined(__MVC__) && defined(__COMPILER_VER__)))
 #error not an xlc compiler
 #endif]])], [$1=xlc]))
 	AS_IF([test "x$$1" = "x"],

--- a/omrsigcompat/omrsig_internal.hpp
+++ b/omrsigcompat/omrsig_internal.hpp
@@ -21,25 +21,25 @@
  *******************************************************************************/
  
 #include <signal.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /* windows.h defined UDATA.  Ignore its definition */
 #define UDATA UDATA_win32_
 #include <windows.h>
 #undef UDATA	/* this is safe because our UDATA is a typedef, not a macro */
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <pthread.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "AtomicSupport.hpp"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include "omrsig.h"
 
 struct sigaction {
 	sighandler_t sa_handler;
 };
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 /* For now, only WIN32 is known to not support POSIX signals. Non-WIN32
  * systems which do not have POSIX signals are also supported.
@@ -59,7 +59,7 @@ typedef void (*sigaction_t)(int sig, siginfo_t *siginfo, void *uc);
 #define SECONDARY_FLAGS_WHITELIST (SA_ONSTACK | SA_NOCLDSTOP | SA_NOCLDWAIT)
 #endif /* defined(J9ZOS390) */
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 struct OMR_SigData {
 	struct sigaction primaryAction;
@@ -76,7 +76,7 @@ struct OMR_SigData {
 #endif /* defined(J9ZOS390) */
 
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 #define LockMask
 #define SIGLOCK(sigMutex) \
@@ -110,7 +110,7 @@ struct OMR_SigData {
 #error "Unrecognized MSVC_RUNTIME_DLL."
 #endif /* (_MSC_VER >= 1200) */
 #endif /* !defined(MSVC_RUINTIME_DLL) */
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 #define LockMask sigset_t *previousMask
 #define SIGLOCK(sigMutex) \
@@ -119,7 +119,7 @@ struct OMR_SigData {
 #define SIGUNLOCK(sigMutex) \
 	sigMutex.unlock(&previousMask);
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 class SigMutex
 {
@@ -134,12 +134,12 @@ public:
 
 	void lock(LockMask)
 	{
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		/* Receiving a signal while a thread is holding a lock would cause deadlock. */
 		sigset_t mask;
 		sigfillset(&mask);
 		pthread_sigmask(SIG_BLOCK, &mask, previousMask);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 		uintptr_t oldLocked = 0;
 		do {
 			oldLocked = locked;
@@ -152,8 +152,8 @@ public:
 		VM_AtomicSupport::readWriteBarrier();
 		locked = 0;
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 		pthread_sigmask(SIG_SETMASK, previousMask, NULL);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 	}
 };

--- a/omrtrace/omrtrace_internal.h
+++ b/omrtrace/omrtrace_internal.h
@@ -97,7 +97,7 @@ extern "C" {
 /* assert() and abort() are a bit useless on Windows - they
  * just print a message. Force a GPF instead.
  */
-#if defined(OMR_OS_WINDOWS) && !defined(__clang__)
+#if (HOST_OS == OMR_WINDOWS) && !defined(__clang__)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -109,12 +109,12 @@ extern "C" {
 		} \
 	} while (0)
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 #include <assert.h>
 #define UT_ASSERT(expr) assert(expr)
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #define DBG_ASSERT(expr) \
 	if (OMR_TRACEGLOBAL(traceDebug) > 0) { \

--- a/port/common/omrcuda.cpp
+++ b/port/common/omrcuda.cpp
@@ -748,13 +748,13 @@ enum J9CudaGlobalState {
 uint32_t
 openDriver(OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	const char *driverLibrary = "libcuda.so";
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	const char *driverLibrary = "libcuda.dylib";
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 	const char *driverLibrary = "nvcuda.dll";
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	J9CudaGlobalData *globals = &portLibrary->portGlobals->cudaGlobals;
 	int deviceCount = 0;
 	int version = 0;
@@ -978,21 +978,21 @@ const J9CudaLibraryDescriptor runtimeLibraries[] = {
 	 * This special entry must appear first for forward compatiblity. In normal
 	 * installations, it is a link to the newest version available.
 	 */
-#if defined(LINUX) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_LINUX) && defined(OMR_ENV_DATA64)
 	{ 5050, "libcudart.so" },
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	{ 5050, "libcudart.dylib" },
 #endif /* LINUX && OMR_ENV_DATA64 */
 
-#if defined(LINUX) && defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_LINUX) && defined(OMR_ENV_DATA64)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("libcudart.so." #major "." #minor)
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("libcudart." #major "." #minor ".dylib")
-#elif defined(OMR_OS_WINDOWS) && defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && defined(OMR_ENV_DATA64)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("cudart64_" #major #minor ".dll")
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 #   define OMRCUDA_LIBRARY_NAME(major, minor) ("cudart32_" #major #minor ".dll")
-#endif /* defined(LINUX) && defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_LINUX) && defined(OMR_ENV_DATA64) */
 
 #define OMRCUDA_LIBRARY_ENTRY(major, minor) { ((major) * 1000) + ((minor) * 10), OMRCUDA_LIBRARY_NAME(major, minor) }
 

--- a/port/common/omrexit.c
+++ b/port/common/omrexit.c
@@ -29,11 +29,11 @@
 
 #include "omrport.h"
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #if defined(OMRPORT_OMRSIG_SUPPORT)
 extern void omrsig_chain_at_shutdown_and_exit(struct OMRPortLibrary *portLibrary);
 #endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 
 /**
@@ -72,11 +72,11 @@ omrexit_shutdown_and_exit(struct OMRPortLibrary *portLibrary, int32_t exitCode)
 	portLibrary->cuda_shutdown(portLibrary);
 #endif /* defined(OMR_OPT_CUDA) */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #if defined(OMRPORT_OMRSIG_SUPPORT)
 	omrsig_chain_at_shutdown_and_exit(portLibrary);
 #endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 	exit((int)exitCode);
 }

--- a/port/common/omrfilestreamtext.c
+++ b/port/common/omrfilestreamtext.c
@@ -57,9 +57,9 @@
  * CRLFNEWLINES will be defined when we require changing newlines from '\n' to '\r\n'
  */
 #undef CRLFNEWLINES
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CRLFNEWLINES
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 static intptr_t
 write_all(struct OMRPortLibrary *portLibrary, OMRFileStream *fileStream, const char *buf, intptr_t nbytes);

--- a/port/common/omrmem32helpers.c
+++ b/port/common/omrmem32helpers.c
@@ -51,7 +51,7 @@ struct {
  * We use a 8MB heap to give us more room in case an application loads a larger amount of classes than usual.
  * For testing purposes, this value is mirrored in port library test. If we tune this value, we should also adjust it in omrmemTest.cpp
  */
-#if defined(AIXPPC) && defined(OMR_GC_COMPRESSED_POINTERS)
+#if (HOST_OS == OMR_AIX) && defined(OMR_GC_COMPRESSED_POINTERS)
 /* virtual memory is allocated in 256M segments on AIX, so grab the whole segment */
 #define HEAP_SIZE_BYTES 256*1024*1024
 #else

--- a/port/common/omrmemtag.c
+++ b/port/common/omrmemtag.c
@@ -224,7 +224,7 @@ omrmem_advise_and_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPo
 	Trc_PRT_mem_omrmem_advise_and_free_memory_Entry(memoryPointer);
 
 	if (memoryPointer != NULL) {
-#if (defined(LINUX) || defined (AIXPPC) || defined(J9ZOS390) || defined(OSX))
+#if ((HOST_OS == OMR_LINUX) || defined (AIXPPC) || defined(J9ZOS390) || (HOST_OS == OMR_OSX))
 
 		J9MemTag *headerTag = NULL;
 		headerTag = omrmem_get_header_tag(memoryPointer);
@@ -237,7 +237,7 @@ omrmem_advise_and_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPo
 		} else {
 			memorySize = 0;
 		}
-#endif /* (defined(LINUX) || defined (AIXPPC) || defined(J9ZOS390) || defined(OSX)) */
+#endif /* ((HOST_OS == OMR_LINUX) || defined (AIXPPC) || defined(J9ZOS390) || (HOST_OS == OMR_OSX)) */
 		memoryPointer = unwrapBlockAndCheckTags(portLibrary, memoryPointer);
 		adviseAndFreeFunction(portLibrary, memoryPointer, memorySize);
 	}

--- a/port/common/omrportcontrol.c
+++ b/port/common/omrportcontrol.c
@@ -104,14 +104,14 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		return 0;
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64)
+#if (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64)
 	if (!strcmp("SIG_INTERNAL_HANDLER", key)) {
 		/* used by optimized code to implement fast signal handling on Windows */
 		extern int structuredExceptionHandler(struct OMRPortLibrary *portLibrary, omrsig_handler_fn handler, void *handler_arg, uint32_t flags, EXCEPTION_POINTERS *exceptionInfo);
 		*(int (**)(struct OMRPortLibrary *, omrsig_handler_fn, void *, uint32_t, EXCEPTION_POINTERS *))value = structuredExceptionHandler;
 		return 0;
 	}
-#endif /* defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64) */
+#endif /* (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64) */
 
 #if defined(OMR_PORT_ZOS_CEEHDLRSUPPORT)
 	if (!strcmp("SIG_INTERNAL_HANDLER", key)) {
@@ -265,7 +265,7 @@ omrport_control(struct OMRPortLibrary *portLibrary, const char *key, uintptr_t v
 		}
 	}
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* OMRPORT_CTLDATA_AIX_PROC_ATTR key is used only on AIX systems */
 	if (0 == strcmp(OMRPORT_CTLDATA_AIX_PROC_ATTR, key)) {
 		return (int32_t)portLibrary->portGlobals->control.aix_proc_attr;

--- a/port/common/omrstr.c
+++ b/port/common/omrstr.c
@@ -20,30 +20,30 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #else
 #include <time.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrportasserts.h"
 
 #include <stdarg.h>
 #include <string.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <malloc.h>
-#elif defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <alloca.h>
 #elif defined(J9ZOS390)
 #include <stdlib.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #include <errno.h>
 
 /*
 #define J9STR_DEBUG
 */
 
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX)
 #include <iconv.h>
 typedef iconv_t  charconvState_t;
 #define J9STR_USE_ICONV
@@ -51,9 +51,9 @@ typedef iconv_t  charconvState_t;
 #define J9_USE_ORIG_EBCDIC_LANGINFO 1
 
 #include "omriconvhelpers.h"
-#else /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX) */
 typedef void *charconvState_t; /*dummy type */
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390) || (HOST_OS == OMR_OSX) */
 
 /* for sprintf, which is used for printing floats */
 #include <stdio.h>
@@ -172,12 +172,12 @@ static int32_t convertWideToPlatform(struct OMRPortLibrary *portLibrary, charcon
 static int32_t convertLatin1ToMutf8(struct OMRPortLibrary *portLibrary, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize);
 static int32_t convertMutf8ToLatin1(struct OMRPortLibrary *portLibrary, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 static void convertJ9TimeToSYSTEMTIME(J9TimeInfo *j9TimeInfo, SYSTEMTIME *systemTime);
 static void convertTimeMillisToJ9Time(int64_t timeMillis, J9TimeInfo *tm);
 static void convertSYSTEMTIMEToJ9Time(SYSTEMTIME *systemTime, J9TimeInfo *j9TimeInfo);
 static BOOLEAN firstDateComesBeforeSecondDate(J9TimeInfo *firstDate, J9TimeInfo *secondDate);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * Write characters to a string as specified by format.
@@ -275,7 +275,7 @@ omrstr_convert(struct OMRPortLibrary *portLibrary, int32_t fromCode, int32_t toC
 		}
 	}
 	break;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	case J9STR_CODE_WINTHREADACP:
 	case J9STR_CODE_WINDEFAULTACP: {
 		switch (toCode) {
@@ -288,7 +288,7 @@ omrstr_convert(struct OMRPortLibrary *portLibrary, int32_t fromCode, int32_t toC
 		}
 	}
 	break;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	case J9STR_CODE_MUTF8: {
 		switch (toCode) {
 		case J9STR_CODE_PLATFORM_RAW:
@@ -1267,7 +1267,7 @@ setJ9TimeToEpoch(struct J9TimeInfo *tm)
  */
 static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *omrtimeInfo)
 {
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 
 	time_t secondsUTC;
 	struct tm localTime;
@@ -1295,7 +1295,7 @@ static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *
 
 	return;
 
-#else /* !defined(OMR_OS_WINDOWS) */
+#else /* !(HOST_OS == OMR_WINDOWS) */
 
 	TIME_ZONE_INFORMATION timeZoneInformation;
 	J9TimeInfo daylightDateAsJ9TimeInfo, standardDateAsJ9TimeInfo;
@@ -1330,7 +1330,7 @@ static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *
 
 	/* Get the TimeZone Information needed to convert to local time */
 	rc = GetTimeZoneInformation(&timeZoneInformation);
-#if ( defined(OMR_OS_WINDOWS) || (_WIN32_WCE>=420) )
+#if ( (HOST_OS == OMR_WINDOWS) || (_WIN32_WCE>=420) )
 	if (rc == TIME_ZONE_ID_INVALID) {
 		return;
 	}
@@ -1412,11 +1412,11 @@ static void convertUTCMillisToLocalJ9Time(int64_t millisUTC, struct J9TimeInfo *
 
 	return;
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 /*
  * @internal
  *
@@ -1700,7 +1700,7 @@ convertTimeMillisToJ9Time(int64_t timeMillis, J9TimeInfo *tm)
 
 }
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 /**
  * @internal
@@ -2487,7 +2487,7 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 	uintptr_t mutf8Limit = outBufferSize;
 	BOOLEAN firstConversion = TRUE;
 	/* set up buffers and convertors */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	uintptr_t requiredBufferSize = 0;
 	encodingState = NULL;
 	/* MultiByteToWideChar is not resumable, so we need a buffer large enough to hold the entire intermediate result */
@@ -2501,7 +2501,7 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		wideBufferSize = requiredBufferSize;
 	}
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #if defined(J9STR_USE_ICONV)
 	/* use the EBCDIC string for UTF-16 on z/OS */
@@ -2519,12 +2519,12 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		uintptr_t tempWideBufferSize = wideBufferPartialSize;
 
 		if (wideBufferPartialSize < 0) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			/* the working buffer is dynamically allocated only on Windows */
 			if (wideBuffer != onStackBuffer) {
 				portLibrary->mem_free_memory(portLibrary, wideBuffer);
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 			iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2540,12 +2540,12 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		}
 		/* updates platformCursor to character after the last translated character */
 		if (wideBufferPartialSize < 0) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			/* the working buffer is dynamically allocated only on Windows */
 			if (wideBuffer != onStackBuffer) {
 				portLibrary->mem_free_memory(portLibrary, wideBuffer);
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 			iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2554,11 +2554,11 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 		/* Now convert the result to modified UTF-8 */
 		mutf8PartialSize = convertWideToMutf8(&tempWideBuffer, &tempWideBufferSize, mutf8Cursor, mutf8Limit);
 		if (0 != tempWideBufferSize) { /* should have consumed all the data */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 			if (wideBuffer != onStackBuffer) {
 				portLibrary->mem_free_memory(portLibrary, wideBuffer);
 			}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 			iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2571,11 +2571,11 @@ convertPlatformToMutf8(struct OMRPortLibrary *portLibrary, uint32_t codePage, co
 			}
 		}
 	}
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (wideBuffer != onStackBuffer) {
 		portLibrary->mem_free_memory(portLibrary, wideBuffer);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 #if defined(J9STR_USE_ICONV)
 	iconv_free(portLibrary, OMRPORT_LANG_TO_UTF16_ICONV_DESCRIPTOR, encodingState);
 #endif
@@ -2609,9 +2609,9 @@ convertMutf8ToPlatform(struct OMRPortLibrary *portLibrary, const uint8_t *inBuff
 		/* wideBuffer is always on stack - no need to free it */
 		return OMRPORT_ERROR_STRING_ICONV_OPEN_FAILED;
 	}
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 	encodingState = NULL;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	while (mutf8Remaining > 0) { /* translated section by section as dictated by the size of wideBuffer */
 		uint8_t wideBuffer[CONVERSION_BUFFER_SIZE];
 		const uint8_t *wideBufferCursor = wideBuffer;
@@ -3089,7 +3089,7 @@ static int32_t
 convertPlatformToWide(struct OMRPortLibrary *portLibrary, charconvState_t encodingState, uint32_t codePage, const uint8_t **inBuffer, uintptr_t *inBufferSize, uint8_t *outBuffer, uintptr_t outBufferSize)
 {
 	int32_t resultSize = -1;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	int32_t mbChars = (int32_t)MultiByteToWideChar(codePage, OS_ENCODING_MB_FLAGS, (LPCSTR)*inBuffer, (int)*inBufferSize, (LPWSTR)outBuffer, (int)outBufferSize);
 	if ((outBufferSize > 0) && (0 == mbChars)) {
 		resultSize = OMRPORT_ERROR_STRING_BUFFER_TOO_SMALL; /* should not happen: caller should have allocated a sufficiently large buffer */
@@ -3116,7 +3116,7 @@ convertPlatformToWide(struct OMRPortLibrary *portLibrary, charconvState_t encodi
 	} else {
 		resultSize = (outBufferSize - wideBufferLimit); /* number of bytes written */
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	if ((outBufferSize > 0) && ((outBufferSize - resultSize) >= 2)) {
 		uint16_t *terminator = (uint16_t *) &outBuffer[resultSize];
 		*terminator = 0;
@@ -3182,7 +3182,7 @@ convertWideToPlatform(struct OMRPortLibrary *portLibrary, charconvState_t encodi
 		*inBuffer = platformCursor;
 		*inBufferSize = platformLimit;
 	}
-#elif defined(OMR_OS_WINDOWS)
+#elif (HOST_OS == OMR_WINDOWS)
 	LPCWSTR wideCursor = (LPCWSTR)*inBuffer;
 	uintptr_t wideRemaining = *inBufferSize / WIDE_CHAR_SIZE;
 	resultSize = WideCharToMultiByte(OS_ENCODING_CODE_PAGE, OS_ENCODING_MB_FLAGS, wideCursor,

--- a/port/linux/omrosdump_helpers.c
+++ b/port/linux/omrosdump_helpers.c
@@ -31,7 +31,7 @@
 #include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include <sys/prctl.h>
 #include <linux/prctl.h>
 #include <sys/resource.h>
@@ -372,7 +372,7 @@ deriveCoreFileName(struct OMRPortLibrary *portLibrary, char *corePatterFormat, B
 				/* literal '%' */
 				charsPrinted = portLibrary->str_printf(portLibrary, outCursor, bytesLeft, "%%");
 				break;
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 			case 'c':
 				{
 					struct rlimit limit = {0};
@@ -448,7 +448,7 @@ deriveCoreFileName(struct OMRPortLibrary *portLibrary, char *corePatterFormat, B
 					return -1;
 				}
 			case 'e':
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #ifndef PR_GET_NAME
 #define PR_GET_NAME 16
 #endif

--- a/port/linux/omrvmem.c
+++ b/port/linux/omrvmem.c
@@ -1271,9 +1271,9 @@ port_numa_interleave_memory(struct OMRPortLibrary *portLibrary, void  *start, ui
 void
 omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t mode, uintptr_t *pageSize, uintptr_t *pageFlags)
 {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	{
 		/* Note that the PPG_vmem_pageSize is a null-terminated list of page sizes.
 		 * There will always be the 0 element (default page size),
@@ -1287,7 +1287,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t
 			*pageFlags = PPG_vmem_pageFlags[1];
 		}
 	}
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	else {
 		if (NULL != pageSize) {
 			/* Return the same page size as used by JIT code cache */
@@ -1302,7 +1302,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary, uintptr_t
 			}
 		}
 	}
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	return;
 }
@@ -1318,7 +1318,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 	Assert_PRT_true_wrapper(OMRPORT_VMEM_PAGE_FLAG_NOT_USED == validPageFlags);
 
 	if (0 != validPageSize) {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		/* On Linux PPC, for executable pages, search through the list of supported page sizes only if
 		 * - request is for 16M pages, and
 		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
@@ -1341,7 +1341,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
 			(codeCacheConsolidationEnabled && (SIXTEEN_M == validPageSize)))
 #endif /* defined(OMR_ENV_DATA64) */
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			uintptr_t pageIndex = 0;
 			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(portLibrary);
@@ -1362,12 +1362,12 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		validPageSize = defaultLargePageSize;
 		validPageFlags = defaultLargePageFlags;
 	} else {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
 			validPageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
 			validPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
 		} else
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			validPageSize = PPG_vmem_pageSize[0];
 			validPageFlags = PPG_vmem_pageFlags[0];

--- a/port/linuxppc64/omrtime.c
+++ b/port/linuxppc64/omrtime.c
@@ -27,9 +27,9 @@
  */
 
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #define _GNU_SOURCE
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #include <stdio.h>
 #include <time.h>

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -53,7 +53,7 @@ typedef struct J9PortControlData {
 	uintptr_t sig_flags;
 	OMRMemCategorySet language_memory_categories;
 	OMRMemCategorySet omr_memory_categories;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	uintptr_t aix_proc_attr;
 #endif
 } J9PortControlData;

--- a/port/unix/j9nlshelpers.c
+++ b/port/unix/j9nlshelpers.c
@@ -78,10 +78,10 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	char regionProp[4] = "US";
 	char *lang = NULL;
 	int langlen = 0;
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	intptr_t result;
 	char langProp[24];
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	intptr_t countryStart = 2;
 
 	/* Get the language */
@@ -90,7 +90,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	 * that the locale is not installed OR not selected & generated (see /etc/locale.gen) */
 	setlocale(LC_ALL, "");
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	lang = setlocale(LC_CTYPE, NULL);
 	/* set lang for later usage, we cannot use the return of setlocale(LC_ALL, "") as its not
 	 * the correct interface to retrieve it (lang/region) */
@@ -103,7 +103,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 			lang = langProp;
 		}
 	}
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	/* Query locale data */
 	lang = setlocale(LC_CTYPE, NULL);
 #if defined (J9ZOS390)
@@ -116,7 +116,7 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 		}
 	}
 #endif /* defined (J9ZOS390) */
-#endif  /* defined(LINUX) || defined(OSX) */
+#endif  /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (lang != NULL && strcmp(lang, "POSIX") && strcmp(lang, "C"))
 		if (lang != NULL && (langlen = strlen(lang)) >= 2) {
 			/* copy the language, stopping at '_'

--- a/port/unix/omrcpu.c
+++ b/port/unix/omrcpu.c
@@ -39,7 +39,7 @@
 #include "omrportpg.h"
 #endif
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
@@ -94,7 +94,7 @@ omrcpu_startup(struct OMRPortLibrary *portLibrary)
 
 #if (__IBMC__ || __IBMCPP__)
 	dcbz((void *) &buf[512]);
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	__asm__(
 		"dcbz 0, %0"
 		: /* no outputs */
@@ -155,7 +155,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if (__IBMC__ || __IBMCPP__)
 		dcbst(addr);
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		__asm__(
 			"dcbst 0,%0"
 			: /* no outputs */
@@ -165,7 +165,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if (__IBMC__ || __IBMCPP__)
 	sync();
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	__asm__("sync");
 #endif
 
@@ -174,7 +174,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if (__IBMC__ || __IBMCPP__)
 		icbi(addr);
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		__asm__(
 			"icbi 0,%0"
 			: /* no outputs */
@@ -185,7 +185,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 #if (__IBMC__ || __IBMCPP__)
 	sync();
 	isync();
-#elif defined(LINUX) || defined(OSX)
+#elif (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	__asm__("sync");
 	__asm__("isync");
 #endif
@@ -214,7 +214,7 @@ omrcpu_get_cache_line_size(struct OMRPortLibrary *portLibrary, int32_t *lineSize
 			*lineSize = (int32_t) result;
 			rc = 0;
 		}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	}
 	return rc;
 }

--- a/port/unix/omrerrorhelpers.c
+++ b/port/unix/omrerrorhelpers.c
@@ -68,7 +68,7 @@ errorMessage(struct OMRPortLibrary *portLibrary, int32_t errorCode)
 		ptBuffers->errorMessageBufferSize = J9ERROR_DEFAULT_BUFFER_SIZE;
 	}
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* On AIX, strerror() returns an error string based on current locale encoding. When printing out the error message in file_write_using_iconv(),
 	 * The NLS message (UTF-8) + the error string is converted from UTF-8 to locale encoding. So non-UTF-8 error string needs to be converted to UTF-8 here.
 	 */
@@ -81,7 +81,7 @@ errorMessage(struct OMRPortLibrary *portLibrary, int32_t errorCode)
 			errString = stackBuf;
 		}
 	}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	/* Copy from OS to ptBuffers */
 	portLibrary->str_printf(portLibrary, ptBuffers->errorMessageBuffer, ptBuffers->errorMessageBufferSize, "%s", errString);

--- a/port/unix/omrfile.c
+++ b/port/unix/omrfile.c
@@ -31,12 +31,12 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <sys/vfs.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <sys/param.h>
 #include <sys/mount.h>
-#endif /*  defined(LINUX)  && !defined(OMRZTPF) */
+#endif /*  (HOST_OS == OMR_LINUX)  && !defined(OMRZTPF) */
 #if !defined(OMRZTPF)
 #include <sys/statvfs.h>
 #endif /* !defined(OMRZTPF) */
@@ -57,27 +57,27 @@
 #undef fread
 #endif
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 typedef struct statfs PlatformStatfs;
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 typedef struct statvfs PlatformStatfs;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 
 static const char *const fileFStatErrorMsgPrefix = "fstat : ";
 static const char *const fileFStatFSErrorMsgPrefix = "fstatfs : ";
-#if defined(AIXPPC) && !defined(J9OS_I5)
+#if (HOST_OS == OMR_AIX) && !defined(J9OS_I5)
 static const char *const fileFStatVFSErrorMsgPrefix = "fstatvfs : ";
-#endif /* defined(AIXPPC) && !defined(J9OS_I5) */
+#endif /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 
 static int32_t EsTranslateOpenFlags(int32_t flags);
 static void setPortableError(OMRPortLibrary *portLibrary, const char *funcName, int32_t portlibErrno, int systemErrno);
 static int32_t findError(int32_t errorCode);
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5))
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5))
 static void updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf, PlatformStatfs *statfsBuf);
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#else /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 static void updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf);
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 
 static int32_t
 EsTranslateOpenFlags(int32_t flags)
@@ -212,13 +212,13 @@ findError(int32_t errorCode)
  *
  * @return void
  */
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5))
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5))
 static void
 updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf, PlatformStatfs *statfsBuf)
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#else /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 static void
 updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, struct stat *statBuf)
-#endif /* (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || (defined(AIXPPC) && !defined(J9OS_I5)) */
+#endif /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || ((HOST_OS == OMR_AIX) && !defined(J9OS_I5)) */
 {
 	if (S_ISDIR(statBuf->st_mode)) {
 		j9statBuf->isDir = 1;
@@ -248,7 +248,7 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 	j9statBuf->ownerUid = statBuf->st_uid;
 	j9statBuf->ownerGid = statBuf->st_gid;
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	if (NULL != statfsBuf) {
 		switch (statfsBuf->f_type) {
 		/* Detect remote filesystem types */
@@ -262,7 +262,7 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 			break;
 		}
 	}
-#elif defined(AIXPPC) && !defined(J9OS_I5) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (NULL != statfsBuf) {
 		/* Detect NFS filesystem */
 		if (NULL != strstr(statfsBuf->f_basetype, "nfs")) {
@@ -271,9 +271,9 @@ updateJ9FileStat(struct OMRPortLibrary *portLibrary, J9FileStat *j9statBuf, stru
 			j9statBuf->isFixed = 1;
 		}
 	}
-#else /* defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 	j9statBuf->isFixed = 1;
-#endif /* defined(AIXPPC) && !defined(J9OS_I5) */
+#endif /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 
 }
 
@@ -634,7 +634,7 @@ omrfile_chown(struct OMRPortLibrary *portLibrary, const char *path, uintptr_t ow
 void
 omrfile_findclose(struct OMRPortLibrary *portLibrary, uintptr_t findhandle)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	closedir64((DIR64 *)findhandle);
 #else
 	closedir((DIR *)findhandle);
@@ -644,13 +644,13 @@ omrfile_findclose(struct OMRPortLibrary *portLibrary, uintptr_t findhandle)
 uintptr_t
 omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *resultbuf)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	DIR64 *dirp = NULL;
 #else
 	DIR *dirp = NULL;
 #endif
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
 #else
 	struct dirent *entry;
@@ -658,7 +658,7 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 
 	Trc_PRT_file_findfirst_Entry2(path, resultbuf);
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	dirp = opendir64(path);
 #else
 	dirp = opendir(path);
@@ -667,13 +667,13 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 		Trc_PRT_file_findfirst_ExitFail(-1);
 		return (uintptr_t)-1;
 	}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64(dirp);
 #else
 	entry = readdir(dirp);
 #endif
 	if (entry == NULL) {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		closedir64(dirp);
 #else
 		closedir(dirp);
@@ -698,7 +698,7 @@ omrfile_findfirst(struct OMRPortLibrary *portLibrary, const char *path, char *re
 int32_t
 omrfile_findnext(struct OMRPortLibrary *portLibrary, uintptr_t findhandle, char *resultbuf)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
 #else
 	struct dirent *entry;
@@ -706,7 +706,7 @@ omrfile_findnext(struct OMRPortLibrary *portLibrary, uintptr_t findhandle, char 
 
 	Trc_PRT_file_findnext_Entry2(findhandle, resultbuf);
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64((DIR64 *)findhandle);
 #else
 	entry = readdir((DIR *)findhandle);
@@ -1139,9 +1139,9 @@ int32_t
 omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if (!defined(OMRZTPF) && defined(LINUX)) || defined(AIXPPC) || defined(OSX)
+#if (!defined(OMRZTPF) && (HOST_OS == OMR_LINUX)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	PlatformStatfs statfsbuf;
-#endif /* (!defined(OMRZTPF) && defined(LINUX)) || defined(AIXPPC) || defined(OSX) */
+#endif /* (!defined(OMRZTPF) && (HOST_OS == OMR_LINUX)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 	int32_t rc = 0;
 	int localfd = (int)fd;
 
@@ -1159,7 +1159,7 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	if (0 != fstatfs(localfd - FD_BIAS, &statfsbuf)) {
 		intptr_t myerror = errno;
 		Trc_PRT_file_fstat_fstatfsFailed(myerror);
@@ -1168,7 +1168,7 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#elif defined(AIXPPC) && !defined(J9OS_I5) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (0 != fstatvfs(localfd - FD_BIAS, &statfsbuf)) {
 		intptr_t myerror = errno;
 		Trc_PRT_file_fstat_fstatvfsFailed(myerror);
@@ -1177,9 +1177,9 @@ omrfile_fstat(struct OMRPortLibrary *portLibrary, intptr_t fd, struct J9FileStat
 		goto _end;
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#else /* defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 	updateJ9FileStat(portLibrary, buf, &statbuf);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 _end:
 	Trc_PRT_file_fstat_Exit(rc);
@@ -1191,9 +1191,9 @@ int32_t
 omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flags, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	PlatformStatfs statfsbuf;
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 	memset(buf, 0, sizeof(J9FileStat));
 
@@ -1202,19 +1202,19 @@ omrfile_stat(struct OMRPortLibrary *portLibrary, const char *path, uint32_t flag
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	if (statfs(path, &statfsbuf)) {
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#elif defined(AIXPPC) && !defined(J9OS_I5) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	if (statvfs(path, &statfsbuf)) {
 		return portLibrary->error_set_last_error(portLibrary, errno, findError(errno));
 	}
 	updateJ9FileStat(portLibrary, buf, &statbuf, &statfsbuf);
-#else /* defined(AIXPPC) && !defined(J9OS_I5) */
+#else /* (HOST_OS == OMR_AIX) && !defined(J9OS_I5) */
 	updateJ9FileStat(portLibrary, buf, &statbuf);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return 0;
 }

--- a/port/unix/omrfiletext.c
+++ b/port/unix/omrfiletext.c
@@ -38,11 +38,11 @@
 
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if (defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)) && !defined(OMRZTPF)
+#if (defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF)
 #define J9VM_USE_WCTOMB
-#else /* (defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)) && !defined(OMRZTPF) */
+#else /* (defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF) */
 #include "omriconvhelpers.h"
-#endif /* (defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)) && !defined(OMRZTPF) */
+#endif /* (defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF) */
 
 /* Some older platforms (Netwinder) don't declare CODESET */
 #ifndef CODESET

--- a/port/unix/omriconvhelpers.c
+++ b/port/unix/omriconvhelpers.c
@@ -41,7 +41,7 @@
 const char *utf8 = "UTF-8";
 #if defined(J9ZOS390)
 const char *utf16 = "01200"; /* z/OS does not accept "UTF-16" */
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 const char *utf16 = "UTF-16LE";
 #else
 const char *utf16 = "UTF-16";

--- a/port/unix/omrintrospect.c
+++ b/port/unix/omrintrospect.c
@@ -26,10 +26,10 @@
  * @brief process introspection support
  */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
 #define _GNU_SOURCE
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #include <pthread.h>
 #include <ucontext.h>
@@ -44,12 +44,12 @@
 #include <time.h>
 #include <fcntl.h>
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include <dirent.h>
 #include <dlfcn.h>
 #include <sys/utsname.h>
 #include <inttypes.h>
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 #include <sys/ldr.h>
 #include <sys/debug.h>
 #include <procinfo.h>
@@ -81,10 +81,10 @@
  * timeout to poll calls whether or not we have a deadline so we have a sample based scheduler visible
  * spinlock.
  */
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 /* poll timeout in milliseconds */
 #define POLL_RETRY_INTERVAL 100
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 /* AIX close call blocks until all other calls using the file descriptor return to user
  * space so we need to spin reasonably quickly or we'll not resume until the timeout in
  * error cases.
@@ -311,7 +311,7 @@ barrier_release_r(barrier_r *barrier, uintptr_t seconds)
 		return -1;
 	}
 
-#if !defined(J9ZOS390) && !defined(AIXPPC)
+#if !defined(J9ZOS390) && !(HOST_OS == OMR_AIX)
 	/* On AIX it is not legal to call fdatasync() inside a signal handler */
 	fdatasync(barrier->descriptor_pair[1]);
 #endif
@@ -431,7 +431,7 @@ barrier_destroy_r(barrier_r *barrier, int block)
 		rc = -1;
 	}
 
-#if !defined(J9ZOS390) && !defined(AIXPPC)
+#if !defined(J9ZOS390) && !(HOST_OS == OMR_AIX)
 	/* On AIX it is not legal to call fdatasync() inside a signal handler */
 	fdatasync(barrier->descriptor_pair[1]);
 #endif
@@ -608,7 +608,7 @@ sem_post_r(sem_t_r *sem)
 	if (write(sem->descriptor_pair[1], &byte, 1) != 1) {
 		return -1;
 	}
-#if !defined(J9ZOS390) && !defined(AIXPPC)
+#if !defined(J9ZOS390) && !(HOST_OS == OMR_AIX)
 	/* On AIX it is not legal to call fdatasync() inside a signal handler */
 	fdatasync(sem->descriptor_pair[1]);
 #endif
@@ -842,7 +842,7 @@ upcall_handler(int signal, siginfo_t *siginfo, void *context_arg)
  * @param data - the platform specific data, ignored on everything but AIX
  * @return number of threads in the process
  */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 static int
 count_threads(struct PlatformWalkData *data)
 {
@@ -905,7 +905,7 @@ count_threads(struct PlatformWalkData *data)
 
 	return thread_count;
 }
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 static int
 count_threads(struct PlatformWalkData *data)
 {
@@ -1483,7 +1483,7 @@ setup_native_thread(J9ThreadWalkState *state, thread_context *sigContext, int he
 static uintptr_t
 sigqueue_is_reliable(void)
 {
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	struct utsname sysinfo;
 	uintptr_t release_major = 0;
 	uintptr_t release_minor = 0;
@@ -1497,13 +1497,13 @@ sigqueue_is_reliable(void)
 
 	/* sigqueue() is sufficiently reliable on newer Linux kernels (version 3.11 and later). */
 	return (3 < release_major) || ((3 == release_major) && (11 <= release_minor));
-#elif defined(AIXPPC) || defined(J9ZOS390)
+#elif (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 	/* The controller can't use sem_timedwait_r on AIX or z/OS. */
 	return 0;
 #else
 	/* Other platforms can use sem_timedwait_r. */
 	return 1;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 }
 
 /*

--- a/port/unix/omrmem.c
+++ b/port/unix/omrmem.c
@@ -41,11 +41,11 @@
 #include "omrportasserts.h"
 #include "ut_omrport.h"
 #include "protect_helpers.h"
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <sys/mman.h>
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/shm.h>
 #include <sys/vminfo.h>
 #endif/*AIXPPC*/
@@ -98,9 +98,9 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 {
 	uintptr_t pageSize = 0;
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	pageSize = sysconf(_SC_PAGESIZE);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	struct vm_page_info pageInfo;
 	pageInfo.addr = (uint64_t) portLibrary->portGlobals;
 	/*  retrieve size of the page backing portLibrary->portGlobals which is allocated
@@ -135,11 +135,11 @@ omrmem_advise_and_free_memory_basic(struct OMRPortLibrary *portLibrary, void *me
 
 			Trc_PRT_mem_advise_and_free_memory_basic_oscall(memPtrPageRounded, memPtrSizePageRounded);
 
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 			if (-1 == madvise((void *)memPtrPageRounded, memPtrSizePageRounded, MADV_DONTNEED)) {
 				Trc_PRT_mem_advise_and_free_memory_basic_madvise_failed((void *)memPtrPageRounded, memPtrSizePageRounded, errno);
 			}
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 			if (-1 == disclaim64((void *)memPtrPageRounded, memPtrSizePageRounded, DISCLAIM_ZEROMEM)) {
 				Trc_PRT_mem_advise_and_free_memory_basic_disclaim64_failed((void *)memPtrPageRounded, memPtrSizePageRounded, errno);
 				Assert_PRT_ShouldNeverHappen_wrapper();
@@ -180,9 +180,9 @@ omrmem_reallocate_memory_basic(struct OMRPortLibrary *portLibrary, void *memoryP
 void
 omrmem_shutdown_basic(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	omrmem_free_memory_basic(portLibrary, portLibrary->portGlobals->procSelfMap);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	omrmem_free_memory_basic(portLibrary, portLibrary->portGlobals);
 }
 
@@ -199,9 +199,9 @@ omrmem_startup_basic(struct OMRPortLibrary *portLibrary, uintptr_t portGlobalSiz
 		return;
 	}
 	memset(portLibrary->portGlobals, 0, portGlobalSize);
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	portLibrary->portGlobals->procSelfMap = omrmem_allocate_memory_basic(portLibrary, J9OSDUMP_SIZE);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(J9ZOS390) && defined(OMR_GC_COMPRESSED_POINTERS)
 	/* 'disableEnsureCap32' is set using omrport_control(OMRPORT_CTLDATA_NOSUBALLOC32BITMEM,...),

--- a/port/unix/omrmmap.c
+++ b/port/unix/omrmmap.c
@@ -50,7 +50,7 @@
 #include "protect_helpers.h"
 #include "omrportpriv.h"
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/shm.h>
 #include <sys/vminfo.h>
 #endif/*AIXPPC*/
@@ -299,14 +299,14 @@ omrmmap_capabilities(struct OMRPortLibrary *portLibrary)
 			| OMRPORT_MMAP_CAPABILITY_READ
 			| OMRPORT_MMAP_CAPABILITY_PROTECT
 			/* If JSE platforms include WRITE and MSYNC - ZOS included, but currently has own omrmmap.c */
-#if ((defined(LINUX) && defined(J9X86)) \
-  || (defined(LINUXPPC)) \
-  || (defined(LINUX) && defined(S390)) \
-  || (defined(LINUX) && defined(J9HAMMER)) \
-  || (defined(LINUX) && defined(ARM)) \
-  || (defined(LINUX) && defined(AARCH64)) \
-  || (defined(AIXPPC)) \
-  || (defined(OSX)))
+#if (((HOST_OS == OMR_LINUX) && defined(J9X86)) \
+  || ((HOST_OS == OMR_LINUX)) \
+  || ((HOST_OS == OMR_LINUX) && defined(S390)) \
+  || ((HOST_OS == OMR_LINUX) && defined(J9HAMMER)) \
+  || ((HOST_OS == OMR_LINUX) && defined(ARM)) \
+  || ((HOST_OS == OMR_LINUX) && defined(AARCH64)) \
+  || ((HOST_OS == OMR_AIX)) \
+  || ((HOST_OS == OMR_OSX)))
 			| OMRPORT_MMAP_CAPABILITY_WRITE
 			| OMRPORT_MMAP_CAPABILITY_MSYNC
 #endif
@@ -344,16 +344,16 @@ omrmmap_dont_need(struct OMRPortLibrary *portLibrary, const void *startAddress, 
 
 			Trc_PRT_mmap_dont_need_oscall(roundedStart, roundedLength);
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 			if (-1 == madvise((void *)roundedStart, roundedLength, MADV_DONTNEED)) {
 				Trc_PRT_mmap_dont_need_madvise_failed((void *)roundedStart, roundedLength, errno);
 			}
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 			/* madvise is not supported on AIX.  disclaim64() fails on virtual memory mapped to a file */
 			if (-1 == disclaim64((void *)roundedStart, roundedLength, DISCLAIM_ZEROMEM)) {
 				Trc_PRT_mmap_dont_need_disclaim64_failed((void *)roundedStart, roundedLength, errno);
 			}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		}
 	}
 }

--- a/port/unix/omrosdump.c
+++ b/port/unix/omrosdump.c
@@ -27,7 +27,7 @@
  */
 
 #include <sys/types.h>
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <sys/proc.h>
 #endif
 #include <unistd.h>
@@ -54,7 +54,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* **********
 These definitions were copied from /usr/include/sys/proc.h in AIX 6.1, because this functionality does not
 exist on AIX 5.3. The code that uses these definitions does a runtime lookup to see if the
@@ -105,7 +105,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 	char *lastSep = NULL;
 	intptr_t pid = 0;
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct vario myvar;
 
 	/* check to see if full core dumps are enabled */
@@ -140,15 +140,15 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 	if (0 == pid) {
 		/* in the child process */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		/*
 		 * on Linux, shared library pages don't appear in core files by default.
 		 * Mark all pages writable to force these pages to appear
 		 */
 		markAllPagesWritable(portLibrary);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		/* On AIX we need to ask sigaction for full dumps */
 		{
 			struct sigaction act;
@@ -157,16 +157,16 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 			sigfillset(&act.sa_mask);
 			sigaction(SIGIOT, &act, 0);
 		}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 		/*
 		 * CMVC 95748: don't use abort() after fork() on Linux as this seems to upset certain levels of glibc
 		 */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define J9_DUMP_SIGNAL  SIGSEGV
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #define J9_DUMP_SIGNAL  SIGABRT
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 		/* Ensure we get default action (core) - reset primary&app handlers */
 		OMRSIG_SIGNAL(J9_DUMP_SIGNAL, SIG_DFL);
@@ -184,9 +184,9 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 			}
 		}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		pthread_kill(pthread_self(), J9_DUMP_SIGNAL);
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 		abort();
 	} /* end of child process */
@@ -197,7 +197,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 		return 1;
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 
 	if (NULL != filename) {
 		/* Wait for child process that is generating core file to finish */
@@ -208,7 +208,7 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 		return 1;
 	}
 
-#elif defined(AIXPPC) /* defined(LINUX) || defined(OSX) */
+#elif (HOST_OS == OMR_AIX) /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	if (filename && filename[0] != '\0') {
 		char corepath[EsMaxPath] = "";
@@ -258,11 +258,11 @@ omrdump_create(struct OMRPortLibrary *portLibrary, char *filename, char *dumpTyp
 
 	return 0;
 
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #error "This platform doesn't have an implementation of omrdump_create"
 
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 #else /* J9OS_I5 */
 
@@ -320,7 +320,7 @@ unlimitCoreFileSize(struct OMRPortLibrary *portLibrary)
 int32_t
 omrdump_startup(struct OMRPortLibrary *portLibrary)
 {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	uintptr_t handle = 0;
 
 	portLibrary->error_set_last_error(portLibrary, 0, 0);
@@ -360,7 +360,7 @@ omrdump_startup(struct OMRPortLibrary *portLibrary)
 		}
 		portLibrary->sl_close_shared_library(portLibrary, handle);
 	}
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 	/* We can only get here omrdump_startup completed successfully */
 

--- a/port/unix/omrsignal.c
+++ b/port/unix/omrsignal.c
@@ -68,7 +68,7 @@
 #include "omrsig.h"
 #endif /* defined(OMRPORT_OMRSIG_SUPPORT) */
 
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 typedef void (*unix_sigaction)(int, siginfo_t *, void *, uintptr_t);
 #else
 typedef void (*unix_sigaction)(int, siginfo_t *, void *);
@@ -120,7 +120,7 @@ static OMRUnixAsyncHandlerRecord *asyncHandlerList;
 
 #if !defined(J9ZOS390)
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #define SIGSEM_T sem_t *
 #define SIGSEM_POST(_sem) sem_post(_sem)
 #define SIGSEM_ERROR SEM_FAILED
@@ -129,7 +129,7 @@ static OMRUnixAsyncHandlerRecord *asyncHandlerList;
 #define SIGSEM_DESTROY(_sem) sem_close(_sem)
 #define SIGSEM_WAIT(_sem) sem_wait(_sem)
 #define SIGSEM_TRY_WAIT(_sem) sem_trywait(_sem)
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define SIGSEM_T sem_t
 #define SIGSEM_POST(_sem) sem_post(&(_sem))
 #define SIGSEM_ERROR -1
@@ -138,7 +138,7 @@ static OMRUnixAsyncHandlerRecord *asyncHandlerList;
 #define SIGSEM_DESTROY(_sem) sem_destroy(&(_sem))
 #define SIGSEM_WAIT(_sem) sem_wait(&(_sem))
 #define SIGSEM_TRY_WAIT(_sem) sem_trywait(&(_sem))
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 static SIGSEM_T wakeUpASyncReporter;
 #else /* !defined(J9ZOS390) */
@@ -173,7 +173,7 @@ typedef struct OMRCurrentSignal {
 	int signal;
 	siginfo_t *sigInfo;
 	void *contextInfo;
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 	uintptr_t breakingEventAddr;
 #endif
 	uint32_t portLibSignalType;
@@ -214,7 +214,7 @@ static struct {
 	{OMRPORT_SIG_FLAG_SIGPROF, SIGPROF},
 	{OMRPORT_SIG_FLAG_SIGIO, SIGIO},
 	{OMRPORT_SIG_FLAG_SIGSYS, SIGSYS}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	, {OMRPORT_SIG_FLAG_SIGRECONFIG, SIGRECONFIG}
 #endif
 #if defined(J9ZOS390)
@@ -242,7 +242,7 @@ static uint32_t countInfoInCategory(struct OMRPortLibrary *portLibrary, void *in
 static void sig_full_shutdown(struct OMRPortLibrary *portLibrary);
 static int32_t initializeSignalTools(OMRPortLibrary *portLibrary);
 
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 static void masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo, uintptr_t breakingEventAddr);
 static void masterASynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo, uintptr_t nullArg);
 #else
@@ -905,7 +905,7 @@ asynchSignalReporter(void *userData)
  * upon receiving a signal they listen for.
  *
  */
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 static void
 masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo, uintptr_t breakingEventAddr)
 #else
@@ -913,7 +913,7 @@ static void
 masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 #endif
 {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	/*
 	 * PR 56956: ensure the right register context is used if a signal occurs in a transaction.
 	 * If there is a signal during a transaction, two contexts are provided: one for the start of the transaction
@@ -974,7 +974,7 @@ masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 		currentSignal.sigInfo = sigInfo;
 		currentSignal.contextInfo = contextInfo;
 		currentSignal.portLibSignalType = portLibType;
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 		currentSignal.breakingEventAddr = breakingEventAddr;
 #endif
 
@@ -1003,7 +1003,7 @@ masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
 				/* found a suitable handler */
 				/* what signal type do we want to pass on here? port or platform based ?*/
 				fillInUnixSignalInfo(thisRecord->portLibrary, contextInfo, &signalInfo);
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 				signalInfo.platformSignalInfo.breakingEventAddr = breakingEventAddr;
 #endif
 
@@ -1166,7 +1166,7 @@ masterSynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo)
  * Each expected aynch signal type has an associated semaphore which is used to count the number of "pending" signals.
  *
  */
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 static void
 masterASynchSignalHandler(int signal, siginfo_t *sigInfo, void *contextInfo, uintptr_t nullArg)
 #else
@@ -1251,7 +1251,7 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 	}
 #endif /* defined(J9ZOS390) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* if we are installing a handler for an asynchronous signal block SIGTRAP */
 	if (OMR_ARE_ANY_BITS_SET(portLibrarySignalNo, OMRPORT_SIG_FLAG_SIGALLASYNC)) {
 		if (sigaddset(&newAction.sa_mask, SIGTRAP)) {
@@ -1268,7 +1268,7 @@ registerSignalHandlerWithOS(OMRPortLibrary *portLibrary, uint32_t portLibrarySig
 	 * masterSynchSignalHandler in there. Since the code is shared on all platforms,
 	 * the change here is used to split them up to avoid any compiling error.
 	 */
-#if defined(S390) && defined(LINUX)
+#if defined(S390) && (HOST_OS == OMR_LINUX)
 	newAction.sa_sigaction = (void *)handler;
 #else
 	newAction.sa_sigaction = handler;
@@ -1490,9 +1490,9 @@ registerMasterHandlers(OMRPortLibrary *portLibrary, uint32_t flags, uint32_t all
 static int32_t
 initializeSignalTools(OMRPortLibrary *portLibrary)
 {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	char semNames[6][128] = {{0}};
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	
 	/* use this to record the end of the list of signal infos */
 	if (omrthread_tls_alloc(&tlsKey)) {
@@ -1523,13 +1523,13 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 	}
 
 #if !defined(J9ZOS390)
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	/* OSX only has named semaphores. They are not shared across processes, so unlink immediately. */
 	portLibrary->str_printf(portLibrary, semNames[0], 128, "/omr/wakeUpASyncReporter-%d", getpid());
 #define SIGSEM_NAME(_i) semNames[_i]
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define SIGSEM_NAME(_i) NULL
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	/* The asynchronous signal reporter will wait on this semaphore  */
 	if (SIGSEM_ERROR == SIGSEM_INIT(wakeUpASyncReporter, SIGSEM_NAME(0))) {
@@ -1553,7 +1553,7 @@ initializeSignalTools(OMRPortLibrary *portLibrary)
 		PPG_resumableTrapsSupported = FALSE;
 	}
 #endif /* defined(J9ZOS390) */
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	/* If a process has blocked signals, then the signals stay blocked in the
 	 * sub-processes across fork(s) and exec(s). Blocked signals prevent signal

--- a/port/unix/omrsl.c
+++ b/port/unix/omrsl.c
@@ -26,13 +26,13 @@
  * @brief shared library
  */
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
 /* defining _GNU_SOURCE allows the use of dladdr() in dlfcn.h */
 #define _GNU_SOURCE
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define _XOPEN_SOURCE
-#endif /* defined(LINUX)  && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX)  && !defined(OMRZTPF) */
 
 /*
  *	Standard unix shared libraries
@@ -51,11 +51,11 @@
 /* Start copy from omrfiletext.c */
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX)
+#if defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #define J9VM_USE_MBTOWC
-#else /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#else /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #include "omriconvhelpers.h"
-#endif /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#endif /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 
 #if defined(J9VM_USE_MBTOWC) || defined(J9VM_USE_ICONV)
@@ -73,11 +73,11 @@
 #include "omrport.h"
 #include "portnls.h"
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #define PLATFORM_DLL_EXTENSION ".dylib"
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 #define PLATFORM_DLL_EXTENSION ".so"
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #if (defined(J9VM_USE_MBTOWC)) /* priv. proto (autogen) */
 
@@ -160,7 +160,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 	/* dlopen(2) called with NULL filename opens a handle to current executable. */
 	handle = dlopen(openExec ? NULL : openName, lazyOrNow);
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	if ((NULL == handle) && !openExec) {
 		/* last ditch, try dir port lib DLL is in */
 		char portLibDir[MAX_STRING_LENGTH];
@@ -195,7 +195,7 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 			}
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	if (NULL == handle) {
 		getDLError(portLibrary, errBuf, sizeof(errBuf));

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -30,9 +30,9 @@
 #define ENV_DEBUG
 #endif
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #define _GNU_SOURCE
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #define _XOPEN_SOURCE
 #include <libproc.h>
 #include <mach/mach.h>
@@ -44,7 +44,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -75,25 +75,25 @@
 #include "omrsysinfo_helpers.h"
 #endif /* defined(J9ZOS390) */
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 #include "auxv.h"
 #include <strings.h>
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 #include <fcntl.h>
 #include <sys/procfs.h>
 #include <sys/systemcfg.h>
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
 /* Start copy from omrfiletext.c */
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if defined(__STDC_ISO_10646__) || defined(LINUX) ||defined(OSX)
+#if defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) ||(HOST_OS == OMR_OSX)
 #define J9VM_USE_MBTOWC
-#else /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#else /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #include "omriconvhelpers.h"
-#endif /* defined(__STDC_ISO_10646__) || defined(LINUX) || defined(OSX) */
+#endif /* defined(__STDC_ISO_10646__) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 /* a2e overrides nl_langinfo to return ASCII strings. We need the native EBCDIC string */
 #if defined(J9ZOS390) && defined (nl_langinfo)
@@ -131,20 +131,20 @@
 #endif
 #endif
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <linux/magic.h>
 #include <sys/sysinfo.h>
 #include <sys/vfs.h>
 #include <sched.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <sys/sysctl.h>
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 #include <unistd.h>
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include "omrcgroup.h"
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include "omrportpriv.h"
 #include "omrportpg.h"
 #include "omrportptb.h"
@@ -257,7 +257,7 @@ struct  {
 #endif
 };
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #define OMR_CGROUP_V1_MOUNT_POINT "/sys/fs/cgroup"
 #define ROOT_CGROUP "/"
@@ -372,35 +372,35 @@ static struct OMRCgroupSubsystemMetricMap omrCgroupCpusetMetricMap[] = {
 
 static uint32_t attachedPortLibraries;
 static omrthread_monitor_t cgroupEntryListMonitor;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 static intptr_t cwdname(struct OMRPortLibrary *portLibrary, char **result);
 static uint32_t getLimitSharedMemory(struct OMRPortLibrary *portLibrary, uint64_t *limit);
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 static intptr_t readSymbolicLink(struct OMRPortLibrary *portLibrary, char *linkFilename, char **result);
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) */
-#if defined(AIXPPC) || defined(J9ZOS390)
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 static BOOLEAN isSymbolicLink(struct OMRPortLibrary *portLibrary, char *filename);
 static intptr_t searchSystemPath(struct OMRPortLibrary *portLibrary, char *filename, char **result);
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
 
 #if defined(J9ZOS390)
 static void setOSFeature(struct OMROSDesc *desc, uint32_t feature);
 static intptr_t getZOSDescription(struct OMRPortLibrary *portLibrary, struct OMROSDesc *desc);
 #endif /* defined(J9ZOS390) */
 
-#if !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF)
+#if !defined(RS6000) && !defined(J9ZOS390) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF)
 static uint64_t getPhysicalMemory(struct OMRPortLibrary *portLibrary);
-#elif defined(OMRZTPF) /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX)  && !defined(OMRZTPF) */
+#elif defined(OMRZTPF) /* !defined(RS6000) && !defined(J9ZOS390) && !(HOST_OS == OMR_OSX)  && !defined(OMRZTPF) */
 static uint64_t getPhysicalMemory();
-#endif /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF) */
+#endif /* !defined(RS6000) && !defined(J9ZOS390) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF) */
 
 #if defined(OMRZTPF)
 	uintptr_t get_IPL_IstreamCount();
 	uintptr_t get_Dispatch_IstreamCount();
 #endif /* defined(OMRZTPF) */
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 static BOOLEAN isCgroupV1Available(struct OMRPortLibrary *portLibrary);
 static void freeCgroupEntries(struct OMRPortLibrary *portLibrary, OMRCgroupEntry *cgEntryList);
 static char * getCgroupNameForSubsystem(struct OMRPortLibrary *portLibrary, OMRCgroupEntry *cgEntryList, const char *subsystem);
@@ -413,15 +413,15 @@ static int32_t readCgroupMetricFromFile(struct OMRPortLibrary *portLibrary, uint
 static int32_t readCgroupSubsystemFile(struct OMRPortLibrary *portLibrary, uint64_t subsystemFlag, const char *fileName, int32_t numItemsToRead, const char *format, ...);
 static int32_t isRunningInContainer(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer);
 static int32_t getCgroupMemoryLimit(struct OMRPortLibrary *portLibrary, uint64_t *limit);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 static int32_t retrieveLinuxMemoryStatsFromProcFS(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 static int32_t retrieveLinuxCgroupMemoryStats(struct OMRPortLibrary *portLibrary, struct OMRCgroupMemoryInfo *cgroupMemInfo);
 static int32_t retrieveLinuxMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 static int32_t retrieveOSXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 static int32_t retrieveAIXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 #elif defined(J9ZOS390)
 static int32_t retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
@@ -503,7 +503,7 @@ omrsysinfo_process_exists(struct OMRPortLibrary *portLibrary, uintptr_t pid)
 const char *
 omrsysinfo_get_CPU_architecture(struct OMRPortLibrary *portLibrary)
 {
-#if defined(RS6000) || defined(LINUXPPC)
+#if defined(RS6000) || (HOST_OS == OMR_LINUX)
 #ifdef PPC64
 #ifdef OMR_ENV_LITTLE_ENDIAN
 	return OMRPORT_ARCH_PPC64LE;
@@ -556,7 +556,7 @@ omrsysinfo_get_OS_type(struct OMRPortLibrary *portLibrary)
 #if defined(J9OS_I5)
 	/* JCL on IBM i expects to see "OS/400" */
 	return "OS/400";
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	return "Mac OS X";
 #else
 	if (NULL == PPG_si_osType) {
@@ -682,7 +682,7 @@ omrsysinfo_get_OS_version(struct OMRPortLibrary *portLibrary)
 		}
 #else
 		rc = uname(&sysinfo);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 		if (rc >= 0) {
 			int len;
@@ -794,7 +794,7 @@ omrsysinfo_get_groups(struct OMRPortLibrary *portLibrary, uint32_t **gidList, ui
 static intptr_t
 find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 {
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	intptr_t retval = readSymbolicLink(portLibrary, "/proc/self/exe", result);
 	if (NULL != *result) {
 		/* The code in this block is a work around for a linux bug. If /proc/self/exe is read after a
@@ -817,7 +817,7 @@ find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 		}
 	}
 	return retval;
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	intptr_t rc = -1;
 	uint32_t size = 0;
 
@@ -829,7 +829,7 @@ find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 		rc = 0;
 	}
 	return rc;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 
 	intptr_t retval = -1;
 	intptr_t length;
@@ -871,7 +871,7 @@ find_executable_name(struct OMRPortLibrary *portLibrary, char **result)
 #else
 	char *execName = NULL;
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	/* On AIX, "/proc" provides a way of determining argument vector (not just using
 	 * argv[0] from within main()).
 	 */
@@ -1046,7 +1046,7 @@ cleanup:
 	}
 
 	return retval;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 
 /**
@@ -1110,7 +1110,7 @@ doAlloc:
 	return 0;
 }
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 /**
  * @internal  Examines the named file to determine if it is a symbolic link.  On platforms which don't have
  * symbolic links (or where we can't tell) or if an unexpected error occurs, just answer FALSE.
@@ -1136,7 +1136,7 @@ isSymbolicLink(struct OMRPortLibrary *portLibrary, char *filename)
 
 	return FALSE;
 }
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
 
 /**
  * @internal  Attempts to read the contents of a symbolic link.  (The contents are the relative pathname of
@@ -1145,11 +1145,11 @@ isSymbolicLink(struct OMRPortLibrary *portLibrary, char *filename)
  * portLibrary->mem_free_memory when it is no longer needed.
  * On success, returns 0.  On error, returns -1.
  */
-#if defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 static intptr_t
 readSymbolicLink(struct OMRPortLibrary *portLibrary, char *linkFilename, char **result)
 {
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 	char fixedBuffer[PATH_MAX + 1];
 	int size = readlink(linkFilename, fixedBuffer, sizeof(fixedBuffer) - 1);
 #ifdef DEBUG
@@ -1166,13 +1166,13 @@ readSymbolicLink(struct OMRPortLibrary *portLibrary, char *linkFilename, char **
 	strcpy(*result, fixedBuffer);
 	return 0;
 
-#else /* defined(LINUX) || defined(AIXPPC) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
 	return -1;
-#endif /* defined(LINUX) || defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) */
 }
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
 
-#if defined(AIXPPC) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || defined(J9ZOS390)
 /**
  * @internal  Searches through the system PATH for the named file.  If found, it returns the path entry
  * which matched the file.  A buffer large enough to hold the proper path entry (without a
@@ -1241,7 +1241,7 @@ searchSystemPath(struct OMRPortLibrary *portLibrary, char *filename, char **resu
 	return -1;
 }
 
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || defined(J9ZOS390) */
 
 uintptr_t
 omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t type)
@@ -1252,7 +1252,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 
 	switch (type) {
 	case OMRPORT_CPU_PHYSICAL:
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 		toReturn = sysconf(_SC_NPROCESSORS_CONF);
 
 		if (0 == toReturn) {
@@ -1284,7 +1284,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedOnline("(no errno) ", 0);
 		}
-#elif (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#elif ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 		/* returns number of online(_SC_NPROCESSORS_ONLN) processors, number configured(_SC_NPROCESSORS_CONF) may  be more than online */
 		toReturn = sysconf(_SC_NPROCESSORS_ONLN);
 
@@ -1315,7 +1315,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 #if defined(J9OS_I5)
 		toReturn = 0;
 		Trc_PRT_sysinfo_get_number_CPUs_by_type_invalidType();
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 		rsid_t who = { .at_tid = thread_self() };
 		rsethandle_t rset = rs_alloc(RS_EMPTY);
 		ra_getrset(R_THREAD, who, 0, rset);
@@ -1325,7 +1325,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 >= toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedBound("errno: ", errno);
 		}
-#elif defined(LINUX) && !defined(OMRZTPF)
+#elif (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 		cpu_set_t cpuSet;
 		int32_t size = sizeof(cpuSet); /* Size in bytes */
 		pid_t mainProcess = getpid();
@@ -1382,7 +1382,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 		if (0 == toReturn) {
 			Trc_PRT_sysinfo_get_number_CPUs_by_type_failedBound("(no errno) ", 0);
 		}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 		/* OS X does not export interfaces that identify processors or control thread
 		 * placement--explicit thread to processor binding is not supported. Thus, this
 		 * just returns number of CPUs.
@@ -1441,7 +1441,7 @@ omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t
 /* Base for the decimal number system is 10. */
 #define COMPUTATION_BASE	10
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #define MEMSTATPATH			"/proc/meminfo"
 
 #define MEMTOTAL_PREFIX		"MemTotal:"
@@ -1794,7 +1794,7 @@ _exit:
 	return rc;
 }
 
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 
 /**
  * Function collects memory usage statistics on OSX and returns the same.
@@ -1869,7 +1869,7 @@ retrieveOSXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *
 	return ret;
 }
 
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 
 /**
  * Function collects memory usage statistics on AIX and returns the same.
@@ -1949,11 +1949,11 @@ omrsysinfo_get_memory_info(struct OMRPortLibrary *portLibrary, struct J9MemoryIn
 	memInfo->hostCached = OMRPORT_MEMINFO_NOT_AVAILABLE;
 	memInfo->hostBuffered = OMRPORT_MEMINFO_NOT_AVAILABLE;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	rc = retrieveLinuxMemoryStats(portLibrary, memInfo);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	rc = retrieveOSXMemoryStats(portLibrary, memInfo);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	rc = retrieveAIXMemoryStats(portLibrary, memInfo);
 #elif defined(J9ZOS390)
 	rc = retrieveZOSMemoryStats(portLibrary, memInfo);
@@ -1988,7 +1988,7 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 {
 	uint64_t result = 0;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	if (portLibrary->sysinfo_cgroup_are_subsystems_enabled(portLibrary, OMR_CGROUP_SUBSYSTEM_MEMORY)) {
 		int32_t rc = portLibrary->sysinfo_cgroup_get_memlimit(portLibrary, &result);
 
@@ -1996,7 +1996,7 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 			return result;
 		}
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined (RS6000)
 	/* physmem is not a field in the system_configuration struct */
@@ -2006,7 +2006,7 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 	J9CVT * __ptr32 cvtp = ((J9PSA * __ptr32)0)->flccvt;
 	J9RCE * __ptr32 rcep = cvtp->cvtrcep;
 	result = ((U_64)rcep->rcepool * J9BYTES_PER_PAGE);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	{
 		int name[2] = {CTL_HW, HW_MEMSIZE};
 		size_t len = sizeof(result);
@@ -2023,7 +2023,7 @@ omrsysinfo_get_physical_memory(struct OMRPortLibrary *portLibrary)
 	return result;
 }
 
-#if !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF)
+#if !defined(RS6000) && !defined(J9ZOS390) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF)
 
 /**
  * Returns physical memory available on the system
@@ -2046,7 +2046,7 @@ getPhysicalMemory(struct OMRPortLibrary *portLibrary)
 		return (uint64_t) pagesize * num_pages;
 	}
 }
-#elif defined(OMRZTPF) /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF) */
+#elif defined(OMRZTPF) /* !defined(RS6000) && !defined(J9ZOS390) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF) */
 
 static uint64_t
 getPhysicalMemory( void ) {
@@ -2074,7 +2074,7 @@ getPhysicalMemory( void ) {
 	return physMemory;
 }
 
-#endif /* !defined(RS6000) && !defined(J9ZOS390) && !defined(OSX) && !defined(OMRZTPF) */
+#endif /* !defined(RS6000) && !defined(J9ZOS390) && !(HOST_OS == OMR_OSX) && !defined(OMRZTPF) */
 
 void
 omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
@@ -2093,7 +2093,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 			portLibrary->mem_free_memory(portLibrary, PPG_si_executableName);
 			PPG_si_executableName = NULL;
 		}
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 		omrthread_monitor_enter(cgroupEntryListMonitor);
 		freeCgroupEntries(portLibrary, PPG_cgroupEntryList);
 		PPG_cgroupEntryList = NULL;
@@ -2103,7 +2103,7 @@ omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 			omrthread_monitor_destroy(cgroupEntryListMonitor);
 			cgroupEntryListMonitor = NULL;
 		}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	}
 }
 
@@ -2118,7 +2118,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	 */
 	(void) find_executable_name(portLibrary, &PPG_si_executableName);
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	PPG_cgroupEntryList = NULL;
 	/* To handle the case where multiple port libraries are started and shutdown,
 	 * as done by some fvtests (eg fvtest/porttest/j9portTest.cpp) that create fake portlibrary
@@ -2132,7 +2132,7 @@ omrsysinfo_startup(struct OMRPortLibrary *portLibrary)
 	}
 	attachedPortLibraries += 1;
 	isRunningInContainer(portLibrary, &PPG_isRunningInContainer);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	return 0;
 }
 
@@ -2302,7 +2302,7 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 	}
 	break;
 	case OMRPORT_RESOURCE_CORE_FLAGS: {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		struct vario myvar;
 
 		if (0 == sys_parm(SYSP_GET, SYSP_V_FULLCORE, &myvar)) {
@@ -2331,7 +2331,7 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 	 * must match "ulimit -n".
 	 */
 	case OMRPORT_RESOURCE_FILE_DESCRIPTORS: {
-#if defined(AIXPPC) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(J9ZOS390)
+#if (HOST_OS == OMR_AIX) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || defined(J9ZOS390)
 		/* getrlimit(2) is a POSIX routine. */
 		if (0 == getrlimit(RLIMIT_NOFILE, &lim)) {
 			*limit = (uint64_t) (hardLimitRequested ? lim.rlim_max : lim.rlim_cur);
@@ -2346,11 +2346,11 @@ omrsysinfo_get_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 			Trc_PRT_sysinfo_getrlimit_error(resource, findError(errno));
 			rc = OMRPORT_LIMIT_UNKNOWN;
 		}
-#else /* defined(AIXPPC) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(J9ZOS390) */
+#else /* (HOST_OS == OMR_AIX) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || defined(J9ZOS390) */
 		/* unsupported on other platforms (just in case). */
 		*limit = OMRPORT_LIMIT_UNKNOWN_VALUE;
 		rc = OMRPORT_LIMIT_UNKNOWN;
-#endif /* defined(AIXPPC) || (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX) || defined(J9ZOS390) */
+#endif /* (HOST_OS == OMR_AIX) || ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX) || defined(J9ZOS390) */
 	}
 	break;
 	default:
@@ -2415,7 +2415,7 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 			if (hardLimitRequested) {
 				lim.rlim_max = limit;
 			} else {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 				/* MacOS doesn't allow the soft file limit to be unlimited */
 				if ((OMRPORT_RESOURCE_FILE_DESCRIPTORS == resourceRequested)
 						&& (RLIM_INFINITY == limit)) {
@@ -2446,7 +2446,7 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 		}
 
 		case OMRPORT_RESOURCE_CORE_FLAGS: {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 			struct vario myvar;
 
 			myvar.v.v_fullcore.value = limit;
@@ -2476,7 +2476,7 @@ omrsysinfo_set_limit(struct OMRPortLibrary *portLibrary, uint32_t resourceID, ui
 static uint32_t
 getLimitSharedMemory(struct OMRPortLibrary *portLibrary, uint64_t *limit)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	int fd = 0;
 	int64_t shmmax = -1;
 	int bytesRead = 0;
@@ -2516,18 +2516,18 @@ errorReturn:
 	Trc_PRT_sysinfo_getLimitSharedMemory_ErrorExit(OMRPORT_LIMIT_UNKNOWN, OMRPORT_LIMIT_UNKNOWN_VALUE);
 	*limit = OMRPORT_LIMIT_UNKNOWN_VALUE;
 	return OMRPORT_LIMIT_UNKNOWN;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	Trc_PRT_sysinfo_getLimitSharedMemory_notImplemented(OMRPORT_LIMIT_UNKNOWN);
 	*limit = OMRPORT_LIMIT_UNKNOWN_VALUE;
 	return OMRPORT_LIMIT_UNKNOWN;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 
 intptr_t
 omrsysinfo_get_load_average(struct OMRPortLibrary *portLibrary, struct J9PortSysInfoLoadData *loadAverageData)
 {
-#if (defined(LINUX) || defined(OSX)) && !defined(OMRZTPF)
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && !defined(OMRZTPF)
 	double loadavg[3];
 	int returnValue = getloadavg(loadavg, 3);
 	if (returnValue == 3) {
@@ -2539,7 +2539,7 @@ omrsysinfo_get_load_average(struct OMRPortLibrary *portLibrary, struct J9PortSys
 	return -1;
 #elif defined(J9OS_I5)
 	return -1;
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	perfstat_cpu_total_t perfstats;
 	int returnValue = perfstat_cpu_total(NULL, &perfstats, sizeof(perfstat_cpu_total_t), 1);
 	if ((returnValue != EINVAL) && (returnValue != EFAULT) && (returnValue != ENOMEM)) {
@@ -2558,14 +2558,14 @@ intptr_t
 omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9SysinfoCPUTime *cpuTime)
 {
 	intptr_t status = OMRPORT_ERROR_SYSINFO_OPFAILED;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	/* omrtime_nano_time() gives monotonically increasing times as against omrtime_hires_clock() that
 	 * returns times that can (and does) decrease. Use this to compute timestamps.
 	 */
 	uint64_t preTimestamp = portLibrary->time_nano_time(portLibrary); /* ticks */
 	uint64_t postTimestamp; /* ticks */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	intptr_t bytesRead = -1;
 	/*
 	 * Read the first line of /proc/stat, which takes the form:
@@ -2605,7 +2605,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 		cpuTime->numberOfCpus = portLibrary->sysinfo_get_number_CPUs_by_type(portLibrary, OMRPORT_CPU_ONLINE);
 		status = 0;
 	}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	processor_cpu_load_info_t cpuLoadInfo;
 	mach_msg_type_number_t msgTypeNumber;
 	natural_t processorCount;
@@ -2637,7 +2637,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	/*Xj9GetSysCPUTime() is newly added to retrieve System CPU Time fromILE.*/
 	cpuTime->cpuTime = Xj9GetSysCPUTime();
 	status = 0;	
-#elif defined(AIXPPC) /* AIX */
+#elif (HOST_OS == OMR_AIX) /* AIX */
 	perfstat_cpu_total_t stats;
 	const uintptr_t NS_PER_CPU_TICK = 10000000L;
 
@@ -2660,7 +2660,7 @@ omrsysinfo_get_CPU_utilization(struct OMRPortLibrary *portLibrary, struct J9Sysi
 	/* Use the average of the timestamps before and after reading processor times to reduce bias. */
 	cpuTime->timestamp = (preTimestamp + postTimestamp) / 2;
 	return status;
-#else /* (defined(LINUX) && !defined(OMRZTPF)) || defined(AIXPPC) || defined(OSX) */
+#else /* ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 	/* Support on z/OS being temporarily removed to avoid wrong CPU stats being passed. */
 	return OMRPORT_ERROR_SYSINFO_NOT_SUPPORTED;
 #endif
@@ -3075,7 +3075,7 @@ omrsysinfo_env_iterator_next(struct OMRPortLibrary *portLibrary, J9SysinfoEnvIte
 
 }
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 #define PROCSTATPATH	"/proc/stat"
 #define PROCSTATPREFIX	"cpu"
@@ -3222,7 +3222,7 @@ retrieveLinuxProcessorStats(struct OMRPortLibrary *portLibrary, struct J9Process
 	return 0;
 }
 
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 
 /**
  * Function collects processor usage statistics on OSX and returns the same.
@@ -3271,7 +3271,7 @@ retrieveOSXProcessorStats(struct OMRPortLibrary *portLibrary, struct J9Processor
 	return ret;
 }
 
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 
 /**
  * Function collects processor usage statistics on AIX and returns the same.
@@ -3460,11 +3460,11 @@ omrsysinfo_get_processor_info(struct OMRPortLibrary *portLibrary, struct J9Proce
 		/* online field for the aggregate record needs to be -1 */
 		procInfo->procInfoArray[0].online = -1;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 		rc = retrieveLinuxProcessorStats(portLibrary, procInfo);
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 		rc = retrieveOSXProcessorStats(portLibrary, procInfo);
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 		rc = retrieveAIXProcessorStats(portLibrary, procInfo);
 #elif defined(J9ZOS390)
 		rc = retrieveZOSProcessorStats(portLibrary, procInfo);
@@ -3620,7 +3620,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 		portLibrary->error_set_last_error(portLibrary, EINVAL, findError(EINVAL));
 		Trc_PRT_sysinfo_get_open_file_count_invalidArgRecvd("count");
 	} else {
-#if defined(LINUX) || defined(AIXPPC)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX)
 		char buffer[PATH_MAX] = {0};
 		const char *procDirectory = "/proc/%d/fd/";
 		DIR *dir = NULL;
@@ -3663,7 +3663,7 @@ omrsysinfo_get_open_file_count(struct OMRPortLibrary *portLibrary, uint64_t *cou
 			}
 			closedir(dir); /* Done reading the /proc file-system. */
 		}
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 		pid_t pid = getpid();
 		/* First call with null to get the size of the buffer required */
 		int32_t bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, 0, 0);
@@ -3794,19 +3794,19 @@ omrsysinfo_os_kernel_info(struct OMRPortLibrary *portLibrary, struct OMROSKernel
 {
 	BOOLEAN success = FALSE;
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	struct utsname name = {{0}};
 	if (0 == uname(&name)) {
 		if (3 == sscanf(name.release, "%u.%u.%u", &kernelInfo->kernelVersion, &kernelInfo->majorRevision, &kernelInfo->minorRevision)) {
 			success = TRUE;
 		}
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	return success;
 }
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 
 /**
  * @internal
@@ -4408,13 +4408,13 @@ _end:
 	return rc;
 }
 
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 BOOLEAN
 omrsysinfo_cgroup_is_system_available(struct OMRPortLibrary *portLibrary)
 {
 	BOOLEAN result = FALSE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
 
 	Trc_PRT_sysinfo_cgroup_is_system_available_Entry();
@@ -4446,29 +4446,29 @@ _end:
 		PPG_cgroupSubsystemsAvailable = 0;
 	}
 	Trc_PRT_sysinfo_cgroup_is_system_available_Exit((uintptr_t)result);
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return result;
 }
 
 uint64_t
 omrsysinfo_cgroup_get_available_subsystems(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	Trc_PRT_sysinfo_cgroup_get_available_subsystems_Entry();
 	if (NULL == PPG_cgroupEntryList) {
 		portLibrary->sysinfo_cgroup_is_system_available(portLibrary);
 	}
 	Trc_PRT_sysinfo_cgroup_get_available_subsystems_Exit(PPG_cgroupSubsystemsAvailable);
 	return PPG_cgroupSubsystemsAvailable;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_are_subsystems_available(struct OMRPortLibrary *portLibrary, uint64_t subsystemFlags)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	uint64_t available = 0;
 	uint64_t rc = 0;
 
@@ -4480,25 +4480,25 @@ omrsysinfo_cgroup_are_subsystems_available(struct OMRPortLibrary *portLibrary, u
 	Trc_PRT_sysinfo_cgroup_are_subsystems_available_Exit(rc);
 
 	return rc;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_get_enabled_subsystems(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	return PPG_cgroupSubsystemsEnabled;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_enable_subsystems(struct OMRPortLibrary *portLibrary, uint64_t requestedSubsystems)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	uint64_t available = 0;
 
 	Trc_PRT_sysinfo_cgroup_enable_subsystems_Entry(requestedSubsystems);
@@ -4509,19 +4509,19 @@ omrsysinfo_cgroup_enable_subsystems(struct OMRPortLibrary *portLibrary, uint64_t
 	Trc_PRT_sysinfo_cgroup_enable_subsystems_Exit(PPG_cgroupSubsystemsEnabled);
 
 	return PPG_cgroupSubsystemsEnabled;
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 uint64_t
 omrsysinfo_cgroup_are_subsystems_enabled(struct OMRPortLibrary *portLibrary, uint64_t subsystemsFlags)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	return (PPG_cgroupSubsystemsEnabled & subsystemsFlags);
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return 0;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 int32_t
@@ -4531,9 +4531,9 @@ omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *lim
 
 	Assert_PRT_true(NULL != limit);
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	rc = getCgroupMemoryLimit(portLibrary, limit);
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 	return rc;
 }
@@ -4542,16 +4542,16 @@ omrsysinfo_cgroup_get_memlimit(struct OMRPortLibrary *portLibrary, uint64_t *lim
 BOOLEAN
 omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	int32_t rc = getCgroupMemoryLimit(portLibrary, NULL);
 	if (0 == rc) {
 		return TRUE;
 	} else {
 		return FALSE;
 	}
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return FALSE;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 }
 
 /*
@@ -4560,7 +4560,7 @@ omrsysinfo_cgroup_is_memlimit_set(struct OMRPortLibrary *portLibrary)
 struct OMRCgroupEntry *
 omrsysinfo_get_cgroup_subsystem_list(struct OMRPortLibrary *portLibrary)
 {
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	return PPG_cgroupEntryList;
 #else
 	return NULL;
@@ -4582,7 +4582,7 @@ omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, ui
 {
 	Assert_PRT_true(NULL != state);
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_UNSUPPORTED_PLATFORM;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	state->count = 0;
 	state->subsystemid = subsystem;
 	state->fileMetricCounter = 0;
@@ -4602,7 +4602,7 @@ omrsysinfo_cgroup_subsystem_iterator_init(struct OMRPortLibrary *portLibrary, ui
 	rc = 0;
 
 _end:
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return rc;
 }
 
@@ -4610,9 +4610,9 @@ BOOLEAN
 omrsysinfo_cgroup_subsystem_iterator_hasNext(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state)
 {
 	BOOLEAN check = FALSE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	check = state->count < state->numElements;
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return check;
 }
 
@@ -4620,7 +4620,7 @@ int32_t
 omrsysinfo_cgroup_subsystem_iterator_metricKey(struct OMRPortLibrary *portLibrary, const struct OMRCgroupMetricIteratorState *state, const char **metricKey)
 {
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_METRIC_NOT_AVAILABLE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	if (NULL != metricKey) {
 		const struct OMRCgroupSubsystemMetricMap *subsystemMetricMap = NULL;
 		switch (state->subsystemid) {
@@ -4653,7 +4653,7 @@ int32_t
 omrsysinfo_cgroup_subsystem_iterator_next(struct OMRPortLibrary *portLibrary, struct OMRCgroupMetricIteratorState *state, struct OMRCgroupMetricElement *metricElement)
 {
 	int32_t rc = OMRPORT_ERROR_SYSINFO_CGROUP_SUBSYSTEM_UNAVAILABLE;
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 	struct OMRCgroupMetricInfoElement *currentElement = NULL;
 	const struct OMRCgroupSubsystemMetricMap *subsystemMetricMap = NULL;
 	const struct OMRCgroupSubsystemMetricMap *subsystemMetricMapElement = NULL;
@@ -4755,7 +4755,7 @@ _end:
 		}
 	}
 	
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return rc;	
 }
 

--- a/port/unix/omrtime.c
+++ b/port/unix/omrtime.c
@@ -26,10 +26,10 @@
  * @brief Timer utilities
  */
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 #include <mach/clock.h>
 #include <mach/mach.h>
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 #include <time.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -40,11 +40,11 @@
 
 #define OMRTIME_NANOSECONDS_PER_SECOND J9CONST_I64(1000000000)
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 static clock_serv_t cs_t;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 static const clockid_t OMRTIME_NANO_CLOCK = CLOCK_MONOTONIC;
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 
 /**
@@ -88,21 +88,21 @@ uint64_t
 omrtime_current_time_nanos(struct OMRPortLibrary *portLibrary, uintptr_t *success)
 {
 	uint64_t nsec = 0;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	struct timeval ts;
 	*success = 0;
 	if (0 == gettimeofday(&ts, NULL)) {
 		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)(ts.tv_usec * 1000);
 		*success = 1;
 	}
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	struct timespec ts;
 	*success = 0;
 	if (0 == clock_gettime(CLOCK_REALTIME, &ts)) {
 		nsec = ((uint64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (uint64_t)ts.tv_nsec;
 		*success = 1;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	return nsec;
 }
 
@@ -110,18 +110,18 @@ int64_t
 omrtime_nano_time(struct OMRPortLibrary *portLibrary)
 {
 	int64_t hiresTime = 0;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	mach_timespec_t mt;
 	if (KERN_SUCCESS == clock_get_time(cs_t, &mt)) {
 		hiresTime = ((int64_t)mt.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)mt.tv_nsec;
 	}
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	struct timespec ts;
 
 	if (0 == clock_gettime(OMRTIME_NANO_CLOCK, &ts)) {
 		hiresTime = ((int64_t)ts.tv_sec * OMRTIME_NANOSECONDS_PER_SECOND) + (int64_t)ts.tv_nsec;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	return hiresTime;
 }
@@ -224,9 +224,9 @@ omrtime_hires_delta(struct OMRPortLibrary *portLibrary, uint64_t startTime, uint
 void
 omrtime_shutdown(struct OMRPortLibrary *portLibrary)
 {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	mach_port_deallocate(mach_task_self(), cs_t);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 /**
  * PortLibrary startup.
@@ -246,20 +246,18 @@ int32_t
 omrtime_startup(struct OMRPortLibrary *portLibrary)
 {
 	int32_t rc = 0;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	if (KERN_SUCCESS != host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cs_t)) {
 		rc = OMRPORT_ERROR_STARTUP_TIME;
 	}
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	struct timespec ts;
 
 	/* check if the clock is available */
 	if (0 != clock_getres(OMRTIME_NANO_CLOCK, &ts)) {
 		rc = OMRPORT_ERROR_STARTUP_TIME;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	return rc;
 }
-
-

--- a/port/unix_include/omrcgroup.h
+++ b/port/unix_include/omrcgroup.h
@@ -22,7 +22,7 @@
 #ifndef omrcgroup_h
 #define omrcgroup_h
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 
 /**
  * Stores memory usage statistics of the cgroup. These stats are collected from the files present
@@ -39,6 +39,6 @@ typedef struct OMRCgroupMemoryInfo {
 	uint64_t cached; /**< page cache memory (as in memory.stat file)*/
 } OMRCgroupMemoryInfo;
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif /* omrcgroup_h */

--- a/port/unix_include/omriconvhelpers.h
+++ b/port/unix_include/omriconvhelpers.h
@@ -29,9 +29,9 @@
 
 /* __STDC_ISO_10646__ indicates that the platform wchar_t encoding is Unicode */
 /* but older versions of libc fail to set the flag, even though they are Unicode */
-#if (!defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX)) || defined(OMRZTPF)
+#if (!defined(__STDC_ISO_10646__) && !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_OSX)) || defined(OMRZTPF)
 #define J9VM_USE_ICONV
-#endif /* !defined(__STDC_ISO_10646__) && !defined(LINUX) && !defined(OSX) */
+#endif /* !defined(__STDC_ISO_10646__) && !(HOST_OS == OMR_LINUX) && !(HOST_OS == OMR_OSX) */
 
 #if defined(J9ZOS390)
 #define J9VM_CACHE_ICONV_DESC

--- a/port/unix_include/omrintrospect.h
+++ b/port/unix_include/omrintrospect.h
@@ -30,14 +30,14 @@
 
 #include "omrintrospect_common.h"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /*
  * CMVC 194846.
  * NOTE: When we use pthread_sigmask on other platforms, we can remove this macro.
  */
 #define sigprocmask pthread_sigmask
 
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 typedef ucontext_t thread_context;
 

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -28,9 +28,9 @@
  */
 
 #include "omrcfg.h"
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #include "omrcgroup.h"
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include "omrport.h"
 #if defined(OMR_ENV_DATA64)
 #include "omrportpriv.h"
@@ -70,7 +70,7 @@ typedef struct OMRPortPlatformGlobals {
 	uintptr_t vmem_pageSize[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of supported page sizes */
 	uintptr_t vmem_pageFlags[OMRPORT_VMEM_PAGESIZE_COUNT]; /** <0 terminated array of flags describing type of the supported page sizes */
 	BOOLEAN isRunningInContainer;	
-#if defined(LINUX) && defined(S390)
+#if (HOST_OS == OMR_LINUX) && defined(S390)
 	int64_t last_clock_delta_update;  /** hw clock microsecond timestamp of last clock delta adjustment */
 	int64_t software_msec_clock_delta; /** signed difference between hw and sw clocks in milliseconds */
 #endif
@@ -84,12 +84,12 @@ typedef struct OMRPortPlatformGlobals {
 #if defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL)
 	int32_t introspect_threadSuspendSignal;
 #endif /* defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL) */
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	uint64_t cgroupSubsystemsAvailable; /**< cgroup subsystems available for port library to use; it is valid only when cgroupEntryList is non-null */
 	uint64_t cgroupSubsystemsEnabled; /**< cgroup subsystems enabled in port library; it is valid only when cgroupEntryList is non-null */
 	OMRCgroupEntry *cgroupEntryList; /**< head of the circular linked list, each element contains information about cgroup of the process for a subsystem */
 	BOOLEAN syscallNotAllowed; /**< Assigned True if the mempolicy syscall is failed due to security opts (Can be seen in case of docker) */
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 } OMRPortPlatformGlobals;
 
 
@@ -111,7 +111,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_vmem_pageSize (portLibrary->portGlobals->platformGlobals.vmem_pageSize)
 #define PPG_vmem_pageFlags (portLibrary->portGlobals->platformGlobals.vmem_pageFlags)
 #define PPG_isRunningInContainer (portLibrary->portGlobals->platformGlobals.isRunningInContainer)
-#if defined(LINUX) && defined(S390)
+#if (HOST_OS == OMR_LINUX) && defined(S390)
 #define PPG_last_clock_delta_update  (portLibrary->portGlobals->platformGlobals.last_clock_delta_update)
 #define PPG_software_msec_clock_delta (portLibrary->portGlobals->platformGlobals.software_msec_clock_delta)
 #endif
@@ -130,13 +130,13 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_introspect_threadSuspendSignal (portLibrary->portGlobals->platformGlobals.introspect_threadSuspendSignal)
 #endif
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* Note that PPG_cgroupSubsystemsAvailable and PPG_cgroupSubsystemsEnabled are valid only if PPG_cgroupEntryList is not NULL */
 #define PPG_cgroupSubsystemsAvailable (portLibrary->portGlobals->platformGlobals.cgroupSubsystemsAvailable)
 #define PPG_cgroupSubsystemsEnabled (portLibrary->portGlobals->platformGlobals.cgroupSubsystemsEnabled)
 #define PPG_cgroupEntryList (portLibrary->portGlobals->platformGlobals.cgroupEntryList)
 #define PPG_numaSyscallNotAllowed (portLibrary->portGlobals->platformGlobals.syscallNotAllowed)
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #endif /* omrportpg_h */
 

--- a/port/ztpf/omrvmem.c
+++ b/port/ztpf/omrvmem.c
@@ -1236,9 +1236,9 @@ void
 omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
 		uintptr_t mode, uintptr_t *pageSize, uintptr_t *pageFlags)
 {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	{
 		/* Note that the PPG_vmem_pageSize is a null-terminated list of page sizes.
 		 * There will always be the 0 element (default page size),
@@ -1252,7 +1252,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
 			*pageFlags = PPG_vmem_pageFlags[1];
 		}
 	}
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	else {
 		if (NULL != pageSize) {
 			/* Return the same page size as used by JIT code cache */
@@ -1267,7 +1267,7 @@ omrvmem_default_large_page_size_ex(struct OMRPortLibrary *portLibrary,
 			}
 		}
 	}
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	return;
 }
@@ -1284,7 +1284,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 	Assert_PRT_true_wrapper(OMRPORT_VMEM_PAGE_FLAG_NOT_USED == validPageFlags);
 
 	if (0 != validPageSize) {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		/* On Linux PPC, for executable pages, search through the list of supported page sizes only if
 		 * - request is for 16M pages, and
 		 * - 64 bit system OR (32 bit system AND CodeCacheConsolidation is enabled)
@@ -1307,7 +1307,7 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		if ((OMRPORT_VMEM_MEMORY_MODE_EXECUTE != (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) ||
 				((TRUE == codeCacheConsolidationEnabled) && (SIXTEEN_M == validPageSize)))
 #endif /* defined(J9VM_ENV_DATA64) */
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			uintptr_t pageIndex = 0;
 			uintptr_t *supportedPageSizes = portLibrary->vmem_supported_page_sizes(
@@ -1331,12 +1331,12 @@ omrvmem_find_valid_page_size(struct OMRPortLibrary *portLibrary, uintptr_t mode,
 		validPageSize = defaultLargePageSize;
 		validPageFlags = defaultLargePageFlags;
 	} else {
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 		if (OMRPORT_VMEM_MEMORY_MODE_EXECUTE == (OMRPORT_VMEM_MEMORY_MODE_EXECUTE & mode)) {
 			validPageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
 			validPageFlags = OMRPORT_VMEM_PAGE_FLAG_NOT_USED;
 		} else
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 		{
 			validPageSize = PPG_vmem_pageSize[0];
 			validPageFlags = PPG_vmem_pageFlags[0];

--- a/third_party/gtest-1.8.0/include/gtest/internal/gtest-port-arch.h
+++ b/third_party/gtest-1.8.0/include/gtest/internal/gtest-port-arch.h
@@ -78,7 +78,7 @@
 # define GTEST_OS_ZOS 1
 #elif defined(__sun) && defined(__SVR4)
 # define GTEST_OS_SOLARIS 1
-#elif defined(_AIX)
+#elif (HOST_OS == OMR_AIX)
 # define GTEST_OS_AIX 1
 #elif defined(__hpux)
 # define GTEST_OS_HPUX 1

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -96,9 +96,9 @@ static uintptr_t monitor_on_notify_all_wait_list(omrthread_t self, omrthread_mon
 static void monitor_notify_all_migration(omrthread_monitor_t monitor);
 
 static intptr_t failedToSetAttr(intptr_t rc);
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 static intptr_t copyAttr(omrthread_attr_t *attrTo, const omrthread_attr_t *attrFrom);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 static intptr_t fixupThreadAccounting(omrthread_t thread, uintptr_t type);
 static void storeExitCpuUsage(omrthread_t thread);
@@ -135,7 +135,7 @@ omrthread_t global_lock_owner = UNOWNED;
 #endif
 
 #ifdef OMR_ENV_DATA64
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 /* See CMVC 87602 - Problems on AIX 5.2 with very long wait times */
 #define BOUNDED_I64_TO_IDATA(longValue) ((longValue) > 0x7FFFFFFFLL ? (intptr_t)0x7FFFFFFF : (intptr_t)(longValue))
 #else /* AIXPPC */
@@ -166,9 +166,9 @@ omrthread_t global_lock_owner = UNOWNED;
 #define J9THR_WAIT_INTERRUPTED(flags) (((flags) & J9THREAD_FLAG_INTERRUPTED) != 0)
 #define J9THR_WAIT_PRI_INTERRUPTED(flags) (((flags) & (J9THREAD_FLAG_PRIORITY_INTERRUPTED | J9THREAD_FLAG_ABORTED)) != 0)
 
-#if defined(OMR_OS_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL)
+#if (HOST_OS == OMR_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL)
 #define NOTIFY_WRAPPER(thread) OMROSCOND_NOTIFY_ALL((thread)->condition);
-#else /* defined(OMR_OS_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
+#else /* (HOST_OS == OMR_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
 #define NOTIFY_WRAPPER(thread) \
 	do { \
 		if (OMR_ARE_ALL_BITS_SET((thread)->library->flags, J9THREAD_LIB_FLAG_NOTIFY_POLICY_BROADCAST)) { \
@@ -177,13 +177,13 @@ omrthread_t global_lock_owner = UNOWNED;
 			OMROSCOND_NOTIFY((thread)->condition); \
 		} \
 	} while (0)
-#endif /* defined(OMR_OS_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
+#endif /* (HOST_OS == OMR_WINDOWS) || !defined(OMR_NOTIFY_POLICY_CONTROL) */
 
 /*
  * Thread Library
  */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 
 /**
  * pthread TLS key destructor for self_ptr
@@ -216,7 +216,7 @@ self_key_destructor(void *current_omr_thread)
 
 #undef OMR_MAX_KEY_DELETION_ATTEMPTS
 
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * Initialize a J9 threading library.
@@ -240,9 +240,9 @@ omrthread_init(omrthread_library_t lib)
 	lib->spinlock = 0;
 	lib->threadCount = 0;
 	lib->globals = NULL;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	lib->stack_usage = 0;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	lib->flags = 0;
 
 	omrthread_mem_init(lib);
@@ -254,11 +254,11 @@ omrthread_init(omrthread_library_t lib)
 #error "CALLER_LAST_INDEX must be <= MAX_CALLER_INDEX"
 #endif
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (TLS_ALLOC(lib->self_ptr))
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	if (TLS_ALLOC_WITH_DESTRUCTOR(lib->self_ptr, self_key_destructor))
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 	{
 		goto init_cleanup1;
 	}
@@ -314,19 +314,19 @@ omrthread_init(omrthread_library_t lib)
 	lib->gc_lock_tracing = NULL;
 #endif
 
-#if	defined(OMR_OS_WINDOWS)
+#if	(HOST_OS == OMR_WINDOWS)
 	lib->flags |= J9THREAD_LIB_FLAG_DESTROY_MUTEX_ON_MONITOR_FREE;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	if (omrthread_attr_init(&lib->systemThreadAttr) != J9THREAD_SUCCESS) {
 		goto init_cleanup10;
 	}
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	if (KERN_SUCCESS != host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &lib->clockService)) {
 		goto init_cleanup11;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #if defined(OMR_PORT_NUMA_SUPPORT)
 	/* Load the numa library from the dll */
@@ -337,11 +337,11 @@ omrthread_init(omrthread_library_t lib)
 	lib->initStatus = 1;
 	return;
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 /* Unused cleanup label for future error handling. */
 /* init_cleanup12:		mach_port_deallocate(mach_task_self(), lib->clockService); */
 init_cleanup11:		omrthread_attr_destroy(&lib->systemThreadAttr);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 init_cleanup10:		pool_kill(lib->global_pool);
 init_cleanup9:		pool_kill(lib->thread_pool);
 init_cleanup8:		OMROSMUTEX_DESTROY(lib->resourceUsageMutex);
@@ -429,7 +429,7 @@ omrthread_lib_control(const char *key, uintptr_t value)
 		}
 	}
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	if (0 == strcmp(J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING, key)) {
 		if ((J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_DISABLED == value)
 		 || (J9THREAD_LIB_CONTROL_USE_REALTIME_SCHEDULING_ENABLED == value)
@@ -468,7 +468,7 @@ omrthread_lib_control(const char *key, uintptr_t value)
 			}
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return rc;
 }
@@ -476,12 +476,12 @@ omrthread_lib_control(const char *key, uintptr_t value)
 BOOLEAN
 omrthread_lib_use_realtime_scheduling(void)
 {
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	omrthread_library_t lib = GLOBAL_DATA(default_library);
 	return OMR_ARE_ALL_BITS_SET(lib->flags, J9THREAD_LIB_FLAG_REALTIME_SCHEDULING_ENABLED);
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	return FALSE;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 }
 
 /**
@@ -709,9 +709,9 @@ omrthread_shutdown(void)
 #if defined(OMR_THR_FORK_SUPPORT)
 	pool_kill(lib->rwmutexPool);
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	mach_port_deallocate(mach_task_self(), lib->clockService);
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 
 
@@ -860,9 +860,9 @@ postForkResetThreads(omrthread_t self)
 			OMROSCOND_INIT(threadIterator->condition);
 			OMROSMUTEX_INIT(threadIterator->mutex);
 			threadIterator->tid = omrthread_get_ras_tid();
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #error "The implementation of postForkResetThreads() is not complete in WIN32."
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 			threadIterator->handle = THREAD_SELF();
 		} else {
 			omrthread_tls_finalizeNoLock(threadIterator);
@@ -1227,11 +1227,11 @@ omrthread_attach_ex(omrthread_t *handle, omrthread_attr_t *attr)
 		goto cleanup2;
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(BREW)
+#if (HOST_OS == OMR_WINDOWS) && !defined(BREW)
 	DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &thread->handle, 0, TRUE, DUPLICATE_SAME_ACCESS);
 #else
 	thread->handle = THREAD_SELF();
-#endif /* defined(OMR_OS_WINDOWS) && !defined(BREW) */
+#endif /* (HOST_OS == OMR_WINDOWS) && !defined(BREW) */
 
 	initialize_thread_priority(thread);
 
@@ -1529,11 +1529,11 @@ thread_wrapper(WRAPPER_ARG arg)
 
 	TLS_SET(lib->self_ptr, thread);
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	if (lib->stack_usage) {
 		paint_stack(thread);
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 
 	if (thread->flags & J9THREAD_FLAG_CANCELED) {
@@ -1595,7 +1595,7 @@ thread_wrapper(WRAPPER_ARG arg)
 
 	threadEnableCpuMonitor(thread);
 
-#if defined(LINUX)  && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX)  && !defined(OMRZTPF)
 	/* Workaround for NPTL bug on Linux. See omrthread_exit() */
 	{
 		jmp_buf jumpBuffer;
@@ -1610,10 +1610,10 @@ thread_wrapper(WRAPPER_ARG arg)
 		}
 		thread->jumpBuffer = NULL;
 	}
-#else /* defined(LINUX) && !defined(OMRZTPF) */
+#else /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	thread->entrypoint(thread->entryarg);
 	/* omrthread_exit not called */
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 
 	threadInternalExit(globalAlreadyLocked);
 	/* UNREACHABLE */
@@ -1717,7 +1717,7 @@ omrthread_exit(omrthread_monitor_t monitor)
 		}
 	}
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	/* NPTL calls __pthread_unwind() from pthread_exit(). That walks the stack.
 	 * We can't allow that to happen, since our caller might have already been
 	 * unloaded. Walking the calling frame could cause a crash. Instead, we
@@ -1728,7 +1728,7 @@ omrthread_exit(omrthread_monitor_t monitor)
 	if (self->jumpBuffer) {
 		longjmp(*(jmp_buf *)self->jumpBuffer, 1);
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	threadInternalExit(GLOBAL_IS_LOCKED);
 
@@ -1766,7 +1766,7 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 
 	/* create a default attr if none was supplied */
 	if (NULL != attr) {
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		/* OSX threads ignore policy inheritance. Create a new attr and do inheritance manually as needed. */
 		if (J9THREAD_SCHEDPOLICY_INHERIT == (*attr)->schedpolicy) {
 			if (J9THREAD_SUCCESS != copyAttr(&tempAttr, attr)) {
@@ -1775,7 +1775,7 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 			}
 			tempAttrAllocated = TRUE;
 		} else
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 		{
 			tempAttr = *attr;
 		}
@@ -1800,12 +1800,12 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 
 	if (self && (J9THREAD_SCHEDPOLICY_INHERIT == tempAttr->schedpolicy)) {
 		thread->priority = self->priority;
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 		if (J9THREAD_SUCCESS != omrthread_attr_set_priority(&tempAttr, self->priority)) {
 			retVal = J9THREAD_ERR_INVALID_SCHEDPOLICY;
 			goto cleanup1;
 		}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 	} else {
 		thread->priority = tempAttr->priority;
 	}
@@ -1838,9 +1838,9 @@ threadCreate(omrthread_t *handle, const omrthread_attr_t *attr, uintptr_t suspen
 	/* Ignore errors, the thead cpu monitor should not cause thread creation failure */
 	omrthread_set_category(thread, tempAttr->category, J9THREAD_TYPE_SET_CREATE);
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	thread->jumpBuffer = NULL;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(OMR_PORT_NUMA_SUPPORT)
 	memset(&(thread->numaAffinity), 0x0, sizeof(thread->numaAffinity));
@@ -1872,7 +1872,7 @@ threadCreateDone:
 	return retVal;
 }
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 static intptr_t
 copyAttr(omrthread_attr_t *attrTo, const omrthread_attr_t *attrFrom)
 {
@@ -1933,7 +1933,7 @@ destroyAttr:
 copyAttrDone:
 	return rc;
 }
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 /**
  * Allocate a omrthread_t from the omrthread_t pool.
@@ -2001,13 +2001,13 @@ threadAllocate(omrthread_library_t lib, int globalIsLocked)
 static intptr_t
 threadDestroy(omrthread_t thread, int globalAlreadyLocked)
 {
-#if defined(OMR_OS_WINDOWS) || defined(THREAD_ASSERTS)
+#if (HOST_OS == OMR_WINDOWS) || defined(THREAD_ASSERTS)
 	omrthread_library_t lib;
 
 	ASSERT(thread);
 	lib = thread->library;
 	ASSERT(lib);
-#endif /* defined(OMR_OS_WINDOWS) || defined(THREAD_ASSERTS) */
+#endif /* (HOST_OS == OMR_WINDOWS) || defined(THREAD_ASSERTS) */
 
 	THREAD_LOCK(thread, CALLER_DESTROY);
 	if ((thread->flags & J9THREAD_FLAG_DEAD) == 0) {
@@ -2024,7 +2024,7 @@ threadDestroy(omrthread_t thread, int globalAlreadyLocked)
 	omrthread_dump_trace(thread);
 #endif
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/* Acquire the global monitor mutex (if needed) while performing handle closing and freeing. */
 	if (!globalAlreadyLocked) {
 		GLOBAL_LOCK_SIMPLE(lib);
@@ -2041,14 +2041,14 @@ threadDestroy(omrthread_t thread, int globalAlreadyLocked)
 		GLOBAL_UNLOCK_SIMPLE(lib);
 	}
 
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 	/* On z/OS, we cannot call GLOBAL_LOCK_SIMPLE(lib) before calling threadFree(), since this leads to
 	 * seg faults in the JVM. See PR 82332: [zOS S390] 80 VM_Extended.TestJvmCpuMonitorMXBeanLocal : crash
 	 */
 	threadFree(thread, globalAlreadyLocked);
 
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	return 0;
 }
@@ -3235,7 +3235,7 @@ omrthread_unpark(omrthread_t thread)
 uintptr_t
 omrthread_current_stack_free(void)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	MEMORY_BASIC_INFORMATION memInfo;
 	SYSTEM_INFO sysInfo;
 	uintptr_t stackFree;
@@ -3251,7 +3251,7 @@ omrthread_current_stack_free(void)
 	return (stackFree < guardPageSize) ? 0 : stackFree - guardPageSize;
 #else
 	return 0;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }
 
 

--- a/thread/common/omrthreadinspect.c
+++ b/thread/common/omrthreadinspect.c
@@ -31,16 +31,16 @@
  * The APIs in this file are only used for inspecting threads -- not for modifying them
  */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* Allowing the use of pthread_attr_getstack in omrthread_get_stack_range */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 #include <features.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <pthread.h>
 #define _XOPEN_SOURCE
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 #include "threaddef.h"
 #include "omrthreadinspect.h"
@@ -300,7 +300,7 @@ uintptr_t
 omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd)
 {
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	pthread_attr_t attr;
 	OSTHREAD osTid = thread->handle;
 	uintptr_t rc = 0;
@@ -338,7 +338,7 @@ omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd
 	/* On Linux, native stack grows from high to low memory */
 	*stackEnd = (void *)((uintptr_t)*stackStart + stackSize);
 	return J9THREAD_SUCCESS;
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 	OSTHREAD osTid = thread->handle;
 	size_t stackSize = 0;
 
@@ -346,9 +346,9 @@ omrthread_get_stack_range(omrthread_t thread, void **stackStart, void **stackEnd
 	stackSize = pthread_get_stacksize_np(osTid);
 	*stackEnd = (void *)((uintptr_t)*stackStart + stackSize);
 	return J9THREAD_SUCCESS;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	return J9THREAD_ERR_UNSUPPORTED_PLAT;
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 }
 
 #if (defined(OMR_THR_JLM))

--- a/thread/common/thread_internal.h
+++ b/thread/common/thread_internal.h
@@ -237,14 +237,14 @@ omrthread_get_mapped_priority(omrthread_prio_t omrthreadPriority);
 
 /* ------------- priority.c ------------ */
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 /**
  * @brief
  * @return intptr_t
  */
 intptr_t
 initialize_priority_map(void);
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 /**
  * @brief

--- a/thread/common/thrprof.c
+++ b/thread/common/thrprof.c
@@ -44,11 +44,11 @@
 #include "ut_j9thr.h"
 
 /* for syscall getrusage() used in omrthread_get_process_times */
-#if defined(LINUX) || defined (J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || defined (J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 #include <errno.h> /* Examine errno codes. */
 #include <sys/time.h> /* Portability */
 #include <sys/resource.h>
-#endif /* defined(LINUX) || defined (J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || defined (J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 #if defined(J9ZOS390)
 #include "omrgetthent.h"
@@ -56,10 +56,10 @@
 #define I32MAXVAL	0x7FFFFFFF
 #endif
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /* pthread_getcpuclockid() is not always declared in pthread.h */
 extern int pthread_getcpuclockid(pthread_t thread_id, clockid_t *clock_id);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #define STACK_PATTERN 0xBAADF00D
 
@@ -113,7 +113,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 		return J9THREAD_ERR_NO_SUCH_THREAD;
 	}
 
-#if defined(OMR_OS_WINDOWS) && !defined(BREW)
+#if (HOST_OS == OMR_WINDOWS) && !defined(BREW)
 	{
 		intptr_t ret = 0;
 		FILETIME creationTime, exitTime, kernelTime, userTime;
@@ -144,7 +144,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 		ret |= J9THREAD_ERR;
 		return ret;
 	}
-#endif	/* defined(OMR_OS_WINDOWS) && !defined(BREW) */
+#endif	/* (HOST_OS == OMR_WINDOWS) && !defined(BREW) */
 
 #ifdef AIXPPC
 	{
@@ -175,7 +175,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 	}
 #endif
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 	{
 		intptr_t ret = 0;
 		int result;
@@ -208,7 +208,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 		ret |= J9THREAD_ERR;
 		return ret;
 	}
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(J9ZOS390)
 	{
@@ -311,7 +311,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 	}
 #endif
 
-#if defined(OSX)
+#if (HOST_OS == OMR_OSX)
 	{
 		mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
 		thread_basic_info_t tbi;
@@ -329,7 +329,7 @@ omrthread_get_cpu_time_ex(omrthread_t thread, int64_t *cpuTime)
 
 		return J9THREAD_SUCCESS;
 	}
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 
 	return J9THREAD_ERR;
 }
@@ -369,7 +369,7 @@ omrthread_get_self_cpu_time(omrthread_t self)
 	 * Testing on various x86 and PPC Linuxes shows some improvement on RHEL5
 	 * and no noticeable degradation on older Linuxes.
 	 */
-#if defined(LINUX) && defined(CLOCK_THREAD_CPUTIME_ID)
+#if (HOST_OS == OMR_LINUX) && defined(CLOCK_THREAD_CPUTIME_ID)
 	{
 		struct timespec time;
 
@@ -377,7 +377,7 @@ omrthread_get_self_cpu_time(omrthread_t self)
 			return ((int64_t)time.tv_sec * 1000 * 1000 * 1000) + time.tv_nsec;
 		}
 	}
-#endif /* defined(LINUX) && defined(CLOCK_THREAD_CPUTIME_ID) */
+#endif /* (HOST_OS == OMR_LINUX) && defined(CLOCK_THREAD_CPUTIME_ID) */
 
 	return omrthread_get_cpu_time(self);
 }
@@ -396,7 +396,7 @@ omrthread_get_self_cpu_time(omrthread_t self)
 int64_t
 omrthread_get_user_time(omrthread_t thread)
 {
-#if defined(OMR_OS_WINDOWS) && !defined(BREW)
+#if (HOST_OS == OMR_WINDOWS) && !defined(BREW)
 
 	/* In Windows, the time spent in user mode is easily acquired.
 	 * Note that this function is not supported in Win95.
@@ -415,9 +415,9 @@ omrthread_get_user_time(omrthread_t thread)
 		return totalTime * 100;
 	}
 
-#endif	/* defined(OMR_OS_WINDOWS) && !defined(BREW) */
+#endif	/* (HOST_OS == OMR_WINDOWS) && !defined(BREW) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 
 	/* AIX provides a function call that returns an entire structure of
 	 * information about the thread.
@@ -487,10 +487,10 @@ omrthread_get_handle(omrthread_t thread)
 void
 omrthread_enable_stack_usage(uintptr_t enable)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	omrthread_library_t lib = GLOBAL_DATA(default_library);
 	lib->stack_usage = enable;
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }
 
 
@@ -506,9 +506,9 @@ omrthread_enable_stack_usage(uintptr_t enable)
 uintptr_t
 omrthread_get_stack_usage(omrthread_t thread)
 {
-#if defined(LINUX) || defined (J9ZOS390) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || defined (J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 	return 0;
-#else /* defined(LINUX) || defined (J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || defined (J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 	uintptr_t *tos = thread->tos;
 	uintptr_t count = thread->stacksize;
 
@@ -525,7 +525,7 @@ omrthread_get_stack_usage(omrthread_t thread)
 	}
 
 	return count;
-#endif /* defined(LINUX) || defined (J9ZOS390) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || defined (J9ZOS390) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 }
 
 
@@ -544,7 +544,7 @@ void
 paint_stack(omrthread_t thread)
 {
 	/* Only supported on Windows */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	MEMORY_BASIC_INFORMATION memInfo;
 	SYSTEM_INFO sysInfo;
 	uintptr_t *curr;
@@ -567,7 +567,7 @@ paint_stack(omrthread_t thread)
 	/* Round up to the system page size. */
 	GetSystemInfo(&sysInfo);
 	thread->stacksize = ((uintptr_t)stack - (uintptr_t)thread->tos + sysInfo.dwPageSize) & ~((uintptr_t)sysInfo.dwPageSize - 1);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }
 
 
@@ -617,7 +617,7 @@ omrthread_get_os_priority(omrthread_t thread, intptr_t *policy, intptr_t *priori
 		*policy = osPolicy;
 	}
 
-#elif defined(OMR_OS_WINDOWS) && !defined(BREW)
+#elif (HOST_OS == OMR_WINDOWS) && !defined(BREW)
 
 	*priority = GetThreadPriority(thread->handle);
 	if (*priority == THREAD_PRIORITY_ERROR_RETURN) {
@@ -666,7 +666,7 @@ omrthread_get_os_priority(omrthread_t thread, intptr_t *policy, intptr_t *priori
 int64_t
 omrthread_get_process_cpu_time(void)
 {
-#if defined(OMR_OS_WINDOWS) && !defined(BREW)
+#if (HOST_OS == OMR_WINDOWS) && !defined(BREW)
 	FILETIME creationTime, exitTime, kernelTime, userTime;
 	int64_t totalTime;
 
@@ -677,7 +677,7 @@ omrthread_get_process_cpu_time(void)
 		/* totalTime is in 100's of nanos.  Convert to nanos */
 		return totalTime * GET_PROCESS_TIMES_IN_NANO;
 	}
-#endif	/* defined(OMR_OS_WINDOWS) && !defined(BREW) */
+#endif	/* (HOST_OS == OMR_WINDOWS) && !defined(BREW) */
 
 	return -1;
 
@@ -692,7 +692,7 @@ intptr_t
 omrthread_get_process_times(omrthread_process_time_t *processTime)
 {
 	if (processTime != NULL) {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 
 		/* We don't use creationTime and exitTime but GetProcessTimes() needs them */
 		FILETIME creationTime;
@@ -719,9 +719,9 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 			Trc_THR_ThreadGetProcessTimes_GetProcessTimesFailed(GetLastError());
 			return -2;
 		}
-#endif	/* defined(OMR_OS_WINDOWS) */
+#endif	/* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(LINUX) || defined(AIXPPC) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX)
 		struct rusage rUsage;
 		memset(&rUsage, 0, sizeof(rUsage));
 
@@ -737,7 +737,7 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 			Trc_THR_ThreadGetProcessTimes_getrusageFailed(errno);
 			return -2;
 		}
-#endif /* defined(LINUX) || defined(AIXPPC) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_AIX) || (HOST_OS == OMR_OSX) */
 
 #if defined (J9ZOS390)
 		/* Input buffer, pointer to buffer, and size of the buffer area. */
@@ -823,7 +823,7 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 uint64_t
 omrthread_get_hires_clock(void)
 {
-#if defined(LINUX) && (defined(J9HAMMER) || defined(J9X86))
+#if (HOST_OS == OMR_LINUX) && (defined(J9HAMMER) || defined(J9X86))
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)
 	struct timespec ts;
 	uint64_t hiresTime = 0;
@@ -833,7 +833,7 @@ omrthread_get_hires_clock(void)
 	}
 
 	return hiresTime;
-#elif defined(OMR_OS_WINDOWS) /* defined(LINUX) && (defined(J9HAMMER) || defined(J9X86)) */
+#elif (HOST_OS == OMR_WINDOWS) /* (HOST_OS == OMR_LINUX) && (defined(J9HAMMER) || defined(J9X86)) */
 	LARGE_INTEGER i;
 
 	if (QueryPerformanceCounter(&i)) {
@@ -841,7 +841,7 @@ omrthread_get_hires_clock(void)
 	} else {
 		return (uint64_t)GetTickCount();
 	}
-#elif defined(OSX) /* defined(OMR_OS_WINDOWS) */
+#elif (HOST_OS == OMR_OSX) /* (HOST_OS == OMR_WINDOWS) */
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)
 	omrthread_library_t lib = GLOBAL_DATA(default_library);
 	mach_timespec_t mt;
@@ -854,9 +854,9 @@ omrthread_get_hires_clock(void)
 	}
 
 	return hiresTime;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	return GET_HIRES_CLOCK();
-#endif /* defined(OSX) */
+#endif /* (HOST_OS == OMR_OSX) */
 }
 
 #define THREAD_WALK_RESOURCE_USAGE_MUTEX_HELD	0x1

--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -289,7 +289,7 @@ omrthread_numa_init(omrthread_library_t threadLibrary)
 	}
 	/* find our current affinity mask since we will need it when removing any affinity binding from threads, later (since we still want to honour restrictions we inherited from the environment) */
 	CPU_ZERO(&defaultAffinityMask);
-#if __GLIBC_PREREQ(2,4) || defined(LINUXPPC)
+#if __GLIBC_PREREQ(2,4) || (HOST_OS == OMR_LINUX)
 	/*
 	 * LIR 902 : On Linux PPC, rolling up tool chain level to VAC 8 on RHEL 4.
 	 * The libc version on RHEL 4 requires 3 arg to sched_setaffinity.
@@ -388,7 +388,7 @@ omrthread_numa_set_node_affinity_nolock(omrthread_t thread, const uintptr_t *nod
 			memcpy(&affinityCPUs, &defaultAffinityMask, sizeof(cpu_set_t));
 		}
 		if ((threadIsStarted) && (0 == result)) {
-#if __GLIBC_PREREQ(2,4) || defined(LINUXPPC)
+#if __GLIBC_PREREQ(2,4) || (HOST_OS == OMR_LINUX)
 			/*
 			 * LIR 902 : On Linux PPC, rolling up tool chain level to VAC 8 on RHEL 4.
 			 * The libc version on RHEL 4 requires 3 arg to sched_setaffinity.
@@ -457,16 +457,16 @@ omrthread_numa_get_node_affinity(omrthread_t thread, uintptr_t *numaNodes, uintp
 			 * by an external program (see: http://www.linuxjournal.com/article/6799)
 			 */
 
-#if __GLIBC_PREREQ(2,4) || defined(LINUXPPC)
+#if __GLIBC_PREREQ(2,4) || (HOST_OS == OMR_LINUX)
 			/*
 			 * LIR 902 : On Linux PPC, rolling up tool chain level to VAC 8 on RHEL 4.
 			 * The libc version on RHEL 4 requires 3 arg to sched_getaffinity.
 			 * Note: this will not compile/run properly on RHEL 3.
 			 */
 			if (0 == sched_getaffinity(thread->tid, sizeof(cpu_set_t), &affinityCPUs))
-#else /* defined(LINUXPPC) */
+#else /* (HOST_OS == OMR_LINUX) */
 			if (0 == sched_getaffinity(thread->tid, &affinityCPUs))
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 			{
 				/* Now try matching it up with CPUs from known NUMA nodes */
 				uintptr_t node = 1;

--- a/thread/unix/omrthreadattr.c
+++ b/thread/unix/omrthreadattr.c
@@ -28,9 +28,9 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <limits.h>	/* for PTHREAD_STACK_MIN */
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 #include <unistd.h> /* required for the _SC_PAGESIZE  constant */
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 #include "omrcfg.h"
 #include "omrcomp.h"
 #include "omrthread.h"
@@ -356,7 +356,7 @@ setSchedpolicy(pthread_attr_t *pattr, omrthread_schedpolicy_t policy)
 	intptr_t pret = 0;
 
 	if (J9THREAD_SCHEDPOLICY_INHERIT == policy) {
-#if defined(AIXPPC) || defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 		/*
 		 * Non-root users are frequently not allowed to create threads
 		 * using SCHED_RR or SCHED_FIFO.
@@ -374,7 +374,7 @@ setSchedpolicy(pthread_attr_t *pattr, omrthread_schedpolicy_t policy)
 		if (pret != 0) {
 			return J9THREAD_ERR_INVALID_VALUE;
 		}
-#endif /* defined(AIXPPC) || defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 		pret = DEBUG_SYSCALL(pthread_attr_setinheritsched(pattr, PTHREAD_INHERIT_SCHED));
 		if (pret != 0) {
 			return J9THREAD_ERR_INVALID_VALUE;
@@ -463,7 +463,7 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 	/* stacksize may be adjusted to satisfy platform-specific quirks */
 
 #if !defined(OMRZTPF)
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 	/* Linux allocates 2MB if you ask for a stack smaller than STACK_MIN */
 	{
 		long pageSafeMinimumStack = 2 * sysconf(_SC_PAGESIZE);
@@ -475,7 +475,7 @@ setStacksize(pthread_attr_t *pattr, uintptr_t stacksize)
 			stacksize = pageSafeMinimumStack;
 		}
 	}
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	if (DEBUG_SYSCALL(pthread_attr_setstacksize(pattr, stacksize)) != 0) {
 		return J9THREAD_ERR_INVALID_VALUE;

--- a/thread/unix/rasthrsup.c
+++ b/thread/unix/rasthrsup.c
@@ -26,16 +26,16 @@
 /* this #include defines the buildspec flags */
 #include "omrthread.h"
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #if __GLIBC_PREREQ(2,4)
 #include <sys/syscall.h>
 #endif /* __GLIBC_PREREQ(2,4) */
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <pthread.h>
 #include <sys/syscall.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 /**
  * This is required to pick up correct thread IDs on Linux
  */
@@ -53,14 +53,14 @@
 /* this line is needed to build the syscall macro which is called (as gettid) within the function */
 _syscall0(pid_t, gettid);
 #endif /* !__GLIBC_PREREQ(2,4) && !defined(OMRZTPF) */
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 uintptr_t
 omrthread_get_ras_tid(void)
 {
 	uintptr_t threadID = 0;
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #if __GLIBC_PREREQ(2,4)
 	/* Want thread id that shows up in /proc etc.  gettid() does not cut it */
 	threadID = syscall(SYS_gettid);
@@ -71,11 +71,11 @@ omrthread_get_ras_tid(void)
 	 */
 	threadID = (uintptr_t) gettid();
 #endif /* __GLIBC_PREREQ(2,4) */
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
     uint64_t tid64;
     pthread_threadid_np(NULL, &tid64);
     threadID = (pid_t)tid64;
-#else /* defined(OSX) */
+#else /* (HOST_OS == OMR_OSX) */
 	pthread_t myThread = pthread_self();
 
 	/*
@@ -89,7 +89,7 @@ omrthread_get_ras_tid(void)
 	} else {
 		threadID = 0;
 	}
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 	return threadID;
 }
 

--- a/thread/unix/thrdsup.c
+++ b/thread/unix/thrdsup.c
@@ -29,10 +29,10 @@
 #include "threaddef.h"
 #include "thread_internal.h"
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <sys/prctl.h>
 #include <linux/prctl.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 #if defined(OMRZTPF)
 #include <tpf/c_eb0eb.h>
@@ -40,9 +40,9 @@
 #include <tpf/tpfapi.h>
 #endif /* if defined(OMRZTPF) */
 
-#if (defined(LINUX) || defined(OSX)) && defined(J9X86)
+#if ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && defined(J9X86)
 #include <fpu_control.h>
-#endif /* (defined(LINUX) || defined(OSX)) && defined(J9X86) */
+#endif /* ((HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)) && defined(J9X86) */
 
 #if J9THREAD_USE_MONOTONIC_COND_CLOCK
 /*
@@ -87,11 +87,11 @@ call_omrthread_init(void)
 {
 	omrthread_library_t lib = GLOBAL_DATA(default_library);
 
-#if defined(LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || (HOST_OS == OMR_OSX)
 	if (initialize_priority_map()) {
 		goto thread_init_error;
 	}
-#endif /* defined(LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || !defined(J9_PRIORITY_MAP) || defined(J9OS_I5) || (HOST_OS == OMR_OSX) */
 
 #ifdef J9ZOS390
 	zos_init_yielding();
@@ -120,7 +120,7 @@ init_thread_library(void)
 	return lib->initStatus != 1;
 }
 
-#if defined(LINUX) || defined(OSX)
+#if (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX)
 intptr_t
 set_pthread_name(pthread_t self, pthread_t thread, const char *name)
 {
@@ -128,7 +128,7 @@ set_pthread_name(pthread_t self, pthread_t thread, const char *name)
 		/* for Linux and OSX, the thread being named must be the current thread */
 		return -1;
 	}
-#if defined(LINUX)
+#if (HOST_OS == OMR_LINUX)
 #ifndef PR_SET_NAME
 #define PR_SET_NAME 15
 #endif
@@ -136,12 +136,12 @@ set_pthread_name(pthread_t self, pthread_t thread, const char *name)
 	prctl(PR_SET_NAME, name);
 #endif
 	/* we ignore the return value of prctl, since naming is not supported on some older linux distributions */
-#else /* defined(LINUX) */
+#else /* (HOST_OS == OMR_LINUX) */
 	pthread_setname_np(name);
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 	return 0;
 }
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 intptr_t
 osthread_join(omrthread_t self, omrthread_t threadToJoin)
@@ -164,7 +164,7 @@ osthread_join(omrthread_t self, omrthread_t threadToJoin)
 #endif /* defined(J9ZOS390) */
 }
 
-#if defined(LINUX) && defined(J9X86)
+#if (HOST_OS == OMR_LINUX) && defined(J9X86)
 int
 linux_pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime)
 {

--- a/tools/configure
+++ b/tools/configure
@@ -3831,7 +3831,7 @@ fi
 	if test "x$OMR_BUILD_TOOLCHAIN" = "x"; then :
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#if !(defined(__xlC__) || (defined(__MVS__) && defined(__COMPILER_VER__)))
+#if !(defined(__xlC__) || (defined(__MVC__) && defined(__COMPILER_VER__)))
 #error not an xlc compiler
 #endif
 int

--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -25,10 +25,10 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #define strdup _strdup
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "HookGen.hpp"
 #include "pugixml.hpp"
@@ -335,7 +335,7 @@ char *
 HookGen::getAbsolutePath(const char *filename)
 {
 	char *absolutePath = NULL;
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	char PATH_SEPARATOR = '\\';
 	char resolved_path[MAX_PATH];
 	DWORD retval = 0;
@@ -352,7 +352,7 @@ HookGen::getAbsolutePath(const char *filename)
 	if (NULL == realpath(filename, resolved_path)) {
 		return absolutePath;
 	}
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	char *chopped = strrchr(resolved_path, PATH_SEPARATOR);
 	if (NULL != chopped) {

--- a/tools/hookgen/main.cpp
+++ b/tools/hookgen/main.cpp
@@ -26,19 +26,19 @@
 #if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 #include "atoe.h"
 #endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "HookGen.hpp"
 
 /* On all platforms operate on UTF-8 encoding */
 int
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 translated_main(int argc, char **argv, char **envp)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 main(int argc, char **argv, char **envp)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	RCType rc = RC_OK;
 #if defined(J9ZOS390) && !defined(OMR_EBCDIC)
@@ -65,7 +65,7 @@ main(int argc, char **argv, char **envp)
 }
 
 /* Convert Windows wide character encoding to UTF-8 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -129,4 +129,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/tools/tracegen/Port.cpp
+++ b/tools/tracegen/Port.cpp
@@ -20,29 +20,29 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #include <sys/vfs.h>
-#elif defined(OSX)
+#elif (HOST_OS == OMR_OSX)
 #include <sys/param.h>
 #include <sys/mount.h>
-#endif /* defined(LINUX) */
+#endif /* (HOST_OS == OMR_LINUX) */
 #include <string.h>
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <direct.h>
 #define J9FILE_UNC_EXTENDED_LENGTH_PREFIX (L"\\\\?\\")
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <sys/types.h>
 #if !defined(OMRZTPF)
 #include <sys/statvfs.h>
 #endif
 #include <dirent.h>
-#endif /* defined(OMR_OS_WINDOWS)*/
+#endif /* (HOST_OS == OMR_WINDOWS)*/
 
 #include "Port.hpp"
 
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 RCType
 Port::omrfile_findfirst(const char *path, char **resultbuf, intptr_t *handle)
 {
@@ -499,7 +499,7 @@ cleanup:
 
 	return resolved_path;
 }
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 
 FILE *
 Port::fopen(const char *path, const char *mode)
@@ -511,37 +511,37 @@ RCType
 Port::omrfile_findfirst(const char *path, char **resultbuf, intptr_t *handle)
 {
 	RCType rc = RC_FAILED;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	DIR64 *dirp = NULL;
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	DIR *dirp = NULL;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	struct dirent *entry;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	dirp = opendir64(path);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	dirp = opendir(path);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	if (NULL == dirp) {
 		return RC_FAILED;
 	}
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64(dirp);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	entry = readdir(dirp);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	if (NULL == entry) {
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 		closedir64(dirp);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 		closedir(dirp);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		return RC_FAILED;
 	}
 
@@ -557,17 +557,17 @@ RCType
 Port::omrfile_findnext(intptr_t findhandle, char **resultbuf)
 {
 	RCType rc = RC_FAILED;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	struct dirent64 *entry;
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	struct dirent *entry;
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	entry = readdir64((DIR64 *)findhandle);
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	entry = readdir((DIR *)findhandle);
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 	if (entry == NULL) {
 		return RC_FAILED;
 	}
@@ -582,11 +582,11 @@ RCType
 Port::omrfile_findclose(intptr_t findhandle)
 {
 	RCType rc = RC_FAILED;
-#if defined(AIXPPC)
+#if (HOST_OS == OMR_AIX)
 	if (0 == closedir64((DIR64 *)findhandle)) {
-#else /* defined(AIXPPC) */
+#else /* (HOST_OS == OMR_AIX) */
 	if (0 == closedir((DIR *)findhandle)) {
-#endif /* defined(AIXPPC) */
+#endif /* (HOST_OS == OMR_AIX) */
 		rc = RC_OK;
 	}
 	return rc;
@@ -640,11 +640,11 @@ RCType
 Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 {
 	struct stat statbuf;
-#if (defined(LINUX) && !defined(OMRZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(OMRZTPF)) || (HOST_OS == OMR_OSX)
 	struct statfs statfsbuf;
-#elif defined(AIXPPC)
+#elif (HOST_OS == OMR_AIX)
 	struct statvfs statvfsbuf;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	memset(buf, 0, sizeof(*buf));
 
@@ -680,7 +680,7 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 	buf->ownerUid = statbuf.st_uid;
 	buf->ownerGid = statbuf.st_gid;
 
-#if (defined(LINUX) && !defined(J9ZTPF)) || defined(OSX)
+#if ((HOST_OS == OMR_LINUX) && !defined(J9ZTPF)) || (HOST_OS == OMR_OSX)
 	if (statfs(path, &statfsbuf)) {
 		return RC_FAILED;
 	}
@@ -695,7 +695,7 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 		buf->isFixed = 1;
 		break;
 	}
-#elif defined(AIXPPC) && !defined(J9OS_I5)
+#elif (HOST_OS == OMR_AIX) && !defined(J9OS_I5)
 	if (statvfs(path, &statvfsbuf)) {
 		return RC_FAILED;
 	}
@@ -705,10 +705,10 @@ Port::omrfile_stat(const char *path, unsigned int flags, struct J9FileStat *buf)
 	} else {
 		buf->isFixed = 1;
 	}
-#else /* defined(LINUX) || defined(OSX) */
+#else /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 	/* Assume we have a fixed file unless the platform can be more specific */
 	buf->isFixed = 1;
-#endif /* defined(LINUX) || defined(OSX) */
+#endif /* (HOST_OS == OMR_LINUX) || (HOST_OS == OMR_OSX) */
 
 	return RC_OK;
 }
@@ -723,16 +723,16 @@ Port::omrfile_realpath(const char *path)
 	}
 	return result;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 int
 Port::strncasecmp(const char *s1, const char *s2, size_t n)
 {
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	return ::_strnicmp(s1, s2, n);
 #elif defined(J9ZOS390)
 	return ::strncasecmp(s1, s2, (int) n);
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 	return ::strncasecmp(s1, s2, n);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 }

--- a/tools/tracegen/Port.hpp
+++ b/tools/tracegen/Port.hpp
@@ -35,15 +35,15 @@
 #include <strings.h>
 #endif
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #include <sys/utime.h>
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #include <limits.h>
 #include <unistd.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define strdup _strdup
 #define stat _stat
 #define snprintf _snprintf
@@ -55,7 +55,7 @@
 #define OS_ENCODING_MB_FLAGS 0
 #define OS_ENCODING_WC_FLAGS 0
 #define UNICODE_BUFFER_SIZE EsMaxPath
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 #define PATH_SEP  "/"
 #define dirstat struct stat
 #define PORT_INVALID_FIND_FILE_HANDLE ((intptr_t) 0)
@@ -65,7 +65,7 @@
 /* EsMaxPath was chosen from unix MAXPATHLEN. */
 #define EsMaxPath 	1024
 #endif /* defined(PATH_MAX) */
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 typedef enum RCType {
 	RC_OK 		= 0,
@@ -116,7 +116,7 @@ private:
 protected:
 public:
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 	/**
 	 * Uses convertFromUTF8 and if the resulting unicode path is longer than the Windows defined MAX_PATH,
 	 * the path is converted to an absolute path and prepended with //?/
@@ -165,7 +165,7 @@ public:
 	 * @return RC_OK on success, RC_FAILED on failure.
 	 */
 	static RCType convertToUTF8(const wchar_t *unicodeString, char **utf8Buffer);
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 	static RCType omrfile_findfirst(const char *path, char **resultbuf, intptr_t *handle);
 

--- a/tools/tracegen/TraceGen.cpp
+++ b/tools/tracegen/TraceGen.cpp
@@ -24,13 +24,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/types.h>
 #include <unistd.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include "ArgParser.hpp"
 #include "CFileWriter.hpp"

--- a/tools/tracegen/main.cpp
+++ b/tools/tracegen/main.cpp
@@ -33,11 +33,11 @@
 
 /* On all platforms operate on UTF-8 encoding */
 int
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 translated_main(int argc, char **argv, char **envp)
-#else /* defined(OMR_OS_WINDOWS) */
+#else /* (HOST_OS == OMR_WINDOWS) */
 main(int argc, char **argv, char **envp)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	RCType rc = RC_OK;
 #if defined(J9ZOS390) && !defined(OMR_EBCDIC)
@@ -64,7 +64,7 @@ main(int argc, char **argv, char **envp)
 }
 
 /* Convert Windows wide character encoding to UTF-8 */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -128,4 +128,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/tools/tracemerge/DATMerge.cpp
+++ b/tools/tracemerge/DATMerge.cpp
@@ -24,12 +24,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if !defined(OMR_OS_WINDOWS)
+#if !(HOST_OS == OMR_WINDOWS)
 #include <fcntl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
-#endif /* !defined(OMR_OS_WINDOWS) */
+#endif /* !(HOST_OS == OMR_WINDOWS) */
 
 #include "DATMerge.hpp"
 #include "ArgParser.hpp"

--- a/tools/tracemerge/main.cpp
+++ b/tools/tracemerge/main.cpp
@@ -32,11 +32,11 @@
 #include "Port.hpp"
 
 int
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 translated_main(int argc, char **argv, char **envp)
 #else
 main(int argc, char **argv, char **envp)
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 {
 	RCType rc = RC_OK;
 #if defined(J9ZOS390) && !defined(OMR_EBCDIC)
@@ -62,7 +62,7 @@ main(int argc, char **argv, char **envp)
 	return (RC_OK == rc) ? 0 : -1;
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -125,4 +125,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/util/main_function/main_function.cpp
+++ b/util/main_function/main_function.cpp
@@ -30,7 +30,7 @@
  * correctly when it is located in a library.
  */
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
 #endif
 #include <stdlib.h>
@@ -41,7 +41,7 @@
 #endif
 
 /* Define a macro for the name of the main function that takes char args */
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #define CHARMAIN translated_main
 #else
 #define CHARMAIN main
@@ -66,7 +66,7 @@ CHARMAIN(int argc, char **argv, char **envp)
 	return omr_main_entry(argc, argv, envp);
 }
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 int
 wmain(int argc, wchar_t **argv, wchar_t **envp)
 {
@@ -129,4 +129,4 @@ wmain(int argc, wchar_t **argv, wchar_t **envp)
 
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/util/omrutil/detectVMDirectory.c
+++ b/util/omrutil/detectVMDirectory.c
@@ -22,13 +22,13 @@
 
 #include "omrcfg.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 #include <windows.h>
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */
 
 #include "omrutil.h"
 
-#if defined(OMR_OS_WINDOWS)
+#if (HOST_OS == OMR_WINDOWS)
 omr_error_t
 detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDirectoryEnd)
 {
@@ -53,4 +53,4 @@ detectVMDirectory(wchar_t *vmDirectory, size_t vmDirectoryLength, wchar_t **vmDi
 	}
 	return rc;
 }
-#endif /* defined(OMR_OS_WINDOWS) */
+#endif /* (HOST_OS == OMR_WINDOWS) */

--- a/util/omrutil/gettimebase.c
+++ b/util/omrutil/gettimebase.c
@@ -26,7 +26,7 @@
 #include "omrcomp.h"
 #include "omrutilbase.h"
 
-#if defined(LINUX) && defined(OMR_ARCH_ARM)
+#if (HOST_OS == OMR_LINUX) && defined(OMR_ARCH_ARM)
 #include <time.h>
 #endif
 
@@ -43,7 +43,7 @@ getTimebase(void)
 	uint32_t upper;
 	asm volatile("rdtsc" : "=a" (lower), "=d" (upper));
 	tsc = ((uint64_t)upper << 32) | lower;
-#elif defined(AIXPPC) || defined(LINUXPPC)
+#elif (HOST_OS == OMR_AIX) || (HOST_OS == OMR_LINUX)
 
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 	tsc = __builtin_ppc_get_timebase();
@@ -77,11 +77,11 @@ getTimebase(void)
 #endif /* OMR_ENV_DATA64 */
 #endif /* GCC 4.8 */
 
-#elif defined(LINUX) && defined(S390)
+#elif (HOST_OS == OMR_LINUX) && defined(S390)
 	asm("stck %0" : "=m" (tsc));
 #elif defined(J9ZOS390)
 	__stck(&tsc);
-#elif defined(LINUX) && defined(OMR_ARCH_ARM)
+#elif (HOST_OS == OMR_LINUX) && defined(OMR_ARCH_ARM)
 	/* For now, use the system nano clock */
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)
 	struct timespec ts;

--- a/util/omrutil/j9memclr.c
+++ b/util/omrutil/j9memclr.c
@@ -32,12 +32,12 @@ void dcbz(char *);
 #pragma reg_killed_by dcbz
 #endif
 
-#if (defined(LINUX) && defined(S390))
+#if ((HOST_OS == OMR_LINUX) && defined(S390))
 /* _j9Z10Zero() is defined in j9memclrz10_31.s and j9memclrz10_64.s */
 extern void _j9Z10Zero(void *ptr, uintptr_t length);
 #endif
 
-#if defined(AIXPPC) || defined (LINUXPPC)
+#if (HOST_OS == OMR_AIX) || defined (LINUXPPC)
 static uintptr_t cacheLineSize = 0;
 #endif
 
@@ -57,17 +57,17 @@ static int isZ10orGreater = -1;
 void
 OMRZeroMemory(void *ptr, uintptr_t length)
 {
-#if defined(AIXPPC) || defined (LINUXPPC)
+#if (HOST_OS == OMR_AIX) || defined (LINUXPPC)
 	char *addr = ptr;
 	char *limit;
 	uintptr_t localCacheLineSize;
 
-#if defined(LINUXPPC)
+#if (HOST_OS == OMR_LINUX)
 	if (length < 2048) {
 		memset(ptr, 0, (size_t)length);
 		return;
 	}
-#endif /* defined(LINUXPPC) */
+#endif /* (HOST_OS == OMR_LINUX) */
 
 	/* one-time-only calculation of cache line size */
 	if (0 == cacheLineSize) {
@@ -116,7 +116,7 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 		*((uintptr_t *)addr) = 0;
 	}
 
-#elif defined(OMR_OS_WINDOWS) && !defined(OMR_ENV_DATA64)
+#elif (HOST_OS == OMR_WINDOWS) && !defined(OMR_ENV_DATA64)
 #if defined(REENABLE_WHEN_THIS_WORKS)
 	/* NOTE: memset on WIN64 (AMD64) seems to do a fine job all on its own,
 	 * so we don't use our own SSE2 code there
@@ -186,7 +186,7 @@ OMRZeroMemory(void *ptr, uintptr_t length)
 uintptr_t
 getCacheLineSize(void)
 {
-#if defined(AIXPPC) || defined (LINUXPPC)
+#if (HOST_OS == OMR_AIX) || defined (LINUXPPC)
 	char buf[1024];
 	uintptr_t i, ppcCacheLineSize;
 

--- a/util/omrutil/unix/linux/s390/archinfo.c
+++ b/util/omrutil/unix/linux/s390/archinfo.c
@@ -21,9 +21,9 @@
  *******************************************************************************/
 
 /* _GNU_SOURCE forces GLIBC_2.0 sscanf/vsscanf/fscanf for RHEL5 compatability */
-#if defined(LINUX) && !defined(OMRZTPF)
+#if (HOST_OS == OMR_LINUX) && !defined(OMRZTPF)
 #define _GNU_SOURCE
-#endif /* defined(LINUX) && !defined(OMRZTPF) */
+#endif /* (HOST_OS == OMR_LINUX) && !defined(OMRZTPF) */
 #if defined(OMRZTPF)
 #include <tpf/c_cinfc.h>   /* for access to cinfc */
 #include <tpf/c_pi1dt.h>   /* for access to machine type. */


### PR DESCRIPTION
Fixes #2619

OS macros defines are standardized

Signed-off-by: Avinash Pydimarri <avinashpydimarry05@gmail.com>