### PR TITLE
Update jitbuilder/release/README.md

### DIFF
--- a/jitbuilder/release/README.md
+++ b/jitbuilder/release/README.md
@@ -20,25 +20,118 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
 -->
 
-JitBuilder
+# JitBuilder
 
-A library for building JIT compilers, and an advance release of the
-Eclipse OMR JIT compiler component
+A library for dynamically generating efficient native code and,
+in particular, for building JIT compilers using the Eclipse OMR
+JIT compiler component
 (see [Eclipse OMR Project](https://github.com/eclipse/omr)).
 
-The library can be found in libjitbuilder.a and can be linked
-against statically using the API in include/Jit.hpp as well
-as using "Builders" : MethodBuilders, IlBuilders, and
-BytecodeBuilders.
+To use JitBuilder, you create `IlBuilder` objects to represent
+the various control flow paths in a function you're trying to create
+at runtime. You can create arbitrarily complex control flow by linking
+these objects together using services like `ForLoop`, `IfThenElse`,
+`Switch` and others. You can then call services on those objects to
+append operations to them (to load/store values or to perform operations
+on them). It's very easy once you get the hang of it, and you won't
+have to learn any of that complicated compiler terminology!
 
-Some simple examples can be found in the src/ directory, and the
-top level directory contains a Makefile that shows you how to
-build them.
+The JitBuilder API also includes a few Vector services for generating
+vector instructions and even has a `Transaction` service that makes it
+simple to build code that takes advantage of hardware transactional
+memory.
 
-Just type 'make' and you'll build a number of examples that
-demonstrate how you can start building native code dynamically!
+And if your goal is to create a JIT compiler for a virtual machine for
+some language, the JitBuilder API has services to help you efficiently
+model pushes and pops on operand stacks or to access registers in an
+operand array that frequently allocate your values to hardware registers
+rather than memory locations. There have even been experiments that look
+at automatically generating both an interpreter and a JIT compiler for
+simple virtual machines using just the definitions of the virtual
+machine (VM) state and descriptions of the operations to be performed
+by the VM's bytecodes.
 
-More details to come!
+JitBuilder can generate efficient native code on X86, POWER, and Z platforms.
+Multiple experiments have found the generated JitBuilder code performance
+to be comparable or, in some cases, even better than what LLVM can do!
+Because it's based on the OMR compiler technology at the heart of the
+[Eclipse OpenJ9](https://www.eclipse.org/openj9), it uses memory
+efficiently and compiles quickly.
 
-This library has been used as the basis of a JIT compiler for
-the SOM++ Simple Object Machine runtime.
+# Steps to build
+
+Here are the basic steps required to build the JitBuilder library and
+run the many available code samples from the C++ language.
+
+First, clone the Eclipse OMR repository:
+
+```
+$ git clone https://github.com/eclipse/omr
+```
+
+Change directory into the OMR project, create a `build` directory, and
+generate the makefiles using `cmake` :
+
+```
+$ cd omr
+$ mkdir build
+$ cd build
+$ cmake .. -DOMR_COMPILER=1 -DOMR_JITBUILDER=1 -DOMR_TEST_COMPILER=1
+```
+
+Now, you're ready to build all the OMR componentry and create the
+JitBuilder static library. This step may take a few minutes! It may
+go faster if you use `make -jN` with `N` set to the number of cores
+on your machine but you can always just type `make` to build the
+library:
+
+```
+$ make
+```
+
+Now that the JitBuilder library has been built, you can change directory
+into the `jitbuilder/release` directory which will eventually have different
+subdirectories for using the JitBuilder API from different languages. We're
+going to use C++, so we'll go into the `cpp` subdirectory:
+
+```
+$ cd ../jitbuilder/release/cpp
+```
+
+You'll need to create a link to the `libjitbuilder.a` library that you
+built. This step should go away some day, but for now you'll need to do
+it manually:
+
+```
+$ ln -s ../../../build/jitbuilder/libjitbuilder.a .
+```
+
+Finally, you can build and run the code samples by running:
+
+```
+$ make test
+```
+
+If you're running on an x86 platform, then you should be able to run all
+28 code samples with:
+
+```
+$ make testall
+```
+
+That's it! If you want to learn more about how JitBuilder is used, you can
+look at the source code for the code samples in the `samples` directory, or
+if you want to see how to build code together with the JitBuilder library,
+just look for the simple options shown in the `Makefile`.
+
+More tuturial content is coming! For now, you can google "jitbuilder" to find
+more presentations and articles that have been written about this library!
+
+# Projects using JitBuilder
+
+JitBuilder has been used in a number of different places, from a
+standalone JIT compiler for [WebAssembly](https://github.com/wasmjit-omr/wasmjit-omr)
+to an experimental JIT compiler for the
+[Rosie Pattern Language](https://github.com/mstoodle/rosie-lpeg/tree/experimental_omrjit)
+to Smalltalk and beyond. There is even an LLVM IR to JitBuilder converter
+currently under construction at https://github.com/nbhuiyan/lljb !


### PR DESCRIPTION
The jitbuilder/README.md is laughably out of date, harkening back
to before the OMR compiler was even open sourced.

I added some better descriptions, proper build steps using cmake,
and tried to make it a little more "peppy".

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>