### PR TITLE
Fix logic in allowGlobalRegisterAcrossBranch() for POWER

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2415,8 +2415,10 @@ int32_t OMR::Power::CodeGenerator::getMaximumNumberOfGPRsAllowedAcrossEdge(TR::N
          if (total <= 9)
             {
             for (ii=3; ii<total &&
-                       (node->getChild(ii)->getCaseConstant()-node->getChild(ii-1)->getCaseConstant())<=UPPER_IMMED; ii++)
-            ;
+                       (node->getChild(ii)->getCaseConstant()-node->getChild(ii-1)->getCaseConstant())<=UPPER_IMMED &&
+                       (node->getChild(ii)->getCaseConstant()-node->getChild(ii-1)->getCaseConstant())>0; /* in case of an overflow */
+                 ii++);
+
             if (ii == total)
                return _numGPR - 2;
             }


### PR DESCRIPTION
The logic in allowGlobalRegisterAcrossBranch() must match the logic in
switchDispatch() when deciding which lookup scheme logic to use. The
failure to check for an overflow in allowGlobalRegisterAcrossBranch()
allowed for GRA to use 25 registers which caused a crash in
freeBestRegister() because all registers were blocked when local RA was
looking to allocate a register needed by the switch lookup code.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>