### PR TITLE
AArch64: Add extraRegister to OMRMemoryReference

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -273,13 +273,13 @@ void TR::ARM64MemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssig
    if (getDependencyConditions())
       getDependencyConditions()->assignPostConditionRegisters(this, kindToBeAssigned, cg());
 
-   sourceVirtual->block();
-   mref->assignRegisters(this, cg());
-   sourceVirtual->unblock();
-
    mref->blockRegisters();
    setSource1Register(machine->assignOneRegister(this, sourceVirtual));
    mref->unblockRegisters();
+
+   sourceVirtual->block();
+   mref->assignRegisters(this, cg());
+   sourceVirtual->unblock();
 
    if (getDependencyConditions())
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -90,7 +90,8 @@ static void loadRelocatableConstant(TR::Node *node,
          }
       else
          {
-         cg->addSnippet(mr->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, node->getOpCode().isStore(), false)));
+         mr->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, node->getOpCode().isStore(), false));
+         cg->addSnippet(mr->getUnresolvedSnippet());
          }
       }
    else
@@ -105,6 +106,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _baseNode(NULL),
    _indexRegister(NULL),
    _indexNode(NULL),
+   _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
    _length(0),
@@ -123,6 +125,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _baseNode(NULL),
    _indexRegister(ir),
    _indexNode(NULL),
+   _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
    _length(0),
@@ -141,6 +144,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _baseNode(NULL),
    _indexRegister(NULL),
    _indexNode(NULL),
+   _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
    _length(0),
@@ -159,6 +163,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _baseNode(NULL),
    _indexRegister(NULL),
    _indexNode(NULL),
+   _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
    _length(len),
@@ -223,6 +228,7 @@ OMR::ARM64::MemoryReference::MemoryReference(
    _baseNode(NULL),
    _indexRegister(NULL),
    _indexNode(NULL),
+   _extraRegister(NULL),
    _unresolvedSnippet(NULL),
    _flag(0),
    _length(len),
@@ -374,6 +380,11 @@ void OMR::ARM64::MemoryReference::decNodeReferenceCounts(TR::CodeGenerator *cg)
          cg->decReferenceCount(_indexNode);
       else
          cg->stopUsingRegister(_indexRegister);
+      }
+
+   if (_extraRegister != NULL)
+      {
+      cg->stopUsingRegister(_extraRegister);
       }
    }
 
@@ -599,6 +610,10 @@ void OMR::ARM64::MemoryReference::incRegisterTotalUseCounts(TR::CodeGenerator * 
    if (_indexRegister != NULL)
       {
       _indexRegister->incTotalUseCount();
+      }
+   if (_extraRegister != NULL)
+      {
+      _extraRegister->incTotalUseCount();
       }
    }
 

--- a/compiler/aarch64/codegen/OMRMemoryReference.hpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.hpp
@@ -64,6 +64,14 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    TR::UnresolvedDataSnippet *_unresolvedSnippet;
    TR::SymbolReference *_symbolReference;
 
+   // Any downstream project can use this extra register to associate an additional
+   // register to a memory reference that can be used for project-specific purposes.
+   // This register is in addition to the base and index registers and isn't directly
+   // part of the addressing expression in the memory reference.
+   // An example of what this could be used for is to help synthesize unresolved data
+   // reference addresses at runtime.
+   TR::Register *_extraRegister;
+
    uint8_t _flag;
    uint8_t _length;
    uint8_t _scale;
@@ -186,6 +194,18 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    TR::Node *setIndexNode(TR::Node *in) {return (_indexNode = in);}
 
    /**
+    * @brief Gets extra register
+    * @return extra register
+    */
+   TR::Register *getExtraRegister() {return _extraRegister;}
+   /**
+    * @brief Sets extra register
+    * @param[in] er : extra register
+    * @return extra register
+    */
+   TR::Register *setExtraRegister(TR::Register *er) {return (_extraRegister = er);}
+
+   /**
     * @brief Gets length
     * @return length
     */
@@ -254,7 +274,8 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
    bool refsRegister(TR::Register *reg)
       {
       return (reg == _baseRegister ||
-              reg == _indexRegister);
+              reg == _indexRegister ||
+              reg == _extraRegister);
       }
 
    /**
@@ -270,6 +291,10 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
          {
          _indexRegister->block();
          }
+      if (_extraRegister != NULL)
+         {
+         _extraRegister->block();
+         }
       }
 
    /**
@@ -284,6 +309,10 @@ class OMR_EXTENSIBLE MemoryReference : public OMR::MemoryReference
       if (_indexRegister != NULL)
          {
          _indexRegister->unblock();
+         }
+      if (_extraRegister != NULL)
+         {
+         _extraRegister->unblock();
          }
       }
 


### PR DESCRIPTION
This commit adds extraRegister and related code to
OMRMemoryReference for AArch64.
It will be used by UnresolvedSnippet.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>