### PR TITLE
Adding a totalTime field for hooks

### DIFF
--- a/include_core/omrhookable.h
+++ b/include_core/omrhookable.h
@@ -96,6 +96,7 @@ typedef struct OMREventInfo4Dump {
 	struct OMRHookInfo4Dump longestHook;
 	struct OMRHookInfo4Dump lastHook;
 	volatile uintptr_t count;
+	volatile uintptr_t totalTime;
 }OMREventInfo4Dump;
 
 typedef struct J9CommonHookInterface {

--- a/util/hookable/hookable.cpp
+++ b/util/hookable/hookable.cpp
@@ -229,18 +229,19 @@ J9HookDispatch(struct J9HookInterface **hookInterface, uintptr_t taggedEventNum,
 				}
 				OMRPORT_ACCESS_FROM_OMRPORT(commonInterface->portLib);
 				if (sampling) {
-					startTime = omrtime_current_time_millis();
+					startTime = omrtime_usec_clock(); 
 				}
 
 				function(hookInterface, eventNum, eventData, userData);
 
 				if (sampling) {
-					uint64_t timeDelta = omrtime_current_time_millis() - startTime;
+					uint64_t timeDelta = omrtime_hires_delta(startTime, omrtime_usec_clock(), OMRPORT_TIME_DELTA_IN_MICROSECONDS);
 
 					eventDump->lastHook.startTime = startTime;
 					eventDump->lastHook.callsite = record->callsite;
 					eventDump->lastHook.func_ptr = (void *)record->function;
 					eventDump->lastHook.duration = timeDelta;
+					VM_AtomicSupport::add((volatile uintptr_t *)&eventDump->totalTime, (uintptr_t)timeDelta);
 
 					if ((eventDump->longestHook.duration < timeDelta) ||
 						(0 == eventDump->longestHook.startTime)) {


### PR DESCRIPTION
- Adding a `totalTime` field for the OMR Hook info, which is sum of previous events duration
- Changing the measurement time from ms to us for increased precision.
- Will be accompanied by a change on j9 side to reflect the time measurement change

Signed-off-by: Cedric Hansen <cedric.hansen@ibm.com>