### PR TITLE
Remove references of deprecated const IL Opcode

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -508,7 +508,7 @@ static TR::Register *shiftHelper(TR::Node *node, TR::ARM64ShiftCode shiftType, T
    bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op;
 
-   if (secondOp == TR::iconst || secondOp == TR::iuconst)
+   if (secondOp == TR::iconst)
       {
       int32_t value = secondChild->getInt();
       uint32_t shift = is64bit ? (value & 0x3F) : (value & 0x1F);

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -81,7 +81,7 @@ TR::Register *OMR::ARM::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGen
    src1Reg = cg->evaluate(firstChild);
    TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
 
-   if ((secondOp == TR::iconst || secondOp == TR::iuconst) &&
+   if (secondOp == TR::iconst &&
        secondChild->getRegister() == NULL)
       {
       trgReg = addConstantToInteger(node, src1Reg, secondChild->getInt(), cg);
@@ -1044,7 +1044,7 @@ TR::Register *OMR::ARM::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeGen
    TR::Register    *srcReg = cg->evaluate(firstChild);
    TR::Register    *trgReg = cg->allocateRegister();
 
-   if (secondChild->getOpCodeValue() == TR::iconst || secondChild->getOpCodeValue() == TR::iuconst)
+   if (secondChild->getOpCodeValue() == TR::iconst)
       {
       int32_t value = secondChild->getInt() & 0x1F;
       if (value != 0)
@@ -1084,7 +1084,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lrolEvaluator(TR::Node *node, TR::CodeGen
    TR::Register    *highReg = cg->allocateRegister();
    TR::Register    *trgReg = cg->allocateRegisterPair(lowReg, highReg);
 
-   if (secondChild->getOpCodeValue() == TR::iconst || secondChild->getOpCodeValue() == TR::iuconst)
+   if (secondChild->getOpCodeValue() == TR::iconst)
       {
       int32_t value = secondChild->getInt() & 0x3F;
       if (value == 0)

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1786,7 +1786,7 @@ OMR::CodeGenerator::convertMultiplyToShift(TR::Node * node)
    //
    int32_t multiplier = 0;
    int32_t shiftAmount = 0;
-   if (secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst)
+   if (secondChild->getOpCodeValue() == TR::lconst)
       {
       int64_t longMultiplier = secondChild->getLongInt();
       if (longMultiplier == 0)
@@ -2700,8 +2700,6 @@ OMR::CodeGenerator::isMaterialized(TR::Node * node)
       value = (int64_t) node->getInt();
    else if (node->getOpCodeValue() == TR::lconst)
       value = node->getLongInt();
-   else if (node->getOpCodeValue() == TR::luconst)
-      value = node->getUnsignedLongInt();
    else
       return false;
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2700,8 +2700,6 @@ OMR::CodeGenerator::isMaterialized(TR::Node * node)
       value = (int64_t) node->getInt();
    else if (node->getOpCodeValue() == TR::lconst)
       value = node->getLongInt();
-   else if (node->getOpCodeValue() == TR::iuconst)
-      value = (int64_t) node->getUnsignedInt();
    else if (node->getOpCodeValue() == TR::luconst)
       value = node->getUnsignedLongInt();
    else

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1329,7 +1329,6 @@ public:
          case TR::ddiv:
             return TR::vdiv;
          case TR::bconst:
-         case TR::cconst:
          case TR::sconst:
          case TR::iconst:
          case TR::lconst:

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -649,7 +649,7 @@ OMR::Node::create(TR::Node * originatingByteCodeNode, TR::ILOpCodes op, uint16_t
 TR::Node *
 OMR::Node::create(TR::Node * originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, int32_t intValue, TR::TreeTop * dest)
    {
-   TR_ASSERT(op != TR::bconst && op != TR::cconst && op != TR::sconst, "Invalid constructor for 8/16-bit constants");
+   TR_ASSERT(op != TR::bconst && op != TR::sconst, "Invalid constructor for 8/16-bit constants");
    TR::Node * node = TR::Node::create(originatingByteCodeNode, op, numChildren, dest);
    if (op == TR::lconst)
       {

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1376,24 +1376,6 @@ OMR::Node::sconst(int16_t val)
    return TR::Node::sconst(0, val);
    }
 
-
-
-TR::Node *
-OMR::Node::cconst(TR::Node *originatingByteCodeNode, uint16_t val)
-   {
-   TR::Node *r = TR::Node::create(originatingByteCodeNode, TR::sconst);
-   r->setUnsignedShortInt(val);
-   return r;
-   }
-
-TR::Node *
-OMR::Node::cconst(uint16_t val)
-   {
-   return TR::Node::cconst(0, val);
-   }
-
-
-
 TR::Node *
 OMR::Node::iconst(TR::Node *originatingByteCodeNode, int32_t val)
    {

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -327,9 +327,6 @@ public:
 
    static TR::Node *sconst(TR::Node *originatingByteCodeNode, int16_t val);
    static TR::Node *sconst(int16_t val);
-
-   static TR::Node *cconst(TR::Node *originatingByteCodeNode, uint16_t val);
-   static TR::Node *cconst(uint16_t val);
 
    static TR::Node *iconst(TR::Node *originatingByteCodeNode, int32_t val);
    static TR::Node *iconst(int32_t val);

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -678,7 +678,6 @@ OMR::Node::getIntegerNodeValue()
    switch(opcode)
       {
       case TR::bconst: length = (T)self()->getUnsignedByte(); break;
-      case TR::cconst: length = (T)self()->getConst<uint16_t>(); break;
       case TR::sconst: length = (T)self()->getShortInt(); break;
       case TR::iconst:
          length = (T)self()->getUnsignedInt(); break;

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -681,7 +681,6 @@ OMR::Node::getIntegerNodeValue()
       case TR::cconst: length = (T)self()->getConst<uint16_t>(); break;
       case TR::sconst: length = (T)self()->getShortInt(); break;
       case TR::iconst:
-      case TR::iuconst:
          length = (T)self()->getUnsignedInt(); break;
       case TR::lconst:
       case TR::luconst:

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -677,7 +677,6 @@ OMR::Node::getIntegerNodeValue()
       }
    switch(opcode)
       {
-      case TR::buconst:
       case TR::bconst: length = (T)self()->getUnsignedByte(); break;
       case TR::cconst: length = (T)self()->getConst<uint16_t>(); break;
       case TR::sconst: length = (T)self()->getShortInt(); break;

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -683,7 +683,6 @@ OMR::Node::getIntegerNodeValue()
       case TR::iconst:
          length = (T)self()->getUnsignedInt(); break;
       case TR::lconst:
-      case TR::luconst:
          length = (T)self()->getUnsignedLongInt(); break;
       case TR::iloadi:
          TR_ASSERT(false, "Invalid type for length node."); break;

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2974,7 +2974,6 @@ int32_t TR_SimplifyAnds::process(TR::TreeTop *startTree, TR::TreeTop *endTree)
                  lastRealNode->getOpCodeValue() == TR::ifiucmpge ||
                  lastRealNode->getOpCodeValue() == TR::iflcmpge) &&
                 (lastRealNode->getSecondChild()->getOpCodeValue() == TR::iconst ||
-                 lastRealNode->getSecondChild()->getOpCodeValue() == TR::iuconst ||
                  lastRealNode->getSecondChild()->getOpCodeValue() == TR::lconst) &&
                 (lastRealNode->getSecondChild()->get64bitIntegralValue() == 0))
                {

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1716,10 +1716,10 @@ TR_Arraytranslate::checkStore(TR::Node * storeNode)
 
       if (shrinkNode->getOpCodeValue() != TR::i2s &&
           shrinkNode->getOpCodeValue() != TR::i2b &&
-          shrinkNode->getOpCodeValue() != TR::cconst &&
+          shrinkNode->getOpCodeValue() != TR::sconst &&
           shrinkNode->getOpCodeValue() != TR::bconst)
          {
-         dumpOptDetails(comp(), "...store tree does not have i2c/i2b/cconst/bconst - no arraytranslate reduction\n");
+         dumpOptDetails(comp(), "...store tree does not have i2c/i2b/sconst/bconst - no arraytranslate reduction\n");
          return false;
          }
 
@@ -1811,7 +1811,7 @@ TR_Arraytranslate::checkBreak(TR::Block * breakBlock, TR::Node * breakNode, TR::
       //      we also conservatively ensure the range is inside the represented ranges such that we can
       //      add or subtract 1 from the value and still represent it in 2**16 bits for a default value
       //      if we need to generate a table.
-      dumpOptDetails(comp(), "...break tree does not have bconst/cconst/iconst, or not in range - no arraytranslate reduction\n");
+      dumpOptDetails(comp(), "...break tree does not have iconst, or not in range - no arraytranslate reduction\n");
       return false;
       }
 

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -2348,10 +2348,11 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
          {
          if (firstOp == TR::su2l)
             {
-            if (secondOp == TR::cconst || secondOp == TR::su2l ||
-                (secondOp == TR::lconst               &&
-                 secondChild->getLongInt() >= 0 &&
-                 secondChild->getLongInt() <= USHRT_MAX))
+            if ( secondOp == TR::sconst || 
+                 secondOp == TR::su2l ||
+                  (secondOp == TR::lconst &&
+                  secondChild->getLongInt() >= 0 &&
+                  secondChild->getLongInt() <= USHRT_MAX))
                {
                node->setAndIncChild(0, firstChild->getFirstChild());
                TR::Node::recreate(node, charOp);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -4325,7 +4325,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
       if (firstOp == TR::su2i && firstChild->getReferenceCount()==1)
          {
          if (secondOp == TR::su2i ||
-             (secondOp == TR::iuconst               &&
+             (secondOp == TR::iconst               &&
               secondChild->getUnsignedInt() <= USHRT_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
@@ -4340,7 +4340,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                   dumpOptDetails(s->comp(), "Integer Compare Narrower: found both children c2i in method %s\n", s->comp()->signature());
                   }
                }
-            else if (secondOp == TR::iuconst)
+            else if (secondOp == TR::iconst)
                {
                if (secondChild->getReferenceCount() > 1)
                   {
@@ -4409,7 +4409,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
       else if (firstOp == TR::b2i && firstChild->getReferenceCount() == 1)
          {
          if (secondOp == TR::b2i ||
-             (secondOp == TR::iuconst               &&
+             (secondOp == TR::iconst               &&
               secondChild->getUnsignedInt() <= SCHAR_MAX))
             {
             node->setAndIncChild(0, firstChild->getFirstChild());
@@ -4424,7 +4424,7 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                   dumpOptDetails(s->comp(), "Integer Compare Narrower: found both children b2i in method %s\n", s->comp()->signature());
                   }
                }
-            else if (secondOp == TR::iuconst)
+            else if (secondOp == TR::iconst)
                {
                if (secondChild->getReferenceCount() > 1)
                   {
@@ -10541,7 +10541,7 @@ TR::Node *iandSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
          TR::Node * lrChild = firstChild->getSecondChild();
          if (lrChild->getOpCodeValue() == TR::iconst)
             {
-            if (secondChildOp == TR::iconst || (secondChildOp == TR::iuconst && lrChild->chkUnsigned()))
+            if (secondChildOp == TR::iconst )
                {
                if (performTransformation(s->comp(), "%sFound iand of iconst with iand of x and iconst in node [%s]\n", s->optDetailString(), node->getName(s->getDebug())))
                   {

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -346,7 +346,7 @@ TR::Node *foldRedundantAND(TR::Node * node, TR::ILOpCodes andOpCode, TR::ILOpCod
       {
       switch(constOpCode)
          {
-         case TR::sconst: case TR::cconst:
+         case TR::sconst:
             val = constChild->getShortInt(); break;
          case TR::iconst:
             val = constChild->getInt(); break;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -10748,8 +10748,7 @@ static TR::Node *constrainCmplessthan(OMR::ValuePropagation *vp, TR::Node *node,
           performTransformation(vp->comp(), "%sChanging node [%p] %s into constant %d\n", OPT_DETAILS, node, node->getOpCode().getName(), result))
          {
          vp->removeChildren(node);
-         TR::ILOpCodes op = /*isUnsigned ? TR::iuconst : */TR::iconst;
-         TR::Node::recreate(node, op);
+         TR::Node::recreate(node, TR::iconst);
          node->setInt(result);
          vp->invalidateValueNumberInfo();
          return node;

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -78,7 +78,7 @@ static inline TR::Register *iorTypeEvaluator(TR::Node *node,
    if (secondChild->getOpCode().isLoadConst() &&
        secondChild->getRegister() == NULL)
       {
-      if (secondOp == TR::lconst || secondOp == TR::luconst)
+      if (secondOp == TR::lconst)
          immValue = (int32_t)secondChild->getLongInt(); // upper 32 bits known to be zero
       else
          immValue = secondChild->get64bitIntegralValue();
@@ -448,7 +448,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
 
    if (cg->comp()->target().is32Bit())
       {
-      if (!setsOrReadsCC && (secondOp == TR::lconst || secondOp == TR::luconst) &&
+      if (!setsOrReadsCC && secondOp == TR::lconst &&
           secondChild->getRegister() == NULL)
          {
          src1Reg = cg->evaluate(firstChild);
@@ -530,7 +530,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
          src1Reg = cg->evaluate(firstChild);
 
          if (!setsOrReadsCC &&
-             (secondOp == TR::lconst || secondOp == TR::luconst) &&
+             secondOp == TR::lconst &&
              secondChild->getRegister() == NULL)
             {
             trgReg = addConstantToLong(node, src1Reg, secondChild->getLongInt(), trgReg, cg);
@@ -853,7 +853,7 @@ TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeG
    bool setsOrReadsCC = NEED_CC(node) || (node->getOpCodeValue() == TR::lusubb);
    TR::InstOpCode::Mnemonic regToRegOpCode = TR::InstOpCode::subfc;
 
-   if (!setsOrReadsCC && (secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst) &&
+   if (!setsOrReadsCC && secondChild->getOpCodeValue() == TR::lconst &&
        secondChild->getRegister() == NULL)
       {
       TR::Register *src1Reg   = cg->evaluate(firstChild);
@@ -869,7 +869,7 @@ TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeG
       {
       TR::Register *lowReg  = cg->allocateRegister();
       TR::Register *highReg = cg->allocateRegister();
-      if (!setsOrReadsCC && (firstChild->getOpCodeValue() == TR::lconst || firstChild->getOpCodeValue() == TR::luconst) &&
+      if (!setsOrReadsCC && firstChild->getOpCodeValue() == TR::lconst &&
          firstChild->getRegister() == NULL)
          {
          TR::Register *src2Reg   = cg->evaluate(secondChild);
@@ -1257,7 +1257,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeG
    if (cg->comp()->target().is64Bit())
       {
       TR::Register *trgReg;
-      if (secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst)
+      if (secondChild->getOpCodeValue() == TR::lconst)
          {
          int64_t value = secondChild->getLongInt();
          if (value > 0 && cg->convertMultiplyToShift(node))
@@ -1298,7 +1298,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeG
    TR::Register *highReg;
    TR::RegisterPair *trgReg;
 
-   if ((secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst) &&
+   if (secondChild->getOpCodeValue() == TR::lconst &&
        secondChild->getRegister() == NULL)
       {
       TR::Register *src1Low = cg->evaluate(firstChild)->getLowOrder();
@@ -1493,7 +1493,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
       {
       TR::Register *src1Reg = cg->evaluate(firstChild);
       TR::Register *trgReg = cg->allocateRegister();
-      if (secondChild->getOpCodeValue() == TR::lconst  || secondChild->getOpCodeValue() == TR::luconst )
+      if (secondChild->getOpCodeValue() == TR::lconst )
          {
          int64_t value = secondChild->getLongInt();
          TR::Register *tempReg = cg->allocateRegister();
@@ -1527,7 +1527,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
    TR::Register *lowReg = cg->allocateRegister();
    TR::Register *highReg = cg->allocateRegister();
 
-   if (secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst)
+   if (secondChild->getOpCodeValue() == TR::lconst)
       {
       int64_t value =  secondChild->getLongInt();
       int32_t lowValue = (int32_t)value;
@@ -1554,7 +1554,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
    generateTrg1Src1Instruction(cg, TR::InstOpCode::addze, node, highReg, highReg);
    generateTrg1Src2Instruction(cg, TR::InstOpCode::addc, node, lowReg, lowReg, temp3Reg);
    generateTrg1Src1Instruction(cg, TR::InstOpCode::addze, node, highReg, highReg);
-   if (secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst)
+   if (secondChild->getOpCodeValue() == TR::lconst)
       {
       cg->stopUsingRegister(second_highReg);
       cg->stopUsingRegister(second_lowReg);
@@ -3210,7 +3210,7 @@ TR::Register *OMR::Power::TreeEvaluator::landEvaluator(TR::Node *node, TR::CodeG
       TR::Register *src1Reg = cg->evaluate(firstChild);
       trgReg  = cg->allocateRegister();
 
-      if ((secondOp == TR::lconst || secondOp == TR::luconst) &&
+      if (secondOp == TR::lconst &&
           secondChild->getRegister() == NULL)
          {
          simplifyANDRegImm(node, trgReg, src1Reg, secondChild->getLongInt(), cg, secondChild);
@@ -3223,7 +3223,7 @@ TR::Register *OMR::Power::TreeEvaluator::landEvaluator(TR::Node *node, TR::CodeG
       }
    else // 32 bit target
       {
-      if ((secondOp == TR::lconst || secondOp == TR::luconst) &&
+      if (secondOp == TR::lconst &&
           secondChild->getRegister() == NULL)
          {
          TR::Register *src1Reg = cg->evaluate(firstChild);
@@ -3273,7 +3273,7 @@ static inline TR::Register *lorTypeEvaluator(TR::Node *node,
 
    if (cg->comp()->target().is64Bit())
       {
-      if ((secondOp == TR::lconst || secondOp == TR::luconst) &&
+      if (secondOp == TR::lconst &&
          secondChild->getRegister() == NULL)
          {
          uint64_t longConst = secondChild->getLongInt();
@@ -3302,7 +3302,7 @@ static inline TR::Register *lorTypeEvaluator(TR::Node *node,
                                                              cg->allocateRegister());
       TR::Register *src1Reg = cg->evaluate(firstChild);
 
-      if ((secondOp == TR::lconst || secondOp == TR::luconst) &&
+      if (secondOp == TR::lconst &&
           secondChild->getRegister() == NULL)
          {
          intParts localVal(secondChild->getLongIntLow());
@@ -3379,8 +3379,9 @@ TR::Register *OMR::Power::TreeEvaluator::lorEvaluator(TR::Node *node, TR::CodeGe
    TR::ILOpCodes secondOp = node->getSecondChild()->getOpCodeValue();
 
    if ((node->getFirstChild()->isHighWordZero() || node->getSecondChild()->isHighWordZero()) &&
-       !((secondOp == TR::lconst || secondOp == TR::luconst) && node->getSecondChild()->getRegister() == NULL) &&
+       !(secondOp == TR::lconst && node->getSecondChild()->getRegister() == NULL) &&
        !(cg->comp()->target().is64Bit()))
+
       {
       return carrylessLongEvaluatorWithAnalyser(node, cg,
                                                     TR::InstOpCode::OR,
@@ -3398,7 +3399,7 @@ TR::Register *OMR::Power::TreeEvaluator::lxorEvaluator(TR::Node *node, TR::CodeG
    TR::ILOpCodes secondOp = node->getSecondChild()->getOpCodeValue();
 
    if ((node->getFirstChild()->isHighWordZero() || node->getSecondChild()->isHighWordZero()) &&
-       !((secondOp == TR::lconst || secondOp == TR::luconst) && node->getSecondChild()->getRegister() == NULL) &&
+       !(secondOp == TR::lconst && node->getSecondChild()->getRegister() == NULL) &&
        !(cg->comp()->target().is64Bit()))
       {
       return carrylessLongEvaluatorWithAnalyser(node, cg,

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -291,8 +291,7 @@ static void genericLongAnalyzer(
          {
          if (firstOp == TR::iu2l || firstOp == TR::su2l ||
              (firstOp == TR::lushr &&
-              (child->getSecondChild()->getOpCodeValue() == TR::iconst ||
-               child->getSecondChild()->getOpCodeValue() == TR::iuconst) &&
+              (child->getSecondChild()->getOpCodeValue() == TR::iconst) &&
               (child->getSecondChild()->getInt() & LONG_SHIFT_MASK) == 32))
             {
             child = child->getFirstChild();
@@ -539,7 +538,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
          // might not be true for aladd, since secondchild of the ladd is made
          // to be an lconst
          else if (!setsOrReadsCC &&
-                  (secondOp == TR::iconst || secondOp == TR::iuconst) && // may be true if aladd?
+                  (secondOp == TR::iconst) && // may be true if aladd?
                   secondChild->getRegister() == NULL)
             {
             trgReg = addConstantToLong(node, src1Reg, (int64_t)secondChild->getInt(), trgReg, cg);
@@ -1454,7 +1453,7 @@ TR::Register *OMR::Power::TreeEvaluator::imulhEvaluator(TR::Node *node, TR::Code
 
    // imulh is generated for constant idiv and the second child is the magic number
    // assume magic number is usually a large odd number with little optimization opportunity
-   if (secondChild->getOpCodeValue() == TR::iconst || secondChild->getOpCodeValue() == TR::iuconst)
+   if (secondChild->getOpCodeValue() == TR::iconst)
       {
       int32_t value = secondChild->get64bitIntegralValue();
       TR::Register *tempReg = cg->allocateRegister();

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -87,7 +87,6 @@ TR::Register *OMR::Power::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::Cod
       }
    }
 
-// also handles luconst
 TR::Register *OMR::Power::TreeEvaluator::lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3414,7 +3414,7 @@ TR::Register *OMR::X86::TreeEvaluator::bushrEvaluator(TR::Node *node, TR::CodeGe
          tempMR = generateX86MemoryReference(firstChild, cg, false);
          }
       }
-   else if ((testOpcode1 == TR::bconst || testOpcode1 == TR::buconst) &&
+   else if (testOpcode1 == TR::bconst &&
             performTransformation(comp, "O^O BUSHREvaluator: first child is not an 8-bit signed two's complement, or an 8 bit unsigned %x\n", testOpcode1))
       {
       targetRegister = cg->allocateRegister();
@@ -3426,7 +3426,7 @@ TR::Register *OMR::X86::TreeEvaluator::bushrEvaluator(TR::Node *node, TR::CodeGe
       targetRegister = cg->intClobberEvaluate(firstChild);
       }
 
-   if ((testOpcode2 == TR::bconst || testOpcode2 == TR::buconst) &&
+   if (testOpcode2 == TR::bconst &&
        performTransformation(comp, "O^O BUSHREvaluator: first child is not an 8-bit signed two's complement, or an 8 bit unsigned %x\n", testOpcode2))
       {
       int32_t value = secondChild->get64bitIntegralValue();

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1740,7 +1740,6 @@ bool OMR::Z::MemoryReference::ZeroBasePtr_EvaluateSubtree(TR::Node * subTree, TR
       case TR::aconst:    // load address constant (zero value means NULL)
       case TR::iconst:    // load integer constant (32-bit signed 2's complement)
       case TR::lconst:    // load long integer constant (64-bit signed 2's complement)
-      case TR::luconst:   // load unsigned long integer constant (64-bit unsigned)
       case TR::bconst:    // load byte integer constant (8-bit signed 2's complement)
       case TR::sconst:    // load short integer constant (16-bit signed 2's complement)
       case TR::cconst:    // load unicode constant (16-bit unsigned)

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1742,7 +1742,6 @@ bool OMR::Z::MemoryReference::ZeroBasePtr_EvaluateSubtree(TR::Node * subTree, TR
       case TR::lconst:    // load long integer constant (64-bit signed 2's complement)
       case TR::bconst:    // load byte integer constant (8-bit signed 2's complement)
       case TR::sconst:    // load short integer constant (16-bit signed 2's complement)
-      case TR::cconst:    // load unicode constant (16-bit unsigned)
          {
          if (subTree->getRegister()) return false;
 

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1743,7 +1743,6 @@ bool OMR::Z::MemoryReference::ZeroBasePtr_EvaluateSubtree(TR::Node * subTree, TR
       case TR::lconst:    // load long integer constant (64-bit signed 2's complement)
       case TR::luconst:   // load unsigned long integer constant (64-bit unsigned)
       case TR::bconst:    // load byte integer constant (8-bit signed 2's complement)
-      case TR::buconst:   // load unsigned byte integer constant (8-bit unsigned)
       case TR::sconst:    // load short integer constant (16-bit signed 2's complement)
       case TR::cconst:    // load unicode constant (16-bit unsigned)
          {

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1739,7 +1739,6 @@ bool OMR::Z::MemoryReference::ZeroBasePtr_EvaluateSubtree(TR::Node * subTree, TR
       {
       case TR::aconst:    // load address constant (zero value means NULL)
       case TR::iconst:    // load integer constant (32-bit signed 2's complement)
-      case TR::iuconst:   // load unsigned integer constant (32-but unsigned)
       case TR::lconst:    // load long integer constant (64-bit signed 2's complement)
       case TR::luconst:   // load unsigned long integer constant (64-bit unsigned)
       case TR::bconst:    // load byte integer constant (8-bit signed 2's complement)

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -380,10 +380,7 @@ getIntegralValue(TR::Node * node)
       switch (node->getDataType())
          {
          case TR::Int8:
-            if (node->getOpCodeValue()==TR::buconst)
-               value = node->getUnsignedByte();
-            else
-               value = node->getByte();
+            value = node->getByte();
             break;
          case TR::Int16:
             if (node->getOpCodeValue()==TR::cconst)
@@ -6179,8 +6176,7 @@ OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
    // Use MVI when we can
    if (valueChild->getRegister()==NULL &&
-      (valueChild->getOpCodeValue() == TR::buconst ||
-      valueChild->getOpCodeValue() == TR::bconst    ) )
+      valueChild->getOpCodeValue() == TR::bconst)
       {
       TR::MemoryReference * tempMR = generateS390MemoryReference(node, cg);
       generateSIInstruction(cg, TR::InstOpCode::MVI, node, tempMR, valueChild->getByte()&0xFF);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -383,10 +383,7 @@ getIntegralValue(TR::Node * node)
             value = node->getByte();
             break;
          case TR::Int16:
-            if (node->getOpCodeValue()==TR::cconst)
-               value = node->getConst<uint16_t>();
-            else
-               value = node->getShortInt();
+            value = node->getShortInt();
             break;
          case TR::Int32:
             value = node->getInt();

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,13 +117,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::bconstEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Register * tempReg = node->setRegister(cg->allocateRegister());
-   if (node->getOpCodeValue() == TR::buconst)
-      generateLoad32BitConstant(cg, node, node->getByte() & 0xFF, tempReg, true);
-   else
-      {
-      TR_ASSERT(1, "Should not have bconst node in the final il-tree!\n");
-      generateLoad32BitConstant(cg, node, node->getByte(), tempReg, true);
-      }
+   generateLoad32BitConstant(cg, node, node->getByte(), tempReg, true);
    return tempReg;
    }
 


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `const` category listed in #2657, namely,  `buconst`, `iuconst`, `luconst`, `cconst`. 
Also removed `TR::Node::cconst` 

*Anything in `SwitchAnalyzer.cpp` as they will be removed explicitly in #3983*

Issue: #2657 
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>

