### PR TITLE
AArch64: Implement TR_Debug::print(ARM64CompareBranchInstruction)

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -676,7 +676,10 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64CompareBranchInstruction *instr)
    {
    printPrefix(pOutFile, instr);
-   TR_UNIMPLEMENTED();
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getLabelSymbol());
+   trfflush(_comp->getOutFile());
    }
 
 void


### PR DESCRIPTION
This commit implements TR_Debug::print() function for
ARM64CompareBranchInstruction.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>