### PR TITLE
Remove _registerSaveDescription from OMRInstruction.hpp

### DIFF
--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -303,7 +303,7 @@ OMR::CodeGenerator::buildGCMapForInstruction(TR::Instruction *instr)
 
    // Build the register save description
    //
-   map->setRegisterSaveDescription(instr->getRegisterSaveDescription());
+   map->setRegisterSaveDescription(0);
 
    // Build the register map
    //

--- a/compiler/codegen/OMRInstruction.cpp
+++ b/compiler/codegen/OMRInstruction.cpp
@@ -47,7 +47,6 @@ Instruction::Instruction(
    _cg(cg),
    _liveLocals(0),
    _liveMonitors(0),
-   _registerSaveDescription(0),
    _gc()
    {
    TR_ASSERT(node || !debug("checkByteCodeInfo"), "TR::Node * not passed to OMR::Instruction ctor");
@@ -112,7 +111,6 @@ Instruction::Instruction(
    _cg(cg),
    _liveLocals(0),
    _liveMonitors(0),
-   _registerSaveDescription(0),
    _gc()
    {
 

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -217,9 +217,6 @@ class OMR_EXTENSIBLE Instruction
    TR_BitVector *getLiveMonitors() { return _liveMonitors; }
    TR_BitVector *setLiveMonitors(TR_BitVector *v) { return (_liveMonitors = v); }
 
-   int32_t getRegisterSaveDescription() { return _registerSaveDescription; }
-   int32_t setRegisterSaveDescription(int32_t v) { return (_registerSaveDescription = v); }
-
    bool    requiresAtomicPatching();
 
    int32_t getMaxPatchableInstructionLength() { return 0; }
@@ -278,7 +275,6 @@ class OMR_EXTENSIBLE Instruction
    protected:
    TR_BitVector *_liveLocals;
    TR_BitVector *_liveMonitors;
-   int32_t _registerSaveDescription;
 
    union TR_GCInfo
       {


### PR DESCRIPTION
Field is no longer in use, neither are its getters and setters.
change `instr->getRegisterSaveDescription()` to zero in the GC stack map.