### PR TITLE
Stop generating deprecated unsigned opcodes of equality compare and const

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1440,13 +1440,13 @@ private:
  * FIXME: I suspect that these templates may be an antipattern, involving a fair
  *        amount of mixing between host and target types...
  */
-template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode< uint8_t>() { return TR::buconst; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode< uint8_t>() { return TR::bconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<  int8_t>() { return TR::bconst; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<uint16_t>() { return TR::cconst; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<uint16_t>() { return TR::sconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode< int16_t>() { return TR::sconst; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<uint32_t>() { return TR::iuconst; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<uint32_t>() { return TR::iconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode< int32_t>() { return TR::iconst; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<uint64_t>() { return TR::luconst; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<uint64_t>() { return TR::lconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode< int64_t>() { return TR::lconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   float>() { return TR::fconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<  double>() { return TR::dconst; }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1351,21 +1351,6 @@ OMR::Node::bconst(int8_t val)
 
 
 
-TR::Node *
-OMR::Node::buconst(TR::Node *originatingByteCodeNode, uint8_t val)
-   {
-   TR::Node *r = TR::Node::create(originatingByteCodeNode, TR::buconst);
-   r->setUnsignedByte(val);
-   return r;
-   }
-
-TR::Node *
-OMR::Node::buconst(uint8_t val)
-   {
-   return TR::Node::buconst(0, val);
-   }
-
-
 
 TR::Node *
 OMR::Node::sconst(TR::Node *originatingByteCodeNode, int16_t val)
@@ -1386,7 +1371,7 @@ OMR::Node::sconst(int16_t val)
 TR::Node *
 OMR::Node::cconst(TR::Node *originatingByteCodeNode, uint16_t val)
    {
-   TR::Node *r = TR::Node::create(originatingByteCodeNode, TR::cconst);
+   TR::Node *r = TR::Node::create(originatingByteCodeNode, TR::sconst);
    r->setUnsignedShortInt(val);
    return r;
    }
@@ -1411,21 +1396,6 @@ OMR::Node::iconst(int32_t val)
    return TR::Node::iconst(0, val);
    }
 
-
-TR::Node *
-OMR::Node::iuconst(TR::Node *originatingByteCodeNode, uint32_t val)
-   {
-   return TR::Node::create(originatingByteCodeNode, TR::iuconst, 0, (int32_t)val);
-   }
-
-TR::Node *
-OMR::Node::iuconst(uint32_t val)
-   {
-   return TR::Node::iuconst(0, val);
-   }
-
-
-
 TR::Node *
 OMR::Node::lconst(TR::Node *originatingByteCodeNode, int64_t val)
    {
@@ -1438,22 +1408,6 @@ TR::Node *
 OMR::Node::lconst(int64_t val)
    {
    return TR::Node::lconst(0, val);
-   }
-
-
-
-TR::Node *
-OMR::Node::luconst(TR::Node *originatingByteCodeNode, uint64_t val)
-   {
-   TR::Node *r = TR::Node::create(originatingByteCodeNode, TR::luconst);
-   r->setUnsignedLongInt(val);
-   return r;
-   }
-
-TR::Node *
-OMR::Node::luconst(uint64_t val)
-   {
-   return TR::Node::luconst(0, val);
    }
 
 

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -600,7 +600,7 @@ OMR::Node::recreateAndCopyValidPropertiesImpl(TR::Node *originalNode, TR::ILOpCo
 TR::Node *
 OMR::Node::createInternal(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *originalNode)
    {
-   TR_ASSERT_FATAL(TR::Node::isNotDeprecatedUnsigned(op), "The unsigned opcode is deprecated: %d \n", op);
+   TR_ASSERT_FATAL(TR::Node::isNotDeprecatedUnsigned(op), "Trying to use a deprecated unsigned opcode: #%d \n", op);
    if (!originalNode)
       return new (TR::comp()->getNodePool()) TR::Node(originatingByteCodeNode, op, numChildren);
    else

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -318,9 +318,6 @@ public:
    static TR::Node *bconst(TR::Node *originatingByteCodeNode, int8_t val);
    static TR::Node *bconst(int8_t val);
 
-   static TR::Node *buconst(TR::Node *originatingByteCodeNode, uint8_t val);
-   static TR::Node *buconst(uint8_t val);
-
    static TR::Node *sconst(TR::Node *originatingByteCodeNode, int16_t val);
    static TR::Node *sconst(int16_t val);
 
@@ -330,14 +327,8 @@ public:
    static TR::Node *iconst(TR::Node *originatingByteCodeNode, int32_t val);
    static TR::Node *iconst(int32_t val);
 
-   static TR::Node *iuconst(TR::Node *originatingByteCodeNode, uint32_t val);
-   static TR::Node *iuconst(uint32_t val);
-
    static TR::Node *lconst(TR::Node *originatingByteCodeNode, int64_t val);
    static TR::Node *lconst(int64_t val);
-
-   static TR::Node *luconst(TR::Node *originatingByteCodeNode, uint64_t val);
-   static TR::Node *luconst(uint64_t val);
 
    static TR::Node *aconst(TR::Node *originatingByteCodeNode, uintptrj_t val);
    static TR::Node *aconst(TR::Node *originatingByteCodeNode, uintptrj_t val, uint8_t precision);

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -364,7 +364,7 @@ private:
       TR_ASSERT(opvalue != TR::vconst, "use createVectorConst to create node: %s", opcode.getName());
       return true;
       }
-
+      
    static bool isNotDeprecatedUnsigned(TR::ILOpCodes opvalue)
       {
       switch (opvalue) 
@@ -388,6 +388,12 @@ private:
          case TR::ifbucmpne:
          case TR::ifsucmpeq:
          case TR::ifsucmpne:
+
+         //Constant
+         case TR::buconst:
+         case TR::iuconst:
+         case TR::luconst:
+         case TR::cconst:
             return false;
             
          default: 

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -369,8 +369,26 @@ private:
       {
       switch (opvalue) 
          {
-            //More cases is going to be added to this function for eclipse/omr#2657.
-            //return false;
+         //Equality compare
+         case TR::bucmpeq:
+         case TR::bucmpne:   
+         case TR::iucmpeq:
+         case TR::iucmpne:
+         case TR::lucmpeq:
+         case TR::lucmpne:
+         case TR::sucmpeq:
+         case TR::sucmpne:
+         
+         //Equality compare and branch
+         case TR::ifiucmpeq:
+         case TR::ifiucmpne:
+         case TR::iflucmpeq:
+         case TR::iflucmpne:
+         case TR::ifbucmpeq:
+         case TR::ifbucmpne:
+         case TR::ifsucmpeq:
+         case TR::ifsucmpne:
+            return false;
             
          default: 
             return true;

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -175,7 +175,7 @@ void TR_DebuggingCounters::insertCounter(const char * name, TR::Compilation * co
       TR::Node* loadNode = TR::Node::createWithSymRef(node, TR::iuload, 0, counterRef);
 
       TR::Node* addNode =
-         TR::Node::create(TR::iadd, 2, loadNode,
+         TR::Node::create(TR::iuadd, 2, loadNode,
 		         TR::Node::create(node, TR::iconst, 0, 1));
 
       TR::TreeTop* incrementTree =

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -175,8 +175,8 @@ void TR_DebuggingCounters::insertCounter(const char * name, TR::Compilation * co
       TR::Node* loadNode = TR::Node::createWithSymRef(node, TR::iuload, 0, counterRef);
 
       TR::Node* addNode =
-         TR::Node::create(TR::iuadd, 2, loadNode,
-		         TR::Node::create(node, TR::iuconst, 0, 1));
+         TR::Node::create(TR::iadd, 2, loadNode,
+		         TR::Node::create(node, TR::iconst, 0, 1));
 
       TR::TreeTop* incrementTree =
          TR::TreeTop::create(comp, TR::Node::createWithSymRef(TR::iustore, 1, 1,

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -13146,7 +13146,7 @@ TR::Node *ificmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       }
 
    if (node->getOpCodeValue() == TR::ificmpeq)
-      intCompareNarrower(node, s, TR::ifsucmpeq, TR::ifscmpeq, TR::ifbcmpeq);
+      intCompareNarrower(node, s, TR::ifscmpeq, TR::ifscmpeq, TR::ifbcmpeq);
    else
       unsignedIntCompareNarrower(node, s, TR::ifscmpeq, TR::ifbcmpeq);
 
@@ -13251,7 +13251,7 @@ TR::Node *ificmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
       }
 
    if (node->getOpCodeValue() == TR::ificmpne)
-      intCompareNarrower(node, s, TR::ifsucmpne, TR::ifscmpne, TR::ifbcmpne);
+      intCompareNarrower(node, s, TR::ifscmpne, TR::ifscmpne, TR::ifbcmpne);
    else
       unsignedIntCompareNarrower(node, s, TR::ifscmpne, TR::ifbcmpne);
 
@@ -13473,7 +13473,7 @@ TR::Node *iflcmpeqSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
 
    if (node->getOpCodeValue() == TR::iflcmpeq)
       {
-      longCompareNarrower(node, s, TR::ificmpeq, TR::ifsucmpeq, TR::ifscmpeq, TR::ifbcmpeq);
+      longCompareNarrower(node, s, TR::ificmpeq, TR::ifscmpeq, TR::ifscmpeq, TR::ifbcmpeq);
       }
 
    removeArithmeticsUnderIntegralCompare(node, s);
@@ -13511,7 +13511,7 @@ TR::Node *iflcmpneSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
 
    if (node->getOpCodeValue() == TR::iflcmpne)
       {
-      longCompareNarrower(node, s, TR::ificmpne, TR::ifsucmpne, TR::ifscmpne, TR::ifbcmpne);
+      longCompareNarrower(node, s, TR::ificmpne, TR::ifscmpne, TR::ifscmpne, TR::ifbcmpne);
       }
    addressCompareConversion(node, s);
    removeArithmeticsUnderIntegralCompare(node, s);

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1653,7 +1653,7 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
                // shift by > 31 bits gets constant 0
                if (newConversionOp == TR::BadILOp)
                   {
-                  TR::Node::recreate(node, isUnsigned ? TR::iuconst : TR::iconst);
+                  TR::Node::recreate(node, TR::iconst);
                   firstChild->recursivelyDecReferenceCount();
                   node->setNumChildren(0);
                   node->setChild(0, 0);
@@ -1661,7 +1661,7 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
                   }
                else
                   {
-                  TR::Node::recreate(firstChild, isUnsigned ? TR::iuconst : TR::iconst);
+                  TR::Node::recreate(firstChild,TR::iconst);
                   firstChild->getFirstChild()->recursivelyDecReferenceCount();
                   firstChild->getSecondChild()->recursivelyDecReferenceCount();
                   firstChild->setInt(0);
@@ -2370,14 +2370,14 @@ static void longCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCod
                   {
                   if (secondChild->getReferenceCount()==1)
                      {
-                     TR::Node::recreate(secondChild, TR::cconst);
+                     TR::Node::recreate(secondChild, TR::sconst);
                      secondChild->setConst<uint16_t>((uint16_t)secondChild->getLongInt());
                      secondChild->notifyChangeToValueOfNode();
                      }
                   else
                      {
                      secondChild->decReferenceCount();
-                     TR::Node * cConstNode = TR::Node::cconst(node, (uint16_t)secondChild->getLongInt());
+                     TR::Node * cConstNode = TR::Node::sconst(node, (uint16_t)secondChild->getLongInt());
                      node->setAndIncChild(1, cConstNode);
                      }
                   if (reportCompareDemotions)
@@ -4202,13 +4202,13 @@ static void intCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::ILOpCode
                {
                if (secondChild->getReferenceCount() > 1)
                   {
-                  TR::Node * newSecondChild = TR::Node::cconst(secondChild, (uint16_t)secondChild->getInt());
+                  TR::Node * newSecondChild = TR::Node::sconst(secondChild, (uint16_t)secondChild->getInt());
                   secondChild->recursivelyDecReferenceCount();
                   node->setAndIncChild(1, newSecondChild);
                   }
                else
                   {
-                  TR::Node::recreate(secondChild, TR::cconst);
+                  TR::Node::recreate(secondChild, TR::sconst);
                   secondChild->setConst<uint16_t>((uint16_t)secondChild->getInt());
                   }
                if (reportCompareDemotions)
@@ -4344,13 +4344,13 @@ static void unsignedIntCompareNarrower(TR::Node * node, TR::Simplifier * s, TR::
                {
                if (secondChild->getReferenceCount() > 1)
                   {
-                  TR::Node * newSecondChild = TR::Node::cconst(secondChild, (uint16_t)secondChild->getInt());
+                  TR::Node * newSecondChild = TR::Node::sconst(secondChild, (uint16_t)secondChild->getInt());
                   secondChild->recursivelyDecReferenceCount();
                   node->setAndIncChild(1, newSecondChild);
                   }
                else
                   {
-                  TR::Node::recreate(secondChild, TR::cconst);
+                  TR::Node::recreate(secondChild, TR::sconst);
                   secondChild->setConst<uint16_t>((uint16_t)secondChild->getUnsignedInt());
                   }
                if (reportCompareDemotions)
@@ -13775,7 +13775,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             if (op != TR::BadILOp)
                {
                TR::Node::recreate(node, op);
-               TR::Node * newSecondChild = TR::Node::cconst(node, cValue);
+               TR::Node * newSecondChild = TR::Node::sconst(node, cValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
                firstChild->recursivelyDecReferenceCount();
@@ -13864,7 +13864,7 @@ TR::Node *normalizeCmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplif
             if (op != TR::BadILOp)
                {
                TR::Node::recreate(node, op);
-               TR::Node * newSecondChild = TR::Node::cconst(node, cValue);
+               TR::Node * newSecondChild = TR::Node::sconst(node, cValue);
                node->setAndIncChild(0, firstChild->getFirstChild());
                node->setAndIncChild(1, newSecondChild);
                firstChild->recursivelyDecReferenceCount();
@@ -15757,7 +15757,7 @@ static void foldUnsignedLongIntConstant(TR::Node * node, uint64_t value, TR::Sim
 
    if (anchorChildrenP) s->anchorChildren(node, s->_curTree);
 
-   s->prepareToReplaceNode(node, TR::luconst);
+   s->prepareToReplaceNode(node, TR::lconst);
    node->setUnsignedLongInt(value);
    setIsHighWordZero(node, s);
 
@@ -15854,7 +15854,7 @@ static void foldUByteConstant(TR::Node * node, uint8_t value, TR::Simplifier * s
 
    if (anchorChildrenP) s->anchorChildren(node, s->_curTree);
 
-   s->prepareToReplaceNode(node, TR::buconst);
+   s->prepareToReplaceNode(node, TR::bconst);
    node->setUnsignedByte(value);
    dumpOptDetails(s->comp(), " to %s %d\n", node->getOpCode().getName(), node->getUnsignedByte());
    }
@@ -15865,7 +15865,7 @@ static void foldCharConstant(TR::Node * node, uint16_t value, TR::Simplifier * s
 
    if (anchorChildrenP) s->anchorChildren(node, s->_curTree);
 
-   s->prepareToReplaceNode(node, TR::cconst);
+   s->prepareToReplaceNode(node, TR::sconst);
    node->setConst<uint16_t>(value);
    dumpOptDetails(s->comp(), " to %s %d\n", node->getOpCode().getName(), node->getConst<uint16_t>());
    }
@@ -16042,7 +16042,7 @@ TR::Node * imulhSimplifier(TR::Node * node, TR::Block *block, TR::Simplifier * s
             uint64_t product = src1 * src2;
             uint64_t high = product >> 32;
             uint32_t result = high;
-            TR::Node::recreate(node, TR::iuconst);
+            TR::Node::recreate(node, TR::iconst);
             node->setUnsignedInt(result);
             }
          else

--- a/compiler/optimizer/OMRSimplifierHelpers.cpp
+++ b/compiler/optimizer/OMRSimplifierHelpers.cpp
@@ -197,7 +197,7 @@ void foldUIntConstant(TR::Node * node, uint32_t value, TR::Simplifier * s, bool 
 
    if (anchorChildrenP) s->anchorChildren(node, s->_curTree);
 
-   s->prepareToReplaceNode(node, TR::iuconst);
+   s->prepareToReplaceNode(node, TR::iconst);
    node->setUnsignedInt(value);
    dumpOptDetails(s->comp(), " to %s %d\n", node->getOpCode().getName(), node->getInt());
    }
@@ -251,18 +251,10 @@ void foldByteConstant(TR::Node * node, int8_t value, TR::Simplifier * s, bool an
 
    if (anchorChildrenP) s->anchorChildren(node, s->_curTree);
 
-   if (node->getOpCode().isUnsigned())
-      {
-      s->prepareToReplaceNode(node, TR::buconst);
-      node->setUnsignedByte((uint8_t)value);
-      dumpOptDetails(s->comp(), " to %s %d\n", node->getOpCode().getName(), node->getUnsignedByte());
-      }
-   else
-      {
-      s->prepareToReplaceNode(node, TR::bconst);
-      node->setByte(value);
-      dumpOptDetails(s->comp(), " to %s %d\n", node->getOpCode().getName(), node->getByte());
-      }
+   s->prepareToReplaceNode(node, TR::bconst);
+   node->setByte(value);
+   dumpOptDetails(s->comp(), " to %s %d\n", node->getOpCode().getName(), node->getByte());
+
    }
 
 void foldShortIntConstant(TR::Node * node, int16_t value, TR::Simplifier * s, bool anchorChildrenP)


### PR DESCRIPTION
Delete any creations or recreations of node with unsigned deprecated IL opcodes in `Equality compare`/`Equality Compare and Branch`/`Constant` category.

Using `TR_ASSERT_FATAL` to ensure no downstream projects will attempt to use aforementioned opcodes.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com