### PR TITLE
Remove unused TR::idoz opcode and evaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -732,7 +732,6 @@ public:
 	static TR::Register *dsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *getstackEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *deallocaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *idozEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *dcosEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *dsinEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *dtanEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -708,7 +708,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dsqrtEvaluator ,	// TR::dsqrt		// square root of double
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::getstackEvaluator ,	// TR::getstack		// returns current value of SP
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::deallocaEvaluator ,	// TR::dealloca		// resets value of SP
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::idozEvaluator ,	// TR::idoz		// difference or zero
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dcosEvaluator ,	// TR::dcos		// cos of double; returning double
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dsinEvaluator ,	// TR::dsin		// sin of double; returning double
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dtanEvaluator ,	// TR::dtan		// tan of double; returning double

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -863,7 +863,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::dealloca
 
-   TR::TreeEvaluator::unImpOpEvaluator,         // TR::idoz
 
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::dcos
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::dsin

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -11134,22 +11134,6 @@
    },
 
    {
-   /* .opcode               = */ TR::idoz,
-   /* .name                 = */ "idoz",
-   /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE,
-   /* .properties3          = */ 0,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int32,
-   /* .typeProperties       = */ ILTypeProp::Size_4 | ILTypeProp::Integer,
-   /* .childProperties      = */ ILChildProp::Unspecified,
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::dcos,
    /* .name                 = */ "dcos",
    /* .properties1          = */ ILProp1::Call | ILProp1::HasSymbolRef,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -791,7 +791,6 @@
    getstack, // returns current value of SP
    dealloca, // resets value of SP
 
-   idoz,     // difference or zero
 
    dcos,       // cos of double, returning double
    dsin,       // sin of double, returning double

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -750,8 +750,6 @@
    dftSimplifier,           // TR::getstack
    dftSimplifier,           // TR::dealloca
 
-   dftSimplifier,           // TR::idoz
-
    dftSimplifier,           // TR::dcos
    dftSimplifier,           // TR::dsin
    dftSimplifier,           // TR::dtan

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -891,7 +891,6 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,        // TR::getstack
    constrainChildren,        // TR::dealloca
 
-   constrainChildren,        // TR::idoz
 
    constrainChildren,        // TR::dcos
    constrainChildren,        // TR::dsin

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -3547,38 +3547,3 @@ TR::Register *OMR::Power::TreeEvaluator::lxfrsEvaluator(TR::Node *node, TR::Code
    cg->decReferenceCount(secondChild);
    return trgReg;
    }
-
-TR::Register *OMR::Power::TreeEvaluator::idozEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-{
-
-   TR::Node * firstChild  = node->getFirstChild();
-   TR::Node * secondChild = node->getSecondChild();
-   TR::Register *src1Reg  = cg->evaluate(firstChild);  // a
-   TR::Register *src2Reg = cg->evaluate(secondChild);  // b
-
-   TR::Register *tmp1Reg = cg->allocateRegister();
-   TR::Register *tmp2Reg = cg->allocateRegister();
-
-   // Flip the sign bit: tmp1 = 2^31 + a; tmp2 = 2^31 + b
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xoris, node, tmp1Reg, src1Reg, 0x8000);
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xoris, node, tmp2Reg, src2Reg, 0x8000);
-
-   // tmp1Reg = a - b
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::subfc, node, tmp1Reg, tmp2Reg, tmp1Reg);
-
-   // tmp2Reg = -1 if a <= b
-   //           0  if a >  b
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::subfe, node, tmp2Reg, tmp1Reg, tmp1Reg);
-
-   TR::Register  *trgReg = cg->allocateRegister();
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::andc, node, trgReg, tmp1Reg, tmp2Reg);
-
-   cg->stopUsingRegister(tmp1Reg);
-   cg->stopUsingRegister(tmp2Reg);
-
-   node->setRegister(trgReg);
-   cg->decReferenceCount(firstChild);
-   cg->decReferenceCount(secondChild);
-
-   return trgReg;
-}

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -505,7 +505,6 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *dsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *getstackEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *deallocaEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *idozEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *dfloorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *libmFuncEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *maxEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -717,7 +717,6 @@
    TR::TreeEvaluator::dsqrtEvaluator,                   // TR::dsqrt
    TR::TreeEvaluator::getstackEvaluator,                // TR::getstack
    TR::TreeEvaluator::deallocaEvaluator,                // TR::dealloca
-   TR::TreeEvaluator::idozEvaluator,                    // TR::idoz
    TR::TreeEvaluator::libmFuncEvaluator,                // TR::dcos
    TR::TreeEvaluator::libmFuncEvaluator,                // TR::dsin
    TR::TreeEvaluator::libmFuncEvaluator,                // TR::dtan

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2994,7 +2994,6 @@ int32_t childTypes[] =
    TR::NoType,                     // TR::getstack
    TR::Address,                    // TR::dealloca
 
-   TR::Int32,                     // TR::idoz
 
    TR::Double,                     // TR::dcos
    TR::Double,                     // TR::dsin

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -711,7 +711,6 @@
    TR::TreeEvaluator::dsqrtEvaluator,                                  // TR::dsqrt
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dealloca
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::idoz
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dcos
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dsin
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dtan

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -711,7 +711,6 @@
    TR::TreeEvaluator::fpSqrtEvaluator,                                 // TR::dsqrt
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dealloca
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::idoz
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dcos
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dsin
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dtan

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -761,7 +761,6 @@
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,    // TR::dealloca
 
-   TR::TreeEvaluator::unImpOpEvaluator,         // TR::idoz
 
    TR::TreeEvaluator::libmFuncEvaluator,    // TR::dcos
    TR::TreeEvaluator::libmFuncEvaluator,    // TR::dsin


### PR DESCRIPTION
Fixes #1400

The opcode and evaluator were deleted and removed from all tables in which it appeared.

Signed-off-by: Rounak Agarwal <rounakr.ag73@gmail.com>