### PR TITLE
Make hookgen invocation less verbose

### DIFF
--- a/tools/hookgen/HookGen.cpp
+++ b/tools/hookgen/HookGen.cpp
@@ -540,7 +540,6 @@ RCType
 HookGen::parseOptions(int argc, char *argv[])
 {
 	for (int i = 1; i < argc; i++) {
-		printf("%d: %s\n", i, argv[i]);
 		if (0 == strcmp(argv[i], "-v")) {
 			_verbose = true;
 		} else {


### PR DESCRIPTION
Hookgen is printing all arguments that were passed to it.  Remove this
as it is not helpful and verbose.

Signed-off-by: Andrew Young <youngar17@gmail.com>