### PR TITLE
Add the newvalue opcode

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -593,6 +593,7 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::checkcastEvaluator ,	// TR::checkcast		// checkcast
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::checkcastAndNULLCHKEvaluator ,	// TR::checkcastAndNULLCHK	// checkcast and NULL check the underlying object reference
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::NewEvaluator ,	// TR::New		// new - child is class
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TR::newvalue		(should be lowered before evaluation)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::newarrayEvaluator ,	// TR::newarray		// new array of primitives
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::anewarrayEvaluator ,	// TR::anewarray		// new array of objects
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::variableNewEvaluator ,	// TR::variableNew	// new - child is class; type not known at compile time

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -723,6 +723,7 @@
    TR::TreeEvaluator::checkcastEvaluator,     // TR::checkcast
    TR::TreeEvaluator::checkcastAndNULLCHKEvaluator,     // TR::checkcastAndNULLCHK
    TR::TreeEvaluator::newObjectEvaluator,   // TR::New
+   TR::TreeEvaluator::unImpOptEvaluator,    // TR::newvalue (should be lowered before evaluation)
    TR::TreeEvaluator::newArrayEvaluator,    // TR::newarray
    TR::TreeEvaluator::anewArrayEvaluator,   // TR::anewarray
    TR::TreeEvaluator::newObjectEvaluator,   // TR::variableNew
@@ -732,6 +733,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::checkcast
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::checkcastAndNULLCHK
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::New
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::newvalue (should be lowered before evaluation)
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::newarray
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::anewarray
    TR::TreeEvaluator::unImpOpEvaluator,     // TR::variableNew

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -9177,6 +9177,22 @@
    /* .ifCompareOpCode      = */ TR::BadILOp,
    },
 
+  {
+   /* .opcode               = */ TR::newvalue,
+   /* .name                 = */ "newvalue",
+   /* .properties1          = */ ILProp1::HasSymbolRef,
+   /* .properties2          = */ ILProp2::CanRaiseException| ILProp2::MayUseSystemStack | ILProp2::New,
+   /* .properties3          = */ ILProp3::LikeDef,
+   /* .properties4          = */ 0,
+   /* .dataType             = */ TR::Address,
+   /* .typeProperties       = */ ILTypeProp::Reference,
+   /* .childProperties      = */ ILChildProp::Unspecified,
+   /* .swapChildrenOpCode   = */ TR::BadILOp,
+   /* .reverseBranchOpCode  = */ TR::BadILOp,
+   /* .booleanCompareOpCode = */ TR::BadILOp,
+   /* .ifCompareOpCode      = */ TR::BadILOp,
+   },
+
    {
    /* .opcode               = */ TR::newarray,
    /* .name                 = */ "newarray",

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -656,6 +656,7 @@
    checkcast,// checkcast
    checkcastAndNULLCHK,// checkcast and NULL check the underlying object reference
    New,      // new - child is class
+   newvalue, //allocate and initialize - children provide field values
    newarray, // new array of primitives
    anewarray,// new array of objects
    variableNew,// new - child is class, type not known at compile time

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -617,6 +617,7 @@
    checkcastSimplifier,     // TR::checkcast
    checkcastAndNULLCHKSimplifier,     // TR::checkcastAndNULLCHK
    NewSimplifier,           // TR::New
+   dftSimplifier,           // TR::newvalue
    dftSimplifier,           // TR::newarray
    dftSimplifier,           // TR::anewarray
    variableNewSimplifier,   // TR::variableNew

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -761,6 +761,7 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainCheckcast,       // TR::checkcast
    constrainCheckcastNullChk,// TR::checkcastAndNULLCHK
    constrainNew,             // TR::New
+   constrainChildren,        // TR::newvalue
    constrainNewArray,        // TR::newarray
    constrainANewArray,       // TR::anewarray
    constrainVariableNew,     // TR::variableNew

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -600,6 +600,7 @@
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::checkcast (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::checkcastAndNULLCHK (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::New (J9)
+   TR::TreeEvaluator::badILOpEvaluator,                    // TR::newvalue (should be lowered before evaluation)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::newarray (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::anewarray (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::variableNew (J9)

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -2865,6 +2865,7 @@ int32_t childTypes[] =
    TR::Address,                    // TR::checkcast
    TR::Address,                    // TR::checkcastAndNULLCHK
    TR::Address,                    // TR::New
+   TR::NoType | (TR::Address<<8),  // TR::newvalue
    TR::Int32,                     // TR::newarray
    TR::Int32 | (TR::Address<<16),  // TR::anewarray
    TR::Address,                    // TR::variableNew

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -596,6 +596,7 @@
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::checkcast (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::checkcastAndNULLCHK (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::New (J9)
+   TR::TreeEvaluator::badILOpEvaluator,                                // TR::newvalue  (should be lowered before evaluation)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::newarray (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::anewarray (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::variableNew (J9)

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -596,6 +596,7 @@
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::checkcast (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::checkcastAndNULLCHK (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::New (J9)
+   TR::TreeEvaluator::badILOpEvaluator,                                // TR::newvalue (should be lowered before evaluation)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::newarray (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::anewarray (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::variableNew (J9)

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -631,6 +631,7 @@
    TR::TreeEvaluator::badILOpEvaluator,     // TR::checkcast
    TR::TreeEvaluator::badILOpEvaluator,     // TR::checkcastAndNULLCHK
    TR::TreeEvaluator::badILOpEvaluator,     // TR::New
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::newvalue (should be lowered before evaluation)
    TR::TreeEvaluator::badILOpEvaluator,     // TR::newarray
    TR::TreeEvaluator::badILOpEvaluator,     // TR::anewarray
    TR::TreeEvaluator::badILOpEvaluator,     // TR::variableNew


### PR DESCRIPTION
The newvalue opcode both allocates and initializes an
immutable object whose identity is either unobservable or otherwise
considered irrelevant, i.e. a value. Allocation and initialization
are combined into a single step so that semantically the fields
are never mutated, allowing highly aggressive aliasing
properties and facilitating scalarization.

Issue: #4028

Signed-off-by: Yiling Han <Yiling.Han@ibm.com>