### PR TITLE
Misc. compiler code cleanup 

### DIFF
--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -50,10 +50,6 @@
 #include "il/AliasSetInterface.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/ObjectModel.hpp"
-#ifdef J9_PROJECT_SPECIFIC
-#include "runtime/RuntimeAssumptions.hpp"
-#include "env/PersistentCHTable.hpp"
-#endif
 #include "env/PersistentInfo.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"

--- a/compiler/codegen/FrontEnd.hpp
+++ b/compiler/codegen/FrontEnd.hpp
@@ -61,10 +61,6 @@
 #include "runtime/Runtime.hpp"
 #include "env/VerboseLog.hpp"
 
-#ifdef J9_PROJECT_SPECIFIC
-#include "env/SharedCache.hpp"
-#endif
-
 class TR_Debug;
 class TR_FrontEnd;
 class TR_Memory;

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -90,36 +90,6 @@ char *feGetEnv(const char *s)
    }
 
 
-// Brought this debug stuff from Compilation.cpp
-//
-// Limit on the size of the debug string
-//
-const int indebugLimit = 1023;
-
-
-// The delimiter characters
-//
-static const char * delimiters = " ";
-// The original value of the environment variable
-//
-static const char *TR_DEBUGValue = 0;
-
-// The original string with embedded nulls between individual values
-//
-static char permDebugString[indebugLimit + 1];
-static int  permDebugStrLen = 0;
-
-struct DebugValue
-   {
-   DebugValue * next;
-   DebugValue *prev;
-   char       *value;
-   };
-
-static DebugValue *head = 0;
-
-
-
 // Options stuff
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"

--- a/compiler/infra/Assert.cpp
+++ b/compiler/infra/Assert.cpp
@@ -37,9 +37,6 @@
 #include "ras/Debug.hpp"
 #include "stdarg.h"
 
-#ifdef J9_PROJECT_SPECIFIC
-#include "env/VMJ9.h"
-#endif
 
 void OMR_NORETURN TR::trap()
    {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -70,10 +70,6 @@
 #include "ras/Debug.hpp"
 #include "ras/DebugCounter.hpp"
 #include "runtime/Runtime.hpp"
-#ifdef J9_PROJECT_SPECIFIC
-#include "runtime/J9Profiler.hpp"
-#include "runtime/J9ValueProfiler.hpp"
-#endif
 #include "x/codegen/HelperCallSnippet.hpp"
 #include "x/codegen/OutlinedInstructions.hpp"
 #include "x/codegen/RegisterRematerialization.hpp"


### PR DESCRIPTION
* Remove obsolete code from FEBase.cpp
* Remove unnecessary J9_PROJECT_SPECIFIC macros