### PR TITLE
AArch64: Add code for creating exception table entries for OOL code

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -299,6 +299,9 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
 
+   // OutOfLineCodeSection List functions
+   TR::list<TR_ARM64OutOfLineCodeSection*> &getARM64OutOfLineCodeSectionList() {return _outOfLineCodeSectionList;}
+
    private:
 
    enum // flags


### PR DESCRIPTION
This commit adds code for creating exception table entries for OOL
code for AArch64.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>