### PR TITLE
AArch64: Implement integer max/min evaluators

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -744,15 +744,15 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::getpmEvaluator ,	// TR::getpm		// get program mask
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::setpmEvaluator ,	// TR::setpm		// set program mask
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::loadAutoOffsetEvaluator ,	// TR::loadAutoOffset	// loads the offset (from the SP) of an auto
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::imaxEvaluator ,	// TR::imax		// max of 2 or more integers
+    TR::TreeEvaluator::imaxEvaluator, // TR::imax		// max of 2 or more integers
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iumaxEvaluator ,	// TR::iumax		// max of 2 or more unsigned integers
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lmaxEvaluator ,	// TR::lmax		// max of 2 or more longs
+    TR::TreeEvaluator::lmaxEvaluator, // TR::lmax		// max of 2 or more longs
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lumaxEvaluator ,	// TR::lumax		// max of 2 or more unsigned longs
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fmaxEvaluator ,	// TR::fmax		// max of 2 or more floats
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dmaxEvaluator ,	// TR::dmax		// max of 2 or more doubles
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iminEvaluator ,	// TR::imin		// min of 2 or more integers
+    TR::TreeEvaluator::iminEvaluator, // TR::imin		// min of 2 or more integers
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iuminEvaluator ,	// TR::iumin		// min of 2 or more unsigned integers
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lminEvaluator ,	// TR::lmin		// min of 2 or more longs
+    TR::TreeEvaluator::lminEvaluator, // TR::lmin		// min of 2 or more longs
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::luminEvaluator ,	// TR::lumin		// min of 2 or more unsigned longs
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fminEvaluator ,	// TR::fmin		// min of 2 or more floats
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dminEvaluator ,	// TR::dmin		// min of 2 or more doubles


### PR DESCRIPTION
This commit implements imax/lmax/imin/lmin evaluators for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>