### PR TITLE
Rename global register allocated indexes on ParameterSymbol

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -566,7 +566,7 @@ OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *c
             TR::ParameterSymbol *sym = child->getChild(i)->getSymbol()->getParmSymbol();
             if (sym != NULL)
                {
-               sym->setAllocatedIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
+               sym->setAssignedGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
                }
             }
          }

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -102,7 +102,7 @@ TR::Instruction *OMR::ARM::Linkage::saveArguments(TR::Instruction *cursor)
       TR::RealRegister     *argRegister;
 //      int32_t lri = paramCursor->getLinkageRegisterIndex();
 
-      int32_t ai  = paramCursor->getAllocatedIndex();
+      int32_t ai  = paramCursor->getAssignedGlobalRegisterIndex();
       int32_t                 offset = paramCursor->getParameterOffset();
 
       if (numIntArgs >= properties.getNumIntArgRegs())

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -1348,7 +1348,7 @@ TR::Register *OMR::ARM::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Code
             TR::ParameterSymbol *sym = child->getChild(i)->getSymbolReference()->getSymbol()->getParmSymbol();
             if (sym != NULL)
                {
-               sym->setAllocatedIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
+               sym->setAssignedGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
                }
             }
          }

--- a/compiler/codegen/OMRLinkage.cpp
+++ b/compiler/codegen/OMRLinkage.cpp
@@ -40,7 +40,7 @@ OMR::Linkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    // be.  Once we move that facility to TR::Linkage, and this function could be
    // more selective.
    //
-   return(parm->getAllocatedIndex()>=0       &&
+   return(parm->getAssignedGlobalRegisterIndex()>=0       &&
           ( (  parm->getLinkageRegisterIndex()==0 &&
                parm->isCollectedReference()
             ) ||

--- a/compiler/il/symbol/OMRParameterSymbol.hpp
+++ b/compiler/il/symbol/OMRParameterSymbol.hpp
@@ -77,11 +77,47 @@ public:
    int8_t   getAllocatedIndex()                { return _allocatedHigh; }
    void     setAllocatedIndex(int8_t ai)       { _allocatedHigh = ai; }
 
+   /**
+    * @return The global register index assigned to this parameter, or -1 if
+    *         a global register has not been assigned.
+    */
+   int8_t   getAssignedGlobalRegisterIndex()   { return _allocatedHigh; }
+
+   /**
+    * @brief Sets the global register index assigned to this parameter symbol.
+    * @param[in] gr : the global register index
+    */
+   void     setAssignedGlobalRegisterIndex(int8_t gr) { _allocatedHigh = gr; }
+
    int8_t   getAllocatedHigh()                 { return _allocatedHigh; }
    void     setAllocatedHigh(int8_t ai)        { _allocatedHigh = ai; }
 
+   /**
+    * @return The high global register index assigned to this parameter, or -1 if
+    *         a global register index has not been assigned.
+    */
+   int8_t   getAssignedHighGlobalRegisterIndex() { return _allocatedHigh; }
+
+   /**
+    * @brief Sets the high global register index assigned to this parameter symbol.
+    * @param[in] gr : the global register index
+    */
+   void     setAssignedHighGlobalRegisterIndex(int8_t gr) { _allocatedHigh = gr; }
+
    int8_t   getAllocatedLow()                  { return _allocatedLow; }
    void     setAllocatedLow(int8_t ai)         { _allocatedLow = ai; }
+
+   /**
+    * @return The low global register index assigned to this parameter, or -1 if
+    *         a global register index has not been assigned.
+    */
+   int8_t   getAssignedLowGlobalRegisterIndex() { return _allocatedLow; }
+
+   /**
+    * @brief Sets the low global register index assigned to this parameter symbol.
+    * @param[in] gr : the global register index
+    */
+   void     setAssignedLowGlobalRegisterIndex(int8_t gr) { _allocatedLow = gr; }
 
    void*    getFixedType()                     { return _fixedType; }
    void     setFixedType(void* t)              { _fixedType = t; }

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -161,7 +161,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
    for (paramCursor=paramIterator.getFirst(); paramCursor!=NULL; paramCursor=paramIterator.getNext())
       {
       int32_t lri = paramCursor->getLinkageRegisterIndex();
-      int32_t ai  = paramCursor->getAllocatedIndex();
+      int32_t ai  = paramCursor->getAssignedGlobalRegisterIndex();
       int32_t offset = paramCursor->getParameterOffset();
       TR::DataType type = paramCursor->getType();
       int32_t dtype = type.getDataType();
@@ -262,7 +262,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
 
             if (TR::Compiler->target.is32Bit() && type.isInt64())
                {
-               int32_t aiLow = paramCursor->getAllocatedLow();
+               int32_t aiLow = paramCursor->getAssignedLowGlobalRegisterIndex();
 
                if (!twoRegs)    // Low part needs to come from memory
                   {
@@ -377,7 +377,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                      busyIndex++;
                      }
 
-                  ai = paramCursor->getAllocatedLow();
+                  ai = paramCursor->getAssignedLowGlobalRegisterIndex();
                   if (freeScratchable.isSet(ai))
                      {
                      cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::lwz, firstNode, REAL_REGISTER(REGNUM(ai)),

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5711,11 +5711,11 @@ TR::Register *OMR::Power::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Co
             if (sym != NULL)
                {
                if (TR::Compiler->target.is64Bit() || !sym->getType().isInt64())
-                  sym->setAllocatedIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
+                  sym->setAssignedGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
                else
                   {
-                  sym->setAllocatedHigh(cg->getGlobalRegister(child->getChild(i)->getHighGlobalRegisterNumber()));
-                  sym->setAllocatedLow(cg->getGlobalRegister(child->getChild(i)->getLowGlobalRegisterNumber()));
+                  sym->setAssignedHighGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getHighGlobalRegisterNumber()));
+                  sym->setAssignedLowGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getLowGlobalRegisterNumber()));
                   }
                }
             }

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -432,7 +432,7 @@ TR::PPCSystemLinkage::getRightToLeft()
 bool
 TR::PPCSystemLinkage::hasToBeOnStack(TR::ParameterSymbol *parm)
    {
-   return(parm->getAllocatedIndex()>=0  && parm->isParmHasToBeOnStack());
+   return(parm->getAssignedGlobalRegisterIndex()>=0  && parm->isParmHasToBeOnStack());
    }
 
 

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -896,7 +896,7 @@ TR::AMD64ABILinkage::mapIncomingParms(
    //
    for (parmCursor = parameterIterator.getFirst(); parmCursor; parmCursor = parameterIterator.getNext())
       {
-      if ((parmCursor->getLinkageRegisterIndex() >= 0) && (parmCursor->getAllocatedIndex() < 0 || hasToBeOnStack(parmCursor)))
+      if ((parmCursor->getLinkageRegisterIndex() >= 0) && (parmCursor->getAssignedGlobalRegisterIndex() < 0 || hasToBeOnStack(parmCursor)))
          {
          uint32_t align = getAlignment(parmCursor->getDataType());
          uint32_t alignMinus1 = (align <= AMD64_STACK_SLOT_SIZE) ? (AMD64_STACK_SLOT_SIZE - 1) : (align - 1);
@@ -909,11 +909,11 @@ TR::AMD64ABILinkage::mapIncomingParms(
          if (comp()->getOption(TR_TraceCG))
             traceMsg(comp(), "mapIncomingParms setParameterOffset %d for param symbol (reg param without home location) %p, hasToBeOnStack() %d\n", parmCursor->getParameterOffset(), parmCursor, hasToBeOnStack(parmCursor));
          }
-      else if (parmCursor->getLinkageRegisterIndex() >=0 && parmCursor->getAllocatedIndex() >= 0)
+      else if (parmCursor->getLinkageRegisterIndex() >=0 && parmCursor->getAssignedGlobalRegisterIndex() >= 0)
          {
          //parmCursor->setDontHaveStackSlot(0); // this is a hack , so as we could print stack layout table in createPrologue
          if (comp()->getOption(TR_TraceCG))
-            traceMsg(comp(), "mapIncomingParms no need to set parm %p, for it has got register %d assigned\n", parmCursor, parmCursor->getAllocatedIndex());
+            traceMsg(comp(), "mapIncomingParms no need to set parm %p, for it has got register %d assigned\n", parmCursor, parmCursor->getAssignedGlobalRegisterIndex());
          }
       }
    }

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -127,7 +127,7 @@ TR::X86SystemLinkage::copyParametersToHomeLocation(TR::Instruction *cursor)
       {
       int8_t lri = paramCursor->getLinkageRegisterIndex();     // How the parameter enters the method
       TR::RealRegister::RegNum ai                              // Where method body expects to find it
-         = (TR::RealRegister::RegNum)paramCursor->getAllocatedIndex();
+         = (TR::RealRegister::RegNum)paramCursor->getAssignedGlobalRegisterIndex();
       int32_t offset = paramCursor->getParameterOffset();      // Location of the parameter's stack slot
       TR_MovDataTypes movDataType = paramMovType(paramCursor); // What sort of MOV instruction does it need?
 
@@ -562,7 +562,7 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
       paramCursor != NULL;
       paramCursor = paramIterator.getNext()
       ){
-      TR::RealRegister::RegNum ai = (TR::RealRegister::RegNum)paramCursor->getAllocatedIndex();
+      TR::RealRegister::RegNum ai = (TR::RealRegister::RegNum)paramCursor->getAssignedGlobalRegisterIndex();
       debugFrameSlotInfo = new (trHeapMemory()) TR_DebugFrameSegmentInfo(comp(),
          paramCursor->getOffset(), paramCursor->getSize(), "Parameter",
          debugFrameSlotInfo,
@@ -821,7 +821,7 @@ TR::X86SystemLinkage::copyGlRegDepsToParameterSymbols(
          {
          TR::Node *child = glRegDeps->getChild(childNum);
          TR::ParameterSymbol *sym = child->getSymbol()->getParmSymbol();
-         sym->setAllocatedIndex(cg->getGlobalRegister(child->getGlobalRegisterNumber()));
+         sym->setAssignedGlobalRegisterIndex(cg->getGlobalRegister(child->getGlobalRegisterNumber()));
          }
       }
    }

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -463,8 +463,8 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 
    for (paramCursor = paramIterator.getFirst(); paramCursor != NULL; paramCursor = paramIterator.getNext())
       {
-      int32_t ai = paramCursor->getAllocatedIndex();
-      int32_t ai_l = paramCursor->getAllocatedLow();  //  low reg of a pair
+      int32_t ai = paramCursor->getAssignedGlobalRegisterIndex();
+      int32_t ai_l = paramCursor->getAssignedLowGlobalRegisterIndex();  //  low reg of a pair
 
       // Contruct list of globally allocated registers
       //
@@ -522,7 +522,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
       {
       parmNum++;
       int32_t lri = paramCursor->getLinkageRegisterIndex();                // linkage register
-      int32_t ai = paramCursor->getAllocatedIndex();                       // global reg number
+      int32_t ai = paramCursor->getAssignedGlobalRegisterIndex();          // global reg number
       TR::DataType dtype = paramCursor->getDataType();
       int32_t offset = paramCursor->getParameterOffset() - frameOffset;
       TR::SymbolReference * paramSymRef = NULL;
@@ -889,7 +889,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #ifdef J9_PROJECT_SPECIFIC
                   else if (dtype == TR::DecimalLongDouble)
                      {
-                     int32_t ai_l = paramCursor->getAllocatedLow();  //  low reg of a pair
+                     int32_t ai_l = paramCursor->getAssignedLowGlobalRegisterIndex();  //  low reg of a pair
                      TR_ASSERT( (ai_l == (ai+2)),"global RA incorrect for long double params");
                      cursor = generateRRInstruction(self()->cg(),  TR::InstOpCode::LXR, firstNode, self()->cg()->allocateFPRegisterPair(self()->getRealRegister(REGNUM(ai_l)), self()->getRealRegister(REGNUM(ai))),
                         self()->cg()->allocateFPRegisterPair(self()->getRealRegister(REGNUM(regNum+2)),self()->getRealRegister(REGNUM(regNum))), (TR::Instruction *) cursor);
@@ -1005,7 +1005,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 
          int32_t ai_l = 0;
          if (!skipLong)
-            ai_l = paramCursor->getAllocatedLow();
+            ai_l = paramCursor->getAssignedLowGlobalRegisterIndex();
          if (ai_l>=0 && !InPreProlog && !skipLong)
             {
             // Some linkages allow for the low half of the argument to be passed
@@ -1082,7 +1082,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
       //
       else if (ai>=0 && !InPreProlog)
          {
-         int32_t ai_l = paramCursor->getAllocatedLow();
+         int32_t ai_l = paramCursor->getAssignedLowGlobalRegisterIndex();
          switch (dtype)
             {
             case TR::Int8:

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -9897,12 +9897,12 @@ OMR::Z::TreeEvaluator::BBStartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 #endif
                    true)
                   {
-                  sym->setAllocatedIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
+                  sym->setAssignedGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getGlobalRegisterNumber()));
                   }
                else
                   {
-                  sym->setAllocatedHigh(cg->getGlobalRegister(child->getChild(i)->getHighGlobalRegisterNumber()));
-                  sym->setAllocatedLow(cg->getGlobalRegister(child->getChild(i)->getLowGlobalRegisterNumber()));
+                  sym->setAssignedHighGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getHighGlobalRegisterNumber()));
+                  sym->setAssignedLowGlobalRegisterIndex(cg->getGlobalRegister(child->getChild(i)->getLowGlobalRegisterNumber()));
                   }
                }
             }

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -70,9 +70,9 @@
 #include "z/codegen/SystemLinkage.hpp"
 
 TR::SystemLinkage::SystemLinkage(TR::CodeGenerator* cg, TR_S390LinkageConventions elc, TR_LinkageConventions lc)
-   : 
+   :
       TR::Linkage(cg, elc,lc),
-      _GPRSaveMask(0), 
+      _GPRSaveMask(0),
       _FPRSaveMask(0)
    {
    }
@@ -353,5 +353,5 @@ void TR::SystemLinkage::mapSingleAutomatic(TR::AutomaticSymbol * p, uint32_t & s
 
 bool TR::SystemLinkage::hasToBeOnStack(TR::ParameterSymbol * parm)
    {
-   return parm->getAllocatedIndex() >=  0 &&  parm->isParmHasToBeOnStack();
+   return parm->getAssignedGlobalRegisterIndex() >=  0 &&  parm->isParmHasToBeOnStack();
    }


### PR DESCRIPTION
Provide more meaningful names for the following APIs to make
the code that uses it more readable:

* `getAllocatedIndex` --> `getAssignedGlobalRegisterIndex`
* `setAllocatedIndex` --> `setAssignedGlobalRegisterIndex`
* `getAllocatedLow` --> `getAssignedLowGlobalRegisterIndex`
* `setAllocatedLow` --> `setAssignedLowGlobalRegisterIndex`
* `getAllocatedHigh` --> `getAssignedHighGlobalRegisterIndex`
* `setAllocatedHigh` --> `setAssignedHighGlobalRegisterIndex`

Add Doxygen comments where appropriate.  Modify references in OMR.

The original API is left in place for now while downstream projects
switch over to the new API.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>