### PR TITLE
Replace REGPAIR_THIS macro with self()

### DIFF
--- a/compiler/codegen/OMRRegisterPair.cpp
+++ b/compiler/codegen/OMRRegisterPair.cpp
@@ -43,7 +43,7 @@ void OMR::RegisterPair::unblock()
 
 bool OMR::RegisterPair::usesRegister(TR::Register* reg)
    {
-   if (REGPAIR_THIS == reg || _lowOrder == reg || _highOrder == reg )
+   if (self() == reg || _lowOrder == reg || _highOrder == reg )
       {
       return true;
       }
@@ -92,6 +92,11 @@ OMR::RegisterPair::getRegister()
 TR::RegisterPair *
 OMR::RegisterPair::getRegisterPair()
    {
-   return REGPAIR_THIS;
+   return self();
    }
 
+TR::RegisterPair *
+OMR::RegisterPair::self()
+   {
+   return static_cast<TR::RegisterPair*>(this);
+   }

--- a/compiler/codegen/OMRRegisterPair.hpp
+++ b/compiler/codegen/OMRRegisterPair.hpp
@@ -39,7 +39,6 @@ namespace OMR { typedef OMR::RegisterPair RegisterPairConnector; }
 namespace TR { class CodeGenerator; }
 namespace TR { class RegisterPair; }
 
-#define REGPAIR_THIS static_cast<TR::RegisterPair*>(this)
 template<typename QueueKind> class TR_Queue;
 
 namespace OMR
@@ -72,6 +71,8 @@ class OMR_EXTENSIBLE RegisterPair : public TR::Register
    private:
    TR::Register *_lowOrder;
    TR::Register *_highOrder;
+
+   TR::RegisterPair *self();
    };
 
 }


### PR DESCRIPTION
Remove `REGPAIR_THIS` macro.
Add `self()` as a private method for `RegisterPair

Fixes #3969