### PR TITLE
Stop generating deprecated Multiply/Ternary/Shift/Shift logical opcodes from OMR

### DIFF
--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -1483,7 +1483,7 @@ template <> inline TR::ILOpCodes OMR::ILOpCode::getSubOpCode<  double>() { retur
 
 template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<  int8_t>() { return TR::bmul; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode< int16_t>() { return TR::smul; }
-template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<uint32_t>() { return TR::iumul; }
+template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<uint32_t>() { return TR::imul; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode< int32_t>() { return TR::imul; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode<uint64_t>() { return TR::lmul; }
 template <> inline TR::ILOpCodes OMR::ILOpCode::getMulOpCode< int64_t>() { return TR::lmul; }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -536,6 +536,7 @@ OMR::Node::recreateWithSymRef(TR::Node *originalNode, TR::ILOpCodes op, TR::Symb
 TR::Node *
 OMR::Node::recreateAndCopyValidPropertiesImpl(TR::Node *originalNode, TR::ILOpCodes op, TR::SymbolReference *newSymRef)
    {
+   TR_ASSERT_FATAL(TR::Node::isNotDeprecatedUnsigned(op), "Trying to use a deprecated unsigned opcode: #%d \n", op);
    TR_ASSERT(originalNode != NULL, "trying to recreate node from a NULL originalNode.");
    if (originalNode->getOpCodeValue() == op)
       {
@@ -599,6 +600,7 @@ OMR::Node::recreateAndCopyValidPropertiesImpl(TR::Node *originalNode, TR::ILOpCo
 TR::Node *
 OMR::Node::createInternal(TR::Node *originatingByteCodeNode, TR::ILOpCodes op, uint16_t numChildren, TR::Node *originalNode)
    {
+   TR_ASSERT_FATAL(TR::Node::isNotDeprecatedUnsigned(op), "The unsigned opcode is deprecated: %d \n", op);
    if (!originalNode)
       return new (TR::comp()->getNodePool()) TR::Node(originatingByteCodeNode, op, numChildren);
    else

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -374,6 +374,39 @@ private:
       return true;
       }
 
+   static bool isNotDeprecatedUnsigned(TR::ILOpCodes opvalue)
+      {
+      switch (opvalue) 
+         {
+         //Multiply
+         case TR::iumul: 
+
+         //Ternary
+         case TR::buternary: 
+         case TR::iuternary: 
+         case TR::luternary: 
+         case TR::suternary: 
+
+         //Shift
+         case TR::iushl: 
+         case TR::lushl:
+
+         //Shift Logical 
+         case TR::ishfl: 
+         case TR::lshfl: 
+         case TR::iushfl: 
+         case TR::lushfl:
+         case TR::bshfl: 
+         case TR::sshfl:  
+         case TR::bushfl:
+         case TR::sushfl:
+            return false;
+            
+         default: 
+            return true;
+         }
+      }
+
 
 /**
  * Public functions


### PR DESCRIPTION
Stop generating deprecated unsigned opcodes of `Multiply`/`Ternary`/`Shift`/`Shift logical` from OMR.
Using `TR_ASSERT_FATAL` to ensure no downstream projects will attempt to use aforementioned opcodes. 
Note that there is no assertion for `TR::cmul` and `TR::cshl` as they no longer exist in the opcode list.


Issue: #2657
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com