### PR TITLE
Remove references of deprecated  load IL opcode

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -453,7 +453,6 @@ OMR::ARM64::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return commonLoadEvaluator(node, TR::InstOpCode::ldrshimmx, cg);
    }
 
-// also handles cloadi
 TR::Register *
 OMR::ARM64::TreeEvaluator::cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -546,8 +546,7 @@ void OMR::CodeGenerator::identifyUnneededByteConvNodes(TR::Node * parent, TR::Tr
                     child->getFirstChild()->getOpCodeValue() == TR::d2s ||
                     child->getFirstChild()->getOpCodeValue() == TR::i2s ||
                     child->getFirstChild()->getOpCodeValue() == TR::l2s ||
-                    child->getFirstChild()->getOpCodeValue() == TR::iRegLoad ||
-                    child->getFirstChild()->getOpCodeValue() == TR::iuRegLoad ) &&
+                    child->getFirstChild()->getOpCodeValue() == TR::iRegLoad) &&
                    performTransformation(self()->comp(), "%sChanging b2i node %p to unsigned conversion\n", OPT_DETAILS, child))
                   {
                   TR::Node::recreate(child, (storeType == TR::Int8 ? TR::bu2i : TR::su2i));

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -595,7 +595,6 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::dloadi: return TR::dstorei;
       case TR::aloadi: return TR::astorei;
       case TR::vloadi: return TR::vstorei;
-      case TR::luloadi: return TR::lstorei;
       case TR::brdbari:
       case TR::srdbari:
       case TR::irdbari:

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -596,7 +596,6 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::aloadi: return TR::astorei;
       case TR::vloadi: return TR::vstorei;
       case TR::cloadi: return TR::cstorei;
-      case TR::buloadi: return TR::bstorei;
       case TR::iuload: return TR::istore;
       case TR::iuloadi: return TR::istorei;
       case TR::luloadi: return TR::lstorei;

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -595,7 +595,6 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::dloadi: return TR::dstorei;
       case TR::aloadi: return TR::astorei;
       case TR::vloadi: return TR::vstorei;
-      case TR::cloadi: return TR::cstorei;
       case TR::iuload: return TR::istore;
       case TR::iuloadi: return TR::istorei;
       case TR::luloadi: return TR::lstorei;

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -595,7 +595,6 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::dloadi: return TR::dstorei;
       case TR::aloadi: return TR::astorei;
       case TR::vloadi: return TR::vstorei;
-      case TR::iuloadi: return TR::istorei;
       case TR::luloadi: return TR::lstorei;
       case TR::brdbari:
       case TR::srdbari:

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -595,7 +595,6 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::dloadi: return TR::dstorei;
       case TR::aloadi: return TR::astorei;
       case TR::vloadi: return TR::vstorei;
-      case TR::iuload: return TR::istore;
       case TR::iuloadi: return TR::istorei;
       case TR::luloadi: return TR::lstorei;
       case TR::brdbari:

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1261,7 +1261,6 @@ public:
       switch (op)
          {
          case TR::bload:
-         case TR::cload:
          case TR::sload:
          case TR::iload:
          case TR::lload:
@@ -1269,7 +1268,6 @@ public:
          case TR::dload:
             return TR::vload;
          case TR::bloadi:
-         case TR::cloadi:
          case TR::sloadi:
          case TR::iloadi:
          case TR::lloadi:

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -531,10 +531,10 @@ TR_CharToByteArraycopy::checkArrayStores(TR::Node * origHighStoreNode, TR::Node 
    if (!iand) return false;
    TR::Node * c2i = testBinaryIConst(comp(), iand, TR::iand, TR::su2i, 0xFF00, "checkArrayStores: high store child is not iand of su2i and 0xFF00\n");
    if (!c2i) return false;
-   TR::Node * icload = testUnary(comp(), c2i->getFirstChild(), TR::cloadi, "checkArrayStores: high store child is not icload\n");
-   if (!icload) return false;
+   TR::Node * isload = testUnary(comp(), c2i->getFirstChild(), TR::sloadi, "checkArrayStores: high store child is not isload\n");
+   if (!isload) return false;
 
-   bool checkLoad = getLoadAddress()->checkAiadd(icload->getFirstChild(), 2);
+   bool checkLoad = getLoadAddress()->checkAiadd(isload->getFirstChild(), 2);
    if (!checkLoad)
       {
       return false;
@@ -544,12 +544,12 @@ TR_CharToByteArraycopy::checkArrayStores(TR::Node * origHighStoreNode, TR::Node 
    if (!iand) return false;
    c2i = testBinaryIConst(comp(), iand, TR::iand, TR::su2i, 0xFF, "checkArrayStores: low store child is not iand of su2i and 0xFF\n");
    if (!c2i) return false;
-   TR::Node * icloadDup = testUnary(comp(), c2i->getFirstChild(), TR::cloadi, "checkArrayStores: low store child is not icload\n");
-   if (!icloadDup) return false;
+   TR::Node * isloadDup = testUnary(comp(), c2i->getFirstChild(), TR::sloadi, "checkArrayStores: low store child is not isload\n");
+   if (!isloadDup) return false;
 
-   if (icloadDup != icload)
+   if (isloadDup != isload)
       {
-      dumpOptDetails(comp(), "checkArrayStores: two icload addresses are not the same\n");
+      dumpOptDetails(comp(), "checkArrayStores: two isload addresses are not the same\n");
       return false;
       }
 
@@ -1596,7 +1596,7 @@ TR_Arraytranslate::checkLoad(TR::Node * loadNode)
       transLoadNode = transLoadNode->skipConversions();
       }
 
-   if (transLoadNode->getOpCodeValue() != TR::cloadi && transLoadNode->getOpCodeValue() != TR::bloadi)
+   if (transLoadNode->getOpCodeValue() != TR::bloadi)
       {
       dumpOptDetails(comp(), "...load tree does not have ibload/icload - no arraytranslate reduction\n");
       return false;
@@ -1656,7 +1656,7 @@ TR_Arraytranslate::checkLoad(TR::Node * loadNode)
    inLoadNode = getMulChild(inLoadNode);
    inLoadNode = inLoadNode->skipConversions();
 
-   if (inLoadNode->getOpCodeValue() != TR::cloadi && inLoadNode->getOpCodeValue() != TR::bloadi)
+   if (inLoadNode->getOpCodeValue() != TR::bloadi)
       {
       dumpOptDetails(comp(), "...load tree does not have 2nd icload/ibload - check if compiler-generated table lookup match\n");
       inLoadNode = transLoadNode;

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -1461,7 +1461,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGe
    TR::Register *trgReg;
 
    if (((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) &&
-       (node->getOpCodeValue() == TR::iu2f && (child->getOpCodeValue() == TR::iuload || child->getOpCodeValue() == TR::iuloadi))) ||
+       (node->getOpCodeValue() == TR::iu2f && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) ||
        (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6) &&
        (node->getOpCodeValue() == TR::i2f && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi)))) &&
        child->getReferenceCount() == 1 && child->getRegister() == NULL &&
@@ -1509,7 +1509,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGe
    TR::Register *trgReg;
 
    if (((cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P7) &&
-       (node->getOpCodeValue() == TR::iu2d && (child->getOpCodeValue() == TR::iuload || child->getOpCodeValue() == TR::iuloadi))) ||
+       (node->getOpCodeValue() == TR::iu2d && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) ||
        (cg->comp()->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P6) &&
        node->getOpCodeValue() == TR::i2d && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) &&
        child->getReferenceCount()==1 &&

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5524,7 +5524,7 @@ TR::Register *OMR::Power::TreeEvaluator::gprRegLoadEvaluator(TR::Node *node, TR:
    else
       {
 #ifdef TR_TARGET_32BIT
-      if (OMR_LIKELY(node->getOpCodeValue() != TR::lRegLoad && node->getOpCodeValue() != TR::luRegLoad))
+      if (OMR_LIKELY(node->getOpCodeValue() != TR::lRegLoad))
          globalReg = cg->allocateRegister();
       else
          globalReg = cg->allocateRegisterPair(cg->allocateRegister(),
@@ -5543,7 +5543,7 @@ TR::Register *OMR::Power::TreeEvaluator::gprRegStoreEvaluator(TR::Node *node, TR
    TR::Node     *child = node->getFirstChild();
    TR::Register *globalReg = cg->evaluate(child);
 
-   if (node->getOpCodeValue() != TR::lRegLoad && node->getOpCodeValue() != TR::luRegLoad && node->needsSignExtension())
+   if (node->getOpCodeValue() != TR::lRegLoad && node->needsSignExtension())
       generateTrg1Src1Instruction(cg, TR::InstOpCode::extsw, node, globalReg, globalReg);
 
    cg->decReferenceCount(child);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -366,7 +366,7 @@ TR::Instruction *fixedSeqMemAccess(TR::CodeGenerator *cg, TR::Node *node, intptr
 
 
 
-// also handles iiload, iuload, iiuload
+// also handles iiload, iiuload
 TR::Register *OMR::Power::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -567,7 +567,7 @@ TR::Register *OMR::Power::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::Code
    return tempReg;
    }
 
-// also handles ilload, luload, iluload
+// also handles ilload, iluload
 TR::Register *OMR::Power::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -244,8 +244,6 @@ TR::Register *OMR::Power::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGe
    if (node->isUnneededConversion() ||
        (child->getOpCodeValue() != TR::bload &&
         child->getOpCodeValue() != TR::bloadi &&
-        child->getOpCodeValue() != TR::buload &&
-        child->getOpCodeValue() != TR::buloadi &&
         child->getOpCodeValue() != TR::s2b &&
         child->getOpCodeValue() != TR::f2b &&
         child->getOpCodeValue() != TR::d2b &&

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -249,8 +249,7 @@ TR::Register *OMR::Power::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGe
         child->getOpCodeValue() != TR::d2b &&
         child->getOpCodeValue() != TR::i2b &&
         child->getOpCodeValue() != TR::l2b &&
-        child->getOpCodeValue() != TR::iRegLoad &&
-        child->getOpCodeValue() != TR::iuRegLoad ))
+        child->getOpCodeValue() != TR::iRegLoad ))
       {
       trgReg = cg->gprClobberEvaluate(child);
       }

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -742,7 +742,7 @@ TR::Register *OMR::X86::TreeEvaluator::bloadEvaluator(TR::Node *node, TR::CodeGe
    return reg;
    }
 
-// also handles cload, isload and icload
+// also handles isload and icload
 TR::Register *OMR::X86::TreeEvaluator::sloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference  *sourceMR = generateX86MemoryReference(node, cg);

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -190,8 +190,8 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
       if (firstChild->getOpCodeValue() == TR::bu2i &&
           firstChild->getReferenceCount() == 1    &&
           firstChild->getRegister() == NULL       &&
-             (firstChild->getFirstChild()->getOpCodeValue() == TR::buload ||
-              firstChild->getFirstChild()->getOpCodeValue() == TR::buloadi  ))
+             (firstChild->getFirstChild()->getOpCodeValue() == TR::bload ||	
+              firstChild->getFirstChild()->getOpCodeValue() == TR::bloadi  ))
           {
           initFirstChild = firstChild;
 
@@ -202,8 +202,8 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
       if (secondChild->getOpCodeValue() == TR::bu2i &&
           secondChild->getReferenceCount() == 1    &&
           secondChild->getRegister() == NULL       &&
-             (secondChild->getFirstChild()->getOpCodeValue() == TR::buload ||
-              secondChild->getFirstChild()->getOpCodeValue() == TR::buloadi  ))
+             (secondChild->getFirstChild()->getOpCodeValue() == TR::bload ||	
+              secondChild->getFirstChild()->getOpCodeValue() == TR::bloadi  ))
           {
           initSecondChild = secondChild;
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3086,11 +3086,11 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
    // FIXME: can't the binary commutative analyser handle this? that's where this should be done
    //
    else if (firstChild->getOpCodeValue()==TR::bu2i && firstChild->getRegister()==NULL && firstChild->getReferenceCount()==1 &&
-            (firstChild->getFirstChild()->getOpCodeValue()==TR::buloadi   ||
+            (firstChild->getFirstChild()->getOpCodeValue()==TR::bloadi   ||
              firstChild->getFirstChild()->getOpCodeValue()==TR::iRegLoad)
             && firstChild->getFirstChild()->getRegister() &&
             secondChild->getOpCodeValue()==TR::bu2i && secondChild->getRegister()==NULL && secondChild->getReferenceCount()==1 &&
-            (secondChild->getFirstChild()->getOpCodeValue()==TR::buloadi  ||
+            (secondChild->getFirstChild()->getOpCodeValue()==TR::bloadi  ||
              secondChild->getFirstChild()->getOpCodeValue()==TR::iRegLoad)
             && secondChild->getFirstChild()->getRegister())
       {
@@ -3696,10 +3696,8 @@ generateTestUnderMaskIfPossible(TR::Node * node, TR::CodeGenerator * cg, TR::Ins
             nonConstNode->getFirstChild()->getReferenceCount() == 1                          &&
             nonConstNode->getFirstChild()->getRegister() == NULL                             &&
             memRefNode != NULL                                                               &&
-            (nonConstNode->getFirstChild()->getOpCodeValue() == TR::buload ||
-             nonConstNode->getFirstChild()->getOpCodeValue() == TR::bload  ||
-             nonConstNode->getFirstChild()->getOpCodeValue() == TR::bloadi ||
-             nonConstNode->getFirstChild()->getOpCodeValue() == TR::buloadi    )                   )
+            (nonConstNode->getFirstChild()->getOpCodeValue() == TR::bload  ||
+             nonConstNode->getFirstChild()->getOpCodeValue() == TR::bloadi )                   )
       {
       TR::MemoryReference * tempMR2 = NULL;
       TR::MemoryReference * tempMR = generateS390MemoryReference(nonConstNode->getFirstChild(), cg);
@@ -6189,10 +6187,8 @@ OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    // If the only consumer is the bstore, then don't bother extending
    //
    else if (valueChild->getReferenceCount() == 1 && valueChild->getRegister() == NULL &&
-             (valueChild->getOpCodeValue() == TR::buload  ||
-              valueChild->getOpCodeValue() == TR::bload   ||
-              valueChild->getOpCodeValue() == TR::buloadi ||
-              valueChild->getOpCodeValue() == TR::buload      ))
+               (valueChild->getOpCodeValue() == TR::bload || 
+                valueChild->getOpCodeValue() == TR::bloadi     ))
       {
       sourceRegister = cg->allocateRegister();
       TR::MemoryReference * tempMR2 = generateS390MemoryReference(valueChild, cg);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -3056,9 +3056,9 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
    //            what about su2i? s2i? mixing of these? bytes? ints? longs?
    //
    else if (firstChild->getOpCodeValue()==TR::su2i && firstChild->getRegister()==NULL && firstChild->getReferenceCount()==1 &&
-            firstChild->getFirstChild()->getOpCodeValue()==TR::cloadi && firstChild->getFirstChild()->getRegister() &&
+            firstChild->getFirstChild()->getOpCodeValue()==TR::sloadi && firstChild->getFirstChild()->getRegister() &&
             secondChild->getOpCodeValue()==TR::su2i && secondChild->getRegister()==NULL && secondChild->getReferenceCount()==1 &&
-            secondChild->getFirstChild()->getOpCodeValue()==TR::cloadi && secondChild->getFirstChild()->getRegister())
+            secondChild->getFirstChild()->getOpCodeValue()==TR::sloadi && secondChild->getFirstChild()->getRegister())
       {
       if (branchTarget != NULL)
          {
@@ -5942,7 +5942,7 @@ OMR::Z::TreeEvaluator::lloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * sload Evaluator: load short integer
- *   - also handles cload, isload and icload
+ *   - also handles isload
  */
 TR::Register *
 OMR::Z::TreeEvaluator::sloadEvaluator(TR::Node * node, TR::CodeGenerator * cg)


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `load` category listed in #2657.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com