### PR TITLE
Remove OMR_GC_ARRAYLETS ifdef

### DIFF
--- a/example/glue/ArrayletObjectModel.hpp
+++ b/example/glue/ArrayletObjectModel.hpp
@@ -25,7 +25,6 @@
 #include "omrcfg.h"
 #include "ModronAssertions.h"
 
-#if defined(OMR_GC_ARRAYLETS)
 
 class MM_GCExtensionsBase;
 class MM_MemorySubSpace;
@@ -79,5 +78,4 @@ public:
 
 };
 
-#endif /*OMR_GC_ARRAYLETS */
 #endif /* ARRAYLETOBJECTMODEL_ */

--- a/gc/base/AllocationContext.hpp
+++ b/gc/base/AllocationContext.hpp
@@ -91,13 +91,11 @@ public:
 		Assert_MM_unreachable();
 		return NULL;
 	}
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, bool shouldCollectOnFailure)
 	{
 		Assert_MM_unreachable();
 		return NULL;
 	}
-#endif /* defined(OMR_GC_ARRAYLETS) */		
 
 protected:
 	virtual void tearDown(MM_EnvironmentBase *env);

--- a/gc/base/AllocationInterfaceGeneric.cpp
+++ b/gc/base/AllocationInterfaceGeneric.cpp
@@ -90,7 +90,6 @@ MM_AllocationInterfaceGeneric::allocateArray(MM_EnvironmentBase *env, MM_Allocat
 	return allocateObject(env, allocateDescription, memorySpace, shouldCollectOnFailure);
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 /**
  * Allocate the arraylet spine.
  */
@@ -110,7 +109,6 @@ MM_AllocationInterfaceGeneric::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_
 	Assert_MM_unreachable();
 	return NULL;
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 /**
  * Flush the allocation cache.

--- a/gc/base/AllocationInterfaceGeneric.hpp
+++ b/gc/base/AllocationInterfaceGeneric.hpp
@@ -40,10 +40,8 @@ public:
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
 	virtual void *allocateArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletSpine(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 
 	virtual void flushCache(MM_EnvironmentBase *env);
 

--- a/gc/base/ArrayObjectModel.hpp
+++ b/gc/base/ArrayObjectModel.hpp
@@ -29,11 +29,7 @@
  * GC_ArrayObjectModel isn't a true class -- instead it's just a typedef for GC_ArrayletObjectModel
  */
 
-#if defined(OMR_GC_ARRAYLETS)
 #include "ArrayletObjectModel.hpp"
 typedef GC_ArrayletObjectModel GC_ArrayObjectModel; /**< object model for arrays (arraylet configuration) */
-#else /* OMR_GC_ARRAYLETS */
-#error "Non-arraylet indexable object model is not implemented"
-#endif /* OMR_GC_ARRAYLETS */
 
 #endif /* ARRAYOBJECTMODEL_HPP_ */

--- a/gc/base/MemoryPool.cpp
+++ b/gc/base/MemoryPool.cpp
@@ -140,7 +140,6 @@ MM_MemoryPool::unregisterMemoryPool(MM_MemoryPool *memoryPool)
 		next->setPrevious(previous);
 	}
 }
-#if defined(OMR_GC_ARRAYLETS)
 	/**
 	 * Allocate an arraylet leaf.
 	 */
@@ -150,7 +149,6 @@ MM_MemoryPool::unregisterMemoryPool(MM_MemoryPool *memoryPool)
 		Assert_MM_unreachable();
 		return NULL;
 	}
-#endif /* OMR_GC_ARRAYLETS */
 
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	void *

--- a/gc/base/MemoryPool.hpp
+++ b/gc/base/MemoryPool.hpp
@@ -223,12 +223,10 @@ public:
 	 * VMs, and arraylet spines (including their leaves, if inline) take this path.
 	 */
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription) = 0;
-#if defined(OMR_GC_ARRAYLETS)
 	/**
 	 * Allocate an arraylet leaf.
 	 */	
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDesc);
-#endif /* OMR_GC_ARRAYLETS */
 	virtual void *collectorAllocate(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, bool lockingRequired);
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, uintptr_t maximumSizeInBytesRequired, void * &addrBase, void * &addrTop);

--- a/gc/base/MemorySubSpace.cpp
+++ b/gc/base/MemorySubSpace.cpp
@@ -1052,11 +1052,9 @@ MM_MemorySubSpace::allocateGeneric(MM_EnvironmentBase* env, MM_AllocateDescripti
 	case ALLOCATION_TYPE_OBJECT:
 		result = attemptSubspace->allocateObject(env, allocateDescription, this, this, false);
 		break;
-#if defined(OMR_GC_ARRAYLETS)
 	case ALLOCATION_TYPE_LEAF:
 		result = attemptSubspace->allocateArrayletLeaf(env, allocateDescription, this, this, false);
 		break;
-#endif /* defined(OMR_GC_ARRAYLETS) */
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	case ALLOCATION_TYPE_TLH:
 		result = attemptSubspace->allocateTLH(env, allocateDescription, objectAllocationInterface, this, this, false);

--- a/gc/base/MemorySubSpaceFlat.cpp
+++ b/gc/base/MemorySubSpaceFlat.cpp
@@ -189,7 +189,6 @@ MM_MemorySubSpaceFlat::allocationRequestFailed(MM_EnvironmentBase* env, MM_Alloc
 	return NULL;
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 void*
 MM_MemorySubSpaceFlat::allocateArrayletLeaf(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure)
 {
@@ -206,7 +205,6 @@ MM_MemorySubSpaceFlat::allocateArrayletLeaf(MM_EnvironmentBase* env, MM_Allocate
 	}
 	return result;
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 /**
  * Return the allocation failure stats for this subSpace.

--- a/gc/base/MemorySubSpaceFlat.hpp
+++ b/gc/base/MemorySubSpaceFlat.hpp
@@ -63,9 +63,7 @@ public:
 	virtual MM_AllocationFailureStats *getAllocationFailureStats();
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 	
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_ObjectAllocationInterface *objectAllocationInterface, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);

--- a/gc/base/MemorySubSpaceGenerational.cpp
+++ b/gc/base/MemorySubSpaceGenerational.cpp
@@ -155,7 +155,6 @@ MM_MemorySubSpaceGenerational::allocationRequestFailed(MM_EnvironmentBase *env, 
 	return addr;
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 void *
 MM_MemorySubSpaceGenerational::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure)
 {
@@ -172,7 +171,6 @@ MM_MemorySubSpaceGenerational::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_
 		return NULL;
 	}
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 void *
 MM_MemorySubSpaceGenerational::allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_ObjectAllocationInterface *objectAllocationInterface, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure)

--- a/gc/base/MemorySubSpaceGenerational.hpp
+++ b/gc/base/MemorySubSpaceGenerational.hpp
@@ -89,9 +89,7 @@ public:
 	virtual const char *getDescription() { return MEMORY_SUBSPACE_DESCRIPTION_GENERATIONAL; }
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 	
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_ObjectAllocationInterface *objectAllocationInterface, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
 

--- a/gc/base/MemorySubSpaceGeneric.cpp
+++ b/gc/base/MemorySubSpaceGeneric.cpp
@@ -314,7 +314,6 @@ MM_MemorySubSpaceGeneric::allocateObject(MM_EnvironmentBase* env, MM_AllocateDes
 /**
  * Allocate the arraylet spine in immortal or scoped memory.
  */
-#if defined(OMR_GC_ARRAYLETS)
 void*
 MM_MemorySubSpaceGeneric::allocateArrayletLeaf(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure)
 {
@@ -337,7 +336,6 @@ MM_MemorySubSpaceGeneric::allocateArrayletLeaf(MM_EnvironmentBase* env, MM_Alloc
 
 	return result;
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 void*
 MM_MemorySubSpaceGeneric::allocationRequestFailed(MM_EnvironmentBase* env, MM_AllocateDescription* allocateDescription, AllocationType allocationType, MM_ObjectAllocationInterface* objectAllocationInterface, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace)

--- a/gc/base/MemorySubSpaceGeneric.hpp
+++ b/gc/base/MemorySubSpaceGeneric.hpp
@@ -80,9 +80,7 @@ public:
 	virtual MM_AllocationFailureStats* getAllocationFailureStats();
 
 	virtual void* allocateObject(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void* allocateArrayletLeaf(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void* allocateTLH(MM_EnvironmentBase* env, MM_AllocateDescription* allocDescription, MM_ObjectAllocationInterface* objectAllocationInterface, MM_MemorySubSpace* baseSubSpace, MM_MemorySubSpace* previousSubSpace, bool shouldCollectOnFailure);

--- a/gc/base/MemorySubSpaceSemiSpace.cpp
+++ b/gc/base/MemorySubSpaceSemiSpace.cpp
@@ -162,7 +162,6 @@ MM_MemorySubSpaceSemiSpace::allocationRequestFailed(MM_EnvironmentBase *env, MM_
 	return addr;
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 void *
 MM_MemorySubSpaceSemiSpace::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure)
 {
@@ -188,7 +187,6 @@ MM_MemorySubSpaceSemiSpace::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_All
 	
 	return addr;	
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 void *
 MM_MemorySubSpaceSemiSpace::allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_ObjectAllocationInterface *objectAllocationInterface, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure)

--- a/gc/base/MemorySubSpaceSemiSpace.hpp
+++ b/gc/base/MemorySubSpaceSemiSpace.hpp
@@ -113,9 +113,7 @@ public:
 	virtual const char *getDescription() { return MEMORY_SUBSPACE_DESCRIPTION_SEMISPACE; }
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 	
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_ObjectAllocationInterface *objectAllocationInterface, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
 

--- a/gc/base/ObjectAllocationInterface.hpp
+++ b/gc/base/ObjectAllocationInterface.hpp
@@ -101,7 +101,6 @@ public:
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure) = 0;
 	virtual void *allocateArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure) = 0;
-#if defined(OMR_GC_ARRAYLETS)
 	/**
 	 * Allocate the arraylet spine.
 	 */
@@ -121,7 +120,6 @@ public:
 		Assert_MM_unreachable();
 		return NULL;
 	}
-#endif /* OMR_GC_ARRAYLETS */
 
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *memorySubSpace, MM_MemoryPool *memoryPool);

--- a/gc/base/ObjectHeapBufferedIterator.cpp
+++ b/gc/base/ObjectHeapBufferedIterator.cpp
@@ -92,9 +92,7 @@ GC_ObjectHeapBufferedIterator::getPopulator()
 	case MM_HeapRegionDescriptor::ADDRESS_ORDERED_IDLE:
 	case MM_HeapRegionDescriptor::BUMP_ALLOCATED_IDLE:
 		/* (for all intents and purposes, an IDLE region is the same as a FREE region) */
-#if defined(OMR_GC_ARRAYLETS)
 	case MM_HeapRegionDescriptor::ARRAYLET_LEAF:
-#endif /* defined(OMR_GC_ARRAYLETS) */
 		populator = &_emptyListPopulator;
 		break;
 	case MM_HeapRegionDescriptor::BUMP_ALLOCATED:

--- a/gc/base/TLHAllocationInterface.cpp
+++ b/gc/base/TLHAllocationInterface.cpp
@@ -220,7 +220,6 @@ MM_TLHAllocationInterface::allocateArray(MM_EnvironmentBase *env, MM_AllocateDes
 	return allocateObject(env, allocateDescription, memorySpace, shouldCollectOnFailure);
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 void *
 MM_TLHAllocationInterface::allocateArrayletSpine(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure)
 {
@@ -251,7 +250,6 @@ MM_TLHAllocationInterface::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_Allo
 
 	return result;
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 /**
  * Replenish the allocation interface TLH cache with new storage.

--- a/gc/base/TLHAllocationInterface.hpp
+++ b/gc/base/TLHAllocationInterface.hpp
@@ -70,10 +70,8 @@ public:
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
 	virtual void *allocateArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletSpine(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 
 	virtual void *allocateTLH(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *memorySubSpace, MM_MemoryPool *memoryPool);
 

--- a/gc/base/segregated/AllocationContextSegregated.cpp
+++ b/gc/base/segregated/AllocationContextSegregated.cpp
@@ -318,7 +318,6 @@ MM_AllocationContextSegregated::preAllocateSmall(MM_EnvironmentBase *env, uintpt
 
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 uintptr_t *
 MM_AllocationContextSegregated::allocateArraylet(MM_EnvironmentBase *env, omrarrayptr_t parent)
 {
@@ -356,7 +355,6 @@ retry:
 
 	return NULL;
 }
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 /* This method is moved here so that AC can see the large full page and cache it */
 uintptr_t *

--- a/gc/base/segregated/AllocationContextSegregated.hpp
+++ b/gc/base/segregated/AllocationContextSegregated.hpp
@@ -107,9 +107,7 @@ public:
 
 	void setMarkingScheme(MM_SegregatedMarkingScheme *markingScheme) { _markingScheme = markingScheme; }
 
-#if defined(OMR_GC_ARRAYLETS)
 	uintptr_t *allocateArraylet(MM_EnvironmentBase *env, omrarrayptr_t parent);
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 protected:
 	MM_AllocationContextSegregated(MM_EnvironmentBase *env, MM_GlobalAllocationManagerSegregated *gam, MM_RegionPoolSegregated *regionPool)

--- a/gc/base/segregated/FreeHeapRegionList.hpp
+++ b/gc/base/segregated/FreeHeapRegionList.hpp
@@ -84,10 +84,8 @@ public:
 			region->setRangeHead(region);
 			if (szClass == OMR_SIZECLASSES_LARGE) {
 				region->setLarge(1);
-#if defined(OMR_GC_ARRAYLETS)
 			} else if (szClass == OMR_SIZECLASSES_ARRAYLET) {
 				region->setArraylet();
-#endif /* defined(OMR_GC_ARRAYLETS) */		
 			} else {
 				region->setSmall(szClass);
 			}

--- a/gc/base/segregated/HeapRegionDescriptorSegregated.cpp
+++ b/gc/base/segregated/HeapRegionDescriptorSegregated.cpp
@@ -167,7 +167,6 @@ MM_HeapRegionDescriptorSegregated::formatFresh(MM_EnvironmentBase *env, uintptr_
 	return numCells;
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 uintptr_t *
 MM_HeapRegionDescriptorSegregated::allocateArraylet(MM_EnvironmentBase *env, omrarrayptr_t parentIndexableObject)
 {
@@ -216,7 +215,6 @@ MM_HeapRegionDescriptorSegregated::addBytesFreedToSmallSpineBackout(MM_Environme
 		_memoryPoolACL.addSweepFreeBytes(env, cellSize);
 	}
 }
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 /**
  * We must be notified when an empty region is allocated so that we can account for the memory lost to
@@ -233,13 +231,11 @@ MM_HeapRegionDescriptorSegregated::emptyRegionAllocated(MM_EnvironmentBase *env)
 		Assert_MM_true(getRange() == 1);
 		/* We need to account for internal fragmentation. */
 		_memoryPoolACL.addBytesAllocated(env, (extensions->regionSize - (getNumCells() * getCellSize())));
-#if defined(OMR_GC_ARRAYLETS)
 	} else if (isArraylet()) {
 		/* We only need to take into account potential internal fragmentation of arraylets, the allocation
 		 * context will call into the allocation tracker for the allocation of the arraylet.
 		 */
 		_memoryPoolACL.addBytesAllocated(env, (extensions->regionSize % env->getOmrVM()->_arrayletLeafSize) * getRange());
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	} else if (isLarge()) {
 		/* We need to account for the entire allocation. */
 		env->_allocationTracker->addBytesAllocated(env, extensions->regionSize * getRange());
@@ -257,11 +253,9 @@ MM_HeapRegionDescriptorSegregated::emptyRegionReturned(MM_EnvironmentBase *env)
 		Assert_MM_true(getRange() == 1);
 		/* We need to account for internal fragmentation. */
 		env->_allocationTracker->addBytesFreed(env, (extensions->regionSize - (getNumCells() * getCellSize())));
-#if defined(OMR_GC_ARRAYLETS)
 	} else if (isArraylet()) {
 		/* We only need to take into account potential internal fragmentation of arraylets. */
 		env->_allocationTracker->addBytesFreed(env, (extensions->regionSize % env->getOmrVM()->_arrayletLeafSize) * getRange());
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	} else if (isLarge()) {
 		/* We need to account for the entire allocation. */
 		env->_allocationTracker->addBytesFreed(env, extensions->regionSize * getRange());
@@ -273,7 +267,6 @@ MM_HeapRegionDescriptorSegregated::emptyRegionReturned(MM_EnvironmentBase *env)
 void
 MM_HeapRegionDescriptorSegregated::updateCounts(MM_EnvironmentBase *env, bool fromFlush)
 {
-#if defined(OMR_GC_ARRAYLETS)
 	if (isArraylet()) {
 
 		_memoryPoolACL.resetCounts();
@@ -285,7 +278,6 @@ MM_HeapRegionDescriptorSegregated::updateCounts(MM_EnvironmentBase *env, bool fr
 			}
 		}
 	} else
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	if (isSmall()) {
 		_memoryPoolACL.updateCounts(env, fromFlush);
 	} else if (isLarge()) {

--- a/gc/base/segregated/HeapRegionDescriptorSegregated.hpp
+++ b/gc/base/segregated/HeapRegionDescriptorSegregated.hpp
@@ -98,9 +98,7 @@ public:
 	bool isReserved() { return getRegionType() == RESERVED; }
 	bool isSmall() { return getRegionType() == SEGREGATED_SMALL; }
 	bool isLarge() { return getRegionType() == SEGREGATED_LARGE; }
-#if defined(OMR_GC_ARRAYLETS)
 	bool isArraylet() { return getRegionType() == ARRAYLET_LEAF; }
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	bool isFree() { return getRegionType() == FREE; }
 	bool isCanonical() { return isReserved() || isSmall() || getRangeCount() >= 1; }
 
@@ -121,7 +119,6 @@ public:
 	void emptyRegionAllocated(MM_EnvironmentBase* env);
 	void emptyRegionReturned(MM_EnvironmentBase* env);
 
-#if defined(OMR_GC_ARRAYLETS)
 	uintptr_t *allocateArraylet(MM_EnvironmentBase *env, omrarrayptr_t parentIndexableObject);
 	void setArraylet();
 	MMINLINE uintptr_t whichArraylet(uintptr_t *arraylet, uintptr_t arrayletLeafLogSize) { return ((uintptr_t)arraylet - (uintptr_t)getLowAddress()) >> arrayletLeafLogSize; }
@@ -134,7 +131,6 @@ public:
 	MMINLINE void setNextArrayletIndex (uintptr_t index)   { _nextArrayletIndex = index; }
 	void addBytesFreedToArrayletBackout(MM_EnvironmentBase* env);
 	void addBytesFreedToSmallSpineBackout(MM_EnvironmentBase* env);
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 	void setLarge(uintptr_t range) { setRange(SEGREGATED_LARGE, range); }
 	void setSmall(uintptr_t sizeClass);

--- a/gc/base/segregated/LockingFreeHeapRegionList.cpp
+++ b/gc/base/segregated/LockingFreeHeapRegionList.cpp
@@ -110,10 +110,8 @@ MM_LockingFreeHeapRegionList::allocate(MM_EnvironmentBase *env, uintptr_t szClas
 				cur->setRangeHead(cur);
 				if (szClass == OMR_SIZECLASSES_LARGE) {
 					cur->setLarge(numRegions);
-#if defined(OMR_GC_ARRAYLETS)
 				} else if (szClass == OMR_SIZECLASSES_ARRAYLET) {
 					cur->setArraylet();
-#endif /* defined(OMR_GC_ARRAYLETS) */		
 				} else {
 					cur->setSmall(szClass);
 				}

--- a/gc/base/segregated/MemoryPoolSegregated.cpp
+++ b/gc/base/segregated/MemoryPoolSegregated.cpp
@@ -29,9 +29,7 @@
 #include <string.h>
 
 #include "AllocateDescription.hpp"
-#if defined(OMR_GC_ARRAYLETS)
 #include "ArrayletObjectModel.hpp"
-#endif /* OMR_GC_ARRAYLETS */
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
 #include "Heap.hpp"
@@ -123,7 +121,6 @@ MM_MemoryPoolSegregated::moveInUseToSweep(MM_EnvironmentBase *env)
 	_regionPool->moveInUseToSweep(env);
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 void*
 MM_MemoryPoolSegregated::allocateChunkedArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocDesc, MM_AllocationContextSegregated *ac)
 {
@@ -203,7 +200,6 @@ MM_MemoryPoolSegregated::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_Alloca
 	
 	return allocationContext->allocateArraylet(env, spine);
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 /**
  * @todo Provide function documentation
@@ -214,7 +210,6 @@ MM_MemoryPoolSegregated::allocateObject(MM_EnvironmentBase *env, MM_AllocateDesc
 	void *result = NULL;
 	MM_AllocationContextSegregated *allocationContext = (MM_AllocationContextSegregated *)env->getAllocationContext();
 
-#if defined(OMR_GC_ARRAYLETS)
 	if (allocDesc->isArrayletSpine()) {
 		result = (void *) allocateContiguous(env, allocDesc, allocationContext);
 	} else if (allocDesc->isChunkedArray()) {
@@ -222,9 +217,6 @@ MM_MemoryPoolSegregated::allocateObject(MM_EnvironmentBase *env, MM_AllocateDesc
 	} else {
 		result = (void *) allocateContiguous(env, allocDesc, allocationContext);
 	}
-#else /* defined(OMR_GC_ARRAYLETS) */
-	result = (void *) allocateContiguous(env, allocDesc, allocationContext);
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	return result;
 }
 

--- a/gc/base/segregated/MemoryPoolSegregated.hpp
+++ b/gc/base/segregated/MemoryPoolSegregated.hpp
@@ -85,9 +85,7 @@ public:
 	virtual void setFreeEntryCount(uintptr_t entryCount);
 	
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDesc);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDesc);
-#endif /* OMR_GC_ARRAYLETS */
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)
 	using MM_MemoryPool::allocateTLH;
 	virtual void *allocateTLH(MM_EnvironmentBase *env, uintptr_t maxSizeInBytesRequired, void * &addrBase, void * &addrTop);
@@ -130,9 +128,7 @@ protected:
 	
 private:
 	uintptr_t *allocateContiguous(MM_EnvironmentBase *env, MM_AllocateDescription *allocDesc, MM_AllocationContextSegregated *ac);
-#if defined(OMR_GC_ARRAYLETS)
 	void *allocateChunkedArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocDesc, MM_AllocationContextSegregated *ac);
-#endif /* OMR_GC_ARRAYLETS */
 
 };
 

--- a/gc/base/segregated/MemorySubSpaceSegregated.cpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.cpp
@@ -57,7 +57,6 @@ MM_MemorySubSpaceSegregated::allocateObject(MM_EnvironmentBase *env, MM_Allocate
 	return result;
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 /**
  * Allocate an arraylet leaf.
  */
@@ -76,7 +75,6 @@ MM_MemorySubSpaceSegregated::allocateArrayletLeaf(MM_EnvironmentBase *env, MM_Al
 	}
 	return leaf;
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 void *
 MM_MemorySubSpaceSegregated::allocate(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, AllocateType allocType)
@@ -87,11 +85,9 @@ MM_MemorySubSpaceSegregated::allocate(MM_EnvironmentBase *env, MM_AllocateDescri
 	case arrayletSpine:
 		result = _memoryPoolSegregated->allocateObject(env, allocDescription);
 		break;
-#if defined(OMR_GC_ARRAYLETS)
 	case arrayletLeaf:
 		result = _memoryPoolSegregated->allocateArrayletLeaf(env, allocDescription);
 		break;
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	default:
 		Assert_MM_unreachable();
 	}
@@ -203,13 +199,11 @@ MM_MemorySubSpaceSegregated::allocationRequestFailed(MM_EnvironmentBase *env, MM
 	return allocateGeneric(env, allocateDescription, allocationType, objectAllocationInterface, baseSubSpace);
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 uintptr_t
 MM_MemorySubSpaceSegregated::largestDesirableArraySpine()
 {
 	return OMR_SIZECLASSES_MAX_SMALL_SIZE_BYTES;
 }
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 void
 MM_MemorySubSpaceSegregated::abandonHeapChunk(void *addrBase, void *addrTop)
@@ -282,11 +276,9 @@ MM_MemorySubSpaceSegregated::expanded(
 	bool result = heapAddRange(env, this, region->getSize(), regionLowAddress, regionHighAddress);
 
 	/* Expand the valid range for arraylets. */
-#if defined(OMR_GC_ARRAYLETS)
 	if (result) {
 		_extensions->indexableObjectModel.expandArrayletSubSpaceRange(this, regionLowAddress, regionHighAddress, largestDesirableArraySpine());
 	}
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 	return result;
 }

--- a/gc/base/segregated/MemorySubSpaceSegregated.hpp
+++ b/gc/base/segregated/MemorySubSpaceSegregated.hpp
@@ -91,10 +91,8 @@ public:
 
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
 
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, MM_MemorySubSpace *baseSubSpace, MM_MemorySubSpace *previousSubSpace, bool shouldCollectOnFailure);
 	virtual uintptr_t largestDesirableArraySpine();
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 	/* Calls for internal collection routines */
 	virtual void abandonHeapChunk(void *addrBase, void *addrTop);

--- a/gc/base/segregated/ObjectHeapIteratorSegregated.cpp
+++ b/gc/base/segregated/ObjectHeapIteratorSegregated.cpp
@@ -55,9 +55,7 @@ GC_ObjectHeapIteratorSegregated::nextObject()
 				_scanPtr = _scanPtrTop;
 			}
 			break;
-#if defined(OMR_GC_ARRAYLETS)
 		case MM_HeapRegionDescriptor::ARRAYLET_LEAF:
-#endif /* defined(OMR_GC_ARRAYLETS) */		
 		case MM_HeapRegionDescriptor::FREE:
 		case MM_HeapRegionDescriptor::RESERVED:
 			/* ARRAYLET, FREE and RESERVED do not contain any objects */
@@ -109,9 +107,7 @@ GC_ObjectHeapIteratorSegregated::nextObjectNoAdvance()
 				_scanPtr = _scanPtrTop;
 			}
 			break;
-#if defined(OMR_GC_ARRAYLETS)
 		case MM_HeapRegionDescriptor::ARRAYLET_LEAF:
-#endif /* defined(OMR_GC_ARRAYLETS) */		
 		case MM_HeapRegionDescriptor::FREE:
 		case MM_HeapRegionDescriptor::RESERVED:
 			/* ARRAYLET, FREE and RESERVED do not contain any objects */

--- a/gc/base/segregated/SegregatedAllocationInterface.cpp
+++ b/gc/base/segregated/SegregatedAllocationInterface.cpp
@@ -195,7 +195,6 @@ void*
 MM_SegregatedAllocationInterface::allocateArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure)
 {
 	void *result = NULL;
-#if defined(OMR_GC_ARRAYLETS)
 	MM_MemorySubSpace *subSpace = memorySpace->getDefaultMemorySubSpace();
 	
 	result = subSpace->allocateObject(env, allocateDescription, NULL, NULL, shouldCollectOnFailure);
@@ -205,13 +204,9 @@ MM_SegregatedAllocationInterface::allocateArray(MM_EnvironmentBase *env, MM_Allo
 		++_stats._allocationCount;
 	}
 
-#else /* OMR_GC_ARRAYLETS */
-	result = allocateObject(env, allocateDescription, memorySpace, shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 	return result;
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 /**
  * Allocate the arraylet spine.
  */
@@ -249,7 +244,6 @@ MM_SegregatedAllocationInterface::allocateArrayletLeaf(MM_EnvironmentBase *env, 
 
 	return result;
 }
-#endif /* OMR_GC_ARRAYLETS */
 
 /**
  * Flush the allocation cache.

--- a/gc/base/segregated/SegregatedAllocationInterface.hpp
+++ b/gc/base/segregated/SegregatedAllocationInterface.hpp
@@ -80,10 +80,8 @@ public:
 	
 	virtual void *allocateObject(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
 	virtual void *allocateArray(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
-#if defined(OMR_GC_ARRAYLETS)
 	virtual void *allocateArrayletSpine(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
 	virtual void *allocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_MemorySpace *memorySpace, bool shouldCollectOnFailure);
-#endif /* OMR_GC_ARRAYLETS */
 	
 	virtual void flushCache(MM_EnvironmentBase *env);
 

--- a/gc/base/segregated/SweepSchemeSegregated.cpp
+++ b/gc/base/segregated/SweepSchemeSegregated.cpp
@@ -107,10 +107,8 @@ MM_SweepSchemeSegregated::sweep(MM_EnvironmentBase *env, MM_MemoryPoolSegregated
 		env->_currentTask->releaseSynchronizedGCThreads(env);
 	}
 	
-#if defined(OMR_GC_ARRAYLETS)
 	incrementalSweepArraylet(env);
 	env->_currentTask->synchronizeGCThreads(env, UNIQUE_ID);
-#endif /* OMR_GC_ARRAYLETS */
 	incrementalSweepLarge(env);
 	
 	MM_RegionPoolSegregated *regionPool = _memoryPool->getRegionPool();
@@ -157,12 +155,10 @@ MM_SweepSchemeSegregated::sweepRegion(MM_EnvironmentBase *env, MM_HeapRegionDesc
 		addBytesFreedAfterSweep(env, region);
 		break;
 
-#if defined(OMR_GC_ARRAYLETS)
 	case MM_HeapRegionDescriptor::ARRAYLET_LEAF:
 		sweepArrayletRegion(env, region);
 		addBytesFreedAfterSweep(env, region);
 		break;
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 	case MM_HeapRegionDescriptor::SEGREGATED_LARGE:
 		sweepLargeRegion(env, region);
@@ -302,7 +298,6 @@ MM_SweepSchemeSegregated::sweepSmallRegion(MM_EnvironmentBase *env, MM_HeapRegio
 	_memoryPool->getRegionPool()->addDarkMatterCellsAfterSweepForSizeClass(region->getSizeClass(), numCells - memoryPoolACL->getMarkCount() - memoryPoolACL->getFreeCount());
 }
 
-#if defined(OMR_GC_ARRAYLETS)
 void
 MM_SweepSchemeSegregated::sweepArrayletRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region)
 {
@@ -330,7 +325,6 @@ MM_SweepSchemeSegregated::sweepArrayletRegion(MM_EnvironmentBase *env, MM_HeapRe
 		}
 	}
 }
-#endif /* defined(OMR_GC_ARRAYLETS) */
 
 void
 MM_SweepSchemeSegregated::sweepLargeRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region)
@@ -358,10 +352,8 @@ MM_SweepSchemeSegregated::addBytesFreedAfterSweep(MM_EnvironmentBase *env, MM_He
 	uintptr_t currentFreeBytes = memoryPoolACL->getFreeCount();
 	if (region->isSmall()) {
 		currentFreeBytes *= region->getCellSize();
-#if defined(OMR_GC_ARRAYLETS)
 	} else if (region->isArraylet()) {
 		currentFreeBytes *= env->getOmrVM()->_arrayletLeafSize;
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	} else {
 		Assert_MM_unreachable();
 	}

--- a/gc/base/segregated/SweepSchemeSegregated.hpp
+++ b/gc/base/segregated/SweepSchemeSegregated.hpp
@@ -93,9 +93,7 @@ protected:
 private:
 	void unmarkRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region);
 	void sweepSmallRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region);
-#if defined(OMR_GC_ARRAYLETS)
 	void sweepArrayletRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region);
-#endif /* defined(OMR_GC_ARRAYLETS) */
 	void sweepLargeRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region);
 	void addBytesFreedAfterSweep(MM_EnvironmentBase *env, MM_HeapRegionDescriptorSegregated *region);
 	void incrementalSweepSmall(MM_EnvironmentBase *env);

--- a/gc/stats/AllocationStats.cpp
+++ b/gc/stats/AllocationStats.cpp
@@ -36,10 +36,8 @@ MM_AllocationStats::clear()
 	_tlhMaxAbandonedListSize = 0;
 #endif /* defined (OMR_GC_THREAD_LOCAL_HEAP) */
 
-#if defined(OMR_GC_ARRAYLETS)
 	_arrayletLeafAllocationCount = 0;
 	_arrayletLeafAllocationBytes = 0;
-#endif
 
 	_allocationCount = 0;
 	_allocationBytes = 0;
@@ -69,10 +67,8 @@ MM_AllocationStats::merge(MM_AllocationStats *stats)
 	}
 #endif /* defined (OMR_GC_THREAD_LOCAL_HEAP) */
 
-#if defined(OMR_GC_ARRAYLETS)
 	MM_AtomicOperations::add(&_arrayletLeafAllocationCount, stats->_arrayletLeafAllocationCount);
 	MM_AtomicOperations::add(&_arrayletLeafAllocationBytes, stats->_arrayletLeafAllocationBytes);
-#endif
 
 	MM_AtomicOperations::add(&_allocationCount, stats->_allocationCount);
 	MM_AtomicOperations::add(&_allocationBytes, stats->_allocationBytes);

--- a/gc/stats/AllocationStats.hpp
+++ b/gc/stats/AllocationStats.hpp
@@ -43,10 +43,8 @@ public:
 	uintptr_t _tlhMaxAbandonedListSize; /**< The maximum size of the abandoned list. */
 #endif /* defined (OMR_GC_THREAD_LOCAL_HEAP) */
 
-#if defined(OMR_GC_ARRAYLETS)
 	uintptr_t _arrayletLeafAllocationCount;	/**< Number of arraylet leaf allocations */
 	uintptr_t _arrayletLeafAllocationBytes; /**< The amount of memory allocated for arraylet leafs */
-#endif
 
 	uintptr_t _allocationCount;
 	uintptr_t _allocationBytes;
@@ -73,9 +71,7 @@ public:
 #else
 		totalBytesAllocated += _allocationBytes;
 #endif
-#if defined(OMR_GC_ARRAYLETS)
 		totalBytesAllocated += _arrayletLeafAllocationBytes;
-#endif
 		return totalBytesAllocated;
 	}
 
@@ -89,10 +85,8 @@ public:
 		_tlhDiscardedBytes(0),
 		_tlhMaxAbandonedListSize(0),
 #endif /* defined (OMR_GC_THREAD_LOCAL_HEAP) */
-#if defined(OMR_GC_ARRAYLETS)
 		_arrayletLeafAllocationCount(0),
 		_arrayletLeafAllocationBytes(0),
-#endif
 		_allocationCount(0),
 		_allocationBytes(0),
 		_ownableSynchronizerObjectCount(0),

--- a/gc/structs/ObjectIteratorState.hpp
+++ b/gc/structs/ObjectIteratorState.hpp
@@ -42,15 +42,11 @@ private:
 protected:
 public:
 	omrobjectptr_t _objectPtr;				/**< pointer to the array object being scanned */
-#if defined(OMR_GC_ARRAYLETS)
 	union {
 		uintptr_t _index;					/**< index into arraylet */
 		fomrobject_t *_scanPtr;			/**< scan pointer into non-arraylet reference slot */
 	};
 	bool _contiguous; /**< whether or not the array being iterated is contiguous */
-#else
-	fomrobject_t *_scanPtr;				/**< scan pointer into next reference slot */
-#endif /* OMR_GC_ARRAYLETS */
 
 	fomrobject_t *_endPtr;				/**< points past last reference slot */
 	uintptr_t *_descriptionPtr;				/**< pointer to next description word */

--- a/gc/verbose/VerboseHandlerOutput.cpp
+++ b/gc/verbose/VerboseHandlerOutput.cpp
@@ -234,9 +234,7 @@ MM_VerboseHandlerOutput::handleInitializedRegion(J9HookInterface** hook, uintptr
 	writer->formatAndOutput(env, 1, "<region>");
 	writer->formatAndOutput(env, 2, "<attribute name=\"regionSize\" value=\"%zu\" />", event->regionSize);
 	writer->formatAndOutput(env, 2, "<attribute name=\"regionCount\" value=\"%zu\" />", event->regionCount);
-#if defined(OMR_GC_ARRAYLETS)
 	writer->formatAndOutput(env, 2, "<attribute name=\"arrayletLeafSize\" value=\"%zu\" />", event->arrayletLeafSize);
-#endif	
 	writer->formatAndOutput(env, 1, "</region>");
 }
 


### PR DESCRIPTION
Now that the OMR_GC_ARRAYLETS flag is permanently on, remove it from the OMR codebase. Note that the flag is still being defined in omrcfg.h for the time being (permanently enabled in a different PR).

Signed-off-by: Robert Young <rwy0717@gmail.com>