### PR TITLE
AArch64: Add DMB instruction to opcode tables

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -89,6 +89,7 @@ static const char *opCodeToNameMap[] =
    "b_cond",
    "brkarm64",
    "dsb",
+   "dmb",
    "br",
    "blr",
    "ret",

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,6 +42,7 @@
 		brkarm64,                                               	/* 0xD4200000	BRK       	AArch64 Specific BRK */
 	/* System */
 		dsb,                                                    	/* 0xD503309F	DSB       	 */
+		dmb,                                                    	/* 0xD50330BF	DMB       	 */
 	/* Unconditional branch (register) */
 		br,                                                     	/* 0xD61F0000	BR        	 */
 		blr,                                                    	/* 0xD63F0000	BLR       	 */

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2018 IBM Corp. and others
+ * Copyright (c) 2018, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,6 +41,7 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0xD4200000,	/* BRK       	brkarm64	AArch64 Specific BRK */
 	/* System */
 		0xD503309F,	/* DSB       	dsb	 */
+		0xD50330BF,	/* DMB       	dmb	 */
 	/* Unconditional branch (register) */
 		0xD61F0000,	/* BR        	br	 */
 		0xD63F0000,	/* BLR       	blr	 */


### PR DESCRIPTION
This commit adds AArch64 DMB (data memory barrier) instruction to
opcode tables.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>