### PR TITLE
Add Power evaluators for sub-int type addition/subtraction

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -107,13 +107,13 @@
    TR::TreeEvaluator::faddEvaluator,                    // TR::fadd
    TR::TreeEvaluator::daddEvaluator,                    // TR::dadd
    TR::TreeEvaluator::iaddEvaluator,                    // TR::badd
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::sadd
+   TR::TreeEvaluator::iaddEvaluator,                    // TR::sadd
    TR::TreeEvaluator::isubEvaluator,                    // TR::isub
    TR::TreeEvaluator::lsubEvaluator,                    // TR::lsub
    TR::TreeEvaluator::fsubEvaluator,                    // TR::fsub
    TR::TreeEvaluator::dsubEvaluator,                    // TR::dsub
    TR::TreeEvaluator::isubEvaluator,                    // TR::bsub
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::ssub
+   TR::TreeEvaluator::isubEvaluator,                    // TR::ssub
    TR::TreeEvaluator::asubEvaluator,                    // TR::asub
    TR::TreeEvaluator::imulEvaluator,                    // TR::imul
    TR::TreeEvaluator::lmulEvaluator,                    // TR::lmul

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -570,8 +570,6 @@ PPCOpCodesTest::UnsupportedOpCodesTests()
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bdiv, "bDiv", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::brem, "bRem", _argTypesBinaryByte, TR::Int8);
 
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sadd, "sAdd", _argTypesBinaryShort, TR::Int16);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::ssub, "sSub", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::smul, "sMul", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sdiv, "sDiv", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::srem, "sRem", _argTypesBinaryShort, TR::Int16);

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -317,6 +317,10 @@ TEST_P(UInt64Arithmetic, UsingLoadParam) {
 }
 
 TEST_P(Int16Arithmetic, UsingConst) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -346,6 +350,10 @@ TEST_P(Int16Arithmetic, UsingConst) {
 }
 
 TEST_P(Int16Arithmetic, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -371,6 +379,10 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
 }
 
 TEST_P(Int8Arithmetic, UsingConst) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -400,6 +412,10 @@ TEST_P(Int8Arithmetic, UsingConst) {
 }
 
 TEST_P(Int8Arithmetic, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+        
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -72,22 +72,6 @@ int32_t imulh(int32_t l, int32_t r) {
     return static_cast<int32_t>(x >> 32); // upper 32 bits
 }
 
-int16_t sadd(int16_t l, int16_t r) {
-    return l+r;
-}
-
-int16_t ssub(int16_t l, int16_t r) {
-    return l-r;
-}
-
-int8_t badd(int8_t l, int8_t r) {
-    return l+r;
-}
-
-int8_t bsub(int8_t l, int8_t r) {
-    return l-r;
-}
-
 class Int32Arithmetic : public TRTest::BinaryOpTest<int32_t> {};
 
 class UInt32Arithmetic : public TRTest::BinaryOpTest<uint32_t> {};
@@ -458,14 +442,14 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int64Arithmetic, ::testing::Combine(
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int16Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int16_t, int16_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("sadd", sadd),
-        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("ssub", ssub))));
+        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("sadd", add<int16_t>),
+        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("ssub", sub<int16_t>))));
 
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int8Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int8_t, int8_t>()),
     ::testing::Values(
-        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("badd", badd),
-        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bsub", bsub))));
+        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("badd", add<int8_t>),
+        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bsub", sub<int8_t>))));
 
 /**
  * @brief Filter function for *div opcodes


### PR DESCRIPTION
Routed sadd/ssub operations to iadd/isubEvaluator and added comptril tests for badd/bsub and sadd/ssub

NOTE: Should not be merged before https://github.com/eclipse/omr/pull/4212

Signed-off-by: Jackie Midroni <jackie.midroni@mail.utoronto.ca>