### PR TITLE
WIP: Rename HeapRegionStateTable to CopyForwardRegionLookupTable

### DIFF
--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -36,7 +36,7 @@ if (OMR_GC_VLHGC)
 if (OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 	target_sources(omrgctest
 		PRIVATE
-		TestHeapRegionStateTable.cpp
+		TestCopyForwardRegionLookupTable.cpp
 	)
 endif()
 endif()

--- a/fvtest/gctest/TestCopyForwardRegionLookupTable.cpp
+++ b/fvtest/gctest/TestCopyForwardRegionLookupTable.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "HeapRegionStateTable.hpp"
+#include "CopyForwardRegionLookupTable.hpp"
 #include "gcTestHelpers.hpp"
 
 #include <Forge.hpp>
@@ -28,7 +28,7 @@
 
 using namespace OMR::GC;
 
-TEST(TestHeapRegionStateTable, HeapRegionStateTable)
+TEST(TestCopyForwardRegionLookupTable, CopyForwardRegionLookupTable)
 {
     uintptr_t heapBase = 0x100;
     uintptr_t regionShift = 1;
@@ -37,7 +37,7 @@ TEST(TestHeapRegionStateTable, HeapRegionStateTable)
     Forge forge;
     ASSERT_TRUE(forge.initialize(gcTestEnv->getPortLibrary()));
 
-    HeapRegionStateTable table;
+    CopyForwardRegionLookupTable table;
     ASSERT_TRUE(table.initialize(&forge, heapBase, regionShift, regionCount));
 
     EXPECT_EQ(table.getIndex((void *)0x100), 0);

--- a/fvtest/gctest/makefile
+++ b/fvtest/gctest/makefile
@@ -37,7 +37,7 @@ SRCS := \
 ifeq (1, $(OMR_GC_VLHGC))
 ifeq (1, $(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD))
 SRCS += \
-  TestHeapRegionStateTable.cpp
+  TestCopyForwardRegionLookupTable.cpp
 endif
 endif
 

--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -334,7 +334,7 @@ endif()
 if(OMR_GC_VLHGC)
 	target_sources(omrgc
 		PRIVATE
-			base/vlhgc/HeapRegionStateTable.cpp
+			base/vlhgc/CopyForwardRegionLookupTable.cpp
 	)
 
 	target_include_directories(omrgc

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -88,7 +88,7 @@ struct J9Pool;
 namespace OMR {
 namespace GC {
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
-class HeapRegionStateTable;
+class CopyForwardRegionLookupTable;
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 } // namespace OMR
 } // namespace GC
@@ -618,7 +618,8 @@ public:
 #endif /* defined(OMR_GC_SEGREGATED_HEAP) */
 
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
-	OMR::GC::HeapRegionStateTable *heapRegionStateTable;
+	/* TODO: Fix the name of this lookup table */
+	OMR::GC::CopyForwardRegionLookupTable *heapRegionStateTable;
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 
 /* OMR_GC_REALTIME (in for all -- see 82589) */
@@ -1281,6 +1282,18 @@ public:
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 	}
 
+	MMINLINE OMR::GC::CopyForwardRegionLookupTable*
+	getCopyForwardRegionLookupTable()
+	{
+		/* TODO update name to CopyForwardRegionLookupTable when OpenJ9 uses this function */
+		return heapRegionStateTable;
+	}
+	MMINLINE void
+	setCopyForwardRegionLookupTable(OMR::GC::CopyForwardRegionLookupTable *table)
+	{
+		/* TODO update name to CopyForwardRegionLookupTable when OpenJ9 uses this function */
+		heapRegionStateTable = table;
+	}
 
 	MM_GCExtensionsBase()
 		: MM_BaseVirtual()

--- a/gc/base/standard/ConfigurationGenerational.cpp
+++ b/gc/base/standard/ConfigurationGenerational.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/gc/base/vlhgc/CopyForwardRegionLookupTable.cpp
+++ b/gc/base/vlhgc/CopyForwardRegionLookupTable.cpp
@@ -21,7 +21,7 @@
 
 #include "omrcfg.h"
 
-#include "HeapRegionStateTable.hpp"
+#include "CopyForwardRegionLookupTable.hpp"
 
 #include "omrcomp.h"
 #include "Forge.hpp"
@@ -31,9 +31,9 @@
 namespace OMR {
 namespace GC {
 
-HeapRegionStateTable *HeapRegionStateTable::newInstance(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount)
+CopyForwardRegionLookupTable *CopyForwardRegionLookupTable::newInstance(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount)
 {
-	HeapRegionStateTable* table = ::new(forge, AllocationCategory::FIXED, OMR_GET_CALLSITE(), std::nothrow) HeapRegionStateTable();
+	CopyForwardRegionLookupTable* table = ::new(forge, AllocationCategory::FIXED, OMR_GET_CALLSITE(), std::nothrow) CopyForwardRegionLookupTable();
 	if(NULL != table) {
 		bool success = table->initialize(forge, heapBase, regionShift, regionCount);
 		if (! success) {
@@ -45,7 +45,7 @@ HeapRegionStateTable *HeapRegionStateTable::newInstance(Forge *forge, uintptr_t 
 }
 
 bool
-HeapRegionStateTable::initialize(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount)
+CopyForwardRegionLookupTable::initialize(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount)
 {
 	_heapBase = heapBase;
 	_regionShift= regionShift;
@@ -62,14 +62,14 @@ HeapRegionStateTable::initialize(Forge *forge, uintptr_t heapBase, uintptr_t reg
 }
 
 void
-HeapRegionStateTable::kill(Forge *forge)
+CopyForwardRegionLookupTable::kill(Forge *forge)
 {
 	tearDown(forge);
 	forge->free(this);
 }
 
 void
-HeapRegionStateTable::tearDown(Forge *forge)
+CopyForwardRegionLookupTable::tearDown(Forge *forge)
 {
 	if (_table != NULL) {
 		forge->free(_table);

--- a/gc/base/vlhgc/CopyForwardRegionLookupTable.hpp
+++ b/gc/base/vlhgc/CopyForwardRegionLookupTable.hpp
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(CopyForwardRegionLookupTable_HPP)
+#define CopyForwardRegionLookupTable_HPP
+
+#include <omrcfg.h>
+
+#include "omrgcconsts.h"
+#include "BaseVirtual.hpp"
+
+#include <stdint.h>
+
+namespace OMR {
+namespace GC {
+
+class Forge;
+
+class CopyForwardRegionLookupTable : public MM_BaseVirtual
+{
+	/*
+	 * Data members
+	 */
+  public:
+  protected:
+  private:
+	uint8_t *_table;
+	uintptr_t _heapBase;
+	uintptr_t _regionShift;
+
+	/*
+	 * Function members
+	 */
+  public:
+
+	static CopyForwardRegionLookupTable *newInstance(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount);
+
+	bool initialize(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount);
+
+	void kill(Forge *forge);
+
+	void tearDown(Forge *forge);
+
+	CopyForwardRegionLookupTable()
+		: _table(NULL)
+		, _heapBase(0)
+		, _regionShift(0)
+	{
+		_typeId = __FUNCTION__;
+	}
+
+	MMINLINE uint8_t *getTable() { return _table; }
+
+	MMINLINE uintptr_t
+	getIndex(const void *heapAddress)
+	{
+		uintptr_t heapDelta = ((uintptr_t)heapAddress) - _heapBase;
+		uintptr_t index = heapDelta >> _regionShift; 
+		return index;
+	}
+
+	MMINLINE uint8_t
+	getRegionState(const void *heapAddress)
+	{
+		return _table[getIndex(heapAddress)];
+	}
+
+	/**
+	 * Set the state of the region in the table.  Must use
+	 * constants defined by enum HeapRegionState,
+	 * 	HEAP_REGION_STATE_NONE, or HEAP_REGION_STATE_COPY_FORWARD
+	 */
+	MMINLINE void
+	setRegionState(const void *heapAddress, uint8_t state)
+	{
+		_table[getIndex(heapAddress)] = state;
+	}
+
+  protected:
+  private:
+};
+
+} // namespace GC
+} // namespace OMR
+
+#endif /* defined(CopyForwardRegionLookupTable_HPP) */

--- a/gc/base/vlhgc/HeapRegionStateTable.hpp
+++ b/gc/base/vlhgc/HeapRegionStateTable.hpp
@@ -19,86 +19,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if !defined(HEAPREGIONSTATETABLE_HPP)
-#define HEAPREGIONSTATETABLE_HPP
+/* TODO: Temporary typedef to rename the HeapRegionStateTable.
+ * This file will be deleted when OpenJ9 is updated */
 
 #include <omrcfg.h>
 
-#include "omrgcconsts.h"
-#include "BaseVirtual.hpp"
-
-#include <stdint.h>
+#include "CopyForwardRegionLookupTable.hpp"
 
 namespace OMR {
 namespace GC {
 
-class Forge;
-
-class HeapRegionStateTable : public MM_BaseVirtual
-{
-	/*
-	 * Data members
-	 */
-  public:
-  protected:
-  private:
-	uint8_t *_table;
-	uintptr_t _heapBase;
-	uintptr_t _regionShift;
-
-	/*
-	 * Function members
-	 */
-  public:
-
-	static HeapRegionStateTable *newInstance(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount);
-
-	bool initialize(Forge *forge, uintptr_t heapBase, uintptr_t regionShift, uintptr_t regionCount);
-
-	void kill(Forge *forge);
-
-	void tearDown(Forge *forge);
-
-	HeapRegionStateTable()
-		: _table(NULL)
-		, _heapBase(0)
-		, _regionShift(0)
-	{
-		_typeId = __FUNCTION__;
-	}
-
-	MMINLINE uint8_t *getTable() { return _table; }
-
-	MMINLINE uintptr_t
-	getIndex(const void *heapAddress)
-	{
-		uintptr_t heapDelta = ((uintptr_t)heapAddress) - _heapBase;
-		uintptr_t index = heapDelta >> _regionShift; 
-		return index;
-	}
-
-	MMINLINE uint8_t
-	getRegionState(const void *heapAddress)
-	{
-		return _table[getIndex(heapAddress)];
-	}
-
-	/**
-	 * Set the state of the region in the table.  Must use
-	 * constants defined by enum HeapRegionState,
-	 * 	HEAP_REGION_STATE_NONE, or HEAP_REGION_STATE_COPY_FORWARD
-	 */
-	MMINLINE void
-	setRegionState(const void *heapAddress, uint8_t state)
-	{
-		_table[getIndex(heapAddress)] = state;
-	}
-
-  protected:
-  private:
-};
+typedef CopyForwardRegionLookupTable HeapRegionStateTable
 
 } // namespace GC
 } // namespace OMR
-
-#endif /* defined(HEAPREGIONSTATETABLE_HPP) */


### PR DESCRIPTION
- Introduce new getter and setter functions to ease the OpenJ9
  transition.

Signed-off-by: Andrew Young <youngar17@gmail.com>