### PR TITLE
Remove references of deprecated Multiply and Ternary IL Opcode

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1793,7 +1793,7 @@ OMR::CodeGenerator::convertMultiplyToShift(TR::Node * node)
    secondChild = TR::Node::create(secondChild, TR::iconst, 0);
    node->setAndIncChild(1, secondChild);
 
-   if (node->getOpCodeValue() == TR::imul || node->getOpCodeValue() == TR::iumul)
+   if (node->getOpCodeValue() == TR::imul)
       TR::Node::recreate(node, TR::ishl);
    else
       {

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -10019,7 +10019,7 @@ TR::Node *ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       // Normalize shift by a constant into multiply by a constant
       //
-      TR::Node::recreate(node, node->getOpCodeValue() == TR::iushl ? TR::iumul : TR::imul);
+      TR::Node::recreate(node, TR::imul);
       int32_t multiplier = 1 << (secondChild->getInt() & INT_SHIFT_MASK);
       if (secondChild->getReferenceCount() > 1)
          {

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7743,7 +7743,7 @@ TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node)
          TR::VPIntRange *range = rhs->asIntRange();
          int32_t low = range->getLowInt();
          int32_t high = range->getHighInt();
-       if((node->getFirstChild()->getOpCodeValue() == TR::imul || node->getFirstChild()->getOpCodeValue() == TR::iumul) &&
+       if(node->getFirstChild()->getOpCodeValue() == TR::imul &&
        ((high & 0x80000000) ==0) &&
        ((low & 0x80000000) ==0))
           {
@@ -7766,7 +7766,7 @@ TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node)
       else if(rhs->asIntConst())
          {
          int32_t iandMask =rhs->asIntConst()->getInt();
-         if((node->getFirstChild()->getOpCodeValue() == TR::imul || node->getFirstChild()->getOpCodeValue() == TR::iumul) &&
+         if(node->getFirstChild()->getOpCodeValue() == TR::imul &&
            ((iandMask & 0x80000000) ==0))
             {
             while(!(mask  & 0x1))

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -209,7 +209,7 @@ TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeG
    TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
 
   if (TR::Compiler->target.cpu.id() >= TR_PPCp9 &&
-      (firstChild->getOpCodeValue() == TR::imul || firstChild->getOpCodeValue() == TR::iumul) &&
+      firstChild->getOpCodeValue() == TR::imul &&
       firstChild->getReferenceCount() == 1 &&
       firstChild->getRegister() == NULL)
      {
@@ -934,7 +934,6 @@ TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeG
    return trgReg;
    }
 
-// also handles iumul
 TR::Register *OMR::Power::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *trgReg;
@@ -3720,8 +3719,7 @@ TR::Register *OMR::Power::TreeEvaluator::iandEvaluator(TR::Node *node, TR::CodeG
       {
       if (cg->isRotateAndMask(node))
          {
-         if (firstChild->getOpCodeValue() == TR::imul ||
-             firstChild->getOpCodeValue() == TR::iumul)
+         if (firstChild->getOpCodeValue() == TR::imul)
             {
             int32_t multiplier = firstChild->getSecondChild()->getInt();
             int32_t shiftAmount = 0;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2674,8 +2674,7 @@ bool OMR::Power::CodeGenerator::isRotateAndMask(TR::Node * node)
           contiguousBits(secondChild->getInt()) &&
           firstChild->getReferenceCount() == 1 &&
           firstChild->getRegister() == NULL &&
-          (((firstOp == TR::imul ||
-             firstOp == TR::iumul) &&
+          ((firstOp == TR::imul &&
              firstChild->getSecondChild()->getOpCodeValue() == TR::iconst &&
             firstChild->getSecondChild()->getInt() > 0 &&
             isNonNegativePowerOf2(firstChild->getSecondChild()->getInt())) ||

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1331,7 +1331,7 @@ TR::Register *OMR::X86::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::Cod
       generateRegRegInstruction(CMOVERegReg(trueValIs64Bit), node, trueReg, falseReg, cg);
       }
 
-   if ((node->getOpCodeValue() == TR::buternary || node->getOpCodeValue() == TR::bternary) &&
+   if (node->getOpCodeValue() == TR::bternary &&
        cg->enableRegisterInterferences())
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(trueReg);
 

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -3653,7 +3653,6 @@ PPCOpCodesTest::compileDisabledIntegerArithmeticTestMethods()
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
    compileOpCodeMethod(_iuDiv, _numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc);
-   compileOpCodeMethod(_iuMul, _numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc);
    compileOpCodeMethod(_iuRem, _numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc);
 
    }
@@ -3661,12 +3660,6 @@ PPCOpCodesTest::compileDisabledIntegerArithmeticTestMethods()
 void
 PPCOpCodesTest::invokeDisabledIntegerArithmeticTests()
    {
-   //unsigned integer constant test will be enabled in another work item.
-   //iumul : overflow just cut
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
-
    //iudiv
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuDiv(UINT_MAXIMUM, 0)

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -3673,7 +3673,6 @@ S390OpCodesTest::compileDisabledIntegerArithmeticTestMethods()
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
    compileOpCodeMethod(_iuDiv, _numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc);
-   compileOpCodeMethod(_iuMul, _numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc);
    compileOpCodeMethod(_iuRem, _numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc);
 
    }
@@ -3681,12 +3680,6 @@ S390OpCodesTest::compileDisabledIntegerArithmeticTestMethods()
 void
 S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
    {
-   //unsigned integer constant test will be enabled in another work item.
-   //iumul : overflow just cut
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
-
    //iudiv
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuDiv(UINT_MAXIMUM, 0)

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -4483,19 +4483,12 @@ X86OpCodesTest::compileDisabledIntegerArithmeticTestMethods()
    //Jazz103 Work Item 103809
    //Testrossa Work Item 121966
    compileOpCodeMethod(_iuDiv, _numberOfBinaryArgs, TR::iudiv, "iuDiv", _argTypesBinaryInt, TR::Int32, rc);
-   compileOpCodeMethod(_iuMul, _numberOfBinaryArgs, TR::iumul, "iuMul", _argTypesBinaryInt, TR::Int32, rc);
    compileOpCodeMethod(_iuRem, _numberOfBinaryArgs, TR::iurem, "iuRem", _argTypesBinaryInt, TR::Int32, rc);
    }
 
 void
 X86OpCodesTest::invokeDisabledIntegerArithmeticTests()
    {
-   //unsigned integer constant test will be enabled in another work item.
-   //iumul : overflow just cut
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MAXIMUM, UINT_MINIMUM), _iuMul(UINT_MAXIMUM, UINT_MINIMUM));
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_MINIMUM, UINT_POS), _iuMul(UINT_MINIMUM, UINT_POS));
-   OMR_CT_EXPECT_EQ(_iuMul, mul(UINT_POS, UINT_MAXIMUM), _iuMul(UINT_POS, UINT_MAXIMUM));
-
    //iudiv
    // TODO: Use ASSERT_DEATH() to catch Remainder by zero which will get "Floating point exception (core dumped)"
    // Test secnario : _iuDiv(UINT_MAXIMUM, 0)


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `Multiply` and `Ternary` category listed in #2657.

Note that there is no commit mentioning `TR::luternary` and `TR::suternary` since there is no references for them.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com