### PR TITLE
Modifying kickoff point for concurrent mark

### DIFF
--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -1107,9 +1107,10 @@ MM_ParallelGlobalGC::internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSp
 	/* Clear overflow flag regardless */
 	_extensions->globalGCStats.workPacketStats.setSTWWorkStackOverflowOccured(false);
 	_extensions->allocationStats.clear();
-#if defined(OMR_GC_IDLE_HEAP_MANAGER)
-	_extensions->lastGCFreeBytes = _extensions->heap->getApproximateActiveFreeMemorySize(MEMORY_TYPE_OLD);
-#endif
+	_extensions->setLastGlobalGCFreeBytes(_extensions->heap->getApproximateActiveFreeMemorySize(MEMORY_TYPE_OLD));
+#if defined(OMR_GC_LARGE_OBJECT_AREA)
+	_extensions->lastGlobalGCFreeBytesLOA = _extensions->heap->getApproximateActiveFreeLOAMemorySize(MEMORY_TYPE_OLD); 
+#endif /* defined (OMR_GC_LARGE_OBJECT_AREA) */
 
 
 #if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)


### PR DESCRIPTION
- Added a few heuristics related to the rate of promotion from nursery to better predict how many scavenges remaining until percolate will occur. These heuristics include a calculation for `headroom` which is related to `concurrentKickoffTenuringHeadroom` and `lastGlobalGCFreeBytes`. Default value for `concurrentKickoffTenuringHeadroom` is 2%
- Kickoff point for concurrent mark will still  be triggered when `scavengesRemaining` point is reached, but this now includes the headroom calculations. The headroom is always set to be 'worst case scenario' between 1, and whatever value is calculated as the headroom remaining
- Added `lastGlobalGCFreeBytesLOA` to `GCExtensionsBase`. The usage of this field is almost identical as `lastGlobalGCFreeBytes`, but only considers LOA. This field is being used in the calculation of `headroom`
- Will be accompanied by changes on the j9 side for parsing `concurrentKickoffTenuringHeadroom` as command line argument

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>