### PR TITLE
Adding Tenure bytes deviation to modify concurrent kickoff

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -267,6 +267,7 @@ public:
 	uintptr_t oldHeapSizeOnLastGlobalGC;
 	uintptr_t freeOldHeapSizeOnLastGlobalGC;
 	float concurrentKickoffTenuringHeadroom; /**< percentage of free memory remaining in tenure heap. Used in conjunction with free memory to determine concurrent mark kickoff */
+	float tenureBytesDeviationBoost; /**< boost factor for tenuring deviation used for concurrent mark kickoff math */
 #endif /* OMR_GC_MODRON_SCAVENGER */
 #if defined(OMR_GC_REALTIME)
 	MM_RememberedSetSATB* sATBBarrierRememberedSet; /**< The snapshot at the beginning barrier remembered set used for the write barrier */
@@ -1348,6 +1349,7 @@ public:
 		, oldHeapSizeOnLastGlobalGC(UDATA_MAX)
 		, freeOldHeapSizeOnLastGlobalGC(UDATA_MAX)
 		, concurrentKickoffTenuringHeadroom((float)0.02)
+		, tenureBytesDeviationBoost((float)2)
 #endif /* OMR_GC_MODRON_SCAVENGER */		
 #if defined(OMR_GC_REALTIME)
 		, sATBBarrierRememberedSet(NULL)

--- a/gc/base/Math.hpp
+++ b/gc/base/Math.hpp
@@ -113,6 +113,15 @@ public:
 
 		return number;
 	}
+
+	/**< return absolute value of a float */
+	static MMINLINE float abs(float number) {
+		if (number < 0) {
+			number = -number;
+		}
+		return number;
+	}
+
 };
 
 #endif /*MATH_HPP_*/

--- a/gc/base/standard/ConcurrentGC.cpp
+++ b/gc/base/standard/ConcurrentGC.cpp
@@ -1828,6 +1828,9 @@ MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentBase *env, MM_AllocateDescript
 		if (!scavengerStats->isAvailable(env)) {
 			return (uintptr_t)-1;
 		}
+		
+		nurseryPromotion = scavengerStats->_avgTenureBytes == 0 ? 1: (uintptr_t)(scavengerStats->_avgTenureBytes + (env->getExtensions()->tenureBytesDeviationBoost * scavengerStats->_avgTenureBytesDeviation));
+
 #if defined(OMR_GC_LARGE_OBJECT_AREA)
 		/* Do we need to tax this allocation ? */
 		if (LOA == _meteringType) {
@@ -1835,13 +1838,11 @@ MM_ConcurrentGC::potentialFreeSpace(MM_EnvironmentBase *env, MM_AllocateDescript
 			currentOldFree = oldSubspace->getApproximateActiveFreeLOAMemorySize();
 			headRoom = (uintptr_t)(_extensions->concurrentKickoffTenuringHeadroom * _extensions->lastGlobalGCFreeBytesLOA);
 		} else {
-			assume0(SOA == _meteringType);
-			nurseryPromotion = scavengerStats->_avgTenureSOABytes == 0 ? 1 : scavengerStats->_avgTenureSOABytes;
+			assume0(SOA == _meteringType);			
 			currentOldFree = oldSubspace->getApproximateActiveFreeMemorySize() - oldSubspace->getApproximateActiveFreeLOAMemorySize();
 			headRoom = (uintptr_t)(_extensions->concurrentKickoffTenuringHeadroom * (_extensions->getLastGlobalGCFreeBytes() - _extensions->lastGlobalGCFreeBytesLOA));
 		}
 #else
-		nurseryPromotion = scavengerStats->_avgTenureBytes == 0 ? 1: scavengerStats->_avgTenureBytes;
 		currentOldFree = oldSubspace->getApproximateActiveFreeMemorySize();
 		headRoom = (uintptr_t)(_extensions->concurrentKickoffTenuringHeadroom * _extensions->getLastGlobalGCFreeBytes()); 
 #endif

--- a/gc/stats/ScavengerStats.cpp
+++ b/gc/stats/ScavengerStats.cpp
@@ -67,11 +67,11 @@ MM_ScavengerStats::MM_ScavengerStats()
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */
 	,_avgInitialFree(0)
 	,_avgTenureBytes(0)
+	,_avgTenureBytesDeviation(0)
 	,_tiltRatio(0)
 	,_nextScavengeWillPercolate(false)
 #if defined(OMR_GC_LARGE_OBJECT_AREA)	
 	,_avgTenureLOABytes(0)
-	,_avgTenureSOABytes(0)
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 	,_flipDiscardBytes(0)
 	,_tenureDiscardBytes(0)

--- a/gc/stats/ScavengerStats.hpp
+++ b/gc/stats/ScavengerStats.hpp
@@ -103,6 +103,7 @@ public:
 	 */ 
 	uintptr_t _avgInitialFree;
 	uintptr_t _avgTenureBytes;
+	uintptr_t _avgTenureBytesDeviation; /**< The average, weighted deviation of the tenureBytes*/
 	
 	uintptr_t _tiltRatio;	/**< use to pass tiltRatio to verbose */
 
@@ -110,7 +111,6 @@ public:
 	
 #if defined(OMR_GC_LARGE_OBJECT_AREA)	
 	uintptr_t _avgTenureLOABytes;
-	uintptr_t _avgTenureSOABytes;
 #endif /* OMR_GC_LARGE_OBJECT_AREA */
 
 	uintptr_t _flipDiscardBytes;		/**< Bytes of survivor discarded by copy scan cache */


### PR DESCRIPTION
- Added heuristics to keep track of bytes moving from nursery to tenure, along with the deviation of this value.
- `_avgTenureBytes` keeps track of average bytes that are being tenured, while `_avgTenureBytesDeviation` keeps track of the average amount of deviation in bytes being tenured.
- Adding this deviation into the calculation for concurrent kickoff
- The default boost for the deviation on top of the existing kickoff logic is 2x. This field is called `tenureBytesDeviationBoost`
- This change results in far less aborts/percolates, but at the expense of more global GC cycles
- Will be accompanied by a change on the j9 side for explicitly setting `tenureBytesDeviationBoost`. Setting this to 0 will effectively disable it's effects
- This calculation is done for both SOA bytes (if OMR_GC_LARGE_OBJECT_AREA flag is set), and tenured bytes in general if not set

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>