### PR TITLE
Fix omrcpu.c assembler helpers for AIX xlC 16

### DIFF
--- a/port/unix/omrcpu.c
+++ b/port/unix/omrcpu.c
@@ -44,7 +44,7 @@
 #include <sys/sysctl.h>
 #endif
 
-#if (__IBMC__ || __IBMCPP__)
+#if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 void dcbf(unsigned char *);
 void dcbst(unsigned char *);
 void icbi(unsigned char *);
@@ -92,9 +92,9 @@ omrcpu_startup(struct OMRPortLibrary *portLibrary)
 	char buf[1024];
 	memset(buf, 255, 1024);
 
-#if (__IBMC__ || __IBMCPP__)
+#if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 	dcbz((void *) &buf[512]);
-#elif defined(LINUX) || defined(OSX)
+#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
 	__asm__(
 		"dcbz 0, %0"
 		: /* no outputs */
@@ -153,9 +153,9 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 	for (addr = (unsigned char *)memoryPointer ; addr < limit; addr += cacheLineSize) {
 
 
-#if (__IBMC__ || __IBMCPP__)
+#if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 		dcbst(addr);
-#elif defined(LINUX) || defined(OSX)
+#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
 		__asm__(
 			"dcbst 0,%0"
 			: /* no outputs */
@@ -163,18 +163,18 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 #endif
 	}
 
-#if (__IBMC__ || __IBMCPP__)
+#if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 	sync();
-#elif defined(LINUX) || defined(OSX)
+#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
 	__asm__("sync");
 #endif
 
 	/* for each cache line  do an icache block invalidate */
 	for (addr = (unsigned char *)memoryPointer; addr < limit; addr += cacheLineSize) {
 
-#if (__IBMC__ || __IBMCPP__)
+#if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 		icbi(addr);
-#elif defined(LINUX) || defined(OSX)
+#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
 		__asm__(
 			"icbi 0,%0"
 			: /* no outputs */
@@ -182,10 +182,10 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 #endif
 	}
 
-#if (__IBMC__ || __IBMCPP__)
+#if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 	sync();
 	isync();
-#elif defined(LINUX) || defined(OSX)
+#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
 	__asm__("sync");
 	__asm__("isync");
 #endif


### PR DESCRIPTION
Fix the following ld problems.
```
12:09:23  ld: 0711-318 ERROR: Undefined symbols were found.
12:09:23  	The following symbols are in error:
12:09:23   Symbol                    Inpndx  TY CL Source-File(Object-File) OR Import-File{Shared-object}
12:09:23                                RLD: Address  Section  Rld-type Referencing Symbol
12:09:23   ----------------------------------------------------------------------------------------------
12:09:23   .dcbz                     [497]   ER PR ./unix/omrcpu.c(../../../../lib/libomrstatic.a[omrcpu.o])
12:09:23                                     00000220 .text    R_RBR    [431]   .omrcpu_startup
12:09:23   .dcbst                    [499]   ER PR ./unix/omrcpu.c(../../../../lib/libomrstatic.a[omrcpu.o])
12:09:23                                     00000520 .text    R_RBR    [453]   .omrcpu_flush_icache
12:09:23   .icbi                     [503]   ER PR ./unix/omrcpu.c(../../../../lib/libomrstatic.a[omrcpu.o])
12:09:23                                     00000580 .text    R_RBR    [453]   .omrcpu_flush_icache
12:09:23   .isync                    [505]   ER PR ./unix/omrcpu.c(../../../../lib/libomrstatic.a[omrcpu.o])
12:09:23                                     000005b0 .text    R_RBR    [453]   .omrcpu_flush_icache
12:09:23  ER: The return code is 8.
```

See also #4087