### PR TITLE
Stop generating deprecated unsigned opcodes of Call/Return and Add/Sub from OMR

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -702,11 +702,11 @@ public:
       {
       switch(type)
          {
-         case TR::Int8:     return TR::buadd;
-         case TR::Int16:    return TR::cadd;
-         case TR::Int32:    return TR::iuadd;
-         case TR::Int64:    return TR::luadd;
-	 case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
+         case TR::Int8:     return TR::badd;
+         case TR::Int16:    return TR::sadd;
+         case TR::Int32:    return TR::iadd;
+         case TR::Int64:    return TR::ladd;
+	      case TR::Address:  return (is64Bit) ? TR::aladd : TR::aiadd;
          default: TR_ASSERT(0, "no add opcode for this datatype");
          }
       return TR::BadILOp;
@@ -737,12 +737,9 @@ public:
       {
       switch(type)
          {
-         case TR::Int8:    return TR::busub;
-         case TR::Int16:   return TR::csub;
-         case TR::Int32:   return TR::iusub;
-         case TR::Int64:   return TR::lusub;
          default: TR_ASSERT(0, "no unsigned sub opcode for this datatype");
          }
+      TR_ASSERT_FATAL(0, "all unsigned subtract opcode has been deprecated. (eclipse/omr#2657)");
       return TR::BadILOp;
       }
 
@@ -910,15 +907,13 @@ public:
       switch (longOp)
          {
          case TR::ladd:   return TR::iadd;
-         case TR::luadd:  return TR::iuadd;
+         case TR::luadd:  return TR::iadd;
          case TR::lsub:   return TR::isub;
-         case TR::lusub:  return TR::iusub;
          case TR::lmul:   return TR::imul;
          case TR::ldiv:   return TR::idiv;
          case TR::lrem:   return TR::irem;
          case TR::labs:   return TR::iabs;
          case TR::lneg:   return TR::ineg;
-         case TR::luneg:  return TR::iuneg;
          case TR::lshr:   return TR::ishr;
          case TR::lushr:  return TR::iushr;
          case TR::lshl:   return TR::ishl;
@@ -1452,24 +1447,24 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   float>() { ret
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<  double>() { return TR::dconst; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getConstOpCode<   void*>() { return TR::aconst; }
 
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< uint8_t>() { return TR::buadd; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< uint8_t>() { return TR::badd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  int8_t>() { return TR::badd; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint16_t>() { return TR::cadd; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint16_t>() { return TR::sadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int16_t>() { return TR::sadd; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint32_t>() { return TR::iuadd; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint32_t>() { return TR::iadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int32_t>() { return TR::iadd; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint64_t>() { return TR::luadd; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<uint64_t>() { return TR::ladd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode< int64_t>() { return TR::ladd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<   float>() { return TR::fadd; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getAddOpCode<  double>() { return TR::dadd; }
 
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< uint8_t>() { return TR::busub; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< uint8_t>() { return TR::bsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  int8_t>() { return TR::bsub; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint16_t>() { return TR::csub; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint16_t>() { return TR::ssub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int16_t>() { return TR::ssub; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint32_t>() { return TR::iusub; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint32_t>() { return TR::isub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int32_t>() { return TR::isub; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint64_t>() { return TR::lusub; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<uint64_t>() { return TR::lsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode< int64_t>() { return TR::lsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<   float>() { return TR::fsub; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  double>() { return TR::dsub; }
@@ -1485,9 +1480,9 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<  double>() { retur
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<  int8_t>() { return TR::bneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int16_t>() { return TR::sneg; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint32_t>() { return TR::iuneg; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint32_t>() { return TR::ineg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int32_t>() { return TR::ineg; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint64_t>() { return TR::luneg; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<uint64_t>() { return TR::lneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode< int64_t>() { return TR::lneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<   float>() { return TR::fneg; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getNegOpCode<  double>() { return TR::dneg; }

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -401,6 +401,28 @@ private:
          case TR::iuconst:
          case TR::luconst:
          case TR::cconst:
+
+         //Call and Return
+         case TR::iucall:
+         case TR::iucalli:
+         case TR::iureturn: 
+         case TR::lucall: 
+         case TR::lucalli: 
+         case TR::lureturn: 
+
+         //Add and Subtract
+         case TR::aiuadd: 
+         case TR::aluadd: 
+         case TR::buadd: 
+         case TR::busub: 
+         case TR::cadd:
+         case TR::csub: 
+         case TR::iuadd: 
+         case TR::iuneg: 
+         case TR::iusub: 
+         case TR::luadd: 
+         case TR::luneg: 
+         case TR::lusub:
             return false;
             
          default: 

--- a/compiler/optimizer/DebuggingCounters.cpp
+++ b/compiler/optimizer/DebuggingCounters.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -175,8 +175,10 @@ void TR_DebuggingCounters::insertCounter(const char * name, TR::Compilation * co
       TR::Node* loadNode = TR::Node::createWithSymRef(node, TR::iuload, 0, counterRef);
 
       TR::Node* addNode =
-         TR::Node::create(TR::iuadd, 2, loadNode,
+
+         TR::Node::create(TR::iadd, 2, loadNode,
 		         TR::Node::create(node, TR::iconst, 0, 1));
+
 
       TR::TreeTop* incrementTree =
          TR::TreeTop::create(comp, TR::Node::createWithSymRef(TR::iustore, 1, 1,

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1623,8 +1623,6 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
       case TR::land: newOp = TR::iand; break;
       case TR::lor:  newOp = TR::ior;  break;
       case TR::lxor: newOp = TR::ixor; break;
-      case TR::luadd: newOp = TR::iuadd; isUnsigned = true; break;
-      case TR::lusub: newOp = TR::iusub; isUnsigned = true; break;
       case TR::lushr:
          isUnsigned = true;
       case TR::lshr:
@@ -1683,14 +1681,14 @@ static bool reduceLongOp(TR::Node * node, TR::Block * block, TR::Simplifier * s,
             return false;
          if (newConversionOp == TR::BadILOp)
             {
-            TR::Node::recreate(node, isUnsigned ? TR::iuneg : TR::ineg);
+            TR::Node::recreate(node, TR::ineg);
             TR::Node::recreate(firstChild, TR::l2i);
             }
          else
             {
             TR::Node * temp = TR::Node::create(TR::l2i, 1, firstChild->getFirstChild());
             firstChild->getFirstChild()->decReferenceCount();
-            TR::Node::recreate(firstChild, isUnsigned ? TR::iuneg : TR::ineg);
+            TR::Node::recreate(firstChild, TR::ineg);
             firstChild->setAndIncChild(0, temp);
             TR::Node::recreate(node, newConversionOp);
             }


### PR DESCRIPTION
Stop generating deprecated unsigned opcodes of `Call/Return` and `Add/Sub` from OMR.
Using `TR_ASSERT_FATAL` to ensure no downstream projects will attempt to use aforementioned opcodes. 
Note that this PR needs support from #4310 and eclipse/openj9#7004

Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com