### PR TITLE
AArch64: Add IsForceRecompilation as Snippet Kind

### DIFF
--- a/compiler/aarch64/codegen/OMRSnippet.hpp
+++ b/compiler/aarch64/codegen/OMRSnippet.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -78,6 +78,7 @@ class OMR_EXTENSIBLE Snippet : public OMR::Snippet
          IsMonitorEnter,
          IsMonitorExit,
       IsRecompilation,
+      IsForceRecompilation,
       IsStackCheckFailure,
       IsUnresolvedData,
       numKinds


### PR DESCRIPTION
This commit adds a new Snippet Kind for AArch64, IsForceRecompilation.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>