### PR TITLE
Deep Scan CS fix

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1711,10 +1711,10 @@ MM_Scavenger::scavengeObjectSlots(MM_EnvironmentStandard *env, MM_CopyScanCacheS
 }
 
 void
-MM_Scavenger::deepScanOutline(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, uintptr_t selfReferencingField1, uintptr_t selfReferencingField2)
+MM_Scavenger::deepScanOutline(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, uintptr_t priorityFieldOffset1, uintptr_t priorityFieldOffset2)
 {
-	void *tempObj = objectPtr;
-	uintptr_t priorityField = selfReferencingField1;
+	void *currentDeepObj = objectPtr;
+	uintptr_t priorityField = priorityFieldOffset1;
 	/* Throttle - Deep scan should be terminated when the free list is utilized more than 50% */
 	uintptr_t freeListUtilizationLimit = _scavengeCacheFreeList.getAllocatedCacheCount() / 2;
 
@@ -1723,30 +1723,31 @@ MM_Scavenger::deepScanOutline(MM_EnvironmentStandard *env, omrobjectptr_t object
 	env->_scavengerStats._totalDeepStructures += 1;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
-	while (true) {
-		GC_SlotObject tempSlot(env->getOmrVM(), (fomrobject_t*)(((uintptr_t) tempObj) + priorityField));
-		if (NULL == tempSlot.readReferenceFromSlot()) {
-			if ((priorityField == selfReferencingField2) || (selfReferencingField2 == 0)) {
+	do {
+		GC_SlotObject prioritySlot(env->getOmrVM(), (fomrobject_t*)(((uintptr_t) currentDeepObj) + priorityField));
+		copyAndForward(env, &prioritySlot);
+		/* Did we encounter an already visited/NULL object? */
+		if (NULL == env->_effectiveCopyScanCache) {
+			/* Can't continue any further - attempt to deep scan with other self referencing field (e.g, prev field) */
+			if ((priorityField == priorityFieldOffset2) || (priorityFieldOffset2 == 0)) {
 				break;
 			}
-			priorityField = selfReferencingField2;
-		} else {
-			copyAndForward(env, &tempSlot);
-			/* Did we encounter an already visited object or hit throttling threshold? */
-			if (NULL == env->_effectiveCopyScanCache) {
-				break;
-			}
+			priorityField = priorityFieldOffset2;
+			continue;
+		}
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
-			objDeepScanned += 1;
+		objDeepScanned += 1;
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 
-			if(env->approxScanCacheCount > freeListUtilizationLimit){
-				break;
-			}
-			tempObj = tempSlot.readReferenceFromSlot();
+		if(env->approxScanCacheCount > freeListUtilizationLimit) {
+			break;
 		}
-	}
+		currentDeepObj = prioritySlot.readReferenceFromSlot();
+
+	/* The successfully copied object slot can possibly be overwritten with NULL by a mutator (CS).
+	 * To avoid race condition, we need a NULL check before we proceed. */
+	} while (NULL != currentDeepObj);
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	env->_scavengerStats._totalObjsDeepScanned += objDeepScanned;

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -270,19 +270,19 @@ public:
 	 * Split into two functions deepScan and deepScanOutline. Frequently called checks (see lazy start check) must be inlined
 	 * @param env The environment.
 	 * @param objectPtr The pointer to the object.
-	 * @param selfReferencingField1 Offset to the first priority field of the object
-	 * @param selfReferencingField2 Offset to the second priority field, if it can't follow through in one direction, 
+	 * @param priorityFieldOffset1 Offset to the first priority field of the object
+	 * @param priorityFieldOffset2 Offset to the second priority field, if it can't follow through in one direction, 
 	 * it will attempt to use the second self referencing field 
 	 */
 	MMINLINE void
-	deepScan(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, uintptr_t selfReferencingField1, uintptr_t selfReferencingField2)
+	deepScan(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, uintptr_t priorityFieldOffset1, uintptr_t priorityFieldOffset2)
 	{
 		/**
 		* Inhibit the special treatment routine with relatively high probability to skip over most  
 		* false positives (shorter lists), while only marginally delay detection of very deep structures.
 		*/	
 		if (shouldStartDeepScan(env, objectPtr)) {
-			deepScanOutline(env, objectPtr, selfReferencingField1, selfReferencingField2);
+			deepScanOutline(env, objectPtr, priorityFieldOffset1, priorityFieldOffset2);
 		}
 	}
 	
@@ -300,7 +300,7 @@ public:
 	}
 	
 	
-	void deepScanOutline(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, uintptr_t selfReferencingField1, uintptr_t selfReferencingField2);
+	void deepScanOutline(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr, uintptr_t priorityFieldOffset1, uintptr_t priorityFieldOffset2);
 
 	MMINLINE bool scavengeRememberedObject(MM_EnvironmentStandard *env, omrobjectptr_t objectPtr);
 	void scavengeRememberedSetList(MM_EnvironmentStandard *env);


### PR DESCRIPTION
- Reorganized DeepScan code to avoid an extra check on hot path
- Added loop check to ensure we break from deep scan on NULL reference
  - Resolves deep scan issue with concurrent scavenger https://github.com/eclipse/openj9/issues/6393
where mutator nulls the next reference link
- Rename fields for clarity

Signed-off-by: Salman Rana <salman.rana@ibm.com>