### PR TITLE
WIP Replaced depreciated opCodes sucmpeq/ne with equivalent scmpeq/ne

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -13140,7 +13140,7 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       }
 
    if (node->getOpCodeValue() == TR::ificmpeq)
-      intCompareNarrower(node, s, TR::ifsucmpeq, TR::ifscmpeq, TR::ifbcmpeq);
+      intCompareNarrower(node, s, TR::ifscmpeq, TR::ifscmpeq, TR::ifbcmpeq);
    else
       unsignedIntCompareNarrower(node, s, TR::ifscmpeq, TR::ifbcmpeq);
 
@@ -13245,7 +13245,7 @@ TR::Node *ificmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       }
 
    if (node->getOpCodeValue() == TR::ificmpne)
-      intCompareNarrower(node, s, TR::ifsucmpne, TR::ifscmpne, TR::ifbcmpne);
+      intCompareNarrower(node, s, TR::ifscmpne, TR::ifscmpne, TR::ifbcmpne);
    else
       unsignedIntCompareNarrower(node, s, TR::ifscmpne, TR::ifbcmpne);
 
@@ -13467,7 +13467,7 @@ TR::Node *iflcmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
 
    if (node->getOpCodeValue() == TR::iflcmpeq)
       {
-      longCompareNarrower(node, s, TR::ificmpeq, TR::ifsucmpeq, TR::ifscmpeq, TR::ifbcmpeq);
+      longCompareNarrower(node, s, TR::ificmpeq, TR::ifscmpeq, TR::ifscmpeq, TR::ifbcmpeq);
       }
 
    removeArithmeticsUnderIntegralCompare(node, s);
@@ -13505,7 +13505,7 @@ TR::Node *iflcmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
 
    if (node->getOpCodeValue() == TR::iflcmpne)
       {
-      longCompareNarrower(node, s, TR::ificmpne, TR::ifsucmpne, TR::ifscmpne, TR::ifbcmpne);
+      longCompareNarrower(node, s, TR::ificmpne, TR::ifscmpne, TR::ifscmpne, TR::ifbcmpne);
       }
    addressCompareConversion(node, s);
    removeArithmeticsUnderIntegralCompare(node, s);


### PR DESCRIPTION
Since compares for equality are the same between signed and unsigned
values, sucmpeq/ne is redundant. Actually refactoring the functions
intCompareNarrow and longCompareNarrow to handle the equality test
opCode would take more time and resources so passing in scmpeq/ne
 twice is an alternative fix.

Signed-off-by: Jacob Nauenberg <jacob.nauenberg@ibm.com>