### PR TITLE
Remove OMR::Compilation::needRelocationsForStatics

### DIFF
--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1027,13 +1027,6 @@ public:
     */
    DebugCounterMap &getDebugCounterMap() { return _debugCounterMap; }
 
-   /**
-    *  @brief needRelocationsForStatics
-    *  @return whether static data addresses need to be relocated
-    */
-   bool needRelocationsForStatics() { return true; }
-
-
 public:
 #ifdef J9_PROJECT_SPECIFIC
    // Access to this list must be performed with assumptionTableMutex in hand

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -2841,7 +2841,7 @@ TR::AMD64RegImm64SymInstruction::addMetaDataForCodeAddress(uint8_t *cursor)
 
          case TR_DataAddress:
             {
-            if (comp->needRelocationsForStatics())
+            if (cg()->needRelocationsForStatics())
                {
                cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
                                                                                          (uint8_t *) getSymbolReference(),


### PR DESCRIPTION
Replace the usage of that query with `CodeGenerator::needRelocationsForStatics`.
They are supposed to be used in the same circumstances but it is more appropriate to have this query in the codegen, since different platforms may require different answers.