### PR TITLE
AArch64: Skip interp->jit arg loading in recursive call

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -74,6 +74,8 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
       if (cg()->comp()->isRecursiveMethodTarget(sym))
          {
          intptrj_t jitToJitStart = (intptrj_t)cg()->getCodeStart();
+         // how many bytes to skip loading interp->jit argument
+         jitToJitStart += ((*(int32_t *)(jitToJitStart - 4)) >> 16) & 0xFFFF;
          TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange(jitToJitStart, (intptrj_t)cursor),
                          "Target address is out of range");
 


### PR DESCRIPTION
This commit adjusts the target address of "bl" instruction when it
is used for a recursive call, so that it can skip the instructions
for loading method arguments from Java stack into registers for
interp->jit transition.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>