### PR TITLE
Revert "Remove references of deprecated  Add/Subtract IL opcodes"

### DIFF
--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -70,7 +70,7 @@ static TR::Register *addConstantToInteger(TR::Node *node, TR::Register *srcReg, 
    return trgReg;
    }
 
-// Also handles TR::aiadd
+// Also handles TR::aiadd, TR::iuadd, aiuadd
 TR::Register *OMR::ARM::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *src1Reg = NULL;
@@ -93,7 +93,7 @@ TR::Register *OMR::ARM::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGen
       generateTrg1Src2Instruction(cg, ARMOp_add, node, trgReg, src1Reg, src2Reg);
       }
 
-   if (node->getOpCodeValue() == TR::aiadd &&
+   if ((node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aiuadd) &&
        node->isInternalPointer())
       {
       if (node->getPinningArrayPointer())

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -436,7 +436,7 @@ public:
    ///         pairFirstChild
    ///         pairSecondChild
    ///
-   /// and the opcodes for highOp/adjunctOp are lumulh/lmul.
+   /// and the opcodes for highOp/adjunctOp are lumulh/lmul, luaddh/luadd, or lusubh/lusub.
    ///
    bool                   isDualHigh();
 
@@ -452,7 +452,7 @@ public:
    ///           pairFirstChild
    ///           pairSecondChild
    ///
-   /// and the opcodes for highOp/adjunctOp are. (All the opcode pairs have been deprecated)
+   /// and the opcodes for highOp/adjunctOp are luaddc/luadd, or lusubb/lusub.
    ///
    bool                   isTernaryHigh();
 
@@ -2053,7 +2053,7 @@ protected:
       allocationCanBeRemoved                = 0x00004000,
       skipZeroInit                          = 0x00008000,
 
-      // Flag used by TR::lmul
+      // Flag used by TR::lmul (possibly TR::luadd, TR::lusub)
       // Whether this node is the adjunct node of a dual high node
       adjunct                               = 0x00010000,
 

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -3895,8 +3895,8 @@ TR_GeneralLoopUnroller::countNodesAndSubscripts(TR::Node *node, int32_t &numNode
    if (node->getOpCodeValue() != TR::treetop)
       numNodes++;
 
-   if (node->getOpCodeValue() == TR::aiadd ||
-       node->getOpCodeValue() == TR::aladd)
+   if (node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aiuadd ||
+       node->getOpCodeValue() == TR::aladd || node->getOpCodeValue() == TR::aluadd)
       {
       // TODO: make this more intelligent -- check if the subscript indexes
       // an induction variable

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1623,6 +1623,8 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
       case TR::land: newOp = TR::iand; break;
       case TR::lor:  newOp = TR::ior;  break;
       case TR::lxor: newOp = TR::ixor; break;
+      case TR::luadd: newOp = TR::iuadd; isUnsigned = true; break;
+      case TR::lusub: newOp = TR::iusub; isUnsigned = true; break;
       case TR::lushr:
          isUnsigned = true;
       case TR::lshr:
@@ -1677,19 +1679,20 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
             }
       break;
       case TR::lneg:
+      case TR::luneg:
          {
          if (!performTransformation(s->comp(), "%sReducing long operation in node [" POINTER_PRINTF_FORMAT "] to an int operation\n", s->optDetailString(), node))
             return false;
          if (newConversionOp == TR::BadILOp)
             {
-            TR::Node::recreate(node, TR::ineg);
+            TR::Node::recreate(node, isUnsigned ? TR::iuneg : TR::ineg);
             TR::Node::recreate(firstChild, TR::l2i);
             }
          else
             {
             TR::Node * temp = TR::Node::create(TR::l2i, 1, firstChild->getFirstChild());
             firstChild->getFirstChild()->decReferenceCount();
-            TR::Node::recreate(firstChild, TR::ineg);
+            TR::Node::recreate(firstChild, isUnsigned ? TR::iuneg : TR::ineg);
             firstChild->setAndIncChild(0, temp);
             TR::Node::recreate(node, newConversionOp);
             }

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -198,7 +198,7 @@ static bool genNullTestForCompressedPointers(TR::Node *node,
    return false;
    }
 
-// Also handles TR::aiadd
+// Also handles TR::aiadd, TR::iuadd, aiuadd
 TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *src1Reg = NULL;
@@ -239,7 +239,7 @@ TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeG
          }
      }
 
-   if (node->getOpCodeValue() == TR::aiadd &&
+   if ((node->getOpCodeValue() == TR::aiadd || node->getOpCodeValue() == TR::aiuadd) &&
        node->isInternalPointer())
       {
       if (node->getPinningArrayPointer())
@@ -441,7 +441,7 @@ static TR::Register *laddEvaluatorWithAnalyser(TR::Node *node, TR::CodeGenerator
    return trgReg;
    }
 
-// Also handles TR::aladd for 64 bit target
+// Also handles TR::aladd for 64 bit target, luadd, aluadd
 TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *firstChild = node->getFirstChild();
@@ -559,7 +559,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
 
             if (setsOrReadsCC)
                {
-               TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luaddc,
+               TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luadd || node->getOpCodeValue() == TR::luaddc,
                   "CC computation not supported for this node %p\n", node);
                TR::Register *carryReg = NULL;
                if ((node->getOpCodeValue() == TR::luaddc) && TR_PPCComputeCC::setCarryBorrow(node->getChild(2), false, &carryReg, cg))
@@ -591,7 +591,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
          generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneSkipAdd, deps);
          }
 
-      if (node->getOpCodeValue() == TR::aladd &&
+      if ((node->getOpCodeValue() == TR::aladd || node->getOpCodeValue() == TR::aluadd) &&
           node->isInternalPointer())
          {
          if (node->getPinningArrayPointer())
@@ -633,7 +633,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
 
 
 // aiaddEvaluator handled by iaddEvaluator
-// also handles TR::asub
+// also handles TR::iusub and TR::asub
 TR::Register *OMR::Power::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node     *secondChild    = node->getSecondChild();
@@ -814,7 +814,7 @@ TR::Register *lsub64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
 
             if (setsOrReadsCC)
                {
-               TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusubb,
+               TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusub || node->getOpCodeValue() == TR::lusubb,
                   "CC computation not supported for this node %p\n", node);
                TR::Register *borrowReg = NULL;
                if ((node->getOpCodeValue() == TR::lusubb) && TR_PPCComputeCC::setCarryBorrow(node->getChild(2), true, &borrowReg, cg))
@@ -840,7 +840,8 @@ TR::Register *lsub64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
    cg->decReferenceCount(secondChild);
    return trgReg;
    }
- 
+
+// also handles lusub
 TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    if (TR::Compiler->target.is64Bit())

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -590,8 +590,9 @@ static void evaluateIfNotConst(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register *OMR::X86::TreeEvaluator::integerDualAddOrSubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT((node->getOpCodeValue() == TR::luaddh) || (node->getOpCodeValue() == TR::lusubh) 
-      , "Unexpected dual operator. Expected luaddh or lusubh as part of cyclic dual.");
+   TR_ASSERT((node->getOpCodeValue() == TR::luaddh) || (node->getOpCodeValue() == TR::luadd)
+      || (node->getOpCodeValue() == TR::lusubh) || (node->getOpCodeValue() == TR::lusub)
+      , "Unexpected dual operator. Expected luadd, luaddh, lusub, or lusubh as part of cyclic dual.");
 
    TR::Node *pair = node->getChild(2);
    bool requiresCarryOnEntry = cg->requiresCarry();
@@ -706,8 +707,8 @@ TR::Register *OMR::X86::TreeEvaluator::integerAddEvaluator(TR::Node *node, TR::C
 
    if (NEED_CC(node) || (opCode == TR::luaddc) || (opCode == TR::iuaddc))
       {
-      TR_ASSERT((nodeIs64Bit  && opCode == TR::ladd || opCode == TR::luaddc) ||
-                (!nodeIs64Bit && opCode == TR::iadd  || opCode == TR::iuaddc),
+      TR_ASSERT((nodeIs64Bit  && (opCode == TR::ladd || opCode == TR::luadd) || opCode == TR::luaddc) ||
+                (!nodeIs64Bit && (opCode == TR::iadd || opCode == TR::iuadd) || opCode == TR::iuaddc),
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(opCode));
 
       // we need eflags from integerAddAnalyser for the CC sequence
@@ -1345,8 +1346,8 @@ TR::Register *OMR::X86::TreeEvaluator::integerSubEvaluator(TR::Node *node, TR::C
 
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::lusubb) || (node->getOpCodeValue() == TR::iusubb))
       {
-      TR_ASSERT((nodeIs64Bit  && opCode == TR::lsub || opCode == TR::lusubb) ||
-                (!nodeIs64Bit && opCode == TR::isub || opCode == TR::iusubb),
+      TR_ASSERT((nodeIs64Bit  && (opCode == TR::lsub || opCode == TR::lusub) || opCode == TR::lusubb) ||
+                (!nodeIs64Bit && (opCode == TR::isub || opCode == TR::iusub) || opCode == TR::iusubb),
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(opCode));
 
       const bool isWithBorrow = (opCode == TR::lusubb) || (opCode == TR::iusubb);
@@ -1499,7 +1500,7 @@ TR::Register *OMR::X86::TreeEvaluator::bsubEvaluator(TR::Node *node, TR::CodeGen
 
    if (NEED_CC(node))
       {
-      TR_ASSERT(node->getOpCodeValue() == TR::bsub,
+      TR_ASSERT(node->getOpCodeValue() == TR::bsub || node->getOpCodeValue() == TR::busub,
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(node->getOpCode()));
 
       // we need eflags from integerAddAnalyser for the CC sequence
@@ -1747,7 +1748,7 @@ TR::Register *OMR::X86::TreeEvaluator::csubEvaluator(TR::Node *node, TR::CodeGen
 
    if (NEED_CC(node))
       {
-      TR_ASSERT(false,
+      TR_ASSERT(node->getOpCodeValue() == TR::csub,
                 "CC computation not supported for this node %p with opcode %s\n", node, cg->comp()->getDebug()->getName(node->getOpCode()));
 
       // we need eflags from integerAddAnalyser for the CC sequence

--- a/compiler/z/codegen/BinaryEvaluator.cpp
+++ b/compiler/z/codegen/BinaryEvaluator.cpp
@@ -333,7 +333,7 @@ laddHelper64(TR::Node * node, TR::CodeGenerator * cg)
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::luaddc))
       {
       TR_ASSERT( !isCompressionSequence, "CC computation not supported with compression sequence.\n");
-      TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luaddc,
+      TR_ASSERT(node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::luadd || node->getOpCodeValue() == TR::luaddc,
               "CC computation not supported for this node %p\n", node);
 
       // we need the carry from integerAddAnalyser for the CC sequence, thus we use logical add instead of add
@@ -1937,7 +1937,7 @@ lsubHelper64(TR::Node * node, TR::CodeGenerator * cg)
    if (NEED_CC(node) || (node->getOpCodeValue() == TR::lusubb))
       {
       TR_ASSERT( !isCompressionSequence,"CC computation not supported with compression sequence.\n");
-      TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusubb,
+      TR_ASSERT(node->getOpCodeValue() == TR::lsub || node->getOpCodeValue() == TR::lusub || node->getOpCodeValue() == TR::lusubb,
               "CC computation not supported for this node %p\n", node);
 
       // we need the borrow from longSubtractAnalyser for the CC sequence,

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -1308,6 +1308,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
       {
       self()->populateMemoryReference(addressChild, cg);
       if ((subTree->getOpCodeValue() != TR::iadd) && (subTree->getOpCodeValue() != TR::aiadd) &&
+          (subTree->getOpCodeValue() != TR::iuadd) && (subTree->getOpCodeValue() != TR::aiuadd) &&
           (subTree->getOpCodeValue() != TR::isub))
          {
          if (subTree->getOpCode().isSub())
@@ -3365,8 +3366,8 @@ static TR::SymbolReference * findBestSymRefForArrayCopy(TR::CodeGenerator *cg, T
    TR::SymbolReference *sym = arrayCopyNode->getSymbolReference();
    TR::Compilation *comp = cg->comp();
 
-   if (srcNode->getOpCodeValue()==TR::aiadd ||
-       srcNode->getOpCodeValue()==TR::aladd ||
+   if (srcNode->getOpCodeValue()==TR::aiadd || srcNode->getOpCodeValue()==TR::aiuadd ||
+       srcNode->getOpCodeValue()==TR::aladd || srcNode->getOpCodeValue()==TR::aluadd ||
        srcNode->getOpCodeValue()==TR::asub)
       {
       TR::Node *firstChild = srcNode->getFirstChild();


### PR DESCRIPTION
Reverts eclipse/omr#4096.

The following tree produces a compile time crash with this change in tact:

```
------------------------------
 n112n    (  0)  treetop                                                                              [     0x3ff469512c0] bci=[-1,57,184] rc=0 vc=929 vn=- li=6 udi=- nc=1
 n111n    (  4)    luaddc ()                                                                          [     0x3ff46951270] bci=[-1,54,184] rc=4 vc=929 vn=- li=6 udi=- nc=3 flg=0x20
 n102n    (  1)      luaddc ()                                                                        [     0x3ff46950fa0] bci=[-1,45,183] rc=1 vc=929 vn=- li=6 udi=- nc=3 flg=0x20
 n79n     (  2)        lumulh ()                                                                      [     0x3ff46950870] bci=[-1,32,182] rc=2 vc=929 vn=- li=6 udi=- nc=3 flg=0x20
 n76n     (  2)          lloadi  <array-shadow>[#238  Shadow] [flags 0x80000604 0x0 ] (cannotOverflow )  [     0x3ff46950780] bci=[-1,29,182] rc=2 vc=929 vn=- li=6 udi=- nc=1 flg=0x1000
 n75n     (  1)            aladd (X>=0 internalPtr sharedMemory )                                     [     0x3ff46950730] bci=[-1,29,182] rc=1 vc=929 vn=- li=6 udi=- nc=2 flg=0x8100
 n1097n   (  3)              ==>aRegLoad (in &GPR_0097) (X!=0 SeenRealReference sharedMemory )
 n74n     (  1)              lsub (highWordZero X>=0 cannotOverflow )                                 [     0x3ff469506e0] bci=[-1,29,182] rc=1 vc=929 vn=- li=6 udi=- nc=2 flg=0x5100
 n72n     (  1)                lshl (X>=0 cannotOverflow )                                            [     0x3ff46950640] bci=[-1,29,182] rc=1 vc=929 vn=- li=6 udi=- nc=2 flg=0x1100
 n71n     (  1)                  i2l (highWordZero X>=0 )                                             [     0x3ff469505f0] bci=[-1,29,182] rc=1 vc=929 vn=- li=6 udi=- nc=1 flg=0x4100
 n1098n   (  3)                    ==>iRegLoad (in GPR_0098) (X>=0 cannotOverflow SeenRealReference )
 n1297n   (  1)                  iconst 3                                                             [     0x3ff46a78520] bci=[-1,29,182] rc=1 vc=929 vn=- li=6 udi=- nc=0
 n73n     (  2)                lconst -8 (X!=0 X<=0 )                                                 [     0x3ff46950690] bci=[-1,29,182] rc=2 vc=929 vn=- li=6 udi=- nc=0 flg=0x204
 n77n     (  2)          lload  <auto slot 6>[#363  Auto] [flags 0x4 0x0 ] (cannotOverflow )          [     0x3ff469507d0] bci=[-1,30,182] rc=2 vc=929 vn=- li=6 udi=- nc=0 flg=0x1000
 n1296n   (  3)          lmul ()                                                                      [     0x3ff46a784d0] bci=[-1,32,182] rc=3 vc=929 vn=- li=6 udi=- nc=3 flg=0x10020
 n76n     (  2)            ==>lloadi (cannotOverflow )
 n77n     (  2)            ==>lload (cannotOverflow )
 n79n     (  2)            ==>lumulh ()
 n99n     (  2)        lconst 0 (highWordZero X==0 X>=0 X<=0 )                                        [     0x3ff46950eb0] bci=[-1,45,183] rc=2 vc=929 vn=- li=6 udi=- nc=0 flg=0x4302
 n101n    (  3)        computeCC                                                                      [     0x3ff46950f50] bci=[-1,45,183] rc=3 vc=929 vn=- li=6 udi=- nc=1
 n100n    (  1)          luadd                                                                        [     0x3ff46950f00] bci=[-1,45,183] rc=1 vc=929 vn=- li=6 udi=- nc=2
 n1296n   (  3)            ==>lmul ()
 n97n     (  2)            lloadi  <array-shadow>[#238  Shadow] [flags 0x80000604 0x0 ] (cannotOverflow )  [     0x3ff46950e10] bci=[-1,44,183] rc=2 vc=929 vn=- li=6 udi=- nc=1 flg=0x1000
 n96n     (  2)              aladd (X>=0 internalPtr sharedMemory )                                   [     0x3ff46950dc0] bci=[-1,44,183] rc=2 vc=929 vn=- li=6 udi=- nc=2 flg=0x8100
 n1096n   (  3)                ==>aRegLoad (in &GPR_0096) (SeenRealReference sharedMemory )
 n95n     (  1)                lsub (highWordZero X>=0 cannotOverflow )                               [     0x3ff46950d70] bci=[-1,44,183] rc=1 vc=929 vn=- li=6 udi=- nc=2 flg=0x5100
 n93n     (  1)                  lshl (X>=0 cannotOverflow )                                          [     0x3ff46950cd0] bci=[-1,44,183] rc=1 vc=929 vn=- li=6 udi=- nc=2 flg=0x1100
 n92n     (  1)                    i2l (highWordZero X>=0 )                                           [     0x3ff46950c80] bci=[-1,44,183] rc=1 vc=929 vn=- li=6 udi=- nc=1 flg=0x4100
 n86n     (  1)                      iadd (X>=0 cannotOverflow )                                      [     0x3ff46950aa0] bci=[-1,43,183] rc=1 vc=929 vn=- li=6 udi=- nc=2 flg=0x1100
 n1100n   (  3)                        ==>iRegLoad (in GPR_0100) (X>=0 cannotOverflow SeenRealReference )
 n1098n   (  3)                        ==>iRegLoad (in GPR_0098) (X>=0 cannotOverflow SeenRealReference )
 n70n     (  1)                    iconst 3 (Unsigned X!=0 X>=0 )                                     [     0x3ff469505a0] bci=[-1,29,182] rc=1 vc=929 vn=- li=6 udi=- nc=0 flg=0x4104
 n73n     (  2)                  ==>lconst -8 (X!=0 X<=0 )
 n99n     (  2)      ==>lconst 0 (highWordZero X==0 X>=0 X<=0 )
 n110n    (  2)      computeCC                                                                        [     0x3ff46951220] bci=[-1,54,184] rc=2 vc=929 vn=- li=6 udi=- nc=1
 n109n    (  1)        luadd                                                                          [     0x3ff469511d0] bci=[-1,54,184] rc=1 vc=929 vn=- li=6 udi=- nc=2
 n101n    (  3)          ==>computeCC
 n1099n   (  2)          ==>lRegLoad (in GPR_0099) (cannotOverflow SeenRealReference )
------------------------------
```

This particular tree sequence was spotted on Linux on Z, but the problem seems to occur on every platform. The problem is a compile time crash with the following backtrace:

```
#12 <signal handler called>
#13 0x000003ffae2c1090 in OMR::CodeGenerator::canClobberNodesRegister(TR::Node*, unsigned short, TR_ClobberEvalData*, bool) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#14 0x000003ffae6feb02 in TR_S390BinaryAnalyser::remapInputs(TR::Node*, TR::Register*, TR::Node*, TR::Register*) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#15 0x000003ffae6ff5e6 in TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#16 0x000003ffae70f560 in lsubHelper64(TR::Node*, TR::CodeGenerator*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#17 0x000003ffae2bdbf6 in OMR::CodeGenerator::evaluate(TR::Node*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#18 0x000003ffae2d015a in OMR::TreeEvaluator::computeCCEvaluator(TR::Node*, TR::CodeGenerator*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#19 0x000003ffae2bdbf6 in OMR::CodeGenerator::evaluate(TR::Node*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#20 0x000003ffae785646 in lstoreHelper64(TR::Node*, TR::CodeGenerator*, bool) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#21 0x000003ffae786376 in OMR::Z::TreeEvaluator::lstoreEvaluator(TR::Node*, TR::CodeGenerator*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#22 0x000003ffae2bdbf6 in OMR::CodeGenerator::evaluate(TR::Node*) () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#23 0x000003ffadf2dcf8 in J9::CodeGenerator::doInstructionSelection() () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#24 0x000003ffae2cc9d0 in OMR::CodeGenPhase::performInstructionSelectionPhase(TR::CodeGenerator*, TR::CodeGenPhase*) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#25 0x000003ffae2cae92 in OMR::CodeGenPhase::performAll() () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#26 0x000003ffae2c8558 in OMR::CodeGenerator::generateCode() () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#27 0x000003ffae2e1b4c in OMR::Compilation::compile() () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#28 0x000003ffadf69cea in TR::CompilationInfoPerThreadBase::compile(J9VMThread*, TR::Compilation*, TR_ResolvedMethod*, TR_J9VMBase&, TR_OptimizationPlan*, TR::SegmentAllocator const&) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#29 0x000003ffadf6ad92 in TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary*, void*) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#30 0x000003ffaf6a92e0 in omrsig_protect () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9prt29.so
#31 0x000003ffadf6c8ce in TR::CompilationInfoPerThreadBase::compile(J9VMThread*, TR_MethodToBeCompiled*, J9::J9SegmentProvider&) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#32 0x000003ffadf6ce30 in TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled&, J9::J9SegmentProvider&) ()
   from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#33 0x000003ffadf6d720 in TR::CompilationInfoPerThread::processEntries() () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
#34 0x000003ffadf6d9e8 in TR::CompilationInfoPerThread::run() () from /j9vm/ascii/builds/bld_422342/sdk/xz6480/jre/lib/s390x/compressedrefs/libj9jit29.so
```

@wbh123456 FYI we'll need some more work in this area.