### PR TITLE
Fix include path for avl

### DIFF
--- a/util/avl/CMakeLists.txt
+++ b/util/avl/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(j9avl
 
 target_include_directories(j9avl
 	PUBLIC
-		$<BUILD_INTERFACE:${OMR_SOURCE_DIR}/include_core>
+		$<BUILD_INTERFACE:${omr_SOURCE_DIR}/include_core>
 		$<INSTALL_INTERFACE:${OMR_INSTALL_INC_DIR}>
 	PRIVATE
 		.


### PR DESCRIPTION
OMR_SOURCE_DIR in all capitals is undefined, causing the include path to
be: `-I/include_core`. The build does not fail because other libraries
have the proper include path `-I../include_core`.

Signed-off-by: Andrew Young <youngar17@gmail.com>