### PR TITLE
Reserve the region from CollectionSet

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -747,6 +747,14 @@ public:
 	double tarokConcurrentMarkingCostWeight; /**< How much we weigh concurrentMarking into our GMP scan time cost calculations */
 	bool tarokAutomaticDefragmentEmptinessThreshold; /**< Whether we should use the automatically derived value for tarokDefragmentEmptinessThreshold or not */
 	bool tarokEnableCopyForwardHybrid; /**< Enable CopyForward Hybrid mode */
+
+	enum ReserveRegions {
+		RESERVE_REGIONS_NO = 0,
+		RESERVE_REGIONS_MOST_ALLOCATABLE,
+		RESERVE_REGIONS_MOST_FREE
+	};
+	ReserveRegions tarokReserveRegionsFromCollectionSet;
+
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 	bool _isConcurrentCopyForward;
 #endif
@@ -1730,6 +1738,7 @@ public:
 		, tarokConcurrentMarkingCostWeight(0.05)
 		, tarokAutomaticDefragmentEmptinessThreshold(false)
 		, tarokEnableCopyForwardHybrid(true)
+		, tarokReserveRegionsFromCollectionSet(RESERVE_REGIONS_NO)
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
 		, _isConcurrentCopyForward(false)
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */


### PR DESCRIPTION
	for Balanced Partial Garbage Collection, all of eden regions(
	age0 and age1) and partial of survivor regions would be selected
	as collection set, some of those regions have a large freespace,
	which could be used as survivor region .perpare reserve list
	("most freespace" for each age region) during pre-collection,
	keep them as candidate of the survivors in order to avoid
	potential copyforward abort case.

	- new global variable tarokReserveRegionsFromCollectionSet for
	deciding if reserving regions from collection set.
	(can be RESERVE_REGIONS_MOST_ALLOCATABLE, RESERVE_REGIONS_MOST_FREE,
	RESERVE_REGIONS_NO(default)).

Signed-off-by: Lin Hu <linhu@ca.ibm.com>