### PR TITLE
Handle Windows version 5.1 in omrsysinfo_get_OS_type()

### DIFF
--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -255,10 +255,13 @@ WIN32_WINNT version constants :
 				case 0:
 					PPG_si_osType = "Windows 2000";
 					break;
+				case 1:
+					PPG_si_osType = "Windows XP"; /* 32-bit */
+					break;
 				case 2:
 					switch (versionInfo.wProductType) {
 					case VER_NT_WORKSTATION:
-						PPG_si_osType = "Windows XP";
+						PPG_si_osType = "Windows XP"; /* 64-bit */
 						break;
 					case VER_NT_DOMAIN_CONTROLLER: /* FALLTHROUGH */
 					case VER_NT_SERVER:


### PR DESCRIPTION
Major verson 5, minor version 1 is Windows XP, 32 bit. An application may
report this version depending on how it is manifested.

Fixes https://github.ibm.com/runtimes/infrastructure/issues/1995

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>