### PR TITLE
Remove deprecated `addEdge` and `addExceptionEdge`

### DIFF
--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -176,32 +176,12 @@ class CFG
    void addEdge(TR::CFGEdge *e);
 
    /**
-    * @deprecated
-    * Please specify where edges are to be allocated during CFG initialization.
-    * E.g.,
-    *     OMR::CFG(c, m, TR::Region &region)
-    * and use the following method to add edges to that region.
-    *     addEdge(TR::CFGNode *f, TR::CFGNode *t);
-    */
-   TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind heapAlloc);
-
-   /**
     * Create and store edge from CFGNode f to CFGNode t
     * @param f   CFGNode from
     * @param t   CFGNode to
     * @return    Pointer to newly created edge
     */
    TR::CFGEdge *addEdge(TR::CFGNode *f, TR::CFGNode *t);
-
-   /**
-    * @deprecated
-    * Please specify where edges are to be allocated during CFG initialization.
-    * E.g.,
-    *     OMR::CFG(c, m, TR::Region &region)
-    * and use the following method to add edges to that region.
-    *     addExceptionEdgeEdge(TR::CFGNode *f, TR::CFGNode *t);
-    */
-   void addExceptionEdge(TR::CFGNode *f, TR::CFGNode *t, TR_AllocationKind heapAlloc);
 
    /**
     * Create and store exception edge from CFGNode f to CFGNode t 


### PR DESCRIPTION
    Commit fbb7aa1713ddc61affecc02dba9c80a393a658af introduced a new API
    for adding edges to the CFG and marked the previous implementations
    of `addEdge` and `addExceptionEdge` as deprecated. This current
    commit removes the deprecated implementations from the code base.

Signed-off-by: Erick Ochoa <eochoa@ualberta.ca>

Depends on this OpenJ9 merge: https://github.com/eclipse/openj9/pull/6141