### PR TITLE
Fatal asserts any creation of deprecated unsigned load/store opcodes

### DIFF
--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -420,6 +420,31 @@ private:
          case TR::luadd: 
          case TR::luneg: 
          case TR::lusub:
+
+         //Load
+         case TR::buload:
+         case TR::buloadi:
+         case TR::cload:
+         case TR::cloadi:
+         case TR::iuload:
+         case TR::iuloadi:
+         case TR::iuRegLoad:
+         case TR::luload:
+         case TR::luloadi:
+         case TR::luRegLoad:
+
+         //Store
+         case TR::bustore:
+         case TR::bustorei:
+         case TR::cstore:
+         case TR::cstorei:
+         case TR::iuRegStore:
+         case TR::iustore:
+         case TR::iustorei:
+         case TR::luRegStore:
+         case TR::lustore:
+         case TR::lustorei:
+         
             return false;
             
          default: 


### PR DESCRIPTION
Use `TR_ASSERT_FATAL` to ensure no downstream projects will attempt to use aforementioned opcodes.

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com