### PR TITLE
Remove JITaaS name references

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -683,8 +683,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"enableIprofilerChanges",             "O\tenable iprofiler changes", SET_OPTION_BIT(TR_EnableIprofilerChanges), "F"},
    {"enableIVTT",                         "O\tenable IV Type Transformation", TR::Options::enableOptimization, IVTypeTransformation, 0, "P"},
    {"enableJCLInline",                    "O\tenable JCL Integer and Long methods inlining", SET_OPTION_BIT(TR_EnableJCLInline), "F"},
-   {"enableJITaaSDoLocalCompilesForRemoteCompiles","O\tenable JITaaS to perform local compilations for its remotely compiled methods", SET_OPTION_BIT(TR_EnableJITaaSDoLocalCompilesForRemoteCompiles), "F"},
-   {"enableJITaaSHeuristics",             "O\tenable JITaaS heuristics", SET_OPTION_BIT(TR_EnableJITaaSHeuristics), "F"},
    {"enableJITHelpershashCodeImpl",       "O\tenable java version of object hashCode()", SET_OPTION_BIT(TR_EnableJITHelpershashCodeImpl), "F"},
    {"enableJITHelpersoptimizedClone",     "O\tenable java version of object clone()", SET_OPTION_BIT(TR_EnableJITHelpersoptimizedClone), "F"},
    {"enableJITServerFollowRemoteCompileWithLocalCompile", "O\tenable JITServer to perform local compilations for its remotely compiled methods", SET_OPTION_BIT(TR_JITServerFollowRemoteCompileWithLocalCompile), "F"},
@@ -4785,7 +4783,6 @@ char *OMR::Options::_verboseOptionNames[TR_NumVerboseOptions] =
    "hookDetailsClassUnloading",
    "sampleDensity",
    "profiling",
-   "JITaaS",
    "JITServer",
    "aotcompression",
    };

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -192,7 +192,6 @@ enum TR_CompilationOptions
    TR_DisableAsyncCompilation             = 0x00004000 + 3,
    TR_DisableCompilationThread            = 0x00008000 + 3,
    TR_EnableCompilationThread             = 0x00010000 + 3,
-   TR_EnableJITaaSHeuristics              = 0x00020000 + 3,
    TR_EnableJITServerHeuristics           = 0x00020000 + 3,
    TR_SoftFailOnAssume                    = 0x00040000 + 3,
    TR_DisableNewBlockOrdering             = 0x00080000 + 3,
@@ -336,7 +335,6 @@ enum TR_CompilationOptions
    TR_DisableDirectToJNI                  = 0x00000040 + 8,
    TR_OldJVMPI                            = 0x00000080 + 8,
    TR_EmitExecutableELFFile               = 0x00000100 + 8,
-   TR_EnableJITaaSDoLocalCompilesForRemoteCompiles = 0x00000200 + 8,
    TR_JITServerFollowRemoteCompileWithLocalCompile = 0x00000200 + 8,
    // Available                           = 0x00000800 + 8,
    TR_DisableLinkageRegisterAllocation    = 0x00001000 + 8,
@@ -1139,7 +1137,6 @@ enum TR_VerboseFlags
    TR_VerboseHookDetailsClassUnloading,
    TR_VerboseSampleDensity,
    TR_VerboseProfiling,
-   TR_VerboseJITaaS,
    TR_VerboseJITServer,
    TR_VerboseAOTCompression,
    //If adding new options add an entry to _verboseOptionNames as well

--- a/compiler/env/VerboseLog.cpp
+++ b/compiler/env/VerboseLog.cpp
@@ -61,7 +61,6 @@ const char * TR_VerboseLog::_vlogTable[] =
    "#DISPATCH: ",
    "#RECLAMATION: ",
    "#PROFILING: ",
-   "#JITaaS: ",
    "#JITServer: ",
    "#AOTCOMPRESSION: ",
    };

--- a/compiler/env/VerboseLog.hpp
+++ b/compiler/env/VerboseLog.hpp
@@ -69,7 +69,6 @@ enum TR_VlogTag
    TR_Vlog_DISPATCH,
    TR_Vlog_RECLAMATION,
    TR_Vlog_PROFILING,
-   TR_Vlog_JITaaS,
    TR_Vlog_JITServer,
    TR_Vlog_AOTCOMPRESSION,
    TR_Vlog_numTags


### PR DESCRIPTION
eclipse/openj9#6643 has made the change to start
using `JITServer` names. As a follow up to PR #4173,
this change removes all the references to `JITaaS` completely.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>