### PR TITLE
Use setAllocation

### DIFF
--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1327,7 +1327,7 @@ TR::Node *
 OMR::Node::createAllocationFence(TR::Node *originatingByteCodeNode, TR::Node *fenceNode)
    {
    TR::Node *node = TR::Node::create(originatingByteCodeNode, TR::allocationFence, 0, 0);
-   node->setChild(0, fenceNode);
+   node->setAllocation(fenceNode);
    return node;
    }
 


### PR DESCRIPTION
allocationfence node doesn't have children, we should use setAllocation
to set the allocation node.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>