### PR TITLE
Minor Header Platform configuration change for z/TPF

### DIFF
--- a/thread/linux/omrthreadnuma.c
+++ b/thread/linux/omrthreadnuma.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,9 @@
 #include <inttypes.h>
 #include <sched.h>
 #include <sys/stat.h>
+#if !defined(OMRZTPF)
 #include <sys/syscall.h>
+#endif /* !defined(OMRZTPF) */
 #include <stdio.h>
 
 #include "omrcfg.h"


### PR DESCRIPTION
z/TPF does not make use of sys/syscall.h.  The update
was to simply move the header include statement into
a !z/TPF guard macro block in the linux/omrthreadnuma.c
segment.

Signed-off-by: James D Johnston <jjohnst@us.ibm.com>