### PR TITLE
__xlC__ is not defined by xlclang

### DIFF
--- a/port/unix/omrcpu.c
+++ b/port/unix/omrcpu.c
@@ -94,7 +94,7 @@ omrcpu_startup(struct OMRPortLibrary *portLibrary)
 
 #if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 	dcbz((void *) &buf[512]);
-#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
+#elif defined(LINUX) || defined(OSX) || defined(RS6000)
 	__asm__(
 		"dcbz 0, %0"
 		: /* no outputs */
@@ -155,7 +155,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 		dcbst(addr);
-#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
+#elif defined(LINUX) || defined(OSX) || defined(RS6000)
 		__asm__(
 			"dcbst 0,%0"
 			: /* no outputs */
@@ -165,7 +165,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 	sync();
-#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
+#elif defined(LINUX) || defined(OSX) || defined(RS6000)
 	__asm__("sync");
 #endif
 
@@ -174,7 +174,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 
 #if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 		icbi(addr);
-#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
+#elif defined(LINUX) || defined(OSX) || defined(RS6000)
 		__asm__(
 			"icbi 0,%0"
 			: /* no outputs */
@@ -185,7 +185,7 @@ omrcpu_flush_icache(struct OMRPortLibrary *portLibrary, void *memoryPointer, uin
 #if ((__IBMC__ || __IBMCPP__) && (!defined(RS6000) || (__xlC__ < 0x1000)))
 	sync();
 	isync();
-#elif defined(LINUX) || defined(OSX) || (defined(RS6000) && (__xlC__ >= 0x1000))
+#elif defined(LINUX) || defined(OSX) || defined(RS6000)
 	__asm__("sync");
 	__asm__("isync");
 #endif


### PR DESCRIPTION
Use a more flexible implementation for changes added by #4099

Not sure #4099 works properly for xlc 16, it may exclude the assembler code. The `__xlC__` macro isn't supported by xlclang/xlclang++.
https://www.ibm.com/support/knowledgecenter/en/SSGH3R_16.1.0/com.ibm.xlcpp161.aix.doc/compiler_ref/xlmacros.html

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>