### PR TITLE
Add support to split blocks post GRA

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -808,11 +808,11 @@ OMR::Block::splitWithGivenMethodSymbol(TR::ResolvedMethodSymbol *methodSymbol, T
 }
 
 // Required data structures for analysis in SplitPostGRA
-typedef TR::typed_allocator<std::pair<TR::Node *, std::pair<int32_t, TR::Node *> >, TR::Region&> NodeTableAllocator; 
+typedef TR::typed_allocator<std::pair<TR::Node* const, std::pair<int32_t, TR::Node *> >, TR::Region&> NodeTableAllocator; 
 typedef std::less< TR::Node *> NodeTableComparator; 
 typedef std::map<TR::Node *, std::pair<int32_t, TR::Node *>, NodeTableComparator, NodeTableAllocator> NodeTable;
 
-typedef TR::typed_allocator<std::pair <int32_t, TR::Node *>, TR::Region&> StoreRegNodeTableAllocator;
+typedef TR::typed_allocator<std::pair <TR::Node* const, TR::Node *>, TR::Region&> StoreRegNodeTableAllocator;
 typedef std::map<TR::Node *, TR::Node *, NodeTableComparator, StoreRegNodeTableAllocator> StoreRegNodeTable;
 
 /*

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -159,7 +159,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
 
    TR::Block * split(TR::TreeTop * startOfNewBlock,  TR::CFG * cfg, bool fixupCommoning = false, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL);
    
-   TR::Block * splitPostGRA(TR::TreeTop *startOfNewBlock, TR::CFG *cfg, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL, bool trace = false);
+   TR::Block * splitPostGRA(TR::TreeTop *startOfNewBlock, TR::CFG *cfg, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL);
    
 
    TR::Block * splitWithGivenMethodSymbol(TR::ResolvedMethodSymbol *methodSymbol, TR::TreeTop * startOfNewBlock,  TR::CFG * cfg, bool fixupCommoning = false, bool copyExceptionSuccessors = true);

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -158,6 +158,10 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    TR::TreeTop * prepend(TR::TreeTop * tt);
 
    TR::Block * split(TR::TreeTop * startOfNewBlock,  TR::CFG * cfg, bool fixupCommoning = false, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL);
+   
+   TR::Block * splitPostGRA(TR::TreeTop *startOfNewBlock, TR::CFG *cfg, bool copyExceptionSuccessors = true, TR::ResolvedMethodSymbol *methodSymbol = NULL, bool trace = false);
+   
+
    TR::Block * splitWithGivenMethodSymbol(TR::ResolvedMethodSymbol *methodSymbol, TR::TreeTop * startOfNewBlock,  TR::CFG * cfg, bool fixupCommoning = false, bool copyExceptionSuccessors = true);
 
    TR::Block *createConditionalSideExitBeforeTree(TR::TreeTop *tree,


### PR DESCRIPTION
Splitting block after Global Register Allocator requires manual uncommoning of nodes while respecting the register dependencies generated by GRA. This commit adds support to split the blocks after GRA is finished.

Co-authored-by: Andrew Craik <ajcraik@ca.ibm.com>
Co-authored-by: Ben Thomas <ben@benthomas.ca>
Co-authored-by: Rahil Shah <rahil@ca.ibm.com>

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>