### PR TITLE
Add a placeholder call symbol for jProfileValue

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -2013,6 +2013,20 @@ TR_BitVector *OMR::SymbolReferenceTable::getSharedAliases(TR::SymbolReference *s
    return NULL;
    }
 
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateJProfileValuePlaceHolderSymbolRef(CommonNonhelperSymbol index)
+   {
+   TR_ASSERT_FATAL(index == jProfileValueSymbol || index == jProfileValueWithNullCHKSymbol, "findOrCreateJProfileValuePlaceHolderSymbolRef should be used with either jProfileValueSymbol or jProfileValueWithNullCHKSymbol");
+   if (!element(index))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_None);
+      sym->setHelper();
+      element(index) = new (trHeapMemory()) TR::SymbolReference(self(), index, sym);
+      }
+   return element(index);
+   }
+
 TR::SymbolReference *
 OMR::SymbolReferenceTable::findOrCreatePotentialOSRPointHelperSymbolRef()
    {

--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -2015,16 +2015,27 @@ TR_BitVector *OMR::SymbolReferenceTable::getSharedAliases(TR::SymbolReference *s
 
 
 TR::SymbolReference *
-OMR::SymbolReferenceTable::findOrCreateJProfileValuePlaceHolderSymbolRef(CommonNonhelperSymbol index)
+OMR::SymbolReferenceTable::findOrCreateJProfileValuePlaceHolderSymbolRef()
    {
-   TR_ASSERT_FATAL(index == jProfileValueSymbol || index == jProfileValueWithNullCHKSymbol, "findOrCreateJProfileValuePlaceHolderSymbolRef should be used with either jProfileValueSymbol or jProfileValueWithNullCHKSymbol");
-   if (!element(index))
+   if (!element(jProfileValueSymbol))
       {
       TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_None);
       sym->setHelper();
-      element(index) = new (trHeapMemory()) TR::SymbolReference(self(), index, sym);
+      element(jProfileValueSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), jProfileValueSymbol, sym);
       }
-   return element(index);
+   return element(jProfileValueSymbol);
+   }
+
+TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateJProfileValuePlaceHolderWithNullCHKSymbolRef()
+   {
+   if (!element(jProfileValueWithNullCHKSymbol))
+      {
+      TR::MethodSymbol * sym = TR::MethodSymbol::create(trHeapMemory(),TR_None);
+      sym->setHelper();
+      element(jProfileValueWithNullCHKSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), jProfileValueWithNullCHKSymbol, sym);
+      }
+   return element(jProfileValueWithNullCHKSymbol); 
    }
 
 TR::SymbolReference *

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -334,6 +334,19 @@ class SymbolReferenceTable
        */
       atomicCompareAndSwapReturnValueSymbol,
 
+      /** \brief
+       *  
+       * These symbols represent placeholder calls for profiling value which will be lowered into trees later.
+       * 
+       * \code
+       *    call <jProfileValue/jProfileValueWithNullCHK>
+       *       <value to be profiled>
+       *       <table address>
+       * \endcode
+       */
+      jProfileValueSymbol, 
+      jProfileValueWithNullCHKSymbol,
+
       firstPerCodeCacheHelperSymbol,
       lastPerCodeCacheHelperSymbol = firstPerCodeCacheHelperSymbol + TR_numCCPreLoadedCode - 1,
 
@@ -444,6 +457,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
 
    TR::SymbolReference * findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbol index);
+   TR::SymbolReference * findOrCreateJProfileValuePlaceHolderSymbolRef(CommonNonhelperSymbol index);
    TR::SymbolReference * findOrCreatePotentialOSRPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateOSRFearPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induceOSRHelper);

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -457,7 +457,8 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateRuntimeHelper(TR_RuntimeHelper index, bool canGCandReturn, bool canGCandExcept, bool preservesAllRegisters);
 
    TR::SymbolReference * findOrCreateCodeGenInlinedHelper(CommonNonhelperSymbol index);
-   TR::SymbolReference * findOrCreateJProfileValuePlaceHolderSymbolRef(CommonNonhelperSymbol index);
+   TR::SymbolReference * findOrCreateJProfileValuePlaceHolderSymbolRef();
+   TR::SymbolReference * findOrCreateJProfileValuePlaceHolderWithNullCHKSymbolRef();
    TR::SymbolReference * findOrCreatePotentialOSRPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateOSRFearPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induceOSRHelper);

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1651,6 +1651,10 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<potentialOSRPointHelper>";
          case TR::SymbolReferenceTable::osrFearPointHelperSymbol:
              return "<osrFearPointHelper>";
+         case TR::SymbolReferenceTable::jProfileValueSymbol:
+             return "<jProfileValuePlaceHolder>";
+         case TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol:
+             return "<jProfileValueWithNullCHKPlaceHolder>";
          }
       }
 
@@ -2105,6 +2109,8 @@ static const char *commonNonhelperSymbolNames[] =
    "<atomicSwap64Bit>",
    "<atomicCompareAndSwapReturnStatus>",
    "<atomicCompareAndSwapReturnValue>",
+   "<jProfileValueSymbol>",
+   "<jProfileValueWithNullCHKSymbol>",
    };
 
 const char *


### PR DESCRIPTION
Add following placeholder call symbol to CommonNonHelperSymbol enum for jProfilingValue.

1. jProfileValue : Symbol for regular value profiling which does not need NULLCHK
2. jProfileValueWithNullCHK : Symbol for value profiling that requires NULLCHK

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>