### PR TITLE
Remove unused DLP SymbolReference management

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -585,10 +585,6 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateMonitorEntrySymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateMonitorExitSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
 
-   // Z
-   TR::SymbolReference * findDLPStaticSymbolReference(TR::SymbolReference * staticSymbolReference);
-   TR::SymbolReference * findOrCreateDLPStaticSymbolReference(TR::SymbolReference * staticSymbolReference);
-
    TR::SymbolReference * findOrCreateGenericIntShadowSymbolReference(intptrj_t offset, bool allocateUseDefBitVector = false);
    TR::SymbolReference * createGenericIntShadowSymbolReference(intptrj_t offset, bool allocateUseDefBitVector = false);
    TR::SymbolReference * findOrCreateGenericIntArrayShadowSymbolReference(intptrj_t offset);
@@ -686,7 +682,6 @@ class SymbolReferenceTable
    List<TR::SymbolReference>            _vtableEntrySymbolRefs;
    List<TR::SymbolReference>            _classLoaderSymbolRefs;
    List<TR::SymbolReference>            _classStaticsSymbolRefs;
-   List<TR::SymbolReference>            _classDLPStaticsSymbolRefs;
    List<TR::SymbolReference>            _debugCounterSymbolRefs;
 
    uint32_t                            _nextRegShadowIndex;

--- a/compiler/il/symbol/OMRStaticSymbol.hpp
+++ b/compiler/il/symbol/OMRStaticSymbol.hpp
@@ -97,21 +97,6 @@ public:
    uint32_t getTOCIndex()                     { return _assignedTOCIndex; }
    void     setTOCIndex(uint32_t idx)         { _assignedTOCIndex = idx; }
 
-
-   /**
-    * Copies a subset of bits from an input flags
-    *
-    * Used as part of the Dynamic Literal Pool code.
-    *
-    * \TODO: Better document this function and what exactly it's intended
-    *        accomplish, as it's not clear at all.
-    */
-   void setUpDLPFlags(int32_t flags)
-      {
-      int32_t value = flags & SetUpDLPFlags;
-      _flags.set(value);
-      }
-
 private:
 
    void * _staticAddress;

--- a/compiler/il/symbol/OMRSymbol.hpp
+++ b/compiler/il/symbol/OMRSymbol.hpp
@@ -499,7 +499,6 @@ public:
       AddressIsCPIndexOfStatic  = 0x40000000,
       RecognizedStatic          = 0x20000000,
       ConstantPoolAddress       = 0x10000000,
-      SetUpDLPFlags             = 0xF0000000, ///< Used by TR::StaticSymbol::SetupDLPFlags(), == ConstString | AddressIsCPIndexOfStatic | RecognizedStatic
       CompiledMethod            = 0x08000000,
       StartPC                   = 0x04000000,
       CountForRecompile         = 0x02000000,

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -681,8 +681,7 @@ static bool findConstant(OMR::ValuePropagation *vp, TR::Node *node)
 
 static bool containsUnsafeSymbolReference(OMR::ValuePropagation *vp, TR::Node *node)
    {
-   if (vp->comp()->getSymRefTab()->findDLPStaticSymbolReference(node->getSymbolReference()) ||
-       node->getSymbolReference()->isLitPoolReference())
+   if (node->getSymbolReference()->isLitPoolReference())
       return true;
 
    if (node->getSymbolReference()->getSymbol()->isShadow())


### PR DESCRIPTION
It is not used in OMR nor any downstream project.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>