### PR TITLE
[WIP] Common buildRegisterMapForInstruction for all code generators

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -350,37 +350,6 @@ static uint32_t registerBitMask(int32_t reg)
    return 1 << (reg-1);
    }
 
-void OMR::ARM64::CodeGenerator::buildRegisterMapForInstruction(TR_GCStackMap *map)
-   {
-   TR_InternalPointerMap * internalPtrMap = NULL;
-   TR::GCStackAtlas *atlas = self()->getStackAtlas();
-   //
-   // Build the register map
-   //
-   for (int i = TR::RealRegister::FirstGPR; i <= TR::RealRegister::LastAssignableGPR; ++i)
-      {
-      TR::RealRegister * reg = self()->machine()->getRealRegister((TR::RealRegister::RegNum)i);
-      if (reg->getHasBeenAssignedInMethod())
-         {
-         TR::Register *virtReg = reg->getAssignedRegister();
-         if (virtReg)
-            {
-            if (virtReg->containsInternalPointer())
-               {
-               if (!internalPtrMap)
-                  internalPtrMap = new (self()->trHeapMemory()) TR_InternalPointerMap(self()->trMemory());
-               internalPtrMap->addInternalPointerPair(virtReg->getPinningArrayPointer(), i);
-               atlas->addPinningArrayPtrForInternalPtrReg(virtReg->getPinningArrayPointer());
-               }
-            else if (virtReg->containsCollectedReference())
-               map->setRegisterBits(registerBitMask(i));
-            }
-         }
-      }
-
-   map->setInternalPointerMap(internalPtrMap);
-   }
-
 TR_GlobalRegisterNumber OMR::ARM64::CodeGenerator::pickRegister(TR_RegisterCandidate *regCan,
                                                           TR::Block **barr,
                                                           TR_BitVector &availRegs,

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -277,12 +277,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
      */
     int64_t getSmallestPosConstThatMustBeMaterialized();
 
-   /**
-    * @brief Builds register map
-    * @param[in] map : GC stack map
-    */
-   void buildRegisterMapForInstruction(TR_GCStackMap *map);
-
    TR_GlobalRegisterNumber _gprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
    TR_GlobalRegisterNumber _fprLinkageGlobalRegisterNumbers[TR::RealRegister::NumRegisters]; // could be smaller
 

--- a/compiler/arm/codegen/OMRCodeGenerator.hpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.hpp
@@ -149,7 +149,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::RealRegister *getMethodMetaDataRegister()                       {return _methodMetaDataRegister;}
    TR::RealRegister *setMethodMetaDataRegister(TR::RealRegister *r) {return (_methodMetaDataRegister = r);}
 
-   void buildRegisterMapForInstruction(TR_GCStackMap *map);
    void apply24BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
    void apply8BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -308,6 +308,12 @@ class OMR_EXTENSIBLE CodeGenerator
    void beginInstructionSelection() {}
    void endInstructionSelection() {}
 
+   /**
+    * @brief Builds register map
+    * @param[in] map : GC stack map
+    */
+   void buildRegisterMapForInstruction(TR_GCStackMap *map);
+
    bool use64BitRegsOn32Bit();
 
 

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -236,8 +236,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    TR_PPCScratchRegisterManager* generateScratchRegisterManager(int32_t capacity = 32);
 
-   void buildRegisterMapForInstruction(TR_GCStackMap *map);
-
    int32_t getPreferredLoopUnrollFactor();
 
    bool canTransformUnsafeCopyToArrayCopy() { return true; }

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -338,8 +338,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool allowGlobalRegisterAcrossBranch(TR_RegisterCandidate *, TR::Node *);
 
-   void buildRegisterMapForInstruction(TR_GCStackMap *map);
-
    bool isReturnInstruction(TR::Instruction *instr);
    bool isBranchInstruction(TR::Instruction *instr);
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -382,9 +382,6 @@ public:
    TR::RealRegister *getMethodMetaDataRealRegister();
    TR::RealRegister *getLitPoolRealRegister();
 
-
-   void buildRegisterMapForInstruction(TR_GCStackMap *map);
-
    // BCDCHK node
    TR::Node * _currentCheckNode;
    void setCurrentCheckNodeBeingEvaluated(TR::Node * n) { _currentCheckNode = n; }


### PR DESCRIPTION
Each code generator implements a function buildRegisterMapForInstruction, that is nearly identical across all architectures. Created a common implementation that can be shared by all backends, and deleted the old implementations.

Fixes #3932 

Signed-off-by: Shishir Halaharvi <shishir.neo95@gmail.com>