### PR TITLE
Remove object pointer from Object Scanner

### DIFF
--- a/example/glue/MixedObjectScanner.hpp
+++ b/example/glue/MixedObjectScanner.hpp
@@ -47,7 +47,7 @@ protected:
 	 * @param[in] flags Scanning context flags
 	 */
 	MMINLINE GC_MixedObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, uintptr_t flags)
-		: GC_ObjectScanner(env, objectPtr, (fomrobject_t *)objectPtr + 1, 0, flags, 0)
+		: GC_ObjectScanner(env, (fomrobject_t *)objectPtr + 1, 0, flags)
 		, _endPtr((fomrobject_t *)((uint8_t*)objectPtr + MM_GCExtensionsBase::getExtensions(env->getOmrVM())->objectModel.getConsumedSizeInBytesWithHeader(objectPtr)))
 		, _mapPtr(_scanPtr)
 	{

--- a/gc/base/IndexableObjectScanner.hpp
+++ b/gc/base/IndexableObjectScanner.hpp
@@ -31,6 +31,7 @@ class GC_IndexableObjectScanner : public GC_ObjectScanner
 private:
 
 protected:
+	omrobjectptr_t _arrayPtr; /**< pointer to array */
 	fomrobject_t *_endPtr; /**< pointer to end of last array element in scan segment */
 	fomrobject_t *_basePtr; /**< pointer to base array element */
 	fomrobject_t *_limitPtr; /**< pointer to end of last array element */
@@ -64,13 +65,8 @@ protected:
 		, uintptr_t elementSize
 		, uintptr_t flags
 	)
-		: GC_ObjectScanner(
-			env
-			, arrayPtr
-			, scanPtr
-			, scanMap
-			, flags | GC_ObjectScanner::indexableObject
-		)
+		: GC_ObjectScanner(env, arrayPtr, scanPtr, scanMap, flags | GC_ObjectScanner::indexableObject)
+		, _arrayPtr(arrayPtr)
 		, _endPtr(endPtr)
 		, _basePtr(basePtr)
 		, _limitPtr(limitPtr)
@@ -106,6 +102,11 @@ public:
 	 * must be called if this scanner cannot be split to hive off the tail
 	 */
 	MMINLINE void scanToLimit() { _endPtr = _limitPtr; }
+
+	/**
+	* Return pointer to array object
+	*/
+	MMINLINE omrobjectptr_t const getArrayObject() { return _arrayPtr; }
 
 	/**
 	 * Split this instance and set split scan/end pointers to indicate split scan range.

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -1612,7 +1612,7 @@ MM_Scavenger::splitIndexableObjectScanner(MM_EnvironmentStandard *env, GC_Object
 			MM_CopyScanCacheStandard* splitCache = getFreeCache(env);
 			if (NULL != splitCache) {
 				/* set up the split copy cache and clone the object scanner into the cache */
-				omrarrayptr_t arrayPtr = (omrarrayptr_t)objectScanner->getParentObject();
+				omrarrayptr_t arrayPtr = (omrarrayptr_t)indexableScanner->getArrayObject();
 				void* arrayTop = (void*)((uintptr_t)arrayPtr + _extensions->indexableObjectModel.getSizeInBytesWithHeader(arrayPtr));
 				reinitCache(splitCache, (omrobjectptr_t)arrayPtr, arrayTop);
 				splitCache->cacheAlloc = splitCache->cacheTop;
@@ -1675,9 +1675,10 @@ MM_Scavenger::scavengeObjectSlots(MM_EnvironmentStandard *env, MM_CopyScanCacheS
 	}
 
 #if defined(OMR_GC_MODRON_SCAVENGER_STRICT)
-	Assert_MM_true(objectPtr == objectScanner->getParentObject());
-	if (NULL != scanCache) {
-		Assert_MM_true(objectScanner->isIndexableObject() == (scanCache->isSplitArray() && (0 < scanCache->_arraySplitIndex)));
+	if ((NULL != scanCache) && objectScanner->isIndexableObject()) {
+		GC_IndexableObjectScanner *indexableScanner = (GC_IndexableObjectScanner *)objectScanner;
+		Assert_MM_true(objectPtr == indexableScanner->getArrayObject());
+		Assert_MM_true(scanCache->isSplitArray() && (0 < scanCache->_arraySplitIndex));
 		Assert_MM_true(rememberedSetSlot == scanCache->_arraySplitRememberedSlot);
 	}
 #endif /* defined(OMR_GC_MODRON_SCAVENGER_STRICT) */
@@ -1817,8 +1818,9 @@ MM_Scavenger::incrementalScavengeObjectSlots(MM_EnvironmentStandard *env, omrobj
 
 #if defined(OMR_GC_MODRON_SCAVENGER_STRICT)
 	if (scanCache->isSplitArray()) {
+		GC_IndexableObjectScanner *indexableScanner = (GC_IndexableObjectScanner *)objectScanner;
 		Assert_MM_true(objectScanner->isIndexableObject());
-		Assert_MM_true(objectPtr == objectScanner->getParentObject());
+		Assert_MM_true(objectPtr == indexableScanner->getArrayObject());
 		Assert_MM_true(0 < scanCache->_arraySplitIndex);
 	} else {
 		Assert_MM_true(0 == scanCache->_arraySplitIndex);


### PR DESCRIPTION
Currently GC_ObjectScanner has slot _parentObjectPtr to store pointer to
header of scanned object. This slot is used for Scan Cache
initialization for split array in Scavenger.
So there is no real use for this field for GC_ObjectScanner or it's
Mixed Object scanners children. In case we need to scan Headless Mixed
object an address of object header is even not available (as far as
there is no any). So the proposal is to move it to
GC_IndexableObjectScanner with renaming of field (_parentObjectPtr to
_arrayPtr) and correspondent function (getParentObject() to
getArrayObject())

This change required a silo dance, so this is first step of three:
- add new constructor to GC_ObjectScanner
- add _arrayPtr field to GC_IndexableObjectScanner
- replace getParentObject() to getArrayObject()
- remove definition of getParentObject()

Note: GC_IndexableObjectScanner has to use old type of GC_ObjectScanner
as far as it still be used in OpenJ9

Second step of change would be modifications in OpenJ9
Third step of change would be clean up of OMR code.

Another minor change is removing _hotFieldsDescriptor. This slot is not
used.


Signed-off-by: Dmitri Pivkine <Dmitri_Pivkine@ca.ibm.com>