### PR TITLE
Recover Region tail during post-sweep of GMP

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -747,14 +747,13 @@ public:
 	double tarokConcurrentMarkingCostWeight; /**< How much we weigh concurrentMarking into our GMP scan time cost calculations */
 	bool tarokAutomaticDefragmentEmptinessThreshold; /**< Whether we should use the automatically derived value for tarokDefragmentEmptinessThreshold or not */
 	bool tarokEnableCopyForwardHybrid; /**< Enable CopyForward Hybrid mode */
-
 	enum ReserveRegions {
 		RESERVE_REGIONS_NO = 0,
 		RESERVE_REGIONS_MOST_ALLOCATABLE,
 		RESERVE_REGIONS_MOST_FREE
 	};
 	ReserveRegions tarokReserveRegionsFromCollectionSet;
-
+	bool tarokEnableRecoverRegionTailsAfterSweep; /**< Enable recovering region tail during post sweep of GMP */
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 	bool _isConcurrentCopyForward;
 #endif
@@ -768,6 +767,7 @@ public:
 
 /* OMR_GC_VLHGC (in for all -- see 82589) */
 	bool tarokEnableExpensiveAssertions; /**< True if the collector should perform extra consistency verifications which are known to be very expensive or poorly parallelized */
+	bool tarokEnableAllocationPointerAssertion;
 /* OMR_GC_VLHGC (in for all) */
 
 	MM_SweepPoolManagerAddressOrderedList* sweepPoolManagerAddressOrderedList; /**< Pointer to Sweep Pool Manager for MPAOL, used for LOA and nursery */
@@ -1739,12 +1739,14 @@ public:
 		, tarokAutomaticDefragmentEmptinessThreshold(false)
 		, tarokEnableCopyForwardHybrid(true)
 		, tarokReserveRegionsFromCollectionSet(RESERVE_REGIONS_NO)
+		, tarokEnableRecoverRegionTailsAfterSweep(false)
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 		, _isConcurrentCopyForward(false)
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 		, tarokTailCandidateListSortOrder(SORT_ORDER_NOORDER)
 #endif /* defined (OMR_GC_VLHGC) */
 		, tarokEnableExpensiveAssertions(false)
+		, tarokEnableAllocationPointerAssertion(false)
 		, sweepPoolManagerAddressOrderedList(NULL)
 		, sweepPoolManagerSmallObjectArea(NULL)
 		, sweepPoolManagerBumpPointer(NULL)


### PR DESCRIPTION
	region tail point to the last freespace which connect to region top,
	can be reused as survivor or tenure space during copyforward.
	the first sweep after GMP does reset all of region tails.
	recover region tails during post-sweep could reduce copyforward
	abort cases.

	- global variable tarokEnableRecoverRegionTailsAfterSweep for
	 enabling/disabling recover region tails during post-sweep.
	- global variable tarokEnableAllocationPointerAssertion for
	enabling verifying recovered tails.
	- add freeList and last free entry in MemoryPoolBumpPointe.r
	- generate freelist during sweep(for MemoryPoolBumpPointer).

Signed-off-by: Lin Hu <linhu@ca.ibm.com>