### PR TITLE
Use CFG's internal region on CFGNodes

### DIFF
--- a/compiler/il/Block.hpp
+++ b/compiler/il/Block.hpp
@@ -38,8 +38,14 @@ class OMR_EXTENSIBLE Block : public OMR::BlockConnector
    Block(TR_Memory * m) :
       OMR::BlockConnector(m) {};
 
+   Block(TR::CFG & cfg) :
+      OMR::BlockConnector(cfg) {};
+
    Block(TR::TreeTop *entry, TR::TreeTop *exit, TR_Memory * m) :
       OMR::BlockConnector(entry,exit,m) {};
+
+   Block(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg) :
+      OMR::BlockConnector(entry,exit,cfg) {};
 
    Block(Block &other, TR::TreeTop *entry, TR::TreeTop *exit) :
       OMR::BlockConnector(other,entry,exit) {};

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -86,43 +86,62 @@ TR::Block *
 OMR::Block::asBlock() { return self(); }
 
 OMR::Block::Block(TR_Memory * m) :
-   TR::CFGNode(m),
-   _pEntry(NULL),
-   _pExit(NULL),
-   _pStructureOf(NULL),
-   _liveLocals(NULL),
-   _globalRegisters(0),
-   _catchBlockExtension(NULL),
-   _firstInstruction(NULL),
-   _lastInstruction(NULL),
-   _blockSize(-1),
-   _debugCounters(NULL),
-   _flags(0),
-   _moreflags(0)
+   TR::CFGNode(m)
    {
+   self()->init(NULL, NULL);
+   self()->setFrequency(-1);
+   self()->setUnrollFactor(0);
+   }
+
+OMR::Block::Block(TR::CFG &cfg) :
+   TR::CFGNode(cfg.getInternalRegion())
+   {
+   self()->init(NULL, NULL);
    self()->setFrequency(-1);
    self()->setUnrollFactor(0);
    }
 
 OMR::Block::Block(TR::TreeTop *entry, TR::TreeTop *exit, TR_Memory * m) :
-   TR::CFGNode(m),
-   _pEntry(entry),
-   _pExit(exit),
-   _pStructureOf(NULL),
-   _liveLocals(NULL),
-   _globalRegisters(0),
-   _catchBlockExtension(NULL),
-   _firstInstruction(NULL),
-   _lastInstruction(NULL),
-   _blockSize(-1),
-   _debugCounters(NULL),
-   _flags(0),
-   _moreflags(0)
+   TR::CFGNode(m)
    {
+   self()->init(entry, exit);
    self()->setFrequency(-1);
    self()->setUnrollFactor(0);
    if (entry && entry->getNode()) entry->getNode()->setBlock(self());
    if (exit && exit->getNode())   exit->getNode()->setBlock(self());
+   }
+
+OMR::Block::Block(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg) :
+   TR::CFGNode(cfg.getInternalRegion())
+   {
+   self()->init(entry, exit);
+   self()->setFrequency(-1);
+   self()->setUnrollFactor(0);
+   if (entry && entry->getNode()) entry->getNode()->setBlock(self());
+   if (exit && exit->getNode())   exit->getNode()->setBlock(self());
+   }
+
+void
+OMR::Block::init(TR::TreeTop *entry, TR::TreeTop *exit)
+   {
+   _pEntry = entry;
+   _pExit = exit;
+   _pStructureOf = NULL;
+   _liveLocals = NULL;
+   _globalRegisters = 0;
+   _catchBlockExtension = NULL;
+   _firstInstruction = NULL;
+   _lastInstruction = NULL;
+   _blockSize = -1;
+   _debugCounters = NULL;
+   _flags = 0;
+   _moreflags = 0;
+   }
+
+TR::Block*
+OMR::Block::createBlock(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg)
+   {
+   return new (cfg.getInternalRegion()) TR::Block(entry, exit, cfg);
    }
 
 /// Copy constructor

--- a/compiler/il/OMRBlock.hpp
+++ b/compiler/il/OMRBlock.hpp
@@ -104,9 +104,12 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
    TR::Block * self();
 
    Block(TR_Memory * m);
+   Block(TR::CFG &cfg);
 
    /// Create a block with the given entry and exit.
    Block(TR::TreeTop *entry, TR::TreeTop *exit, TR_Memory * m);
+   Block(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg);
+
 
    /// Copy Constructor.
    ///
@@ -124,7 +127,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
       }
 
    virtual const char * getName(TR_Debug *);
-
+   static TR::Block * createBlock(TR::TreeTop *entry, TR::TreeTop *exit, TR::CFG &cfg);
    static TR::Block * createEmptyBlock(TR::Node *, TR::Compilation *, int32_t frequency = -1, TR::Block *block = NULL);
    static TR::Block * createEmptyBlock(TR::Compilation *comp, int32_t frequency = -1, TR::Block *block = NULL);
 
@@ -483,6 +486,7 @@ class OMR_EXTENSIBLE Block : public TR::CFGNode
     */
 
    private:
+   void init(TR::TreeTop *entry, TR::TreeTop *exit);
 
    void uncommonNodesBetweenBlocks(TR::Compilation *, TR::Block *, TR::ResolvedMethodSymbol *methodSymbol = NULL);
 

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -3256,3 +3256,9 @@ OMR::CFG::findReachableBlocks(TR_BitVector *result)
          addEdge(getStart(), edge->getTo());
       }
    }
+
+TR::Region&
+OMR::CFG::getInternalRegion()
+   {
+   return self()->_internalRegion;
+   }

--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -331,8 +331,9 @@ class CFG
    //
    void getBranchCountersFromProfilingData(TR::Node *node, TR::Block *block, int32_t *taken, int32_t *notTaken) { return; }
 
-protected:
+   TR::Region& getInternalRegion();
 
+protected:
    TR::Compilation *_compilation;
    TR::ResolvedMethodSymbol *_method;
 


### PR DESCRIPTION
Base class CFGNode has two constructors,
1) one that takes a TR_Memory * parameter
2) one that takes a TR::Region& parameter
When the first constructor is used the sucessors and predecessors
are stored in the parameter region. Otherwise, they are stored in the
heap memory region.
Child class OMR::Block only implements the first type of constructor.
This commit creates another constructor for OMR::Block which takes a
TR::CFG & parameter and uses the internal memory region for calling
the second type of CFGNode constructor.

Signed-off-by: Erick Ochoa <eochoa@ualberta.ca>

Must be merged this OpenJ9 PR before https://github.com/eclipse/openj9/pull/6866