### PR TITLE
Use TR_ASSERT_FATAL for JitBuilder assertions

### DIFF
--- a/compiler/ilgen/OMRBytecodeBuilder.cpp
+++ b/compiler/ilgen/OMRBytecodeBuilder.cpp
@@ -146,7 +146,7 @@ OMR::BytecodeBuilder::addAllSuccessorBuildersToWorklist()
 void
 OMR::BytecodeBuilder::AddFallThroughBuilder(TR::BytecodeBuilder *ftb)
    {
-   TR_ASSERT(comesBack(), "builder does not appear to have a fall through path");
+   TR_ASSERT_FATAL(comesBack(), "builder does not appear to have a fall through path");
 
    TraceIL("IlBuilder[ %p ]:: fallThrough successor [ %p ]\n", this, ftb);
 
@@ -212,7 +212,7 @@ OMR::BytecodeBuilder::propagateVMState(TR::VirtualMachineState *fromVMState)
 void
 OMR::BytecodeBuilder::transferVMState(TR::BytecodeBuilder **b)
    {
-   TR_ASSERT(_vmState != NULL, "asked to transfer a NULL vmState from builder %p [ bci %d ]", this, _bcIndex);
+   TR_ASSERT_FATAL(_vmState != NULL, "asked to transfer a NULL vmState from builder %p [ bci %d ]", this, _bcIndex);
    if ((*b)->initialVMState())
       {
       // there is already a vm state at the target builder
@@ -262,7 +262,7 @@ OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1, TR
 void
 OMR::BytecodeBuilder::IfCmpEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpEqual(dest, v1, v2);
    }
@@ -278,7 +278,7 @@ OMR::BytecodeBuilder::IfCmpEqualZero(TR::BytecodeBuilder **dest, TR::IlValue *c)
 void
 OMR::BytecodeBuilder::IfCmpEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpEqualZero(dest, c);
    }
@@ -294,7 +294,7 @@ OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder **dest, TR::IlValue *v1,
 void
 OMR::BytecodeBuilder::IfCmpNotEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpNotEqual(dest, v1, v2);
    }
@@ -310,7 +310,7 @@ OMR::BytecodeBuilder::IfCmpNotEqualZero(TR::BytecodeBuilder **dest, TR::IlValue 
 void
 OMR::BytecodeBuilder::IfCmpNotEqualZero(TR::BytecodeBuilder *dest, TR::IlValue *c)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpNotEqualZero(dest, c);
    }
@@ -326,7 +326,7 @@ OMR::BytecodeBuilder::IfCmpLessThan(TR::BytecodeBuilder **dest, TR::IlValue *v1,
 void
 OMR::BytecodeBuilder::IfCmpLessThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpLessThan(dest, v1, v2);
    }
@@ -342,7 +342,7 @@ OMR::BytecodeBuilder::IfCmpUnsignedLessThan(TR::BytecodeBuilder **dest, TR::IlVa
 void
 OMR::BytecodeBuilder::IfCmpUnsignedLessThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedLessThan(dest, v1, v2);
    }
@@ -358,7 +358,7 @@ OMR::BytecodeBuilder::IfCmpLessOrEqual(TR::BytecodeBuilder **dest, TR::IlValue *
 void
 OMR::BytecodeBuilder::IfCmpLessOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpLessOrEqual(dest, v1, v2);
    }
@@ -374,7 +374,7 @@ OMR::BytecodeBuilder::IfCmpUnsignedLessOrEqual(TR::BytecodeBuilder **dest, TR::I
 void
 OMR::BytecodeBuilder::IfCmpUnsignedLessOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedLessOrEqual(dest, v1, v2);
    }
@@ -390,7 +390,7 @@ OMR::BytecodeBuilder::IfCmpGreaterThan(TR::BytecodeBuilder **dest, TR::IlValue *
 void
 OMR::BytecodeBuilder::IfCmpGreaterThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpGreaterThan(dest, v1, v2);
    }
@@ -406,7 +406,7 @@ OMR::BytecodeBuilder::IfCmpUnsignedGreaterThan(TR::BytecodeBuilder **dest, TR::I
 void
 OMR::BytecodeBuilder::IfCmpUnsignedGreaterThan(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedGreaterThan(dest, v1, v2);
    }
@@ -422,7 +422,7 @@ OMR::BytecodeBuilder::IfCmpGreaterOrEqual(TR::BytecodeBuilder **dest, TR::IlValu
 void
 OMR::BytecodeBuilder::IfCmpGreaterOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpGreaterOrEqual(dest, v1, v2);
    }
@@ -437,7 +437,7 @@ OMR::BytecodeBuilder::IfCmpUnsignedGreaterOrEqual(TR::BytecodeBuilder **dest, TR
 void
 OMR::BytecodeBuilder::IfCmpUnsignedGreaterOrEqual(TR::BytecodeBuilder *dest, TR::IlValue *v1, TR::IlValue *v2)
    {
-   TR_ASSERT(dest != NULL, "service cannot be called with NULL destination builder");
+   TR_ASSERT_FATAL(dest != NULL, "service cannot be called with NULL destination builder");
    AddSuccessorBuilder(&dest);
    OMR::IlBuilder::IfCmpUnsignedGreaterOrEqual(dest, v1, v2);
    }

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -210,14 +210,14 @@ OMR::IlBuilder::printBlock(TR::Block *block)
 TR::SymbolReference *
 OMR::IlBuilder::lookupSymbol(const char *name)
    {
-   TR_ASSERT(_methodBuilder, "cannot look up symbols in an IlBuilder that has no MethodBuilder");
+   TR_ASSERT_FATAL(_methodBuilder, "cannot look up symbols in an IlBuilder that has no MethodBuilder");
    return _methodBuilder->lookupSymbol(name);
    }
 
 void
 OMR::IlBuilder::defineSymbol(const char *name, TR::SymbolReference *symRef)
    {
-   TR_ASSERT(_methodBuilder, "cannot define symbols in an IlBuilder that has no MethodBuilder");
+   TR_ASSERT_FATAL(_methodBuilder, "cannot define symbols in an IlBuilder that has no MethodBuilder");
    _methodBuilder->defineSymbol(name, symRef);
    }
 
@@ -279,16 +279,16 @@ OMR::IlBuilder::Copy(TR::IlValue *value)
 TR::TreeTop *
 OMR::IlBuilder::getFirstTree()
    {
-   TR_ASSERT(_blocks, "_blocks not created yet");
-   TR_ASSERT(_blocks[0], "_blocks[0] not created yet");
+   TR_ASSERT_FATAL(_blocks, "_blocks not created yet");
+   TR_ASSERT_FATAL(_blocks[0], "_blocks[0] not created yet");
    return _blocks[0]->getEntry();
    }
 
 TR::TreeTop *
 OMR::IlBuilder::getLastTree()
    {
-   TR_ASSERT(_blocks, "_blocks not created yet");
-   TR_ASSERT(_blocks[_numBlocks], "_blocks[0] not created yet");
+   TR_ASSERT_FATAL(_blocks, "_blocks not created yet");
+   TR_ASSERT_FATAL(_blocks[_numBlocks], "_blocks[0] not created yet");
    return _blocks[_numBlocks]->getExit();
    }
 
@@ -453,7 +453,7 @@ OMR::IlBuilder::zero(TR::DataType dt)
       case TR::Int64 : return TR::Node::lconst(0);
       default :        return TR::Node::create(TR::ILOpCode::constOpCode(dt), 0, 0);
       }
-   TR_ASSERT(0, "should not reach here");
+   TR_ASSERT_FATAL(0, "should not reach here");
    }
 
 TR::Node *
@@ -546,7 +546,7 @@ OMR::IlBuilder::appendBlock(TR::Block *newBlock, bool addEdge)
 void
 OMR::IlBuilder::AppendBuilder(TR::IlBuilder *builder)
    {
-   TR_ASSERT(builder->_partOfSequence == false, "builder cannot be in two places");
+   TR_ASSERT_FATAL(builder->_partOfSequence == false, "builder cannot be in two places");
 
    builder->_partOfSequence = true;
    _sequenceAppender->add(builderEntry(builder));
@@ -588,10 +588,10 @@ OMR::IlBuilder::indirectStoreNode(TR::Node *addr, TR::Node *v)
 TR::IlValue *
 OMR::IlBuilder::indirectLoadNode(TR::IlType *dt, TR::Node *addr, bool isVectorLoad)
    {
-   TR_ASSERT(dt->isPointer(), "indirectLoadNode must apply to pointer type");
+   TR_ASSERT_FATAL(dt->isPointer(), "indirectLoadNode must apply to pointer type");
    TR::IlType * baseType = dt->baseType();
    TR::DataType primType = baseType->getPrimitiveType();
-   TR_ASSERT(primType != TR::NoType, "Dereferencing an untyped pointer.");
+   TR_ASSERT_FATAL(primType != TR::NoType, "Dereferencing an untyped pointer.");
    TR::DataType symRefType = primType;
    if (isVectorLoad)
       symRefType = symRefType.scalarToVector();
@@ -674,7 +674,7 @@ OMR::IlBuilder::VectorStore(const char *varName, TR::IlValue *value)
 void
 OMR::IlBuilder::StoreAt(TR::IlValue *address, TR::IlValue *value)
    {
-   TR_ASSERT(address->getDataType() == TR::Address, "StoreAt needs an address operand");
+   TR_ASSERT_FATAL(address->getDataType() == TR::Address, "StoreAt needs an address operand");
 
    TraceIL("IlBuilder[ %p ]::StoreAt address %d gets %d\n", this, address->getID(), value->getID());
    indirectStoreNode(loadValue(address), loadValue(value));
@@ -689,7 +689,7 @@ OMR::IlBuilder::StoreAt(TR::IlValue *address, TR::IlValue *value)
 void
 OMR::IlBuilder::VectorStoreAt(TR::IlValue *address, TR::IlValue *value)
    {
-   TR_ASSERT(address->getDataType() == TR::Address, "VectorStoreAt needs an address operand");
+   TR_ASSERT_FATAL(address->getDataType() == TR::Address, "VectorStoreAt needs an address operand");
 
    TraceIL("IlBuilder[ %p ]::VectorStoreAt address %d gets %d\n", this, address->getID(), value->getID());
 
@@ -769,7 +769,7 @@ OMR::IlBuilder::VectorLoad(const char *name)
    {
    TR::SymbolReference *nameSymRef = lookupSymbol(name);
    TR::DataType returnType = nameSymRef->getSymbol()->getDataType();
-   TR_ASSERT(returnType.isVector(), "VectorLoad must load symbol with a vector type");
+   TR_ASSERT_FATAL(returnType.isVector(), "VectorLoad must load symbol with a vector type");
 
    TR::Node *loadNode = TR::Node::createWithSymRef(0, TR::comp()->il.opCodeForDirectLoad(returnType), 0, nameSymRef);
    TR::IlValue *returnValue = newValue(returnType, loadNode);
@@ -792,7 +792,7 @@ OMR::IlBuilder::LoadIndirect(const char *type, const char *field, TR::IlValue *o
 TR::IlValue *
 OMR::IlBuilder::LoadAt(TR::IlType *dt, TR::IlValue *address)
    {
-   TR_ASSERT(address->getDataType() == TR::Address, "LoadAt needs an address operand");
+   TR_ASSERT_FATAL(address->getDataType() == TR::Address, "LoadAt needs an address operand");
    TR::IlValue *returnValue = indirectLoadNode(dt, loadValue(address));
    TraceIL("IlBuilder[ %p ]::%d is LoadAt type %d address %d\n", this, returnValue->getID(), dt->getPrimitiveType(), address->getID());
    return returnValue;
@@ -801,7 +801,7 @@ OMR::IlBuilder::LoadAt(TR::IlType *dt, TR::IlValue *address)
 TR::IlValue *
 OMR::IlBuilder::VectorLoadAt(TR::IlType *dt, TR::IlValue *address)
    {
-   TR_ASSERT(address->getDataType() == TR::Address, "LoadAt needs an address operand");
+   TR_ASSERT_FATAL(address->getDataType() == TR::Address, "LoadAt needs an address operand");
    TR::IlValue *returnValue = indirectLoadNode(dt, loadValue(address), true);
    TraceIL("IlBuilder[ %p ]::%d is VectorLoadAt type %d address %d\n", this, returnValue->getID(), dt->getPrimitiveType(), address->getID());
    return returnValue;
@@ -811,9 +811,9 @@ TR::IlValue *
 OMR::IlBuilder::IndexAt(TR::IlType *dt, TR::IlValue *base, TR::IlValue *index)
    {
    TR::IlType *elemType = dt->baseType();
-   TR_ASSERT(base->getDataType() == TR::Address, "IndexAt must be called with a pointer base");
-   TR_ASSERT(elemType != NULL, "IndexAt should be called with pointer type");
-   TR_ASSERT(elemType->getPrimitiveType() != TR::NoType, "Cannot use IndexAt with pointer to NoType.");
+   TR_ASSERT_FATAL(base->getDataType() == TR::Address, "IndexAt must be called with a pointer base");
+   TR_ASSERT_FATAL(elemType != NULL, "IndexAt should be called with pointer type");
+   TR_ASSERT_FATAL(elemType->getPrimitiveType() != TR::NoType, "Cannot use IndexAt with pointer to NoType.");
    TR::Node *baseNode = loadValue(base);
    TR::Node *indexNode = loadValue(index);
    TR::Node *elemSizeNode;
@@ -973,7 +973,7 @@ OMR::IlBuilder::ConstInteger(TR::IlType *intType, int64_t value)
    else if (intType == Int32) return ConstInt32((int32_t) value);
    else if (intType == Int64) return ConstInt64(          value);
 
-   TR_ASSERT(0, "unknown integer type");
+   TR_ASSERT_FATAL(0, "unknown integer type");
    return NULL;
    }
 
@@ -1013,7 +1013,7 @@ OMR::IlBuilder::Negate(TR::IlValue *v)
    TR::DataType dataType = v->getDataType();
 
    TR::ILOpCodes negateOp = ILOpCode::negateOpCode(dataType);
-   TR_ASSERT(negateOp != TR::BadILOp, "Builder [ %p ] cannot negate value %d of type %s", this, v->getID(), dataType.toString());
+   TR_ASSERT_FATAL(negateOp != TR::BadILOp, "Builder [ %p ] cannot negate value %d of type %s", this, v->getID(), dataType.toString());
 
    TR::Node *result = TR::Node::create(negateOp, 1, loadValue(v));
    TR::IlValue *negatedValue = newValue(dataType, result);
@@ -1027,7 +1027,7 @@ OMR::IlBuilder::convertTo(TR::DataType typeTo, TR::IlValue *v, bool needUnsigned
    TR::DataType typeFrom = v->getDataType();
 
    TR::ILOpCodes convertOp = ILOpCode::getProperConversion(typeFrom, typeTo, needUnsigned);
-   TR_ASSERT(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d %s to %s", this, v->getID(), typeFrom.toString(), typeTo.toString());
+   TR_ASSERT_FATAL(convertOp != TR::BadILOp, "Builder [ %p ] unknown conversion requested for value %d %s to %s", this, v->getID(), typeFrom.toString(), typeTo.toString());
 
    TR::Node *result = TR::Node::create(convertOp, 1, loadValue(v));
    TR::IlValue *convertedValue = newValue(typeTo, result);
@@ -1047,10 +1047,10 @@ OMR::IlBuilder::ConvertBitsTo(TR::IlType* t, TR::IlValue* v)
       }
 
    TR::ILOpCodes convertOpcode = TR::DataType::getDataTypeBitConversion(typeFrom, typeTo);
-   TR_ASSERT(convertOpcode != TR::BadILOp && TR::DataType::getSize(typeTo) == TR::DataType::getSize(typeFrom),
+   TR_ASSERT_FATAL(convertOpcode != TR::BadILOp && TR::DataType::getSize(typeTo) == TR::DataType::getSize(typeFrom),
              "Builder [ %p ] requested bit conversion for value %d from type of size %d (%s) to type of size %d (%s) (consider using ConvertTo() to for narrowing/widening)",
              this, v->getID(), TR::DataType::getSize(typeFrom), typeFrom.toString(), TR::DataType::getSize(typeTo), typeTo.toString());
-   TR_ASSERT(convertOpcode != TR::BadILOp, "Builder [ %p ] unknown bit conversion requested for value %d (%s) to type %s", this, v->getID(), typeFrom.toString(), t->getName());
+   TR_ASSERT_FATAL(convertOpcode != TR::BadILOp, "Builder [ %p ] unknown bit conversion requested for value %d (%s) to type %s", this, v->getID(), typeFrom.toString(), t->getName());
 
    TR::Node *result = TR::Node::create(convertOpcode, 1, loadValue(v));
    TR::IlValue *convertedValue = newValue(t, result);
@@ -1113,7 +1113,7 @@ OMR::IlBuilder::binaryOpNodeFromNodes(TR::ILOpCodes op,
                             (rightType == TR::Int32 || rightType == TR::Int64));
    bool isRevAddressBump = ((rightType == TR::Address) &&
                                (leftType == TR::Int32 || leftType == TR::Int64));
-   TR_ASSERT(leftType == rightType || isAddressBump || isRevAddressBump, "binaryOp requires both left and right operands to have same type or one is address and other is Int32/64");
+   TR_ASSERT_FATAL(leftType == rightType || isAddressBump || isRevAddressBump, "binaryOp requires both left and right operands to have same type or one is address and other is Int32/64");
 
    if (isRevAddressBump) // swap them
       {
@@ -1190,7 +1190,7 @@ OMR::IlBuilder::Goto(TR::IlBuilder **dest)
 void
 OMR::IlBuilder::Goto(TR::IlBuilder *dest)
    {
-   TR_ASSERT(dest != NULL, "This goto implementation requires a non-NULL builder object");
+   TR_ASSERT_FATAL(dest != NULL, "This goto implementation requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::Goto %p\n", this, dest);
    appendGoto(dest->getEntry());
    setDoesNotComeBack();
@@ -1202,7 +1202,7 @@ OMR::IlBuilder::Return()
    TR::IlBuilder *returnBuilder = _methodBuilder->returnBuilder();
    if (returnBuilder != NULL)
       {
-      TR_ASSERT(_methodBuilder->returnSymbol() == NULL, "Return() from inlined call did not expect a pre-existing returnSymbol");
+      TR_ASSERT_FATAL(_methodBuilder->returnSymbol() == NULL, "Return() from inlined call did not expect a pre-existing returnSymbol");
       TraceIL("IlBuilder[ %p ]::Return back to caller's returnBuilder [ %p ]\n", this, returnBuilder);
 
       // redirect flow back to the caller's return block
@@ -1335,7 +1335,7 @@ OMR::IlBuilder::appendExceptionHandler(TR::Block *blockThrowsException, TR::IlBu
  
    //append handler, add exception edge and merge edge
    *handler = createBuilderIfNeeded(*handler);
-   TR_ASSERT(*handler != NULL, "exception handler cannot be NULL\n");
+   TR_ASSERT_FATAL(*handler != NULL, "exception handler cannot be NULL\n");
    (*handler)->_isHandler = true;
    cfg()->addExceptionEdge(blockThrowsException, (*handler)->getEntry());
    AppendBuilder(*handler);
@@ -1403,7 +1403,7 @@ OMR::IlBuilder::getOpCode(TR::IlValue *leftValue, TR::IlValue *rightValue)
    TR::ILOpCodes op;
    if (leftValue->getDataType() == TR::Address)
       {
-      TR_ASSERT((TR::Compiler->target.is64Bit() && rightValue->getDataType() == TR::Int64) || (TR::Compiler->target.is32Bit() && rightValue->getDataType() == TR::Int32),
+      TR_ASSERT_FATAL((TR::Compiler->target.is64Bit() && rightValue->getDataType() == TR::Int64) || (TR::Compiler->target.is32Bit() && rightValue->getDataType() == TR::Int32),
                 "the right child type must be either TR::Int32 (on 32-bit ISA) or TR::Int64 (on 64-bit ISA) when the left child of Add is TR::Address\n");
       op = TR::Compiler->target.is32Bit() ? TR::aiadd : TR::aladd;
       }
@@ -1591,7 +1591,7 @@ OMR::IlBuilder::shiftOpNodeFromNodes(TR::ILOpCodes op,
    {
    TR::DataType leftType = leftNode->getDataType();
    TR::DataType rightType = rightNode->getDataType();
-   TR_ASSERT(leftType.isIntegral() && rightType.isInt32(), "shift operation first operand must be an integer, and shift amount must be 32-bit integer");
+   TR_ASSERT_FATAL(leftType.isIntegral() && rightType.isInt32(), "shift operation first operand must be an integer, and shift amount must be 32-bit integer");
 
    return TR::Node::create(op, 2, leftNode, rightNode);
    }
@@ -1613,7 +1613,7 @@ OMR::IlBuilder::shiftOpFromOpMap(OpCodeMapper mapOp,
    {
    TR::Node *leftNode = loadValue(left);
    TR::DataType leftType = leftNode->getDataType();
-   TR_ASSERT(leftType.isIntegral(), "left operand of shift must be integer type");
+   TR_ASSERT_FATAL(leftType.isIntegral(), "left operand of shift must be integer type");
 
    TR::Node *rightNode = loadValue(right);
    if (!rightNode->getDataType().isInt32())
@@ -1726,7 +1726,7 @@ void
 OMR::IlBuilder::IfAnd(TR::IlBuilder **allTrueBuilder, TR::IlBuilder **anyFalseBuilder, int32_t numTerms, ...)
    {
    JBCondition **terms = (JBCondition **) _comp->trMemory()->allocateHeapMemory(numTerms * sizeof(JBCondition *));
-   TR_ASSERT(NULL != terms, "out of memory");
+   TR_ASSERT_FATAL(NULL != terms, "out of memory");
 
    va_list args;
    va_start(args, numTerms);
@@ -1823,7 +1823,7 @@ void
 OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBuilder, int32_t numTerms, ...)
    {
    JBCondition **terms = (JBCondition **) _comp->trMemory()->allocateHeapMemory(numTerms * sizeof(JBCondition *));
-   TR_ASSERT(NULL != terms, "out of memory");
+   TR_ASSERT_FATAL(NULL != terms, "out of memory");
 
    va_list args;
    va_start(args, numTerms);
@@ -1839,8 +1839,8 @@ OMR::IlBuilder::IfOr(TR::IlBuilder **anyTrueBuilder, TR::IlBuilder **allFalseBui
 TR::IlBuilder::JBCondition *
 OMR::IlBuilder::MakeCondition(TR::IlBuilder *conditionBuilder, TR::IlValue *conditionValue)
    {
-   TR_ASSERT(conditionBuilder != NULL, "MakeCondition needs to have non-null conditionBuilder");
-   TR_ASSERT(conditionValue != NULL, "MakeCondition needs to have non-null conditionValue");
+   TR_ASSERT_FATAL(conditionBuilder != NULL, "MakeCondition needs to have non-null conditionBuilder");
+   TR_ASSERT_FATAL(conditionValue != NULL, "MakeCondition needs to have non-null conditionValue");
    return new (_comp->trHeapMemory()) JBCondition(conditionBuilder, conditionValue);
    }
 
@@ -1964,7 +1964,7 @@ OMR::IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, ...)
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
    if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
       resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+   TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
@@ -1983,7 +1983,7 @@ OMR::IlBuilder::ComputedCall(const char *functionName, int32_t numArgs, TR::IlVa
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
    if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
       resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+   TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateComputedStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues, false /*isDirectCall*/);
@@ -2083,7 +2083,7 @@ OMR::IlBuilder::Call(const char *functionName, int32_t numArgs, ...)
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
    if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
       resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+   TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues);
@@ -2096,7 +2096,7 @@ OMR::IlBuilder::Call(const char *functionName, int32_t numArgs, TR::IlValue ** a
    TR::ResolvedMethod *resolvedMethod = _methodBuilder->lookupFunction(functionName);
    if (resolvedMethod == NULL && _methodBuilder->RequestFunction(functionName))
       resolvedMethod = _methodBuilder->lookupFunction(functionName);
-   TR_ASSERT(resolvedMethod, "Could not identify function %s\n", functionName);
+   TR_ASSERT_FATAL(resolvedMethod, "Could not identify function %s\n", functionName);
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, resolvedMethod);
    return genCall(methodSymRef, numArgs, argValues);
@@ -2149,11 +2149,11 @@ OMR::IlBuilder::genCall(TR::SymbolReference *methodSymRef, int32_t numArgs, TR::
 TR::IlValue *
 OMR::IlBuilder::AtomicAdd(TR::IlValue * baseAddress, TR::IlValue * value)
    {
-   TR_ASSERT(baseAddress->getDataType() == TR::Address, "baseAddress must be TR::Address");
+   TR_ASSERT_FATAL(baseAddress->getDataType() == TR::Address, "baseAddress must be TR::Address");
 
    //Determine the implementation type and returnType by detecting "value"'s type
    TR::DataType returnType = value->getDataType();
-   TR_ASSERT(returnType == TR::Int32 || (returnType == TR::Int64 && TR::Compiler->target.is64Bit()), "AtomicAdd currently only supports Int32/64 values");
+   TR_ASSERT_FATAL(returnType == TR::Int32 || (returnType == TR::Int64 && TR::Compiler->target.is64Bit()), "AtomicAdd currently only supports Int32/64 values");
    TraceIL("IlBuilder[ %p ]::AtomicAdd(%d, %d)\n", this, baseAddress->getID(), value->getID());
 
    TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateCodeGenInlinedHelper(TR::SymbolReferenceTable::atomicAddSymbol);
@@ -2241,7 +2241,7 @@ void
 OMR::IlBuilder::Transaction(TR::IlBuilder **persistentFailureBuilder, TR::IlBuilder **transientFailureBuilder, TR::IlBuilder **transactionBuilder)
    {   
    //This assertion is to rule out platforms which don't have tstart evaluator yet. 
-   TR_ASSERT(comp()->cg()->hasTMEvaluator(), "this platform doesn't support tstart or tfinish evaluator yet");   
+   TR_ASSERT_FATAL(comp()->cg()->hasTMEvaluator(), "this platform doesn't support tstart or tfinish evaluator yet");   
     
    TraceIL("IlBuilder[ %p ]::transactionBegin %p, %p, %p, %p)\n", this, *persistentFailureBuilder, *transientFailureBuilder, *transactionBuilder);
 
@@ -2323,7 +2323,7 @@ OMR::IlBuilder::IfCmpNotEqualZero(TR::IlBuilder **target, TR::IlValue *condition
 void
 OMR::IlBuilder::IfCmpNotEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
    {
-   TR_ASSERT(target != NULL, "This IfCmpNotEqualZero requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpNotEqualZero requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpNotEqualZero %d? -> [ %p ] B%d\n", this, condition->getID(), target, target->getEntry()->getNumber());
    ifCmpNotEqualZero(condition, target->getEntry());
    }
@@ -2338,7 +2338,7 @@ OMR::IlBuilder::IfCmpNotEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlV
 void
 OMR::IlBuilder::IfCmpNotEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(target != NULL, "This IfCmpNotEqual requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpNotEqual requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpNotEqual %d == %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
    ifCmpCondition(TR_cmpNE, false, left, right, target->getEntry());
    }
@@ -2353,7 +2353,7 @@ OMR::IlBuilder::IfCmpEqualZero(TR::IlBuilder **target, TR::IlValue *condition)
 void
 OMR::IlBuilder::IfCmpEqualZero(TR::IlBuilder *target, TR::IlValue *condition)
    {
-   TR_ASSERT(target != NULL, "This IfCmpEqualZero requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpEqualZero requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpEqualZero %d == 0? -> [ %p ] B%d\n", this, condition->getID(), target, target->getEntry()->getNumber());
    ifCmpEqualZero(condition, target->getEntry());
    }
@@ -2368,7 +2368,7 @@ OMR::IlBuilder::IfCmpEqual(TR::IlBuilder **target, TR::IlValue *left, TR::IlValu
 void
 OMR::IlBuilder::IfCmpEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(target != NULL, "This IfCmpEqual requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpEqual requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpEqual %d == %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
    ifCmpCondition(TR_cmpEQ, false, left, right, target->getEntry());
    }
@@ -2383,7 +2383,7 @@ OMR::IlBuilder::IfCmpLessThan(TR::IlBuilder **target, TR::IlValue *left, TR::IlV
 void
 OMR::IlBuilder::IfCmpLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(target != NULL, "This IfCmpLessThan requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpLessThan requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpLessThan %d < %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
    ifCmpCondition(TR_cmpLT, false, left, right, target->getEntry());
    }
@@ -2398,7 +2398,7 @@ OMR::IlBuilder::IfCmpUnsignedLessThan(TR::IlBuilder **target, TR::IlValue *left,
 void
 OMR::IlBuilder::IfCmpUnsignedLessThan(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(target != NULL, "This IfCmpUnsignedLessThan requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpUnsignedLessThan requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpUnsignedLessThan %d < %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
    ifCmpCondition(TR_cmpLT, true, left, right, target->getEntry());
    }
@@ -2413,7 +2413,7 @@ OMR::IlBuilder::IfCmpLessOrEqual(TR::IlBuilder **target, TR::IlValue *left, TR::
 void
 OMR::IlBuilder::IfCmpLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(target != NULL, "This IfCmpLessOrEqual requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpLessOrEqual requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpLessOrEqual %d <= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
    ifCmpCondition(TR_cmpLE, false, left, right, target->getEntry());
    }
@@ -2428,7 +2428,7 @@ OMR::IlBuilder::IfCmpUnsignedLessOrEqual(TR::IlBuilder **target, TR::IlValue *le
 void
 OMR::IlBuilder::IfCmpUnsignedLessOrEqual(TR::IlBuilder *target, TR::IlValue *left, TR::IlValue *right)
    {
-   TR_ASSERT(target != NULL, "This IfCmpUnsignedLessOrEqual requires a non-NULL builder object");
+   TR_ASSERT_FATAL(target != NULL, "This IfCmpUnsignedLessOrEqual requires a non-NULL builder object");
    TraceIL("IlBuilder[ %p ]::IfCmpUnsignedLessOrEqual %d <= %d? -> [ %p ] B%d\n", this, left->getID(), right->getID(), target, target->getEntry()->getNumber());
    ifCmpCondition(TR_cmpLE, true, left, right, target->getEntry());
    }
@@ -2534,7 +2534,7 @@ OMR::IlBuilder::appendGoto(TR::Block *destBlock)
 void
 OMR::IlBuilder::IfThenElse(TR::IlBuilder **thenPath, TR::IlBuilder **elsePath, TR::IlValue *condition)
    {
-   TR_ASSERT(thenPath != NULL || elsePath != NULL, "IfThenElse needs at least one conditional path");
+   TR_ASSERT_FATAL(thenPath != NULL || elsePath != NULL, "IfThenElse needs at least one conditional path");
 
    TR::Block *thenEntry = NULL;
    TR::Block *elseEntry = NULL;
@@ -2605,7 +2605,7 @@ OMR::IlBuilder::Switch(const char *selectionVar,
                   JBCase **cases)
    {
    TR::IlValue *selectorValue = Load(selectionVar);
-   TR_ASSERT(selectorValue->getDataType() == TR::Int32, "Switch only supports selector having type Int32");
+   TR_ASSERT_FATAL(selectorValue->getDataType() == TR::Int32, "Switch only supports selector having type Int32");
    *defaultBuilder = createBuilderIfNeeded(*defaultBuilder);
 
    TR::Node *defaultNode = TR::Node::createCase(0, (*defaultBuilder)->getEntry()->getEntry());
@@ -2636,12 +2636,12 @@ OMR::IlBuilder::TableSwitch(const char *selectionVar,
                   JBCase **cases)
    {
    TR::IlValue *selectorValue = Load(selectionVar);
-   TR_ASSERT(selectorValue->getDataType() == TR::Int32, "TableSwitch only supports selector having type Int32");
-   TR_ASSERT(numCases > 0, "TableSwitch requires at least 1 case");
+   TR_ASSERT_FATAL(selectorValue->getDataType() == TR::Int32, "TableSwitch only supports selector having type Int32");
+   TR_ASSERT_FATAL(numCases > 0, "TableSwitch requires at least 1 case");
    int32_t low = cases[0]->_value;
    int32_t high = cases[numCases -1]->_value;
    int32_t casesCovered = (high - low) + 1;
-   TR_ASSERT(numCases == casesCovered, "TableSwitch only supports dense case sets");
+   TR_ASSERT_FATAL(numCases == casesCovered, "TableSwitch only supports dense case sets");
    if (low != 0)
       selectorValue = Sub(selectorValue, ConstInt32(low));
 
@@ -2673,7 +2673,7 @@ OMR::IlBuilder::TableSwitch(const char *selectionVar,
 TR::IlBuilder::JBCase *
 OMR::IlBuilder::MakeCase(int32_t caseValue, TR::IlBuilder **caseBuilder, int32_t caseFallsThrough)
    {
-   TR_ASSERT(caseBuilder != NULL, "MakeCase, needs to have non-null caseBuilder");
+   TR_ASSERT_FATAL(caseBuilder != NULL, "MakeCase, needs to have non-null caseBuilder");
    *caseBuilder = createBuilderIfNeeded(*caseBuilder);
    auto * c = new (_comp->trHeapMemory()) JBCase(caseValue, *caseBuilder, caseFallsThrough);
    return c;
@@ -2682,10 +2682,10 @@ OMR::IlBuilder::MakeCase(int32_t caseValue, TR::IlBuilder **caseBuilder, int32_t
 TR::IlValue *
 OMR::IlBuilder::Select(TR::IlValue * condition, TR::IlValue * trueValue, TR::IlValue * falseValue)
    {
-   TR_ASSERT(condition != NULL && trueValue != NULL && falseValue != NULL,
+   TR_ASSERT_FATAL(condition != NULL && trueValue != NULL && falseValue != NULL,
                      "Select requires condition, trueValue and falseValue");
    TR::DataType dt = trueValue->getDataType();
-   TR_ASSERT(dt == falseValue->getDataType(),
+   TR_ASSERT_FATAL(dt == falseValue->getDataType(),
                      "Select requires trueValue and falseValue to be of the same type");
    TR::ILOpCodes opCode = TR::ILOpCode::ternaryOpCode(dt);
    TR::IlValue * result = NULL;
@@ -2714,7 +2714,7 @@ TR::IlBuilder::JBCase **
 OMR::IlBuilder::createCaseArray(uint32_t numCases, va_list args)
    {
    JBCase **cases = (JBCase **) _comp->trMemory()->allocateHeapMemory(numCases * sizeof(JBCase *));
-   TR_ASSERT(NULL != cases, "out of memory");
+   TR_ASSERT_FATAL(NULL != cases, "out of memory");
 
    for (uint32_t c = 0; c < numCases; ++c)
       {
@@ -2782,7 +2782,7 @@ OMR::IlBuilder::ForLoop(bool countsUp,
                    TR::IlValue *increment)
    {
    methodSymbol()->setMayHaveLoops(true);
-   TR_ASSERT(loopCode != NULL, "ForLoop needs to have loopCode builder");
+   TR_ASSERT_FATAL(loopCode != NULL, "ForLoop needs to have loopCode builder");
    *loopCode = createBuilderIfNeeded(*loopCode);
 
    TraceIL("IlBuilder[ %p ]::ForLoop ind %s initial %d end %d increment %d loopCode %p countsUp %d\n", this, indVar, initial->getID(), end->getID(), increment->getID(), *loopCode, countsUp);
@@ -2799,14 +2799,14 @@ OMR::IlBuilder::ForLoop(bool countsUp,
 
    if (breakBuilder)
       {
-      TR_ASSERT(*breakBuilder == NULL, "ForLoop returns breakBuilder, cannot provide breakBuilder as input");
+      TR_ASSERT_FATAL(*breakBuilder == NULL, "ForLoop returns breakBuilder, cannot provide breakBuilder as input");
       *breakBuilder = OrphanBuilder();
       AppendBuilder(*breakBuilder);
       }
 
    if (continueBuilder)
       {
-      TR_ASSERT(*continueBuilder == NULL, "ForLoop returns continueBuilder, cannot provide continueBuilder as input");
+      TR_ASSERT_FATAL(*continueBuilder == NULL, "ForLoop returns continueBuilder, cannot provide continueBuilder as input");
       *continueBuilder = loopContinue;
       }
 
@@ -2839,7 +2839,7 @@ void
 OMR::IlBuilder::DoWhileLoop(const char *whileCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder, TR::IlBuilder **continueBuilder)
    {
    methodSymbol()->setMayHaveLoops(true);
-   TR_ASSERT(body != NULL, "doWhileLoop needs to have a body");
+   TR_ASSERT_FATAL(body != NULL, "doWhileLoop needs to have a body");
 
    if (!_methodBuilder->symbolDefined(whileCondition))
       _methodBuilder->defineValue(whileCondition, Int32);
@@ -2852,7 +2852,7 @@ OMR::IlBuilder::DoWhileLoop(const char *whileCondition, TR::IlBuilder **body, TR
 
    if (continueBuilder)
       {
-      TR_ASSERT(*continueBuilder == NULL, "DoWhileLoop returns continueBuilder, cannot provide continueBuilder as input");
+      TR_ASSERT_FATAL(*continueBuilder == NULL, "DoWhileLoop returns continueBuilder, cannot provide continueBuilder as input");
       loopContinue = *continueBuilder = OrphanBuilder();
       }
    else
@@ -2864,7 +2864,7 @@ OMR::IlBuilder::DoWhileLoop(const char *whileCondition, TR::IlBuilder **body, TR
 
    if (breakBuilder)
       {
-      TR_ASSERT(*breakBuilder == NULL, "DoWhileLoop returns breakBuilder, cannot provide breakBuilder as input");
+      TR_ASSERT_FATAL(*breakBuilder == NULL, "DoWhileLoop returns breakBuilder, cannot provide breakBuilder as input");
       *breakBuilder = OrphanBuilder();
       AppendBuilder(*breakBuilder);
       }
@@ -2877,20 +2877,20 @@ void
 OMR::IlBuilder::WhileDoLoop(const char *whileCondition, TR::IlBuilder **body, TR::IlBuilder **breakBuilder, TR::IlBuilder **continueBuilder)
    {
    methodSymbol()->setMayHaveLoops(true);
-   TR_ASSERT(body != NULL, "WhileDo needs to have a body");
+   TR_ASSERT_FATAL(body != NULL, "WhileDo needs to have a body");
    TraceIL("IlBuilder[ %p ]::WhileDoLoop while %s do body %p\n", this, whileCondition, *body);
 
    TR::IlBuilder *done = OrphanBuilder();
    if (breakBuilder)
       {
-      TR_ASSERT(*breakBuilder == NULL, "WhileDoLoop returns breakBuilder, cannot provide breakBuilder as input");
+      TR_ASSERT_FATAL(*breakBuilder == NULL, "WhileDoLoop returns breakBuilder, cannot provide breakBuilder as input");
       *breakBuilder = done;
       }
 
    TR::IlBuilder *loopContinue = OrphanBuilder();
    if (continueBuilder)
       {
-      TR_ASSERT(*continueBuilder == NULL, "WhileDoLoop returns continueBuilder, cannot provide continueBuilder as input");
+      TR_ASSERT_FATAL(*continueBuilder == NULL, "WhileDoLoop returns continueBuilder, cannot provide continueBuilder as input");
       *continueBuilder = loopContinue;
       }
 

--- a/compiler/ilgen/OMRIlType.cpp
+++ b/compiler/ilgen/OMRIlType.cpp
@@ -96,7 +96,7 @@ OMR::IlType::primitiveType(TR::TypeDictionary *d)
 size_t
 OMR::IlType::getSize()
    {
-   TR_ASSERT(0, "The input type does not have a defined size\n");
+   TR_ASSERT_FATAL(0, "The input type does not have a defined size\n");
    return 0;
    }
 

--- a/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
+++ b/compiler/ilgen/OMRJitBuilderRecorderBinaryBuffer.cpp
@@ -43,7 +43,7 @@ OMR::JitBuilderRecorderBinaryBuffer::String(const char * const string)
    // length(int16) characters
    const size_t len = strlen(string);
    const int max = std::numeric_limits<int16_t>::max();
-   TR_ASSERT(len < max, "JBIL: binary String format limited to %d characters", max);
+   TR_ASSERT_FATAL(len < max, "JBIL: binary String format limited to %d characters", max);
 
    Number((int16_t)len);
    for (int16_t i=0;i < len;i++)
@@ -138,7 +138,7 @@ OMR::JitBuilderRecorderBinaryBuffer::ID(TypeID id)
       Number(*num);
       }
    else
-      TR_ASSERT(0, "Unexpected id size value %d", _idSize);
+      TR_ASSERT_FATAL(0, "Unexpected id size value %d", _idSize);
    }
 
 void

--- a/compiler/ilgen/OMRMethodBuilder.cpp
+++ b/compiler/ilgen/OMRMethodBuilder.cpp
@@ -612,7 +612,7 @@ OMR::MethodBuilder::getParameterTypes()
    if (_cachedParameterTypes)
       return _cachedParameterTypes;
 
-   TR_ASSERT(_numParameters < 10, "too many parameters for parameter types array");
+   TR_ASSERT_FATAL(_numParameters < 10, "too many parameters for parameter types array");
    TR::IlType **paramTypesArray = _cachedParameterTypesArray;
    for (int32_t p=0;p < _numParameters;p++)
       {

--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -120,7 +120,7 @@ public:
 
    TR::IlType *primitiveType(TR::TypeDictionary * d) { return d->Address; }
    TR::DataType getPrimitiveType()                   { return TR::Address; }
-   void Close(size_t finalSize)                      { TR_ASSERT(_size <= finalSize, "Final size %d of struct %s is less than its current size %d\n", finalSize, _name, _size); _size = finalSize; _closed = true; };
+   void Close(size_t finalSize)                      { TR_ASSERT_FATAL(_size <= finalSize, "Final size %d of struct %s is less than its current size %d\n", finalSize, _name, _size); _size = finalSize; _closed = true; };
    void Close()                                      { _closed = true; };
 
    void AddField(const char *name, TR::IlType *fieldType, size_t offset);
@@ -194,7 +194,7 @@ public:
       _baseType(baseType)
       {
       char *baseName = (char *)_baseType->getName();
-      TR_ASSERT(strlen(baseName) < 45, "cannot store name of pointer type");
+      TR_ASSERT_FATAL(strlen(baseName) < 45, "cannot store name of pointer type");
       sprintf(_nameArray, "L%s;", baseName);
       }
    virtual bool isPointer() { return true; }
@@ -222,7 +222,7 @@ OMR::StructType::AddField(const char *name, TR::IlType *typeInfo, size_t offset)
    if (_closed)
       return;
 
-   TR_ASSERT(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
+   TR_ASSERT_FATAL(_size <= offset, "Offset of new struct field %s::%s is %d, which is less than the current size of the struct %d\n", _name, name, offset, _size);
 
    OMR::FieldInfo *fieldInfo = new (PERSISTENT_NEW) OMR::FieldInfo(name, offset, typeInfo);
    if (0 != _lastField)
@@ -381,7 +381,7 @@ TR::SymbolReference *
 OMR::UnionType::getFieldSymRef(const char *fieldName)
    {
    OMR::FieldInfo *info = findField(fieldName);
-   TR_ASSERT(info, "Struct %s has no field with name %s\n", getName(), fieldName);
+   TR_ASSERT_FATAL(info, "Struct %s has no field with name %s\n", getName(), fieldName);
 
    TR::SymbolReference *symRef = info->getSymRef();
    if (NULL == symRef)

--- a/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandArray.cpp
@@ -102,17 +102,17 @@ void
 OMR::VirtualMachineOperandArray::MergeInto(TR::VirtualMachineState *o, TR::IlBuilder *b)
    {
    TR::VirtualMachineOperandArray *other = (TR::VirtualMachineOperandArray *)o;
-   TR_ASSERT(_numberOfElements == other->_numberOfElements, "array are not same size");
+   TR_ASSERT_FATAL(_numberOfElements == other->_numberOfElements, "array are not same size");
    for (int32_t i=0;i < _numberOfElements;i++)
       {
       if (NULL == other->_values[i])
          {
-         TR_ASSERT(_values[i] == NULL, "if an element in the dest array at index is NULL it has to be NULL in the src array");
+         TR_ASSERT_FATAL(_values[i] == NULL, "if an element in the dest array at index is NULL it has to be NULL in the src array");
          }
       else if (other->_values[i]->getID() != _values[i]->getID())
          {
          // Types have to match!!!
-         TR_ASSERT(_values[i]->getDataType() == other->_values[i]->getDataType(), "invalid array merge: primitive type mismatch at same index");
+         TR_ASSERT_FATAL(_values[i]->getDataType() == other->_values[i]->getDataType(), "invalid array merge: primitive type mismatch at same index");
          TraceIL("VirtualMachineOperandArray[ %p ]::MergeInto builder %p index %d storeOver %p(%d) with %p(%d)\n", this, b, i, other->_values[i], other->_values[i]->getID(), _values[i], _values[i]->getID());
          b->StoreOver(other->_values[i], _values[i]);
          }
@@ -141,16 +141,16 @@ OMR::VirtualMachineOperandArray::MakeCopy()
 TR::IlValue *
 OMR::VirtualMachineOperandArray::Get(int32_t index)
    {
-   TR_ASSERT(index < _numberOfElements, "index has to be less than the number of elements");
-   TR_ASSERT(index >= 0, "index can not be negative");
+   TR_ASSERT_FATAL(index < _numberOfElements, "index has to be less than the number of elements");
+   TR_ASSERT_FATAL(index >= 0, "index can not be negative");
    return _values[index];
    }
 
 void
 OMR::VirtualMachineOperandArray::Set(int32_t index, TR::IlValue *value)
    {
-   TR_ASSERT(index < _numberOfElements, "index has to be less than the number of elements");
-   TR_ASSERT(index >= 0, "index can not be negative");
+   TR_ASSERT_FATAL(index < _numberOfElements, "index has to be less than the number of elements");
+   TR_ASSERT_FATAL(index >= 0, "index can not be negative");
 
    if (NULL != _values[index])
       {
@@ -168,10 +168,10 @@ OMR::VirtualMachineOperandArray::Set(int32_t index, TR::IlValue *value)
 void
 OMR::VirtualMachineOperandArray::Move(TR::IlBuilder *b, int32_t dstIndex, int32_t srcIndex)
    {
-   TR_ASSERT(dstIndex < _numberOfElements, "dstIndex has to be less than the number of elements");
-   TR_ASSERT(dstIndex >= 0, "dstIndex can not be negative");
-   TR_ASSERT(srcIndex < _numberOfElements, "srcIndex has to be less than the number of elements");
-   TR_ASSERT(srcIndex >= 0, "srcIndex can not be negative");
+   TR_ASSERT_FATAL(dstIndex < _numberOfElements, "dstIndex has to be less than the number of elements");
+   TR_ASSERT_FATAL(dstIndex >= 0, "dstIndex can not be negative");
+   TR_ASSERT_FATAL(srcIndex < _numberOfElements, "srcIndex has to be less than the number of elements");
+   TR_ASSERT_FATAL(srcIndex >= 0, "srcIndex can not be negative");
 
    _values[dstIndex] = b->Copy(_values[srcIndex]);
    TraceIL("VirtualMachineOperandArray[ %p ]::Move builder %p move srcIndex %d %p(%d) to dstIndex %d %p(%d)\n", this, b, srcIndex, _values[srcIndex], _values[srcIndex]->getID(), dstIndex, _values[dstIndex], _values[dstIndex]->getID());

--- a/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
+++ b/compiler/ilgen/OMRVirtualMachineOperandStack.cpp
@@ -112,7 +112,7 @@ void
 OMR::VirtualMachineOperandStack::MergeInto(TR::VirtualMachineState* o, TR::IlBuilder* b)
    {
    TR::VirtualMachineOperandStack *other = static_cast<TR::VirtualMachineOperandStack *>(o);
-   TR_ASSERT(_stackTop == other->_stackTop, "stacks are not same size");
+   TR_ASSERT_FATAL(_stackTop == other->_stackTop, "stacks are not same size");
    for (int32_t i=_stackTop;i >= 0;i--)
       {
       // only need to do something if the two entries aren't already the same
@@ -123,7 +123,7 @@ OMR::VirtualMachineOperandStack::MergeInto(TR::VirtualMachineState* o, TR::IlBui
          // two incoming control flow edges can have different primitive types. objects, sure
          // but not primitive types (even different types of objects should have same primitive
          // type: Address. Expecting to be disappointed here some day...
-         TR_ASSERT(_stack[i]->getDataType() == other->_stack[i]->getDataType(), "invalid stack merge: primitive type mismatch at same depth stack elements");
+         TR_ASSERT_FATAL(_stack[i]->getDataType() == other->_stack[i]->getDataType(), "invalid stack merge: primitive type mismatch at same depth stack elements");
          b->StoreOver(other->_stack[i], _stack[i]);
          }
       }
@@ -158,35 +158,35 @@ OMR::VirtualMachineOperandStack::Push(TR::IlBuilder *b, TR::IlValue *value)
 TR::IlValue *
 OMR::VirtualMachineOperandStack::Top()
    {
-   TR_ASSERT(_stackTop >= 0, "no top: stack empty");
+   TR_ASSERT_FATAL(_stackTop >= 0, "no top: stack empty");
    return _stack[_stackTop];
    }
 
 TR::IlValue *
 OMR::VirtualMachineOperandStack::Pop(TR::IlBuilder *b)
    {
-   TR_ASSERT(_stackTop >= 0, "stack underflow"); 
+   TR_ASSERT_FATAL(_stackTop >= 0, "stack underflow"); 
    return _stack[_stackTop--];
    }
 
 TR::IlValue *
 OMR::VirtualMachineOperandStack::Pick(int32_t depth)
    {
-   TR_ASSERT(_stackTop >= depth, "pick request exceeds stack depth");
+   TR_ASSERT_FATAL(_stackTop >= depth, "pick request exceeds stack depth");
    return _stack[_stackTop - depth];
    }
 
 void
 OMR::VirtualMachineOperandStack::Drop(TR::IlBuilder *b, int32_t depth)
    {
-   TR_ASSERT(_stackTop >= depth-1, "stack underflow");
+   TR_ASSERT_FATAL(_stackTop >= depth-1, "stack underflow");
    _stackTop-=depth; 
    }
 
 void
 OMR::VirtualMachineOperandStack::Dup(TR::IlBuilder *b)
    {
-   TR_ASSERT(_stackTop >= 0, "cannot dup: stack empty");
+   TR_ASSERT_FATAL(_stackTop >= 0, "cannot dup: stack empty");
    TR::IlValue *top = _stack[_stackTop];
    Push(b, top);
    }

--- a/compiler/ilgen/OMRVirtualMachineRegister.cpp
+++ b/compiler/ilgen/OMRVirtualMachineRegister.cpp
@@ -35,7 +35,7 @@ OMR::VirtualMachineRegister::VirtualMachineRegister(
    _pointerToRegisterType(pointerToRegisterType),
    _adjustByStep(adjustByStep)
    {
-   TR_ASSERT(pointerToRegisterType->isPointer(),
+   TR_ASSERT_FATAL(pointerToRegisterType->isPointer(),
          "VirtualMachineRegister for %s requires pointerToRegisterType (%s) to be a pointer",
          localName, pointerToRegisterType->getName());
 
@@ -44,14 +44,14 @@ OMR::VirtualMachineRegister::VirtualMachineRegister(
       {
       TR::IlType *baseType = _integerTypeForAdjustments->baseType();
       _integerTypeForAdjustments = b->typeDictionary()->getWord();
-      TR_ASSERT(adjustByStep == baseType->getSize(),
+      TR_ASSERT_FATAL(adjustByStep == baseType->getSize(),
             "VirtualMachineRegister for %s adjustByStep (%u) != size represented by pointerToRegisterType (%u)",
             localName, _adjustByStep, baseType->getSize());
       _isAdjustable = true;
       }
    else
       {
-      TR_ASSERT(adjustByStep == 0, "VirtualMachineRegister for %s is representing a primitive type but adjustByStep (%u) != 0", localName, _adjustByStep);
+      TR_ASSERT_FATAL(adjustByStep == 0, "VirtualMachineRegister for %s is representing a primitive type but adjustByStep (%u) != 0", localName, _adjustByStep);
       _isAdjustable = false;
       }
    Reload(b);
@@ -60,7 +60,7 @@ OMR::VirtualMachineRegister::VirtualMachineRegister(
 void
 OMR::VirtualMachineRegister::adjust(TR::IlBuilder *b, TR::IlValue *rawAmount)
    {
-   TR_ASSERT(_isAdjustable, "VirtualMachineRegister can not be adjusted as it is simulating a primitive type");
+   TR_ASSERT_FATAL(_isAdjustable, "VirtualMachineRegister can not be adjusted as it is simulating a primitive type");
    b->Store(_localName,
    b->   Add(
    b->      Load(_localName),


### PR DESCRIPTION
Every condition being checked by assertions in the JitBuilder
implementation classes is non-recoverable, so we should make
these assertions fatal.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>