### PR TITLE
Remove unused TR::bztestnset opcode and evaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -711,7 +711,6 @@ public:
 	static TR::Register *lusubbEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *lcmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bztestnsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *ibatomicorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *isatomicorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iiatomicorEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -683,7 +683,6 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lusubbEvaluator ,	// TR::lusubb			// Subtract two longs with borrow
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::icmpsetEvaluator ,	// TR::icmpset			// icmpset(pointer;c;r): compare *pointer with c; if it matches; replace with r.  Returns 0 on match; 1 otherwise
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lcmpsetEvaluator ,	// TR::lcmpset			// the operation is done atomically - return type is int for both [il]cmpset
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bztestnsetEvaluator ,	// TR::bztestnset		// bztestnset(pointer;c): atomically sets *pointer to c and returns the original value of *p (represents Test And Set on Z) the atomic ops.. atomically update the symref.  first child is address; second child is the RHS interestingly; these ops act like loads and stores at the same time
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ibatomicorEvaluator ,	// TR::ibatomicor 
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::isatomicorEvaluator ,	// TR::isatomicor 
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iiatomicorEvaluator ,	// TR::iiatomicor 

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -832,7 +832,6 @@
 
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::icmpset
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::lcmpset
-   TR::TreeEvaluator::unImpOpEvaluator,         // TR::btestnset
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::ibatomicor
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::isatomicor
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::iiatomicor

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -10732,22 +10732,6 @@
    },
 
    {
-   /* .opcode               = */ TR::bztestnset,
-   /* .name                 = */ "bztestnset",
-   /* .properties1          = */ ILProp1::Call | ILProp1::HasSymbolRef,
-   /* .properties2          = */ 0,
-   /* .properties3          = */ ILProp3::LikeUse | ILProp3::LikeDef,
-   /* .properties4          = */ 0,
-   /* .dataType             = */ TR::Int8,
-   /* .typeProperties       = */ ILTypeProp::Size_1 | ILTypeProp::Integer,
-   /* .childProperties      = */ TWO_CHILD(TR::Address, ILChildProp::UnspecifiedChildType),
-   /* .swapChildrenOpCode   = */ TR::BadILOp,
-   /* .reverseBranchOpCode  = */ TR::BadILOp,
-   /* .booleanCompareOpCode = */ TR::BadILOp,
-   /* .ifCompareOpCode      = */ TR::BadILOp,
-   },
-
-   {
    /* .opcode               = */ TR::ibatomicor,
    /* .name                 = */ "ibatomicor",
    /* .properties1          = */ ILProp1::LoadVar | ILProp1::Store | ILProp1::Indirect | ILProp1::TreeTop | ILProp1::HasSymbolRef,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -753,8 +753,7 @@
 
    icmpset,    // icmpset(pointer,c,r): compare *pointer with c, if it matches, replace with r.  Returns 0 on match, 1 otherwise
    lcmpset,    // the operation is done atomically - return type is int for both [il]cmpset
-   bztestnset, // bztestnset(pointer,c): atomically sets *pointer to c and returns the original value of *p (represents Test And Set on Z)
-
+   
    // the atomic ops.. atomically update the symref.  first child is address, second child is the RHS
    // interestingly, these ops act like loads and stores at the same time
    ibatomicor, //

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -720,7 +720,6 @@
    lsubSimplifier,          // TR::lusubb
    dftSimplifier,           // TR::icmpset
    dftSimplifier,           // TR::lcmpset
-   dftSimplifier,           // TR::btestnset
    dftSimplifier,           // TR::ibatomicor
    dftSimplifier,           // TR::isatomicor
    dftSimplifier,           // TR::iiatomicor

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -864,7 +864,6 @@ const ValuePropagationPtr constraintHandlers[] =
 
    constrainChildren,        // TR::icmpset
    constrainChildren,        // TR::lcmpset
-   constrainChildren,        // TR::bztestnset
    constrainChildren,        // TR::ibatomicor
    constrainChildren,        // TR::isatomicor
    constrainChildren,        // TR::iiatomicor

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -689,8 +689,7 @@
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::iusubb
    TR::TreeEvaluator::lsubEvaluator,                    // TR::lusubb
    TR::TreeEvaluator::cmpsetEvaluator,                  // TR::icmpset
-   TR::TreeEvaluator::cmpsetEvaluator,                  // TR::lcmpset
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::bztestnset
+   TR::TreeEvaluator::cmpsetEvaluator,                  // TR::lcmpset   
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::ibatomicor
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::isatomicor
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::iiatomicor

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2965,7 +2965,6 @@ int32_t childTypes[] =
    TR::Int64 | (TR::Int8<<24),    // TR::lusubb
    TR::Int32 | (TR::Address<<8),    // TR::icmpset
    TR::Int64 | (TR::Address<<8),    // TR::lcmpset
-   TR::Int8  | (TR::Address<<8),    // TR::bztestnset
    TR::Int8  | (TR::Address<<8),     // TR::ibatomicor
    TR::Int16 | (TR::Address<<8),     // TR::isatomicor
    TR::Int32 | (TR::Address<<8),     // TR::iiatomicor

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -685,8 +685,7 @@
    TR::TreeEvaluator::integerSubEvaluator,                             // TR::iusubb
    TR::TreeEvaluator::integerSubEvaluator,                             // TR::lusubb
    TR::TreeEvaluator::icmpsetEvaluator,                                // TR::icmpset
-   TR::TreeEvaluator::icmpsetEvaluator,                                // TR::lcmpset
-   TR::TreeEvaluator::bztestnsetEvaluator,                             // TR::bztestnset
+   TR::TreeEvaluator::icmpsetEvaluator,                                // TR::lcmpset 
    TR::TreeEvaluator::atomicorEvaluator,                               // TR::ibatomicor
    TR::TreeEvaluator::atomicorEvaluator,                               // TR::isatomicor
    TR::TreeEvaluator::atomicorEvaluator,                               // TR::iiatomicor

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3796,32 +3796,6 @@ OMR::X86::TreeEvaluator::icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return resultReg;
    }
 
-TR::Register *
-OMR::X86::TreeEvaluator::bztestnsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR::Node *pointer      = node->getChild(0);
-   TR::Node *replaceValue = node->getChild(1);
-
-   TR::Register *pointerReg = cg->evaluate(pointer);
-   TR::MemoryReference *memRef = generateX86MemoryReference(pointerReg, 0, cg);
-   TR::Register *replaceReg = cg->evaluate(replaceValue);
-
-   if (replaceValue->getReferenceCount() > 1)
-      {
-      TR::Register* replaceRegPrev = replaceReg;
-      replaceReg = cg->allocateRegister();
-      generateRegRegInstruction(MOV1RegReg, node, replaceReg, replaceRegPrev, cg);
-      }
-
-   generateMemRegInstruction(XCHG1RegMem, node, memRef, replaceReg, cg);
-
-   node->setRegister(replaceReg);
-   cg->decReferenceCount(replaceValue);
-   cg->decReferenceCount(pointer);
-
-   return replaceReg;
-   }
-
 
 TR::Register *OMR::X86::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -307,8 +307,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *SIMDgetvelemEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *bztestnsetEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-
+   
    // VM dependent routines
    static TR::Register *VMmergenewEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static bool VMinlineCallEvaluator(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -685,8 +685,7 @@
    TR::TreeEvaluator::integerSubEvaluator,                             // TR::iusubb (zPDT)
    TR::TreeEvaluator::integerPairSubEvaluator,                         // TR::lusubb
    TR::TreeEvaluator::icmpsetEvaluator,                                // TR::icmpset (zPDT)
-   TR::TreeEvaluator::lcmpsetEvaluator,                                // TR::lcmpset (zPDT)
-   TR::TreeEvaluator::bztestnsetEvaluator,                             // TR::bztestnset (zPDT)
+   TR::TreeEvaluator::lcmpsetEvaluator,                                // TR::lcmpset (zPDT) 
    TR::TreeEvaluator::atomicorEvaluator,                               // TR::ibatomicor (zPDT)
    TR::TreeEvaluator::atomicorEvaluator,                               // TR::isatomicor (zPDT)
    TR::TreeEvaluator::atomicorEvaluator,                               // TR::iiatomicor (zPDT)

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -726,7 +726,6 @@
    TR::TreeEvaluator::lsubEvaluator,        // TR::lusubb
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::icmpset
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::lcmpset
-   TR::TreeEvaluator::unImpOpEvaluator,         // TR::btestnset
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::ibatomicor
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::isatomicor
    TR::TreeEvaluator::unImpOpEvaluator,         // TR::iiatomicor


### PR DESCRIPTION
Fixes #1401

The opcode and evaluator were deleted and removed from all tables in which it appeared.

Signed-off-by: Rounak Agarwal <rounakr.ag73@gmail.com>