### PR TITLE
Make JitBuilder sources private

### DIFF
--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -44,7 +44,7 @@ if(OMR_HOST_ARCH STREQUAL "x86")
 endif()
 
 if(NOT OMR_HOST_ARCH STREQUAL "ppc")
-	target_sources(jitbuildertest PUBLIC UnsignedDivRemTest.cpp)
+	target_sources(jitbuildertest PRIVATE UnsignedDivRemTest.cpp)
 endif()
 
 target_link_libraries(jitbuildertest


### PR DESCRIPTION
Make JitBuilder sources private due to CMP0076 warning policy and path type conversion.

Fixes: #4069

Signed-off-by: Batyr Nuryyev <nuryyev@ualberta.ca>