### PR TITLE
Remove references of deprecated  Add/Subtract IL opcodes

### DIFF
--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -70,7 +70,7 @@ static TR::Register *addConstantToInteger(TR::Node *node, TR::Register *srcReg, 
    return trgReg;
    }
 
-// Also handles TR::aiadd, TR::iuadd
+// Also handles TR::aiadd
 TR::Register *OMR::ARM::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *src1Reg = NULL;

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -70,7 +70,7 @@ static TR::Register *addConstantToInteger(TR::Node *node, TR::Register *srcReg, 
    return trgReg;
    }
 
-// Also handles TR::aiadd, TR::iuadd, aiuadd
+// Also handles TR::aiadd, TR::iuadd
 TR::Register *OMR::ARM::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *src1Reg = NULL;
@@ -93,7 +93,7 @@ TR::Register *OMR::ARM::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGen
       generateTrg1Src2Instruction(cg, ARMOp_add, node, trgReg, src1Reg, src2Reg);
       }
 
-   if ((node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aiuadd) &&
+   if (node->getOpCodeValue() == TR::aiadd &&
        node->isInternalPointer())
       {
       if (node->getPinningArrayPointer())

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -698,7 +698,6 @@ public:
       {
       switch(type)
          {
-         case TR::Int16:    return TR::cadd;
          case TR::Int32:    return TR::iuadd;
          case TR::Int64:    return TR::luadd;
 	 case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
@@ -732,7 +731,6 @@ public:
       {
       switch(type)
          {
-         case TR::Int16:   return TR::csub;
          case TR::Int32:   return TR::iusub;
          case TR::Int64:   return TR::lusub;
          default: TR_ASSERT(0, "no unsigned sub opcode for this datatype");
@@ -1293,7 +1291,6 @@ public:
          case TR::dstorei:
             return TR::vstorei;
          case TR::badd:
-         case TR::cadd:
          case TR::sadd:
          case TR::iadd:
          case TR::ladd:
@@ -1301,7 +1298,6 @@ public:
          case TR::dadd:
             return TR::vadd;
          case TR::bsub:
-         case TR::csub:
          case TR::ssub:
          case TR::isub:
          case TR::lsub:
@@ -1447,7 +1443,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<  double>() { ret
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   void*>() { return TR::aconst; }
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  int8_t>() { return TR::badd; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint16_t>() { return TR::cadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int16_t>() { return TR::sadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint32_t>() { return TR::iuadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int32_t>() { return TR::iadd; }
@@ -1457,7 +1452,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<   float>() { retur
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  double>() { return TR::dadd; }
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  int8_t>() { return TR::bsub; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint16_t>() { return TR::csub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int16_t>() { return TR::ssub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint32_t>() { return TR::iusub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int32_t>() { return TR::isub; }

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -362,7 +362,6 @@ public:
              getOpCodeValue() == TR::lsub      ||
              getOpCodeValue() == TR::iusubb    ||
              getOpCodeValue() == TR::asub      ||
-             getOpCodeValue() == TR::lusub     ||
              getOpCodeValue() == TR::lusubb;
       }
 
@@ -724,11 +723,9 @@ public:
 
    static TR::ILOpCodes unsignedSubtractOpCode(TR::DataType type)
       {
-      switch(type)
-         {
-         case TR::Int64:   return TR::lusub;
-         default: TR_ASSERT(0, "no unsigned sub opcode for this datatype");
-         }
+      //All unsigned sub opcode for this datatype should be deprecated
+      //TODO (#2657): Remove this function
+      TR_ASSERT(0, "no unsigned sub opcode for this datatype");
       return TR::BadILOp;
       }
 
@@ -1443,7 +1440,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  double>() { retur
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  int8_t>() { return TR::bsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int16_t>() { return TR::ssub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int32_t>() { return TR::isub; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint64_t>() { return TR::lusub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int64_t>() { return TR::lsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<   float>() { return TR::fsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  double>() { return TR::dsub; }
@@ -1460,7 +1456,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<  double>() { retur
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<  int8_t>() { return TR::bneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int16_t>() { return TR::sneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int32_t>() { return TR::ineg; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint64_t>() { return TR::luneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int64_t>() { return TR::lneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<   float>() { return TR::fneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<  double>() { return TR::dneg; }

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -356,7 +356,6 @@ public:
              getOpCodeValue() == TR::ladd      ||
              getOpCodeValue() == TR::iuaddc    ||
              getOpCodeValue() == TR::aiadd     ||
-             getOpCodeValue() == TR::luadd     ||
              getOpCodeValue() == TR::luaddc    ||
              getOpCodeValue() == TR::aladd     ||
              getOpCodeValue() == TR::isub      ||
@@ -696,8 +695,7 @@ public:
       {
       switch(type)
          {
-         case TR::Int64:    return TR::luadd;
-	 case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
+	      case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
          default: TR_ASSERT(0, "no add opcode for this datatype");
          }
       return TR::BadILOp;
@@ -1438,7 +1436,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   void*>() { ret
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  int8_t>() { return TR::badd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int16_t>() { return TR::sadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int32_t>() { return TR::iadd; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint64_t>() { return TR::luadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int64_t>() { return TR::ladd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<   float>() { return TR::fadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  double>() { return TR::dadd; }

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -698,7 +698,6 @@ public:
       {
       switch(type)
          {
-         case TR::Int8:     return TR::buadd;
          case TR::Int16:    return TR::cadd;
          case TR::Int32:    return TR::iuadd;
          case TR::Int64:    return TR::luadd;
@@ -733,7 +732,6 @@ public:
       {
       switch(type)
          {
-         case TR::Int8:    return TR::busub;
          case TR::Int16:   return TR::csub;
          case TR::Int32:   return TR::iusub;
          case TR::Int64:   return TR::lusub;
@@ -1448,7 +1446,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   float>() { ret
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<  double>() { return TR::dconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   void*>() { return TR::aconst; }
 
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< uint8_t>() { return TR::buadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  int8_t>() { return TR::badd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint16_t>() { return TR::cadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int16_t>() { return TR::sadd; }
@@ -1459,7 +1456,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int64_t>() { retur
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<   float>() { return TR::fadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  double>() { return TR::dadd; }
 
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< uint8_t>() { return TR::busub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  int8_t>() { return TR::bsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint16_t>() { return TR::csub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int16_t>() { return TR::ssub; }

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -279,9 +279,7 @@ public:
    bool hasPinningArrayPointer()
       {
       return (getOpCodeValue() == TR::aiadd)  ||
-             (getOpCodeValue() == TR::aladd)  ||
-             (getOpCodeValue() == TR::aiuadd) ||
-             (getOpCodeValue() == TR::aluadd);
+             (getOpCodeValue() == TR::aladd);
       }
 
    bool isLongCompare() const
@@ -359,11 +357,9 @@ public:
              getOpCodeValue() == TR::iuadd     ||
              getOpCodeValue() == TR::iuaddc    ||
              getOpCodeValue() == TR::aiadd     ||
-             getOpCodeValue() == TR::aiuadd    ||
              getOpCodeValue() == TR::luadd     ||
              getOpCodeValue() == TR::luaddc    ||
              getOpCodeValue() == TR::aladd     ||
-             getOpCodeValue() == TR::aluadd    ||
              getOpCodeValue() == TR::isub      ||
              getOpCodeValue() == TR::lsub      ||
              getOpCodeValue() == TR::iusub     ||

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -354,7 +354,6 @@ public:
              getOpCodeValue() == TR::iflucmpgt ||
              getOpCodeValue() == TR::iadd      ||
              getOpCodeValue() == TR::ladd      ||
-             getOpCodeValue() == TR::iuadd     ||
              getOpCodeValue() == TR::iuaddc    ||
              getOpCodeValue() == TR::aiadd     ||
              getOpCodeValue() == TR::luadd     ||
@@ -362,7 +361,6 @@ public:
              getOpCodeValue() == TR::aladd     ||
              getOpCodeValue() == TR::isub      ||
              getOpCodeValue() == TR::lsub      ||
-             getOpCodeValue() == TR::iusub     ||
              getOpCodeValue() == TR::iusubb    ||
              getOpCodeValue() == TR::asub      ||
              getOpCodeValue() == TR::lusub     ||
@@ -698,7 +696,6 @@ public:
       {
       switch(type)
          {
-         case TR::Int32:    return TR::iuadd;
          case TR::Int64:    return TR::luadd;
 	 case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
          default: TR_ASSERT(0, "no add opcode for this datatype");
@@ -731,7 +728,6 @@ public:
       {
       switch(type)
          {
-         case TR::Int32:   return TR::iusub;
          case TR::Int64:   return TR::lusub;
          default: TR_ASSERT(0, "no unsigned sub opcode for this datatype");
          }
@@ -913,15 +909,12 @@ public:
       switch (longOp)
          {
          case TR::ladd:   return TR::iadd;
-         case TR::luadd:  return TR::iuadd;
          case TR::lsub:   return TR::isub;
-         case TR::lusub:  return TR::iusub;
          case TR::lmul:   return TR::imul;
          case TR::ldiv:   return TR::idiv;
          case TR::lrem:   return TR::irem;
          case TR::labs:   return TR::iabs;
          case TR::lneg:   return TR::ineg;
-         case TR::luneg:  return TR::iuneg;
          case TR::lshr:   return TR::ishr;
          case TR::lushr:  return TR::iushr;
          case TR::lshl:   return TR::ishl;
@@ -1444,7 +1437,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   void*>() { ret
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  int8_t>() { return TR::badd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int16_t>() { return TR::sadd; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint32_t>() { return TR::iuadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int32_t>() { return TR::iadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint64_t>() { return TR::luadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int64_t>() { return TR::ladd; }
@@ -1453,7 +1445,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  double>() { retur
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  int8_t>() { return TR::bsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int16_t>() { return TR::ssub; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint32_t>() { return TR::iusub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int32_t>() { return TR::isub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint64_t>() { return TR::lusub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int64_t>() { return TR::lsub; }
@@ -1471,7 +1462,6 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<  double>() { retur
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<  int8_t>() { return TR::bneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int16_t>() { return TR::sneg; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint32_t>() { return TR::iuneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int32_t>() { return TR::ineg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint64_t>() { return TR::luneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int64_t>() { return TR::lneg; }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2066,7 +2066,7 @@ OMR::Node::isThisPointer()
  *        pairFirstChild
  *        pairSecondChild
  *
- * and the opcodes for highOp/adjunctOp are lumulh/lmul or lusubh/lusub.
+ * and the opcodes for highOp/adjunctOp are lumulh/lmul.
  */
 bool
 OMR::Node::isDualHigh()
@@ -2074,8 +2074,7 @@ OMR::Node::isDualHigh()
    if ((self()->getNumChildren() == 3) && self()->getChild(2))
       {
       TR::ILOpCodes pairOpValue = self()->getChild(2)->getOpCodeValue();
-      if (((self()->getOpCodeValue() == TR::lumulh) && (pairOpValue == TR::lmul))
-          || ((self()->getOpCodeValue() == TR::lusubh) && (pairOpValue == TR::lusub)))
+      if ((self()->getOpCodeValue() == TR::lumulh) && (pairOpValue == TR::lmul))
          return true;
       }
    return false;
@@ -2094,21 +2093,13 @@ OMR::Node::isDualHigh()
  *          pairFirstChild
  *          pairSecondChild
  *
- * and the opcodes for highOp/adjunctOp is lusubb/lusub.
+ * and the opcodes for highOp/adjunctOp are. (All the opcode pairs have been deprecated)
  */
 bool
 OMR::Node::isTernaryHigh()
    {
-   if (((self()->getOpCodeValue() == TR::luaddc) || (self()->getOpCodeValue() == TR::lusubb))
-       && (self()->getNumChildren() == 3) && self()->getChild(2)
-       && (self()->getChild(2)->getNumChildren() == 1) && self()->getChild(2)->getFirstChild())
-      {
-      TR::ILOpCodes ccOpValue = self()->getChild(2)->getOpCodeValue();
-      TR::ILOpCodes pairOpValue = self()->getChild(2)->getFirstChild()->getOpCodeValue();
-      if ((ccOpValue == TR::computeCC) &&
-          (self()->getOpCodeValue() == TR::lusubb) && (pairOpValue == TR::lusub))
-         return true;
-      }
+   //This function always returns false after removing deprecated unsigned IL opcodes
+   //TODO (#2657): could fold this function as false
    return false;
    }
 
@@ -8153,13 +8144,13 @@ OMR::Node::printCanSkipZeroInitialization()
 bool
 OMR::Node::isAdjunct()
    {
-   return (self()->getOpCodeValue() == TR::lmul || self()->getOpCodeValue() == TR::lusub) && _flags.testAny(adjunct);
+   return (self()->getOpCodeValue() == TR::lmul) && _flags.testAny(adjunct);
    }
 
 void
 OMR::Node::setIsAdjunct(bool v)
    {
-   TR_ASSERT(self()->getOpCodeValue() == TR::lmul || self()->getOpCodeValue() == TR::lusub, "Opcode must be lmul or lusub");
+   TR_ASSERT(self()->getOpCodeValue() == TR::lmul , "Opcode must be lmul");
    _flags.set(adjunct, v);
    }
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2392,7 +2392,7 @@ OMR::Node::isNotCollected()
  *
  * \note
  *    This query currently only works on opcodes that can have a pinning array pointer,
- *    i.e. aiadd, aiuadd, aladd, aluadd. Suppport for other opcodes can be added if necessary.
+ *    i.e. aiadd, aladd. Suppport for other opcodes can be added if necessary.
  */
 bool
 OMR::Node::computeIsInternalPointer()

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -2066,7 +2066,7 @@ OMR::Node::isThisPointer()
  *        pairFirstChild
  *        pairSecondChild
  *
- * and the opcodes for highOp/adjunctOp are lumulh/lmul, luaddh/luadd, or lusubh/lusub.
+ * and the opcodes for highOp/adjunctOp are lumulh/lmul or lusubh/lusub.
  */
 bool
 OMR::Node::isDualHigh()
@@ -2075,7 +2075,6 @@ OMR::Node::isDualHigh()
       {
       TR::ILOpCodes pairOpValue = self()->getChild(2)->getOpCodeValue();
       if (((self()->getOpCodeValue() == TR::lumulh) && (pairOpValue == TR::lmul))
-          || ((self()->getOpCodeValue() == TR::luaddh) && (pairOpValue == TR::luadd))
           || ((self()->getOpCodeValue() == TR::lusubh) && (pairOpValue == TR::lusub)))
          return true;
       }
@@ -2095,7 +2094,7 @@ OMR::Node::isDualHigh()
  *          pairFirstChild
  *          pairSecondChild
  *
- * and the opcodes for highOp/adjunctOp are luaddc/luadd, or lusubb/lusub.
+ * and the opcodes for highOp/adjunctOp is lusubb/lusub.
  */
 bool
 OMR::Node::isTernaryHigh()
@@ -2107,8 +2106,7 @@ OMR::Node::isTernaryHigh()
       TR::ILOpCodes ccOpValue = self()->getChild(2)->getOpCodeValue();
       TR::ILOpCodes pairOpValue = self()->getChild(2)->getFirstChild()->getOpCodeValue();
       if ((ccOpValue == TR::computeCC) &&
-          (((self()->getOpCodeValue() == TR::luaddc) && (pairOpValue == TR::luadd))
-           || ((self()->getOpCodeValue() == TR::lusubb) && (pairOpValue == TR::lusub))))
+          (self()->getOpCodeValue() == TR::lusubb) && (pairOpValue == TR::lusub))
          return true;
       }
    return false;
@@ -8155,13 +8153,13 @@ OMR::Node::printCanSkipZeroInitialization()
 bool
 OMR::Node::isAdjunct()
    {
-   return (self()->getOpCodeValue() == TR::lmul || self()->getOpCodeValue() == TR::luadd || self()->getOpCodeValue() == TR::lusub) && _flags.testAny(adjunct);
+   return (self()->getOpCodeValue() == TR::lmul || self()->getOpCodeValue() == TR::lusub) && _flags.testAny(adjunct);
    }
 
 void
 OMR::Node::setIsAdjunct(bool v)
    {
-   TR_ASSERT(self()->getOpCodeValue() == TR::lmul || self()->getOpCodeValue() == TR::luadd || self()->getOpCodeValue() == TR::lusub, "Opcode must be lmul, lusub, or luadd");
+   TR_ASSERT(self()->getOpCodeValue() == TR::lmul || self()->getOpCodeValue() == TR::lusub, "Opcode must be lmul or lusub");
    _flags.set(adjunct, v);
    }
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -436,7 +436,7 @@ public:
    ///         pairFirstChild
    ///         pairSecondChild
    ///
-   /// and the opcodes for highOp/adjunctOp are lumulh/lmul, luaddh/luadd, or lusubh/lusub.
+   /// and the opcodes for highOp/adjunctOp are lumulh/lmul, or lusubh/lusub.
    ///
    bool                   isDualHigh();
 
@@ -452,7 +452,7 @@ public:
    ///           pairFirstChild
    ///           pairSecondChild
    ///
-   /// and the opcodes for highOp/adjunctOp are luaddc/luadd, or lusubb/lusub.
+   /// and the opcodes for highOp/adjunctOp is lusubb/lusub.
    ///
    bool                   isTernaryHigh();
 
@@ -2053,7 +2053,7 @@ protected:
       allocationCanBeRemoved                = 0x00004000,
       skipZeroInit                          = 0x00008000,
 
-      // Flag used by TR::lmul (possibly TR::luadd, TR::lusub)
+      // Flag used by TR::lmul (possibly TR::lusub)
       // Whether this node is the adjunct node of a dual high node
       adjunct                               = 0x00010000,
 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -436,7 +436,7 @@ public:
    ///         pairFirstChild
    ///         pairSecondChild
    ///
-   /// and the opcodes for highOp/adjunctOp are lumulh/lmul, or lusubh/lusub.
+   /// and the opcodes for highOp/adjunctOp are lumulh/lmul.
    ///
    bool                   isDualHigh();
 
@@ -452,7 +452,7 @@ public:
    ///           pairFirstChild
    ///           pairSecondChild
    ///
-   /// and the opcodes for highOp/adjunctOp is lusubb/lusub.
+   /// and the opcodes for highOp/adjunctOp are. (All the opcode pairs have been deprecated)
    ///
    bool                   isTernaryHigh();
 
@@ -2053,7 +2053,7 @@ protected:
       allocationCanBeRemoved                = 0x00004000,
       skipZeroInit                          = 0x00008000,
 
-      // Flag used by TR::lmul (possibly TR::lusub)
+      // Flag used by TR::lmul
       // Whether this node is the adjunct node of a dual high node
       adjunct                               = 0x00010000,
 

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -3895,8 +3895,8 @@ TR_GeneralLoopUnroller::countNodesAndSubscripts(TR::Node *node, int32_t &numNode
    if (node->getOpCodeValue() != TR::treetop)
       numNodes++;
 
-   if (node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aiuadd ||
-       node->getOpCodeValue() == TR::aladd || node->getOpCodeValue() == TR::aluadd)
+   if (node->getOpCodeValue() == TR::aiadd ||
+       node->getOpCodeValue() == TR::aladd)
       {
       // TODO: make this more intelligent -- check if the subscript indexes
       // an induction variable

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1623,8 +1623,6 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
       case TR::land: newOp = TR::iand; break;
       case TR::lor:  newOp = TR::ior;  break;
       case TR::lxor: newOp = TR::ixor; break;
-      case TR::luadd: newOp = TR::iuadd; isUnsigned = true; break;
-      case TR::lusub: newOp = TR::iusub; isUnsigned = true; break;
       case TR::lushr:
          isUnsigned = true;
       case TR::lshr:
@@ -1685,14 +1683,14 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
             return false;
          if (newConversionOp == TR::BadILOp)
             {
-            TR::Node::recreate(node, isUnsigned ? TR::iuneg : TR::ineg);
+            TR::Node::recreate(node, TR::ineg);
             TR::Node::recreate(firstChild, TR::l2i);
             }
          else
             {
             TR::Node * temp = TR::Node::create(TR::l2i, 1, firstChild->getFirstChild());
             firstChild->getFirstChild()->decReferenceCount();
-            TR::Node::recreate(firstChild, isUnsigned ? TR::iuneg : TR::ineg);
+            TR::Node::recreate(firstChild, TR::ineg);
             firstChild->setAndIncChild(0, temp);
             TR::Node::recreate(node, newConversionOp);
             }

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1677,7 +1677,6 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
             }
       break;
       case TR::lneg:
-      case TR::luneg:
          {
          if (!performTransformation(s->comp(), "%sReducing long operation in node [" POINTER_PRINTF_FORMAT "] to an int operation\n", s->optDetailString(), node))
             return false;

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -198,7 +198,7 @@ static bool genNullTestForCompressedPointers(TR::Node *node,
    return false;
    }
 
-// Also handles TR::aiadd, TR::iuadd
+// Also handles TR::aiadd
 TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *src1Reg = NULL;
@@ -633,7 +633,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
 
 
 // aiaddEvaluator handled by iaddEvaluator
-// also handles TR::iusub and TR::asub
+// also handles TR::asub
 TR::Register *OMR::Power::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node     *secondChild    = node->getSecondChild();

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -441,7 +441,7 @@ static TR::Register *laddEvaluatorWithAnalyser(TR::Node *node, TR::CodeGenerator
    return trgReg;
    }
 
-// Also handles TR::aladd for 64 bit target, luadd
+// Also handles TR::aladd for 64 bit target
 TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *firstChild = node->getFirstChild();
@@ -559,7 +559,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
 
             if (setsOrReadsCC)
                {
-               TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luadd || node->getOpCodeValue() == TR::luaddc,
+               TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luaddc,
                   "CC computation not supported for this node %p\n", node);
                TR::Register *carryReg = NULL;
                if ((node->getOpCodeValue() == TR::luaddc) && TR_PPCComputeCC::setCarryBorrow(node->getChild(2), false, &carryReg, cg))

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -198,7 +198,7 @@ static bool genNullTestForCompressedPointers(TR::Node *node,
    return false;
    }
 
-// Also handles TR::aiadd, TR::iuadd, aiuadd
+// Also handles TR::aiadd, TR::iuadd
 TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *src1Reg = NULL;
@@ -239,7 +239,7 @@ TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeG
          }
      }
 
-   if ((node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aiuadd) &&
+   if (node->getOpCodeValue() == TR::aiadd &&
        node->isInternalPointer())
       {
       if (node->getPinningArrayPointer())
@@ -441,7 +441,7 @@ static TR::Register *laddEvaluatorWithAnalyser(TR::Node *node, TR::CodeGenerator
    return trgReg;
    }
 
-// Also handles TR::aladd for 64 bit target, luadd, aluadd
+// Also handles TR::aladd for 64 bit target, luadd
 TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *firstChild = node->getFirstChild();
@@ -591,7 +591,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
          generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneSkipAdd, deps);
          }
 
-      if ((node->getOpCodeValue() == TR::aladd || node->getOpCodeValue() == TR::aluadd) &&
+      if (node->getOpCodeValue() == TR::aladd &&
           node->isInternalPointer())
          {
          if (node->getPinningArrayPointer())

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -814,7 +814,7 @@ TR::Register *lsub64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
 
             if (setsOrReadsCC)
                {
-               TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusub || node->getOpCodeValue() == TR::lusubb,
+               TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusubb,
                   "CC computation not supported for this node %p\n", node);
                TR::Register *borrowReg = NULL;
                if ((node->getOpCodeValue() == TR::lusubb) && TR_PPCComputeCC::setCarryBorrow(node->getChild(2), true, &borrowReg, cg))
@@ -840,8 +840,7 @@ TR::Register *lsub64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    cg->decReferenceCount(secondChild);
    return trgReg;
    }
-
-// also handles lusub
+ 
 TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -1500,7 +1500,7 @@ TR::Register *OMR::X86::TreeEvaluator::bsubEvaluator(TR::Node *node, TR::CodeGen
 
    if (NEED_CC(node))
       {
-      TR_ASSERT(node->getOpCodeValue() == TR::bsub || node->getOpCodeValue() == TR::busub,
+      TR_ASSERT(node->getOpCodeValue() == TR::bsub,
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(node->getOpCode()));
 
       // we need eflags from integerAddAnalyser for the CC sequence

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -591,8 +591,7 @@ static void evaluateIfNotConst(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *OMR::X86::TreeEvaluator::integerDualAddOrSubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR_ASSERT((node->getOpCodeValue() == TR::luaddh) || (node->getOpCodeValue() == TR::lusubh) 
-      || (node->getOpCodeValue() == TR::lusub)
-      , "Unexpected dual operator. Expected luaddh, lusub, or lusubh as part of cyclic dual.");
+      , "Unexpected dual operator. Expected luaddh or lusubh as part of cyclic dual.");
 
    TR::Node *pair = node->getChild(2);
    bool requiresCarryOnEntry = cg->requiresCarry();
@@ -1346,7 +1345,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerSubEvaluator(TR::Node *node, TR::C
 
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::lusubb) || (node->getOpCodeValue() == TR::iusubb))
       {
-      TR_ASSERT((nodeIs64Bit  && (opCode == TR::lsub || opCode == TR::lusub) || opCode == TR::lusubb) ||
+      TR_ASSERT((nodeIs64Bit  && opCode == TR::lsub || opCode == TR::lusubb) ||
                 (!nodeIs64Bit && opCode == TR::isub || opCode == TR::iusubb),
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(opCode));
 

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -590,9 +590,9 @@ static void evaluateIfNotConst(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register *OMR::X86::TreeEvaluator::integerDualAddOrSubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT((node->getOpCodeValue() == TR::luaddh) || (node->getOpCodeValue() == TR::luadd)
-      || (node->getOpCodeValue() == TR::lusubh) || (node->getOpCodeValue() == TR::lusub)
-      , "Unexpected dual operator. Expected luadd, luaddh, lusub, or lusubh as part of cyclic dual.");
+   TR_ASSERT((node->getOpCodeValue() == TR::luaddh) || (node->getOpCodeValue() == TR::lusubh) 
+      || (node->getOpCodeValue() == TR::lusub)
+      , "Unexpected dual operator. Expected luaddh, lusub, or lusubh as part of cyclic dual.");
 
    TR::Node *pair = node->getChild(2);
    bool requiresCarryOnEntry = cg->requiresCarry();
@@ -707,7 +707,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
 
    if (NEED_CC(node) || (opCode == TR::luaddc) || (opCode == TR::iuaddc))
       {
-      TR_ASSERT((nodeIs64Bit  && (opCode == TR::ladd || opCode == TR::luadd) || opCode == TR::luaddc) ||
+      TR_ASSERT((nodeIs64Bit  && opCode == TR::ladd || opCode == TR::luaddc) ||
                 (!nodeIs64Bit && opCode == TR::iadd  || opCode == TR::iuaddc),
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(opCode));
 

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -708,7 +708,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
    if (NEED_CC(node) || (opCode == TR::luaddc) || (opCode == TR::iuaddc))
       {
       TR_ASSERT((nodeIs64Bit  && (opCode == TR::ladd || opCode == TR::luadd) || opCode == TR::luaddc) ||
-                (!nodeIs64Bit && (opCode == TR::iadd || opCode == TR::iuadd) || opCode == TR::iuaddc),
+                (!nodeIs64Bit && opCode == TR::iadd  || opCode == TR::iuaddc),
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(opCode));
 
       // we need eflags from integerAddAnalyser for the CC sequence
@@ -1347,7 +1347,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerSubEvaluator(TR::Node *node, TR::C
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::lusubb) || (node->getOpCodeValue() == TR::iusubb))
       {
       TR_ASSERT((nodeIs64Bit  && (opCode == TR::lsub || opCode == TR::lusub) || opCode == TR::lusubb) ||
-                (!nodeIs64Bit && (opCode == TR::isub || opCode == TR::iusub) || opCode == TR::iusubb),
+                (!nodeIs64Bit && opCode == TR::isub || opCode == TR::iusubb),
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(opCode));
 
       const bool isWithBorrow = (opCode == TR::lusubb) || (opCode == TR::iusubb);

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -1748,7 +1748,7 @@ TR::Register *OMR::X86::TreeEvaluator::csubEvaluator(TR::Node *node, TR::CodeGen
 
    if (NEED_CC(node))
       {
-      TR_ASSERT(node->getOpCodeValue() == TR::csub,
+      TR_ASSERT(false,
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(node->getOpCode()));
 
       // we need eflags from integerAddAnalyser for the CC sequence

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -333,7 +333,7 @@ laddHelper64(TR::Node * node, TR::CodeGenerator * cg)
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::luaddc))
       {
       TR_ASSERT( !isCompressionSequence, "CC computation not supported with compression sequence.\n");
-      TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luadd || node->getOpCodeValue() == TR::luaddc,
+      TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luaddc,
               "CC computation not supported for this node %p\n", node);
 
       // we need the carry from integerAddAnalyser for the CC sequence, thus we use logical add instead of add

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -1937,7 +1937,7 @@ lsubHelper64(TR::Node * node, TR::CodeGenerator * cg)
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::lusubb))
       {
       TR_ASSERT( !isCompressionSequence,"CC computation not supported with compression sequence.\n");
-      TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusub || node->getOpCodeValue() == TR::lusubb,
+      TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusubb,
               "CC computation not supported for this node %p\n", node);
 
       // we need the borrow from longSubtractAnalyser for the CC sequence,

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1308,7 +1308,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
       {
       self()->populateMemoryReference(addressChild, cg);
       if ((subTree->getOpCodeValue() != TR::iadd) && (subTree->getOpCodeValue() != TR::aiadd) &&
-          (subTree->getOpCodeValue() != TR::iuadd) && (subTree->getOpCodeValue() != TR::aiuadd) &&
+          (subTree->getOpCodeValue() != TR::iuadd) &&
           (subTree->getOpCodeValue() != TR::isub))
          {
          if (subTree->getOpCode().isSub())
@@ -3367,8 +3367,8 @@ static TR::SymbolReference * findBestSymRefForArrayCopy(TR::CodeGenerator *cg, T
    TR::SymbolReference *sym = arrayCopyNode->getSymbolReference();
    TR::Compilation *comp = cg->comp();
 
-   if (srcNode->getOpCodeValue()==TR::aiadd || srcNode->getOpCodeValue()==TR::aiuadd ||
-       srcNode->getOpCodeValue()==TR::aladd || srcNode->getOpCodeValue()==TR::aluadd ||
+   if (srcNode->getOpCodeValue()==TR::aiadd ||
+       srcNode->getOpCodeValue()==TR::aladd ||
        srcNode->getOpCodeValue()==TR::asub)
       {
       TR::Node *firstChild = srcNode->getFirstChild();

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1308,7 +1308,6 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
       {
       self()->populateMemoryReference(addressChild, cg);
       if ((subTree->getOpCodeValue() != TR::iadd) && (subTree->getOpCodeValue() != TR::aiadd) &&
-          (subTree->getOpCodeValue() != TR::iuadd) &&
           (subTree->getOpCodeValue() != TR::isub))
          {
          if (subTree->getOpCode().isSub())


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `Add/Subtract` category listed in #2657.

Note:

- Function `bool OMR::Node::isTernaryHigh()` will always return `false` after removing these unsigned opcodes. Therefore, should fold this function in the future. But be CAUTION that this function is also referenced in the OpenJ9.

- Function `static TR::ILOpCodes unsignedSubtractOpCode(TR::DataType type)` should also be removed as all unsigned sub opcode for this datatype should have been deprecated

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com