### PR TITLE
Skip estimate code size for force inlining targets

### DIFF
--- a/compiler/optimizer/CallInfo.hpp
+++ b/compiler/optimizer/CallInfo.hpp
@@ -352,7 +352,7 @@ struct TR_CallSite : public TR_Link<TR_CallSite>
       TR_ResolvedMethod *          _callerResolvedMethod;
       TR::TreeTop *                 _callNodeTreeTop;
       TR::TreeTop *                 _cursorTreeTop;
-      TR::Node *                    _parent;
+      TR::Node *                    _parent;    /* tree top node of the call site callNode */
       TR::Node *                    _callNode;
 
       // Initial Information We Need to Calculate a CallTarget

--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -4074,7 +4074,9 @@ void TR_InlinerBase::applyPolicyToTargets(TR_CallStack *callStack, TR_CallSite *
 
       int32_t bytecodeSize = getPolicy()->getInitialBytecodeSize(calltarget->_calleeMethod, calltarget->_calleeSymbol, comp());
 
-      getUtil()->estimateAndRefineBytecodeSize(callsite, calltarget, callStack, bytecodeSize);
+      if (!forceInline(calltarget))
+         getUtil()->estimateAndRefineBytecodeSize(callsite, calltarget, callStack, bytecodeSize);
+
       if (calltarget->_calleeSymbol && strstr(calltarget->_calleeSymbol->signature(trMemory()), "FloatingDecimal"))
          {
          bytecodeSize >>= 1;


### PR DESCRIPTION
Limits set by exceedsSizeThreshold are ignored for force inlining
targets. The bytecode size for those targets won't be used so
skip calling estimateAndRefineBytecodeSize for them to save some
compilation time.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>