### PR TITLE
Fix TR::sucmpeq evaluator

### DIFF
--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -2239,7 +2239,7 @@ TR::Register *OMR::X86::TreeEvaluator::sucmpeqEvaluator(TR::Node *node, TR::Code
    if (cg->enableRegisterInterferences())
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(targetRegister);
 
-   generateRegInstruction(SETNE1Reg, node, targetRegister, cg);
+   generateRegInstruction(node->getOpCodeValue() == TR::sucmpeq ? SETE1Reg : SETNE1Reg, node, targetRegister, cg);
    generateRegRegInstruction(MOVZXReg4Reg1, node, targetRegister, targetRegister, cg);
    return targetRegister;
    }


### PR DESCRIPTION
sucmpeq evaluator is used to evaluate both sucmpeq and sucmpne
and Codegen fails when CFGSimplifier was performed generating 
setne regardless of evaluation. Added Boolean to properly select
correct sete/ne instruction.  

Signed-off-by: Jacob Nauenberg <jacob.nauenberg@ibm.com>