### PR TITLE
Initial implementation of extensible TR::Method base class

### DIFF
--- a/compiler/compile/CMakeLists.txt
+++ b/compiler/compile/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,7 +22,7 @@
 compiler_library(compile
 
 	${CMAKE_CURRENT_LIST_DIR}/OSRData.cpp
-	${CMAKE_CURRENT_LIST_DIR}/Method.cpp
+	${CMAKE_CURRENT_LIST_DIR}/OMRMethod.cpp
 	${CMAKE_CURRENT_LIST_DIR}/VirtualGuard.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRSymbolReferenceTable.cpp
 	${CMAKE_CURRENT_LIST_DIR}/OMRAliasBuilder.cpp

--- a/compiler/compile/Method.cpp
+++ b/compiler/compile/Method.cpp
@@ -297,55 +297,55 @@ bool TR_ResolvedMethod::isDAAIntrinsicMethod()
 #endif
    }
 
-uint32_t              TR::Method::numberOfExplicitParameters() { TR_UNIMPLEMENTED(); return 0; }
-TR::DataType          TR::Method::parmType(uint32_t)           { TR_UNIMPLEMENTED(); return TR::NoType; }
-TR::ILOpCodes         TR::Method::directCallOpCode()           { TR_UNIMPLEMENTED(); return TR::BadILOp; }
-TR::ILOpCodes         TR::Method::indirectCallOpCode()         { TR_UNIMPLEMENTED(); return TR::BadILOp; }
-TR::DataType          TR::Method::returnType()                 { TR_UNIMPLEMENTED(); return TR::NoType; }
-bool                  TR::Method::returnTypeIsUnsigned()       { TR_UNIMPLEMENTED(); return TR::NoType;}
-uint32_t              TR::Method::returnTypeWidth()            { TR_UNIMPLEMENTED(); return 0; }
-TR::ILOpCodes         TR::Method::returnOpCode()               { TR_UNIMPLEMENTED(); return TR::BadILOp; }
-uint16_t              TR::Method::classNameLength()            { TR_UNIMPLEMENTED(); return 0; }
-uint16_t              TR::Method::nameLength()                 { TR_UNIMPLEMENTED(); return 0; }
-uint16_t              TR::Method::signatureLength()            { TR_UNIMPLEMENTED(); return 0; }
-char *                TR::Method::classNameChars()             { TR_UNIMPLEMENTED(); return 0; }
-char *                TR::Method::nameChars()                  { TR_UNIMPLEMENTED(); return 0; }
-char *                TR::Method::signatureChars()             { TR_UNIMPLEMENTED(); return 0; }
-bool                  TR::Method::isConstructor()              { TR_UNIMPLEMENTED(); return false; }
-bool                  TR::Method::isFinalInObject()            { TR_UNIMPLEMENTED(); return false; }
-const char *          TR::Method::signature(TR_Memory *, TR_AllocationKind) { TR_UNIMPLEMENTED(); return 0; }
-void                  TR::Method::setArchetypeSpecimen(bool b) { TR_UNIMPLEMENTED(); }
+uint32_t              OMR::Method::numberOfExplicitParameters() { TR_UNIMPLEMENTED(); return 0; }
+TR::DataType          OMR::Method::parmType(uint32_t)           { TR_UNIMPLEMENTED(); return TR::NoType; }
+TR::ILOpCodes         OMR::Method::directCallOpCode()           { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+TR::ILOpCodes         OMR::Method::indirectCallOpCode()         { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+TR::DataType          OMR::Method::returnType()                 { TR_UNIMPLEMENTED(); return TR::NoType; }
+bool                  OMR::Method::returnTypeIsUnsigned()       { TR_UNIMPLEMENTED(); return TR::NoType;}
+uint32_t              OMR::Method::returnTypeWidth()            { TR_UNIMPLEMENTED(); return 0; }
+TR::ILOpCodes         OMR::Method::returnOpCode()               { TR_UNIMPLEMENTED(); return TR::BadILOp; }
+uint16_t              OMR::Method::classNameLength()            { TR_UNIMPLEMENTED(); return 0; }
+uint16_t              OMR::Method::nameLength()                 { TR_UNIMPLEMENTED(); return 0; }
+uint16_t              OMR::Method::signatureLength()            { TR_UNIMPLEMENTED(); return 0; }
+char *                OMR::Method::classNameChars()             { TR_UNIMPLEMENTED(); return 0; }
+char *                OMR::Method::nameChars()                  { TR_UNIMPLEMENTED(); return 0; }
+char *                OMR::Method::signatureChars()             { TR_UNIMPLEMENTED(); return 0; }
+bool                  OMR::Method::isConstructor()              { TR_UNIMPLEMENTED(); return false; }
+bool                  OMR::Method::isFinalInObject()            { TR_UNIMPLEMENTED(); return false; }
+const char *          OMR::Method::signature(TR_Memory *, TR_AllocationKind) { TR_UNIMPLEMENTED(); return 0; }
+void                  OMR::Method::setArchetypeSpecimen(bool b) { TR_UNIMPLEMENTED(); }
 
 TR_MethodParameterIterator *
-TR::Method::getParameterIterator(TR::Compilation&, TR_ResolvedMethod *)
+OMR::Method::getParameterIterator(TR::Compilation&, TR_ResolvedMethod *)
    {
    TR_UNIMPLEMENTED();
    return 0;
    }
 
 bool
-TR::Method::isBigDecimalMethod(TR::Compilation * comp)
+OMR::Method::isBigDecimalMethod(TR::Compilation * comp)
    {
    TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
-TR::Method::isUnsafeCAS(TR::Compilation * comp)
+OMR::Method::isUnsafeCAS(TR::Compilation * comp)
    {
    TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
-TR::Method::isUnsafeWithObjectArg(TR::Compilation * comp)
+OMR::Method::isUnsafeWithObjectArg(TR::Compilation * comp)
    {
    TR_UNIMPLEMENTED();
    return false;
    }
 
 bool
-TR::Method::isBigDecimalConvertersMethod(TR::Compilation * comp)
+OMR::Method::isBigDecimalConvertersMethod(TR::Compilation * comp)
    {
    TR_UNIMPLEMENTED();
    return false;

--- a/compiler/compile/OMRMethod.cpp
+++ b/compiler/compile/OMRMethod.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,23 +19,4 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TR_METHOD_INCL
-#define TR_METHOD_INCL
-
-#include "compile/OMRMethod.hpp"
-#include "infra/Annotations.hpp"
-
-namespace TR
-{
-
-class Method : public OMR::MethodConnector
-   {
-public:
-
-   Method(Type t = J9) : OMR::MethodConnector(t) {}
-
-   };
-
-}
-
-#endif
+#include "compiler/compile/Method.cpp"

--- a/compiler/compile/OMRMethod.hpp
+++ b/compiler/compile/OMRMethod.hpp
@@ -19,8 +19,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef METHOD_INCL
-#define METHOD_INCL
+#ifndef OMR_METHOD_INCL
+#define OMR_METHOD_INCL
+
+/*
+ * The following #define and typedef must appear before any #includes in this file
+ */
+#ifndef OMR_METHOD_CONNECTOR
+#define OMR_METHOD_CONNECTOR
+namespace OMR { class Method; }
+namespace OMR { typedef OMR::Method MethodConnector; }
+#endif
+
 
 #include <limits.h>
 #include <stddef.h>
@@ -29,6 +39,7 @@
 #include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
 #include "il/ILOpCodes.hpp"
+#include "infra/Annotations.hpp"
 
 class TR_OpaqueClassBlock;
 class TR_ResolvedMethod;
@@ -86,7 +97,17 @@ protected:
    };
 
 
-class TR_Method
+typedef struct TR_AOTMethodInfo
+   {
+   TR_ResolvedMethod *resolvedMethod;
+   int32_t cpIndex;
+   } TR_AOTMethodInfo;
+
+
+namespace OMR
+{
+
+class Method
    {
    public:
 
@@ -116,7 +137,7 @@ class TR_Method
    bool isJ9()     { return _typeOfMethod == J9;     }
    Type methodType() { return _typeOfMethod; }
 
-   TR_Method(Type t = J9) : _typeOfMethod(t) { _recognizedMethod = _mandatoryRecognizedMethod = TR::unknownMethod; }
+   Method(Type t = J9) : _typeOfMethod(t) { _recognizedMethod = _mandatoryRecognizedMethod = TR::unknownMethod; }
 
    // --------------------------------------------------------------------------
    // J9
@@ -145,9 +166,6 @@ class TR_Method
    void setRecognizedMethod(TR::RecognizedMethod rm) { _recognizedMethod = rm; }
    void setMandatoryRecognizedMethod(TR::RecognizedMethod rm) { _mandatoryRecognizedMethod = rm; }
 
-   protected:
-
-
    private:
 
    TR::RecognizedMethod _recognizedMethod;
@@ -156,14 +174,6 @@ class TR_Method
 
    };
 
-
-typedef struct TR_AOTMethodInfo
-   {
-   TR_ResolvedMethod *resolvedMethod;
-   int32_t cpIndex;
-   } TR_AOTMethodInfo;
-
-
-namespace TR { typedef ::TR_Method Method; }
+}
 
 #endif

--- a/compiler/il/symbol/MethodSymbol.hpp
+++ b/compiler/il/symbol/MethodSymbol.hpp
@@ -27,7 +27,7 @@
 #include <stddef.h>
 #include "codegen/LinkageConventionsEnum.hpp"
 
-class TR_Method;
+namespace TR { class Method; }
 
 namespace TR
 {

--- a/compiler/optimizer/CallInfo.hpp
+++ b/compiler/optimizer/CallInfo.hpp
@@ -47,12 +47,12 @@ class TR_InlineBlocks;
 class TR_InlinerBase;
 class TR_InlinerTracer;
 class TR_InnerPreexistenceInfo;
-class TR_Method;
 class TR_PrexArgInfo;
 class TR_ResolvedMethod;
 namespace TR { class AutomaticSymbol; }
 namespace TR { class Block; }
 namespace TR { class CFG; }
+namespace TR { class Method; }
 namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SymbolReference; }
 namespace TR { class TreeTop; }

--- a/compiler/optimizer/DebuggingCounters.hpp
+++ b/compiler/optimizer/DebuggingCounters.hpp
@@ -24,12 +24,11 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "compile/Method.hpp"
 #include "env/TRMemory.hpp"
 #include "env/jittypes.h"
 
-class TR_Method;
 namespace TR { class Compilation; }
+namespace TR { class Method; }
 namespace TR { class TreeTop; }
 
 // This is the type of the debugging counters.

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -76,12 +76,12 @@ class TR_FrontEnd;
 class TR_HashTabInt;
 class TR_InlineBlocks;
 class TR_InnerAssumption;
-class TR_Method;
 class TR_PrexArgInfo;
 class TR_ResolvedMethod;
 class TR_TransformInlinedFunction;
 namespace TR { class Block; }
 namespace TR { class CFG; }
+namespace TR { class Method; }
 namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
 namespace TR { class ResolvedMethodSymbol; }

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2576,7 +2576,6 @@ void OMR::Power::CodeGenerator::addRealRegisterInterference(TR::Register    *reg
 
 #if defined(AIXPPC)
 #include <unistd.h>
-class  TR_Method;
 static TR::Instruction    *nextIntervalInstructionPtr;
 static uint8_t           *nextIntervalBufferPtr;
 static bool               segmentInBlock;
@@ -3576,7 +3575,7 @@ void mulConstant(TR::Node * node, TR::Register *trgReg, TR::Register *sourceReg,
       }
    }
 
-   
+
 TR::Register *addConstantToLong(TR::Node *node, TR::Register *srcReg,
                                 int64_t value, TR::Register *trgReg, TR::CodeGenerator *cg)
    {

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -21,7 +21,7 @@
 
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/compile/OSRData.cpp \
-    $(JIT_OMR_DIRTY_DIR)/compile/Method.cpp \
+    $(JIT_OMR_DIRTY_DIR)/compile/OMRMethod.cpp \
     $(JIT_OMR_DIRTY_DIR)/compile/VirtualGuard.cpp \
     $(JIT_OMR_DIRTY_DIR)/control/OMROptions.cpp \
     $(JIT_OMR_DIRTY_DIR)/control/OptimizationPlan.cpp \

--- a/fvtest/compilertest/compile/Method.hpp
+++ b/fvtest/compilertest/compile/Method.hpp
@@ -29,7 +29,10 @@
 
 #include <string.h>
 
-#include "compile/OMRMethod.hpp"
+// Choose the OMR base version directly.  This is only temporary
+// while the Method class is being made extensible.
+//
+#include "compiler/compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 
 namespace TR { class IlGeneratorMethodDetails; }

--- a/jitbuilder/build/files/common.mk
+++ b/jitbuilder/build/files/common.mk
@@ -23,7 +23,7 @@
 
 JIT_PRODUCT_BACKEND_SOURCES+=\
     $(JIT_OMR_DIRTY_DIR)/compile/OSRData.cpp \
-    $(JIT_OMR_DIRTY_DIR)/compile/Method.cpp \
+    $(JIT_OMR_DIRTY_DIR)/compile/OMRMethod.cpp \
     $(JIT_OMR_DIRTY_DIR)/compile/VirtualGuard.cpp \
     $(JIT_OMR_DIRTY_DIR)/control/OMROptions.cpp \
     $(JIT_OMR_DIRTY_DIR)/control/OptimizationPlan.cpp \

--- a/jitbuilder/compile/Method.hpp
+++ b/jitbuilder/compile/Method.hpp
@@ -30,7 +30,10 @@
 
 #include <string.h>
 
-#include "compile/OMRMethod.hpp"
+// Choose the OMR base version directly.  This is only temporary
+// while the Method class is being made extensible.
+//
+#include "compiler/compile/Method.hpp"
 #include "compile/ResolvedMethod.hpp"
 
 namespace TR { class IlGeneratorMethodDetails; }


### PR DESCRIPTION
* create the OMR base class structure and the concrete class in
  the TR:: namespace.  Fixup forward declarations.
* the class does not have the OMR_EXTENSIBLE attribute yet
* connect the existing JitBuilder and CompilerTest hierarchies
  without making them extensible classes yet

Signed-off-by: Daryl Maier <maier@ca.ibm.com>