### PR TITLE
AArch64: Fix fstore/dstore evaluators

### DIFF
--- a/compiler/aarch64/codegen/FPTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/FPTreeEvaluator.cpp
@@ -140,14 +140,14 @@ OMR::ARM64::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::ARM64::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::vstrimms, 4, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::vstrimms, 4, cg);
    }
 
 // also handles dstorei
 TR::Register *
 OMR::ARM64::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return commonLoadEvaluator(node, TR::InstOpCode::vstrimmd, 8, cg);
+   return commonStoreEvaluator(node, TR::InstOpCode::vstrimmd, 8, cg);
    }
 
 TR::Register *


### PR DESCRIPTION
This commit fixes fstore/dstore evaluators for AArch64.
They have been calling commonLoadEvaluator() instead of
commonStoreEvaluator().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>