### PR TITLE
Change floating point min/max and double min/max to UnImpOpEvaluator on Z

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -810,15 +810,15 @@
    TR::TreeEvaluator::maxEvaluator,         // TR::iumax
    TR::TreeEvaluator::maxEvaluator,         // TR::lmax
    TR::TreeEvaluator::maxEvaluator,         // TR::lumax
-   TR::TreeEvaluator::maxEvaluator,         // TR::fmax
-   TR::TreeEvaluator::maxEvaluator,         // TR::dmax
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::fmax
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::dmax
 
    TR::TreeEvaluator::minEvaluator,         // TR::imin
    TR::TreeEvaluator::minEvaluator,         // TR::iumin
    TR::TreeEvaluator::minEvaluator,         // TR::lmin
    TR::TreeEvaluator::minEvaluator,         // TR::lumin
-   TR::TreeEvaluator::minEvaluator,         // TR::fmin
-   TR::TreeEvaluator::minEvaluator,         // TR::dmin
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::fmin
+   TR::TreeEvaluator::unImpOpEvaluator,     // TR::dmin
    TR::TreeEvaluator::trtEvaluator,         // TR::trt
    TR::TreeEvaluator::trtEvaluator,         // TR::trtSimple
 

--- a/fvtest/compilertriltest/MaxMinTest.cpp
+++ b/fvtest/compilertriltest/MaxMinTest.cpp
@@ -38,6 +38,32 @@ int64_t lmax(int64_t l, int64_t r) {
 int64_t lmin(int64_t l, int64_t r) {
   return std::min(l,r);
 }
+
+float f_max(float l, float r) {
+  return std::max(l,r);
+}
+
+float f_min(float l, float r) {
+  return std::min(l,r);
+}
+
+double dmax(double l, double r) {
+  return std::max(l,r);
+}
+
+double dmin(double l, double r) {
+  return std::min(l,r);
+}
+
+template <typename T>
+bool smallFp_filter(std::tuple<T, T> a)
+   {
+   // workaround: avoid failure caused by snprintf("%f")
+   auto a0 = std::get<0>(a);
+   auto a1 = std::get<1>(a);
+   return ((std::abs(a0) < 0.01 && a0 != 0.0) || (std::abs(a1) < 0.01 && a1 != 0.0));
+   }
+
 class Int32MaxMin : public TRTest::BinaryOpTest<int32_t> {};
 
 TEST_P(Int32MaxMin, UsingConst) {
@@ -159,3 +185,138 @@ INSTANTIATE_TEST_CASE_P(MaxMin, Int64MaxMin, ::testing::Combine(
     ::testing::Values(
         std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmax", lmax),
         std::make_tuple<const char*, int64_t(*)(int64_t, int64_t)>("lmin", lmin))));
+
+class FloatMaxMin : public TRTest::BinaryOpTest<float> {};
+
+TEST_P(FloatMaxMin, UsingConst) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+        << "The " << arch << " code generator currently doesn't support fmax/fmin (see issue #4276)";
+    auto param = TRTest::to_struct(GetParam());
+    char inputTrees[1024] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Float"
+        "  (block"
+        "    (freturn"
+        "      (%s"
+        "        (fconst %f )"
+        "        (fconst %f ))"
+        ")))",
+        param.opcode.c_str(),
+        param.lhs,
+        param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<float (*)(void)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point());
+}
+
+TEST_P(FloatMaxMin, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+        << "The " << arch << " code generator currently doesn't support fmax/fmin (see issue #4276)";
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[1024] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Float args=[Float, Float]"
+        "  (block"
+        "    (freturn"
+        "      (%s"
+        "        (fload parm=0)"
+        "        (fload parm=1))"
+        ")))",
+        param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<float (*)(float, float)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+
+INSTANTIATE_TEST_CASE_P(MaxMin, FloatMaxMin, ::testing::Combine(
+    ::testing::ValuesIn(
+        TRTest::filter(TRTest::const_value_pairs<float, float>(), smallFp_filter<float>)),
+    ::testing::Values(
+        std::make_tuple<const char*, float(*)(float, float)>("fmax", f_max),
+        std::make_tuple<const char*, float(*)(float, float)>("fmin", f_min))));
+
+class DoubleMaxMin : public TRTest::BinaryOpTest<double> {};
+
+TEST_P(DoubleMaxMin, UsingConst) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+        << "The " << arch << " code generator currently doesn't support dmax/dmin (see issue #4276)";
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[1024] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Double"
+        "  (block"
+        "    (dreturn"
+        "      (%s"
+        "        (dconst %f )"
+        "        (dconst %f ))"
+        ")))",
+        param.opcode.c_str(),
+        param.lhs,
+        param.rhs);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<double (*)(void)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point());
+}
+
+TEST_P(DoubleMaxMin, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch || OMRPORT_ARCH_HAMMER == arch || OMRPORT_ARCH_AARCH64 == arch, KnownBug)
+        << "The " << arch << " code generator currently doesn't support dmax/dmin (see issue #4276)";
+    auto param = TRTest::to_struct(GetParam());
+
+    char inputTrees[1024] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Double args=[Double, Double]"
+        "  (block"
+        "    (dreturn"
+        "      (%s"
+        "        (dload parm=0)"
+        "        (dload parm=1))"
+        ")))",
+        param.opcode.c_str());
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<double (*)(double, double)>();
+    ASSERT_EQ(param.oracle(param.lhs, param.rhs), entry_point(param.lhs, param.rhs));
+}
+
+
+INSTANTIATE_TEST_CASE_P(MaxMin, DoubleMaxMin, ::testing::Combine(
+    ::testing::ValuesIn(
+        TRTest::filter(TRTest::const_value_pairs<double, double>(), smallFp_filter<double>)),
+    ::testing::Values(
+        std::make_tuple<const char*, double(*)(double, double)>("dmax", dmax),
+        std::make_tuple<const char*, double(*)(double, double)>("dmin", dmin))));


### PR DESCRIPTION
Change evaluator for `fmax`, `fmin`, `dmax` and `dmin` from `maxEvaluator` to `UnImpOpEvaluator`.

Add Tril tests for `fmax`, `fmin`, `dmax` and `dmin`.

Fixes #4176
