### PR TITLE
Prepare JITaaS to be replaced with JITServer

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -687,6 +687,8 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableJITaaSHeuristics",             "O\tenable JITaaS heuristics", SET_OPTION_BIT(TR_EnableJITaaSHeuristics), "F"},
    {"enableJITHelpershashCodeImpl",       "O\tenable java version of object hashCode()", SET_OPTION_BIT(TR_EnableJITHelpershashCodeImpl), "F"},
    {"enableJITHelpersoptimizedClone",     "O\tenable java version of object clone()", SET_OPTION_BIT(TR_EnableJITHelpersoptimizedClone), "F"},
+   {"enableJITServerFollowRemoteCompileWithLocalCompile", "O\tenable JITServer to perform local compilations for its remotely compiled methods", SET_OPTION_BIT(TR_JITServerFollowRemoteCompileWithLocalCompile), "F"},
+   {"enableJITServerHeuristics",          "O\tenable JITServer heuristics", SET_OPTION_BIT(TR_EnableJITServerHeuristics), "F"},
    {"enableJProfiling",                   "O\tenable JProfiling", SET_OPTION_BIT(TR_EnableJProfiling), "F"},
    {"enableJProfilingInProfilingCompilations","O\tuse jprofiling instrumentation in profiling compilations", SET_OPTION_BIT(TR_EnableJProfilingInProfilingCompilations), "F"},
    {"enableJVMPILineNumbers",            "M\tenable output of line numbers via JVMPI",       SET_OPTION_BIT(TR_EnableJVMPILineNumbers), "F"},
@@ -4784,6 +4786,7 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "sampleDensity",
    "profiling",
    "JITaaS",
+   "JITServer",
    "aotcompression",
    };
 

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -193,6 +193,7 @@ enum TR_CompilationOptions
    TR_DisableCompilationThread            = 0x00008000 + 3,
    TR_EnableCompilationThread             = 0x00010000 + 3,
    TR_EnableJITaaSHeuristics              = 0x00020000 + 3,
+   TR_EnableJITServerHeuristics           = 0x00020000 + 3,
    TR_SoftFailOnAssume                    = 0x00040000 + 3,
    TR_DisableNewBlockOrdering             = 0x00080000 + 3,
    TR_DisableZNext                        = 0x00100000 + 3,
@@ -336,6 +337,7 @@ enum TR_CompilationOptions
    TR_OldJVMPI                            = 0x00000080 + 8,
    TR_EmitExecutableELFFile               = 0x00000100 + 8,
    TR_EnableJITaaSDoLocalCompilesForRemoteCompiles = 0x00000200 + 8,
+   TR_JITServerFollowRemoteCompileWithLocalCompile = 0x00000200 + 8,
    // Available                           = 0x00000800 + 8,
    TR_DisableLinkageRegisterAllocation    = 0x00001000 + 8,
    // Available                           = 0x00002000 + 8,
@@ -1138,6 +1140,7 @@ enum TR_VerboseFlags
    TR_VerboseSampleDensity,
    TR_VerboseProfiling,
    TR_VerboseJITaaS,
+   TR_VerboseJITServer,
    TR_VerboseAOTCompression,
    //If adding new options add an entry to _verboseOptionNames as well
    TR_NumVerboseOptions        // Must be the last one;

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -62,6 +62,7 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#RECLAMATION: ",
    "#PROFILING: ",
    "#JITaaS: ",
+   "#JITServer: ",
    "#AOTCOMPRESSION: ",
    };
 

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -70,6 +70,7 @@ enum TR_VlogTag
    TR_Vlog_RECLAMATION,
    TR_Vlog_PROFILING,
    TR_Vlog_JITaaS,
+   TR_Vlog_JITServer,
    TR_Vlog_AOTCOMPRESSION,
    TR_Vlog_numTags
    };


### PR DESCRIPTION
As decided by eclipse/openj9#6203, name `JITaaS` is replaced with `JITServer`.
Add new option and verbose log names using `JITServer`.
After the new names are picked up by OpenJ9, the old names
with `JITaaS` will be removed.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>