### PR TITLE
AArch64: Add addToAtlas() in doBinaryEncoding()

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -263,6 +263,7 @@ OMR::ARM64::CodeGenerator::doBinaryEncoding()
    while (cursorInstruction)
       {
       self()->setBinaryBufferCursor(cursorInstruction->generateBinaryEncoding());
+      self()->addToAtlas(cursorInstruction);
       cursorInstruction = cursorInstruction->getNext();
       }
    }


### PR DESCRIPTION
This commit adds a call to missing addToAtlas() in doBinaryEncoding()
for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>