### PR TITLE
Disable dark matter compact for concurrent sweep

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1403,7 +1403,7 @@ public:
 		, heapAlignment(HEAP_ALIGNMENT)
 		, absoluteMinimumOldSubSpaceSize(MINIMUM_OLD_SPACE_SIZE)
 		, absoluteMinimumNewSubSpaceSize(MINIMUM_NEW_SPACE_SIZE)
-		, darkMatterCompactThreshold((float)0.20)
+		, darkMatterCompactThreshold((float)0.40)
 		, parSweepChunkSize(0)
 		, heapExpansionMinimumSize(1024 * 1024)
 		, heapExpansionMaximumSize(0)

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -719,7 +719,10 @@ MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_Allocate
 
 	{
 		MM_MemoryPool *memoryPool= _extensions->heap->getDefaultMemorySpace()->getTenureMemorySubSpace()->getMemoryPool();
-		uintptr_t darkMatterBytes = memoryPool->getDarkMatterBytes();
+		uintptr_t darkMatterBytes = 0;
+		if (!_extensions->concurrentSweep) {
+			darkMatterBytes = memoryPool->getDarkMatterBytes();
+		}
 		uintptr_t freeMemorySize = memoryPool->getActualFreeMemorySize();
 		float darkMatterRatio = ((float)darkMatterBytes)/((float)freeMemorySize);
 
@@ -741,7 +744,10 @@ MM_ParallelGlobalGC::shouldCompactThisCycle(MM_EnvironmentBase *env, MM_Allocate
 		uintptr_t freeMemory = stats->getFreeMemory();
 		uintptr_t reusableFreeMemory = stats->getPageAlignedFreeMemory(pageSize);
 
-		uintptr_t darkMatter = memoryPool->getDarkMatterBytes();
+		uintptr_t darkMatter = 0;
+		if (!_extensions->concurrentSweep){
+			darkMatter = memoryPool->getDarkMatterBytes();
+		}
 		uintptr_t memoryFragmentationDiff = freeMemory - reusableFreeMemory;
 		uintptr_t totalFragmentation = memoryFragmentationDiff + darkMatter;
 		float totalFragmentationRatio = ((float)totalFragmentation)/((float)freeMemory);


### PR DESCRIPTION
- Disabled dark matter compaction when concurrent sweep is enabled, due to concurrent sweep reporting innacurate dark matter info
- Doubled default value for `darkMatterCompactThreshold` so that it doesn't trigger unless specified by command line option.
- Refer to https://github.com/eclipse/omr/pull/3939 for description of the dark matter compact metrics

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>