### PR TITLE
Add internal memory to CFG

### DIFF
--- a/compiler/infra/Cfg.hpp
+++ b/compiler/infra/Cfg.hpp
@@ -34,7 +34,10 @@ class CFG : public OMR::CFGConnector
    {
    public:
 
-   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method, TR::Region *region = NULL) :
+   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method) :
+      OMR::CFGConnector(comp, method) {}
+
+   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method, TR::Region &region) :
       OMR::CFGConnector(comp, method, region) {}
    };
 }

--- a/compiler/infra/Cfg.hpp
+++ b/compiler/infra/Cfg.hpp
@@ -34,7 +34,7 @@ class CFG : public OMR::CFGConnector
    {
    public:
 
-   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method) :
+   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method, TR::Region *region) :
       OMR::CFGConnector(comp, method) {}
    };
 }

--- a/compiler/infra/Cfg.hpp
+++ b/compiler/infra/Cfg.hpp
@@ -34,8 +34,8 @@ class CFG : public OMR::CFGConnector
    {
    public:
 
-   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method, TR::Region *region) :
-      OMR::CFGConnector(comp, method) {}
+   CFG(TR::Compilation *comp, TR::ResolvedMethodSymbol *method, TR::Region *region = NULL) :
+      OMR::CFGConnector(comp, method, region) {}
    };
 }
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -146,7 +146,7 @@ OMR::CFG::addEdge(TR::CFGEdge *e)
 
 
 TR::CFGEdge *
-OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
+OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t)
    {
 
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
@@ -156,7 +156,7 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
 
    TR_ASSERT(!f->hasExceptionSuccessor(t), "adding a non exception edge when there's already an exception edge");
 
-   TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, trMemory(), allocKind);
+   TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, _internalRegion);
    addEdge(e);
    return e;
    }
@@ -165,8 +165,7 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
 void
 OMR::CFG::addExceptionEdge(
       TR::CFGNode *f,
-      TR::CFGNode *t,
-      TR_AllocationKind allocKind)
+      TR::CFGNode *t)
    {
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
       {
@@ -212,7 +211,7 @@ OMR::CFG::addExceptionEdge(
          return;
          }
       }
-   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, trMemory(), allocKind);
+   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, _internalRegion);
    _numEdges++;
 
    // Tell the control tree to modify the structures containing this edge

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -146,7 +146,7 @@ OMR::CFG::addEdge(TR::CFGEdge *e)
 
 
 TR::CFGEdge *
-OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t)
+OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
    {
 
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
@@ -165,7 +165,8 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t)
 void
 OMR::CFG::addExceptionEdge(
       TR::CFGNode *f,
-      TR::CFGNode *t)
+      TR::CFGNode *t,
+      TR_AllocationKind allocKind)
    {
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
       {

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -145,8 +145,32 @@ OMR::CFG::addEdge(TR::CFGEdge *e)
    }
 
 
+/**
+ * @deprecated
+ * Please specify where edges are to be allocated during CFG initialization.
+ * E.g.,
+ *     OMR::CFG(c, m, TR::Region &region)
+ * and use the following method to add edges to that region.
+ *     addEdge(TR::CFGNode *f, TR::CFGNode *t);
+ */
 TR::CFGEdge *
 OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
+   {
+
+   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+      {
+      traceMsg(comp(),"\nAdding real edge %d-->%d:\n", f->getNumber(), t->getNumber());
+      }
+
+   TR_ASSERT(!f->hasExceptionSuccessor(t), "adding a non exception edge when there's already an exception edge");
+
+   TR::CFGEdge * e = TR::CFGEdge::createEdge(f, t, trMemory(), allocKind);
+   addEdge(e);
+   return e;
+   }
+
+TR::CFGEdge *
+OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t)
    {
 
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
@@ -161,12 +185,84 @@ OMR::CFG::addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind allocKind)
    return e;
    }
 
-
+/**
+ * @deprecated
+ * Please specify where edges are to be allocated during CFG initialization.
+ * E.g.,
+ *     OMR::CFG(c, m, TR::Region &region)
+ * and use the following method to add edges to that region.
+ *     addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
+ */
 void
 OMR::CFG::addExceptionEdge(
       TR::CFGNode *f,
       TR::CFGNode *t,
       TR_AllocationKind allocKind)
+   {
+   if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+      {
+      traceMsg(comp(),"\nAdding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
+      }
+
+   TR_ASSERT(!f->hasSuccessor(t), "adding an exception edge when there's already a non exception edge");
+   TR::Block * newCatchBlock = toBlock(t);
+   for (auto e = f->getExceptionSuccessors().begin(); e != f->getExceptionSuccessors().end(); ++e)
+      {
+      TR::Block * existingCatchBlock = toBlock((*e)->getTo());
+      if (newCatchBlock == existingCatchBlock) return;
+
+      // OSR exception edges are special and we do not want any 'optimization' done to them
+      // from the following special checks
+      if (newCatchBlock->isOSRCatchBlock() || existingCatchBlock->isOSRCatchBlock()) continue;
+
+      // If the existing catch block is going to be considered first and it catches everything that
+      // the new catch block does then the new catch block isn't reaching from the 'f' block
+      //
+      // Catch block 'A' is considered before catch block 'B' if 'A' is from a greater inline depth
+      // or 'A' and 'B' are from the same inline depth and 'A' handler index is less than 'B's.
+      //
+      int32_t existingDepth = existingCatchBlock->getInlineDepth();
+      int32_t newDepth = newCatchBlock->getInlineDepth();
+      if (existingDepth < newDepth ||
+          (existingDepth == newDepth && existingCatchBlock->getHandlerIndex() > newCatchBlock->getHandlerIndex()))
+         continue;
+
+      // The existing catch block is going to be considered first.  Don't add an edge to the new catch
+      // block if the existing one catches everything that the new one catches.
+      //
+      /////void * newEC = newCatchBlock->getExceptionClass(), * existingEC = existingCatchBlock->getExceptionClass();
+
+      if (existingCatchBlock->getCatchType() == 0 ||
+          /////(newEC && existingEC && isInstanceOf(newEC, existingEC)) ||
+          (existingDepth == newDepth && existingCatchBlock->getCatchType() == newCatchBlock->getCatchType()))
+         {
+         if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+            {
+            traceMsg(comp(),"\nAddition of exception edge aborted - existing catch alredy handles this case!");
+            }
+         return;
+         }
+      }
+   TR::CFGEdge* e = TR::CFGEdge::createExceptionEdge(f,t, trMemory(), allocKind);
+   _numEdges++;
+
+   // Tell the control tree to modify the structures containing this edge
+   //
+   if (getStructure() != NULL)
+      {
+      getStructure()->addEdge(e, true);
+      if (comp()->getOption(TR_TraceAddAndRemoveEdge))
+         {
+         traceMsg(comp(),"\nStructures after adding exception edge %d-->%d:\n", f->getNumber(), t->getNumber());
+         comp()->getDebug()->print(comp()->getOutFile(), _rootStructure, 6);
+         }
+      }
+   }
+
+void
+OMR::CFG::addExceptionEdge(
+      TR::CFGNode *f,
+      TR::CFGNode *t)
    {
    if (comp()->getOption(TR_TraceAddAndRemoveEdge))
       {
@@ -227,8 +323,6 @@ OMR::CFG::addExceptionEdge(
          }
       }
    }
-
-
 
 void
 OMR::CFG::addSuccessorEdges(TR::Block * block)

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -96,14 +96,14 @@ class CFG
 
    TR_ALLOC(TR_Memory::CFG)
 
-   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region *region = NULL) :
+   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m) :
       _compilation(c),
       _method(m),
       _rootStructure(NULL),
       _pStart(NULL),
       _pEnd(NULL),
       _structureRegion(c->trMemory()->heapMemoryRegion()),
-      _internalRegion(region ? *region : c->trMemory()->heapMemoryRegion()),
+      _internalRegion(c->trMemory()->heapMemoryRegion()),
       _nextNodeNumber(0),
       _numEdges(0),
       _mightHaveUnreachableBlocks(false),
@@ -125,6 +125,37 @@ class CFG
       _edgeProbabilities(NULL)
       {
       }
+
+   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region &r) :
+      _compilation(c),
+      _method(m),
+      _rootStructure(NULL),
+      _pStart(NULL),
+      _pEnd(NULL),
+      _structureRegion(c->trMemory()->heapMemoryRegion()),
+      _internalRegion(r),
+      _nextNodeNumber(0),
+      _numEdges(0),
+      _mightHaveUnreachableBlocks(false),
+      _doesHaveUnreachableBlocks(false),
+      _removingUnreachableBlocks(false),
+      _ignoreUnreachableBlocks(false),
+      _removeEdgeNestingDepth(0),
+      _forwardTraversalOrder(NULL),
+      _backwardTraversalOrder(NULL),
+      _forwardTraversalLength(0),
+      _backwardTraversalLength(0),
+      _maxFrequency(-1),
+      _maxEdgeFrequency(-1),
+      _oldMaxFrequency(-1),
+      _oldMaxEdgeFrequency(-1),
+      _frequencySet(NULL),
+      _calledFrequency(0),
+      _initialBlockFrequency(-1),
+      _edgeProbabilities(NULL)
+      {
+      }
+
 
    TR::CFG * self();
 
@@ -162,8 +193,8 @@ class CFG
    void removeStructureSubGraphNodes(TR_StructureSubGraphNode *node);
 
    void addEdge(TR::CFGEdge *e);
-   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t);
-   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
+   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
+   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
    void addSuccessorEdges(TR::Block * block);
 
    void copyExceptionSuccessors(TR::CFGNode *from, TR::CFGNode *to, bool (*predicate)(TR::CFGEdge *) = OMR::alwaysTrue);

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -184,7 +184,15 @@ class CFG
     *     addEdge(TR::CFGNode *f, TR::CFGNode *t);
     */
    TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind heapAlloc);
+
+   /**
+    * Create and store edge from CFGNode f to CFGNode t
+    * @param f   CFGNode from
+    * @param t   CFGNode to
+    * @return    Pointer to newly created edge
+    */
    TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t);
+
    /**
     * @deprecated
     * Please specify where edges are to be allocated during CFG initialization.
@@ -194,6 +202,13 @@ class CFG
     *     addExceptionEdgeEdge(TR::CFGNode *f, TR::CFGNode *t);
     */
    void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind heapAlloc);
+
+   /**
+    * Create and store exception edge from CFGNode f to CFGNode t 
+    * @param f   CFGNode from
+    * @param t   CFGNode to
+    * @return    Pointer to newly created exception edge
+    */
    void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
    void addSuccessorEdges(TR::Block * block);
 

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -97,65 +97,46 @@ class CFG
    TR_ALLOC(TR_Memory::CFG)
 
    CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m) :
-      _compilation(c),
-      _method(m),
-      _rootStructure(NULL),
-      _pStart(NULL),
-      _pEnd(NULL),
       _structureRegion(c->trMemory()->heapMemoryRegion()),
-      _internalRegion(c->trMemory()->heapMemoryRegion()),
-      _nextNodeNumber(0),
-      _numEdges(0),
-      _mightHaveUnreachableBlocks(false),
-      _doesHaveUnreachableBlocks(false),
-      _removingUnreachableBlocks(false),
-      _ignoreUnreachableBlocks(false),
-      _removeEdgeNestingDepth(0),
-      _forwardTraversalOrder(NULL),
-      _backwardTraversalOrder(NULL),
-      _forwardTraversalLength(0),
-      _backwardTraversalLength(0),
-      _maxFrequency(-1),
-      _maxEdgeFrequency(-1),
-      _oldMaxFrequency(-1),
-      _oldMaxEdgeFrequency(-1),
-      _frequencySet(NULL),
-      _calledFrequency(0),
-      _initialBlockFrequency(-1),
-      _edgeProbabilities(NULL)
+      _internalRegion(c->trMemory()->heapMemoryRegion())
       {
+         init(c, m);
       }
 
    CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region &r) :
-      _compilation(c),
-      _method(m),
-      _rootStructure(NULL),
-      _pStart(NULL),
-      _pEnd(NULL),
       _structureRegion(c->trMemory()->heapMemoryRegion()),
-      _internalRegion(r),
-      _nextNodeNumber(0),
-      _numEdges(0),
-      _mightHaveUnreachableBlocks(false),
-      _doesHaveUnreachableBlocks(false),
-      _removingUnreachableBlocks(false),
-      _ignoreUnreachableBlocks(false),
-      _removeEdgeNestingDepth(0),
-      _forwardTraversalOrder(NULL),
-      _backwardTraversalOrder(NULL),
-      _forwardTraversalLength(0),
-      _backwardTraversalLength(0),
-      _maxFrequency(-1),
-      _maxEdgeFrequency(-1),
-      _oldMaxFrequency(-1),
-      _oldMaxEdgeFrequency(-1),
-      _frequencySet(NULL),
-      _calledFrequency(0),
-      _initialBlockFrequency(-1),
-      _edgeProbabilities(NULL)
+      _internalRegion(r)
       {
+         init(c, m);
       }
 
+   void init(TR::Compilation *c, TR::ResolvedMethodSymbol *m)
+   {
+      _compilation = c;
+      _method = m;
+      _rootStructure = NULL;
+      _pStart = NULL;
+      _pEnd = NULL;
+      _nextNodeNumber = 0;
+      _numEdges = 0;
+      _mightHaveUnreachableBlocks = false;
+      _doesHaveUnreachableBlocks = false;
+      _removingUnreachableBlocks = false;
+      _ignoreUnreachableBlocks = false;
+      _removeEdgeNestingDepth = 0;
+      _forwardTraversalOrder = NULL;
+      _backwardTraversalOrder = NULL;
+      _forwardTraversalLength = 0;
+      _backwardTraversalLength = 0;
+      _maxFrequency = -1;
+      _maxEdgeFrequency = -1;
+      _oldMaxFrequency = -1;
+      _oldMaxEdgeFrequency = -1;
+      _frequencySet = NULL;
+      _calledFrequency = 0;
+      _initialBlockFrequency = -1;
+      _edgeProbabilities = NULL;
+   }
 
    TR::CFG * self();
 
@@ -193,8 +174,27 @@ class CFG
    void removeStructureSubGraphNodes(TR_StructureSubGraphNode *node);
 
    void addEdge(TR::CFGEdge *e);
-   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
-   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
+
+   /**
+    * @deprecated
+    * Please specify where edges are to be allocated during CFG initialization.
+    * E.g.,
+    *     OMR::CFG(c, m, TR::Region &region)
+    * and use the following method to add edges to that region.
+    *     addEdge(TR::CFGNode *f, TR::CFGNode *t);
+    */
+   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind heapAlloc);
+   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t);
+   /**
+    * @deprecated
+    * Please specify where edges are to be allocated during CFG initialization.
+    * E.g.,
+    *     OMR::CFG(c, m, TR::Region &region)
+    * and use the following method to add edges to that region.
+    *     addExceptionEdgeEdge(TR::CFGNode *f, TR::CFGNode *t);
+    */
+   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind heapAlloc);
+   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
    void addSuccessorEdges(TR::Block * block);
 
    void copyExceptionSuccessors(TR::CFGNode *from, TR::CFGNode *to, bool (*predicate)(TR::CFGEdge *) = OMR::alwaysTrue);

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -96,13 +96,14 @@ class CFG
 
    TR_ALLOC(TR_Memory::CFG)
 
-   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m) :
+   CFG(TR::Compilation *c, TR::ResolvedMethodSymbol *m, TR::Region *region = NULL) :
       _compilation(c),
       _method(m),
       _rootStructure(NULL),
       _pStart(NULL),
       _pEnd(NULL),
       _structureRegion(c->trMemory()->heapMemoryRegion()),
+      _internalRegion(region ? *region : c->trMemory()->heapMemoryRegion()),
       _nextNodeNumber(0),
       _numEdges(0),
       _mightHaveUnreachableBlocks(false),
@@ -161,8 +162,8 @@ class CFG
    void removeStructureSubGraphNodes(TR_StructureSubGraphNode *node);
 
    void addEdge(TR::CFGEdge *e);
-   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
-   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind = heapAlloc);
+   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t);
+   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t);
    void addSuccessorEdges(TR::Block * block);
 
    void copyExceptionSuccessors(TR::CFGNode *from, TR::CFGNode *to, bool (*predicate)(TR::CFGEdge *) = OMR::alwaysTrue);
@@ -312,6 +313,7 @@ protected:
    TR::CFGNode *_pStart;
    TR::CFGNode *_pEnd;
    TR::Region _structureRegion;
+   TR::Region _internalRegion;
    TR_Structure *_rootStructure;
 
    TR_LinkHead1<TR::CFGNode> _nodes;


### PR DESCRIPTION
This commit adds an internal memory region to the CFG.
By default, the internal memory region is created from the heap
region. CFG edges are now allocated to this internal memory
region.

Signed-off-by: Erick Ochoa <eochoa@ualberta.ca>

Needed for this [openj9 issue](https://github.com/eclipse/openj9/issues/6099)
Will be needed for this [openj9 PR](https://github.com/eclipse/openj9/pull/6141)