### PR TITLE
Enable change to determine calling method for OSR code in Inliner

### DIFF
--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -30,6 +30,13 @@
 #ifndef INLINER_INCL
 #define INLINER_INCL
 
+// TODO:  This macro enables a change to the way the calling method is found
+//        for OSR-related code in the Inliner.  Once downstream components
+//        have had their changes enabled unconditionalloy, corresponding
+//        changes in OMR that are guarded by this macro can be made
+//        unconditional, and this definition can be removed.
+#define INLINER_OSR_CALLING_METHOD
+
 #include "optimizer/CallInfo.hpp"
 
 #include <stddef.h>


### PR DESCRIPTION
Changes to the way the calling method is determined for OSR-related code in the Inliner are conditionally compiled under `#if defined(INLINER_OSR_CALLING_METHOD)`.  This change enables that code.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>