### PR TITLE
Remove deprecated element privatization from FieldPrivatizer

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1784,14 +1784,6 @@ OMR::SymbolReferenceTable::findOrCreateTemporaryWithKnowObjectIndex(TR::Resolved
    }
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::createCoDependentTemporary(TR::ResolvedMethodSymbol *owningMethodSymbol, TR::DataType type, bool isInternalPointer, size_t size, TR::Symbol *coDependent, int32_t offset)
-   {
-   TR::SymbolReference *tempSymRef = findOrCreateAutoSymbol(owningMethodSymbol, offset, type, true, isInternalPointer, false, false, size);
-   return tempSymRef;
-   }
-
-
-TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreatePendingPushTemporary(
    TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType type, size_t size)
    {

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -452,8 +452,6 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateAutoSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, bool isReference = true,
          bool isInternalPointer = false, bool reuseAuto = true, bool isAdjunct = false, size_t size = 0);
    TR::SymbolReference * createTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer = false, size_t size = 0);
-   TR::SymbolReference * createCoDependentTemporary(TR::ResolvedMethodSymbol * owningMethodSymbol, TR::DataType, bool isInternalPointer, size_t size,
-         TR::Symbol *coDependent, int32_t offset);
    TR::SymbolReference * findStaticSymbol(TR_ResolvedMethod * owningMethod, int32_t cpIndex, TR::DataType);
 
    // --------------------------------------------------------------------------

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -655,7 +655,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableDynamicSamplingWindow",        "M\t", RESET_OPTION_BIT(TR_DisableDynamicSamplingWindow), "F", NOT_IN_SUBSET},
    {"enableEarlyCompilationDuringIdleCpu","M\t", SET_OPTION_BIT(TR_EnableEarlyCompilationDuringIdleCpu), "F", NOT_IN_SUBSET},
    {"enableEBBCCInfo",                    "C\tenable tracking CCInfo in Extended Basic Block scope",  SET_OPTION_BIT(TR_EnableEBBCCInfo), "F"},
-   {"enableElementPrivatization",         "O\tenable privatization of stack declared elements accessed by const indices\n", SET_OPTION_BIT(TR_EnableElementPrivatization), "F"},
    {"enableExecutableELFGeneration",      "I\tenable the generation of executable ELF files", SET_OPTION_BIT(TR_EmitExecutableELFFile), "F", NOT_IN_SUBSET},
    {"enableExpensiveOptsAtWarm",          "O\tenable store sinking and OSR at warm and below", SET_OPTION_BIT(TR_EnableExpensiveOptsAtWarm), "F" },
    {"enableFastHotRecompilation",         "R\ttry to recompile at hot sooner", SET_OPTION_BIT(TR_EnableFastHotRecompilation), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -271,7 +271,7 @@ enum TR_CompilationOptions
    // Option word 6
    //
    TR_EnableAggressiveLoopVersioning      = 0x00000020 + 6,
-   TR_EnableElementPrivatization          = 0x00000040 + 6,
+   // Available                           = 0x00000040 + 6,
    TR_CompileBit                          = 0x00000080 + 6,
    TR_WaitBit                             = 0x00000100 + 6,
    TR_DisableZ14                          = 0x00000200 + 6,

--- a/compiler/optimizer/FieldPrivatizer.hpp
+++ b/compiler/optimizer/FieldPrivatizer.hpp
@@ -23,7 +23,6 @@
 #define FIELDPRIV_INCL
 
 #include <stdint.h>
-#include "cs2/bitvectr.h"
 #include "env/TRMemory.hpp"
 #include "il/Node.hpp"
 #include "il/SymbolReference.hpp"
@@ -47,61 +46,61 @@ namespace TR { class TreeTop; }
  * Class TR_FieldPrivatizer
  * ========================
  *
- * Field privatizer aims to replace accesses to fields and statics inside loops 
- * with accesses of new temps that it creates (allowing the loop to run faster 
- * since the temp is an access from the stack, plus the temp gets to be a 
- * candidate for global register allocation whereas the original field or static 
+ * Field privatizer aims to replace accesses to fields and statics inside loops
+ * with accesses of new temps that it creates (allowing the loop to run faster
+ * since the temp is an access from the stack, plus the temp gets to be a
+ * candidate for global register allocation whereas the original field or static
  * would not be).
 
- * Field privatizer would attempt to replace loads as well as stores of fields 
- * and statics and so if there are calls inside the loop or any other implicit 
- * use points for the original field or static (e.g. an exception check, 
- * that could fail and reach an exception handler that uses the field or static) 
- * then the transformation cannot be done (since omitting stores to the field 
- * or static inside the loop may change program behaviour at those use points 
- * inside the loop). Assuming field privatizer finds a field or static without 
- * any potential use inside the loop and subject to certain other conditions it 
+ * Field privatizer would attempt to replace loads as well as stores of fields
+ * and statics and so if there are calls inside the loop or any other implicit
+ * use points for the original field or static (e.g. an exception check,
+ * that could fail and reach an exception handler that uses the field or static)
+ * then the transformation cannot be done (since omitting stores to the field
+ * or static inside the loop may change program behaviour at those use points
+ * inside the loop). Assuming field privatizer finds a field or static without
+ * any potential use inside the loop and subject to certain other conditions it
  * checks to keep the implementation simple, the transformation is to
- * 
- * a) initialize the new temp it creates with the field or static value in 
+ *
+ * a) initialize the new temp it creates with the field or static value in
  * the loop preheader
- * b) change every load and store of the field or static inside the loop to 
+ * b) change every load and store of the field or static inside the loop to
  * use the new temp
- * c) restore the field or static value on all exits out of the loop by using 
+ * c) restore the field or static value on all exits out of the loop by using
  * the temp value on exit from the loop
  *
- * This optimization differs from what PRE (a form of load elimination as 
- * part of the global commoning it does) may do in the same loop in that 
- * field privatizer eliminates stores as well as loads, whereas PRE could 
- * only have eliminated the loads of the field or static; PRE would not omit 
+ * This optimization differs from what PRE (a form of load elimination as
+ * part of the global commoning it does) may do in the same loop in that
+ * field privatizer eliminates stores as well as loads, whereas PRE could
+ * only have eliminated the loads of the field or static; PRE would not omit
  * the store to the field or static.
  *
  * As a very simple example...
  *
  * Original loop
- * 
+ *
  * while (o.f < n)
  * o.f = o.f + 1;
- * 
+ *
  * Field Privatizer optimized loop
- * 
+ *
  * t = o.f;
  * while (t < n)
  * t = t + 1;
  * o.f = t;
- * 
+ *
  * PRE optimized loop
- * 
+ *
  * t = o.f;
  * while (t < n)
  * {
  * o.f = t + 1;
  * t = t + 1;
  * }
- * 
- * So, what PRE would do to the loop is somewhat similar but still less powerful; 
- * however PRE can do such optimizations even outside of loops and more importantly 
- * can do exactly the same thing even if there were implicit uses of o.f inside 
+ *
+ * So, what PRE would do to the loop is somewhat similar but still less powerful;
+ * however PRE can do such optimizations even outside of loops and more importantly
+ * can do exactly the same thing even if there were implicit uses of o.f inside
  * the loop. So it's more general in that sense.
  */
 
@@ -164,47 +163,6 @@ class TR_FieldPrivatizer : public TR_LoopTransformer
    List<TR::TreeTop> _appendCalls;
 
    TR_PostDominators *_postDominators;
-
-   // Element Privatization
-   // This Optimization looks to convert locally declared arrays/structs/etc in languages like C/C++ which are accessed using indirect loads/stores with direct loads/stores
-   // Ex:
-   // iiload  #57 shadow sym m[]
-   //   aadd
-   //     loadaddr #56 base ptr m
-   //     lconst 8
-
-   // into:
-   // iload #103 temp
-   // where temp will have a stack offset equivalent to m + 8.
-
-   // the second part of this optimization will be an alias refinement which will try to remove m and m[] from alias sets of temps if we are able to eliminate all references to m and m[] in the trees.
-
-   struct EPCandidate
-      {
-      EPCandidate(TR::Node *n, TR::TreeTop *tt, int32_t num) : node(n), rootTT(tt), valueNum(num) { }
-      TR::Node *node;
-      TR::TreeTop *rootTT;
-      int32_t valueNum;
-      };
-
-
-   void elementPrivatization();
-   void findElementCandidates();
-   void privatizeElementCandidates();
-
-   void setVisitCount(vcount_t count) { _visitCount = count; }
-   TR::Node* walkTreeForLoadOrStoreNode(TR::Node *node);
-   bool isNodeInCorrectForm(TR::Node *node);
-   int64_t getOffSetFromAddressNode(TR::Node *addressNode);
-
-   private:
-
-   vcount_t _visitCount;
-   TR_ValueNumberInfo *_valueNumberInfo;
-
-   TR::list<EPCandidate> _epCandidates;       // A list of candidates that are in the right form to be privatized.
-   CS2::ABitVector<TR::Allocator> _epValueNumbers;              // this bit vector is to keep track of value numbers that we know are 'safe' to transform.  Allowing us to catch move opportunities.
-
    };
 
 

--- a/compiler/optimizer/OMROptimizationManager.cpp
+++ b/compiler/optimizer/OMROptimizationManager.cpp
@@ -122,8 +122,6 @@ OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFact
          break;
       case OMR::fieldPrivatization:
          _flags.set(requiresStructure);
-         if(self()->comp()->getOption(TR_EnableElementPrivatization))
-            _flags.set(requiresLocalsUseDefInfo | requiresLocalsValueNumbering | requiresStructure);
          break;
       case OMR::catchBlockRemoval:
          _flags.set(verifyTrees | verifyBlocks | checkTheCFG);


### PR DESCRIPTION
This is a legacy optimization that has never been enabled and not
immediately useful to OMR or any known downstream projects.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>