### PR TITLE
Fix `breakOnEntry` option on Z

### DIFF
--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2335,6 +2335,12 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
       cursor = cursor->getNext();
       }
 
+   if (comp()->getOption(TR_EntryBreakPoints))
+      {
+      TR::Node *node = comp()->getStartTree()->getNode();
+      cursor = generateS390EInstruction(self(), TR::InstOpCode::BREAK, node, cursor);
+      }
+
    if (recomp != NULL)
       {
       cursor = recomp->generatePrologue(cursor);

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2335,9 +2335,9 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
       cursor = cursor->getNext();
       }
 
-   if (comp()->getOption(TR_EntryBreakPoints))
+   if (self()->comp()->getOption(TR_EntryBreakPoints))
       {
-      TR::Node *node = comp()->getStartTree()->getNode();
+      TR::Node *node = self()->comp()->getStartTree()->getNode();
       cursor = generateS390EInstruction(self(), TR::InstOpCode::BREAK, node, cursor);
       }
 

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -1986,25 +1986,6 @@ generateS390PseudoInstruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic op
    {
    TR::Instruction* cursor;
 
-   switch (op)
-      {
-      case TR::InstOpCode::PROC:
-         {
-         if (cg->comp()->getOption(TR_EntryBreakPoints))
-            {
-            if (preced)
-               {
-               preced = new (INSN_HEAP) TR::S390EInstruction(TR::InstOpCode::BREAK, n, preced, cg);
-               }
-            else
-               {
-               preced = new (INSN_HEAP) TR::S390EInstruction(TR::InstOpCode::BREAK, n, cg);
-               }
-            }
-         }
-         break;
-      }
-
    if (preced)
       {
       cursor = new (INSN_HEAP) TR::S390PseudoInstruction(op, n, fenceNode, preced, cg);


### PR DESCRIPTION
Move `BREAK` instruction to one instruction after `PROC` when adding `breakOnEntry` option in command, so that the debugger can stop at the beginning of methods. Also, generating `BREAK` instruction in `doBinaryEncoding` function instead of in the function where `PROC` gets generated.

Signed-off-by: simonameng <simonameng97@gmail.com>