### PR TITLE
Recognize the rdbar op code in NullChk evaluator

### DIFF
--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -2275,7 +2275,8 @@ TR::Register *OMR::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node
                reference->setIsNonNull(true);
                n = reference->getFirstChild();
                TR::ILOpCodes loadOp = comp->il.opCodeForIndirectLoad(TR::Int32);
-               while (n->getOpCodeValue() != loadOp)
+               TR::ILOpCodes rdbarOp = comp->il.opCodeForIndirectReadBarrier(TR::Int32);
+               while (n->getOpCodeValue() != loadOp && n->getOpCodeValue() != rdbarOp)
                   {
                   n->setIsNonZero(true);
                   n = n->getFirstChild();


### PR DESCRIPTION
The nullChkWithPossibleResolve evaluator has a special case for compressed references. The node to be checked is not the iloadi itself and is instead its child. When fieldwatch is enabled, the iloadi is transformed into an irdbari. Therefore, in those cases the NullChk evaluator must try to find the child of the irdbari node instead of trying to find the iloadi node.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>