### PR TITLE
Add edges on regions

### DIFF
--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -148,22 +148,15 @@ OMR::CFG::addEdge(TR::CFGEdge *e)
 TR::CFGEdge *
 OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
    {
-
-   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
-      {
-      traceMsg(comp(),"\nAdding real edge %d-->%d:\n", f->getNumber(), t->getNumber());
-      }
-
-   TR_ASSERT(!f->hasExceptionSuccessor(t), "adding a non exception edge when there's already an exception edge");
-
+   addEdgeChecks(f, t);
    TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, trMemory(), allocKind);
    addEdge(e);
    return e;
+
    }
 
-
-TR::CFGEdge *
-OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR::Region &region)
+void
+OMR::CFG::addEdgeChecks(TR::CFGNode *f, TR::CFGNode *t)
    {
 
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
@@ -173,6 +166,14 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR::Region &region)
 
    TR_ASSERT(!f->hasExceptionSuccessor(t), "adding a non exception edge when there's already an exception edge");
 
+   }
+
+
+TR::CFGEdge *
+OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR::Region &region)
+   {
+
+   addEdgeChecks(f, t);
    TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, region);
    addEdge(e);
    return e;
@@ -185,71 +186,16 @@ OMR::CFG::addExceptionEdge(
       TR::CFGNode *t,
       TR_AllocationKind allocKind)
    {
-   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
-      {
-      traceMsg(comp(),"\nAdding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
-      }
-
-   TR_ASSERT(!f->hasSuccessor(t), "adding an exception edge when there's already a non exception edge");
-   TR::Block * newCatchBlock = toBlock(t);
-   for (auto e = f->getExceptionSuccessors().begin(); e != f->getExceptionSuccessors().end(); ++e)
-      {
-      TR::Block * existingCatchBlock = toBlock((*e)->getTo());
-      if (newCatchBlock == existingCatchBlock) return;
-
-      // OSR exception edges are special and we do not want any 'optimization' done to them
-      // from the following special checks
-      if (newCatchBlock->isOSRCatchBlock() || existingCatchBlock->isOSRCatchBlock()) continue;
-
-      // If the existing catch block is going to be considered first and it catches everything that
-      // the new catch block does then the new catch block isn't reaching from the 'f' block
-      //
-      // Catch block 'A' is considered before catch block 'B' if 'A' is from a greater inline depth
-      // or 'A' and 'B' are from the same inline depth and 'A' handler index is less than 'B's.
-      //
-      int32_t existingDepth = existingCatchBlock->getInlineDepth();
-      int32_t newDepth = newCatchBlock->getInlineDepth();
-      if (existingDepth < newDepth ||
-          (existingDepth == newDepth && existingCatchBlock->getHandlerIndex() > newCatchBlock->getHandlerIndex()))
-         continue;
-
-      // The existing catch block is going to be considered first.  Don't add an edge to the new catch
-      // block if the existing one catches everything that the new one catches.
-      //
-      /////void * newEC = newCatchBlock->getExceptionClass(), * existingEC = existingCatchBlock->getExceptionClass();
-
-      if (existingCatchBlock->getCatchType() == 0 ||
-          /////(newEC && existingEC && isInstanceOf(newEC, existingEC)) ||
-          (existingDepth == newDepth && existingCatchBlock->getCatchType() == newCatchBlock->getCatchType()))
-         {
-         if (comp()->getOption(TR_TraceAddAndRemoveEdge))
-            {
-            traceMsg(comp(),"\nAddition of exception edge aborted - existing catch alredy handles this case!");
-            }
-         return;
-         }
-      }
+   if (!shouldAddExceptionEdge(f, t)) return;
    TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, trMemory(), allocKind);
    _numEdges++;
-
-   // Tell the control tree to modify the structures containing this edge
-   //
-   if (getStructure() != NULL)
-      {
-      getStructure()->addEdge(e, true);
-      if (comp()->getOption(TR_TraceAddAndRemoveEdge))
-         {
-         traceMsg(comp(),"\nStructures after adding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
-         comp()->getDebug()->print(comp()->getOutFile(), _rootStructure, 6);
-         }
-      }
+   addExceptionEdgeToStructure(f, t, e);
    }
 
-void
-OMR::CFG::addExceptionEdge(
+bool
+OMR::CFG::shouldAddExceptionEdge(
       TR::CFGNode *f,
-      TR::CFGNode *t,
-      TR::Region &region)
+      TR::CFGNode *t)
    {
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
       {
@@ -261,7 +207,7 @@ OMR::CFG::addExceptionEdge(
    for (auto e = f->getExceptionSuccessors().begin(); e != f->getExceptionSuccessors().end(); ++e)
       {
       TR::Block * existingCatchBlock = toBlock((*e)->getTo());
-      if (newCatchBlock == existingCatchBlock) return;
+      if (newCatchBlock == existingCatchBlock) return false;
 
       // OSR exception edges are special and we do not want any 'optimization' done to them
       // from the following special checks
@@ -292,12 +238,15 @@ OMR::CFG::addExceptionEdge(
             {
             traceMsg(comp(),"\nAddition of exception edge aborted - existing catch alredy handles this case!");
             }
-         return;
+         return false;
          }
       }
-   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, region);
-   _numEdges++;
+   return true;
+   }
 
+void
+OMR::CFG::addExceptionEdgeToStructure(TR::CFGNode *f, TR::CFGNode *t, TR::CFGEdge *e)
+   {
    // Tell the control tree to modify the structures containing this edge
    //
    if (getStructure() != NULL)
@@ -311,6 +260,18 @@ OMR::CFG::addExceptionEdge(
       }
    }
 
+
+void
+OMR::CFG::addExceptionEdge(
+      TR::CFGNode *f,
+      TR::CFGNode *t,
+      TR::Region &region)
+   {
+   if (!shouldAddExceptionEdge(f, t)) return;
+   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, region);
+   _numEdges++;
+   addExceptionEdgeToStructure(f, t, e);
+   }
 
 void
 OMR::CFG::addSuccessorEdges(TR::Block * block)

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -162,6 +162,23 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
    }
 
 
+TR::CFGEdge *
+OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR::Region &region)
+   {
+
+   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+      {
+      traceMsg(comp(),"\nAdding real edge %d-->%d:\n", f->getNumber(), t->getNumber());
+      }
+
+   TR_ASSERT(!f->hasExceptionSuccessor(t), "adding a non exception edge when there's already an exception edge");
+
+   TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, region);
+   addEdge(e);
+   return e;
+   }
+
+
 void
 OMR::CFG::addExceptionEdge(
       TR::CFGNode *f,
@@ -228,6 +245,71 @@ OMR::CFG::addExceptionEdge(
       }
    }
 
+void
+OMR::CFG::addExceptionEdge(
+      TR::CFGNode *f,
+      TR::CFGNode *t,
+      TR::Region &region)
+   {
+   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+      {
+      traceMsg(comp(),"\nAdding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
+      }
+
+   TR_ASSERT(!f->hasSuccessor(t), "adding an exception edge when there's already a non exception edge");
+   TR::Block * newCatchBlock = toBlock(t);
+   for (auto e = f->getExceptionSuccessors().begin(); e != f->getExceptionSuccessors().end(); ++e)
+      {
+      TR::Block * existingCatchBlock = toBlock((*e)->getTo());
+      if (newCatchBlock == existingCatchBlock) return;
+
+      // OSR exception edges are special and we do not want any 'optimization' done to them
+      // from the following special checks
+      if (newCatchBlock->isOSRCatchBlock() || existingCatchBlock->isOSRCatchBlock()) continue;
+
+      // If the existing catch block is going to be considered first and it catches everything that
+      // the new catch block does then the new catch block isn't reaching from the 'f' block
+      //
+      // Catch block 'A' is considered before catch block 'B' if 'A' is from a greater inline depth
+      // or 'A' and 'B' are from the same inline depth and 'A' handler index is less than 'B's.
+      //
+      int32_t existingDepth = existingCatchBlock->getInlineDepth();
+      int32_t newDepth = newCatchBlock->getInlineDepth();
+      if (existingDepth < newDepth ||
+          (existingDepth == newDepth && existingCatchBlock->getHandlerIndex() > newCatchBlock->getHandlerIndex()))
+         continue;
+
+      // The existing catch block is going to be considered first.  Don't add an edge to the new catch
+      // block if the existing one catches everything that the new one catches.
+      //
+      /////void * newEC = newCatchBlock->getExceptionClass(), * existingEC = existingCatchBlock->getExceptionClass();
+
+      if (existingCatchBlock->getCatchType() == 0 ||
+          /////(newEC && existingEC && isInstanceOf(newEC, existingEC)) ||
+          (existingDepth == newDepth && existingCatchBlock->getCatchType() == newCatchBlock->getCatchType()))
+         {
+         if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+            {
+            traceMsg(comp(),"\nAddition of exception edge aborted - existing catch alredy handles this case!");
+            }
+         return;
+         }
+      }
+   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, region);
+   _numEdges++;
+
+   // Tell the control tree to modify the structures containing this edge
+   //
+   if (getStructure() != NULL)
+      {
+      getStructure()->addEdge(e, true);
+      if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+         {
+         traceMsg(comp(),"\nStructures after adding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
+         comp()->getDebug()->print(comp()->getOutFile(), _rootStructure, 6);
+         }
+      }
+   }
 
 
 void

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -162,7 +162,9 @@ class CFG
 
    void addEdge(TR::CFGEdge *e);
    TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
+   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR::Region &region);
    void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
+   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR::Region &region);
    void addSuccessorEdges(TR::Block * block);
 
    void copyExceptionSuccessors(TR::CFGNode *from, TR::CFGNode *to, bool (*predicate)(TR::CFGEdge *) = OMR::alwaysTrue);

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -306,6 +306,11 @@ class CFG
    //
    void getBranchCountersFromProfilingData(TR::Node *node, TR::Block *block, int32_t *taken, int32_t *notTaken) { return; }
 
+private:
+   void addEdgeChecks(TR::CFGNode *f, TR::CFGNode *t);
+   bool shouldAddExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
+   void addExceptionEdgeToStructure(TR::CFGNode *f, TR::CFGNode *t, TR::CFGEdge *e);
+
 protected:
 
    TR::Compilation *_compilation;


### PR DESCRIPTION
Adds an interface to allow adding edges on a specific memory region.
Outline common code between the different `addEdge` and `addExceptionEdge` methods.

This contributes to [this](https://github.com/eclipse/openj9/issues/6099) openj9 issue