### PR TITLE
Remove ARM32 resolveCHKEvaluator()

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1615,18 +1615,6 @@ TR::Register *OMR::ARM::TreeEvaluator::resolveAndNULLCHKEvaluator(TR::Node *node
    return evaluateNULLCHKWithPossibleResolve(node, true, cg);
    }
 
-TR::Register *OMR::ARM::TreeEvaluator::resolveCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   // No code is generated for the resolve check. The child will reference an
-   // unresolved symbol and all check handling is done via the corresponding
-   // snippet.
-   //
-   TR::Node *firstChild = node->getFirstChild();
-   cg->evaluate(firstChild);
-   firstChild->decReferenceCount();
-   return NULL;
-   }
-
 TR::Register *OMR::ARM::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *secondChild = node->getFirstChild()->getSecondChild();

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -377,7 +377,6 @@ public:
    static TR::Register *NULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *ZEROCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *resolveAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *resolveCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *DIVCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *aRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *iRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -779,7 +779,7 @@
    TR::TreeEvaluator::exceptionRangeFenceEvaluator,       // TR::exceptionRangeFence
    TR::TreeEvaluator::exceptionRangeFenceEvaluator,       // TR::dbgFence
    TR::TreeEvaluator::NULLCHKEvaluator,     // TR::NULLCHK
-   TR::TreeEvaluator::resolveCHKEvaluator,  // TR::ResolveCHK
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::ResolveCHK
    TR::TreeEvaluator::resolveAndNULLCHKEvaluator, // TR::ResolveAndNULLCHK
    TR::TreeEvaluator::DIVCHKEvaluator,      // TR::DIVCHK
    TR::TreeEvaluator::badILOpEvaluator,      // TR::OverflowCHK


### PR DESCRIPTION
This commit removes resolveCHKEvaluator() for ARM32, and uses the
function in the OpenJ9 side.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>