### PR TITLE
AArch64: Pretty print for compare instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -785,8 +785,24 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src1ImmInstruction *instr)
    {
    printPrefix(pOutFile, instr);
-   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
-   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   bool isCmp = false;
+   if (op == TR::InstOpCode::subsimmx || op == TR::InstOpCode::subsimmw)
+      {
+      TR::Register *r = instr->getTargetRegister();
+      if (r && r->getRealRegister()
+          && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr)
+         {
+         // cmp alias
+         isCmp = true;
+         trfprintf(pOutFile, "cmpimm%c \t", (op == TR::InstOpCode::subsimmx) ? 'x' : 'w');
+         }
+      }
+   if (!isCmp)
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      }
    print(pOutFile, instr->getSource1Register(), TR_WordReg);
    trfprintf(pOutFile, ", %d", instr->getSourceImmediate());
 
@@ -800,9 +816,24 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2Instruction *instr)
    {
    printPrefix(pOutFile, instr);
-   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
-
-   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   bool isCmp = false;
+   if (op == TR::InstOpCode::subsx || op == TR::InstOpCode::subsw)
+      {
+      TR::Register *r = instr->getTargetRegister();
+      if (r && r->getRealRegister()
+          && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr)
+         {
+         // cmp alias
+         isCmp = true;
+         trfprintf(pOutFile, "cmp%c \t", (op == TR::InstOpCode::subsx) ? 'x' : 'w');
+         }
+      }
+   if (!isCmp)
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+      }
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
 


### PR DESCRIPTION
This commit changes the output of subs/subsimm instructions from
TR_Debug::print(ARM64Trg1Src1ImmInstruction) and
TR_Debug::print(ARM64Trg1Src2Instruction), for better readability.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>