### PR TITLE
AArch64: Fix genericBinaryEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/BinaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/BinaryEvaluator.cpp
@@ -57,7 +57,7 @@ genericBinaryEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic regOp, TR::InstO
       }
    else if(1 == secondChild->getReferenceCount() && secondChild->getRegister() != NULL)
       {
-      trgReg = src2Reg;
+      trgReg = secondChild->getRegister();
       }
    else
       {


### PR DESCRIPTION
This commit fixes genericBinaryEvaluator() for AArch64.
The function fails with trgReg being NULL in a specific case.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>