### PR TITLE
Add Heuristic Region in Cold Block Marker

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -350,6 +350,18 @@ public:
 
    bool compilationShouldBeInterrupted(TR_CallingContext) { return false; }
 
+   /**
+    * @brief denotes the start of a region wherein decisions do not need to be
+    *        remembered (for example, in relocatable compilations)
+    */
+   void enterHeuristicRegion() {}
+
+   /**
+    * @brief denotes the end of a region wherein decisions do not need to be
+    *        remembered (for example, in relocatable compilations)
+    */
+   void exitHeuristicRegion() {}
+
    /* Can be used to ensure that a implementer chosen for inlining is valid;
     * for example, to ensure that the implementer can be used for inlining
     * in a relocatable compilation

--- a/compiler/env/HeuristicRegion.hpp
+++ b/compiler/env/HeuristicRegion.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef OMR_HEURISTIC_REGION_HPP
+#define OMR_HEURISTIC_REGION_HPP
+
+#pragma once
+
+#include "compile/Compilation.hpp"
+
+namespace TR 
+{
+
+class HeuristicRegion
+   {
+public:
+   HeuristicRegion(TR::Compilation *comp) :
+      _comp(comp)
+      {
+      _comp->enterHeuristicRegion();
+      }
+
+   ~HeuristicRegion()
+      {
+      _comp->exitHeuristicRegion();
+      }
+
+private:
+   TR::Compilation *_comp;
+   };
+
+}
+
+#endif // OMR_HEURISTIC_REGION_HPP
+

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -47,6 +47,7 @@
 #include "cs2/llistof.h"
 #include "cs2/sparsrbit.h"
 #include "env/CompilerEnv.hpp"
+#include "env/HeuristicRegion.hpp"
 #include "env/PersistentInfo.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
@@ -8054,6 +8055,7 @@ TR_ColdBlockMarker::hasNotYetRun(TR::Node *node)
          char *name = TR::Compiler->cls.classNameChars(comp(), node->getSymbolReference(), len);
          if (name)
             {
+            TR::HeuristicRegion heuristicRegion(comp());
             char *sig = classNameToSignature(name, len, comp());
             TR_OpaqueClassBlock *classObject = fe()->getClassFromSignature(sig, len, node->getSymbolReference()->getOwningMethod(comp()));
             if (classObject && !TR::Compiler->cls.isInterfaceClass(comp(), classObject))


### PR DESCRIPTION
The getClassFromSignature call in TR_ColdBlockMarker::hasNotYetRun is
only used to make a heuristic decision as to whether or not the block
should be marked cold. In a relocatable compile (currently in OpenJ9),
the getClassFromSignature will result in a validation record that will
be used in the load run. This validation could fail because the class
from signature might not yet exist. However, executing the body in a
subsequent run does not require this class to exist (assuming this is
the only reference to it during the compilation), since its existence
was only used for a heuristic decision regarding cold block marking -
an act that only mattered during the compilation.

This PR wraps the getClassFromSignature call in a heuristic
region.

Signed-off-by: Irwin D'Souza <dsouzai.gh@gmail.com>