### PR TITLE
Deep Scan TGC Stats Gathering

### DIFF
--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -61,6 +61,9 @@ MM_ScavengerStats::MM_ScavengerStats()
 	,_workStallTime(0)
 	,_completeStallTime(0)
 	,_syncStallTime(0)
+	,_totalDeepStructures(0)
+	,_totalObjsDeepScanned(0)
+	,_depthDeepestStructure(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	,_avgInitialFree(0)
 	,_avgTenureBytes(0)
@@ -163,6 +166,9 @@ MM_ScavengerStats::clear(bool firstIncrement)
 	_workStallTime = 0;
 	_completeStallTime = 0;
 	_syncStallTime = 0;
+	_totalDeepStructures = 0;
+	_totalObjsDeepScanned = 0;
+	_depthDeepestStructure = 0;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	/* NOTE: _startTime and _endTime are also not cleared
 	 * as they are recorded before/after all stat clearing/gathering.

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -92,6 +92,9 @@ public:
 	uint64_t _workStallTime; /**< The time, in hi-res ticks, the thread spent stalled waiting to receive more work */
 	uint64_t _completeStallTime; /**< The time, in hi-res ticks, the thread spent stalled waiting for all other threads to complete working */
 	uint64_t _syncStallTime; /**< The time, in hi-res ticks, the thread spent stalled at a sync point */
+	uintptr_t _totalDeepStructures; /**<  The number of deep structures that are scanned with priority (number of deepScanOutline function calls) */
+	uintptr_t _totalObjsDeepScanned; /**< The total number of deep structure objects that are special treated (number of copyAndForward with priority)*/
+	uintptr_t _depthDeepestStructure; /**< Length of longest deep structure that is special treated */
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
 	/* Average (weighted) number of bytes free after a collection and


### PR DESCRIPTION
Gather the following Scavenger stats (to be reported part of TGC
parallel):

- The number of deep structures that are scanned with
priority (number of deepScanOutline function calls)
- The total number of deep structure nodes that are special treated
(number of copyAndForward with priority)
- Length of longest deep structure that is special treated

Signed-off-by: Salman Rana <salman.rana@ibm.com>