### PR TITLE
Fix ARM64ImmInstruction functionality

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -49,7 +49,7 @@ uint8_t *TR::ARM64ImmInstruction::generateBinaryEncoding()
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
-   *(int32_t *)cursor = (int32_t)getSourceImmediate();
+   insertImmediateField(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;
    setBinaryLength(ARM64_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);
@@ -435,18 +435,6 @@ uint8_t *TR::ARM64Src2Instruction::generateBinaryEncoding()
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
    insertSource1Register(toARM64Cursor(cursor));
    insertSource2Register(toARM64Cursor(cursor));
-   cursor += ARM64_INSTRUCTION_LENGTH;
-   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
-   setBinaryEncoding(instructionStart);
-   return cursor;
-   }
-
-uint8_t *TR::ARM64SynchronizationInstruction::generateBinaryEncoding()
-   {
-   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
-   uint8_t *cursor = instructionStart;
-   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
-   insertImmediateField(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;
    setBinaryLength(ARM64_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -512,6 +512,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsImm:
          print(pOutFile, (TR::ARM64ImmInstruction *)instr);
          break;
+      case OMR::Instruction::IsSynchronization:
+         print(pOutFile, (TR::ARM64ImmInstruction *)instr); // printing handled by superclass
+         break;
       case OMR::Instruction::IsImmSym:
          print(pOutFile, (TR::ARM64ImmSymInstruction *)instr);
          break;

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -49,13 +49,23 @@ inline bool constantIsImm9(int32_t intValue)
    }
 
 /*
- * @brief Answers if the unsigned integer value can be placed in 12-bit field
+ * @brief Answers if the unsigned integer value can be encoded in a 4-bit field
  * @param[in] intValue : unsigned integer value
- * @return true if the value can be placed in 12-bit field, false otherwise
+ * @return true if the value can be encoded in a 4-bit field, false otherwise
+ */
+inline bool constantIsUnsignedImm4(uint64_t intValue)
+   {
+   return (intValue < (1<<4));  // 16
+   }
+
+/*
+ * @brief Answers if the unsigned integer value can be encoded in a 12-bit field
+ * @param[in] intValue : unsigned integer value
+ * @return true if the value can be encoded in a 12-bit field, false otherwise
  */
 inline bool constantIsUnsignedImm12(uint64_t intValue)
    {
-   return (intValue < 4096);
+   return (intValue < (1<<12));  // 4096
    }
 
 /*
@@ -74,8 +84,6 @@ namespace TR
 class ARM64ImmInstruction : public TR::Instruction
    {
    uint32_t _sourceImmediate;
-   TR_ExternalRelocationTargetKind _reloKind;
-   TR::SymbolReference *_symbolReference;
 
 public:
 
@@ -88,7 +96,7 @@ public:
     * @param[in] cg : CodeGenerator
     */
    ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
+      : TR::Instruction(op, node, cg), _sourceImmediate(imm)
       {
       }
    /*
@@ -101,72 +109,8 @@ public:
     */
    ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
                         TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(TR_NoRelocation), _symbolReference(NULL)
+      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm)
       {
-      }
-
-   // Constructors with relocation types
-   /*
-    * @brief Constructor
-    * @param[in] op : instruction opcode
-    * @param[in] node : node
-    * @param[in] imm : immediate value
-    * @param[in] relocationKind : relocation kind
-    * @param[in] cg : CodeGenerator
-    */
-   ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
-      {
-      setNeedsAOTRelocation(true);
-      }
-   /*
-    * @brief Constructor
-    * @param[in] op : instruction opcode
-    * @param[in] node : node
-    * @param[in] imm : immediate value
-    * @param[in] relocationKind : relocation kind
-    * @param[in] precedingInstruction : preceding instruction
-    * @param[in] cg : CodeGenerator
-    */
-   ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
-      {
-      setNeedsAOTRelocation(true);
-      }
-
-   // Constructors with relocation typesand associated symbol references
-   /*
-    * @brief Constructor
-    * @param[in] op : instruction opcode
-    * @param[in] node : node
-    * @param[in] imm : immediate value
-    * @param[in] relocationKind : relocation kind
-    * @param[in] sr : symbol reference
-    * @param[in] cg : CodeGenerator
-    */
-   ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
-      {
-      setNeedsAOTRelocation(true);
-      }
-   /*
-    * @brief Constructor
-    * @param[in] op : instruction opcode
-    * @param[in] node : node
-    * @param[in] imm : immediate value
-    * @param[in] relocationKind : relocation kind
-    * @param[in] sr : symbol reference
-    * @param[in] precedingInstruction : preceding instruction
-    * @param[in] cg : CodeGenerator
-    */
-   ARM64ImmInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm, TR_ExternalRelocationTargetKind relocationKind,
-                        TR::SymbolReference *sr, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
-      {
-      setNeedsAOTRelocation(true);
       }
 
    /**
@@ -188,29 +132,16 @@ public:
    uint32_t setSourceImmediate(uint32_t si) {return (_sourceImmediate = si);}
 
    /**
-    * @brief Gets relocation kind
-    * @return relocation kind
+    * @brief Encodes the immediate field into the instruction
+    * @param[in] instruction : instruction address
     */
-   TR_ExternalRelocationTargetKind getReloKind() { return _reloKind; }
-   /**
-    * @brief Sets relocation kind
-    * @param[in] reloKind : relocation kind
-    */
-   void setReloKind(TR_ExternalRelocationTargetKind reloKind) { _reloKind = reloKind; }
-
-   /**
-    * @brief Gets symbol reference
-    * @return symbol reference
-    */
-   TR::SymbolReference *getSymbolReference() {return _symbolReference;}
-   /**
-    * @brief Sets symbol reference
-    * @param[in] sr : symbol reference
-    * @return symbol reference
-    */
-   TR::SymbolReference *setSymbolReference(TR::SymbolReference *sr)
+   virtual void insertImmediateField(uint32_t *instruction)
       {
-      return (_symbolReference = sr);
+      // Write the 32-bit immediate with no masking or shifting.
+      // Be aware this will overwrite the entire 32-bit instruction
+      // with the immediate value.
+      //
+      *instruction = _sourceImmediate;
       }
 
    /**
@@ -1594,7 +1525,7 @@ class ARM64CondTrg1Src2Instruction : public ARM64Trg1Src2Instruction
                              TR::ARM64ConditionCode cc,
                              TR::CodeGenerator *cg)
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg), _cc(cc)
-      {      
+      {
       }
 
    /*
@@ -1667,7 +1598,7 @@ class ARM64CondTrg1Src2Instruction : public ARM64Trg1Src2Instruction
       : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cond, precedingInstruction, cg), _cc(cc)
       {
       }
-      
+
    /**
     * @brief Gets instruction kind
     * @return instruction kind
@@ -1685,7 +1616,7 @@ class ARM64CondTrg1Src2Instruction : public ARM64Trg1Src2Instruction
     * @param[in] cc : condition code
     * @return condition code
     */
-   TR::ARM64ConditionCode setConditionCode(TR::ARM64ConditionCode cc) 
+   TR::ARM64ConditionCode setConditionCode(TR::ARM64ConditionCode cc)
       {
       return (_cc = cc);
       }
@@ -2629,9 +2560,8 @@ class ARM64Src2Instruction : public ARM64Src1Instruction
    virtual uint8_t *generateBinaryEncoding();
    };
 
-class ARM64SynchronizationInstruction : public TR::Instruction
+class ARM64SynchronizationInstruction : public ARM64ImmInstruction
    {
-   uint32_t _sourceImmediate;
 
    public:
 
@@ -2644,7 +2574,7 @@ class ARM64SynchronizationInstruction : public TR::Instruction
     */
    ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
                                     uint32_t imm, TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, cg), _sourceImmediate(imm)
+      : ARM64ImmInstruction(op, node, imm, cg)
       {
       }
 
@@ -2656,10 +2586,10 @@ class ARM64SynchronizationInstruction : public TR::Instruction
     * @param[in] preced : preceding instruction
     * @param[in] cg : CodeGenerator
     */
-   ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, 
-                                    uint32_t imm, TR::Instruction *precedingInstruction, 
+   ARM64SynchronizationInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+                                    uint32_t imm, TR::Instruction *precedingInstruction,
                                     TR::CodeGenerator *cg)
-      : TR::Instruction(op, node, precedingInstruction, cg), _sourceImmediate(imm)
+      : ARM64ImmInstruction(op, node, imm, precedingInstruction, cg)
       {
       }
 
@@ -2669,30 +2599,12 @@ class ARM64SynchronizationInstruction : public TR::Instruction
     */
    virtual Kind getKind() { return IsSynchronization; }
 
-   /**
-    * @brief Gets source immediate
-    * @return source immediate
-    */
-   uint32_t getSourceImmediate() {return _sourceImmediate;}
-   
-   /**
-    * @brief Sets source immediate
-    * @param[in] si : immediate value
-    * @return source immediate
-    */
-   uint32_t setSourceImmediate(uint32_t si) {return (_sourceImmediate = si);}
-
-   void insertImmediateField(uint32_t *instruction)
+   virtual void insertImmediateField(uint32_t *instruction)
       {
-      TR_ASSERT(_sourceImmediate <= 0xF, "Immediate value exceeds 4 bits.");
-      *instruction |= ((_sourceImmediate & 0xF) << 8);
+      TR_ASSERT_FATAL(constantIsUnsignedImm4(getSourceImmediate()), "Immediate value exceeds 4 bits.");
+      *instruction |= ((getSourceImmediate() & 0xF) << 8);
       }
 
-   /**
-    * @brief Generates binary encoding of the instruction
-    * @return instruction cursor
-    */
-   virtual uint8_t *generateBinaryEncoding();
    };
 
 } // TR

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -44,28 +44,12 @@ TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
    return new (cg->trHeapMemory()) TR::Instruction(op, node, cg);
    }
 
-TR::Instruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
+TR::ARM64ImmInstruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
                                        TR::Instruction *preced)
    {
    if (preced)
       return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, preced, cg);
    return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, cg);
-   }
-
-TR::Instruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
-                                       TR_ExternalRelocationTargetKind relocationKind, TR::Instruction *preced)
-   {
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, relocationKind, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, relocationKind, cg);
-   }
-
-TR::Instruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node, uint32_t imm,
-                                       TR_ExternalRelocationTargetKind relocationKind, TR::SymbolReference *sr, TR::Instruction *preced)
-   {
-   if (preced)
-      return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, relocationKind, sr, preced, cg);
-   return new (cg->trHeapMemory()) TR::ARM64ImmInstruction(op, node, imm, relocationKind, sr, cg);
    }
 
 TR::Instruction *generateImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
@@ -469,7 +453,7 @@ TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node,
    return new (cg->trHeapMemory()) TR::ARM64Trg1CondInstruction(op, node, treg, cc_invert(cc), cg);
    }
 
-TR::Instruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
+TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op,
    TR::Node *node, uint32_t imm, TR::Instruction *preced)
    {
    if (preced)

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/ARM64ConditionCode.hpp"
+#include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64ShiftCode.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/Instruction.hpp"
@@ -64,49 +65,11 @@ TR::Instruction *generateInstruction(
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateImmInstruction(
+TR::ARM64ImmInstruction *generateImmInstruction(
                    TR::CodeGenerator *cg,
                    TR::InstOpCode::Mnemonic op,
                    TR::Node *node,
                    uint32_t imm,
-                   TR::Instruction *preced = NULL);
-
-/*
- * @brief Generates imm instruction with relocation
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] imm : immediate value
- * @param[in] relocationKind : relocation kind
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateImmInstruction(
-                   TR::CodeGenerator *cg,
-                   TR::InstOpCode::Mnemonic op,
-                   TR::Node *node,
-                   uint32_t imm,
-                   TR_ExternalRelocationTargetKind relocationKind,
-                   TR::Instruction *preced = NULL);
-
-/*
- * @brief Generates imm instruction with symbol reference
- * @param[in] cg : CodeGenerator
- * @param[in] op : instruction opcode
- * @param[in] node : node
- * @param[in] imm : immediate value
- * @param[in] relocationKind : relocation kind
- * @param[in] sr : symbol reference
- * @param[in] preced : preceding instruction
- * @return generated instruction
- */
-TR::Instruction *generateImmInstruction(
-                   TR::CodeGenerator *cg,
-                   TR::InstOpCode::Mnemonic op,
-                   TR::Node *node,
-                   uint32_t imm,
-                   TR_ExternalRelocationTargetKind relocationKind,
-                   TR::SymbolReference *sr,
                    TR::Instruction *preced = NULL);
 
 /*
@@ -780,7 +743,7 @@ TR::Instruction *generateCSetInstruction(
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
-TR::Instruction *generateSynchronizationInstruction(
+TR::ARM64SynchronizationInstruction *generateSynchronizationInstruction(
                   TR::CodeGenerator *cg,
                   TR::InstOpCode::Mnemonic op,
                   TR::Node *node,

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -128,7 +128,7 @@ OMR::ARM64::CodeGenerator::beginInstructionSelection()
    TR::Node *startNode = comp->getStartTree()->getNode();
    if (comp->getMethodSymbol()->getLinkageConvention() == TR_Private)
       {
-      _returnTypeInfoInstruction = new (self()->trHeapMemory()) TR::ARM64ImmInstruction(TR::InstOpCode::dd, startNode, 0, self());
+      _returnTypeInfoInstruction = generateImmInstruction(self(), TR::InstOpCode::dd, startNode, 0);
       }
    else
       {

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -26,6 +26,7 @@
 
    IsNotExtended,
    IsImm,
+      IsSynchronization,
    IsImmSym,
    IsLabel,
       IsConditionalBranch,
@@ -47,4 +48,3 @@
       IsMemSrc1,
    IsSrc1,
       IsSrc2,
-   IsSynchronization,


### PR DESCRIPTION
* Make ARM64ImmInstruction a base class purely for immediate values by removing
  unnecessary functionality
* Correct Imm instruction binary encoding
* Rebase the ARM64SynchronizationInstruction to extend ARM64ImmediateInstruction
  and share functionality

Fixes #4165

Signed-off-by: Daryl Maier <maier@ca.ibm.com>