### PR TITLE
Consolidate JIT-to-JIT entry point alignment on all codegens

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2162,7 +2162,7 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
    uint32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
 
    // Align cursor to boundary as long as it meets the threshold
-   if (boundary > 1)
+   if (self()->supportsJitMethodEntryAlignment() && boundary > 1)
       {
       uint32_t offset = self()->getPreJitMethodEntrySize();
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2162,7 +2162,7 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
    uint32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
 
    // Align cursor to boundary as long as it meets the threshold
-   if (boundary && (boundary & boundary - 1) == 0)
+   if (boundary > 1)
       {
       uint32_t offset = self()->getPreJitMethodEntrySize();
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2182,6 +2182,12 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
    return _binaryBufferCursor;
    }
 
+bool
+OMR::CodeGenerator::supportsJitMethodEntryAlignment()
+   {
+   return true;
+   }
+
 uint32_t
 OMR::CodeGenerator::getJitMethodEntryAlignmentBoundary()
    {

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -109,6 +109,7 @@
 #include "runtime/CodeCacheManager.hpp"
 #include "runtime/Runtime.hpp"
 #include "stdarg.h"
+#include "OMR/Bytes.hpp"
 
 namespace TR { class Optimizer; }
 namespace TR { class RegisterDependencyConditions; }
@@ -2158,22 +2159,21 @@ loop:
 uint8_t *
 OMR::CodeGenerator::alignBinaryBufferCursor()
    {
-   uintptr_t boundary = self()->getJitMethodEntryAlignmentBoundary();
+   uint32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
 
    // Align cursor to boundary as long as it meets the threshold
    if (boundary && (boundary & boundary - 1) == 0)
       {
-      uintptr_t round = boundary - 1;
-      uintptr_t offset = self()->getPreJitMethodEntrySize();
+      uint32_t offset = self()->getPreJitMethodEntrySize();
 
-      uint8_t* alignedBufferCursor = _binaryBufferCursor;
-      alignedBufferCursor += offset;
-      alignedBufferCursor = (uint8_t *)(((uintptr_t)alignedBufferCursor + round) & ~round);
-      alignedBufferCursor -= offset;
+      uint8_t* alignedBinaryBufferCursor = _binaryBufferCursor;
+      alignedBinaryBufferCursor += offset;
+      alignedBinaryBufferCursor = reinterpret_cast<uint8_t*>(OMR::align(reinterpret_cast<size_t>(alignedBinaryBufferCursor), boundary));
+      alignedBinaryBufferCursor -= offset;
 
-      if (alignedBufferCursor - _binaryBufferCursor <= self()->getJitMethodEntryAlignmentThreshold())
+      if (alignedBinaryBufferCursor - _binaryBufferCursor <= self()->getJitMethodEntryAlignmentThreshold())
          {
-         _binaryBufferCursor = alignedBufferCursor;
+         _binaryBufferCursor = alignedBinaryBufferCursor;
          self()->setJitMethodEntryPaddingSize(_binaryBufferCursor - _binaryBufferStart);
          memset(_binaryBufferStart, 0, self()->getJitMethodEntryPaddingSize());
          }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2161,6 +2161,8 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
    {
    uint32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
 
+   TR_ASSERT_FATAL(boundary > 0, "JIT method entry alignment boundary (%d) definition is violated", boundary);
+
    // Align cursor to boundary as long as it meets the threshold
    if (self()->supportsJitMethodEntryAlignment() && boundary > 1)
       {
@@ -2169,9 +2171,17 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
       uint8_t* alignedBinaryBufferCursor = _binaryBufferCursor;
       alignedBinaryBufferCursor += offset;
       alignedBinaryBufferCursor = reinterpret_cast<uint8_t*>(OMR::align(reinterpret_cast<size_t>(alignedBinaryBufferCursor), boundary));
+
+      TR_ASSERT_FATAL(OMR::aligned(reinterpret_cast<size_t>(alignedBinaryBufferCursor), boundary),
+         "alignedBinaryBufferCursor [%p] is not aligned to the specified boundary (%d)", alignedBinaryBufferCursor, boundary);
+
       alignedBinaryBufferCursor -= offset;
 
-      if (alignedBinaryBufferCursor - _binaryBufferCursor <= self()->getJitMethodEntryAlignmentThreshold())
+      uint32_t threshold = self()->getJitMethodEntryAlignmentThreshold();
+
+      TR_ASSERT_FATAL(threshold <= boundary, "JIT method entry alignment threshold (%d) definition is violated as it is larger than the boundary (%d)", threshold, boundary);
+
+      if (alignedBinaryBufferCursor - _binaryBufferCursor <= threshold)
          {
          _binaryBufferCursor = alignedBinaryBufferCursor;
          self()->setJitMethodEntryPaddingSize(_binaryBufferCursor - _binaryBufferStart);

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -2158,7 +2158,7 @@ loop:
 uint8_t *
 OMR::CodeGenerator::alignBinaryBufferCursor()
    {
-   uintptr_t boundary = self()->comp()->getOptions()->getJitMethodEntryAlignmentBoundary(self());
+   uintptr_t boundary = self()->getJitMethodEntryAlignmentBoundary();
 
    /* Align cursor to boundary */
    if (boundary && (boundary & boundary - 1) == 0)
@@ -2176,6 +2176,11 @@ OMR::CodeGenerator::alignBinaryBufferCursor()
    return _binaryBufferCursor;
    }
 
+uint32_t
+OMR::CodeGenerator::getJitMethodEntryAlignmentBoundary()
+   {
+   return 1;
+   }
 
 int32_t
 OMR::CodeGenerator::setEstimatedLocationsForSnippetLabels(int32_t estimatedSnippetStart)

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -368,7 +368,6 @@ class OMR_EXTENSIBLE CodeGenerator
    void setNextAvailableBlockIndex(int32_t blockIndex) {}
    int32_t getNextAvailableBlockIndex() { return -1; }
 
-   bool supportsMethodEntryPadding() { return true; }
    bool mustGenerateSwitchToInterpreterPrePrologue() { return false; }
    bool buildInterpreterEntryPoint() { return false; }
    void generateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction) { return; }
@@ -760,6 +759,11 @@ class OMR_EXTENSIBLE CodeGenerator
 
    uint32_t getPreJitMethodEntrySize() {return _preJitMethodEntrySize;}
    uint32_t setPreJitMethodEntrySize(uint32_t s) {return (_preJitMethodEntrySize = s);}
+   
+   /** \brief
+    *     Determines whether the code generator supports or allows JIT-to-JIT method entry point alignment.
+    */
+   bool supportsJitMethodEntryAlignment();
 
    /** \brief
     *     Determines the byte boundary at which to align the JIT-to-JIT method entry point. If the boundary is

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -761,6 +761,12 @@ class OMR_EXTENSIBLE CodeGenerator
    uint32_t getPreJitMethodEntrySize() {return _preJitMethodEntrySize;}
    uint32_t setPreJitMethodEntrySize(uint32_t s) {return (_preJitMethodEntrySize = s);}
 
+   /** \brief
+    *     Determines the byte boundary at which to align the JIT-to-JIT method entry point. If the boundary is
+    *     specified to be \c x and the JIT-to-JIT method entry point to be \c y then <c>y & (x - 1) == 0</c>.
+    */
+   uint32_t getJitMethodEntryAlignmentBoundary();
+
    uint32_t getJitMethodEntryPaddingSize() {return _jitMethodEntryPaddingSize;}
    uint32_t setJitMethodEntryPaddingSize(uint32_t s) {return (_jitMethodEntryPaddingSize = s);}
 

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -766,6 +766,17 @@ class OMR_EXTENSIBLE CodeGenerator
     *     specified to be \c x and the JIT-to-JIT method entry point to be \c y then <c>y & (x - 1) == 0</c>.
     */
    uint32_t getJitMethodEntryAlignmentBoundary();
+   
+   /** \brief
+    *     Determines the byte threshold at which the JIT-to-JIT method entry point boundary alignment will not be
+    *     performed. If the JIT-to-JIT method entry point is already close to the boundary then it may not make sense
+    *     to perform the boundary alignment as much code cache can be wasted. This threshold can be used to avoid such
+    *     situations.
+    *
+    *  \note
+    *     This value must be less than or equal to the boundary returned via \see getJitMethodEntryAlignmentBoundary.
+    */
+   uint32_t getJitMethodEntryAlignmentThreshold();
 
    uint32_t getJitMethodEntryPaddingSize() {return _jitMethodEntryPaddingSize;}
    uint32_t setJitMethodEntryPaddingSize(uint32_t s) {return (_jitMethodEntryPaddingSize = s);}

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -866,9 +866,6 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"iprofilerVerbose",          "O\tEnable Interpreter Profiling output messages",           SET_OPTION_BIT(TR_VerboseInterpreterProfiling), "F"},
 
    {"jitAllAtMain",          "D\tjit all loaded methods when main is called", SET_OPTION_BIT(TR_jitAllAtMain), "F" },
-
-   {"jitMethodEntryAlignmentBoundary=",      "C<nnn>\tAlignment boundary (in bytes) for JIT method entry",
-        TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_jitMethodEntryAlignmentBoundary), 0, "F%d"},
    {"jProfilingLoopRecompThreshold=",      "C<nnn>\tLoop recompilation threshold for jProfiling",
         TR::Options::set32BitSignedNumeric, offsetof(OMR::Options,_jProfilingLoopRecompThreshold), 0, "F%d"},
    {"jProfilingMethodRecompThreshold=",      "C<nnn>\tMethod invocations for jProfiling body",
@@ -2565,11 +2562,6 @@ OMR::Options::jitPreProcess()
    _minCounterFidelity = INT_MIN;
    _labelTargetNOPLimit = TR_LABEL_TARGET_NOP_LIMIT;
    _lastIpaOptTransformationIndex = INT_MAX;
-#if defined(TR_HOST_POWER)
-   _jitMethodEntryAlignmentBoundary = 128;
-#else
-   _jitMethodEntryAlignmentBoundary = 0;
-#endif
    _jProfilingMethodRecompThreshold = 4000;
    _jProfilingLoopRecompThreshold = 2000;
    _blockShufflingSequence = "S";
@@ -5404,15 +5396,4 @@ void OMR::Options::setDefaultsForDeterministicMode()
          default: break;
          }
       }
-   }
-
-
-int32_t
-OMR::Options::getJitMethodEntryAlignmentBoundary(TR::CodeGenerator *cg)
-   {
-   if (cg->supportsMethodEntryPadding())
-      {
-      return _jitMethodEntryAlignmentBoundary;
-      }
-   return 0;
    }

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -1916,8 +1916,6 @@ public:
    bool getOptLevelDowngraded() const { return _optLevelDowngraded; }
    static char *getCompilationStrategyName() { return _compilationStrategyName; }
 
-   int32_t getJitMethodEntryAlignmentBoundary(TR::CodeGenerator *cg);
-   void setJitMethodEntryAlignmentBoundary(int32_t boundary) { _jitMethodEntryAlignmentBoundary = boundary; }
 /**   \brief Returns a threshold on the profiling method invocations to trip recompilation
  */
    int32_t getJProfilingMethodRecompThreshold() { return _jProfilingMethodRecompThreshold; }
@@ -2391,7 +2389,6 @@ protected:
 
    bool                        _isAOTCompile;
 
-   int32_t                     _jitMethodEntryAlignmentBoundary; /* Alignment boundary for JIT method entry */
    int32_t                     _jProfilingMethodRecompThreshold;
    int32_t                     _jProfilingLoopRecompThreshold;
    char *                      _blockShufflingSequence;

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1684,11 +1684,10 @@ void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       data->cursorInstruction = data->cursorInstruction->getNext();
       }
 
-   int32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
-   if (boundary > 4)
+   if (self()->supportsJitMethodEntryAlignment())
       {
       self()->setPreJitMethodEntrySize(data->estimate);
-      data->estimate += (boundary - 4);
+      data->estimate += (self()->getJitMethodEntryAlignmentBoundary() - 1);
       }
 
    self()->getLinkage()->createPrologue(data->cursorInstruction);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1685,7 +1685,7 @@ void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       }
 
    int32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
-   if (boundary && (boundary > 4) && ((boundary & (boundary - 1)) == 0))
+   if (boundary > 4)
       {
       self()->setPreJitMethodEntrySize(data->estimate);
       data->estimate += (boundary - 4);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1684,10 +1684,9 @@ void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       data->cursorInstruction = data->cursorInstruction->getNext();
       }
 
-   int32_t boundary = comp->getOptions()->getJitMethodEntryAlignmentBoundary(self());
+   int32_t boundary = self()->getJitMethodEntryAlignmentBoundary();
    if (boundary && (boundary > 4) && ((boundary & (boundary - 1)) == 0))
       {
-      comp->getOptions()->setJitMethodEntryAlignmentBoundary(boundary);
       self()->setPreJitMethodEntrySize(data->estimate);
       data->estimate += (boundary - 4);
       }
@@ -3444,6 +3443,12 @@ OMR::Power::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNon
       }
 
    return result;
+   }
+
+uint32_t
+OMR::Power::CodeGenerator::getJitMethodEntryAlignmentBoundary()
+   {
+   return 128;
    }
 
 bool

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -395,6 +395,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
       return  ((size < (lineSize<<1)) && (size > (lineSize >> 2)));
       }
 
+   uint32_t getJitMethodEntryAlignmentBoundary();
+
    using OMR::CodeGenerator::getSupportsConstantOffsetInAddressing;
    bool getSupportsConstantOffsetInAddressing(int64_t value) { return (value>=LOWER_IMMED) && (value<=UPPER_IMMED);}
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1735,11 +1735,9 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
          gcMapCursor->setGCMap(self()->getStackAtlas()->getParameterMap()->clone(self()->trMemory()));
       }
 
-   /* Adjust estimate based on jitted method entry alignment requirement */
-   uintptr_t boundary = self()->getJitMethodEntryAlignmentBoundary();
-   if (boundary > 1)
+   if (self()->supportsJitMethodEntryAlignment())
       {
-      estimate += boundary - 1;
+      estimate += (self()->getJitMethodEntryAlignmentBoundary() - 1);
       }
 
    if (self()->comp()->getOption(TR_TraceVFPSubstitution))

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1737,8 +1737,10 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
 
    /* Adjust estimate based on jitted method entry alignment requirement */
    uintptr_t boundary = self()->getJitMethodEntryAlignmentBoundary();
-   if (boundary && (boundary & boundary - 1) == 0)
+   if (boundary > 1)
+      {
       estimate += boundary - 1;
+      }
 
    if (self()->comp()->getOption(TR_TraceVFPSubstitution))
       traceMsg(self()->comp(), "\n<instructions\n"

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1736,7 +1736,7 @@ void OMR::X86::CodeGenerator::doBinaryEncoding()
       }
 
    /* Adjust estimate based on jitted method entry alignment requirement */
-   uintptr_t boundary = self()->comp()->getOptions()->getJitMethodEntryAlignmentBoundary(self());
+   uintptr_t boundary = self()->getJitMethodEntryAlignmentBoundary();
    if (boundary && (boundary & boundary - 1) == 0)
       estimate += boundary - 1;
 

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2455,30 +2455,9 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    uint8_t *coldCode = NULL;
    uint8_t *temp = self()->allocateCodeMemory(self()->getEstimatedCodeLength(), 0, &coldCode);
 
-
    self()->setBinaryBufferStart(temp);
    self()->setBinaryBufferCursor(temp);
-
-
-   static char *disableAlignJITEP = feGetEnv("TR_DisableAlignJITEP");
-
-   // Adjust the binary buffer cursor with appropriate padding.
-   if (!disableAlignJITEP && !self()->comp()->compileRelocatableCode())
-      {
-      int32_t alignedBase = 256 - self()->getPreJitMethodEntrySize();
-      int32_t padBase = ( 256 + alignedBase - ((intptrj_t)temp) % 256) % 256;
-
-      // Threshold determines the maximum number of bytes to align.  If the JIT EP is already close
-      // to the beginning of the cache line (i.e. pad bytes is big), then we might not benefit from
-      // aligning JIT EP to the true cache boundary.  By default, we align only if padByte exceed 192.
-      static char *alignJITEPThreshold = feGetEnv("TR_AlignJITEPThreshold");
-      int32_t threshold = (alignJITEPThreshold)?atoi(alignJITEPThreshold):192;
-
-      if (padBase < threshold)
-         {
-         self()->setBinaryBufferCursor(temp + padBase);
-         }
-      }
+   self()->alignBinaryBufferCursor();
 
    while (data.cursorInstruction)
       {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4699,6 +4699,12 @@ OMR::Z::CodeGenerator::getJitMethodEntryAlignmentBoundary()
    return 256;
    }
 
+uint32_t
+OMR::Z::CodeGenerator::getJitMethodEntryAlignmentThreshold()
+   {
+   return 192;
+   }
+
 /**
  * This function sign extended the specified number of high order bits in the register.
  */

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -468,8 +468,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
    self()->setSupportsLoweringConstIDiv();
    self()->setSupportsTestUnderMask();
 
-   // Initialize preprologue offset to be 8 bytes for bodyInfo / methodInfo
-   self()->setPreprologueOffset(8);
+   // Initialize to be 8 bytes for bodyInfo / methodInfo
+   self()->setPreJitMethodEntrySize(8);
 
    // Support divided by power of 2 logic in ldivSimplifier
    self()->setSupportsLoweringConstLDivPower2();
@@ -2465,7 +2465,7 @@ OMR::Z::CodeGenerator::doBinaryEncoding()
    // Adjust the binary buffer cursor with appropriate padding.
    if (!disableAlignJITEP && !self()->comp()->compileRelocatableCode())
       {
-      int32_t alignedBase = 256 - self()->getPreprologueOffset();
+      int32_t alignedBase = 256 - self()->getPreJitMethodEntrySize();
       int32_t padBase = ( 256 + alignedBase - ((intptrj_t)temp) % 256) % 256;
 
       // Threshold determines the maximum number of bytes to align.  If the JIT EP is already close

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4693,6 +4693,12 @@ OMR::Z::CodeGenerator::excludeInvariantsFromGRAEnabled()
    return true;
    }
 
+uint32_t
+OMR::Z::CodeGenerator::getJitMethodEntryAlignmentBoundary()
+   {
+   return 256;
+   }
+
 /**
  * This function sign extended the specified number of high order bits in the register.
  */

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -783,6 +783,8 @@ public:
 
    uint32_t getJitMethodEntryAlignmentBoundary();
 
+   uint32_t getJitMethodEntryAlignmentThreshold();
+
    // LL: move to .cpp
    bool arithmeticNeedsLiteralFromPool(TR::Node *node);
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -781,6 +781,8 @@ public:
       return 7;
       }
 
+   uint32_t getJitMethodEntryAlignmentBoundary();
+
    // LL: move to .cpp
    bool arithmeticNeedsLiteralFromPool(TR::Node *node);
 

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -441,9 +441,6 @@ public:
    virtual bool getSupportsBitPermute();
    int32_t getEstimatedExtentOfLitLoop()  {return _extentOfLitPool;}
 
-   int32_t getPreprologueOffset()               { return _preprologueOffset; }
-   int32_t setPreprologueOffset(int32_t offset) { return _preprologueOffset = offset; }
-
    bool supportsBranchPreload()          {return _cgFlags.testAny(S390CG_enableBranchPreload);}
    void setEnableBranchPreload()          {_cgFlags.set(S390CG_enableBranchPreload);}
    void setDisableBranchPreload()          {_cgFlags.reset(S390CG_enableBranchPreload);}
@@ -852,10 +849,6 @@ private:
 #endif
 
    bool  TR_LiteralPoolOnDemandOnRun;
-
-
-   /** Saves the preprologue offset to allow JIT entry point alignment padding. */
-   int32_t _preprologueOffset;
 
    TR_BackingStore* _localF2ISpill;
 


### PR DESCRIPTION
This series of commits consolidates the JIT-to-JIT entry point alignment on all codegens so we all use the same API, namely `alignBinaryBufferCursor`, to perform the alignment. As part of this change we introduce several new APIs and rename some existing ones so as to stay more consistent. We also take this opportunity to document all the APIs.

This cleanup is a step towards commoning up the Binary Encoding phase across codegens and will hopefully help the adaptation of new code generators, such as ARM, AArch64, and RISC-V.