### PR TITLE
Correct double decrement of node reference counts in x86 integer compare analyser

### DIFF
--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -143,15 +143,21 @@ void TR_X86CompareAnalyser::integerCompareAnalyser(
       tempMR->decNodeReferenceCounts(cg());
       }
 
-   if (realFirstChild)
-      cg()->recursivelyDecReferenceCount(realFirstChild);
-   else
-      cg()->decReferenceCount(firstChild);
-
-   if (realSecondChild)
-      cg()->recursivelyDecReferenceCount(realSecondChild);
-   else
-      cg()->decReferenceCount(secondChild);
+   if (realFirstChild) {
+       if (!getCmpMem1Reg2())
+	 cg()->recursivelyDecReferenceCount(realFirstChild);
+       else
+	 cg()->decReferenceCount(realFirstChild);
+   } else
+	cg()->decReferenceCount(firstChild);
+   
+   if (realSecondChild) {
+	if(!getCmpReg1Mem2())
+	  cg()->recursivelyDecReferenceCount(realSecondChild);
+	else
+	  cg()->decReferenceCount(realSecondChild);
+   } else
+	cg()->decReferenceCount(secondChild);
    }
 
 


### PR DESCRIPTION
This commit corrects the double decrement of node reference counts in the x86 integer compare analyser by bounding the depth of recursion used to decrement node reference counts in subtrees. It expands this logic:

```
   if (realFirstChild)
      cg()->recursivelyDecReferenceCount(realFirstChild);
   else
      cg()->decReferenceCount(firstChild);

   if (realSecondChild)
      cg()->recursivelyDecReferenceCount(realSecondChild);
   else
      cg()->decReferenceCount(secondChild);
```
to this:

```
   if (realFirstChild) {
       if (!getCmpMem1Reg2())
	 cg()->recursivelyDecReferenceCount(realFirstChild);
       else
	 cg()->decReferenceCount(realFirstChild);
   } else
	cg()->decReferenceCount(firstChild);
   
   if (realSecondChild) {
	if(!getCmpReg1Mem2())
	  cg()->recursivelyDecReferenceCount(realSecondChild);
	else
	  cg()->decReferenceCount(realSecondChild);
   } else
	cg()->decReferenceCount(secondChild);
```

Signed-off-by Mark Thom markjordanthom@gmail.com