### PR TITLE
DDR: Fix missing information

### DIFF
--- a/ddr/include/ddr/ir/ClassType.hpp
+++ b/ddr/include/ddr/ir/ClassType.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,6 @@ using std::vector;
 class ClassType : public NamespaceUDT
 {
 public:
-	bool _isComplete; /* as opposed to just a forward declaration */
 	vector<Field *> _fieldMembers;
 
 	explicit ClassType(size_t size, unsigned int lineNumber = 0);

--- a/ddr/lib/ddr-ir/ClassType.cpp
+++ b/ddr/lib/ddr-ir/ClassType.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -25,7 +25,6 @@
 
 ClassType::ClassType(size_t size, unsigned int lineNumber)
 	: NamespaceUDT(lineNumber)
-	, _isComplete(false)
 	, _fieldMembers()
 {
 	_sizeOf = size;

--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -334,6 +334,21 @@ MergeVisitor::visitComposite(ClassType *type) const
 DDR_RC
 MergeVisitor::visitClass(ClassUDT *type) const
 {
+	if (NULL == type->_superClass) {
+		ClassUDT *otherSuper = ((ClassUDT *)_other)->_superClass;
+
+		if (NULL != otherSuper) {
+			Type *thisSuper = _ir->findTypeInMap(otherSuper);
+
+			if (NULL != thisSuper) {
+				otherSuper = (ClassUDT *)thisSuper;
+			} else {
+				_merged->push_back(otherSuper);
+			}
+			type->_superClass = otherSuper;
+		}
+	}
+
 	return visitComposite(type);
 }
 


### PR DESCRIPTION
Fix handling of forward declarations
* Types can't be considered complete until something more than a forward declaration is encountered. Previously missed, for example, were the enum literals of `MM_ConcurrentGC::InitType`.

Fix merging of super type of classes
* Forward declarations will not provide information about base types. When base type information is available later, it must be merged. An example of a (previously) missed super type is: `class MM_Scavenger : public MM_Collector`.