### PR TITLE
AArch64: OMRMemoryReference changes for loadaddrEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -731,76 +731,98 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
       int32_t displacement = self()->getOffset(true);
 
       TR::InstOpCode op = currentInstruction->getOpCode();
-      uint32_t enc = (uint32_t)op.getOpCodeBinaryEncoding();
 
-      if (index)
+      if (op.getMnemonic() != TR::InstOpCode::addimmx)
          {
-         TR_ASSERT(displacement == 0, "Non-zero offset with index register.");
+         // load/store instruction
+         uint32_t enc = (uint32_t)op.getOpCodeBinaryEncoding();
 
-         if (isRegisterOffsetInstruction(enc))
+         if (index)
             {
-            base->setRegisterFieldRN(wcursor);
-            index->setRegisterFieldRM(wcursor);
+            TR_ASSERT(displacement == 0, "Non-zero offset with index register.");
 
-            if (self()->getScale() == 0)
+            if (isRegisterOffsetInstruction(enc))
                {
-               // default: LSL #0
-               *wcursor |= 0x6 << 12;
+               base->setRegisterFieldRN(wcursor);
+               index->setRegisterFieldRM(wcursor);
+
+               if (self()->getScale() == 0)
+                  {
+                  // default: LSL #0
+                  *wcursor |= 0x6 << 12;
+                  }
+               else
+                  {
+                  // Eclipse OMR Issue #4227 tracks this
+                  TR_UNIMPLEMENTED();
+                  }
+
+               cursor += ARM64_INSTRUCTION_LENGTH;
                }
             else
                {
-               // Eclipse OMR Issue #4227 tracks this
-               TR_UNIMPLEMENTED();
+               TR_ASSERT(false, "Unsupported instruction type.");
                }
-
-            cursor += ARM64_INSTRUCTION_LENGTH;
             }
          else
             {
-            TR_ASSERT(false, "Unsupported instruction type.");
+            /* no index register */
+            base->setRegisterFieldRN(wcursor);
+
+            if (isImm9OffsetInstruction(enc))
+               {
+               if (constantIsImm9(displacement))
+                  {
+                  *wcursor |= (displacement & 0x1ff) << 12; /* imm9 */
+                  cursor += ARM64_INSTRUCTION_LENGTH;
+                  }
+               else
+                  {
+                  TR_ASSERT(false, "Offset is too large for specified instruction.");
+                  }
+               }
+            else if (isImm12OffsetInstruction(enc))
+               {
+               uint32_t size = (enc >> 30) & 3; /* b=0, h=1, w=2, x=3 */
+               uint32_t shifted = displacement >> size;
+
+               if (size > 0)
+                  {
+                  TR_ASSERT((displacement & ((1 << size) - 1)) == 0, "Non-aligned offset in 2/4/8-byte memory access.");
+                  }
+
+               if (constantIsUnsignedImm12(shifted))
+                  {
+                  *wcursor |= (shifted & 0xfff) << 10; /* imm12 */
+                  cursor += ARM64_INSTRUCTION_LENGTH;
+                  }
+               else
+                  {
+                  TR_ASSERT(false, "Offset is too large for specified instruction.");
+                  }
+               }
+            else
+               {
+               /* Register pair, literal, exclusive instructions to be supported */
+               TR_UNIMPLEMENTED();
+               }
             }
          }
       else
          {
-         /* no index register */
+         // loadaddrEvaluator() uses addimmx in generateTrgMemInstruction
+         TR_ASSERT(index == NULL, "MemoryReference with unexpected indexed form");
+
          base->setRegisterFieldRN(wcursor);
 
-         if (isImm9OffsetInstruction(enc))
+         if (constantIsUnsignedImm12(displacement))
             {
-            if (constantIsImm9(displacement))
-               {
-               *wcursor |= (displacement & 0x1ff) << 12; /* imm9 */
-               cursor += ARM64_INSTRUCTION_LENGTH;
-               }
-            else
-               {
-               TR_ASSERT(false, "Offset is too large for specified instruction.");
-               }
-            }
-         else if (isImm12OffsetInstruction(enc))
-            {
-            uint32_t size = (enc >> 30) & 3; /* b=0, h=1, w=2, x=3 */
-            uint32_t shifted = displacement >> size;
-
-            if (size > 0)
-               {
-               TR_ASSERT((displacement & ((1 << size) - 1)) == 0, "Non-aligned offset in 2/4/8-byte memory access.");
-               }
-
-            if (constantIsUnsignedImm12(shifted))
-               {
-               *wcursor |= (shifted & 0xfff) << 10; /* imm12 */
-               cursor += ARM64_INSTRUCTION_LENGTH;
-               }
-            else
-               {
-               TR_ASSERT(false, "Offset is too large for specified instruction.");
-               }
+            *wcursor |= (displacement & 0xfff) << 10; /* imm12 */
+            cursor += ARM64_INSTRUCTION_LENGTH;
             }
          else
             {
-            /* Register pair, literal, exclusive instructions to be supported */
-            TR_UNIMPLEMENTED();
+            TR_ASSERT(false, "Offset is too large for specified instruction.");
             }
          }
       }
@@ -817,50 +839,69 @@ uint32_t OMR::ARM64::MemoryReference::estimateBinaryLength(TR::InstOpCode op)
       }
    else
       {
-      if (self()->getIndexRegister())
+      if (op.getMnemonic() != TR::InstOpCode::addimmx)
          {
-         return ARM64_INSTRUCTION_LENGTH;
-         }
-      else
-         {
-         /* no index register */
-         int32_t displacement = self()->getOffset(true);
-         uint32_t enc = (uint32_t)op.getOpCodeBinaryEncoding();
-
-         if (isImm9OffsetInstruction(enc))
+         // load/store instruction
+         if (self()->getIndexRegister())
             {
-            if (constantIsImm9(displacement))
-               {
-               return ARM64_INSTRUCTION_LENGTH;
-               }
-            else
-               {
-               TR_ASSERT(false, "Offset is too large for specified instruction.");
-               }
-            }
-         else if (isImm12OffsetInstruction(enc))
-            {
-            uint32_t size = (enc >> 30) & 3; /* b=0, h=1, w=2, x=3 */
-            uint32_t shifted = displacement >> size;
-
-            if (size > 0)
-               {
-               TR_ASSERT((displacement & ((1 << size) - 1)) == 0, "Non-aligned offset in 2/4/8-byte memory access.");
-               }
-
-            if (constantIsUnsignedImm12(shifted))
-               {
-               return ARM64_INSTRUCTION_LENGTH;
-               }
-            else
-               {
-               TR_ASSERT(false, "Offset is too large for specified instruction.");
-               }
+            return ARM64_INSTRUCTION_LENGTH;
             }
          else
             {
-            /* Register pair, literal, exclusive instructions to be supported */
-            TR_UNIMPLEMENTED();
+            /* no index register */
+            int32_t displacement = self()->getOffset(true);
+            uint32_t enc = (uint32_t)op.getOpCodeBinaryEncoding();
+
+            if (isImm9OffsetInstruction(enc))
+               {
+               if (constantIsImm9(displacement))
+                  {
+                  return ARM64_INSTRUCTION_LENGTH;
+                  }
+               else
+                  {
+                  TR_ASSERT(false, "Offset is too large for specified instruction.");
+                  }
+               }
+            else if (isImm12OffsetInstruction(enc))
+               {
+               uint32_t size = (enc >> 30) & 3; /* b=0, h=1, w=2, x=3 */
+               uint32_t shifted = displacement >> size;
+
+               if (size > 0)
+                  {
+                  TR_ASSERT((displacement & ((1 << size) - 1)) == 0, "Non-aligned offset in 2/4/8-byte memory access.");
+                  }
+
+               if (constantIsUnsignedImm12(shifted))
+                  {
+                  return ARM64_INSTRUCTION_LENGTH;
+                  }
+               else
+                  {
+                  TR_ASSERT(false, "Offset is too large for specified instruction.");
+                  }
+               }
+            else
+               {
+               /* Register pair, literal, exclusive instructions to be supported */
+               TR_UNIMPLEMENTED();
+               }
+            }
+         }
+      else
+         {
+         // addimmx instruction
+         TR_ASSERT(self()->getIndexRegister() == NULL, "MemoryReference with unexpected indexed form");
+
+         int32_t displacement = self()->getOffset(true);
+         if (constantIsUnsignedImm12(displacement))
+            {
+            return ARM64_INSTRUCTION_LENGTH;
+            }
+         else
+            {
+            TR_ASSERT(false, "Offset is too large for specified instruction.");
             }
          }
       }


### PR DESCRIPTION
This commit makes changes to OMRMemoryReference for AArch64.
They are required by loadaddrEvaluator().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>