### PR TITLE
DDR: merge enum sizes

### DIFF
--- a/ddr/lib/ddr-ir/Symbol_IR.cpp
+++ b/ddr/lib/ddr-ir/Symbol_IR.cpp
@@ -310,6 +310,10 @@ MergeVisitor::visitEnum(EnumUDT *type) const
 {
 	/* Merge by adding the fields/subtypes of '_other' into 'type'. */
 	EnumUDT *other = (EnumUDT *)_other;
+	/* This type may be derived from only a forward declaration; if so, update the size now. */
+	if (0 == type->_sizeOf) {
+		type->_sizeOf = other->_sizeOf;
+	}
 	_ir->mergeEnums(&type->_enumMembers, &other->_enumMembers);
 	return DDR_RC_OK;
 }


### PR DESCRIPTION
The size of an enum type is unknown if first seen in the debug info from:
```
    enum Flavour;
    void * sample(enum Flavour *flavour) { return flavour; }
```
(e.g. in DWARF, there is no `DW_AT_byte_size` attribute); remember the size if available in a subsequent compilation unit.

This is like #2336, but for enums.