### PR TITLE
Fix issue with SYS_getcpu not being defined

### DIFF
--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -552,7 +552,12 @@ uintptr_t
 omrthread_numa_get_current_node()
 {
     unsigned node = 0;
-#if OMR_PORT_NUMA_SUPPORT
+#if defined(OMR_PORT_NUMA_SUPPORT)
+	/* On some older kernels the syscall appears to be SYS_get_cpu rather than SYS_getcpu */
+#if !defined(SYS_getcpu)
+#define SYS_getcpu SYS_get_cpu
+#endif
+
     if (0 == syscall(SYS_getcpu, NULL, &node, NULL)) {
         ++node;
     } else {


### PR DESCRIPTION
Older kernels seem to define the system call as SYS_get_cpu

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>