### PR TITLE
Removed monexitfenceEvaluator from ARM and AArch64

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -390,13 +390,6 @@ OMR::ARM64::TreeEvaluator::monexitEvaluator(TR::Node *node, TR::CodeGenerator *c
 	}
 
 TR::Register *
-OMR::ARM64::TreeEvaluator::monexitfenceEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-	{
-	// TODO:ARM64: Enable TR::TreeEvaluator::monexitfenceEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.
-	return OMR::ARM64::TreeEvaluator::unImpOpEvaluator(node, cg);
-	}
-
-TR::Register *
 OMR::ARM64::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 	{
 	// TODO:ARM64: Enable TR::TreeEvaluator::arraytranslateAndTestEvaluator in compiler/aarch64/codegen/TreeEvaluatorTable.hpp when Implemented.

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -612,7 +612,6 @@ public:
 	static TR::Register *cstoreiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *monexitfenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -755,11 +755,6 @@ TR::Register *OMR::ARM::TreeEvaluator::monexitEvaluator(TR::Node *node, TR::Code
    }
 #endif
 
-TR::Register *OMR::ARM::TreeEvaluator::monexitfenceEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   return NULL;         //this op code does not evaluate to anything
-   }
-
 TR::Register *OMR::ARM::TreeEvaluator::integerHighestOneBit(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
 TR::Register *OMR::ARM::TreeEvaluator::integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }
 TR::Register *OMR::ARM::TreeEvaluator::integerNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg) { TR_UNIMPLEMENTED(); return NULL; }

--- a/compiler/arm/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.hpp
@@ -94,7 +94,6 @@ public:
    static TR::Register *returnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monentEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *monexitEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *monexitfenceEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *asynccheckEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 #if J9_PROJECT_SPECIFIC
    static TR::Register *instanceofEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -714,7 +714,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::monent
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::monexit
 #endif
-   TR::TreeEvaluator::monexitfenceEvaluator, // TR::monexitfence
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::monexitfence
    TR::TreeEvaluator::badILOpEvaluator,     // TR::tstart
    TR::TreeEvaluator::badILOpEvaluator,     // TR::tfinish
    TR::TreeEvaluator::badILOpEvaluator,     // TR::tabort


### PR DESCRIPTION
Removed ARM and AArch64 specific monexitfenceEvaluator code.
monexitfenceEvaluator is now shared across architectures in openj9.

Signed-off-by: Michael Flawn <mflawn@unb.ca>