### PR TITLE
Fix hang in gcexample

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -50,10 +50,7 @@ if(OMR_GC)
 		${OMR_PORT_LIB}
 	)
 
-	# TODO: The example is currently broken.
-	# Hashtable iteration appears to be broken, which in turn breaks root
-	# marking, and causes the example to spin forever.
-	# add_test(gcexample gcexample)
+	add_test(NAME gcexample COMMAND gcexample)
 endif(OMR_GC)
 
 add_subdirectory(glue)

--- a/example/gcmain.cpp
+++ b/example/gcmain.cpp
@@ -87,7 +87,7 @@ omr_main_entry(int argc, char ** argv, char **envp)
 	omrtty_printf("allocation interface is %s\n", allocationInterface->getBaseVirtualTypeId());
 
 	/* Allocate objects without collection until heap exhausted */
-	uintptr_t allocatedFlags = 0;
+	uintptr_t allocatedFlags = OMR_GC_ALLOCATE_OBJECT_NO_GC;
 	uintptr_t allocSize = 24;
 	uintptr_t allocatedCount = 0;
 	while (true) {
@@ -113,7 +113,7 @@ omr_main_entry(int argc, char ** argv, char **envp)
 		allocationStats->tlhBytesAllocated(), allocationStats->nontlhBytesAllocated(), allocatedCount);
 
 	/* Force GC to print verbose system allocation stats -- should match thread allocation stats from before GC */
-	MM_ObjectAllocationModel allocationModel(env, allocSize, allocatedFlags);
+	MM_ObjectAllocationModel allocationModel(env, allocSize, 0);
 	omrobjectptr_t obj = (omrobjectptr_t)OMR_GC_AllocateObject(omrVMThread, &allocationModel);
 	Assert_MM_false(NULL == obj);
 


### PR DESCRIPTION
`gcexample` allocates objects with the NO_GC flag in a loop until the
heap is exausted.  After this it allocated one more time causing a
garbage collection.  At some point it stopped using the NO_GC flag,
causing the test to constantly allocate objects and collect them in an
infinite loop. This change fixes the allocation flags

Signed-off-by: Andrew Young <youngar17@gmail.com>