### PR TITLE
AArch64: Set SupportsGlRegDeps flags

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -62,6 +62,9 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
    self()->setLastGlobalGPR(TR::Machine::getLastGlobalGPRRegisterNumber());
    self()->setLastGlobalFPR(TR::Machine::getLastGlobalFPRRegisterNumber());
 
+   self()->setSupportsGlRegDeps();
+   self()->setSupportsGlRegDepOnFirstBlock();
+
    self()->getLinkage()->initARM64RealRegisterLinkage();
 
    _numberBytesReadInaccessible = 0;


### PR DESCRIPTION
This commit sets SupportsGlRegDeps flags in OMRCodeGenerator.cpp for
AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>