### PR TITLE
Misc. OMRMethod.hpp cleanup

### DIFF
--- a/compiler/compile/OMRAliasBuilder.hpp
+++ b/compiler/compile/OMRAliasBuilder.hpp
@@ -33,6 +33,7 @@ namespace OMR { typedef OMR::AliasBuilder AliasBuilderConnector; }
 
 #include "compile/Method.hpp"
 #include "env/TRMemory.hpp"
+#include "il/Node.hpp"
 #include "infra/BitVector.hpp"
 #include "infra/Array.hpp"
 #include "infra/List.hpp"

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -22,8 +22,6 @@
 #ifndef METHOD_INCL
 #define METHOD_INCL
 
-#include "compile/InlineBlock.hpp"
-
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -31,24 +29,11 @@
 #include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
-#include "il/Node.hpp"
-#include "infra/Assert.hpp"
 
-class TR_BitVector;
-class TR_CompactLocals;
-class TR_GlobalRegisterAllocator;
-class TR_InlinerBase;
 class TR_OpaqueClassBlock;
 class TR_ResolvedMethod;
-namespace TR { class S390SystemLinkage; }
-class TR_Value;
-namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
-namespace TR { class Node; }
-namespace TR { class Snippet; }
-namespace TR { class Symbol; }
-namespace TR { class SymbolReference; }
-template <class T> class TR_ScratchList;
+
 
 // Method indexes
 //
@@ -99,6 +84,7 @@ protected:
    TR_MethodParameterIterator(TR::Compilation& comp) : _comp(comp) { }
    TR::Compilation &                 _comp;
    };
+
 
 class TR_Method
    {

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -82,16 +82,6 @@ public:
 #define JITTED_METHOD_INDEX (mcount_t::valueOf((uint32_t)0)) // Index of the top-level method being compiled
 #define MAX_CALLER_INDEX (mcount_t::valueOf((uint32_t)INT_MAX)) // Could be UINT_MAX, in theory, but let's avoid corner cases until that day comes when we need 3 billion caller indexes
 
-enum NonUserMethod
-   {
-   unknownNonUserMethod,
-   nonUser_java_util_HashMap_rehash,
-   nonUser_java_util_HashMap_analyzeMap,
-   nonUser_java_util_HashMap_calculateCapacity,
-   nonUser_java_util_HashMap_findNullKeyEntry,
-
-   numNonUserMethods
-   };
 
 class TR_MethodParameterIterator
    {


### PR DESCRIPTION
* Remove NonUserMethod enum
* Remove unnecessary includes and forward decls from OMRMethod.hpp