### PR TITLE
Provide IlValue as condition for the Switch IlBuilder service

### DIFF
--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2604,14 +2604,7 @@ OMR::IlBuilder::Switch(const char *selectionVar,
                   uint32_t numCases,
                   JBCase **cases)
    {
-   TR::IlValue *selectorValue = Load(selectionVar);
-   TR_ASSERT_FATAL(selectorValue->getDataType() == TR::Int32, "Switch only supports selector having type Int32");
-   *defaultBuilder = createBuilderIfNeeded(*defaultBuilder);
-
-   TR::Node *defaultNode = TR::Node::createCase(0, (*defaultBuilder)->getEntry()->getEntry());
-   TR::Node *lookupNode = TR::Node::create(TR::lookup, numCases + 2, loadValue(selectorValue), defaultNode);
-
-   generateSwitchCases(lookupNode, defaultNode, defaultBuilder, numCases, cases);
+   Switch(Load(selectionVar), defaultBuilder, numCases, cases);
    }
 
 void
@@ -2626,6 +2619,35 @@ OMR::IlBuilder::Switch(const char *selectionVar,
    va_end(args);
 
    Switch(selectionVar, defaultBuilder, numCases, cases);
+   }
+
+void
+OMR::IlBuilder::Switch(TR::IlValue *selectorValue,
+                  TR::IlBuilder **defaultBuilder,
+                  uint32_t numCases,
+                  JBCase **cases)
+   {
+   TR_ASSERT_FATAL(selectorValue->getDataType() == TR::Int32, "Switch only supports selector having type Int32");
+   *defaultBuilder = createBuilderIfNeeded(*defaultBuilder);
+
+   TR::Node *defaultNode = TR::Node::createCase(0, (*defaultBuilder)->getEntry()->getEntry());
+   TR::Node *lookupNode = TR::Node::create(TR::lookup, numCases + 2, loadValue(selectorValue), defaultNode);
+
+   generateSwitchCases(lookupNode, defaultNode, defaultBuilder, numCases, cases);
+   }
+
+void
+OMR::IlBuilder::Switch(TR::IlValue *selectorValue,
+                  TR::IlBuilder **defaultBuilder,
+                  uint32_t numCases,
+                  ...)
+   {
+   va_list args;
+   va_start(args, numCases);
+   JBCase **cases = createCaseArray(numCases, args);
+   va_end(args);
+
+   Switch(selectorValue, defaultBuilder, numCases, cases);
    }
 
 void

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2657,7 +2657,31 @@ OMR::IlBuilder::TableSwitch(const char *selectionVar,
                   uint32_t numCases,
                   JBCase **cases)
    {
-   TR::IlValue *selectorValue = Load(selectionVar);
+   TableSwitch(Load(selectionVar), defaultBuilder, generateBoundsCheck, numCases, cases);
+   }
+
+void
+OMR::IlBuilder::TableSwitch(const char *selectionVar,
+                  TR::IlBuilder **defaultBuilder,
+                  bool generateBoundsCheck,
+                  uint32_t numCases,
+                  ...)
+   {
+   va_list args;
+   va_start(args, numCases);
+   JBCase **cases = createCaseArray(numCases, args);
+   va_end(args);
+
+   TableSwitch(selectionVar, defaultBuilder, generateBoundsCheck, numCases, cases);
+   }
+
+void
+OMR::IlBuilder::TableSwitch(TR::IlValue * selectorValue,
+               TR::IlBuilder **defaultBuilder,
+               bool generateBoundsCheck,
+               uint32_t numCases,
+               JBCase** cases)
+   {
    TR_ASSERT_FATAL(selectorValue->getDataType() == TR::Int32, "TableSwitch only supports selector having type Int32");
    TR_ASSERT_FATAL(numCases > 0, "TableSwitch requires at least 1 case");
    int32_t low = cases[0]->_value;
@@ -2678,18 +2702,18 @@ OMR::IlBuilder::TableSwitch(const char *selectionVar,
    }
 
 void
-OMR::IlBuilder::TableSwitch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  bool generateBoundsCheck,
-                  uint32_t numCases,
-                  ...)
+OMR::IlBuilder::TableSwitch(TR::IlValue * selectorValue,
+               TR::IlBuilder **defaultBuilder,
+               bool generateBoundsCheck,
+               uint32_t numCases,
+               ...)
    {
    va_list args;
    va_start(args, numCases);
    JBCase **cases = createCaseArray(numCases, args);
    va_end(args);
 
-   TableSwitch(selectionVar, defaultBuilder, generateBoundsCheck, numCases, cases);
+   TableSwitch(selectorValue, defaultBuilder, generateBoundsCheck, numCases, cases);
    }
 
 TR::IlBuilder::JBCase *

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -2599,29 +2599,6 @@ OMR::IlBuilder::IfThenElse(TR::IlBuilder **thenPath, TR::IlBuilder **elsePath, T
    }
 
 void
-OMR::IlBuilder::Switch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  uint32_t numCases,
-                  JBCase **cases)
-   {
-   Switch(Load(selectionVar), defaultBuilder, numCases, cases);
-   }
-
-void
-OMR::IlBuilder::Switch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  uint32_t numCases,
-                  ...)
-   {
-   va_list args;
-   va_start(args, numCases);
-   JBCase **cases = createCaseArray(numCases, args);
-   va_end(args);
-
-   Switch(selectionVar, defaultBuilder, numCases, cases);
-   }
-
-void
 OMR::IlBuilder::Switch(TR::IlValue *selectorValue,
                   TR::IlBuilder **defaultBuilder,
                   uint32_t numCases,
@@ -2648,31 +2625,6 @@ OMR::IlBuilder::Switch(TR::IlValue *selectorValue,
    va_end(args);
 
    Switch(selectorValue, defaultBuilder, numCases, cases);
-   }
-
-void
-OMR::IlBuilder::TableSwitch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  bool generateBoundsCheck,
-                  uint32_t numCases,
-                  JBCase **cases)
-   {
-   TableSwitch(Load(selectionVar), defaultBuilder, generateBoundsCheck, numCases, cases);
-   }
-
-void
-OMR::IlBuilder::TableSwitch(const char *selectionVar,
-                  TR::IlBuilder **defaultBuilder,
-                  bool generateBoundsCheck,
-                  uint32_t numCases,
-                  ...)
-   {
-   va_list args;
-   va_start(args, numCases);
-   JBCase **cases = createCaseArray(numCases, args);
-   va_end(args);
-
-   TableSwitch(selectionVar, defaultBuilder, generateBoundsCheck, numCases, cases);
    }
 
 void

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -605,6 +605,39 @@ public:
                ...);
 
    /**
+    * @brief Generates a table switch-case control flow structure (IlValue overload).
+    *
+    * @param selectorValue the IlValue to switch on.
+    * @param defaultBuilder the builder for the default case.
+    * @param generateBoundsCheck generate the bounds check or not for the range of the cases
+    * @param numCases the number of cases.
+    * @param cases array of pointers to JBCase instances corresponding to each case.
+    */
+   void TableSwitch(TR::IlValue * selectorValue,
+               TR::IlBuilder **defaultBuilder,
+               bool generateBoundsCheck,
+               uint32_t numCases,
+               JBCase** cases);
+
+   /**
+    * @brief Generates a table switch-case control flow structure (IlValue and vararg overload).
+    *
+    * Instead of taking an array of pointers to JBCase instances, this overload
+    * takes a pointer to each instance as a separate varargs argument.
+    *
+    * @param selectorValue the IlValue to switch on.
+    * @param defaultBuilder the builder for the default case.
+    * @param generateBoundsCheck generate the bounds check or not for the range of the cases
+    * @param numCases the number of cases.
+    * @param ... the list of pointers to JBCase instances corresponding to each case.
+    */
+   void TableSwitch(TR::IlValue * selectorValue,
+               TR::IlBuilder **defaultBuilder,
+               bool generateBoundsCheck,
+               uint32_t numCases,
+               ...);
+
+   /**
     * @brief Construct an instance for JBCase.
     *
     * @param caseValue the value matched by the case.

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -542,6 +542,36 @@ public:
                ...);
 
    /**
+    * @brief Generates a lookup switch-case control flow structure (IlValue overload)
+    *
+    * @param selectorValue the IlValue to switch on.
+    * @param defaultBuilder the builder for the default case.
+    * @param numCases the number of cases.
+    * @param cases array of pointers to JBCase instances corresponding to each case.
+    */
+   void Switch(TR::IlValue *selectorValue,
+               TR::IlBuilder **defaultBuilder,
+               uint32_t numCases,
+               JBCase** cases);
+
+   /**
+    * @brief Generates a lookup switch-case control flow structure (IlValue and
+    * vararg overload).
+    *
+    * Instead of taking an array of pointers to JBCase instances, this overload
+    * takes a pointer to each instance as a separate varargs argument.
+    *
+    * @param selectorValue the IlValue to switch on.
+    * @param defaultBuilder the builder for the default case.
+    * @param numCases the number of cases.
+    * @param ... the list of pointers to JBCase instances corresponding to each case.
+    */
+   void Switch(TR::IlValue *selectorValue,
+               TR::IlBuilder **defaultBuilder,
+               uint32_t numCases,
+               ...);
+
+   /**
     * @brief Generates a table switch-case control flow structure.
     *
     * @param selectionVar the variable to switch on.

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -513,36 +513,7 @@ public:
       }
 
    /**
-    * @brief Generates a lookup switch-case control flow structure.
-    *
-    * @param selectionVar the variable to switch on.
-    * @param defaultBuilder the builder for the default case.
-    * @param numCases the number of cases.
-    * @param cases array of pointers to JBCase instances corresponding to each case.
-    */
-   void Switch(const char *selectionVar,
-               TR::IlBuilder **defaultBuilder,
-               uint32_t numCases,
-               JBCase** cases);
-
-   /**
-    * @brief Generates a lookup switch-case control flow structure (vararg overload).
-    *
-    * Instead of taking an array of pointers to JBCase instances, this overload
-    * takes a pointer to each instance as a separate varargs argument.
-    *
-    * @param selectionVar the variable to switch on.
-    * @param defaultBuilder the builder for the default case.
-    * @param numCases the number of cases.
-    * @param ... the list of pointers to JBCase instances corresponding to each case.
-    */
-   void Switch(const char *selectionVar,
-               TR::IlBuilder **defaultBuilder,
-               uint32_t numCases,
-               ...);
-
-   /**
-    * @brief Generates a lookup switch-case control flow structure (IlValue overload)
+    * @brief Generates a lookup switch-case control flow structure
     *
     * @param selectorValue the IlValue to switch on.
     * @param defaultBuilder the builder for the default case.
@@ -555,8 +526,7 @@ public:
                JBCase** cases);
 
    /**
-    * @brief Generates a lookup switch-case control flow structure (IlValue and
-    * vararg overload).
+    * @brief Generates a lookup switch-case control flow structure (vararg overload).
     *
     * Instead of taking an array of pointers to JBCase instances, this overload
     * takes a pointer to each instance as a separate varargs argument.
@@ -573,39 +543,6 @@ public:
 
    /**
     * @brief Generates a table switch-case control flow structure.
-    *
-    * @param selectionVar the variable to switch on.
-    * @param defaultBuilder the builder for the default case.
-    * @param generateBoundsCheck generate the bounds check or not for the range of the cases
-    * @param numCases the number of cases.
-    * @param cases array of pointers to JBCase instances corresponding to each case.
-    */
-   void TableSwitch(const char *selectionVar,
-               TR::IlBuilder **defaultBuilder,
-               bool generateBoundsCheck,
-               uint32_t numCases,
-               JBCase** cases);
-
-   /**
-    * @brief Generates a table switch-case control flow structure (vararg overload).
-    *
-    * Instead of taking an array of pointers to JBCase instances, this overload
-    * takes a pointer to each instance as a separate varargs argument.
-    *
-    * @param selectionVar the variable to switch on.
-    * @param defaultBuilder the builder for the default case.
-    * @param generateBoundsCheck generate the bounds check or not for the range of the cases
-    * @param numCases the number of cases.
-    * @param ... the list of pointers to JBCase instances corresponding to each case.
-    */
-   void TableSwitch(const char *selectionVar,
-               TR::IlBuilder **defaultBuilder,
-               bool generateBoundsCheck,
-               uint32_t numCases,
-               ...);
-
-   /**
-    * @brief Generates a table switch-case control flow structure (IlValue overload).
     *
     * @param selectorValue the IlValue to switch on.
     * @param defaultBuilder the builder for the default case.

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -1464,18 +1464,7 @@
                 , "parms": [ {"name":"value","type":"IlValue"} ]
                 },
                 { "name": "Switch"
-                , "overloadsuffix": "WithArgArray"
-                , "flags": []
-                , "return": "none"
-                , "parms": [
-                    {"name":"selectionVar","type":"constString"},
-                    {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
-                    {"name":"numCases","type":"int32"},
-                    {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
-                    ]
-                },
-                { "name": "Switch"
-                    , "overloadsuffix": "ValWithArgArray"
+                    , "overloadsuffix": "WithArgArray"
                     , "flags": []
                     , "return": "none"
                     , "parms": [
@@ -1486,24 +1475,13 @@
                         ]
                 },
                 { "name": "TableSwitch"
-                , "overloadsuffix": "WithArgArray"
-                , "flags": []
-                , "return": "none"
-                , "parms": [
-                    {"name":"selectionVar","type":"constString"},
-                    {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
-                    {"name":"generateBoundsCheck","type":"boolean"},
-                    {"name":"numCases","type":"int32"},
-                    {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
-                    ]
-                },
-                { "name": "TableSwitch"
-                    , "overloadsuffix": "ValWithArgArray"
+                    , "overloadsuffix": "WithArgArray"
                     , "flags": []
                     , "return": "none"
                     , "parms": [
                         {"name":"selectorValue","type":"IlValue"},
                         {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
+                        {"name": "generateBoundsCheck", "type": "boolean"},
                         {"name":"numCases","type":"int32"},
                         {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
                         ]

--- a/jitbuilder/apigen/jitbuilder.api.json
+++ b/jitbuilder/apigen/jitbuilder.api.json
@@ -1474,6 +1474,17 @@
                     {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
                     ]
                 },
+                { "name": "Switch"
+                    , "overloadsuffix": "ValWithArgArray"
+                    , "flags": []
+                    , "return": "none"
+                    , "parms": [
+                        {"name":"selectorValue","type":"IlValue"},
+                        {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
+                        {"name":"numCases","type":"int32"},
+                        {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
+                        ]
+                },
                 { "name": "TableSwitch"
                 , "overloadsuffix": "WithArgArray"
                 , "flags": []
@@ -1485,6 +1496,17 @@
                     {"name":"numCases","type":"int32"},
                     {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
                     ]
+                },
+                { "name": "TableSwitch"
+                    , "overloadsuffix": "ValWithArgArray"
+                    , "flags": []
+                    , "return": "none"
+                    , "parms": [
+                        {"name":"selectorValue","type":"IlValue"},
+                        {"name":"defaultBuilder","type":"IlBuilder","attributes":["in_out"]},
+                        {"name":"numCases","type":"int32"},
+                        {"name":"cases","type":"JBCase","attributes":["array","can_be_vararg"],"array-len":"numCases"}
+                        ]
                 },
                 { "name": "MakeCase"
                 , "overloadsuffix": ""

--- a/jitbuilder/release/cpp/samples/Switch.cpp
+++ b/jitbuilder/release/cpp/samples/Switch.cpp
@@ -87,7 +87,7 @@ SwitchMethod::buildIL()
    {
    OMR::JitBuilder::IlBuilder *defaultBldr=NULL;
    OMR::JitBuilder::IlBuilder *case1Bldr=NULL, *case2Bldr=NULL, *case3Bldr=NULL;
-   Switch("selector", &defaultBldr, 3,
+   Switch(Load("selector"), &defaultBldr, 3,
           MakeCase(1, &case1Bldr, false),
           MakeCase(2, &case2Bldr, false),
           MakeCase(3, &case3Bldr, false));

--- a/jitbuilder/release/cpp/samples/TableSwitch.cpp
+++ b/jitbuilder/release/cpp/samples/TableSwitch.cpp
@@ -87,7 +87,7 @@ TableSwitchMethod::buildIL()
    {
    OMR::JitBuilder::IlBuilder *defaultBldr=NULL;
    OMR::JitBuilder::IlBuilder *case1Bldr=NULL, *case2Bldr=NULL, *case3Bldr=NULL;
-   TableSwitch("selector", &defaultBldr, true, 3,
+   TableSwitch(Load("selector"), &defaultBldr, true, 3,
           MakeCase(1, &case1Bldr, false),
           MakeCase(2, &case2Bldr, false),
           MakeCase(3, &case3Bldr, false));


### PR DESCRIPTION
The existing Switch and  TableSwitch (and their overloads) services
could only be used if the condition to switch upon was a named
variable. It was not possible to provide an IlValue to switch on,
which limited the scenarios where we could use the Switch service.

This changeset adds 2 overloads of the Switch service to use IlValue
as the condition to switch on, while still ensuring that the IlValue
provided is of Int32 data type.

Signed-off-by: Nazim Uddin Bhuiyan <nazimudd@ualberta.ca>

This changeset was motivated by the [lljb project](https://github.com/nbhuiyan/lljb).