### PR TITLE
Skip OSR Guards nodes that have already been removed

### DIFF
--- a/compiler/infra/Checklist.hpp
+++ b/compiler/infra/Checklist.hpp
@@ -47,6 +47,7 @@ class Checklist
    Checklist(TR::Compilation* c);
    ~Checklist();
    bool isEmpty(){ return _v->isEmpty(); }
+   void print(TR::Compilation *c) { _v->print(c); }
    };
 
 class NodeChecklist: public Checklist


### PR DESCRIPTION
In `TR_LoopVersioner::versionNaturalLoop`, while walking through the loop body looking for OSRGuards, the code should skip any OSRGuards that have already been included in the list of removed nodes.

Also added a debugging print method to `TR::NodeCheckList`.

Submitted on behalf of Andrew Craik <ajcraik@ca.ibm.com>.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>