### PR TITLE
Update hook tracepoint threshold to microsecond instead of millisecond

### DIFF
--- a/include_core/omrhookable.h
+++ b/include_core/omrhookable.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -76,7 +76,7 @@ typedef struct J9HookInterface {
 #define J9HOOK_AGENTID_LAST  ((uintptr_t)-1)
 
 /* time threshold (=100 milliseconds) for triggering the tracepoint  */
-#define OMRHOOK_DEFAULT_THRESHOLD_IN_MILLISECONDS_WARNING_CALLBACK_ELAPSED_TIME	100
+#define OMRHOOK_DEFAULT_THRESHOLD_IN_MICROSECONDS_WARNING_CALLBACK_ELAPSED_TIME	(100 * 1000)
 
 /* array of OMREventInfo4Dump is added in individual hookInterface by Hook generation tool to avoid
    rumtime native memory allocation(malloc), use this macro to access &infos4Dump[event]

--- a/util/hookable/hookable.cpp
+++ b/util/hookable/hookable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2017 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -141,7 +141,7 @@ J9HookInitializeInterface(struct J9HookInterface **hookInterface, OMRPortLibrary
 
 	commonInterface->nextAgentID = J9HOOK_AGENTID_DEFAULT + 1;
 	commonInterface->portLib = portLib;
-	commonInterface->threshold4Trace = OMRHOOK_DEFAULT_THRESHOLD_IN_MILLISECONDS_WARNING_CALLBACK_ELAPSED_TIME;
+	commonInterface->threshold4Trace = OMRHOOK_DEFAULT_THRESHOLD_IN_MICROSECONDS_WARNING_CALLBACK_ELAPSED_TIME;
 
 	commonInterface->eventSize = (interfaceSize - sizeof(J9CommonHookInterface)) / (sizeof(U_8) + sizeof(OMREventInfo4Dump) + sizeof(J9HookRecord*));
 	return 0;


### PR DESCRIPTION
	- measurement time has been changed from ms to us for
	increased precision in Hook tracepoint(Pull request#4221).
	- need to update the default tracepoint threshold to microsecond
	to avoid triggering warning too frequent.

	related: eclipse/omr#4221

Signed-off-by: Lin Hu <linhu@ca.ibm.com>