### PR TITLE
Disable boolean store simplification

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -732,6 +732,10 @@ bool OMR::CFGSimplifier::simplifyNullToException(bool needToDuplicateTree)
 //
 bool OMR::CFGSimplifier::simplifyBooleanStore(bool needToDuplicateTree) 
    {
+   static char *enableSimplifyBooleanStore = feGetEnv("TR_enableSimplifyBooleanStore");
+   if (enableSimplifyBooleanStore == NULL)
+      return false;
+
    if (trace())
       traceMsg(comp(), "Start simplifyBooleanStore\n");
 


### PR DESCRIPTION
Boolean store simplification has caused test failures in downstream
project openj9. We haven't fully understood the defect, so disable this
opt until we have a fix for it.

Signed-off-by: liqunl <liqunl@ca.ibm.com>