### PR TITLE
Remove support for multiple children for certain opcodes

### DIFF
--- a/compiler/arm/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/arm/codegen/ControlFlowEvaluator.cpp
@@ -1812,6 +1812,7 @@ static TR::Register *generateMaxMin(TR::Node *node, TR::CodeGenerator *cg, bool 
 
    TR_ARMConditionCode cond = max ? (isUnsigned ? ARMConditionCodeHI : ARMConditionCodeGT) : (isUnsigned ? ARMConditionCodeLS : ARMConditionCodeLT);
    int n = node->getNumChildren();
+   TR_ASSERT(n == 2, "Expected 2 children only");
    int i = 1;
    for ( ; i < n; i++)
       {

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -16948,6 +16948,7 @@ TR::Node *imaxminSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
 
    int32_t i = 0;
    int32_t num_children = node->getNumChildren();
+   TR_ASSERT(num_children == 2, "Expected 2 children only");
    int32_t min = 0, max = 0;
    uint32_t umin = 0, umax = 0;
    bool is_all_const = true;
@@ -17035,6 +17036,7 @@ TR::Node *lmaxminSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
    bool is_all_const = true;
    int32_t numNonConst = 0;
    int32_t num_children = node->getNumChildren();
+   TR_ASSERT(num_children == 2, "Expected 2 children only");
    int64_t min = 0, max = 0;
    uint64_t umin = 0, umax = 0;
    bool is_signed = node->getOpCodeValue() == TR::lmax || node->getOpCodeValue() == TR::lmin;
@@ -17114,6 +17116,7 @@ TR::Node *fmaxminSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
 
    int32_t i;
    int32_t num_children = node->getNumChildren();
+   TR_ASSERT(num_children == 2, "Expected 2 children only");
    bool has_const = false;
    bool is_all_const = true;
    int32_t numNonConst = 0;
@@ -17178,6 +17181,7 @@ TR::Node *dmaxminSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier *
 
    int32_t i;
    int32_t num_children = node->getNumChildren();
+   TR_ASSERT(num_children == 2, "Expected 2 children only");
    double min, max;
    uint64_t mini, maxi;
    bool has_const = false;

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3974,6 +3974,7 @@ static TR::Register *generateMaxMin(TR::Node *node, TR::CodeGenerator *cg, bool 
       }
 
    int n = node->getNumChildren();
+   TR_ASSERT(n == 2, "Expected 2 children only");
    for (int i = 1; i < n; i++)
       {
       TR::Node *child = node->getChild(i);


### PR DESCRIPTION
 Remove support for multiple children for the following opcodes:
```
TR::imax
TR::imin
TR::lmax
TR::lmin
TR::iumax
TR::iumin
TR::lumax
TR::lumin
TR::fmax
TR::fmin
TR::dmax
TR::dmin
```
 Replace `num_children` with a constant (2) in `imaxminSimplifier()`.
Replace `n` with `2` in `generateMaxMin()`.

Fixes #4176