### PR TITLE
Fix Scavenger.cpp flag OMR_GC_MODRON_SCAVENGER position

### DIFF
--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -5242,8 +5242,6 @@ MM_Scavenger::completeConcurrentCycle(MM_EnvironmentBase *env)
 
 #endif /* OMR_GC_CONCURRENT_SCAVENGER */
 
-#endif /* OMR_GC_MODRON_SCAVENGER */
-
 #if defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS)
 void
 MM_Scavenger::scavenger_poisonSlots(MM_EnvironmentBase *env)
@@ -5258,3 +5256,6 @@ MM_Scavenger::scavenger_healSlots(MM_EnvironmentBase *env)
 	_delegate.healSlots(env);
 }
 #endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
+
+#endif /* OMR_GC_MODRON_SCAVENGER */
+


### PR DESCRIPTION
Code does not compile without flag OMR_GC_MODRON_SCAVENGER
because end of file was outside of final #endif

Signed-off-by: Jason Hall <jasonhal@ca.ibm.com>