### PR TITLE
Added ccls-cache and compile_commands.json into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,12 @@ x64/
 # CLion
 .idea/
 
+# CCLS (language server for C/C++)
+.ccls-cache/
+
+# config cmake file for vim autocompletion
+compile_commands.json
+
 # Test Output
 core
 core.*


### PR DESCRIPTION
Folder ccls-cache and compile_commands.json used by Vim for autocompletion.

Closes: #4270

Signed-off-by: Batyr Nuryyev <nuryyev@ualberta.ca>