### PR TITLE
Implement TR::badd and TR::bsub evaluators

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -106,13 +106,13 @@
    TR::TreeEvaluator::laddEvaluator,                    // TR::ladd
    TR::TreeEvaluator::faddEvaluator,                    // TR::fadd
    TR::TreeEvaluator::daddEvaluator,                    // TR::dadd
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::badd
+   TR::TreeEvaluator::iaddEvaluator,                    // TR::badd
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::sadd
    TR::TreeEvaluator::isubEvaluator,                    // TR::isub
    TR::TreeEvaluator::lsubEvaluator,                    // TR::lsub
    TR::TreeEvaluator::fsubEvaluator,                    // TR::fsub
    TR::TreeEvaluator::dsubEvaluator,                    // TR::dsub
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::bsub
+   TR::TreeEvaluator::isubEvaluator,                    // TR::bsub
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::ssub
    TR::TreeEvaluator::asubEvaluator,                    // TR::asub
    TR::TreeEvaluator::imulEvaluator,                    // TR::imul

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -566,8 +566,6 @@ PPCOpCodesTest::UnsupportedOpCodesTests()
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float);
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double);
 
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::badd, "bAdd", _argTypesBinaryByte, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bsub, "bSub", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bmul, "bMul", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bdiv, "bDiv", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::brem, "bRem", _argTypesBinaryByte, TR::Int8);


### PR DESCRIPTION
A cfgSimplifier opt is generating bsub which can be converted
to badd, both of which are not implemented in the POWER code
generator. The cfgSimplifier opt that makes use of bsub is
currently disabled, but it could be re-enabled at any time so
we need to have bsub and badd supported on POWER.

Signed-off-by: Kevin Langman <langman@ca.ibm.com>