### PR TITLE
Implement ternary Select IlBuilder service

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1137,6 +1137,19 @@ public:
       return TR::BadILOp;
       }
 
+   static TR::ILOpCodes ternaryOpCode(TR::DataType type)
+      {
+      switch(type)
+         {
+         case TR::Int8:     return TR::bternary;
+         case TR::Int16:    return TR::sternary;
+         case TR::Int32:    return TR::iternary;
+         case TR::Int64:    return TR::lternary;
+         case TR::Address:  return TR::aternary;
+         default: return TR::BadILOp;
+         }
+      }
+
    static TR::ILOpCodes getCorrespondingLogicalComparison(TR::ILOpCodes op)
          {
          switch (op)

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -586,6 +586,17 @@ public:
                      TR::IlBuilder **caseBuilder,
                      int32_t caseFallsThrough);
 
+   // ternary
+   /**
+    * @brief Service to select a value based on a condition without branching
+    *
+    * @param condition the condition value
+    * @param trueValue value to select if true
+    * @param falseValue value to select if false
+    * @return TR::IlValue* IlValue corresponding to the selected value
+    */
+   TR::IlValue * Select(TR::IlValue * condition, TR::IlValue * trueValue, TR::IlValue * falseValue);
+
    /**
     * @brief associates this object with a particular client object
     */

--- a/compiler/ilgen/StatementNames.hpp
+++ b/compiler/ilgen/StatementNames.hpp
@@ -116,6 +116,7 @@ static const char * const STATEMENT_UNSIGNEDSHIFTR               = "UnsignedShif
 static const char * const STATEMENT_RETURN                       = "Return";
 static const char * const STATEMENT_RETURNVALUE                  = "ReturnValue";
 static const char * const STATEMENT_IFTHENELSE                   = "IfThenElse";
+static const char * const STATEMENT_SELECT                       = "Select";
 static const char * const STATEMENT_IFCMPEQUALZERO               = "IfCmpEqualZero";
 static const char * const STATEMENT_IFCMPNOTEQUALZERO            = "IfCmpNotEqualZero";
 static const char * const STATEMENT_IFCMPNOTEQUAL                = "IfCmpNotEqual";

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(jitbuildertest
 	WorklistTest.cpp
 	FieldNameTest.cpp
 	ConvertBitsTest.cpp
+	SelectTest.cpp
 )
 
 if(OMR_HOST_ARCH STREQUAL "x86")

--- a/fvtest/jitbuildertest/Makefile
+++ b/fvtest/jitbuildertest/Makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,20 +26,21 @@ MODULE_NAME := omrjitbuildertest
 ARTIFACT_TYPE := cxx_executable
 
 OBJECTS := \
-	main \
-	selftest \
-	UnionTest \
-	FieldAddressTest \
-	AnonymousTest \
-	ControlFlowTest \
-	SystemLinkageTest \
-	NegateTest \
-	WorklistTest \
-	IfThenElseTest \
-	CallReturnTest \
-	FieldNameTest \
-	ConvertBitsTest \
-	UnsignedDivRemTest
+  main \
+  selftest \
+  UnionTest \
+  FieldAddressTest \
+  AnonymousTest \
+  ControlFlowTest \
+  SystemLinkageTest \
+  NegateTest \
+  WorklistTest \
+  IfThenElseTest \
+  CallReturnTest \
+  FieldNameTest \
+  ConvertBitsTest \
+  UnsignedDivRemTest \
+  SelectTest
 
 OBJECTS := $(addsuffix $(OBJEXT),$(OBJECTS))
 

--- a/fvtest/jitbuildertest/SelectTest.cpp
+++ b/fvtest/jitbuildertest/SelectTest.cpp
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "JBTestUtil.hpp"
+
+DEFINE_BUILDER(TestInt8Select,
+               Int8,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Int8),
+               PARAM("falseValue", Int8))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt16Select,
+               Int16,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Int16),
+               PARAM("falseValue", Int16))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt32Select,
+               Int32,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Int32),
+               PARAM("falseValue", Int32))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestInt64Select,
+               Int64,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Int64),
+               PARAM("falseValue", Int64))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestAddressSelect,
+               Address,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Address),
+               PARAM("falseValue", Address))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestFloatSelect,
+               Float,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Float),
+               PARAM("falseValue", Float))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+DEFINE_BUILDER(TestDoubleSelect,
+               Double,
+               PARAM("condition", Int32),
+               PARAM("trueValue", Double),
+               PARAM("falseValue", Double))
+   {
+   OMR::JitBuilder::IlValue * condition = Load("condition");
+   OMR::JitBuilder::IlValue * trueValue = Load("trueValue");
+   OMR::JitBuilder::IlValue * falseValue = Load("falseValue");
+   OMR::JitBuilder::IlValue * result = Select(condition, trueValue, falseValue);
+   Return(result);
+   return true;
+   }
+
+class SelectTest : public JitBuilderTest {};
+
+typedef int8_t (*Int8TestFunctionType)(int32_t,int8_t,int8_t);
+TEST_F(SelectTest, Int8_Test)
+   {
+   Int8TestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestInt8Select, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }
+
+typedef int16_t (*Int16TestFunctionType)(int32_t,int16_t,int16_t);
+TEST_F(SelectTest, Int16_Test)
+   {
+   Int16TestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestInt16Select, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }
+
+typedef int32_t (*Int32TestFunctionType)(int32_t,int32_t,int32_t);
+TEST_F(SelectTest, Int32_Test)
+   {
+   Int32TestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestInt32Select, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }
+
+typedef int64_t (*Int64TestFunctionType)(int32_t,int64_t,int64_t);
+TEST_F(SelectTest, Int64_Test)
+   {
+   Int64TestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestInt64Select, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }
+
+typedef uintptr_t (*AddressTestFunctionType)(int32_t,uintptr_t,uintptr_t);
+TEST_F(SelectTest, Address_Test)
+   {
+   AddressTestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestAddressSelect, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }
+
+typedef float (*FloatTestFunctionType)(int32_t,float,float);
+TEST_F(SelectTest, Float_Test)
+   {
+   FloatTestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestFloatSelect, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }
+
+typedef double (*DoubleTestFunctionType)(int32_t,double,double);
+TEST_F(SelectTest, Double_Test)
+   {
+   DoubleTestFunctionType testFunction;
+   ASSERT_COMPILE(OMR::JitBuilder::TypeDictionary, TestDoubleSelect, testFunction);
+   ASSERT_EQ(testFunction(1,1,0), 1);
+   ASSERT_EQ(testFunction(0,1,0), 0);
+   }

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -1374,6 +1374,16 @@
                     {"name":"condition","type":"IlValue"}
                     ]
                 },
+                { "name": "Select"
+                , "overloadsuffix": ""
+                , "flags": []
+                , "return": "IlValue"
+                , "parms": [
+                    {"name":"condition","type":"IlValue"},
+                    {"name":"trueValue","type":"IlValue"},
+                    {"name":"falseValue","type":"IlValue"}
+                    ]
+                },
                 { "name": "ForLoop"
                 , "overloadsuffix": ""
                 , "flags": []


### PR DESCRIPTION
This changeset also includes the following:
 * JitBuilder tests added to test the Select service
 * Introduced OMR::IlOpCode::ternaryOpCode static function to lookup the right
   opcode for different data types
 * Updated jitbuilder.api.json with the new entry

The need for this service was driven by the [LLJB project](https://github.com/nbhuiyan/lljb) when trying to translate LLVM IR's [`select` instruction](https://llvm.org/docs/LangRef.html#select-instruction) to JITBuilder API calls.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>