### PR TITLE
Remove unsigned ILopcode: TR::iflucmpeq and TR::ifiucmpeq from SwitchAnalyzer

### DIFF
--- a/compiler/optimizer/SwitchAnalyzer.cpp
+++ b/compiler/optimizer/SwitchAnalyzer.cpp
@@ -627,7 +627,7 @@ TR::Block *TR::SwitchAnalyzer::peelOffTheHottestValue(TR_LinkHead<SwitchInfo> *c
 
       TR::Block *newBlock = NULL;
 
-      cmpOp = _isInt64 ? (_signed ? TR::iflcmpeq : TR::iflucmpeq) : (_signed ? TR::ificmpeq : TR::ifiucmpeq);
+      cmpOp = _isInt64 ? TR::iflcmpeq : TR::ificmpeq;
       newBlock = addIfBlock(cmpOp, topNode->_min, topNode->_target);
 
       if (trace())
@@ -960,7 +960,7 @@ TR::Block *TR::SwitchAnalyzer::binSearch(SwitchInfo *startNode, SwitchInfo *endN
       else
          {
          addGotoBlock(_defaultDest);
-         cmpOp = _isInt64 ? (_signed ? TR::iflcmpeq : TR::iflucmpeq) : (_signed ? TR::ificmpeq : TR::ifiucmpeq);
+         cmpOp = _isInt64 ? TR::iflcmpeq : TR::ificmpeq;
          return addIfBlock  (cmpOp, endNode->_max, endNode->_target);
          }
       }
@@ -1175,7 +1175,7 @@ TR::Block *TR::SwitchAnalyzer::linearSearch(SwitchInfo *start)
       {
       if (cursor->_kind == Unique)
          {
-         cmpOp = _isInt64 ? (_signed ? TR::iflcmpeq : TR::iflucmpeq) : (_signed ? TR::ificmpeq : TR::ifiucmpeq);
+         cmpOp = _isInt64 ? TR::iflcmpeq : TR::ificmpeq;
          newBlock = addIfBlock(cmpOp, cursor->_min, cursor->_target);
          }
       else if (cursor->_kind == Range)


### PR DESCRIPTION
The unsigned ILopcode: `TR::iflucmpeq` and `TR::ifiucmpeq` have already been deprecated. Remove the two unsigned opcodes from the` SwitchAnalyzer.cpp`.

Issue: #3983
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>