### PR TITLE
WIP: Enable XL C/C++ 13.1 on Linux PPC BE

### DIFF
--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -32,6 +32,11 @@ if(OMR_HOST_ARCH STREQUAL "ppc")
 
 	list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qlanglvl=extended0x)
 
+	if(NOT OMR_ENV_LITTLE_ENDIAN)
+		# add -qdebug=NETHUNK for BE platforms to C++ flags
+		list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qdebug=NETHUNK)
+	endif()
+
 	if(OMR_ENV_DATA64)
 		list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
 			-q64

--- a/omrmakefiles/rules.linux.mk
+++ b/omrmakefiles/rules.linux.mk
@@ -183,6 +183,14 @@ ifeq (1,$(OMR_DEBUG))
   endif
 endif
 
+ifeq (ppc,$(OMR_HOST_ARCH))
+  ifeq (xlc,$(OMR_TOOLCHAIN))
+    ifeq ($(OMR_ENV_LITTLE_ENDIAN),0)
+      GLOBAL_CXXFLAGS+=-qdebug=NETHUNK
+    endif
+  endif
+endif
+
 #-- Add Platform flags
 ifeq (x86,$(OMR_HOST_ARCH))
     ifeq (1,$(OMR_ENV_DATA64))


### PR DESCRIPTION
Add -qdebug=NETHUNK to C/C++ flags for Linux PPC BE

Issue: https://github.com/eclipse/omr/issues/4252

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>