### PR TITLE
Remove cfnan and cdnan pseudoinstructions

### DIFF
--- a/compiler/il/OMRDataTypes.hpp
+++ b/compiler/il/OMRDataTypes.hpp
@@ -82,7 +82,7 @@ typedef int32_t CASECONST_TYPE;
 #define DOUBLE_NAN            DOUBLE_ORDER(((uint64_t)0x7FF80000)<<32)
 
 #define DOUBLE_NAN_1_LOW      ((uint64_t)((((uint64_t)0x7FF00000)<<32)+1))
-#define DOUBLE_NAN_1_HIGH     ((uint64_t)TR::getMaxSigned<TR::Int32>())
+#define DOUBLE_NAN_1_HIGH     ((uint64_t)TR::getMaxSigned<TR::Int64>())
 #define DOUBLE_NAN_2_LOW      ((uint64_t)((((uint64_t)0xFFF00000)<<32)+1))
 #define DOUBLE_NAN_2_HIGH     ((uint64_t)((int64_t)-1))
 #define IN_DOUBLE_NAN_1_RANGE(d) (DOUBLE_ORDER(d) >= DOUBLE_NAN_1_LOW && DOUBLE_ORDER(d) <= DOUBLE_NAN_1_HIGH)

--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -566,8 +566,6 @@
    ldiv,             // long divide for 64 bit target
    irem,             // integer remainder
    lrem,             // long remainder for 64 bit target
-   cdnan,            // canonise double NaN to 0x7ff80..0 (in gprs)
-   cfnan,            // canonise float NaN to 0x7fc00..0 (in gprs)
    d2i,              // converts from double to integer
    d2l,              // converts from double to long
    ifx,              // compare and branch complex

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -6027,26 +6027,6 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::cdnan,
-   /* .name        = */ "cdnan",
-   /* .description =    "canonise double NaN to 0x7ff80..0 (in gprs)", */
-   /* .opcode      = */ 0x00000000,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_None,
-   },
-
-   {
-   /* .mnemonic    = */ OMR::InstOpCode::cfnan,
-   /* .name        = */ "cfnan",
-   /* .description =    "canonise float NaN to 0x7fc00..0 (in gprs)", */
-   /* .opcode      = */ 0x00000000,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_None,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::d2i,
    /* .name        = */ "d2i",
    /* .description =    "converts from double to integer", */

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -963,12 +963,6 @@ int32_t TR::PPCControlFlowInstruction::estimateBinaryLength(int32_t currentEstim
       case TR::InstOpCode::lcmp:
          setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 11);
          break;
-      case TR::InstOpCode::cfnan:
-         setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 2);
-         break;
-      case TR::InstOpCode::cdnan:
-         setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH * 3);
-         break;
       default:
          TR_ASSERT(false,"unknown control flow instruction (estimateBinaryLength)");
       }

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1479,32 +1479,6 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
             }
          cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
          break;
-      case TR::InstOpCode::cfnan:
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
-            // use PPC AS branch hint
-            cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, PPCOpProp_BranchLikely, currentNode, label2, getSourceRegister(1), cursor));
-         else
-            cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, currentNode, label2, getSourceRegister(1), cursor));
-         cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::lis, currentNode, getTargetRegister(0), 0x7fc0, cursor));
-         cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
-         break;
-      case TR::InstOpCode::cdnan:
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
-            // use PPC AS branch hint
-            cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, PPCOpProp_BranchLikely, currentNode, label2, getSourceRegister(0), cursor));
-         else
-            cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, currentNode, label2, getSourceRegister(0), cursor));
-         if (TR::Compiler->target.is64Bit())
-            {
-            cg()->traceRAInstruction(cursor = loadConstant(cg(), currentNode, (int64_t)CONSTANT64(0x7ff8000000000000), getTargetRegister(0), cursor));
-            }
-         else
-            {
-            cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::lis, currentNode, getTargetRegister(1), 0x7ff8, cursor));
-            cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(0), 0, cursor));
-            }
-         cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
-         break;
       case TR::InstOpCode::d2i:
          cg()->traceRAInstruction(cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::fcmpu, currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(0), cursor));
          cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::fctiwz, currentNode, getTargetRegister(1), getSourceRegister(0), cursor));

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -1382,6 +1382,8 @@ static std::vector<uint32_t> normalize_fnan_values()
       0xBF800000u, // -1.0
       0x7F800000u, // inf
       0xFF800000u, // -inf
+      0x7F800001u, // snan
+      0xFF800001u, // -snan
       0x7FC00000u, // nan
       0xFFC00000u, // -nan
       0x7FFFFFFFu, // nan(0x7fffff)
@@ -1399,6 +1401,8 @@ static std::vector<uint64_t> normalize_dnan_values()
       0xBFF0000000000000ull, // -1.0
       0x7FF0000000000000ull, // inf
       0xFFF0000000000000ull, // -inf
+      0x7FF0000000000001ull, // snan
+      0xFFF0000000000001ull, // -snan
       0x7FF8000000000000ull, // nan
       0xFFF8000000000000ull, // -nan
       0x7FFFFFFFFFFFFFFFull, // nan(0xfffffffff)

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -1434,6 +1434,10 @@ class NormalizeNanTest : public TRTest::JitTest, public ::testing::WithParamInte
 class FloatNormalizeNan : public NormalizeNanTest<uint32_t> {};
 
 TEST_P(FloatNormalizeNan, UsingLoadIndirect) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+
     char *inputTrees =
         "(method return=Int32 args=[Address]"
         "  (block"
@@ -1455,6 +1459,10 @@ TEST_P(FloatNormalizeNan, UsingLoadIndirect) {
 }
 
 TEST_P(FloatNormalizeNan, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+
     char *inputTrees =
         "(method return=Int32 args=[Int32]"
         "  (block"
@@ -1477,6 +1485,10 @@ TEST_P(FloatNormalizeNan, UsingLoadParam) {
 }
 
 TEST_P(FloatNormalizeNan, UsingLoadConst) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+
     uint32_t value = GetParam();
 
     char inputTrees[300] = {0};
@@ -1505,6 +1517,10 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, FloatNormalizeNan, ::testing::Values
 class DoubleNormalizeNan : public NormalizeNanTest<uint64_t> {};
 
 TEST_P(DoubleNormalizeNan, UsingLoadIndirect) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+
     char *inputTrees =
         "(method return=Int64 args=[Address]"
         "  (block"
@@ -1526,6 +1542,10 @@ TEST_P(DoubleNormalizeNan, UsingLoadIndirect) {
 }
 
 TEST_P(DoubleNormalizeNan, UsingLoadParam) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+
     char *inputTrees =
         "(method return=Int64 args=[Int64]"
         "  (block"
@@ -1548,6 +1568,10 @@ TEST_P(DoubleNormalizeNan, UsingLoadParam) {
 }
 
 TEST_P(DoubleNormalizeNan, UsingLoadConst) {
+    std::string arch = omrsysinfo_get_CPU_architecture();
+    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
+        << "The Z code generator crashes when specifying the mustNormalizeNanValues flag (see issue #4381)";
+
     uint64_t value = GetParam();
 
     char inputTrees[300] = {0};

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -21,6 +21,7 @@
 
 #include "OpCodeTest.hpp"
 #include "default_compiler.hpp"
+#include "omrformatconsts.h"
 
 #include <cmath>
 
@@ -1372,3 +1373,198 @@ INSTANTIATE_TEST_CASE_P(TypeConversionTest, DoubleToFloat, ::testing::Combine(
     ::testing::Values(
         std::make_tuple<const char*, float(*)(double)>("d2f", d2f)
     )));
+
+static std::vector<uint32_t> normalize_fnan_values()
+   {
+   uint32_t inputArray[] = {
+      0,
+      0x3F800000u, // 1.0
+      0xBF800000u, // -1.0
+      0x7F800000u, // inf
+      0xFF800000u, // -inf
+      0x7FC00000u, // nan
+      0xFFC00000u, // -nan
+      0x7FFFFFFFu, // nan(0x7fffff)
+      0xFFFFFFFFu  // -nan(0x7fffff)
+   };
+
+   return std::vector<uint32_t>(inputArray, inputArray + sizeof(inputArray) / sizeof(uint32_t));
+   }
+
+static std::vector<uint64_t> normalize_dnan_values()
+   {
+   uint64_t inputArray[] = {
+      0,
+      0x3FF0000000000000ull, // 1.0
+      0xBFF0000000000000ull, // -1.0
+      0x7FF0000000000000ull, // inf
+      0xFFF0000000000000ull, // -inf
+      0x7FF8000000000000ull, // nan
+      0xFFF8000000000000ull, // -nan
+      0x7FFFFFFFFFFFFFFFull, // nan(0xfffffffff)
+      0xFFFFFFFFFFFFFFFFull  // -nan(0xfffffffff)
+   };
+
+   return std::vector<uint64_t>(inputArray, inputArray + sizeof(inputArray) / sizeof(uint64_t));
+   }
+
+uint32_t normalize_fnan(uint32_t x) {
+    if ((x & 0x7f800000u) == 0x7f800000u && (x & 0x007fffffu) != 0u) {
+        return 0x7fc00000u;
+    } else {
+        return x;
+    }
+}
+
+uint64_t normalize_dnan(uint64_t x) {
+    if ((x & 0x7ff0000000000000ull) == 0x7ff0000000000000ull && (x & 0x000fffffffffffff) != 0u) {
+        return 0x7ff8000000000000ull;
+    } else {
+        return x;
+    }
+}
+
+template <typename T>
+class NormalizeNanTest : public TRTest::JitTest, public ::testing::WithParamInterface<T> {};
+
+class FloatNormalizeNan : public NormalizeNanTest<uint32_t> {};
+
+TEST_P(FloatNormalizeNan, UsingLoadIndirect) {
+    char *inputTrees =
+        "(method return=Int32 args=[Address]"
+        "  (block"
+        "    (ireturn"
+        "      (fbits2i flags=[15]" // FLAG: mustNormalizeNanValues
+        "        (floadi (aload parm=0))))))";
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    uint32_t value = GetParam();
+
+    auto entry_point = compiler.getEntryPoint<uint32_t (*)(uint32_t*)>();
+    ASSERT_EQ(normalize_fnan(value), entry_point(&value));
+}
+
+TEST_P(FloatNormalizeNan, UsingLoadParam) {
+    char *inputTrees =
+        "(method return=Int32 args=[Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (fbits2i flags=[15]" // FLAG: mustNormalizeNanValues
+        "        (ibits2f"
+        "          (iload parm=0))))))";
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    uint32_t value = GetParam();
+
+    auto entry_point = compiler.getEntryPoint<uint32_t (*)(uint32_t)>();
+    ASSERT_EQ(normalize_fnan(value), entry_point(value));
+}
+
+TEST_P(FloatNormalizeNan, UsingLoadConst) {
+    uint32_t value = GetParam();
+
+    char inputTrees[300] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int32 args=[Int32]"
+        "  (block"
+        "    (ireturn"
+        "      (fbits2i flags=[15]" // FLAG: mustNormalizeNanValues
+        "        (ibits2f"
+        "          (iconst %u))))))",
+        value);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<uint32_t (*)()>();
+    ASSERT_EQ(normalize_fnan(value), entry_point());
+}
+
+INSTANTIATE_TEST_CASE_P(TypeConversionTest, FloatNormalizeNan, ::testing::ValuesIn(normalize_fnan_values()));
+
+class DoubleNormalizeNan : public NormalizeNanTest<uint64_t> {};
+
+TEST_P(DoubleNormalizeNan, UsingLoadIndirect) {
+    char *inputTrees =
+        "(method return=Int64 args=[Address]"
+        "  (block"
+        "    (lreturn"
+        "      (dbits2l flags=[15]" // FLAG: mustNormalizeNanValues
+        "        (dloadi (aload parm=0))))))";
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    uint64_t value = GetParam();
+
+    auto entry_point = compiler.getEntryPoint<uint64_t (*)(uint64_t*)>();
+    ASSERT_EQ(normalize_dnan(value), entry_point(&value));
+}
+
+TEST_P(DoubleNormalizeNan, UsingLoadParam) {
+    char *inputTrees =
+        "(method return=Int64 args=[Int64]"
+        "  (block"
+        "    (lreturn"
+        "      (dbits2l flags=[15]" // FLAG: mustNormalizeNanValues
+        "        (lbits2d"
+        "          (lload parm=0))))))";
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    uint64_t value = GetParam();
+
+    auto entry_point = compiler.getEntryPoint<uint64_t (*)(uint64_t)>();
+    ASSERT_EQ(normalize_dnan(value), entry_point(value));
+}
+
+TEST_P(DoubleNormalizeNan, UsingLoadConst) {
+    uint64_t value = GetParam();
+
+    char inputTrees[300] = {0};
+    std::snprintf(inputTrees, sizeof(inputTrees),
+        "(method return=Int64 args=[Int64]"
+        "  (block"
+        "    (lreturn"
+        "      (dbits2l flags=[15]" // FLAG: mustNormalizeNanValues
+        "        (lbits2d"
+        "          (lconst %" OMR_PRIu64 "))))))",
+        value);
+    auto trees = parseString(inputTrees);
+
+    ASSERT_NOTNULL(trees);
+
+    Tril::DefaultCompiler compiler(trees);
+
+    ASSERT_EQ(0, compiler.compile()) << "Compilation failed unexpectedly\n" << "Input trees: " << inputTrees;
+
+    auto entry_point = compiler.getEntryPoint<uint64_t (*)()>();
+    ASSERT_EQ(normalize_dnan(value), entry_point());
+}
+
+INSTANTIATE_TEST_CASE_P(TypeConversionTest, DoubleNormalizeNan, ::testing::ValuesIn(normalize_dnan_values()));

--- a/fvtest/tril/tril/compiler_util.hpp
+++ b/fvtest/tril/tril/compiler_util.hpp
@@ -25,6 +25,7 @@
 #include "il/DataTypes.hpp"
 #include "ast.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
+#include "infra/Flags.hpp"
 
 namespace Tril { 
 /**
@@ -72,6 +73,29 @@ static std::vector<TR::DataTypes> parseArgTypes(const ASTNode* node) {
    }
 
    return argTypes;
+}
+
+/**
+ * @brief Return a parsed 32-bit flags value from a node with a
+ *        "flags" list.
+ * @param node is the node being processed.
+ * @return a flags32_t representing the flags that the ASTNode's
+ *         "flags" list specified should be set.
+ */
+static OMR::flags32_t parseFlags(const ASTNode* node) {
+   OMR::flags32_t flags = 0;
+
+   auto flagsArg = node->getArgByName("flags");
+   if (flagsArg != NULL) {
+      auto flagsValue = flagsArg->getValue();
+      while (flagsValue != NULL) {
+         if (flagsValue->getInteger() >= 0 && flagsValue->getInteger() < 32)
+            flags.set(1u << flagsValue->getInteger());
+         flagsValue = flagsValue->next;
+      }
+   }
+
+   return flags;
 }
 
 /**

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -319,6 +319,8 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
         TraceIL("  unrecognized opcode; using default creation mechanism\n", "");
         node = TR::Node::create(opcode.getOpCodeValue(), childCount);
      }
+     node->setFlags(parseFlags(tree));
+
      TraceIL("  node address %p\n", node);
      TraceIL("  node index n%dn\n", node->getGlobalIndex());
 


### PR DESCRIPTION
Previously, the Power codegen was performing NaN canonicalization using
the control flow pseudoinstructions cfnan and cdnan. These have now been
replaced with proper internal control flow.

Signed-off-by: Ben Thomas <ben@benthomas.ca>