### PR TITLE
Call TR_PersistentMethodInfo::get() after checking RecompilationInfo

### DIFF
--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -480,7 +480,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
 
 #ifdef J9_PROJECT_SPECIFIC
          TR_ResolvedMethod * method = resolvedMethodSymbol->getResolvedMethod();
-         TR_PersistentMethodInfo * methodInfo = TR_PersistentMethodInfo::get(method);
+         TR_PersistentMethodInfo * methodInfo = comp->getRecompilationInfo() ? TR_PersistentMethodInfo::get(method) : NULL;
          if (methodInfo && (methodInfo->hasRefinedAliasSets() ||
                             comp->getMethodHotness() >= veryHot ||
                             resolvedMethodSymbol->hasVeryRefinedAliasSets()) &&


### PR DESCRIPTION
This commit changes the code in Aliases.cpp that calls
TR_PersistentMethodInfo::get() so that it checks RecompilationInfo
before that.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>