### PR TITLE
Remove invalid target before EstimateCodeSize

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -3935,6 +3935,7 @@ void TR_InlinerBase::getSymbolAndFindInlineTargets(TR_CallStack *callStack, TR_C
 
    if (callsite->_initialCalleeSymbol)
       {
+      callsite->_initialCalleeMethod = callsite->_initialCalleeSymbol->getResolvedMethod();
       if (getPolicy()->supressInliningRecognizedInitialCallee(callsite, comp()))
          isInlineable = Recognized_Callee;
 
@@ -3951,9 +3952,6 @@ void TR_InlinerBase::getSymbolAndFindInlineTargets(TR_CallStack *callStack, TR_C
          TR_VirtualGuardSelection *guard = new (trStackMemory()) TR_VirtualGuardSelection(TR_NoGuard);
          callsite->addTarget(trMemory(),this ,guard ,callsite->_initialCalleeSymbol->getResolvedMethod(),callsite->_receiverClass);
          }
-
-      callsite->_initialCalleeMethod = callsite->_initialCalleeSymbol->getResolvedMethod();
-
       }
    else if ((isInlineable = static_cast<TR_InlinerFailureReason> (checkInlineableWithoutInitialCalleeSymbol (callsite, comp()))) != InlineableTarget)
       {
@@ -4075,58 +4073,6 @@ void TR_InlinerBase::applyPolicyToTargets(TR_CallStack *callStack, TR_CallSite *
          continue;
          }
 
-      int32_t bytecodeSize = getPolicy()->getInitialBytecodeSize(calltarget->_calleeMethod, calltarget->_calleeSymbol, comp());
-
-      if (!forceInline(calltarget))
-         getUtil()->estimateAndRefineBytecodeSize(callsite, calltarget, callStack, bytecodeSize);
-
-      if (calltarget->_calleeSymbol && strstr(calltarget->_calleeSymbol->signature(trMemory()), "FloatingDecimal"))
-         {
-         bytecodeSize >>= 1;
-
-         if (comp()->trace(OMR::inlining))
-            traceMsg( comp(), "Reducing bytecode size to %d because it's method of FloatingDecimal\n", bytecodeSize);
-         }
-
-      bool toInline = getPolicy()->tryToInline(calltarget, callStack, true);
-
-      TR_ByteCodeInfo &bcInfo = callsite->_bcInfo;
-      // get the number of locals in the callee
-      int32_t numberOfLocalsInCallee = calltarget->_calleeMethod->numberOfParameterSlots();// + calleeResolvedMethod->numberOfTemps();
-      if (!forceInline(calltarget) &&
-            exceedsSizeThreshold(callsite, bytecodeSize,
-                                   (callsite->_callerBlock != NULL) ? callsite->_callerBlock :
-                                      (callsite->_callNodeTreeTop ? callsite->_callNodeTreeTop->getEnclosingBlock() : 0),
-                                   bcInfo, numberOfLocalsInCallee, callsite->_callerResolvedMethod,
-                                   calltarget->_calleeMethod,callsite->_callNode,callsite->_allConsts)
-
-         )
-         {
-         if (toInline)
-            {
-            if (comp()->trace(OMR::inlining))
-               traceMsg(comp(), "tryToInline pattern matched.  Skipping size check for %s\n", calltarget->_calleeMethod->signature(comp()->trMemory()));
-            callsite->tagcalltarget(i, tracer(), OverrideInlineTarget);
-            }
-         else
-           {
-            // debugging counters inserted in call
-            callsite->removecalltarget(i, tracer(), Exceeds_ByteCode_Threshold);
-            i--;
-            continue;
-            }
-         }
-      else
-         {
-         if (toInline)
-            {
-            if (comp()->trace(OMR::inlining))
-               traceMsg(comp(), "tryToInline pattern matched.  Within the size check for %s\n", calltarget->_calleeMethod->signature(comp()->trMemory()));
-            // change the default InlineableTarget
-            callsite->tagcalltarget(i,tracer(),TryToInlineTarget);
-            }
-         }
-
       // only inline recursive calls once
       //
       static char *selfInliningLimitStr = feGetEnv("TR_selfInliningLimit");
@@ -4231,7 +4177,57 @@ void TR_InlinerBase::applyPolicyToTargets(TR_CallStack *callStack, TR_CallSite *
             }
          }
 
+      int32_t bytecodeSize = getPolicy()->getInitialBytecodeSize(calltarget->_calleeMethod, calltarget->_calleeSymbol, comp());
 
+      if (!forceInline(calltarget))
+         getUtil()->estimateAndRefineBytecodeSize(callsite, calltarget, callStack, bytecodeSize);
+
+      if (calltarget->_calleeSymbol && strstr(calltarget->_calleeSymbol->signature(trMemory()), "FloatingDecimal"))
+         {
+         bytecodeSize >>= 1;
+
+         if (comp()->trace(OMR::inlining))
+            traceMsg( comp(), "Reducing bytecode size to %d because it's method of FloatingDecimal\n", bytecodeSize);
+         }
+
+      bool toInline = getPolicy()->tryToInline(calltarget, callStack, true);
+
+      TR_ByteCodeInfo &bcInfo = callsite->_bcInfo;
+      // get the number of locals in the callee
+      int32_t numberOfLocalsInCallee = calltarget->_calleeMethod->numberOfParameterSlots();// + calleeResolvedMethod->numberOfTemps();
+      if (!forceInline(calltarget) &&
+            exceedsSizeThreshold(callsite, bytecodeSize,
+                                   (callsite->_callerBlock != NULL) ? callsite->_callerBlock :
+                                      (callsite->_callNodeTreeTop ? callsite->_callNodeTreeTop->getEnclosingBlock() : 0),
+                                   bcInfo, numberOfLocalsInCallee, callsite->_callerResolvedMethod,
+                                   calltarget->_calleeMethod,callsite->_callNode,callsite->_allConsts)
+
+         )
+         {
+         if (toInline)
+            {
+            if (comp()->trace(OMR::inlining))
+               traceMsg(comp(), "tryToInline pattern matched.  Skipping size check for %s\n", calltarget->_calleeMethod->signature(comp()->trMemory()));
+            callsite->tagcalltarget(i, tracer(), OverrideInlineTarget);
+            }
+         else
+           {
+            // debugging counters inserted in call
+            callsite->removecalltarget(i, tracer(), Exceeds_ByteCode_Threshold);
+            i--;
+            continue;
+            }
+         }
+      else
+         {
+         if (toInline)
+            {
+            if (comp()->trace(OMR::inlining))
+               traceMsg(comp(), "tryToInline pattern matched.  Within the size check for %s\n", calltarget->_calleeMethod->signature(comp()->trMemory()));
+            // change the default InlineableTarget
+            callsite->tagcalltarget(i,tracer(),TryToInlineTarget);
+            }
+         }
       }
 
    return;

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -630,6 +630,13 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
        */
       virtual bool isInlineableNativeMethod(TR::Compilation *comp, TR::ResolvedMethodSymbol *methodSymbol) { return false; }
 
+      /**
+       * \brief sometimes we choose not to inline certain callsite because they will be handled specially in other optimizations or in codegen
+       *
+       * \return true if the method shouldn't be inlined in inliner
+       */
+      virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
+
    protected:
       virtual bool tryToInlineTrivialMethod (TR_CallStack* callStack, TR_CallTarget* calltarget);
       virtual bool alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::Node *callNode);
@@ -637,7 +644,6 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
       bool tryToInlineGeneral(TR_CallTarget *, TR_CallStack *, bool);
       virtual bool callMustBeInlined(TR_CallTarget *calltarget);
       bool mustBeInlinedEvenInDebug(TR_ResolvedMethod * calleeMethod, TR::TreeTop *callNodeTreeTop);
-      virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
       virtual TR_InlinerFailureReason checkIfTargetInlineable(TR_CallTarget* target, TR_CallSite* callsite, TR::Compilation* comp);
       virtual bool suitableForRemat(TR::Compilation *comp, TR::Node *node, TR_VirtualGuardSelection *guard);
    };


### PR DESCRIPTION
Before this change, applyPolicyToTargets removes the invalid targets
**AFTER** calling estimate code size on them. Estimating code size for
invalid targets is redundant since they are removed no matter what the
code size is. In case of not inlineable native methods, there is
functional issue because estimate code size iterates bytecode
in the callee which doesn't even exist for native methods.

This change removes the invalid targets **BEFORE** estimate code size
to both save compilation time and fix the functional issue with non-inlineable
native method.

Fixes: eclipse/openj9#6547
Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>