### PR TITLE
Add late goto elimination pass to JitBuilder's opt strategy

### DIFF
--- a/jitbuilder/optimizer/JBOptimizer.cpp
+++ b/jitbuilder/optimizer/JBOptimizer.cpp
@@ -135,6 +135,7 @@ static const OptimizationStrategy JBwarmStrategyOpts[] =
    { OMR::trivialDeadTreeRemoval,                    OMR::IfEnabled                },
    { OMR::cheapTacticalGlobalRegisterAllocatorGroup                                },
    { OMR::globalDeadStoreGroup,                                                    },
+   { OMR::redundantGotoElimination,                  OMR::IfEnabled                }, // if global register allocator created new block
    { OMR::rematerialization                                                        },
    { OMR::deadTreesElimination,                      OMR::IfEnabled                }, // remove dead anchors created by check/store removal
    { OMR::deadTreesElimination,                      OMR::IfEnabled                }, // remove dead RegStores produced by previous deadTrees pass


### PR DESCRIPTION
Somehow, the warm strategy used by JitBuilder is missing a late
redundant goto cleanup pass needed to cleanup after GRA, which
tends to introduce blocks that end up as simple goto's after
global dead store elimination.

Signed-off-by: Mark Stoodley <mstoodle@ca.ibm.com>