### PR TITLE
Fix warnings in compiler files

### DIFF
--- a/compiler/env/CompileTimeProfiler.hpp
+++ b/compiler/env/CompileTimeProfiler.hpp
@@ -79,7 +79,7 @@ public:
          snprintf(timestr, sizeof(timestr), "%i", (int32_t)timer % 100000);
          
          char tidstr[_threadIDLength];
-         snprintf(tidstr, sizeof(tidstr), "%d", syscall(SYS_gettid));
+         snprintf(tidstr, sizeof(tidstr), "%ld", syscall(SYS_gettid));
 
          // Construct the output filename, with the thread id and time in seconds
          char filename[_fileLength];

--- a/compiler/infra/BitVector.cpp
+++ b/compiler/infra/BitVector.cpp
@@ -198,7 +198,7 @@ const char *TR_BitVector::getHexString()
    #endif
    for (int32_t i = _numChunks-1; i >= 0; i--)
       {
-      sprintf(pos, "%0*llX", chunk_hexlen, _chunks[i]);
+      sprintf(pos, "%0*lX", chunk_hexlen, _chunks[i]);
       pos += chunk_hexlen;
       }
    return buf;

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -232,7 +232,7 @@ void TR_DebuggingCounters::report()
          int32_t deviation = ((counterInfo->delta + 1)*counterInfo->bucketSize);
 
          if (deviation != INT_MAX)
-            fprintf(output, "Name: [%31s (%5d)] dynamic : (%5.2lf ) static : (%5.2lf ) [%llu]\n",
+            fprintf(output, "Name: [%31s (%5d)] dynamic : (%5.2lf ) static : (%5.2lf ) [%lu]\n",
 	   	             counterInfo->counterName,
                    ((counterInfo->delta + 1)*counterInfo->bucketSize),
                    //(uint32_t) counterInfo->totalCount,
@@ -252,7 +252,7 @@ void TR_DebuggingCounters::report()
 	       }
       }
 
-   fprintf(output, "Compilation sum %d Dynamic sum %llu \n", (int32_t) compilationSum, dynamicSum);
+   fprintf(output, "Compilation sum %d Dynamic sum %lu \n", (int32_t) compilationSum, dynamicSum);
    fprintf(output, "\n");
 
    if (output != stdout)

--- a/compiler/ras/CallStack.cpp
+++ b/compiler/ras/CallStack.cpp
@@ -182,7 +182,7 @@ void TR_LinuxCallStackIterator::printSymbol(int32_t frame, char *sig, TR::Compil
    intptr_t offset;
    intptr_t address;
 
-   int rc = sscanf(sig, "%255[^(](%255[^+]+%llx) [%llx]", lib, func, &offset, &address);
+   int rc = sscanf(sig, "%255[^(](%255[^+]+%lx) [%lx]", lib, func, &offset, &address);
    if (rc == 4)
       {
       char *funcToPrint = func;
@@ -192,13 +192,13 @@ void TR_LinuxCallStackIterator::printSymbol(int32_t frame, char *sig, TR::Compil
       char *demangled = abi::__cxa_demangle(func, buffer, &length, &status);
       if (status == 0) funcToPrint = demangled;
       if (comp)
-         traceMsg(comp, "#%d: function %s+%#x [%#p]\n",
+         traceMsg(comp, "#%d: function %s+%#lx [%#p]\n",
               frame,
               funcToPrint,
               offset,
               address);
       else
-         fprintf(stderr, "#%d: function %s+%#x [%#p]\n",
+         fprintf(stderr, "#%d: function %s+%#lx [%#p]\n",
                  frame,
                  funcToPrint,
                  offset,

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -5013,7 +5013,6 @@ void TR_Debug::setupDebugger(void *startaddr, void *endaddr, bool before)
 
             fprintf(cf, "finish\n");
             fprintf(cf, "shell rm %s\n",cfname);
-            fprintf(cf, "");
             fclose(cf);
 
             Argv[1] = "-x";


### PR DESCRIPTION
Correct several printf format specifiers.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>