### PR TITLE
Misc. Z CodeGenerator cleanups

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2258,7 +2258,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    // overload of the constructor which can accept a NULL preceding instruction. If cursor is NULL the generated
    // label instruction will be prepended to the start of the instruction stream.
    _methodBegin = new (self()->trHeapMemory()) TR::S390LabelInstruction(TR::InstOpCode::LABEL, self()->comp()->getStartTree()->getNode(), generateLabelSymbol(self()), static_cast<TR::Instruction*>(NULL), self());
-   
+
    _methodEnd = generateS390LabelInstruction(self(), TR::InstOpCode::LABEL, self()->comp()->findLastTree()->getNode(), generateLabelSymbol(self()));
 
    TR_S390BinaryEncodingData data;
@@ -2272,7 +2272,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    if (self()->comp()->getJittedMethodSymbol()->isJNI() && !self()->comp()->getOption(TR_FullSpeedDebug))
       {
       data.preProcInstruction = TR::Compiler->target.is64Bit() ?
-         data.cursorInstruction->getNext()->getNext()->getNext() : 
+         data.cursorInstruction->getNext()->getNext()->getNext() :
          data.cursorInstruction->getNext()->getNext();
       }
    else
@@ -5280,15 +5280,6 @@ bool OMR::Z::CodeGenerator::IsInMemoryType(TR::DataType type)
    return false;
 #endif
    }
-
-/**
- * Determine if the Left-to-right copy semantics is allowed on NDmemcpyWithPad
- * Communicates with the evaluator to do MVC semantics under certain condition no matter how the overlap is
- */
-bool OMR::Z::CodeGenerator::inlineNDmemcpyWithPad(TR::Node * node, int64_t * maxLengthPtr)
-      {
-      return false;
-      }
 
 
 uint32_t getRegMaskFromRange(TR::Instruction * inst);

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -299,7 +299,6 @@ public:
 
    bool supportsLengthMinusOneForMemoryOpts() {return true;}
 
-   bool inlineNDmemcpyWithPad(TR::Node * node, int64_t * maxLengthPtr = NULL);
    bool codegenSupportsLoadlessBNDCheck() {return TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12);}
    TR::Register *evaluateLengthMinusOneForMemoryOps(TR::Node *,  bool , bool &lenMinusOne);
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -9995,6 +9995,13 @@ OMR::Z::TreeEvaluator::BBEndEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             }                                                         \
          }
 
+#define AlwaysClobberRegisterForLoops(evaluateChildren,baseAddr,baseReg) \
+         { if (evaluateChildren)                                      \
+            {                                                         \
+            baseReg = cg->gprClobberEvaluate(baseAddr);               \
+            }                                                         \
+         }
+
 ///////////////////////////////////////////////////////////////////////////////////////
 
 TR::Register *
@@ -11121,7 +11128,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
          if (isZero)
             {
             MemClearVarLenMacroOp op(node, baseAddr, cg, elemsRegister, elemsExpr, lenMinusOne);
-            ClobberRegisterForLoops(evaluateChildren, op, baseAddr, baseReg);
+            AlwaysClobberRegisterForLoops(evaluateChildren, baseAddr, baseReg);
             op.setUseEXForRemainder(true);
             op.generate(baseReg);
             }
@@ -11130,14 +11137,14 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
             if (useMVI)
                {
                MemInitVarLenMacroOp op(node, baseAddr, cg, elemsRegister, constExpr->getByte(), elemsExpr, lenMinusOne);
-               ClobberRegisterForLoops(evaluateChildren, op, baseAddr, baseReg);
+               AlwaysClobberRegisterForLoops(evaluateChildren, baseAddr, baseReg);
                op.setUseEXForRemainder(true);
                op.generate(baseReg);
                }
             else
                {
                MemInitVarLenMacroOp op(node, baseAddr, cg, elemsRegister, constExprRegister, elemsExpr, lenMinusOne);
-               ClobberRegisterForLoops(evaluateChildren, op, baseAddr, baseReg);
+               AlwaysClobberRegisterForLoops(evaluateChildren, baseAddr, baseReg);
                op.setUseEXForRemainder(true);
                op.generate(baseReg);
                }

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -107,8 +107,6 @@ MemToMemVarLenMacroOp::generateLoop()
    if (getKind() == MemToMemMacroOp::IsMemInit)
       generateInstruction(0, 1);
 
-   if (!needsLoop()) return NULL;
-
    TR::LabelSymbol * topOfLoop = generateLabelSymbol(_cg);
    TR::LabelSymbol * bottomOfLoop = generateLabelSymbol(_cg);
 
@@ -194,11 +192,6 @@ MemToMemVarLenMacroOp::generateLoop()
       _cg->stopUsingRegister(_raReg);
 
    return cursor;
-   }
-bool
-MemToMemVarLenMacroOp::needsLoop()
-   {
-   return true;
    }
 
 TR::Instruction *
@@ -978,7 +971,7 @@ MemToMemVarLenMacroOp::generateRemainder()
 
       TR::Instruction* cursor = NULL;
 
-      if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || comp->getOption(TR_DisableInlineEXTarget) || !needsLoop())
+      if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || comp->getOption(TR_DisableInlineEXTarget))
          {
          cursor = generateInstruction(0, 1);
          }
@@ -998,7 +991,7 @@ MemToMemVarLenMacroOp::generateRemainder()
         }
 
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget) && needsLoop())
+      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
          {
          TR_ASSERT(_EXTargetLabel != NULL, "Assert: EXTarget label must not be NULL");
 
@@ -1034,9 +1027,6 @@ MemToMemVarLenMacroOp::generateRemainder()
       generateRXInstruction(_cg, TR::InstOpCode::BAS, _rootNode, _raReg, targetMR);
       _cursor = generateS390LabelInstruction(_cg, TR::InstOpCode::LABEL, _rootNode, remainderDoneLabel);
       }
-
-   if(!needsLoop() && _doneLabel==NULL)
-     _startControlFlow = _cursor; // If loop was not generated there is no need for control flow
 
    return _cursor;
    }

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -198,15 +198,6 @@ MemToMemVarLenMacroOp::generateLoop()
 bool
 MemToMemVarLenMacroOp::needsLoop()
    {
-   int64_t maxLength = 0;
-   if (_cg->inlineNDmemcpyWithPad(_rootNode, &maxLength))
-      {
-      if (maxLength == 0 || maxLength > 256)
-         return true;
-      else
-         return false;
-      }
-
    return true;
    }
 
@@ -357,7 +348,7 @@ MemToMemConstLenMacroOp::generateLoop()
    uint64_t dstOffset = 0;
 
 
-   if (inRange && (aliasingPattern || !_cg->storageMayOverlap(_srcNode, len, _dstNode, len)) && !_cg->inlineNDmemcpyWithPad(_rootNode))
+   if (inRange && (aliasingPattern || !_cg->storageMayOverlap(_srcNode, len, _dstNode, len)))
       {
       TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::MVCL;
 

--- a/compiler/z/codegen/OpMemToMem.hpp
+++ b/compiler/z/codegen/OpMemToMem.hpp
@@ -297,8 +297,6 @@ class MemToMemConstLenMacroOp : public MemToMemMacroOp
 
 class MemToMemVarLenMacroOp : public MemToMemMacroOp
    {
-   public:
-      bool needsLoop();
    protected:
       MemToMemVarLenMacroOp(TR::Node* rootNode, TR::Node* dstNode, TR::Node* srcNode, TR::CodeGenerator * cg, TR::Register* regLen, TR::Node * lenNode, bool lengthMinusOne=false, TR::InstOpCode::Mnemonic opcode = TR::InstOpCode::MVC, TR::Register * itersReg = 0, TR::Register * raReg = 0)
          : MemToMemMacroOp(rootNode, dstNode, srcNode, cg, lenNode, itersReg), _regLen(regLen), _raReg(raReg), _doneLabel(0), _opcode(opcode), _lengthMinusOne(lengthMinusOne)


### PR DESCRIPTION
* Remove inlineNDmemcpyWithPad and fold code assuming false
* Fold code assuming MemToMemVarLenMacroOp::needsLoop is always true