### PR TITLE
Remove redundant z13 processor checks on Z

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -577,8 +577,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableWrtBarSrcObjCheck",           "O\tdisable to not check srcObj location for wrtBar in gc", SET_OPTION_BIT(TR_DisableWrtBarSrcObjCheck), "F"},
    {"disableZ10",                         "O\tdisable z10 support",                            SET_OPTION_BIT(TR_DisableZ10), "F"},
    {"disableZ13",                         "O\tdisable z13 support",                        SET_OPTION_BIT(TR_DisableZ13), "F"},
-   {"disableZ13LoadAndMask",              "O\tdisable load-and-mask instruction generation on z13",   SET_OPTION_BIT(TR_DisableZ13LoadAndMask), "F"},
-   {"disableZ13LoadImmediateOnCond",      "O\tdisable load halfword immediate on condition instruction generation on z13",   SET_OPTION_BIT(TR_DisableZ13LoadImmediateOnCond), "F"},
    {"disableZ14",                         "O\tdisable z14 support",                            SET_OPTION_BIT(TR_DisableZ14), "F"},
    {"disableZ15",                         "O\tdisable z15 support",                        SET_OPTION_BIT(TR_DisableZ15), "F"},
    {"disableZ196",                        "O\tdisable z196 support",                           SET_OPTION_BIT(TR_DisableZ196), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -450,7 +450,7 @@ enum TR_CompilationOptions
 
    // Option word 12
    // Available                               = 0x00000020 + 12,
-   TR_DisableZ13LoadAndMask                   = 0x00000040 + 12,
+   // Available                               = 0x00000040 + 12,
    TR_DisablePartialInlining                  = 0x00000080 + 12,
    TR_AssumeStartupPhaseUntilToldNotTo        = 0x00000100 + 12,
    // Available                               = 0x00000200 + 12,
@@ -845,7 +845,7 @@ enum TR_CompilationOptions
    TR_DisableSIMDArrayCompare                         = 0x00000020 + 26,
    TR_EnableJITHelpersoptimizedClone                  = 0x00000040 + 26,
    TR_DontAllocateScratchBTL                          = 0x00000080 + 26,
-   TR_DisableZ13LoadImmediateOnCond                   = 0x00000100 + 26,
+   // Available                                       = 0x00000100 + 26,
    // Available                                       = 0x00000200 + 26,
    TR_TrustAllInterfaceTypeInfo                       = 0x00000400 + 26,
    TR_DisableRefinedAliases                           = 0x00000800 + 26,

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -552,13 +552,6 @@ OMR::Z::CodeGenerator::CodeGenerator()
 
    // Set up vector register support for machine after zEC12.
    // This should also happen before prepareForGRA
-
-   if(!(self()->comp()->target().cpu.getSupportsArch(TR::CPU::z13) && !comp->getOption(TR_DisableZ13)))
-     {
-     comp->setOption(TR_DisableZ13LoadAndMask);
-     comp->setOption(TR_DisableZ13LoadImmediateOnCond);
-     }
-
    if (comp->getOption(TR_DisableSIMD))
       {
       comp->setOption(TR_DisableAutoSIMD);

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -1282,10 +1282,8 @@ TR_S390PostRAPeephole::LGFRReduction()
 bool
 TR_S390PostRAPeephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branchOPReplacement)
    {
-   bool disabled = comp()->getOption(TR_DisableZ13) || comp()->getOption(TR_DisableZ13LoadImmediateOnCond);
-
    // This optimization relies on hardware instructions introduced in z13
-   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z13) || disabled)
+   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z13))
       return false;
 
    TR::S390RIEInstruction* branchInst = static_cast<TR::S390RIEInstruction*> (_cursor);
@@ -1450,10 +1448,8 @@ TR_S390PostRAPeephole::CompareAndBranchReduction()
 bool
 TR_S390PostRAPeephole::LoadAndMaskReduction(TR::InstOpCode::Mnemonic LZOpCode)
    {
-   bool disabled = comp()->getOption(TR_DisableZ13) || comp()->getOption(TR_DisableZ13LoadAndMask);
-
    // This optimization relies on hardware instructions introduced in z13
-   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z13) || disabled)
+   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z13))
       return false;
 
    if (_cursor->getNext()->getOpCodeValue() == TR::InstOpCode::NILL)


### PR DESCRIPTION
Similarly to all other processors, since the migration of CPU checks to
the CPU class we no longer need to explicitly check for specific
"disableZ13*" options when also checking for processor support since
these checks are already performed for us.

We simplify the implementation here to stay consistent with all the
other checks for the various CPU processors.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>