### PR TITLE
AArch64: Fix register assignment for ARM64MemSrc1Instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.cpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.cpp
@@ -278,14 +278,8 @@ void TR::ARM64MemSrc1Instruction::assignRegisters(TR_RegisterKinds kindToBeAssig
    sourceVirtual->unblock();
 
    mref->blockRegisters();
-   TR::RealRegister *assignedRegister = sourceVirtual->getAssignedRealRegister();
-   if (assignedRegister == NULL)
-      {
-      assignedRegister = machine->assignOneRegister(this, sourceVirtual);
-      }
+   setSource1Register(machine->assignOneRegister(this, sourceVirtual));
    mref->unblockRegisters();
-
-   setSource1Register(assignedRegister);
 
    if (getDependencyConditions())
       getDependencyConditions()->assignPreConditionRegisters(this->getPrev(), kindToBeAssigned, cg());


### PR DESCRIPTION
This commit fixes the register assignment for the source1 register
in ARM64MemSrc1Instruction.
decFutureUseCount() was not called for the source1 register when
it had an assigned real register.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>