### PR TITLE
Option to sort Tail Candidate List by free size

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -750,6 +750,12 @@ public:
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 	bool _isConcurrentCopyForward;
 #endif
+	enum TarokRegionTailCondidateListSortOrder {
+		SORT_ORDER_NOORDER = 0,
+		SORT_ORDER_ASCENDING,
+		SORT_ORDER_DESCENDING
+	};
+	TarokRegionTailCondidateListSortOrder tarokTailCandidateListSortOrder;
 #endif /* defined (OMR_GC_VLHGC) */
 
 /* OMR_GC_VLHGC (in for all -- see 82589) */
@@ -1727,6 +1733,7 @@ public:
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 		, _isConcurrentCopyForward(false)
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
+		, tarokTailCandidateListSortOrder(SORT_ORDER_NOORDER)
 #endif /* defined (OMR_GC_VLHGC) */
 		, tarokEnableExpensiveAssertions(false)
 		, sweepPoolManagerAddressOrderedList(NULL)


### PR DESCRIPTION
	tail candidate list is created for reusing free space of survivor
	regions and tenure regions. sort the list Ascending or Descending
	might help reduce fragmentation or increasing Cache locality.
	- add global variable tarokTailCandidateListSortOrder
	the variable can be set Ascending, Descending or no order.
	- default is no order.

Signed-off-by: Lin Hu <linhu@ca.ibm.com>