### PR TITLE
[WIP] Add API for fetching only specified memory fields.

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -284,6 +284,22 @@
 #define ROUND_UP_TO_POWEROF2(value, powerof2) (((value) + ((powerof2) - 1)) & (UDATA)~((powerof2) - 1))
 #define ROUND_DOWN_TO_POWEROF2(value, powerof2) ((value) & (UDATA)~((powerof2) - 1))
 
+/**
+ * @name Memory Info Types
+ * Constants used to denote memory types.
+ * @{
+ */
+#define OMR_SYSINFO_TOTAL_PHYSICAL	0x00000001
+#define OMR_SYSINFO_AVAIL_PHYSICAL	0x00000010 
+#define OMR_SYSINFO_BUFFERED	0x00000100 
+#define OMR_SYSINFO_CACHED	0x00001000
+#define OMR_SYSINFO_TOTAL_SWAP	0x00010000
+#define OMR_SYSINFO_AVAIL_SWAP	0x00100000
+#define OMR_SYSINFO_TOTAL_VIRTUAL	0x01000000 
+#define OMR_SYSINFO_AVAIL_VIRTUAL	0x10000000
+#define OMR_SYSINFO_FETCH_ALL	0x11111111
+/** @} */
+
 typedef struct J9Permission {
 	uint32_t isUserWriteable : 1;
 	uint32_t isUserReadable : 1;
@@ -1154,6 +1170,8 @@ typedef struct OMRPortLibrary {
 	uintptr_t (*sysinfo_get_ppid)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_memory_info "omrsysinfo_get_memory_info"*/
 	int32_t (*sysinfo_get_memory_info)(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo, ...) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_get_required_memory_info "omrsysinfo_get_required_memory_info"*/
+	int32_t (*sysinfo_get_required_memory_info)(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo, int8_t memoryFlags);
 	/** see @ref omrsysinfo.c::omrsysinfo_get_processor_info "omrsysinfo_get_processor_info"*/
 	int32_t (*sysinfo_get_processor_info)(struct OMRPortLibrary *portLibrary, struct J9ProcessorInfos *procInfo) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_destroy_processor_info "omrsysinfo_destroy_processor_info"*/

--- a/port/unix_include/omrcgroup.h
+++ b/port/unix_include/omrcgroup.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corp. and others
+ * Copyright (c) 2017, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,8 +34,8 @@
 typedef struct OMRCgroupMemoryInfo {
 	uint64_t memoryLimit; /**< memory limit in bytes (as in memory.limit_in_bytes file)*/
 	uint64_t memoryUsage; /**< current memory usage in bytes (as in memory.usage_in_bytes file)*/
-	uint64_t memoryAndSwapLimit; /**< memory + swap limit in bytes (as in memory.memsw.limit_in_bytes file)*/
-	uint64_t memoryAndSwapUsage; /**< current memory + swap usage in bytes (as in memory.memsw.usage_in_bytes file) */
+	uint64_t swapLimit; /**< memory + swap limit in bytes (as in memory.memsw.limit_in_bytes file)*/
+	uint64_t swapUsage; /**< current memory + swap usage in bytes (as in memory.memsw.usage_in_bytes file) */
 	uint64_t cached; /**< page cache memory (as in memory.stat file)*/
 } OMRCgroupMemoryInfo;
 

--- a/port/zos390/omrsysinfo_helpers.h
+++ b/port/zos390/omrsysinfo_helpers.h
@@ -42,7 +42,7 @@ extern "C" {
  * @return                 0 on success; negative value on failure.
  */
 int32_t
-retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
+retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo, int8_t memoryFlags);
 
 /**
  * Function retrieves and populates processor usage statistics on a z/OS platform.


### PR DESCRIPTION
Added a new API `omrsysinfo_get_required_memory_info` that
wraps around `omrsysinfo_get_memory_info` and fetches only
specified fields.

The macros for the flags are added in `omrport.h`

Signed-off-by: Shishir Halaharvi <shishir.neo95@gmail.com>