### PR TITLE
Create known object temps when splitting block

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3117,6 +3117,9 @@ TR_HandleInjectedBasicBlock::createTemps(bool replaceAllReferences)
                value = valueToTempConv;
                }
 
+            if (value->getOpCode().hasSymbolReference() && value->getSymbolReference()->hasKnownObjectIndex())
+               symRef = comp()->getSymRefTab()->findOrCreateTemporaryWithKnowObjectIndex(_methodSymbol, value->getSymbolReference()->getKnownObjectIndex());
+
             OMR_InlinerUtil::storeValueInATemp(comp(), value, symRef, tt, _methodSymbol, _injectedBasicBlockTemps, _availableTemps, 0);
             }
 


### PR DESCRIPTION
When splitting a block, temps are created to uncommon references across
the splitted blocks. Use known object temps, if the original referenced
value is a known object.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>