### PR TITLE
Setting utf16 value based on system endianess

### DIFF
--- a/port/unix/omriconvhelpers.c
+++ b/port/unix/omriconvhelpers.c
@@ -45,7 +45,11 @@ const char *utf16 = "01200"; /* z/OS does not accept "UTF-16" */
 #elif defined(OSX) /* defined(J9ZOS390) */
 const char *utf16 = "UTF-16LE";
 #else /* defined(J9ZOS390) */
-const char *utf16 = "UTF-16";
+#if defined(OMR_ENV_LITTLE_ENDIAN)
+const char *utf16 = "UTF-16LE";
+#else
+const char *utf16 = "UTF-16BE";
+#endif /* defined(OMR_ENV_LITTLE_ENDIAN) */
 #endif /* defined(J9ZOS390) */
 const char *ebcdic = "IBM-1047";
 #if defined(J9ZOS390)


### PR DESCRIPTION
Musl Libc `iconv` api returns the byte stream in `Big Endian` when we pass the `To charset encoding type` as  `UTF-16` as [documented in here](https://wiki.musl-libc.org/functional-differences-from-glibc.html#Character-sets-and-locale). So if a Little Endian system reads this stream it points to a different char codes. To avoid such miss matches we can pass the charset type based on system endianess. So instead of `UTF-16` we pass either `UTF-16LE` or `UTF-16BE`
 
Signed-off-by: bharathappali <bharath.appali@gmail.com>