### PR TITLE
Runtime compressed refs work

### DIFF
--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -158,12 +158,18 @@ typedef struct OMR_VM {
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+/* Mixed mode - necessarily 64-bit */
 #define OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) (0 != (omrVM)->_compressObjectReferences)
+#define OMRVM_REFERENCE_SHIFT(omrVM) (OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) ? 2 : 3)
 #else /* OMR_GC_FULL_POINTERS */
+/* Compressed only - necessarily 64-bit */
 #define OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) TRUE
+#define OMRVM_REFERENCE_SHIFT(omrVM) 2
 #endif /* OMR_GC_FULL_POINTERS */
 #else /* OMR_GC_COMPRESSED_POINTERS */
+/* Full only - could be 32 or 64-bit */
 #define OMRVM_COMPRESS_OBJECT_REFERENCES(omrVM) FALSE
+#define OMRVM_REFERENCE_SHIFT(omrVM) OMR_LOG_POINTER_SIZE
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 
 typedef struct OMR_VMThread {
@@ -212,12 +218,18 @@ typedef struct OMR_VMThread {
 
 #if defined(OMR_GC_COMPRESSED_POINTERS)
 #if defined(OMR_GC_FULL_POINTERS)
+/* Mixed mode - necessarily 64-bit */
 #define OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) (0 != (omrVMThread)->_compressObjectReferences)
+#define OMRVMTHREAD_REFERENCE_SHIFT(omrVMThread) (OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) ? 2 : 3)
 #else /* OMR_GC_FULL_POINTERS */
+/* Compressed only - necessarily 64-bit */
 #define OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) TRUE
+#define OMRVMTHREAD_REFERENCE_SHIFT(omrVMThread) 2
 #endif /* OMR_GC_FULL_POINTERS */
 #else /* OMR_GC_COMPRESSED_POINTERS */
+/* Full only - could be 32 or 64-bit */
 #define OMRVMTHREAD_COMPRESS_OBJECT_REFERENCES(omrVMThread) FALSE
+#define OMRVMTHREAD_REFERENCE_SHIFT(omrVMThread) OMR_LOG_POINTER_SIZE
 #endif /* OMR_GC_COMPRESSED_POINTERS */
 
 /**

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -594,6 +594,13 @@ typedef struct U_128 {
 #define OMR_STR(x) OMR_STR_(x)
 #define OMR_GET_CALLSITE() __FILE__ ":" OMR_STR(__LINE__)
 
+/* Shift value to convert between pointers and bytes */
+#if defined(OMR_ENV_DATA64)
+#define OMR_LOG_POINTER_SIZE 3
+#else /* defined(OMR_ENV_DATA64) */
+#define OMR_LOG_POINTER_SIZE 2
+#endif /* defined(OMR_ENV_DATA64) */
+
 /* Legacy defines - remove once code cleanup is complete */
 #define J9VM_ENV_DIRECT_FUNCTION_POINTERS
 #define J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING


### PR DESCRIPTION
Add macros OMRVM_REFERENCE_SHIFT, OMRVMTHREAD_REFERENCE_SHIFT and
OMR_LOG_POINTER_SIZE for use in mixed mode.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>