### PR TITLE
Remove deprecated const IL Opcodes from SwitchAnalyzer

### DIFF
--- a/compiler/optimizer/SwitchAnalyzer.cpp
+++ b/compiler/optimizer/SwitchAnalyzer.cpp
@@ -1224,7 +1224,7 @@ TR::Block *TR::SwitchAnalyzer::addGotoBlock(TR::TreeTop *dest)
    }
 TR::Block *TR::SwitchAnalyzer::addIfBlock(TR::ILOpCodes opCode, CASECONST_TYPE val, TR::TreeTop *dest)
    {
-   TR::Node *constNode = TR::Node::create(_switch, _isInt64 ? (_signed ? TR::lconst : TR::luconst) : (_signed ? TR::iconst : TR::iuconst), 0);
+   TR::Node *constNode = TR::Node::create(_switch, _isInt64 ? TR::lconst : TR::iconst , 0);
    constNode->set64bitIntegralValue(val);
    TR::Node *node = TR::Node::createif(opCode,
                                      TR::Node::createLoad(_switch, _temp),
@@ -1265,14 +1265,9 @@ TR::Block *TR::SwitchAnalyzer::addTableBlock(SwitchInfo *dense)
    if(_switch && _switch->chkCannotOverflow())
      node->setCannotOverflow(true); // Pass on info to code gen that table will have all cases covered and not use default case
 
-   if (_signed)
-      node->setAndIncChild(0, TR::Node::create(TR::isub, 2,
-                                           (_isInt64 ? TR::Node::create(TR::l2i, 1, TR::Node::createLoad(_switch, _temp)) : TR::Node::createLoad(_switch, _temp)),
-                                           TR::Node::create(_switch, TR::iconst, 0, dense->_min)));
-   else
-      node->setAndIncChild(0, TR::Node::create(TR::iusub, 2,
-                                           (_isInt64 ? TR::Node::create(TR::l2i, 1, TR::Node::createLoad(_switch, _temp)) : TR::Node::createLoad(_switch, _temp)),
-                                           TR::Node::create(_switch, TR::iuconst, 0, dense->_min)));
+   node->setAndIncChild(0, TR::Node::create(TR::isub, 2,
+                                          (_isInt64 ? TR::Node::create(TR::l2i, 1, TR::Node::createLoad(_switch, _temp)) : TR::Node::createLoad(_switch, _temp)),
+                                          TR::Node::create(_switch, TR::iconst, 0, dense->_min)));
 
    node->setAndIncChild(1, TR::Node::createCase(_switch, _defaultDest));
 


### PR DESCRIPTION
From `SwtichAnalyzer.cpp`, remove deprecated `const` unsigned IL Opcodes listed in #3983.
e.g. `TR::iuconst` and `TR::luconst`

Issue: #3983
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>