### PR TITLE
Add DSB instruction to AArch64 opcode tables

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -440,3 +440,15 @@ uint8_t *TR::ARM64Src2Instruction::generateBinaryEncoding()
    setBinaryEncoding(instructionStart);
    return cursor;
    }
+
+uint8_t *TR::ARM64SynchronizationInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertImmediateField(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -88,6 +88,7 @@ static const char *opCodeToNameMap[] =
    "tbnz",
    "b_cond",
    "brkarm64",
+   "dsb",
    "br",
    "blr",
    "ret",

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2629,6 +2629,72 @@ class ARM64Src2Instruction : public ARM64Src1Instruction
    virtual uint8_t *generateBinaryEncoding();
    };
 
+class ARM64SynchronizationInstruction : public TR::Instruction
+   {
+   uint32_t _sourceImmediate;
+
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] imm : immediate value
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+                                    uint32_t imm, TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, cg), _sourceImmediate(imm)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] imm : immediate value
+    * @param[in] preced : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, 
+                                    uint32_t imm, TR::Instruction *precedingInstruction, 
+                                    TR::CodeGenerator *cg)
+      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsSynchronization; }
+
+   /**
+    * @brief Gets source immediate
+    * @return source immediate
+    */
+   uint32_t getSourceImmediate() {return _sourceImmediate;}
+   
+   /**
+    * @brief Sets source immediate
+    * @param[in] si : immediate value
+    * @return source immediate
+    */
+   uint32_t setSourceImmediate(uint32_t si) {return (_sourceImmediate = si);}
+
+   void insertImmediateField(uint32_t *instruction)
+      {
+      TR_ASSERT(_sourceImmediate <= 0xF, "Immediate value exceeds 4 bits.");
+      *instruction |= ((_sourceImmediate & 0xF) << 8);
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
 } // TR
 
 #endif

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -468,3 +468,11 @@ TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node,
       return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), preced, cg);
    return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), cg);
    }
+
+TR::Instruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+   TR::Node *node, uint32_t imm, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64SynchronizationInstruction(op, node, imm, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64SynchronizationInstruction(op, node, imm, cg);
+   }

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -771,4 +771,20 @@ TR::Instruction *generateCSetInstruction(
                   TR::ARM64ConditionCode cc,
                   TR::Instruction *preced = NULL);
 
+/*
+ * @brief Generates data synchronization instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] imm : immediate value
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateSynchronizationInstruction(
+                  TR::CodeGenerator *cg,
+                  TR::InstOpCode::Mnemonic op,
+                  TR::Node *node,
+                  uint32_t imm,
+                  TR::Instruction *preced = NULL);
+
 #endif

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -24,7 +24,7 @@
  * definitions are permitted.
  */
 
-//		Opcode                                                         BINARY    	OPCODE    	comments
+//		Opcode                                                          BINARY    	OPCODE    	comments
 /* UNALLOCATED */
 		bad,                                                    	/* 0x00000000	BAD       	invalid operation */
 /* Branch,exception generation and system Instruction */
@@ -41,6 +41,7 @@
 	/* Exception generation */
 		brkarm64,                                               	/* 0xD4200000	BRK       	AArch64 Specific BRK */
 	/* System */
+		dsb,                                                    	/* 0xD503309F	DSB       	 */
 	/* Unconditional branch (register) */
 		br,                                                     	/* 0xD61F0000	BR        	 */
 		blr,                                                    	/* 0xD63F0000	BLR       	 */

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -47,3 +47,4 @@
       IsMemSrc1,
    IsSrc1,
       IsSrc2,
+   IsSynchronization,

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -23,7 +23,7 @@
 
 const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEncodings[ARM64NumOpCodes] =
 {
-//		BINARY			Opcode    	Opcode		comments
+//		BINARY    		Opcode    	Opcode		comments
 /* UNALLOCATED */
 		0x00000000,	/* BAD       	bad	invalid operation */
 /* Branch,exception generation and system Instruction */
@@ -40,6 +40,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 	/* Exception generation */
 		0xD4200000,	/* BRK       	brkarm64	AArch64 Specific BRK */
 	/* System */
+		0xD503309F,	/* DSB       	dsb	 */
 	/* Unconditional branch (register) */
 		0xD61F0000,	/* BR        	br	 */
 		0xD63F0000,	/* BLR       	blr	 */


### PR DESCRIPTION
This PR adds DSB to the opcode tables in AArch64, as it is
needed in OpenJ9.

Signed-off-by: Hillary Soontiens <hsoontie@unb.ca>