### PR TITLE
Create TR::CFGSimplifier instead of CFGSimplifier

### DIFF
--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -54,6 +54,11 @@
 
 #define OPT_DETAILS "O^O CFG SIMPLIFICATION: "
 
+TR::Optimization* OMR::CFGSimplifier::create(TR::OptimizationManager *manager)
+    {
+    return new (manager->allocator()) TR::CFGSimplifier(manager);
+    }
+
 OMR::CFGSimplifier::CFGSimplifier(TR::OptimizationManager *manager)
    : TR::Optimization(manager)
    {}

--- a/compiler/optimizer/OMRCFGSimplifier.hpp
+++ b/compiler/optimizer/OMRCFGSimplifier.hpp
@@ -44,10 +44,7 @@ class CFGSimplifier : public TR::Optimization
    {
    public:
    CFGSimplifier(TR::OptimizationManager *manager);
-   static TR::Optimization *create(TR::OptimizationManager *manager)
-      {
-      return new (manager->allocator()) CFGSimplifier(manager);
-      }
+   static TR::Optimization *create(TR::OptimizationManager *manager);
 
    virtual int32_t perform();
    virtual const char * optDetailString() const throw();


### PR DESCRIPTION
`new CFGSimplifier` in OMR namespace will create an
`OMR::CFGSimplifier` object, so implementation from downstream project will
never be picked up. Fix this by using `TR::CFGSimplifier`.

Signed-off-by: liqunl <liqunl@ca.ibm.com>