### PR TITLE
Created Function Prototypes for OMRSocketAPI

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -43,6 +43,7 @@
 #include "omrthread.h"
 #include "omrmemcategories.h"
 #include "omrporterror.h"
+#include "omrportsock.h"
 #if defined(OMR_OPT_CUDA)
 #include "omrcuda.h"
 #endif /* OMR_OPT_CUDA */
@@ -1688,6 +1689,40 @@ typedef struct OMRPortLibrary {
 	uintptr_t (*heap_query_size)(struct OMRPortLibrary *portLibrary, struct J9Heap *heap, void *address) ;
 	/** see @ref omrheap.c::omrheap_grow "omrheap_grow"*/
 	BOOLEAN (*heap_grow)(struct OMRPortLibrary *portLibrary, struct J9Heap *heap, uintptr_t growAmount) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_create_hints "omrsock_getaddrinfo_create_hints"*/
+	int32_t (*sock_getaddrinfo_create_hints)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int32_t family, int32_t socktype, int32_t protocol, int32_t flags) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo "omrsock_getaddrinfo"*/
+	int32_t (*sock_getaddrinfo)(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_length "omrsock_getaddrinfo_length"*/
+	int32_t (*sock_getaddrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_family "omrsock_getaddrinfo_family"*/
+	int32_t (*sock_getaddrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int32_t index )	;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_socktype "omrsock_getaddrinfo_socktype"*/
+	int32_t (*sock_getaddrinfo_socktype)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index) ;
+	/** see @ref omrsock.c::omrsock_getaddrinfo_protocol "omrsock_getaddrinfo_protocol"*/
+	int32_t (*sock_getaddrinfo_protocol)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int32_t index) ;
+	/** see @ref omrsock.c::omrsock_freeaddrinfo "omrsock_freeaddrinfo"*/
+	int32_t (*sock_freeaddrinfo)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle) ;
+	/** see @ref omrsock.c::omrsock_socket "omrsock_socket"*/
+	int32_t (*sock_socket)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol) ;
+	/** see @ref omrsock.c::omrsock_bind "omrsock_bind"*/
+	int32_t (*sock_bind)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr) ;
+	/** see @ref omrsock.c::omrsock_listen "omrsock_listen"*/
+	int32_t (*sock_listen)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog) ;
+	/** see @ref omrsock.c::omrsock_connect "omrsock_connect"*/
+	int32_t (*sock_connect)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr) ;
+	/** see @ref omrsock.c::omrsock_accept "omrsock_accept"*/
+	int32_t (*sock_accept)(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle) ;
+	/** see @ref omrsock.c::omrsock_send "omrsock_send"*/
+	int32_t (*sock_send)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags) ;
+	/** see @ref omrsock.c::omrsock_sendto "omrsock_sendto"*/
+	int32_t (*sock_sendto)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle) ;
+	/** see @ref omrsock.c::omrsock_recv "omrsock_recv"*/
+	int32_t (*sock_recv)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags) ;
+	/** see @ref omrsock.c::omrsock_recvfrom "omrsock_recvfrom"*/
+	int32_t (*sock_recvfrom)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle) ;
+	/** see @ref omrsock.c::omrsock_close "omrsock_close"*/
+	int32_t (*sock_close)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock) ;
 #if defined(OMR_OPT_CUDA)
 	/** CUDA configuration data */
 	J9CudaConfig *cuda_configData;
@@ -2128,7 +2163,23 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrmem_categories_decrement_counters(param1,param2) privateOmrPortLibrary->mem_categories_decrement_counters((param1), (param2))
 #define omrheap_query_size(param1,param2) privateOmrPortLibrary->heap_query_size(privateOmrPortLibrary, (param1), (param2))
 #define omrheap_grow(param1,param2) privateOmrPortLibrary->heap_grow(privateOmrPortLibrary, (param1), (param2))
-
+#define omrsock_getaddrinfo_create_hints(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_getaddrinfo_create_hints(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
+#define omrsock_getaddrinfo(param1,param2,param3,param4) privateOmrPortLibrary->sock_getaddrinfo(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_getaddrinfo_length(param1,param2) privateOmrPortLibrary->sock_getaddrinfo_length(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_getaddrinfo_family(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_family(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_getaddrinfo_socktype(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_socktype(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_getaddrinfo_protocol(param1,param2,param3) privateOmrPortLibrary->sock_getaddrinfo_protocol(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_freeaddrinfo(param1) privateOmrPortLibrary->sock_freeaddrinfo(privateOmrPortLibrary, (param1))
+#define omrsock_socket(param1, param2, param3, param4) privateOmrPortLibrary->sock_socket(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_bind(param1,param2) privateOmrPortLibrary->sock_bind(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_listen(param1,param2) privateOmrPortLibrary->sock_listen(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_connect(param1,param2) privateOmrPortLibrary->sock_connect(privateOmrPortLibrary, (param1), (param2))
+#define omrsock_accept(param1,param2,param3) privateOmrPortLibrary->sock_accept(privateOmrPortLibrary, (param1), (param2), (param3))
+#define omrsock_send(param1,param2,param3,param4) privateOmrPortLibrary->sock_send(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_sendto(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_sendto(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
+#define omrsock_recv(param1,param2,param3,param4) privateOmrPortLibrary->sock_recv(privateOmrPortLibrary, (param1), (param2), (param3), (param4))
+#define omrsock_recvfrom(param1,param2,param3,param4,param5) privateOmrPortLibrary->sock_recvfrom(privateOmrPortLibrary, (param1), (param2), (param3), (param4), (param5))
+#define omrsock_close(param1) privateOmrPortLibrary->sock_close(privateOmrPortLibrary, (param1))
 #if defined(OMR_OPT_CUDA)
 #define omrcuda_startup() \
 				privateOmrPortLibrary->cuda_startup(privateOmrPortLibrary)

--- a/include_core/omrportsock.h
+++ b/include_core/omrportsock.h
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#if !defined(OMRPORTSOCK_H_)
+#define OMRPORTSOCK_H_
+
+/**
+ * WIN32_LEAN_AND_MEAN determines what is inluded in Windows.h. If it is
+ * defined, some unneeded header files in Windows.h will not be included.
+ */
+#if defined(OMR_OS_WINDOWS) && !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif /* defined(OMR_OS_WINDOWS) && !defined(WIN32_LEAN_AND_MEAN) */
+
+/* To avoid WINSOCK redefinition errors. */
+#if defined(OMR_OS_WINDOWS) && defined(_WINSOCKAPI_)
+#undef _WINSOCKAPI_
+#endif /* defined(OMR_OS_WINDOWS) && defined(_WINSOCKAPI_) */
+
+#if defined(OMR_OS_WINDOWS)
+/* windows.h defined UDATA. Ignore its definition to avoid redefinition errors */
+#define UDATA UDATA_win32_
+#include <windows.h>
+#undef UDATA
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "Ws2_32.lib")
+#pragma comment (lib, "Mswsock.lib") 
+#pragma comment (lib, "AdvApi32.lib") 
+#else /* defined(OMR_OS_WINDOWS) */
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif /* defined(OMR_OS_WINDOWS) */
+
+#include<stdlib.h>
+#include<stdio.h>
+
+/* Common data types required for using the omr socket API */
+
+#if defined(OMR_OS_WINDOWS)
+typedef SOCKET OMRSocket;
+typedef SOCKADDR OMRSockAddr; /* for IPv4 */
+typedef SOCKADDR_IN OMRSockAddrIn;	/* for IPv4 addresses*/
+typedef SOCKADDR_IN6 OMRSockAddrIn6;  /* for IPv6 addresses*/
+typedef struct sockaddr_storage OMRSockAddrStorage; /* For IPv4 or IPv6 addresses */
+typedef struct addrinfoW OMRAddrInfo;  /* addrinfo structure – Unicode, for IPv4 or IPv6 */
+#else /* defined(OMR_OS_WINDOWS) */
+typedef int32_t OMRSocket;
+typedef struct sockaddr OMRSockAddr;
+typedef struct sockaddr_in OMRSockAddrIn; /* for IPv4 addresses*/
+typedef struct sockaddr_in6 OMRSockAddrIn6; /* for IPv6 addresses*/
+typedef struct sockaddr_storage OMRSockAddrStorage; /* For IPv4 or IPv6 addresses */
+typedef struct addrinfo OMRAddrInfo; /* addrinfo structure for IPv4 or IPv6*/
+#endif /* defined(OMR_OS_WINDOWS) */
+
+/* Filled in using @ref omr_getaddrinfo. */
+typedef struct OMRAddrInfoNode {
+	/* Defined differently depending on the operating system.
+	 * Pointer to the first addrinfo node in listed list. 
+	 */
+	OMRAddrInfo *addrInfo;
+	/* Number of addrinfo nodes in linked list */
+	uint32_t length;
+} OMRAddrInfoNode;
+typedef OMRAddrInfoNode *omrsock_addrinfo_t;
+
+/* Pointer to ip address. It has enough space for Ipv4 or IPv6 addresses. */
+typedef OMRSockAddrStorage *omrsock_sockaddr_t;
+
+/* Pointer to a socket descriptor */
+typedef OMRSocket *omrsock_socket_t;
+
+#endif /* !defined(OMRPORTSOCK_H_) */

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -169,6 +169,7 @@ list(APPEND OBJECTS
 	omrmemcategories.c
 	omrport.c
 	omrmmap.c
+	omrsock.c
 	j9nls.c
 	j9nlshelpers.c
 	omrosbacktrace.c

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -299,6 +299,23 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrmem_categories_decrement_counters, /* mem_categories_decrement_counters */
 	omrheap_query_size, /* heap_query_size */
 	omrheap_grow, /* heap_grow*/
+	omrsock_getaddrinfo_create_hints, /* sock_getaddrinfo_create_hints */
+	omrsock_getaddrinfo, /* sock_getaddrinfo */
+	omrsock_getaddrinfo_length, /* sock_getaddrinfo_length */
+	omrsock_getaddrinfo_family, /* sock_getaddrinfo_family */
+	omrsock_getaddrinfo_socktype, /* sock_getaddrinfo_socktype */
+	omrsock_getaddrinfo_protocol, /* sock_getaddrinfo_protocol */
+	omrsock_freeaddrinfo, /* sock_freeaddrinfo */
+	omrsock_socket, /* sock_socket */
+	omrsock_bind, /* sock_bind */
+	omrsock_listen, /* sock_listen */
+	omrsock_connect, /* sock_connect */
+	omrsock_accept, /* sock_accept */
+	omrsock_send, /* sock_send */
+	omrsock_sendto, /* sock_sendto */
+	omrsock_recv, /* sock_recv */
+	omrsock_recvfrom, /* sock_recvfrom */
+	omrsock_close, /* sock_close */
 #if defined(OMR_OPT_CUDA)
 	NULL, /* cuda_configData */
 	omrcuda_startup, /* cuda_startup */

--- a/port/common/omrsock.c
+++ b/port/common/omrsock.c
@@ -1,0 +1,371 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup Port
+ * @brief Sockets
+ */
+
+#include "omrport.h"
+#include "omrporterror.h"
+#include "omrportsock.h"
+
+/**
+ * Returns hints as a double pointer to an OMRAddInfoNode structure.
+ * 
+ * This hints structure is used to modify the results returned by a call to 
+ * @ref omrsock_getaddrinfo. 
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] hints The filled-in hints structure.
+ * @param[in] family Address family type.
+ * @param[in] socktype Socket type.
+ * @param[in] protocol Protocol family.
+ * @param[in] flags Flags for modifying the result. Pass multiple flags using the 
+ * bitwise-OR operation.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int32_t family, int32_t socktype, int32_t protocol, int32_t flags)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Answers a list of addresses as an opaque struct in "result".
+ * 
+ * Use the following functions to extract the details:
+ * @arg @ref omrsock_getaddrinfo_length
+ * @arg @ref omrsock_getaddrinfo_family
+ * @arg @ref omrsock_getaddrinfo_socktype
+ * @arg @ref omrsock_getaddrinfo_protocol
+
+ * @param[in] portLibrary The port library.
+ * @param[in] node The name of the host in either host name format or in IPv4 or IPv6 accepted 
+ * notations.
+ * @param[in] service The port of the host in string form.
+ * @param[in] hints Hints on what results are returned (can be NULL for default action). Use 
+ * @ref omrsock_getaddrinfo_create_hints to create the hints.
+ * @param[out] result An opaque pointer to a list of results (OMRAddrInfoNode must be preallocated).
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ *
+ * @note Must free the "result" structure with @ref omrsock_freeaddrinfo to free up memory.
+ */
+int32_t
+omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Answers the number of results returned from @ref omrsock_getaddrinfo.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] length The number of results.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+
+/**
+ * Answers the family type of the address at "index" in the structure returned from 
+ * @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] family The family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int32_t index)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Answers the socket type of the address at "index" in the structure returned from 
+ * @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] socktype The socket type at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Answers the protocol of the address at "index" in the structure returned from 
+ * @ref omrsock_getaddrinfo, indexed starting at 0.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle The result structure returned by @ref omrsock_getaddrinfo.
+ * @param[out] protocol The protocol family at "index".
+ * @param[in] index The index into the structure returned by @ref omrsock_getaddrinfo.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int32_t index)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Frees the memory created by the call to @ref omrsock_getaddrinfo.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] handle Pointer to results returned by @ref omrsock_getaddrinfo.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Creates a new socket descriptor and any related resources.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] sock Pointer to the omrsocket, to be allocated.
+ * @param[in] family The address family.
+ * @param[in] socktype Specifies what type of socket is created, for example stream
+ * or datagram.
+ * @param[in] protocol The Protocol family.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Used on an unconnected socket before subsequent calls to 
+ * the @ref omrsock_connect or @ref omrsock_listen functions. When a socket is created 
+ * with a call to @ref omrsock_socket, it exists in a name space (address family), but 
+ * it has no name assigned to it. Use omrsock_bind to establish the local association 
+ * of the socket by assigning a local name to an unnamed socket.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be be associated with the specified name.
+ * @param[in] addr Address to bind to socket.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Set the socket to listen for incoming connection requests. This call is made prior to 
+ * accepting requests, via the @ref omrsock_accept function. The backlog specifies the 
+ * maximum length of the queue of pending connections, after which further requests are 
+ * rejected.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket.
+ * @param[in] backlog The maximum number of queued requests.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_listen(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Establish a connection to a peer.
+ *
+ * For stream sockets, it first binds the socket if it hasn't already been done. Then, it
+ * tries to set up a connection.
+ * 
+ * For datagram sockets, omrsock_connect function will set up the peer information. No actual
+ * connection is made. Subsequent calls to connect can be made to change destination address.
+ *
+ * It is not recommended that users call this function multiple times to determine when the 
+ * connection attempt has succeeded. Instead, the @ref omrsock_select function can be used to 
+ * determine when the socket is ready for reading or writing.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the unconnected local socket.
+ * @param[in] addr Pointer to the sockaddr, specifying remote host/port.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_connect(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Extracts the first connection on the queue of pending connections on socket serverSock. 
+ * It then creates a new socket and returns a handle to the new socket. The newly created 
+ * socket is the socket that will handle the actual the connection and has the same 
+ * properties as the socket serverSock.  
+ *
+ * The omrsock_accept function can block the caller until a connection is present if no pending 
+ * connections are present on the queue.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] serverSock An omrsock_socket_t that tries to accept a connection.
+ * @param[in] addrHandle An optional pointer to a buffer that receives the address of the 
+ * connecting entity, as known to the communications layer. The exact format of the addr 
+ * parameter is determined by the address family established when the socket was created.
+ * @param[out] sockHandle A pointer to an omrsock_socket_t which will point to the newly created 
+ * socket once accept returns successfully.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+
+int32_t
+omrsock_accept(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Sends data to a connected socket. The successful completion of an omrsock_send does 
+ * not indicate that the data was successfully delivered. If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, omrsock_send will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on.
+ * @param[in] buf The bytes to be sent.
+ * @param[in] nbyte The number of bytes to send.
+ * @param[in] flags The flags to modify the send behavior.
+ *
+ * @return the total number of bytes sent if no error occured, which can be less than the 
+ * 'nbyte' for nonblocking sockets, otherwise return an error.
+ */
+int32_t
+omrsock_send(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Sends data to a datagram socket. The successful completion of an omrsock_sento does 
+ * not indicate that the data was successfully delivered. If no buffer space is available 
+ * within the transport system to hold the data to be transmitted, omrsock_sendto will block.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to send on.
+ * @param[in] buf The bytes to be sent.
+ * @param[in] nbyte The number of bytes to send.
+ * @param[in] flags The flags to modify the send behavior.
+ * @param [in] addrHandle The network address to send the datagram to.
+ *
+ * @return the total number of bytes sent if no error occured, otherwise return an error.
+ */
+int32_t
+omrsock_sendto(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Receives data from a connected socket.  
+ * 
+ * This will return available information up to the size of the buffer supplied. 
+ * 
+ * Its behavior will depend on the blocking characteristic of the socket.
+ * Blocking socket: If no incoming data is available, the call blocks and waits for data to arrive. 
+ * Non-blocking socket: TODO.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to read on.
+ * @param[out] buf Pointer to the buffer where input bytes are written.
+ * @param[in] nbyte The length of buf.
+ * @param[in] flags The flags, to influence this read (in addition to the socket options).
+ *
+ * @return the number of bytes received if no error occured. If the connection has been 
+ * gracefully closed, return 0. Otherwise, return an error.
+ */
+int32_t
+omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Receives data from a possibly connected socket. 
+ * 
+ * Calling omrsock_recvfrom will return available information up to the size of the buffer 
+ * supplied. If the information is too large for the buffer, the excess will be discarded. 
+ * If no incoming data is available at the socket, the omrsock_recvfrom call blocks and 
+ * waits for data to arrive. It the address argument is not null, the address will be updated 
+ * with address of the message sender.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] sock Pointer to the socket to read on.
+ * @param[out] buf Pointer to the buffer where input bytes are written.
+ * @param[in] nbyte The length of buf.
+ * @param[in] flags Tthe flags, to influence this read.
+ * @param[out] addrHandle If provided, the address to be updated with the sender information.
+ *
+ * @return the number of bytes received if no error occured. If the connection has been 
+ * gracefully closed, return 0. Otherwise, return an error.
+ */
+int32_t
+omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}
+
+/**
+ * Closes a socket. Use it to release the socket so that further references 
+ * to socket will fail.
+ * 
+ * @param[in] portLibrary The port library.
+ * @param[in] sock The socket that will be closed.
+ *
+ * @return 0, if no errors occurred, otherwise return an error.
+ */
+int32_t
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock)
+{
+	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+}

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -600,6 +600,42 @@ omrsl_open_shared_library(struct OMRPortLibrary *portLibrary, char *name, uintpt
 extern J9_CFUNC void
 omrsl_shutdown(struct OMRPortLibrary *portLibrary);
 
+/* J9SourceJ9Sock*/
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_create_hints(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *hints, int32_t family, int32_t socktype, int32_t protocol, int32_t flags);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *service, omrsock_addrinfo_t hints, omrsock_addrinfo_t result);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int32_t index);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index);
+extern J9_CFUNC int32_t
+omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *protocol, int32_t index);
+extern J9_CFUNC int32_t
+omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle);
+extern J9_CFUNC int32_t
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol);
+extern J9_CFUNC int32_t
+omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr);
+extern J9_CFUNC int32_t
+omrsock_listen(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t backlog);
+extern J9_CFUNC int32_t
+omrsock_connect(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr);
+extern J9_CFUNC int32_t
+omrsock_accept(struct OMRPortLibrary *portLibrary, omrsock_socket_t serverSock, omrsock_sockaddr_t addrHandle, omrsock_socket_t *sockHandle);
+extern J9_CFUNC int32_t
+omrsock_send(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags);
+extern J9_CFUNC int32_t
+omrsock_sendto(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle);
+extern J9_CFUNC int32_t
+omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags);
+extern J9_CFUNC int32_t
+omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle);
+extern J9_CFUNC int32_t
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock);
+
 /* J9SourceJ9Str*/
 extern J9_CFUNC uintptr_t
 omrstr_vprintf(struct OMRPortLibrary *portLibrary, char *buf, uintptr_t bufLen, const char *format, va_list args);

--- a/port/port_objects.mk
+++ b/port/port_objects.mk
@@ -132,6 +132,7 @@ OBJECTS += omrmemtag
 OBJECTS += omrmemcategories
 OBJECTS += omrport
 OBJECTS += omrmmap
+OBJECTS += omrsock
 OBJECTS += j9nls
 OBJECTS += j9nlshelpers
 OBJECTS += omrosbacktrace


### PR DESCRIPTION
Created Functions Unimplemented Prototypes in omrsock.c

-Modified omr files to be able to see and compile omrsock code
-Added new omrsock.c files for common, this
 includes function prototypes proposed by the Socket API proprosal
-Added omrsock variables needed by the function prototypes. They are
 created in omrportsock.h

Issue #4102

Signed-off-by: Haley Cao <haleycao88@hotmail.com>