### PR TITLE
Add options for compressing AOT Code

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -231,6 +231,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableAndSimplification",           "O\tdisable and simplification",                     TR::Options::disableOptimization, andSimplification, 0, "P"},
    {DisableAnnotations,                   "O\tdisable annotation support",                     RESET_OPTION_BIT(TR_EnableAnnotations), "F"},
    {"disableAOTAtCheapWarm",              "O\tdisable AOT with cheap warm opt level", SET_OPTION_BIT(TR_DisableAotAtCheapWarm), "F", NOT_IN_SUBSET},
+   {"disableAOTBytesCompression",         "O\tdisable compressing AOT bytes",    SET_OPTION_BIT(TR_DisableAOTBytesCompression), "F"},
    {"disableAOTCheckCastInlining",        "O\tdisable AOT check cast inlining",                SET_OPTION_BIT(TR_DisableAOTCheckCastInlining), "F"},
    {"disableAOTColdCheapTacticalGRA",   "O\tdisable AOT cold cheap tactical GRA",                      SET_OPTION_BIT(TR_DisableAOTColdCheapTacticalGRA), "F"},
    {"disableAOTInstanceFieldResolution",   "O\tdisable AOT instance field resolution",                      SET_OPTION_BIT(TR_DisableAOTInstanceFieldResolution), "F"},
@@ -4793,6 +4794,7 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "sampleDensity",
    "profiling",
    "JITaaS",
+   "aotcompression",
    };
 
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -454,7 +454,7 @@ enum TR_CompilationOptions
    TR_DisablePartialInlining                  = 0x00000080 + 12,
    TR_AssumeStartupPhaseUntilToldNotTo        = 0x00000100 + 12,
    // Available                               = 0x00000200 + 12,
-   // Available                               = 0x00000400 + 12,
+   TR_DisableAOTBytesCompression              = 0x00000400 + 12,
    TR_X86UseMFENCE                            = 0x00000800 + 12,
    // Available                               = 0x00001000 + 12,
    // Available                               = 0x00002000 + 12,
@@ -1139,7 +1139,7 @@ enum TR_VerboseFlags
    TR_VerboseSampleDensity,
    TR_VerboseProfiling,
    TR_VerboseJITaaS,
-
+   TR_VerboseAOTCompression,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;
    };

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -62,6 +62,7 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#RECLAMATION: ",
    "#PROFILING: ",
    "#JITaaS: ",
+   "#AOTCOMPRESSION: ",
    };
 
 void TR_VerboseLog::writeLine(TR_VlogTag tag, const char *format, ...)

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -70,6 +70,7 @@ enum TR_VlogTag
    TR_Vlog_RECLAMATION,
    TR_Vlog_PROFILING,
    TR_Vlog_JITaaS,
+   TR_Vlog_AOTCOMPRESSION,
    TR_Vlog_numTags
    };
 


### PR DESCRIPTION
This commit adds following options to control and trace compression of AOT code.
1. disableAOTBytesCompression : Disable compressing AOT compiled method
   before storing it into cache.
2. verbose={compression} : Support verbose out put about compressing/decompressing
   AOT compiled method in the verbose log.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>