### PR TITLE
Fix macOS failures in Post GRA Block splitter

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1267,7 +1267,7 @@ OMR::Block::splitPostGRA(TR::TreeTop * startOfNewBlock, TR::CFG *cfg, bool copyE
             {
             (*nodeInfo)[node] = std::make_pair<int32_t, TR::Node*>(node->getReferenceCount() - 1, NULL);
             }
-         else if (entry->second.first > 1)
+         else if (entry != nodeInfo->end() && entry->second.first > 1)
             {
             entry->second.first -= 1;
             }
@@ -1281,7 +1281,7 @@ OMR::Block::splitPostGRA(TR::TreeTop * startOfNewBlock, TR::CFG *cfg, bool copyE
          // Record the last used RegStore for the node before split point
          if (node->getOpCode().isStoreReg())
             {
-            (*storeNodeInfo)[node->getFirstChild()] = node;
+            storeNodeInfo->insert(std::make_pair(node->getFirstChild(), node));
             }
          }
 


### PR DESCRIPTION
In Post GRA Block splitter, std::map is used to store information about nodes which are referenced after the split point and will be uncommonned. In this information we basically store how many times node is referenced after split point and a replacement node to use post split point.
There was a bug in the routine where it scans treetops before split-point and adds nodes into this map. In cases where node is not added into the map and referenced only one time, it was accessing value field from `map::end` and illegally modifies it. On macOS this was causing an alteration into memory area which happened to be pointing at a `stackMemoryRegion` which was used to allocate some of the data structures required by this same routine. This later on manifested into segmentation fault.
Changes in this PR fixes this issue.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>