### PR TITLE
Remove references of deprecated Call/Return IL opcode

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -820,7 +820,6 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
                      pp.getIntegerReturnRegister());
          break;
       case TR::lcall:
-      case TR::lucall:
       case TR::acall:
          retReg = dependencies->searchPostConditionRegister(
                      pp.getLongReturnRegister());

--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -816,7 +816,6 @@ TR::Register *TR::ARM64SystemLinkage::buildDirectDispatch(TR::Node *callNode)
    switch(callNode->getOpCodeValue())
       {
       case TR::icall:
-      case TR::iucall:
          retReg = dependencies->searchPostConditionRegister(
                      pp.getIntegerReturnRegister());
          break;

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -52,7 +52,7 @@ OMR::ARM64::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::CodeGenerator *c
    return genericReturnEvaluator(node, cg->getProperties().getIntegerReturnRegister(), TR_GPR, TR_IntReturn, cg);
    }
 
-// also handles lureturn, areturn
+// also handles areturn
 TR::Register *
 OMR::ARM64::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -46,7 +46,6 @@ genericReturnEvaluator(TR::Node *node, TR::RealRegister::RegNum rnum, TR_Registe
    return NULL;
    }
 
-// also handles iureturn
 TR::Register *
 OMR::ARM64::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1213,7 +1213,6 @@ public:
       switch (ind)
          {
          case TR::icalli:    return TR::icall;
-         case TR::iucalli:   return TR::iucall;
          case TR::lcalli:    return TR::lcall;
          case TR::lucalli:   return TR::lucall;
          case TR::fcalli:    return TR::fcall;

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1214,7 +1214,6 @@ public:
          {
          case TR::icalli:    return TR::icall;
          case TR::lcalli:    return TR::lcall;
-         case TR::lucalli:   return TR::lucall;
          case TR::fcalli:    return TR::fcall;
          case TR::dcalli:    return TR::dcall;
          case TR::acalli:    return TR::acall;

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -857,7 +857,7 @@ TR::Register *OMR::Power::TreeEvaluator::gotoEvaluator(TR::Node *node, TR::CodeG
    return NULL;
    }
 
-// also handles areturn, iureturn
+// also handles areturn
 TR::Register *OMR::Power::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -872,8 +872,7 @@ TR::Register *OMR::Power::TreeEvaluator::ireturnEvaluator(TR::Node *node, TR::Co
    cg->decReferenceCount(node->getFirstChild());
    return NULL;
    }
-
-// also handles lureturn
+ 
 TR::Register *OMR::Power::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *returnRegister = cg->evaluate(node->getFirstChild());

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -1457,7 +1457,6 @@ TR::Register *TR::PPCSystemLinkage::buildDirectDispatch(TR::Node *callNode)
    switch(callNode->getOpCodeValue())
       {
       case TR::icall:
-      case TR::iucall:
       case TR::acall:
          returnRegister = dependencies->searchPostConditionRegister(
                              pp.getIntegerReturnRegister());
@@ -1590,7 +1589,6 @@ TR::Register *TR::PPCSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
    switch(callNode->getOpCodeValue())
       {
       case TR::icalli:
-      case TR::iucalli:
       case TR::acalli:
          returnRegister = dependencies->searchPostConditionRegister(
                              pp.getIntegerReturnRegister());

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -1462,7 +1462,6 @@ TR::Register *TR::PPCSystemLinkage::buildDirectDispatch(TR::Node *callNode)
                              pp.getIntegerReturnRegister());
          break;
       case TR::lcall:
-      case TR::lucall:
          {
          if (TR::Compiler->target.is64Bit())
             returnRegister = dependencies->searchPostConditionRegister(
@@ -1594,7 +1593,6 @@ TR::Register *TR::PPCSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
                              pp.getIntegerReturnRegister());
          break;
       case TR::lcalli:
-      case TR::lucalli:
          {
          if (TR::Compiler->target.is64Bit())
             returnRegister = dependencies->searchPostConditionRegister(

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -648,7 +648,7 @@ OMR::Z::TreeEvaluator::igotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * Handles all types of return opcodes
- * (return, areturn, ireturn, lreturn, freturn, dreturn, iureturn, lureturn, oreturn)
+ * (return, areturn, ireturn, lreturn, freturn, dreturn, lureturn, oreturn)
  */
 TR::Register *
 OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -700,12 +700,6 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          comp->setReturnInfo(TR_IntReturn);
          if (linkage->isNeedsWidening())
             new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LGFR, node, returnValRegister, returnValRegister, cg);
-         break;
-      case TR::iureturn:
-         comp->setReturnInfo(TR_IntReturn);
-         dependencies->addPostCondition(returnValRegister, linkage->getIntegerReturnRegister());
-         if (linkage->isNeedsWidening())
-            new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LLGFR, node, returnValRegister, returnValRegister, cg);
          break;
       case TR::lreturn:
       case TR::lureturn:

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -648,7 +648,7 @@ OMR::Z::TreeEvaluator::igotoEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
 /**
  * Handles all types of return opcodes
- * (return, areturn, ireturn, lreturn, freturn, dreturn, lureturn, oreturn)
+ * (return, areturn, ireturn, lreturn, freturn, dreturn, oreturn)
  */
 TR::Register *
 OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
@@ -702,7 +702,6 @@ OMR::Z::TreeEvaluator::returnEvaluator(TR::Node * node, TR::CodeGenerator * cg)
             new (cg->trHeapMemory()) TR::S390RRInstruction(TR::InstOpCode::LGFR, node, returnValRegister, returnValRegister, cg);
          break;
       case TR::lreturn:
-      case TR::lureturn:
          comp->setReturnInfo(TR_LongReturn);
 
          if (TR::Compiler->target.is64Bit())

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -382,8 +382,6 @@ TR::S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
          break;
       case TR::lcall:
       case TR::lcalli:
-      case TR::lucall:
-      case TR::lucalli:
          {
          if (TR::Compiler->target.is64Bit())
             {

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -376,8 +376,6 @@ TR::S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
       {
       case TR::icall:
       case TR::icalli:
-      case TR::iucall:
-      case TR::iucalli:
       case TR::acall:
       case TR::acalli:
          returnRegister = deps->searchPostConditionRegister(getIntegerReturnRegister());

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -335,9 +335,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
             }                                           //until it's known that dispatch functions can return non-64bit addresses.
          break;
       case TR::icall:
-      case TR::iucall:
       case TR::icalli:
-      case TR::iucalli:
          retReg = deps->searchPostConditionRegister(getIntegerReturnRegister());
          returnRegister = deps->searchPostConditionRegister(getIntegerReturnRegister());
          break;

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -340,9 +340,7 @@ TR::S390zOSSystemLinkage::callNativeFunction(TR::Node * callNode, TR::RegisterDe
          returnRegister = deps->searchPostConditionRegister(getIntegerReturnRegister());
          break;
       case TR::lcalli:
-      case TR::lucalli:
       case TR::lcall:
-      case TR::lucall:
          {
          if (TR::Compiler->target.is64Bit())
             {


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `Call/Return` category listed in #2657.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com