### PR TITLE
General z/OS improvements

### DIFF
--- a/port/unix/omriconvhelpers.c
+++ b/port/unix/omriconvhelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,24 +32,25 @@
 #include "ut_omrport.h"
 
 #if defined(J9VM_PROVIDE_ICONV)
+#include <string.h>
 #include "omrportptb.h"
 #include "omrportpriv.h"
 
 #if defined(J9ZOS390)
 #pragma convlit(suspend)
-#endif
+#endif /* defined(J9ZOS390) */
 const char *utf8 = "UTF-8";
 #if defined(J9ZOS390)
 const char *utf16 = "01200"; /* z/OS does not accept "UTF-16" */
-#elif defined(OSX)
+#elif defined(OSX) /* defined(J9ZOS390) */
 const char *utf16 = "UTF-16LE";
-#else
+#else /* defined(J9ZOS390) */
 const char *utf16 = "UTF-16";
-#endif
+#endif /* defined(J9ZOS390) */
 const char *ebcdic = "IBM-1047";
 #if defined(J9ZOS390)
 #pragma convlit(resume)
-#endif
+#endif /* defined(J9ZOS390) */
 
 #if defined(J9ZOS390)
 /*
@@ -90,7 +91,7 @@ openIconvDescriptor(iconv_t *globalConverter, MUTEX *globalConverterMutex, uint3
 	}
 	return success;
 }
-#endif
+#endif /* defined(J9ZOS390) */
 
 /* There are  converters that are permanently cached
  * within the portLibraryGlobal structure
@@ -136,7 +137,7 @@ iconv_global_init(struct OMRPortLibrary *portLibrary)
 		}
 		rc = 1;
 	}
-#endif
+#endif /* defined(J9ZOS390) */
 	return rc;
 }
 
@@ -157,7 +158,7 @@ iconv_global_destroy(struct OMRPortLibrary *portLibrary)
 			MUTEX_DESTROY(globalConverterMutex[iconvIndex]);
 		}
 	}
-#endif
+#endif /* defined(J9ZOS390) */
 }
 
 /**
@@ -183,7 +184,6 @@ iconv_get(struct OMRPortLibrary *portLibrary, J9IconvName converterName, const c
 	PortlibPTBuffers_t ptBuffer = NULL;
 	iconv_t converter = J9VM_INVALID_ICONV_DESCRIPTOR;
 #if defined(J9ZOS390)
-
 	if (PPG_global_converter_enabled) {
 		/* NOTE: using original nl_langinfo implementation that returns an EBCDIC string
 		 * by defining J9_USE_ORIG_EBCDIC_LANGINFO which is checked in a2e/headers/langinfo.h */
@@ -222,7 +222,7 @@ iconv_get(struct OMRPortLibrary *portLibrary, J9IconvName converterName, const c
 			return globalConverter[index];
 		}
 	}
-#endif
+#endif /* defined(J9ZOS390) */
 
 	if (converterName < UNCACHED_ICONV_DESCRIPTOR) {
 		ptBuffer = (PortlibPTBuffers_t) omrport_tls_get(portLibrary);
@@ -250,7 +250,6 @@ void
 iconv_free(struct OMRPortLibrary *portLibrary, J9IconvName converterName, iconv_t converter)
 {
 #if defined(J9ZOS390)
-
 	if (PPG_global_converter_enabled) {
 		iconv_t *globalConverter = PPG_global_converter;
 		MUTEX *globalConverterMutex = PPG_global_converter_mutex;
@@ -266,7 +265,7 @@ iconv_free(struct OMRPortLibrary *portLibrary, J9IconvName converterName, iconv_
 			}
 		}
 	}
-#endif
+#endif /* defined(J9ZOS390) */
 	if (converterName < UNCACHED_ICONV_DESCRIPTOR) {
 		PortlibPTBuffers_t ptBuffer = (PortlibPTBuffers_t) omrport_tls_get(portLibrary);
 		if (ptBuffer && (converter == ptBuffer->converterCache[converterName])) {

--- a/port/zos390/omrgetjobname.c
+++ b/port/zos390/omrgetjobname.c
@@ -26,6 +26,7 @@
  * @brief shared library
  */
 #include <stdlib.h>
+#include <string.h>
 #include "omrport.h"
 #include "omrgetjobname.h"
 #include "atoe.h"
@@ -40,16 +41,14 @@
  *       jobname.
  * @param[in] length The length of the data area addressed by
  *       jobname.
- *
  */
 void
 omrget_jobname(struct OMRPortLibrary *portLibrary, char *jobname, uintptr_t length)
 {
 	char *tmp_jobname = (char *)__malloc31(J9_MAX_JOBNAME);
-	char *ascname;
-	uintptr_t width;
 
-	if (tmp_jobname) {
+	if (NULL != tmp_jobname) {
+		char *ascname = NULL;
 		memset(tmp_jobname, '\0', J9_MAX_JOBNAME);
 		_JOBNAME(tmp_jobname);  /* requires <31bit address */
 #if !defined(OMR_EBCDIC)
@@ -58,8 +57,8 @@ omrget_jobname(struct OMRPortLibrary *portLibrary, char *jobname, uintptr_t leng
 		ascname = tmp_jobname;
 #endif /* !defined(OMR_EBCDIC) */
 
-		if (ascname) {
-			width = strcspn(ascname, " ");
+		if (NULL != ascname) {
+			uintptr_t width = strcspn(ascname, " ");
 			strncpy(jobname, ascname, width);
 			jobname[width] = '\0';
 #if !defined(OMR_EBCDIC)
@@ -67,12 +66,9 @@ omrget_jobname(struct OMRPortLibrary *portLibrary, char *jobname, uintptr_t leng
 #endif /* !defined(OMR_EBCDIC) */
 		}
 		free(tmp_jobname);
-
 	} else {
 		if (length >= 5) {
 			strcpy(jobname, "%job");
 		}
 	}
 }
-
-

--- a/port/zos390/omrgetuserid.c
+++ b/port/zos390/omrgetuserid.c
@@ -26,6 +26,7 @@
  * @brief shared library
  */
 #include <stdlib.h>
+#include <string.h>
 #include "atoe.h"
 #include "omrgetuserid.h"
 
@@ -41,7 +42,6 @@
  *       the user id string will be return as an empty string.
  *
  * @return 0 on success, size of required buffer on failure.
- *
  */
 uintptr_t
 omrget_userid(char *userid, uintptr_t length)
@@ -49,13 +49,12 @@ omrget_userid(char *userid, uintptr_t length)
 	/* _USERID() requires that memory be <31bit address, allocating here for use in
 	 * _USERID() call.  */
 	char *tmp_userid = (char *)__malloc31(J9_MAX_USERID);
-	char *ascname;
-	uintptr_t width;
 	uintptr_t result = 0;
 
 	userid[0] = '\0';
 
-	if (tmp_userid) {
+	if (NULL != tmp_userid) {
+		char *ascname = NULL;
 		memset(tmp_userid, '\0', J9_MAX_USERID);
 		_USERID(tmp_userid);  /* requires <31bit address */
 #if !defined(OMR_EBCDIC)
@@ -64,8 +63,8 @@ omrget_userid(char *userid, uintptr_t length)
 		ascname = tmp_userid;
 #endif /* !defined(OMR_EBCDIC) */
 
-		if (ascname) {
-			width = strcspn(ascname, " ");
+		if (NULL != ascname) {
+			uintptr_t width = strcspn(ascname, " ");
 			if (width < length) {
 				strncpy(userid, ascname, width);
 				userid[width] = '\0';
@@ -85,5 +84,3 @@ omrget_userid(char *userid, uintptr_t length)
 
 	return result;
 }
-
-

--- a/port/zos390/omrmmap.c
+++ b/port/zos390/omrmmap.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 
 #include <sys/stat.h>
 #include <errno.h>
+#include <string.h>
 
 #include "omrport.h"
 #include "omrportasserts.h"
@@ -115,21 +116,25 @@ omrmmap_unmap_file(struct OMRPortLibrary *portLibrary, J9MmapHandle *handle)
 		portLibrary->mem_free_memory(portLibrary, handle);
 	}
 }
+
 intptr_t
 omrmmap_msync(struct OMRPortLibrary *portLibrary, void *start, uintptr_t length, uint32_t flags)
 {
 	Trc_PRT_mmap_msync_default_entered(start, length, flags);
 	return -1;
 }
+
 int32_t
 omrmmap_startup(struct OMRPortLibrary *portLibrary)
 {
 	return 0;
 }
+
 void
 omrmmap_shutdown(struct OMRPortLibrary *portLibrary)
 {
 }
+
 int32_t
 omrmmap_capabilities(struct OMRPortLibrary *portLibrary)
 {
@@ -156,6 +161,7 @@ int omrdiscard_data(void *address, int numFrames);
 #endif /*OMR_ENV_DATA64 */
 
 intptr_t Pgser_Release(void *address, int byteAmount);
+
 void
 omrmmap_dont_need(struct OMRPortLibrary *portLibrary, const void *startAddress, size_t length)
 {
@@ -168,7 +174,6 @@ omrmmap_dont_need(struct OMRPortLibrary *portLibrary, const void *startAddress, 
 		uintptr_t roundedStart = ROUND_UP_TO_POWEROF2((uintptr_t) startAddress, pageSize);
 		size_t roundedLength = ROUND_DOWN_TO_POWEROF2(endAddress - roundedStart, pageSize);
 		if (roundedLength >= pageSize) {
-
 			Trc_PRT_mmap_dont_need_oscall(roundedStart, roundedLength);
 
 #if defined(OMR_ENV_DATA64)
@@ -183,7 +188,3 @@ omrmmap_dont_need(struct OMRPortLibrary *portLibrary, const void *startAddress, 
 		}
 	}
 }
-
-
-
-

--- a/port/zos390/omrsyslog.c
+++ b/port/zos390/omrsyslog.c
@@ -27,6 +27,7 @@
  */
 #include "omrportpriv.h"
 #include "atoe.h"
+#include <string.h>
 #include <sys/__messag.h>
 
 uintptr_t writeToZOSLog(const char *message);
@@ -88,8 +89,8 @@ syslogClose(struct OMRPortLibrary *portLibrary)
 uintptr_t
 writeToZOSLog(const char *message)
 {
-	char *ebcdicbuf;
-	int rc;
+	char *ebcdicbuf = NULL;
+	int rc = 0;
 	struct __cons_msg2 cons;
 	int modcmd = 0;
 	unsigned int routeCodes[2] = {2, 0}; /* routing code 2 = Operator Information */
@@ -98,7 +99,7 @@ writeToZOSLog(const char *message)
 #if !defined(OMR_EBCDIC)
 	/* Convert from the internal ascii format to ebcdic */
 	ebcdicbuf = a2e_func((char *) message, strlen(message));
-	if (ebcdicbuf == NULL) {
+	if (NULL == ebcdicbuf) {
 		return FALSE;
 	}
 #else
@@ -142,12 +143,8 @@ writeToZOSLog(const char *message)
 uintptr_t
 omrsyslog_query(struct OMRPortLibrary *portLibrary)
 {
-	uintptr_t options;
-
 	/* query the logging options here */
-	options = PPG_syslog_flags;
-
-	return options;
+	return PPG_syslog_flags;
 }
 
 /**
@@ -164,4 +161,3 @@ omrsyslog_set(struct OMRPortLibrary *portLibrary, uintptr_t options)
 	/* set the logging options here */
 	PPG_syslog_flags = options;
 }
-


### PR DESCRIPTION
Heed compiler advice about built-in functions, for example:
```
INFORMATIONAL CCN3573 ./zos390/omrgetjobname.c: To use the built-in form of the strcpy function add the #include <string.h> directive.
```