### PR TITLE
CMake: add export symbol info onto shared libraries

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -398,7 +398,6 @@ omr_add_exports(omrport_obj
 	omrport_init_library
 	omrport_isCompatible
 	omrport_startup_library
-
 )
 
 target_enable_ddr(omrport_obj)
@@ -407,13 +406,19 @@ ddr_add_headers(omrport_obj
 )
 ddr_set_add_targets(omrddr omrport_obj)
 
-add_library(omrport STATIC
-	$<TARGET_OBJECTS:omrport_obj>
-)
+
 
 ###
 ### omrport static lib
 ###
+
+add_library(omrport STATIC
+	$<TARGET_OBJECTS:omrport_obj>
+)
+
+# Duplicate the export list onto the static library version
+get_target_property(port_exports omrport_obj EXPORTED_SYMBOLS)
+omr_add_exports(omrport ${port_exports})
 
 target_link_libraries(omrport
 	PUBLIC

--- a/thread/CMakeLists.txt
+++ b/thread/CMakeLists.txt
@@ -134,8 +134,6 @@ if(OMR_ENHANCED_WARNINGS)
 	target_compile_options(j9thr_obj PRIVATE ${OMR_ENHANCED_WARNING_FLAG})
 endif()
 
-include(exports.cmake)
-
 target_enable_ddr(j9thr_obj)
 ddr_add_headers(j9thr_obj
 	${omr_SOURCE_DIR}/include_core/omrthread.h
@@ -148,6 +146,8 @@ ddr_set_add_targets(omrddr j9thr_obj)
 add_library(j9thrstatic STATIC
 	$<TARGET_OBJECTS:j9thr_obj>
 )
+
+include(exports.cmake)
 
 target_include_directories(j9thrstatic
 	INTERFACE

--- a/thread/exports.cmake
+++ b/thread/exports.cmake
@@ -190,3 +190,7 @@ if(OMR_THR_TRACING)
 		omrthread_reset_tracing
 	)
 endif()
+
+# also apply the exports to j9thrstatic
+get_target_property(thread_exports j9thr_obj EXPORTED_SYMBOLS)
+omr_add_exports(j9thrstatic ${thread_exports})

--- a/util/hookable/CMakeLists.txt
+++ b/util/hookable/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corp. and others
+# Copyright (c) 2017, 2019 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -55,6 +55,9 @@ ddr_set_add_targets(omrddr j9hook_obj)
 add_library(j9hookstatic STATIC
 	$<TARGET_OBJECTS:j9hook_obj>
 )
+# Duplicate the export list onto the static library version
+get_target_property(hook_exports j9hook_obj EXPORTED_SYMBOLS)
+omr_add_exports(j9hookstatic ${hook_exports})
 
 if(OMR_WARNINGS_AS_ERRORS)
 	target_compile_options(j9hook_obj PRIVATE ${OMR_WARNING_AS_ERROR_FLAG})

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -162,6 +162,11 @@ ddr_set_add_targets(omrddr omrutil_obj)
 add_library(omrutil STATIC
 	$<TARGET_OBJECTS:omrutil_obj>
 )
+
+# Duplicate the export list onto the static library version
+get_target_property(util_exports omrutil_obj EXPORTED_SYMBOLS)
+omr_add_exports(omrutil ${util_exports})
+
 # Add in the interface include dirs from omrutil_obj to omrutil
 target_include_directories(omrutil PUBLIC $<TARGET_PROPERTY:omrutil_obj,INTERFACE_INCLUDE_DIRECTORIES>)
 


### PR DESCRIPTION
This is in preparation of removing the object libraries see #4357

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>