### PR TITLE
Fix omrtrace component build when CMAKE_BUILD_TYPE=Release

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -23,6 +23,10 @@ set(OMR_WARNING_AS_ERROR_FLAG -Werror)
 
 set(OMR_ENHANCED_WARNING_FLAG -Wall)
 
+# disable builtin strncpy buffer length check for components that use variable length
+# array fields at the end of structs
+set(OMR_STRNCPY_FORTIFY_OPTIONS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1)
+
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -pthread -fno-strict-aliasing)
 
 list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -std=c++0x)

--- a/omrtrace/CMakeLists.txt
+++ b/omrtrace/CMakeLists.txt
@@ -40,6 +40,12 @@ if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(omrtrace PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
+# Avoid a problem verifying strncpys inlined to operate on array fields used
+# to implement variable length structs
+if (OMR_STRNCPY_FORTIFY_OPTIONS)
+	target_compile_options(omrtrace PRIVATE ${OMR_STRNCPY_FORTIFY_OPTIONS})
+endif()
+
 target_link_libraries(omrtrace
 	PUBLIC
 		omr_base


### PR DESCRIPTION
Fixes a problem with strncpy inlining in the omrtrace component
when the build type is Release. Without this fix, the following
error can occur on the Linux platform using the GNU toolchain:

In file included from /usr/include/string.h:635:0,
                 from omr/include_core/omrstdarg.h:27,
                 from omr/omrtrace/omrtracelog.cpp:25:
    In function ‘char* strncpy(char*, const char*, size_t)’,
       inlined from ‘OMR_TraceBuffer* getTrcBuf(OMR_TraceThread*, OMR_TraceBuffer*, int)’ at omr/omrtrace/omrtracelog.cpp:290:75:
    /usr/include/x86_64-linux-gnu/bits/string3.h:126:71: error: call to char* __builtin___strncpy_chk(char*, const char*, long unsigned int, long unsigned int) will always overflow destination buffer [-Werror]
      return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));

This problem was fixed in the autotools based makefiles by adding the
following compiler options: -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1

This commit causes the same options to be used in the CMake based build
for the omrtrace component when the GNU toolchain is used.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>