### PR TITLE
Stop generating deprecated unsigned opcodes of load and store from OMR

### DIFF
--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -596,10 +596,10 @@ OMR::IL::opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode)
       case TR::aloadi: return TR::astorei;
       case TR::vloadi: return TR::vstorei;
       case TR::cloadi: return TR::cstorei;
-      case TR::buloadi: return TR::bustorei;
-      case TR::iuload: return TR::iustore;
-      case TR::iuloadi: return TR::iustorei;
-      case TR::luloadi: return TR::lustorei;
+      case TR::buloadi: return TR::bstorei;
+      case TR::iuload: return TR::istore;
+      case TR::iuloadi: return TR::istorei;
+      case TR::luloadi: return TR::lstorei;
       case TR::brdbari:
       case TR::srdbari:
       case TR::irdbari:

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -634,11 +634,11 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
       case TR::astorei:  return TR::aloadi;
       case TR::awrtbari: return TR::aloadi;
       case TR::vstorei:  return TR::vloadi;
-      case TR::cstorei:  return TR::cloadi;
-      case TR::bustorei: return TR::buloadi;
-      case TR::iustore:  return TR::iuload;
-      case TR::iustorei: return TR::iuloadi;
-      case TR::lustorei: return TR::luloadi;
+      case TR::cstorei:  return TR::sloadi;
+      case TR::bustorei: return TR::bloadi;
+      case TR::iustore:  return TR::iload;
+      case TR::iustorei: return TR::iloadi;
+      case TR::lustorei: return TR::lloadi;
       case TR::bwrtbari:
       case TR::swrtbari:
       case TR::iwrtbari:

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -172,7 +172,7 @@ void TR_DebuggingCounters::insertCounter(const char * name, TR::Compilation * co
       // Treetops for counterRef = counterRef + 1;
 
       TR::Node * node = tt->getNode();
-      TR::Node* loadNode = TR::Node::createWithSymRef(node, TR::iuload, 0, counterRef);
+      TR::Node* loadNode = TR::Node::createWithSymRef(node, TR::iload, 0, counterRef);
 
       TR::Node* addNode =
          TR::Node::create(TR::iuadd, 2, loadNode,

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -179,7 +179,7 @@ void TR_DebuggingCounters::insertCounter(const char * name, TR::Compilation * co
 		         TR::Node::create(node, TR::iuconst, 0, 1));
 
       TR::TreeTop* incrementTree =
-         TR::TreeTop::create(comp, TR::Node::createWithSymRef(TR::iustore, 1, 1,
+         TR::TreeTop::create(comp, TR::Node::createWithSymRef(TR::istore, 1, 1,
 					          addNode, counterRef));
 
       tt->getPrevTreeTop()->insertAfter(incrementTree);


### PR DESCRIPTION
Stop generating deprecated unsigned opcodes of `load` and `store` from OMR.
Will use `TR_ASSERT_FATAL` to ensure no downstream projects will attempt to use aforementioned opcodes in #4363.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com