### PR TITLE
Avoid EBCDIC to ASCII translation in omrfile_write_text in OMR

### DIFF
--- a/port/common/j9nls.c
+++ b/port/common/j9nls.c
@@ -1215,11 +1215,11 @@ read_from_catalog(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 	char temp[BUF_SIZE];
 	intptr_t count, nbytes = bufsize;
 	char *cursor = buf;
-#ifdef J9ZOS390
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	iconv_t converter;
 	size_t inbytesleft, outbytesleft;
 	char *inbuf, *outbuf;
-#endif
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 	if (nbytes <= 0) {
 		return 0;
@@ -1229,7 +1229,7 @@ read_from_catalog(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 	nbytes -= 1;
 
 
-#ifdef J9ZOS390
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	/* iconv_get is not an a2e function, so we need to pass it honest-to-goodness EBCDIC strings */
 #pragma convlit(suspend)
 	converter = iconv_get(portLibrary, J9NLS_ICONV_DESCRIPTOR, "UTF-8", "IBM-1047");
@@ -1237,7 +1237,7 @@ read_from_catalog(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 	if (J9VM_INVALID_ICONV_DESCRIPTOR == converter) {
 		return NULL;
 	}
-#endif
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 
 	while (nbytes) {
@@ -1245,9 +1245,9 @@ read_from_catalog(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 		count = portLibrary->file_read(portLibrary, fd, temp, count);
 
 		if (count < 0) {
-#ifdef J9ZOS390
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 			iconv_free(portLibrary, J9NLS_ICONV_DESCRIPTOR, converter);
-#endif
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 			/* if we've made it through a successful read, return the buf. */
 			if (nbytes + 1 != bufsize) {
 				return buf;
@@ -1255,7 +1255,7 @@ read_from_catalog(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 			return NULL;
 		}
 
-#ifdef J9ZOS390
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 		inbuf = temp;
 		inbytesleft = count;
 		outbuf = cursor;
@@ -1271,18 +1271,18 @@ read_from_catalog(struct OMRPortLibrary *portLibrary, intptr_t fd, char *buf, in
 		}
 		nbytes -= count - inbytesleft;
 		cursor += count - inbytesleft;
-#else
+#else /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 		memcpy(cursor, temp, count);
 		cursor += count;
 		nbytes -= count;
-#endif
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 	}
 
 	*cursor = '\0';
 
-#ifdef J9ZOS390
+#if defined(J9ZOS390) && !defined(OMR_EBCDIC)
 	iconv_free(portLibrary, J9NLS_ICONV_DESCRIPTOR, converter);
-#endif
+#endif /* defined(J9ZOS390) && !defined(OMR_EBCDIC) */
 
 	return buf;
 }

--- a/port/unix/omrfiletext.c
+++ b/port/unix/omrfiletext.c
@@ -84,8 +84,11 @@ omrfile_write_text(struct OMRPortLibrary *portLibrary, intptr_t fd, const char *
 #endif
 
 #if defined(J9ZOS390) || defined(OMRZTPF)
-	/* z/OS and z/TPF always needs to translate to EBCDIC */
+#if !defined(OMR_EBCDIC)
+	/* z/OS and z/TPF always needs to translate to EBCDIC, unless we are already using EBCDIC as the native encoding, */
+	/* in which case no translation is required. */
 	requiresTranslation = 1;
+#endif /* !defined(OMR_EBCDIC) */
 #else
 	/* we can short circuit if the string is all ASCII */
 	for (i = 0; i < nbytes; i++) {


### PR DESCRIPTION
In OMR the default encoding of all strings on z/OS is the native
encoding, which is EBCDIC. As such we do not want to convert strings
from EBCDIC to ASCII when using the various tty OMR APIs. In this
instance calls to `omrtty_err_printf` for example will end up being
incorrectly converted from EBCDIC to EBCDIC and garbage characters will
be printed out to the screen.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>