### PR TITLE
Improve rotate then insert selected bits on Z

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -235,13 +235,23 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
     *
     *   \param cg
     *      The code generator used to generate the instructions
+    * 
+    *    \param shiftAmount
+    *      The number of bits we should shift the result of the logical AND. A positive value represents a left shift,
+    *      a negative value represents a right shift, and a value of zero represents no shift.
+    *      Note that if the absolute value of number is greater than 6 bits, then this optimization will not work
+    *      since the RISBG instruction will only hold 6 bits for the shift operand.
+    * 
+    *   \param isSignedShift
+    *      If replacing a signed shift+and combination, this variable evaluates to true. Else it will evaluate to false.
+    *      Note: If we are using this function to replace a standalone 'and', then this variable should be false.
     *
     *   \return
     *      The target register for the instruction, or NULL if generating a 
     *      RISBG instruction is not suitable
     *
     */
-   static TR::Register *tryToReplaceLongAndWithRotateInstruction(TR::Node * node, TR::CodeGenerator * cg);
+   static TR::Register *tryToReplaceShiftLandWithRotateInstruction(TR::Node * node, TR::CodeGenerator * cg, int32_t shiftAmount, bool isSignedShift);
 
    static TR::Register *bandEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *sandEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -1018,13 +1018,26 @@ std::vector<T> test_masks();
 static uint64_t mask64Values[] =
     {
     0x0000000000000000,
-    0xffffffffffffffff,
+    0x0000000000000001,
+    0x0000000000000002,
+    0x000000000000003e,
+    0x000000000000ffff,
+    0x00000000ffffffff,
+    0x00000003c0000000,
+    0x0000003f00000000,
+    0x00007fffffffffff,
+    0x4000000000000000,
+    0x4000000000000001,
+    0x7000000000000000,
+    0x7c00000000000000,
     0x7fffffffffffffff,
     0x8000000000000000,
-    0x0000003f00000000,
+    0x8000000000000002,
+    0xf0f0f0f0f0f0f0f0,
+    0xffff000000000000,
     0xffffffff00000000,
-    0x00000000ffffffff,
-    0xffff00000000ffff
+    0xffffffffffff0000,
+    0xffffffffffffffff
     };
 
 template <>
@@ -1132,6 +1145,20 @@ T mask_then_shift_right(T value, T mask, int32_t shift)
     }
 
 template <typename T>
+T mask_then_shift_left(T value, T mask, int32_t shift)
+    {
+    if (sizeof(T) <= sizeof(int32_t))
+        {
+        shift &= (shift & (8 * sizeof(int32_t) - 1));
+        }
+    else
+        {
+        shift &= (8 * sizeof(int64_t) - 1);
+        }
+    return (value & mask) << shift;
+    }
+
+template <typename T>
 struct MaskThenShiftParamStruct {
     T value;
     T mask;
@@ -1223,7 +1250,9 @@ TEST_P(Int64MaskThenShift, UsingLoadParam) {
 
 INSTANTIATE_TEST_CASE_P(ShiftAndRotateTest, Int64MaskThenShift, ::testing::Combine(
     ::testing::ValuesIn(static_cast< std::vector<std::tuple<std::tuple<int64_t, int64_t>, int32_t>> (*) (void)>(test_mask_then_shift_values)()),
-    ::testing::Values(std::make_tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshr", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_right))
+    ::testing::Values(
+        std::make_tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshr", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_right)),
+        std::make_tuple<const char*, int64_t (*) (int64_t, int64_t, int32_t)>("lshl", static_cast<int64_t (*) (int64_t, int64_t, int32_t)>(mask_then_shift_left))
     )));
 
 class UInt32MaskThenShift : public MaskThenShiftArithmetic<uint32_t> {};


### PR DESCRIPTION
Add a case in genericLongShiftSingle that would generate
a RISBG command for a LSHR->LAND pattern

Add a similar case for LSHL->LAND pattern

Add a similar case for the unsigned variants of the
instruction(LUSHR and LUSHL)

Rename tryToReplaceLongAndWithRotateInstruction() to
tryToReplaceShiftLandWithRotateInstruction()

Allocate target register properly in
tryToReplaceShiftLandWithRotateInstruction()

Add respective Tril test for these changes

Fixes #3212

Signed-off-by: Aidan Ha <qbha@edu.uwaterloo.ca>