### PR TITLE
CI cleanup, part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ VerboseGC_*.xml*
 *.swp
 tags
 *~
+
+# test results
+*-results.xml

--- a/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
+++ b/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/aix_ppc-64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -22,9 +21,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -60,10 +59,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
+++ b/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
@@ -16,6 +16,7 @@ pipeline {
         PATH = "/home/u0020236/tools:$PATH"
         LIBPATH="."
         CCACHE_CPP2="1"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -52,6 +53,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-linux_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_390-64
@@ -14,6 +14,7 @@ pipeline {
     agent{label 'Linux && 390'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -50,6 +51,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-linux_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_390-64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_390-64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -20,9 +19,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -58,10 +57,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-linux_aarch64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_aarch64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_aarch64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -22,9 +21,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -55,10 +54,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-linux_arm
+++ b/buildenv/jenkins/jobs/builds/Build-linux_arm
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_arm"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -22,9 +21,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -55,10 +54,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-linux_ppc-64_le_gcc
+++ b/buildenv/jenkins/jobs/builds/Build-linux_ppc-64_le_gcc
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_ppc-64_le_gcc"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -20,9 +19,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -58,10 +57,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-linux_ppc-64_le_gcc
+++ b/buildenv/jenkins/jobs/builds/Build-linux_ppc-64_le_gcc
@@ -14,6 +14,7 @@ pipeline {
     agent{label 'Linux && PPCLE'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -50,6 +51,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_x86"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -20,9 +19,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -58,10 +57,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86
@@ -14,6 +14,7 @@ pipeline {
     agent{label 'Linux && x86'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -50,6 +51,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_x86-64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -20,9 +19,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
-                    
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    checkout scm
+
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -31,15 +30,15 @@ pipeline {
                 timestamps {
                     echo 'Output CCACHE stats before running and clear them'
                     sh '''ccache -s -z'''
-                    
+
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
-                       
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..'''
+
                         echo 'Compile...'
                         sh '''make -j4'''
                     }
-                    
+
                     echo 'Output CCACHE stats after running'
                     sh '''ccache -s'''
                 }
@@ -58,10 +57,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64
@@ -14,6 +14,7 @@ pipeline {
     agent{label 'Linux && x86'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -50,6 +51,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64_cmprssptrs
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/linux_x86-64_cmprssptrs"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -21,9 +20,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -55,10 +54,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-osx_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-osx_x86-64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/osx_x86-64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -21,9 +20,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -59,10 +58,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-osx_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-osx_x86-64
@@ -15,6 +15,7 @@ pipeline {
     environment {
         GTEST_FILTER = "-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:*DeathTest*"
         PATH = "/usr/local/opt/ccache/libexec:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -51,6 +52,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-win_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-win_x86-64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/win_x86-64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -21,9 +20,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -53,10 +52,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/builds/Build-win_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-win_x86-64
@@ -14,7 +14,7 @@ pipeline {
     agent{label 'Windows && x86'}
     environment {
         GTEST_FILTER="-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:PortSysinfoTest.sysinfo_test0:PortSysinfoTest.sysinfo_test_get_tmp3:ThreadExtendedTest.TestOtherThreadCputime"
-        GTEST_COLOR="1"
+        GTEST_COLOR="0"
     }
     stages {
         stage('Get Sources') {
@@ -45,6 +45,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V -C Debug -j1'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/builds/Build-zos_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-zos_390-64
@@ -2,7 +2,6 @@ def setBuildStatus(String message, String state, String sha) {
     context = "continuous-integration/eclipse-omr/branch/zos_390-64"
     step([
         $class: "GitHubCommitStatusSetter",
-        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "git://github.com/eclipse/omr"],
         contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
         errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
         commitShaSource: [$class: "ManuallyEnteredShaSource", sha: sha ],
@@ -20,9 +19,9 @@ pipeline {
         stage('Get Sources') {
             steps {
                 timestamps {
-                    checkout([$class: 'GitSCM', branches: [[name: '${MERGE_COMMIT}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'git://github.com/eclipse/omr.git']]])
+                    checkout scm
                     
-                    setBuildStatus("In Progress","PENDING","${MERGE_COMMIT}")
+                    setBuildStatus("In Progress","PENDING","${env.GIT_COMMIT}")
                 }
             }
         }
@@ -55,10 +54,10 @@ pipeline {
     }
     post {
         success {
-            setBuildStatus("Complete","SUCCESS","${MERGE_COMMIT}")
+            setBuildStatus("Complete","SUCCESS","${env.GIT_COMMIT}")
         }
         failure {
-            setBuildStatus("Complete","FAILURE","${MERGE_COMMIT}")
+            setBuildStatus("Complete","FAILURE","${env.GIT_COMMIT}")
         }
         always {
             echo 'Cleanup workspace'

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
@@ -4,6 +4,7 @@ pipeline {
         PATH = "/home/u0020236/tools:$PATH"
         LIBPATH="."
         CCACHE_CPP2="1"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -38,6 +39,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_390-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_390-64
@@ -2,6 +2,7 @@ pipeline {
     agent{label 'Linux && 390'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -36,6 +37,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_ppc-64_le_gcc
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_ppc-64_le_gcc
@@ -2,6 +2,7 @@ pipeline {
     agent{label 'Linux && PPCLE'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -36,6 +37,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86
@@ -2,6 +2,7 @@ pipeline {
     agent{label 'Linux && x86'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -36,6 +37,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64
@@ -2,6 +2,7 @@ pipeline {
     agent{label 'Linux && x86'}
     environment {
         PATH = "/usr/lib/ccache/:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -36,6 +37,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-osx_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-osx_x86-64
@@ -3,6 +3,7 @@ pipeline {
     environment {
         GTEST_FILTER = "-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:*DeathTest*"
         PATH = "/usr/local/opt/ccache/libexec:$PATH"
+        GTEST_COLOR = "0"
     }
     stages {
         stage('Get Sources') {
@@ -37,6 +38,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-win_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-win_x86-64
@@ -2,7 +2,7 @@ pipeline {
     agent{label 'Windows && x86'}
     environment {
         GTEST_FILTER="-*dump_test_create_dump_*:*NumaSetAffinity:*NumaSetAffinitySuspended:PortSysinfoTest.sysinfo_test0:PortSysinfoTest.sysinfo_test_get_tmp3:ThreadExtendedTest.TestOtherThreadCputime"
-        GTEST_COLOR="1"
+        GTEST_COLOR="0"
     }
     stages {
         stage('Get Sources') {
@@ -31,6 +31,7 @@ pipeline {
                     dir('build') {
                         echo "Sanity Test..."
                         sh'''ctest -V -C Debug -j1'''
+                        junit '**/*results.xml'
                     }
                 }
             }

--- a/fvtest/algotest/CMakeLists.txt
+++ b/fvtest/algotest/CMakeLists.txt
@@ -64,4 +64,4 @@ endif()
 
 set_property(TARGET omralgotest PROPERTY FOLDER fvtest)
 
-add_test(NAME algotest COMMAND omralgotest -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)
+add_test(NAME algotest COMMAND omralgotest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omralgotest-results.xml -avltest:${CMAKE_CURRENT_SOURCE_DIR}/avltest.lst)

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -122,4 +122,4 @@ target_link_libraries(compilertest
 
 set_property(TARGET compilertest PROPERTY FOLDER fvtest)
 
-add_test(NAME CompilerTest COMMAND compilertest)
+add_test(NAME CompilerTest COMMAND compilertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -64,5 +64,5 @@ set_property(TARGET comptest PROPERTY FOLDER fvtest)
 
 add_test(
 	NAME comptest
-	COMMAND comptest --gtest_color=yes
+	COMMAND comptest --gtest_color=yes --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/comptest-results.xml
 )

--- a/fvtest/coretest/CMakeLists.txt
+++ b/fvtest/coretest/CMakeLists.txt
@@ -33,7 +33,7 @@ function(omr_add_core_test testname)
 	)
 	add_test(
 		NAME    "${testname}"
-		COMMAND "${testname}"
+		COMMAND "${testname}" --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${testname}-results.xml
 	)
 endfunction(omr_add_core_test)
 

--- a/fvtest/gc_api_test/CMakeLists.txt
+++ b/fvtest/gc_api_test/CMakeLists.txt
@@ -36,6 +36,6 @@ function(omr_add_gc_test testname)
 	)
 	add_test(
 		NAME    "${testname}"
-		COMMAND "${testname}"
+		COMMAND "${testname}" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${testname}-results.xml"
 	)
 endfunction(omr_add_gc_test)

--- a/fvtest/gctest/CMakeLists.txt
+++ b/fvtest/gctest/CMakeLists.txt
@@ -74,6 +74,6 @@ endif()
 set_property(TARGET omrgctest PROPERTY FOLDER fvtest)
 
 add_test(NAME gctest
-	COMMAND omrgctest "--gtest_filter=gcFunctionalTest*"
+	COMMAND omrgctest "--gtest_filter=gcFunctionalTest*" "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrgctest-results.xml"
 	WORKING_DIRECTORY "${omr_SOURCE_DIR}"
 )

--- a/fvtest/jitbuildertest/CMakeLists.txt
+++ b/fvtest/jitbuildertest/CMakeLists.txt
@@ -56,4 +56,4 @@ target_link_libraries(jitbuildertest
 
 set_property(TARGET jitbuildertest PROPERTY FOLDER fvtest)
 
-add_test(NAME JitBuilderTest COMMAND jitbuildertest)
+add_test(NAME JitBuilderTest COMMAND jitbuildertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/jitbuildertest-results.xml)

--- a/fvtest/porttest/CMakeLists.txt
+++ b/fvtest/porttest/CMakeLists.txt
@@ -113,8 +113,8 @@ endif()
 
 set_target_properties(omrporttest sltestlib PROPERTIES FOLDER fvtest)
 
-add_test(NAME porttest COMMAND omrporttest)
+add_test(NAME porttest COMMAND omrporttest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml)
 
 if(OMR_OPT_CUDA)
-	add_test(NAME cuda_porttest COMMAND omrporttest --gtest_filter="Cuda*" -earlyExit)
+	add_test(NAME cuda_porttest COMMAND omrporttest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrporttest-results.xml --gtest_filter="Cuda*" -earlyExit)
 endif()

--- a/fvtest/rastest/CMakeLists.txt
+++ b/fvtest/rastest/CMakeLists.txt
@@ -238,9 +238,9 @@ add_dependencies(omrtraceoptiontest
 	traceOptionAgent
 )
 
-add_test(NAME rastest COMMAND omrrastest)
-add_test(NAME subscribertest COMMAND omrsubscribertest)
-add_test(NAME traceoptiontest COMMAND omrtraceoptiontest)
+add_test(NAME rastest COMMAND omrrastest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrrastest-results.xml)
+add_test(NAME subscribertest COMMAND omrsubscribertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsubscribertest-results.xml)
+add_test(NAME traceoptiontest COMMAND omrtraceoptiontest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrtraceoptiontest-results.xml)
 
 set_target_properties(
 	omrrastest

--- a/fvtest/sigtest/CMakeLists.txt
+++ b/fvtest/sigtest/CMakeLists.txt
@@ -87,4 +87,4 @@ endif()
 
 set_property(TARGET omrsigtest PROPERTY FOLDER fvtest)
 
-add_test(NAME sigtest COMMAND omrsigtest)
+add_test(NAME sigtest COMMAND omrsigtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrsigtest-results.xml)

--- a/fvtest/threadextendedtest/CMakeLists.txt
+++ b/fvtest/threadextendedtest/CMakeLists.txt
@@ -43,4 +43,4 @@ endif()
 
 set_property(TARGET omrthreadextendedtest PROPERTY FOLDER fvtest)
 
-add_test(NAME threadextendedtest COMMAND omrthreadextendedtest)
+add_test(NAME threadextendedtest COMMAND omrthreadextendedtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadextendedtest-results.xml)

--- a/fvtest/threadtest/CMakeLists.txt
+++ b/fvtest/threadtest/CMakeLists.txt
@@ -79,8 +79,8 @@ endif()
 
 set_property(TARGET omrthreadtest PROPERTY FOLDER fvtest)
 
-add_test(NAME threadtest COMMAND omrthreadtest)
-add_test(NAME threadSetAttrThreadWeightTest COMMAND omrthreadtest --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
+add_test(NAME threadtest COMMAND omrthreadtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml)
+add_test(NAME threadSetAttrThreadWeightTest COMMAND omrthreadtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_also_run_disabled_tests --gtest_filter=ThreadCreateTest.DISABLED_SetAttrThreadWeight)
 if(OMR_HOST_OS STREQUAL "linux")
-	add_test(NAME threadRealtimeTest COMMAND omrthreadtest --gtest_filter=ThreadCreateTest.* -realtime)
+	add_test(NAME threadRealtimeTest COMMAND omrthreadtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrthreadtest-results.xml --gtest_filter=ThreadCreateTest.* -realtime)
 endif()

--- a/fvtest/tril/test/CMakeLists.txt
+++ b/fvtest/tril/test/CMakeLists.txt
@@ -57,5 +57,5 @@ set_property(TARGET triltest PROPERTY FOLDER fvtest/tril)
 
 add_test(
 	NAME triltest
-	COMMAND triltest
+	COMMAND triltest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/triltest-results.xml
 )

--- a/fvtest/utiltest/CMakeLists.txt
+++ b/fvtest/utiltest/CMakeLists.txt
@@ -40,4 +40,4 @@ endif()
 
 set_property(TARGET omrutiltest PROPERTY FOLDER fvtest)
 
-add_test(NAME utiltest COMMAND omrutiltest)
+add_test(NAME utiltest COMMAND omrutiltest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrutiltest-results.xml)

--- a/fvtest/vmtest/CMakeLists.txt
+++ b/fvtest/vmtest/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(omrvmtest
 
 set_property(TARGET omrvmtest PROPERTY FOLDER fvtest)
 
-add_test(NAME vmtest COMMAND omrvmtest)
+add_test(NAME vmtest COMMAND omrvmtest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/omrvmtest-results.xml)


### PR DESCRIPTION
This PR improves current Jenkins build scripts in two ways: 
1) allow setting up build jobs from repositories other than `github.com:eclipse/omr` (such as, personal forks on github or non-github repositories)
2) collect and store test results for later inspection. This is useful to see if particular test is (was) run on given platform and whether it pass (passed) or not. 