### PR TITLE
WIP: Created Function Prototypes for OMR SocketAPI

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -43,6 +43,7 @@
 #include "omrthread.h"
 #include "omrmemcategories.h"
 #include "omrporterror.h"
+#include "omrportsock.h"
 #if defined(OMR_OPT_CUDA)
 #include "omrcuda.h"
 #endif /* OMR_OPT_CUDA */
@@ -1688,6 +1689,39 @@ typedef struct OMRPortLibrary {
 	uintptr_t (*heap_query_size)(struct OMRPortLibrary *portLibrary, struct J9Heap *heap, void *address) ;
 	/** see @ref omrheap.c::omrheap_grow "omrheap_grow"*/
 	BOOLEAN (*heap_grow)(struct OMRPortLibrary *portLibrary, struct J9Heap *heap, uintptr_t growAmount) ;
+	int32_t (*sock_getaddrinfo_create_hints)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int family, int socktype, int protocol, int flags) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo "omrsock_getaddrinfo"*/
+	int32_t (*sock_getaddrinfo)(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_length "omrsock_getaddrinfo_length"*/
+	int32_t (*sock_getaddrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, int32_t *length) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_family "omrsock_getaddrinfo_family"*/
+	int32_t (*sock_getaddrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int index )	;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_socktype "omrsock_getaddrinfo_socktype"*/
+	int32_t (*sock_getaddrinfo_socktype)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int index) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_protocol "omrsock_getaddrinfo_protocol"*/
+	int32_t (*sock_getaddrinfo_protocol)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int index) ;
+	/** see @ref omrsock.c::omrsock_freeaddrinfo "omrsock_freeaddrinfo"*/
+	int32_t (*sock_freeaddrinfo)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle) ;
+	/** see @ref omrsock.c::omrsock_socket "omrsock_socket"*/
+	int32_t (*sock_socket)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol) ;
+	/** see @ref omrsock.c::omrsock_bind "omrsock_bind"*/
+	int32_t (*sock_bind)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr) ;
+	/** see @ref omrsock.c::omrsock_listen "omrsock_listen"*/
+	int32_t (*sock_listen)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog) ;
+	/** see @ref omrsock.c::omrsock_connect "omrsock_connect"*/
+	int32_t (*sock_connect)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr) ;
+	/** see @ref omrsock.c::omrsock_accept "omrsock_accept"*/
+	int32_t (*sock_accept)(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle) ;
+	/** see @ref omrsock.c::omrsock_send "omrsock_send"*/
+	int32_t (*sock_send)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags) ;
+	/** see @ref omrsock.c::omrsock_sendto "omrsock_sendto"*/
+	int32_t (*sock_sendto)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle) ;
+	/** see @ref omrsock.c::omrsock_recv "omrsock_recv"*/
+	int32_t (*sock_recv)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags) ;
+	/** see @ref omrsock.c::omrsock_recvfrom "omrsock_recvfrom"*/
+	int32_t (*sock_recvfrom)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle) ;
+	/** see @ref omrsock.c::omrsock_close "omrsock_close"*/
+	int32_t (*sock_close)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock) ;
 #if defined(OMR_OPT_CUDA)
 	/** CUDA configuration data */
 	J9CudaConfig *cuda_configData;
@@ -2128,7 +2162,23 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrmem_categories_decrement_counters(param1,param2) privateOmrPortLibrary->mem_categories_decrement_counters((param1), (param2))
 #define omrheap_query_size(param1,param2) privateOmrPortLibrary->heap_query_size(privateOmrPortLibrary, (param1), (param2))
 #define omrheap_grow(param1,param2) privateOmrPortLibrary->heap_grow(privateOmrPortLibrary, (param1), (param2))
-
+#define omrsock_getaddrinfo_create_hints(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_getaddrinfo_create_hints(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
+#define omrsock_getaddrinfo(param1,param2,param3,param4) privateOmrPortLibrary->sock_getaddrinfo(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_getaddrinfo_length(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_length(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_getaddrinfo_family(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_family(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_getaddrinfo_socktype(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_socktype(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_getaddrinfo_protocol(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_protocol(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_freeaddrinfo(param1) privateOmrPortLibrary->sock_freeaddrinfo(privateOmrPortLibrary, (param1))
+#define omrsock_socket(param1, param2, param3, param4) privateOmrPortLibrary->sock_socket(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_bind(param1,param2) privateOmrPortLibrary->sock_bind(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_listen(param1,param2) privateOmrPortLibrary->sock_listen(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_connect(param1,param2) privateOmrPortLibrary->sock_connect(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_accept(param1,param2,param3) privateOmrPortLibrary->sock_accept(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_send(param1,param2,param3,param4) privateOmrPortLibrary->sock_send(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_sendto(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_sendto(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
+#define omrsock_recv(param1,param2,param3,param4) privateOmrPortLibrary->sock_recv(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_recvfrom(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_recvfrom(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
+#define omrsock_close(param1) privateOmrPortLibrary->sock_close(privateOmrPortLibrary, (param1))
 #if defined(OMR_OPT_CUDA)
 #define omrcuda_startup() \
 				privateOmrPortLibrary->cuda_startup(privateOmrPortLibrary)

--- a/include_core/omrportsock.h
+++ b/include_core/omrportsock.h
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/******************************************************\
+		Common data types required for using the omr socket API
+\******************************************************/
+
+#if !defined(OMRPORTSOCK_H_)
+#define OMRPORTSOCK_H_
+
+#if defined(OMR_OS_WINDOWS) && defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
+#undef _WINSOCKAPI_
+#endif /* defined(OMR_OS_WINDOWS) && defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_) */
+
+#if defined(OMR_OS_WINDOWS)
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else /* defined(OMR_OS_WINDOWS) */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif /* defined(OMR_OS_WINDOWS) */
+
+
+#if defined(OMR_OS_WINDOWS)
+typedef SOCKET OMRSocket;
+typedef SOCKADDR OMRSockAddr; /* for IPv4 */
+typedef SOCKADDR_IN OMRSockAddrIn;	/* for IPv4 addresses*/
+typedef SOCKADDR_IN6 OMRSockAddrIn6;  /* for IPv6 addresses*/
+typedef struct sockaddr_storage OMRSockAddrStorage; /* Big enough storage for IPv4 or IPv6 addresses */
+typedef struct addrinfoW OMRAddrInfo;  /* addrinfo structure – Unicode for both IPv4 and IPv6 */
+#else /* defined(OMR_OS_WINDOWS) */
+typedef int OMRSocket;
+typedef struct sockaddr OMRSockAddr;
+typedef struct sockaddr_in OMRSockAddrIn; /* for IPv4 addresses*/
+typedef struct sockaddr_in6 OMRSockAddrIn6; /* for IPv6 addresses*/
+typedef struct sockaddr_storage OMRSockAddrStorage; /* Big enough storage for IPv4 or IPv6 addresses */
+typedef struct addrinfo OMRAddrInfo; /* addrinfo structure for both IPv4 and IPv6 */
+#endif /* defined(OMR_OS_WINDOWS) */
+
+/* Filled in using @omr_getaddrinfo. */
+typedef struct OMRAddrInfoNode {
+	OMRAddrInfo* addrInfo;		/* Defined differently depending on the operating system. Pointer to the first addrinfo node in listed list. */
+	int length; 				/* Number of addrinfo nodes in linked list */
+} OMRAddrInfoNode;
+typedef OMRAddrInfoNode* omrsock_addrinfo_t;
+
+/* Used for storage of ip addresses. If we are only supporting IPv4, then we allocate smaller storage space. */
+#if defined(IPv6_FUNCTION_SUPPORT)
+typedef struct sockaddr_storage OMRSockAddr; /* Big enough storage for IPv4 or IPv6 addresses */
+#else /* defined(IPv6_FUNCTION_SUPPORT) */
+typedef struct sockaddr OMRSockAddr;
+#endif /* defined(IPv6_FUNCTION_SUPPORT) */
+typedef OMRSockAddr* omrsock_sockaddr_t;
+
+
+/* Used to store information about a host. Should never modify or free the content of hostent. */
+typedef struct hostent OMRHostent;
+
+
+/* Pointer to a socket descriptor */
+typedef OMRSocket* omrsock_socket_t;	/* OMRSocket is SOCKET type for Windows, int for all other operating systems */
+
+/* Socket Types */
+#define OMRSOCK_ANY			 0                   /* for getaddrinfo hints */
+#define OMRSOCK_STREAM     SOCK_STREAM              /* stream socket */
+#define OMRSOCK_DGRAM      SOCK_DGRAM               /* datagram socket */
+#if 0 /* Future Implementations*/
+#define OMR_SOCK_RAW        SOCK_RAW                 /* raw-protocol interface */
+#define OMR_SOCK_RDM        SOCK_RDM                 /* reliably-delivered message */
+#define OMR_SOCK_SEQPACKET  SOCK_SEQPACKET           /* sequenced packet stream */
+#endif /* Future Implementations*/
+
+/* Address Family */
+#define OMRSOCK_AF_UNSPEC       AF_UNSPEC
+#define OMRSOCK_AF_INET4        AF_INET
+#define OMRSOCK_PF_UNSPEC       PF_UNSPEC
+#define OMRSOCK_PF_INET4        PF_INET
+#define OMRSOCK_INET4_ADDRESS_LENGTH INET_ADDRSTRLEN
+#define OMRSOCK_AF_INET6        AF_INET6
+#define OMRSOCK_PF_INET6 PF_INET6
+#define OMRSOCK_INET6_ADDRESS_LENGTH INET6_ADDRSTRLEN
+
+/* Socket Flag */
+#define OMRSOCK_AI_CANONNAME    AI_CANONNAME
+#define OMRSOCK_AI_NUMERICHOST  AI_NUMERICHOST
+#define OMRSOCK_AI_PASSIVE      AI_PASSIVE
+
+/* Socket Options */
+#define OMRSOCK_SO_KEEPALIVE    SO_KEEPALIVE
+#define OMRSOCK_SO_REUSEADDR    SO_REUSEADDR
+#if 0 /* Future Implementations */
+#define OMRSOCK_SO_LINGER       SO_LINGER
+#define OMRSOCK_SO_SNDBUF       SO_SNDBUF
+#define OMRSOCK_SO_RCVBUF       SO_RCVBUF
+#define OMRSOCK_SO_BROADCAST    SO_BROADCAST /*[PR1FLSKTU] Support datagram broadcasts */
+#define OMRSOCK_SO_OOBINLINE    SO_OOBINLINE
+#endif /* Future Implementations */
+
+/* Socket Level */
+#define OMRSOCK_SOL_SOCKET      SOL_SOCKET
+/* Protocol Family */
+#define OMRSOCK_IPPROTO_IP      IPPROTO_IP       /* Dummy protocol for TCP (default) */
+#define OMRSOCK_IPPROTO_TCP     IPPROTO_TCP     /* Transmission Control Protocol */
+#define OMRSOCK_IPPROTO_IPV6    IPPROTO_IPV6   /* IPv6 header */
+#define OMRSOCK_IPPROTO_UDP     IPPROTO_UDP     /* User Datagram Protocol */
+
+#endif /* !defined(OMRPORTSOCK_H_) */

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -169,6 +169,7 @@ list(APPEND OBJECTS
 	omrmemcategories.c
 	omrport.c
 	omrmmap.c
+	omrsock.c
 	j9nls.c
 	j9nlshelpers.c
 	omrosbacktrace.c

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -299,6 +299,23 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrmem_categories_decrement_counters, /* mem_categories_decrement_counters */
 	omrheap_query_size, /* heap_query_size */
 	omrheap_grow, /* heap_grow*/
+	omrsock_getaddrinfo_create_hints, /* sock_getaddrinfo_create_hints */
+	omrsock_getaddrinfo, /* sock_getaddrinfo */
+	omrsock_getaddrinfo_length, /* sock_getaddrinfo_length */
+	omrsock_getaddrinfo_family, /* sock_getaddrinfo_family */
+	omrsock_getaddrinfo_socktype, /* sock_getaddrinfo_socktype */
+	omrsock_getaddrinfo_protocol, /* sock_getaddrinfo_protocol */
+	omrsock_freeaddrinfo, /* sock_freeaddrinfo */
+	omrsock_socket, /* sock_socket */
+	omrsock_bind, /* sock_bind */
+	omrsock_listen, /* sock_listen */
+	omrsock_connect, /* sock_connect */
+	omrsock_accept, /* sock_accept */
+	omrsock_send, /* sock_send */
+	omrsock_sendto, /* sock_sendto */
+	omrsock_recv, /* sock_recv */
+	omrsock_recvfrom, /* sock_recvfrom */
+	omrsock_close, /* sock_close */
 #if defined(OMR_OPT_CUDA)
 	NULL, /* cuda_configData */
 	omrcuda_startup, /* cuda_startup */

--- a/port/common/omrsock.c
+++ b/port/common/omrsock.c
@@ -1,0 +1,392 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Sockets
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "omrsock.h"
+
+/**
+ * Returns hints as a double pointer to an OMRAddInfoNode structure.
+ * 
+ * This hints structure is used to modify the results returned by a call to @ref omrsock_getaddrinfo. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] hints The filled-in hints structure
+ * @param[in] family A address family type
+ * @param[in] socktype A socket type
+ * @param[in] protocol A protocol family
+ * @param[in] flags Flags for modifying the result. If you wish to use multiple flags, perform the OR operation on the flags before passing it in.
+ *
+ * @return
+ * @arg 0, if no errors occurred, otherwise the (negative) error code
+ *
+ * @note current supported family types are:
+ * @arg OMRSOCK_AF_UNSPEC
+ * @arg OMRSOCK_AF_INET4
+ * @arg OMRSOCK_AF_INET6
+ *
+ * @note Works with both IPv4 and IPv6 support.
+ */
+int32_t
+omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int family, int socktype, int protocol, int flags)
+{
+	return -1;
+}
+
+/**
+ * Answers a list of addresses as an opaque struct in "result".
+ * 
+ * Use the following functions to extract the details:
+ * @arg @ref omrsock_getaddrinfo_length
+ * @arg @ref omrsock_getaddrinfo_family
+ * @arg @ref omrsock_getaddrinfo_socktype
+ * @arg @ref omrsock_getaddrinfo_protocol
+
+ * @param[in] portLibrary The port library.
+ * @param[in] node The name of the host in either host name format or in IPv4 or IPv6 accepted notations.
+ * @param[in] service The port of the host in string form.
+ * @param[in] hints Hints on what results are returned (can be NULL for default action). Use omrsock_getaddrinfo_create_hints to create the hints.
+ * @param[out] result An opaque pointer to a list of results (OMRAddrInfoNode must be preallocated).
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ *
+ * @note you must free the "result" structure with @ref omrsock_freeaddrinfo to free up memory.
+ */
+int32_t
+omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result)
+{
+	return -1;
+}
+
+/**
+ * Answers the number of results returned from @ref omrsock_getaddrinfo.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] length The number of results.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, int32_t *length)
+{
+	return -1;
+}
+
+
+/**
+ * Answers the family type of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the family types we support are OMRSOCK_AF_INET and OMRSOCK_AF_INET6.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] family The family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int index)
+{
+	return -1;
+}
+
+/**
+ * Answers the socket type of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the socket types we support are OMRSOCK_STREAM and OMRSOCK_DATAGRAM.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] socktype The socket type at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int index)
+{
+	return -1;
+}
+
+/**
+ * Answers the protocol of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the protocols we support are OMRSOCK_IPPROTO_IP, OMRSOCK_IPPROTO_TCP, OMRSOCK_IPPROTO_IPV6, and OMRSOCK_IPPROTO_UDP. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] protocol The protocol family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int index)
+{
+	return -1;
+}
+
+/**
+ * Frees the memory created by the call to @ref omrsock_getaddrinfo().
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle Hints on what results are returned for getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ *
+ */
+
+int32_t
+omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle)
+{
+	return -1;
+}
+
+/**
+ * Creates a new socket descriptor and any related resources.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] sock Pointer to the omrsocket, to be allocated
+ * @param[in] family The address family
+ * @arg OMRSOCK_AF_INET, for a IPv4 socket
+ * @arg OMRSOCK_AF_INET6, for a IPv6 socket
+ * @param[in] socktype Specifies what type of socket is created
+ * @arg OMRSOCK_STREAM, for a stream socket
+ * @arg OMRSOCK_DGRAM, for a datagram socket
+ * @param[in] protocol Type/family specific creation parameter
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol)
+{
+	return -1;
+}
+
+/**
+ * The bind function is used on an unconnected socket before subsequent 
+ * calls to the connect or listen functions. When a socket is created with a 
+ * call to the socket function, it exists in a name space (address family), but 
+ * it has no name assigned to it. Use bind to establish the local association 
+ * of the socket by assigning a local name to an unnamed socket.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be be associated with the specified name.
+ * @param[in] addr Address to bind to socket.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return -1;
+}
+
+/**
+ * Set the socket to listen for incoming connection requests.  This call is made prior to accepting requests,
+ * via the @ref omrsock_accept function.  The backlog specifies the maximum length of the queue of pending connections,
+ * after which further requests are rejected.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket.
+ * @param[in] backlog The maximum number of queued requests.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_listen(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog)
+{
+	return -1;
+}
+
+/**
+ * Establish a connection to a peer.
+ *
+ * For stream sockets, it first binds the socket if it hasn't already been done. Then, it
+ * tries to set up a connection.
+ * 
+ * For datagram sockets, connect function will set up the peer information. No actual
+ * connection is made. Subsequent calls to connect can be made to change destination address.
+ *
+ * It is not recommended that users call this
+ * function multiple times to determine when the connection attempt has succeeded.
+ * Instead, the omrsock_select() function can be used to determine when the socket 
+ * is ready for reading or writing.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the unconnected local socket.
+ * @param[in] addr Pointer to the sockaddr, specifying remote host/port.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_connect(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return -1;
+}
+
+/**
+ * The accept function extracts the first connection on the queue of pending connections 
+ * on socket serverSock. It then creates a new socket and returns a handle to the new socket. 
+ * The newly created socket is the socket that will handle the actual the connection and 
+ * has the same properties as socket serverSock.  
+ *
+ * The accept function can block the caller until a connection is present if no pending 
+ * connections are present on the queue.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] serverSock  A omrsock_socket_t that tries to accept a connection.
+ * @param[in] addrHandle An optional pointer to a buffer that receives the address of the connecting 
+ * entity, as known to the communications layer. The exact format of the addr parameter 
+ * is determined by the address family established when the socket was created
+ * @param[out] sockHandle A pointer to a omrsock_socket_t which will point to the newly created 
+ * socket once accept returns successfully
+ *
+* @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+
+int32_t
+omrsock_accept(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle)
+{
+	return -1;
+}
+
+/**
+ * The send function sends data to a connected socket.  The successful completion of a send 
+ * does not indicate that the data was successfully delivered.  If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, send will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on
+ * @param[in] buf The bytes to be sent
+ * @param[in] nbyte The number of bytes to send
+ * @param[in] flags The flags to modify the send behavior
+ *
+ * @return	If no error occur, return the total number of bytes sent, which can be less than the 
+ * 'nbyte' for nonblocking sockets, otherwise the (negative) error code
+ */
+int32_t
+omrsock_send(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return -1;
+}
+
+/**
+ * The sendto function sends data to a datagram socket.  The successful completion of a writeto
+ * does not indicate that the data was successfully delivered.  If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, sendto will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on
+ * @param[in] buf The bytes to be sent
+ * @param[in] nbyte The number of bytes to send
+ * @param[in] flags The flags to modify the send behavior
+ * @param [in] addrHandle The network address to send the datagram to
+ *
+ * @return	If no error occur, return the total number of bytes sent, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_sendto(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return -1;
+}
+
+/**
+ * Receives data from a connected socket.  
+ * 
+ * This will return as much information as is currently available up to the size of the buffer supplied. 
+ * 
+ * We will implement in the future so that bbehaviour depending on the blocking characteristic of the socket.
+ *
+ *	Blocking socket:
+ * 		- If no incoming data is available, the call blocks and waits for data to arrive. 
+ * 
+ * 	Non-blocking socket:
+ * 		- Will be implemented in the future
+ * 		- If no incoming data is immediately available, the negative portable error code OMRERROR_SOCKET_WOULDBLOCK is returned.
+ * 
+ * @param[in]	portLibrary The port library.
+ * @param[in] 	sock Pointer to the socket to read on
+ * @param[out] 	buf Pointer to the buffer where input bytes are written
+ * @param[in] 	nbyte The length of buf
+ * @param[in] 	flags The flags, to influence this read (in addition to the socket options)
+ *
+ * @return
+ * @arg If no error occurs, return the number of bytes received.
+ * @arg If the connection has been gracefully closed, return 0.
+ * @arg Otherwise return the (negative) error code.
+ */
+int32_t
+omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return -1;
+}
+
+/**
+ * The recvfrom function receives data from a possibly connected socket.  Calling recvfrom will return as much 
+ * information as is currently available up to the size of the buffer supplied.  If the information is too large
+ * for the buffer, the excess will be discarded.  If no incoming  data is available at the socket, the recv call 
+ * blocks and waits for data to arrive.  It the address argument is not null, the address will be updated with
+ * address of the message sender.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to read on.
+ * @param[out] buf Pointer to the buffer where input bytes are written.
+ * @param[in] nbyte The length of buf.
+ * @param[in] flags Tthe flags, to influence this read.
+ * @param[out] addrHandle	if provided, the address to be updated with the sender information.
+ *
+ * @return
+ * @arg If no error occurs, return the number of bytes received.
+ * @arg If the connection has been gracefully closed, return 0.
+ * @arg Otherwise return the (negative) error code.
+ */
+int32_t
+omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return -1;
+}
+
+/**
+ * The close function closes a socket. Use it to release the socket descriptor socket so 
+ * further references to socket will fail.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be closed.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock)
+{
+	return -1;
+}
+

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -600,6 +600,42 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 extern J9_CFUNC void
 omrsl_shutdown(struct OMRPortLibrary *portLibrary);
 
+/* J9SourceJ9Sock*/
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int family, int socktype, int protocol, int flags);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, int32_t *length);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int index);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int index);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int index);
+extern J9_CFUNC int32_t
+omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle);
+extern J9_CFUNC int32_t
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol);
+extern J9_CFUNC int32_t
+omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr);
+extern J9_CFUNC int32_t
+omrsock_listen(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog);
+extern J9_CFUNC int32_t
+omrsock_connect(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr);
+extern J9_CFUNC int32_t
+omrsock_accept(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle);
+extern J9_CFUNC int32_t
+omrsock_send(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags);
+extern J9_CFUNC int32_t
+omrsock_sendto(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle);
+extern J9_CFUNC int32_t
+omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags);
+extern J9_CFUNC int32_t
+omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle);
+extern J9_CFUNC int32_t
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock);
+
 /* J9SourceJ9Str*/
 extern J9_CFUNC uintptr_t
 omrstr_vprintf(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen, const char *format, va_list args);

--- a/port/unix/omrsock.c
+++ b/port/unix/omrsock.c
@@ -1,0 +1,401 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Sockets
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <sys/wait.h>
+#include <signal.h>
+
+#include "omrsock.h"
+
+/**
+ * Returns hints as a double pointer to an OMRAddInfoNode structure.
+ * 
+ * This hints structure is used to modify the results returned by a call to @ref omrsock_getaddrinfo. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] hints The filled-in hints structure
+ * @param[in] family A address family type
+ * @param[in] socktype A socket type
+ * @param[in] protocol A protocol family
+ * @param[in] flags Flags for modifying the result. If you wish to use multiple flags, perform the OR operation on the flags before passing it in.
+ *
+ * @return
+ * @arg 0, if no errors occurred, otherwise the (negative) error code
+ *
+ * @note current supported family types are:
+ * @arg OMRSOCK_AF_UNSPEC
+ * @arg OMRSOCK_AF_INET4
+ * @arg OMRSOCK_AF_INET6
+ *
+ * @note Works with both IPv4 and IPv6 support.
+ */
+int32_t
+omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int family, int socktype, int protocol, int flags)
+{
+	return 0;
+}
+
+/**
+ * Answers a list of addresses as an opaque struct in "result".
+ * 
+ * Use the following functions to extract the details:
+ * @arg @ref omrsock_getaddrinfo_length
+ * @arg @ref omrsock_getaddrinfo_family
+ * @arg @ref omrsock_getaddrinfo_socktype
+ * @arg @ref omrsock_getaddrinfo_protocol
+
+ * @param[in] portLibrary The port library.
+ * @param[in] node The name of the host in either host name format or in IPv4 or IPv6 accepted notations.
+ * @param[in] service The port of the host in string form.
+ * @param[in] hints Hints on what results are returned (can be NULL for default action). Use omrsock_getaddrinfo_create_hints to create the hints.
+ * @param[out] result An opaque pointer to a list of results (OMRAddrInfoNode must be preallocated).
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ *
+ * @note you must free the "result" structure with @ref omrsock_freeaddrinfo to free up memory.
+ */
+int32_t
+omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result)
+{
+	return 0;
+}
+
+/**
+ * Answers the number of results returned from @ref omrsock_getaddrinfo.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] length The number of results.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, int32_t *length)
+{
+	return 0;
+}
+
+
+/**
+ * Answers the family type of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the family types we support are OMRSOCK_AF_INET and OMRSOCK_AF_INET6.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] family The family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int index)
+{
+	return 0;
+}
+
+/**
+ * Answers the socket type of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the socket types we support are OMRSOCK_STREAM and OMRSOCK_DATAGRAM.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] socktype The socket type at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int index)
+{
+	return 0;
+}
+
+/**
+ * Answers the protocol of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the protocols we support are OMRSOCK_IPPROTO_IP, OMRSOCK_IPPROTO_TCP, OMRSOCK_IPPROTO_IPV6, and OMRSOCK_IPPROTO_UDP. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] protocol The protocol family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int index)
+{
+	return 0;
+}
+
+/**
+ * Frees the memory created by the call to @ref omrsock_getaddrinfo().
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle Hints on what results are returned for getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ *
+ */
+
+int32_t
+omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle)
+{
+	return 0;
+}
+
+/**
+ * Creates a new socket descriptor and any related resources.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] sock Pointer to the omrsocket, to be allocated
+ * @param[in] family The address family
+ * @arg OMRSOCK_AF_INET, for a IPv4 socket
+ * @arg OMRSOCK_AF_INET6, for a IPv6 socket
+ * @param[in] socktype Specifies what type of socket is created
+ * @arg OMRSOCK_STREAM, for a stream socket
+ * @arg OMRSOCK_DGRAM, for a datagram socket
+ * @param[in] protocol Type/family specific creation parameter
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype,  int32_t protocol)
+{
+	return 0;
+}
+
+/**
+ * The bind function is used on an unconnected socket before subsequent 
+ * calls to the connect or listen functions. When a socket is created with a 
+ * call to the socket function, it exists in a name space (address family), but 
+ * it has no name assigned to it. Use bind to establish the local association 
+ * of the socket by assigning a local name to an unnamed socket.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be be associated with the specified name.
+ * @param[in] addr Address to bind to socket.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return 0;
+}
+
+/**
+ * Set the socket to listen for incoming connection requests.  This call is made prior to accepting requests,
+ * via the @ref omrsock_accept function.  The backlog specifies the maximum length of the queue of pending connections,
+ * after which further requests are rejected.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket.
+ * @param[in] backlog The maximum number of queued requests.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_listen(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog)
+{
+	return 0;
+}
+
+/**
+ * Establish a connection to a peer.
+ *
+ * For stream sockets, it first binds the socket if it hasn't already been done. Then, it
+ * tries to set up a connection.
+ * 
+ * For datagram sockets, connect function will set up the peer information. No actual
+ * connection is made. Subsequent calls to connect can be made to change destination address.
+ *
+ * It is not recommended that users call this
+ * function multiple times to determine when the connection attempt has succeeded.
+ * Instead, the omrsock_select() function can be used to determine when the socket 
+ * is ready for reading or writing.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the unconnected local socket.
+ * @param[in] addr Pointer to the sockaddr, specifying remote host/port.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_connect(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return 0;
+}
+
+/**
+ * The accept function extracts the first connection on the queue of pending connections 
+ * on socket serverSock. It then creates a new socket and returns a handle to the new socket. 
+ * The newly created socket is the socket that will handle the actual the connection and 
+ * has the same properties as socket serverSock.  
+ *
+ * The accept function can block the caller until a connection is present if no pending 
+ * connections are present on the queue.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] serverSock  A omrsock_socket_t that tries to accept a connection.
+ * @param[in] addrHandle An optional pointer to a buffer that receives the address of the connecting 
+ * entity, as known to the communications layer. The exact format of the addr parameter 
+ * is determined by the address family established when the socket was created
+ * @param[out] sockHandle A pointer to a omrsock_socket_t which will point to the newly created 
+ * socket once accept returns successfully
+ *
+* @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+
+int32_t
+omrsock_accept(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle)
+{
+	return 0;
+}
+
+/**
+ * The send function sends data to a connected socket.  The successful completion of a send 
+ * does not indicate that the data was successfully delivered.  If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, send will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on
+ * @param[in] buf The bytes to be sent
+ * @param[in] nbyte The number of bytes to send
+ * @param[in] flags The flags to modify the send behavior
+ *
+ * @return	If no error occur, return the total number of bytes sent, which can be less than the 
+ * 'nbyte' for nonblocking sockets, otherwise the (negative) error code
+ */
+int32_t
+omrsock_send(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return 0;
+}
+
+/**
+ * The sendto function sends data to a datagram socket.  The successful completion of a writeto
+ * does not indicate that the data was successfully delivered.  If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, sendto will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on
+ * @param[in] buf The bytes to be sent
+ * @param[in] nbyte The number of bytes to send
+ * @param[in] flags The flags to modify the send behavior
+ * @param [in] addrHandle The network address to send the datagram to
+ *
+ * @return	If no error occur, return the total number of bytes sent, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_sendto(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return 0;
+}
+
+/**
+ * Receives data from a connected socket.  
+ * 
+ * This will return as much information as is currently available up to the size of the buffer supplied. 
+ * 
+ * We will implement in the future so that bbehaviour depending on the blocking characteristic of the socket.
+ *
+ *	Blocking socket:
+ * 		- If no incoming data is available, the call blocks and waits for data to arrive. 
+ * 
+ * 	Non-blocking socket:
+ * 		- Will be implemented in the future
+ * 		- If no incoming data is immediately available, the negative portable error code OMRERROR_SOCKET_WOULDBLOCK is returned.
+ * 
+ * @param[in]	portLibrary The port library.
+ * @param[in] 	sock Pointer to the socket to read on
+ * @param[out] 	buf Pointer to the buffer where input bytes are written
+ * @param[in] 	nbyte The length of buf
+ * @param[in] 	flags The flags, to influence this read (in addition to the socket options)
+ *
+ * @return
+ * @arg If no error occurs, return the number of bytes received.
+ * @arg If the connection has been gracefully closed, return 0.
+ * @arg Otherwise return the (negative) error code.
+ */
+int32_t
+omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return 0;
+}
+
+/**
+ * The recvfrom function receives data from a possibly connected socket.  Calling recvfrom will return as much 
+ * information as is currently available up to the size of the buffer supplied.  If the information is too large
+ * for the buffer, the excess will be discarded.  If no incoming  data is available at the socket, the recv call 
+ * blocks and waits for data to arrive.  It the address argument is not null, the address will be updated with
+ * address of the message sender.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to read on.
+ * @param[out] buf Pointer to the buffer where input bytes are written.
+ * @param[in] nbyte The length of buf.
+ * @param[in] flags Tthe flags, to influence this read.
+ * @param[out] addrHandle	if provided, the address to be updated with the sender information.
+ *
+ * @return
+ * @arg If no error occurs, return the number of bytes received.
+ * @arg If the connection has been gracefully closed, return 0.
+ * @arg Otherwise return the (negative) error code.
+ */
+int32_t
+omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return 0;
+}
+
+/**
+ * The close function closes a socket. Use it to release the socket descriptor socket so 
+ * further references to socket will fail.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be closed.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock)
+{
+	return 0;
+}
+

--- a/port/unix_include/omrsock.h
+++ b/port/unix_include/omrsock.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMRSOCK_H_)
+#define OMRSOCK_H_
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "omrportsock.h"
+
+/* Per-thread buffer for platform-dependent socket information */
+typedef struct OMRSocketPTB {
+	struct OMRPortLibrary *portLibrary;
+	OMRAddrInfoNode addrInfoHints;
+} OMRSocketPTB;
+
+
+#endif /* !defined(OMRSOCK_H_) */

--- a/port/win32/omrsock.c
+++ b/port/win32/omrsock.c
@@ -1,0 +1,399 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Sockets
+ */
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif /* WIN32_LEAN_AND_MEAN */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include "omrsock.h"
+
+/**
+ * Returns hints as a double pointer to an OMRAddInfoNode structure.
+ * 
+ * This hints structure is used to modify the results returned by a call to @ref omrsock_getaddrinfo. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] hints The filled-in hints structure
+ * @param[in] family A address family type
+ * @param[in] socktype A socket type
+ * @param[in] protocol A protocol family
+ * @param[in] flags Flags for modifying the result. If you wish to use multiple flags, perform the OR operation on the flags before passing it in.
+ *
+ * @return
+ * @arg 0, if no errors occurred, otherwise the (negative) error code
+ *
+ * @note current supported family types are:
+ * @arg OMRSOCK_AF_UNSPEC
+ * @arg OMRSOCK_AF_INET4
+ * @arg OMRSOCK_AF_INET6
+ *
+ * @note Works with both IPv4 and IPv6 support.
+ */
+int32_t
+omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int family, int socktype, int protocol, int flags)
+{
+	return 0;
+}
+
+/**
+ * Answers a list of addresses as an opaque struct in "result".
+ * 
+ * Use the following functions to extract the details:
+ * @arg @ref omrsock_getaddrinfo_length
+ * @arg @ref omrsock_getaddrinfo_family
+ * @arg @ref omrsock_getaddrinfo_socktype
+ * @arg @ref omrsock_getaddrinfo_protocol
+
+ * @param[in] portLibrary The port library.
+ * @param[in] node The name of the host in either host name format or in IPv4 or IPv6 accepted notations.
+ * @param[in] service The port of the host in string form.
+ * @param[in] hints Hints on what results are returned (can be NULL for default action). Use omrsock_getaddrinfo_create_hints to create the hints.
+ * @param[out] result An opaque pointer to a list of results (OMRAddrInfoNode must be preallocated).
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ *
+ * @note you must free the "result" structure with @ref omrsock_freeaddrinfo to free up memory.
+ */
+int32_t
+omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result)
+{
+	return 0;
+}
+
+/**
+ * Answers the number of results returned from @ref omrsock_getaddrinfo.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] length The number of results.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, int32_t *length)
+{
+	return 0;
+}
+
+
+/**
+ * Answers the family type of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the family types we support are OMRSOCK_AF_INET and OMRSOCK_AF_INET6.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] family The family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int index)
+{
+	return 0;
+}
+
+/**
+ * Answers the socket type of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the socket types we support are OMRSOCK_STREAM and OMRSOCK_DATAGRAM.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] socktype The socket type at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int index)
+{
+	return 0;
+}
+
+/**
+ * Answers the protocol of the address at "index" in the structure returned from @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * Currently the protocols we support are OMRSOCK_IPPROTO_IP, OMRSOCK_IPPROTO_TCP, OMRSOCK_IPPROTO_IPV6, and OMRSOCK_IPPROTO_UDP. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] protocol The protocol family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int index)
+{
+	return 0;
+}
+
+/**
+ * Frees the memory created by the call to @ref omrsock_getaddrinfo().
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle Hints on what results are returned for getaddrinfo.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ *
+ */
+
+int32_t
+omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle)
+{
+	return 0;
+}
+
+/**
+ * Creates a new socket descriptor and any related resources.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] sock Pointer to the omrsocket, to be allocated
+ * @param[in] family The address family
+ * @arg OMRSOCK_AF_INET, for a IPv4 socket
+ * @arg OMRSOCK_AF_INET6, for a IPv6 socket
+ * @param[in] socktype Specifies what type of socket is created
+ * @arg OMRSOCK_STREAM, for a stream socket
+ * @arg OMRSOCK_DGRAM, for a datagram socket
+ * @param[in] protocol Type/family specific creation parameter
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype,  int32_t protocol)
+{
+	return 0;
+}
+
+/**
+ * The bind function is used on an unconnected socket before subsequent 
+ * calls to the connect or listen functions. When a socket is created with a 
+ * call to the socket function, it exists in a name space (address family), but 
+ * it has no name assigned to it. Use bind to establish the local association 
+ * of the socket by assigning a local name to an unnamed socket.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be be associated with the specified name.
+ * @param[in] addr Address to bind to socket.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return 0;
+}
+
+/**
+ * Set the socket to listen for incoming connection requests.  This call is made prior to accepting requests,
+ * via the @ref omrsock_accept function.  The backlog specifies the maximum length of the queue of pending connections,
+ * after which further requests are rejected.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket.
+ * @param[in] backlog The maximum number of queued requests.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_listen(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog)
+{
+	return 0;
+}
+
+/**
+ * Establish a connection to a peer.
+ *
+ * For stream sockets, it first binds the socket if it hasn't already been done. Then, it
+ * tries to set up a connection.
+ * 
+ * For datagram sockets, connect function will set up the peer information. No actual
+ * connection is made. Subsequent calls to connect can be made to change destination address.
+ *
+ * It is not recommended that users call this
+ * function multiple times to determine when the connection attempt has succeeded.
+ * Instead, the omrsock_select() function can be used to determine when the socket 
+ * is ready for reading or writing.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the unconnected local socket.
+ * @param[in] addr Pointer to the sockaddr, specifying remote host/port.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_connect(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return 0;
+}
+
+/**
+ * The accept function extracts the first connection on the queue of pending connections 
+ * on socket serverSock. It then creates a new socket and returns a handle to the new socket. 
+ * The newly created socket is the socket that will handle the actual the connection and 
+ * has the same properties as socket serverSock.  
+ *
+ * The accept function can block the caller until a connection is present if no pending 
+ * connections are present on the queue.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] serverSock  A omrsock_socket_t that tries to accept a connection.
+ * @param[in] addrHandle An optional pointer to a buffer that receives the address of the connecting 
+ * entity, as known to the communications layer. The exact format of the addr parameter 
+ * is determined by the address family established when the socket was created
+ * @param[out] sockHandle A pointer to a omrsock_socket_t which will point to the newly created 
+ * socket once accept returns successfully
+ *
+* @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+
+int32_t
+omrsock_accept(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle)
+{
+	return 0;
+}
+
+/**
+ * The send function sends data to a connected socket.  The successful completion of a send 
+ * does not indicate that the data was successfully delivered.  If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, send will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on
+ * @param[in] buf The bytes to be sent
+ * @param[in] nbyte The number of bytes to send
+ * @param[in] flags The flags to modify the send behavior
+ *
+ * @return	If no error occur, return the total number of bytes sent, which can be less than the 
+ * 'nbyte' for nonblocking sockets, otherwise the (negative) error code
+ */
+int32_t
+omrsock_send(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return 0;
+}
+
+/**
+ * The sendto function sends data to a datagram socket.  The successful completion of a writeto
+ * does not indicate that the data was successfully delivered.  If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, sendto will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on
+ * @param[in] buf The bytes to be sent
+ * @param[in] nbyte The number of bytes to send
+ * @param[in] flags The flags to modify the send behavior
+ * @param [in] addrHandle The network address to send the datagram to
+ *
+ * @return	If no error occur, return the total number of bytes sent, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_sendto(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return 0;
+}
+
+/**
+ * Receives data from a connected socket.  
+ * 
+ * This will return as much information as is currently available up to the size of the buffer supplied. 
+ * 
+ * We will implement in the future so that bbehaviour depending on the blocking characteristic of the socket.
+ *
+ *	Blocking socket:
+ * 		- If no incoming data is available, the call blocks and waits for data to arrive. 
+ * 
+ * 	Non-blocking socket:
+ * 		- Will be implemented in the future
+ * 		- If no incoming data is immediately available, the negative portable error code OMRERROR_SOCKET_WOULDBLOCK is returned.
+ * 
+ * @param[in]	portLibrary The port library.
+ * @param[in] 	sock Pointer to the socket to read on
+ * @param[out] 	buf Pointer to the buffer where input bytes are written
+ * @param[in] 	nbyte The length of buf
+ * @param[in] 	flags The flags, to influence this read (in addition to the socket options)
+ *
+ * @return
+ * @arg If no error occurs, return the number of bytes received.
+ * @arg If the connection has been gracefully closed, return 0.
+ * @arg Otherwise return the (negative) error code.
+ */
+int32_t
+omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return 0;
+}
+
+/**
+ * The recvfrom function receives data from a possibly connected socket.  Calling recvfrom will return as much 
+ * information as is currently available up to the size of the buffer supplied.  If the information is too large
+ * for the buffer, the excess will be discarded.  If no incoming  data is available at the socket, the recv call 
+ * blocks and waits for data to arrive.  It the address argument is not null, the address will be updated with
+ * address of the message sender.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to read on.
+ * @param[out] buf Pointer to the buffer where input bytes are written.
+ * @param[in] nbyte The length of buf.
+ * @param[in] flags Tthe flags, to influence this read.
+ * @param[out] addrHandle	if provided, the address to be updated with the sender information.
+ *
+ * @return
+ * @arg If no error occurs, return the number of bytes received.
+ * @arg If the connection has been gracefully closed, return 0.
+ * @arg Otherwise return the (negative) error code.
+ */
+int32_t
+omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return 0;
+}
+
+/**
+ * The close function closes a socket. Use it to release the socket descriptor socket so 
+ * further references to socket will fail.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be closed.
+ *
+ * @return	0, if no errors occurred, otherwise the (negative) error code.
+ */
+int32_t
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock)
+{
+	return 0;
+}
+

--- a/port/win32_include/omrsock.h
+++ b/port/win32_include/omrsock.h
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 1991, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMRSOCK_H_)
+#define OMRSOCK_H_
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif /* WIN32_LEAN_AND_MEAN */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include "omrportsock.h"
+
+/* Per-thread buffer for platform-dependent socket information */
+typedef struct OMRSocketPTB {
+	struct OMRPortLibrary *portLibrary;
+	OMRAddrInfoNode addrInfoHints;
+} OMRSocketPTB;
+
+
+#endif /* !defined(OMRSOCK_H_) */


### PR DESCRIPTION
-Modified omr files to be able to see and compile omrsock code
-Added new omrsock.c files for common, unix, and win32, this
 includes function prototypes proposed by the Socket API proprosal
-Added omrsock variables needed by the function prototypes. They are
 created in omrportsock.h
-Struct for the omrsock per thread buffers are initialized in omrsock.h

Issue: #4102

Signed-off-by: Haley Cao <haleycao88@hotmail.com>