### PR TITLE
CMake: Add omr_process_template utility function

### DIFF
--- a/cmake/modules/platform/toolcfg/msvc.cmake
+++ b/cmake/modules/platform/toolcfg/msvc.cmake
@@ -116,9 +116,10 @@ function(_omr_toolchain_process_exports TARGET_NAME)
 
 	set(def_file "$<TARGET_PROPERTY:${TARGET_NAME},BINARY_DIR>/${TARGET_NAME}.def")
 
-	file(READ "${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/msvc_exports.def.in" template)
-	string(CONFIGURE "${template}" configured_template)
-	file(GENERATE OUTPUT "${def_file}" CONTENT "${configured_template}")
+	omr_process_template(
+		"${omr_SOURCE_DIR}/cmake/modules/platform/toolcfg/msvc_exports.def.in"
+		"${def_file}"
+	)
 
 	target_sources("${TARGET_NAME}" PRIVATE "${def_file}")
 endfunction()


### PR DESCRIPTION
Processes a template by expanding variable references, then evaluation
generator expressions.

Resolves #4104

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>