### PR TITLE
AArch64: Add ARM64CondTrg1Src2Instruction to ARM64Debug.cpp

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -552,6 +552,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsTrg1Src2:
          print(pOutFile, (TR::ARM64Trg1Src2Instruction *)instr);
          break;
+      case OMR::Instruction::IsCondTrg1Src2:
+         print(pOutFile, (TR::ARM64CondTrg1Src2Instruction *)instr);
+         break;
       case OMR::Instruction::IsTrg1Src2Shifted:
          print(pOutFile, (TR::ARM64Trg1Src2ShiftedInstruction *)instr);
          break;
@@ -796,6 +799,23 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2Instruction *instr)
    print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
+
+   if (instr->getDependencyConditions())
+      print(pOutFile, instr->getDependencyConditions());
+
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64CondTrg1Src2Instruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource2Register(), TR_WordReg);
+   trfprintf(pOutFile, ", %s", ARM64ConditionNames[instr->getConditionCode()]);
 
    if (instr->getDependencyConditions())
       print(pOutFile, instr->getDependencyConditions());

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -345,6 +345,7 @@ namespace TR { class ARM64Trg1ImmInstruction; }
 namespace TR { class ARM64Trg1Src1Instruction; }
 namespace TR { class ARM64Trg1Src1ImmInstruction; }
 namespace TR { class ARM64Trg1Src2Instruction; }
+namespace TR { class ARM64CondTrg1Src2Instruction; }
 namespace TR { class ARM64Trg1Src2ShiftedInstruction; }
 namespace TR { class ARM64Trg1Src2ExtendedInstruction; }
 namespace TR { class ARM64Trg1Src3Instruction; }
@@ -1085,6 +1086,7 @@ public:
    void print(TR::FILE *, TR::ARM64Trg1Src1Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src1ImmInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2Instruction *);
+   void print(TR::FILE *, TR::ARM64CondTrg1Src2Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ShiftedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ExtendedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src3Instruction *);


### PR DESCRIPTION
This commit adds support for a new instruction kind,
ARM64CondTrg1Src2Instruction, to ARM64Debug.cpp.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>