### PR TITLE
Remove forward declaration of retrieveZOSMemoryStats

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -422,8 +422,6 @@ static int32_t retrieveLinuxMemoryStats(struct OMRPortLibrary *portLibrary, stru
 static int32_t retrieveOSXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 #elif defined(AIXPPC)
 static int32_t retrieveAIXMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-#elif defined(J9ZOS390)
-static int32_t retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
 #endif
 
 /**


### PR DESCRIPTION
Declaration is provided by omrsysinfohelpers.h. Also, since function is
implemented in omrsysinfohelpers.c, the function does not have static
linkage

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>