### PR TITLE
Correct double decrement of node reference counts in x86 integer compare analyser

### DIFF
--- a/compiler/x/codegen/CompareAnalyser.cpp
+++ b/compiler/x/codegen/CompareAnalyser.cpp
@@ -144,16 +144,37 @@ void TR_X86CompareAnalyser::integerCompareAnalyser(
       }
 
    if (realFirstChild)
-      cg()->recursivelyDecReferenceCount(realFirstChild);
+      {
+      if (!getCmpMem1Reg2())
+         {
+         cg()->recursivelyDecReferenceCount(realFirstChild);
+         }
+      else
+         {
+         cg()->decReferenceCount(realFirstChild);
+         }
+      }
    else
+      {
       cg()->decReferenceCount(firstChild);
+      }
 
    if (realSecondChild)
-      cg()->recursivelyDecReferenceCount(realSecondChild);
+      {
+      if (!getCmpReg1Mem2())
+         {
+         cg()->recursivelyDecReferenceCount(realSecondChild);
+         }
+      else
+         {
+         cg()->decReferenceCount(realSecondChild);
+         }
+      }
    else
+      {
       cg()->decReferenceCount(secondChild);
+      }
    }
-
 
 void TR_X86CompareAnalyser::integerCompareAnalyser(
    TR::Node       *root,


### PR DESCRIPTION
Fix double decrement on node reference counts and properly sign it

Corrects the double decrement of node reference counts in the x86 integer compare analyser by bounding the depth of recursion used to decrement node reference counts in subtrees.

Fixes: #4121 
Signed-off-by: Mark Thom <mark.thom@unb.ca>