### PR TITLE
Handle args in FindLEX/FindYACC

### DIFF
--- a/cmake/modules/FindLEX.cmake
+++ b/cmake/modules/FindLEX.cmake
@@ -19,6 +19,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #############################################################################
 
+include(FindPackageHandleStandardArgs)
+
 find_program(LEX_EXECUTABLE NAMES lex DOC "Path to the lex executable")
 mark_as_advanced(LEX_EXECUTABLE)
 
@@ -78,3 +80,8 @@ if(LEX_EXECUTABLE)
 			PROPERTIES OBJECT_DEPENDS ${YACC_${YACCTarget}_OUTPUT_HEADER})
 	endmacro()
 endif()
+
+find_package_handle_standard_args(LEX
+	REQUIRES_VARS
+		LEX_EXECUTABLE
+)

--- a/cmake/modules/FindYACC.cmake
+++ b/cmake/modules/FindYACC.cmake
@@ -19,6 +19,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 #############################################################################
 
+include(FindPackageHandleStandardArgs)
+
 find_program(YACC_EXECUTABLE NAMES yacc DOC "Path to the YACC executable")
 mark_as_advanced(YACC_EXECUTABLE)
 
@@ -91,3 +93,8 @@ if(YACC_EXECUTABLE)
 		endif()
 	endmacro()
 endif()
+
+find_package_handle_standard_args(YACC
+	REQUIRES_VARS
+		YACC_EXECUTABLE
+)


### PR DESCRIPTION
The `find_package_handle_standard_args` utility in cmake is used to help implement FindXyz.cmake modules. Specifically, the macro will test whether the package was required, or whether a specific version was required.

This macro will also define the `YACC_FOUND` / `LEX_FOUND` variables, which can be used to determine success.

It also gives us a nice little print out:
```
-- Found YACC: /usr/bin/yacc
-- Found LEX: /usr/bin/lex
```

Fixes: #4070
Signed-off-by: Robert Young <rwy0717@gmail.com>