### PR TITLE
Remove references of deprecated Store IL Opcode

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -549,7 +549,7 @@ OMR::ARM64::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg
    return commonStoreEvaluator(node, TR::InstOpCode::strbimm, cg);
    }
 
-// also handles sstorei, cstore, cstorei
+// also handles sstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -703,7 +703,7 @@ TR::Register *OMR::ARM::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeG
    return commonStoreEvaluator(node, ARMOp_strb, 1, cg);
    }
 
-// also handles isstore, icstore, cstore,isstore,icstore
+// also handles isstore, icstore,isstore,icstore
 TR::Register *OMR::ARM::TreeEvaluator::sstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return commonStoreEvaluator(node, ARMOp_strh, 2, cg);

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -1,5 +1,9 @@
 /*******************************************************************************
+<<<<<<< HEAD
  * Copyright (c) 2000, 2020 IBM Corp. and others
+=======
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+>>>>>>> e74336a0f... Remove references of IL opcode TR::bustore and TR::bustorei
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -630,7 +634,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
       case TR::cstorei:  return TR::sloadi;
-      case TR::bustorei: return TR::bloadi;
       case TR::iustore:  return TR::iload;
       case TR::iustorei: return TR::iloadi;
       case TR::lustorei: return TR::lloadi;

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -1,9 +1,5 @@
 /*******************************************************************************
-<<<<<<< HEAD
  * Copyright (c) 2000, 2020 IBM Corp. and others
-=======
- * Copyright (c) 2000, 2019 IBM Corp. and others
->>>>>>> e74336a0f... Remove references of IL opcode TR::bustore and TR::bustorei
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -633,7 +629,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::astorei:  return TR::aloadi;
       case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
-      case TR::cstorei:  return TR::sloadi;
       case TR::iustore:  return TR::iload;
       case TR::iustorei: return TR::iloadi;
       case TR::lustorei: return TR::lloadi;

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -629,7 +629,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::astorei:  return TR::aloadi;
       case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
-      case TR::lustorei: return TR::lloadi;
       case TR::bwrtbari:
       case TR::swrtbari:
       case TR::iwrtbari:

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -629,7 +629,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::astorei:  return TR::aloadi;
       case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
-      case TR::iustore:  return TR::iload;
       case TR::iustorei: return TR::iloadi;
       case TR::lustorei: return TR::lloadi;
       case TR::bwrtbari:

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -629,7 +629,6 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::astorei:  return TR::aloadi;
       case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
-      case TR::iustorei: return TR::iloadi;
       case TR::lustorei: return TR::lloadi;
       case TR::bwrtbari:
       case TR::swrtbari:

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1275,7 +1275,6 @@ public:
          case TR::dloadi:
             return TR::vloadi;
          case TR::bstore:
-         case TR::cstore:
          case TR::sstore:
          case TR::istore:
          case TR::lstore:
@@ -1283,7 +1282,6 @@ public:
          case TR::dstore:
             return TR::vstore;
          case TR::bstorei:
-         case TR::cstorei:
          case TR::sstorei:
          case TR::istorei:
          case TR::lstorei:

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -357,7 +357,7 @@ TR_Arraycopy::checkArrayStore(TR::Node * storeNode)
 bool
 TR_ByteToCharArraycopy::checkArrayStore(TR::Node * storeNode)
    {
-   if (storeNode->getOpCodeValue() != TR::cstorei)
+   if (storeNode->getOpCodeValue() != TR::sstorei)
       {
       dumpOptDetails(comp(), "byte to char arraycopy arraystore tree does not have an indirect store as root\n");
       return false;
@@ -1694,7 +1694,7 @@ TR_Arraytranslate::checkLoad(TR::Node * loadNode)
 bool
 TR_Arraytranslate::checkStore(TR::Node * storeNode)
    {
-   if (storeNode->getOpCodeValue() != TR::cstorei && storeNode->getOpCodeValue() != TR::bstorei)
+   if (storeNode->getOpCodeValue() != TR::sstorei && storeNode->getOpCodeValue() != TR::bstorei)
       {
       dumpOptDetails(comp(), "...store tree does not have icstore/ibstore - no arraytranslate reduction\n");
       return false;
@@ -1750,7 +1750,7 @@ TR_Arraytranslate::checkStore(TR::Node * storeNode)
       }
    else
       {
-      if (storeNode->getOpCodeValue() == TR::cstorei)
+      if (storeNode->getOpCodeValue() == TR::sstorei)
          {
          _byteOutput = false;
          }

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2907,7 +2907,7 @@ TR::Node *constrainStore(OMR::ValuePropagation *vp, TR::Node *node)
    return node;
    }
 
-// Handles istore, bstore, cstore, sstore
+// Handles istore, bstore, sstore
 //
 TR::Node *constrainIntStore(OMR::ValuePropagation *vp, TR::Node *node)
    {

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1077,7 +1077,7 @@ TR::Register *OMR::Power::TreeEvaluator::astoreEvaluator(TR::Node *node, TR::Cod
    }
 
 
-// also handles ilstore, lustore, ilustore
+// also handles ilstore, ilustore
 TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1346,7 +1346,7 @@ TR::Register *OMR::Power::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::Cod
    return NULL;
    }
 
-// also handles ibstore, bustore, ibustore
+// also handles ibstore, ibustore
 TR::Register *OMR::Power::TreeEvaluator::bstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::MemoryReference *tempMR;


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `Store` category listed in #2657.

Did not remove the reference of `TR:iustore` in `DebuggingCounters.cpp` as
the opcode is used in a function argument. Will investigate on this
in the future.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com