### PR TITLE
Remove references of deprecated Shift IL Opcode

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -866,14 +866,10 @@ public:
       return TR::BadILOp;
       }
 
+//TODO (#2657): remove this function as unsigned shfit opcodes have been deprecated
    static TR::ILOpCodes unsignedShiftLeftOpCode(TR::DataType type)
       {
-      switch(type)
-         {
-         case TR::Int32:  return TR::iushl;
-         case TR::Int64:  return TR::lushl;
-         default: TR_ASSERT(false, "no ushl opcode for datatype %s",type.toString());
-         }
+      TR_ASSERT(false, "no ushl opcode for datatype %s",type.toString());
       return TR::BadILOp;
       }
 

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1638,14 +1638,12 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
                }
             }
          break;
-      case TR::lushl:
-    isUnsigned = true;
       case TR::lshl:
          if (firstChild->getSecondChild()->getOpCode().isLoadConst())
             {
             if ((firstChild->getSecondChild()->get64bitIntegralValue() & LONG_SHIFT_MASK) < 32)
                {
-               newOp = isUnsigned ? TR::iushl : TR::ishl;
+               newOp = TR::ishl;
                convertSecondChild = false; // the second child is already an iconst
                }
             else
@@ -10019,7 +10017,7 @@ TR::Node *ishlSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
       {
       // Normalize shift by a constant into multiply by a constant
       //
-      TR::Node::recreate(node, node->getOpCodeValue() == TR::iushl ? TR::iumul : TR::imul);
+      TR::Node::recreate(node, TR::imul);
       int32_t multiplier = 1 << (secondChild->getInt() & INT_SHIFT_MASK);
       if (secondChild->getReferenceCount() > 1)
          {
@@ -10282,8 +10280,7 @@ TR::Node *lushrSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s
    // shift right and conversion to byte, char, or int
    //
    if (secondChild->getOpCode().isLoadConst() &&
-      (firstChild->getOpCodeValue() == TR::lushl ||
-       firstChild->getOpCodeValue() == TR::lshl) &&
+       firstChild->getOpCodeValue() == TR::lshl &&
        firstChild->getSecondChild()->getOpCode().isLoadConst())
       {
       int64_t left = firstChild->getSecondChild()->get64bitIntegralValue() & LONG_SHIFT_MASK;

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -7755,7 +7755,7 @@ TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node)
           if(high <  1 << shift )
            constraint = TR::VPIntConst::create(vp, 0);
           }
-       else if((node->getFirstChild()->getOpCodeValue() == TR::ishl || node->getFirstChild()->getOpCodeValue() == TR::iushl) &&
+       else if(node->getFirstChild()->getOpCodeValue() == TR::ishl &&
             ((high & 0x80000000) ==0) &&
             ((low & 0x80000000) ==0))
           {
@@ -7777,7 +7777,7 @@ TR::Node *constrainIand(OMR::ValuePropagation *vp, TR::Node *node)
             if(iandMask <  1 << shift )
               constraint = TR::VPIntConst::create(vp, 0);
             }
-         else if((node->getFirstChild()->getOpCodeValue() == TR::ishl || node->getFirstChild()->getOpCodeValue() == TR::iushl) &&
+         else if(node->getFirstChild()->getOpCodeValue() == TR::ishl &&
                 ((iandMask & 0x80000000) ==0))
             {
             if(iandMask < 1 << mask)

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -2357,7 +2357,7 @@ TR::Register *OMR::Power::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeG
    return trgReg;
    }
 
-// also handles bshl,iushl
+// also handles bshl
 TR::Register *OMR::Power::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *trgReg         = cg->allocateRegister();
@@ -2387,7 +2387,6 @@ TR::Register *OMR::Power::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeG
    return trgReg;
    }
 
-// also handles lushl
 TR::Register *OMR::Power::TreeEvaluator::lshlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *trgReg;

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -2046,7 +2046,7 @@ TR_S390PostRAPeephole::revertTo32BitShift()
    // Note the NOT in front of second boolean expr. pair
    TR::InstOpCode::Mnemonic oldOpCode = instr->getOpCodeValue();
    if ((oldOpCode == TR::InstOpCode::SLLG || oldOpCode == TR::InstOpCode::SLAG)
-         && !(instr->getNode()->getOpCodeValue() == TR::ishl || instr->getNode()->getOpCodeValue() == TR::iushl))
+         && instr->getNode()->getOpCodeValue() != TR::ishl)
       {
       return false;
       }


### PR DESCRIPTION
Remove all references to the IL Opcodes in the `Shift` category listed in #2657.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang <aaronwang0407@gmail.com>