### PR TITLE
WIP: Silence zos compiler warnings

### DIFF
--- a/compiler/infra/OMRMonitor.hpp
+++ b/compiler/infra/OMRMonitor.hpp
@@ -47,14 +47,14 @@ class Monitor
    static TR::Monitor *create(char *name);
    static void destroy(TR::Monitor *monitor);
    void enter();
-   int32_t try_enter() { TR_UNIMPLEMENTED(); }
+   OMR_NORETURN int32_t try_enter() { TR_UNIMPLEMENTED(); }
    int32_t exit(); // returns 0 on success
    void destroy();
    void wait() { TR_UNIMPLEMENTED(); }
-   intptr_t wait_timed(int64_t millis, int32_t nanos) { TR_UNIMPLEMENTED(); }
+   OMR_NORETURN intptr_t wait_timed(int64_t millis, int32_t nanos) { TR_UNIMPLEMENTED(); }
    void notify() { TR_UNIMPLEMENTED(); }
    void notifyAll() { TR_UNIMPLEMENTED(); }
-   int32_t num_waiting() { TR_UNIMPLEMENTED(); }
+   OMR_NORETURN int32_t num_waiting() { TR_UNIMPLEMENTED(); }
    char const *getName();
    bool init(char *name);
 


### PR DESCRIPTION
xlc on zos does not seem to realize that calling a non returning function
means you also don't return

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>