### PR TITLE
Add Power evaluators for sub-int type multiplication

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1768,7 +1768,7 @@ OMR::CodeGenerator::convertMultiplyToShift(TR::Node * node)
       }
    else
       {
-      multiplier = secondChild->getInt();
+      multiplier = secondChild->get32bitIntegralValue();
       if (multiplier == 0)
          return false;  // Can't handle this case
       if (multiplier < 0)
@@ -1794,6 +1794,10 @@ OMR::CodeGenerator::convertMultiplyToShift(TR::Node * node)
 
    if (node->getOpCodeValue() == TR::imul)
       TR::Node::recreate(node, TR::ishl);
+   else if (node->getOpCodeValue() == TR::smul)
+      TR::Node::recreate(node, TR::sshl);
+   else if (node->getOpCodeValue() == TR::bmul)
+      TR::Node::recreate(node, TR::bshl);
    else
       {
       TR::Node::recreate(node, TR::lshl);

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -937,11 +937,11 @@ TR::Register *OMR::Power::TreeEvaluator::imulEvaluator(TR::Node *node, TR::CodeG
    TR::Node     *firstChild         = node->getFirstChild();
    TR::Node     *secondChild        = node->getSecondChild();
    TR::Register *src1Reg            = cg->evaluate(firstChild);
-   TR::ILOpCodes secondOp                = secondChild->getOpCodeValue();
+   TR::ILOpCode secondOp                = secondChild->getOpCode();
 
-   if (secondOp == TR::iconst || secondOp == TR::iuconst)
+   if (secondOp.isLoadConst())
       {
-      int32_t value = secondChild->getInt();
+      int32_t value = secondChild->get32bitIntegralValue();
       if (value > 0 && cg->convertMultiplyToShift(node))
          {
          // The multiply has been converted to a shift.

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -119,8 +119,8 @@
    TR::TreeEvaluator::lmulEvaluator,                    // TR::lmul
    TR::TreeEvaluator::fmulEvaluator,                    // TR::fmul
    TR::TreeEvaluator::dmulEvaluator,                    // TR::dmul
-   TR::TreeEvaluator::unImpOpEvaluator,                 // TR::bmul
-   TR::TreeEvaluator::badILOpEvaluator,                    // TR::smul
+   TR::TreeEvaluator::imulEvaluator,                    // TR::bmul
+   TR::TreeEvaluator::imulEvaluator,                    // TR::smul
    TR::TreeEvaluator::imulEvaluator,                    // TR::iumul
    TR::TreeEvaluator::idivEvaluator,                    // TR::idiv
    TR::TreeEvaluator::ldivEvaluator,                    // TR::ldiv

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -1298,14 +1298,12 @@ OpCodesTest::invokeDisabledOpCodesTests()
 void
 OpCodesTest::UnsupportedOpCodesTests()
    {
-   //bdiv, bmul, brem
+   //bdiv, brem
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bdiv, "bDiv", _argTypesBinaryByte, TR::Int8);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bmul, "bMul", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::brem, "bRem", _argTypesBinaryByte, TR::Int8);
 
-   //sdiv, smul, srem
+   //sdiv, srem
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sdiv, "sDiv", _argTypesBinaryShort, TR::Int16);
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::smul, "sMul", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::srem, "sRem", _argTypesBinaryShort, TR::Int16);
 
    //bucmplt, bucmple, bucmpgt, bucmpge

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -566,11 +566,9 @@ PPCOpCodesTest::UnsupportedOpCodesTests()
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float);
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double);
 
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bmul, "bMul", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::bdiv, "bDiv", _argTypesBinaryByte, TR::Int8);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::brem, "bRem", _argTypesBinaryByte, TR::Int8);
 
-   addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::smul, "sMul", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::sdiv, "sDiv", _argTypesBinaryShort, TR::Int16);
    addUnsupportedOpCodeTest(_numberOfBinaryArgs, TR::srem, "sRem", _argTypesBinaryShort, TR::Int16);
 

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -459,13 +459,15 @@ INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int16Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int16_t, int16_t>()),
     ::testing::Values(
         std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("sadd", add<int16_t>),
-        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("ssub", sub<int16_t>))));
+        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("ssub", sub<int16_t>),
+        std::make_tuple<const char*, int16_t(*)(int16_t, int16_t)>("smul", mul<int16_t>))));
 
 INSTANTIATE_TEST_CASE_P(ArithmeticTest, Int8Arithmetic, ::testing::Combine(
     ::testing::ValuesIn(TRTest::const_value_pairs<int8_t, int8_t>()),
     ::testing::Values(
         std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("badd", add<int8_t>),
-        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bsub", sub<int8_t>))));
+        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bsub", sub<int8_t>),
+        std::make_tuple<const char*, int8_t(*)(int8_t, int8_t)>("bmul", mul<int8_t>))));
 
 /**
  * @brief Filter function for *div opcodes

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -321,6 +321,9 @@ TEST_P(Int16Arithmetic, UsingConst) {
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
+        << "smul/sdiv not yet implemented on x86 (see Issue #4408)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -354,6 +357,9 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
 
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
+        << "smul/sdiv not yet implemented on x86 (see Issue #4408)";
+
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -382,6 +388,9 @@ TEST_P(Int8Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
+        << "bmul/bdiv not yet implemented on x86 (see Issue #4408)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -415,6 +424,9 @@ TEST_P(Int8Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+
+    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
+        << "bmul/bdiv not yet implemented on x86 (see Issue #4408)";
         
     auto param = TRTest::to_struct(GetParam());
 


### PR DESCRIPTION
Routed bmul/smul to imulEvaluator, modified imulEvaluator accordingly, and added corresponding tril tests.

NOTE: Should not be merged before https://github.com/eclipse/omr/pull/4249

Signed-off-by: Jackie Midroni <jackie.midroni@mail.utoronto.ca>