### PR TITLE
 Fix calculation of XPLINK call descriptor offset

### DIFF
--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -530,8 +530,8 @@ TR::S390zOSSystemLinkage::genCallNOPAndDescriptor(TR::Instruction* cursor, TR::N
       {
       uint32_t callDescriptorValue = TR::XPLINKCallDescriptorSnippet::generateCallDescriptorValue(this, callNode);
 
-      TR::Snippet* callDescriptor = new (self()->trHeapMemory()) TR::XPLINKCallDescriptorSnippet(cg(), this, callDescriptorValue);
-      cg()->addSnippet(callDescriptor);
+      TR::S390ConstantDataSnippet* callDescriptor = new (self()->trHeapMemory()) TR::XPLINKCallDescriptorSnippet(cg(), this, callDescriptorValue);
+      cg()->addDataConstantSnippet(callDescriptor);
 
       uint32_t nopDescriptor = 0x47000000 | (static_cast<uint32_t>(callType) << 16);
       cursor = generateDataConstantInstruction(cg(), TR::InstOpCode::DC, node, nopDescriptor, cursor);
@@ -1020,7 +1020,13 @@ TR::S390zOSSystemLinkage::XPLINKCallDescriptorRelocation::getUpdateLocation()
 void
 TR::S390zOSSystemLinkage::XPLINKCallDescriptorRelocation::apply(TR::CodeGenerator* cg)
    {
-   uint8_t* p = getUpdateLocation();
+   int64_t offsetToCallDescriptor = static_cast<int64_t>(getLabel()->getCodeLocation() - (_nop->getBinaryEncoding() - 7)) / 8;
 
+   if (offsetToCallDescriptor < std::numeric_limits<int16_t>::min() || offsetToCallDescriptor > std::numeric_limits<int16_t>::max())
+      {
+      cg->comp()->failCompilation<TR::ExcessiveComplexity>("Unable to encode offset to XPLINK call descriptor");
+      }
+
+   uint8_t* p = getUpdateLocation();
    *reinterpret_cast<int16_t*>(p) = static_cast<int16_t>(getLabel()->getCodeLocation() - (_nop->getBinaryEncoding() - 7)) / 8;
    }

--- a/compiler/z/codegen/SystemLinkagezOS.cpp
+++ b/compiler/z/codegen/SystemLinkagezOS.cpp
@@ -1028,5 +1028,5 @@ TR::S390zOSSystemLinkage::XPLINKCallDescriptorRelocation::apply(TR::CodeGenerato
       }
 
    uint8_t* p = getUpdateLocation();
-   *reinterpret_cast<int16_t*>(p) = static_cast<int16_t>(getLabel()->getCodeLocation() - (_nop->getBinaryEncoding() - 7)) / 8;
+   *reinterpret_cast<int16_t*>(p) = static_cast<int16_t>(offsetToCallDescriptor);
    }

--- a/compiler/z/codegen/SystemLinkagezOS.hpp
+++ b/compiler/z/codegen/SystemLinkagezOS.hpp
@@ -27,6 +27,7 @@
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"
+#include "codegen/Relocation.hpp"
 #include "codegen/SystemLinkage.hpp"
 #include "codegen/snippet/PPA1Snippet.hpp"
 #include "codegen/snippet/PPA2Snippet.hpp"
@@ -72,6 +73,38 @@ namespace TR {
 
 class S390zOSSystemLinkage : public TR::SystemLinkage
    {
+   private:
+
+   /** \brief
+    *
+    *  Represents the XPLINK 31-bit call descriptor relocation which is a (positive) signed offset in doublewords from 
+    *  the doubleword at or preceding the return point (NOP) to the XPLINK call descriptor for this signature.
+    *
+    *  [1] https://www-01.ibm.com/servers/resourcelink/svc00100.nsf/pages/zOSV2R3SA380688/$file/ceev100_v2r3.pdf (page 137)
+    */
+   class XPLINKCallDescriptorRelocation : public TR::LabelRelocation
+      {
+      public:
+
+      /** \brief
+       *     Initializes the XPLINKCallDescriptorRelocation relocation using a \c NULL base target pointer
+       *
+       *  \param nop
+       *     The 4-byte NOP descriptor instruction whose binary encoding location (+2) will be used for the relocation
+       *
+       *  \param callDescriptor
+       *     The label marking the call descriptor for this signature
+       */
+      XPLINKCallDescriptorRelocation(TR::Instruction* nop, TR::LabelSymbol* callDescriptor);
+      
+      virtual uint8_t* getUpdateLocation();
+      virtual void apply(TR::CodeGenerator* cg);
+
+      private:
+
+      TR::Instruction* _nop;
+      };
+
    public:
 
    /** \brief

--- a/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.hpp
+++ b/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.hpp
@@ -56,7 +56,7 @@ namespace TR {
  *       +----------------------------------+----------------------------------+----------------------------------+----------------------------------+
  *  \endverbatim
  */
-class XPLINKCallDescriptorSnippet : public TR::Snippet
+class XPLINKCallDescriptorSnippet : public TR::S390ConstantDataSnippet
    {
    public:
 
@@ -72,8 +72,6 @@ class XPLINKCallDescriptorSnippet : public TR::Snippet
    XPLINKCallDescriptorSnippet(TR::CodeGenerator* cg, TR::S390zOSSystemLinkage* linkage, uint32_t callDescriptorValue);
 
    virtual uint8_t* emitSnippetBody();
-
-   virtual uint32_t getLength(int32_t estimatedSnippetStart);
 
    private:
    


### PR DESCRIPTION
The call descriptor offset in the NOP following a call within an XPLINK
frame was not being correctly calculated. The patch location was
correct, however the offset encoded was from the patch location, which
is incorrect.

As per the documentation linked in the source code the value we wish to
encoding is a (positive) signed offset in doublewords from  the
doubleword at or preceding the return point (NOP) to the XPLINK call
descriptor for this signature.

This is not something we can encoding with the existing locations, and
due to the doubleword alignment that is required it is not something
that we should generalize either since we don't envision other uses for
such a strict API. Instead we create a private relocation in the XPLINK
linkage class and handle the relocation there.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>