### PR TITLE
WIP:  Use separate enum constants for recognized J9 System.arraycopy methods

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -1454,7 +1454,9 @@ OMR::SymbolReferenceTable::findOrCreateMethodSymbol(
       TR::ResolvedMethodSymbol *resSym = TR::ResolvedMethodSymbol::create(trHeapMemory(),resolvedMethod,comp());
       sym = resSym;
 #ifdef J9_PROJECT_SPECIFIC
-      canGCandReturn = !(resSym->canDirectNativeCall() || resSym->getRecognizedMethod()==TR::java_lang_System_arraycopy);
+      canGCandReturn = !(resSym->canDirectNativeCall()
+                           || resSym->getRecognizedMethod()==TR::java_lang_System_arraycopy_Array
+                           || resSym->getRecognizedMethod()==TR::java_lang_System_arraycopy_Object);
       canGCandExcept = !resSym->canDirectNativeCall();
 #endif
       }

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -397,7 +397,12 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             switch (resolvedMethodSymbol->getRecognizedMethod())
                {
 #ifdef J9_PROJECT_SPECIFIC
+#ifdef J9_RECOGNIZED_METHOD_ARRAYCOPY_DISTINCT_ENUM_VALUES
+               case TR::java_lang_System_arraycopy_Object:
+               case TR::java_lang_System_arraycopy_Array:
+#else
                case TR::java_lang_System_arraycopy:
+#endif
                   {
                   TR_BitVector * aliases = new (aliasRegion) TR_BitVector(bvInitialSize, aliasRegion, growability);
                   *aliases |= symRefTab->aliasBuilder.arrayElementSymRefs();


### PR DESCRIPTION
The handling of System.arraycopy as a recognized method is changing in OpenJ9 under the proposed [OpenJ9 pull request #6598](https://github.com/eclipse/openj9/pull/6598) .  Previously J9 used one enum constant name for all System.arraycopy methods, but under the pull request it will change to use distinct names.

Initially, the distinct names in J9 will have the same values but will change to having distinct values.  The macro `J9_RECOGNIZED_METHOD_ARRAYCOPY_DISTINCT_ENUM_VALUES` allows OMR to be compiled in the context of J9 with either a single constant value or distinct constant values to allow for the transition.  After the transition is made, the reference to that macro will be removed.

This pull request depends on [OpenJ9 pull request #6598](https://github.com/eclipse/openj9/pull/6598), and so it will remain marked as a work in progress until after that pull request is merged.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>