### PR TITLE
Enable change to determine calling method for OSR code unconditionally

### DIFF
--- a/compiler/optimizer/Inliner.cpp
+++ b/compiler/optimizer/Inliner.cpp
@@ -2012,17 +2012,8 @@ TR_InlinerBase::addGuardForVirtual(
    TR::ResolvedMethodSymbol *callingMethod = callNode->getByteCodeInfo().getCallerIndex() == -1 ?
       comp()->getMethodSymbol() : comp()->getInlinedResolvedMethodSymbol(callNode->getByteCodeInfo().getCallerIndex());
 
-   // TODO:  Need to coordinate change between OMR's inliner and downstream
-   //        implementations of inliner.  They must access the calling method
-   //        for OSR in the same way, guarded by INLINER_OSR_CALLING_METHOD,
-   //        until INLINER_OSR_CALLING_METHOD is ultimately defined in OMR.
-#if defined(INLINER_OSR_CALLING_METHOD)
    if ((comp()->getHCRMode() != TR::osr || guard->_kind != TR_HCRGuard)
        && callingMethod->supportsInduceOSR(callNode->getByteCodeInfo(), block1, comp(), false))
-#else /* !defined(INLINER_OSR_CALLING_METHOD) */
-   if ((comp()->getHCRMode() != TR::osr || guard->_kind != TR_HCRGuard)
-       && callNode->getSymbolReference()->getOwningMethodSymbol(comp())->supportsInduceOSR(callNode->getByteCodeInfo(), block1, comp(), false))
-#endif /* defined(INLINER_OSR_CALLING_METHOD) */
       {
       bool shouldUseOSR = heuristicForUsingOSR(callNode, calleeSymbol, callerSymbol, createdHCRAndVirtualGuard);
 

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -30,13 +30,6 @@
 #ifndef INLINER_INCL
 #define INLINER_INCL
 
-// TODO:  This macro enables a change to the way the calling method is found
-//        for OSR-related code in the Inliner.  Once downstream components
-//        have had their changes enabled unconditionalloy, corresponding
-//        changes in OMR that are guarded by this macro can be made
-//        unconditional, and this definition can be removed.
-#define INLINER_OSR_CALLING_METHOD
-
 #include "optimizer/CallInfo.hpp"
 
 #include <stddef.h>


### PR DESCRIPTION
Changes to the way the calling method is determined for OSR-related code in the Inliner were guarded by `if defined(INLINER_OSR_CALLING_METHOD)`.  Now that downstream components
have made that change unconditional, it can be unconditional in OMR.  The downstream change was made in [OpenJ9 pull request 6651](https://github.com/eclipse/openj9/pull/6651).

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>