### PR TITLE
Add .ccls to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ x64/
 
 # CCLS (language server for C/C++)
 .ccls-cache/
+.ccls
 
 # config cmake file for vim autocompletion
 compile_commands.json


### PR DESCRIPTION
.ccls stores completion data for the CCLS autocomplete engine

Signed-off-by: Andrew Young <youngar17@gmail.com>