### PR TITLE
Enabling GC Startup Hints by default

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1389,7 +1389,7 @@ public:
 		, heapContractionStabilizationCount(3)
 		, heapSizeStartupHintConservativeFactor((float)0.7)
 		, heapSizeStartupHintWeightNewValue((float)0.8)	
-		, useGCStartupHints(false)	
+		, useGCStartupHints(true)	
 		, workpacketCount(0) /* only set if -Xgcworkpackets specified */
 		, packetListSplit(0)
 		, cacheListSplit(0)


### PR DESCRIPTION
As requested by
https://github.com/eclipse/openj9/issues/3743#issuecomment-505569900
(the feature is really only available in OpenJ9)


Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>