### PR TITLE
Deprecate isBreakPoint in favor of the BREAK pseudo-instruction

### DIFF
--- a/compiler/arm/codegen/OMRInstruction.hpp
+++ b/compiler/arm/codegen/OMRInstruction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -178,8 +178,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    // @@ bool     isCompare()             {return _opcode.isCompare();}
    // @@ bool     isLongRunningFPOp()     {return _opcode.isLongRunningFPOp();}
    // @@ bool     isFXMult()              {return _opcode.isFXMult();}
-   // @@ bool      isBreakPoint() {return (_index & BreakPoint) != 0;}
-   // @@ void      setBreakPoint(bool v) {v ? _index |= BreakPoint : _index &= ~BreakPoint;}
 
    // @@ virtual bool     isLoad()           {return _opcode.isLoad();}
    // @@ virtual bool     isStore()          {return _opcode.isStore();}

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -219,7 +219,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _relocationList(getTypedAllocator<TR::Relocation*>(TR::comp()->allocator())),
      _externalRelocationList(getTypedAllocator<TR::Relocation*>(TR::comp()->allocator())),
      _staticRelocationList(_compilation->allocator()),
-     _breakPointList(getTypedAllocator<uint8_t*>(TR::comp()->allocator())),
      _preJitMethodEntrySize(0),
      _jitMethodEntryPaddingSize(0),
      _lastInstructionBeforeCurrentEvaluationTreeTop(NULL),

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -547,9 +547,6 @@ class OMR_EXTENSIBLE CodeGenerator
    // Z only
    //
 
-   TR::list<uint8_t*>& getBreakPointList() {return _breakPointList;}
-   void addBreakPointAddress(uint8_t *b) {_breakPointList.push_front(b);}
-
    bool AddArtificiallyInflatedNodeToStack(TR::Node* n);
 
    // --------------------------------------------------------------------------
@@ -1859,7 +1856,6 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR::Relocation *> _relocationList;
    TR::list<TR::Relocation *> _externalRelocationList;
    TR::list<TR::StaticRelocation> _staticRelocationList;
-   TR::list<uint8_t*> _breakPointList;
 
    TR::list<TR::SymbolReference*> _variableSizeSymRefPendingFreeList;
    TR::list<TR::SymbolReference*> _variableSizeSymRefFreeList;

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -5009,16 +5009,6 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
                printf("\n methodStartAddress = %p",startaddr);
                printf("\n methodEndAddress = %p\n",endaddr);
                fprintf(cf, "break *%p\n",startaddr);
-
-               // Insert breakpoints requested by codegen
-               //
-               for (auto bpIterator = _comp->cg()->getBreakPointList().begin();
-                    bpIterator != _comp->cg()->getBreakPointList().end();
-                    ++bpIterator)
-                  {
-                  fprintf(cf, "break *%p\n",*bpIterator);
-                  }
-
                fprintf(cf, "disassemble %p %p\n",startaddr,endaddr);
                }
 
@@ -5090,15 +5080,6 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
                {
                printf("\n methodStartAddress = %p",startaddr);
                printf("\n methodEndAddress = %p\n",endaddr);
-
-               // Insert breakpoints requested by codegen
-               //
-               for (auto bpIterator = _comp->cg()->getBreakPointList().begin();
-                    bpIterator != _comp->cg()->getBreakPointList().end(); ++bpIterator)
-                  {
-                  fprintf(cf, "stopi at 0x%p\n",*bpIterator);
-                  }
-
                fprintf(cf, "stopi at 0x%p\n" ,startaddr);
                }
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2482,11 +2482,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
 
    while (data.cursorInstruction)
       {
-      uint8_t * const instructionStart = self()->getBinaryBufferCursor();
-      if (data.cursorInstruction->isBreakPoint())
-         {
-         self()->addBreakPointAddress(instructionStart);
-         }
+      uint8_t* const instructionStart = self()->getBinaryBufferCursor();
 
       self()->setBinaryBufferCursor(data.cursorInstruction->generateBinaryEncoding());
 

--- a/compiler/z/codegen/OMRInstruction.hpp
+++ b/compiler/z/codegen/OMRInstruction.hpp
@@ -231,7 +231,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    bool     sourceRegUsedInMemoryReference(uint32_t i);
 
    void addComment(char *) { }
-   void      setBreakPoint(bool v) {v ? _index |= BreakPoint : _index &= ~BreakPoint;}
 
    virtual bool isCall();
 
@@ -246,7 +245,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
    void clearCCInfo();
 
    const char *getName(TR_Debug * debug);
-   bool isBreakPoint() {return (_index & BreakPoint) != 0;}
    bool isWillBePatched() { return (_index & WillBePatched) != 0; }
    void setWillBePatched() { _index |= WillBePatched; }
    virtual char *description() { return "S390"; }
@@ -276,7 +274,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
       StartInternalControlFlow            = 0x2000,
       EndInternalControlFlow              = 0x4000,
       WillBePatched                       = 0x08000000,
-      BreakPoint                          = 0x20000000,  ///< Z codegen
       DebugHookOp                         = 0x8000 ///< (WCODE) instruction for debug hooks
       };
 

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -9856,11 +9856,6 @@ OMR::Z::TreeEvaluator::BBStartEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       //keeping proper track of block indexes by codegen, can comment out following
       //cg->setCurrentBlockIndex(node->getBlock()->getNumber());
       node->getLabel()->setInstruction(labelInstr);
-
-      if (comp->getOption(TR_BreakBBStart))
-         {
-         firstInstr->setBreakPoint(true);
-         }
       }
 
 


### PR DESCRIPTION
There is currently overlap on the Z codegen on ways to add breakpoints
in compiled code. We deprecate the break point list in favor of using
the more robust `BREAK` pseudo-instruction which generates a the binary
encoding recognized by debuggers.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>