### PR TITLE
Add self method to ClassEnv

### DIFF
--- a/compiler/env/OMRClassEnv.cpp
+++ b/compiler/env/OMRClassEnv.cpp
@@ -27,6 +27,12 @@
 #include "infra/Assert.hpp"
 #include "compile/Compilation.hpp"
 
+TR::ClassEnv *
+OMR::ClassEnv::self()
+   {
+   return static_cast<TR::ClassEnv *>(this);
+   }
+
 char *
 OMR::ClassEnv::classNameChars(TR::Compilation *comp, TR::SymbolReference *symRef, int32_t & len)
    {

--- a/compiler/env/OMRClassEnv.hpp
+++ b/compiler/env/OMRClassEnv.hpp
@@ -36,6 +36,7 @@ namespace OMR { typedef OMR::ClassEnv ClassEnvConnector; }
 #include "env/jittypes.h"
 
 struct OMR_VMThread;
+namespace TR { class ClassEnv; }
 namespace TR { class Compilation; }
 namespace TR { class SymbolReference; }
 class TR_ResolvedMethod;
@@ -47,6 +48,8 @@ namespace OMR
 class OMR_EXTENSIBLE ClassEnv
    {
 public:
+
+   TR::ClassEnv *self();
 
    // Are classes allocated on the object heap?
    //


### PR DESCRIPTION
New member functions are being added
to `J9::ClassEnv` (eclipse/openj9#7018)
In order for member functions to be called
without using the implicit `this` pointer,
add `self()` method to the extensible class `ClassEnv`.

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>