### PR TITLE
Use CMake for z/OS Build pipeline

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-zos_390-64
+++ b/buildenv/jenkins/jobs/builds/Build-zos_390-64
@@ -13,7 +13,7 @@ def setBuildStatus(String message, String state, String sha) {
 pipeline {
     agent{label 'zOS && 390'}
     environment {
-        PATH = "/u/open1/rocket/bin:$PATH"
+        LIBPATH=".:$LIBPATH"
     }
     stages {
         stage('Get Sources') {
@@ -28,26 +28,22 @@ pipeline {
         stage('Build') {
             steps {
                 timestamps {
-                    //echo 'Output CCACHE stats before running and clear them'
-                    //echo '''ccache -s -z'''
-                    
-                    echo 'Configure...'
-                    //TODO remove the EXTRA_CONFIGURE_ARGS once #1560 is merged
-                    sh'''make -f run_configure.mk OMRGLUE=./example/glue SPEC=zos_390-64 EXTRA_CONFIGURE_ARGS=--disable-warnings-as-errors'''
-                    
-                    echo 'Compile...'
-                    sh'''make -j4'''
-                    
-                    //echo 'Output CCACHE stats after running'
-                    //sh '''ccache -s'''
+                    dir('build') {
+                        echo 'Configure...'
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DCMAKE_C_COMPILER=/bin/c89 -DCMAKE_CXX_COMPILER=/bin/xlc -DOMR_DDR=OFF -DOMR_THR_FORK_SUPPORT=0 ..'''
+                        echo 'Compile...'
+                        sh '''make -j4'''
+                    }
                 }
             }
         }
         stage('Test') {
             steps {
                 timestamps {
-                    echo "Sanity Test..."
-                    sh'''make SPEC=zos_390-64 -j1 test'''
+                    dir('build') {
+                        echo "Sanity Test..."
+                        sh'''./omralgotest -avltest:fvtest/algotest/avltest.lst && ./omrvmtest && ./omrutiltest && ./omrsigtest && ./omrrastest && ./omrsubscribertest && ./omrtraceoptiontest'''
+                    }
                 }
             }
         }


### PR DESCRIPTION
Synchronize the PullRequest and Build pipelines to use the same method
of building and testing commits. The current state of the z/OS builds
as seen in [1] is not great as they're more or less always failing
because we are not running the same set of tests which get tested via
PRs. This commit synchronizes so we test the exact same thing,
similarly to what we do on all the other platforms.

[1] https://github.com/eclipse/omr/commits/master

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>