### PR TITLE
WIP: Add Dynamic Breadth First Scan Ordering to GC

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -1617,7 +1617,7 @@ int32_t       OMR::Options::_interpreterSamplingDivisorInStartupMode = -1; // un
 int32_t       OMR::Options::_numJitEntries = 0;
 int32_t       OMR::Options::_numVmEntries = 0;
 int32_t       OMR::Options::_numVecRegsToLock=0;
-int32_t       OMR::Options::_hotFieldThreshold = 100;
+int32_t       OMR::Options::_hotFieldThreshold = 200;
 int32_t       OMR::Options::_maxNumPrexAssumptions = 209;
 int32_t       OMR::Options::_maxNumVisitedSubclasses = 500;
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2759,15 +2759,15 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
             }
          }
       }
-
+   int32_t frequency = vp->_curBlock->getGlobalNormalizedFrequency(vp->comp()->getFlowGraph());
    TR::VPConstraint * base = vp->getConstraint(node->getFirstChild(), isGlobal);
 
    if (base && base->getClass() && !vp->comp()->getOption(TR_DisableMarkingOfHotFields) &&
       node->getFirstChild()->getOpCode().hasSymbolReference() &&
       node->getFirstChild()->getSymbol()->isCollectedReference() &&
-      vp->_curBlock->getGlobalNormalizedFrequency(vp->comp()->getFlowGraph()) >= TR::Options::_hotFieldThreshold)
+      frequency >= TR::Options::_hotFieldThreshold)
       {
-      vp->comp()->fej9()->markHotField(vp->comp(), node->getSymbolReference(), base->getClass(), base->isFixedClass());
+      vp->comp()->fej9()->markHotField(frequency, vp->comp(), node->getSymbolReference(), base->getClass(), base->isFixedClass());
       }
 
    if (node->getSymbolReference())

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -2767,7 +2767,7 @@ TR::Node *constrainIaload(OMR::ValuePropagation *vp, TR::Node *node)
       node->getFirstChild()->getSymbol()->isCollectedReference() &&
       frequency >= TR::Options::_hotFieldThreshold)
       {
-      vp->comp()->fej9()->markHotField(frequency, vp->comp(), node->getSymbolReference(), base->getClass(), base->isFixedClass());
+      vp->comp()->fej9()->markHotField(vp->comp(), node->getSymbolReference(), base->getClass(), base->isFixedClass(), frequency);
       }
 
    if (node->getSymbolReference())

--- a/example/glue/ObjectModelDelegate.hpp
+++ b/example/glue/ObjectModelDelegate.hpp
@@ -201,6 +201,18 @@ public:
 		return false;
 	}
 
+	MMINLINE UDATA
+	getHotFieldOffset(MM_ForwardedHeader *forwardedHeader)
+	{
+		return UDATA_MAX;
+	}
+
+	MMINLINE UDATA
+	getHotFieldOffset2(MM_ForwardedHeader *forwardedHeader)
+	{
+		return UDATA_MAX;
+	}
+
 	/**
 	 * Get the instance size (total) of a forwarded object from the forwarding pointer. The  size must
 	 * include the header and any expansion bytes to be allocated if the object will grow when moved.

--- a/gc/base/EnvironmentBase.hpp
+++ b/gc/base/EnvironmentBase.hpp
@@ -148,7 +148,10 @@ public:
 
 	uintptr_t _oolTraceAllocationBytes; /**< Tracks the bytes allocated since the last ool object trace */
 
-	uintptr_t approxScanCacheCount; /**< Local copy of approximate entries in global Cache Scan List. Updated upon allocation of new cache. */
+#if defined(OMR_GC_MODRON_SCAVENGER)
+	uintptr_t _approxScanCacheCount; /**< Local copy of approximate entries in global Cache Scan List. Updated upon allocation of new cache. */
+	uintptr_t _hotFieldCopyDepthCount; /**< Used for dynamic breadth first scan ordering. Counter for the current copying depth based on the initial object copied. */
+#endif /* OMR_GC_MODRON_SCAVENGER */
 
 	MM_Validator *_activeValidator; /**< Used to identify and report crashes inside Validators */
 
@@ -646,7 +649,10 @@ public:
 		,_slaveThreadCpuTimeNanos(0)
 		,_freeEntrySizeClassStats()
 		,_oolTraceAllocationBytes(0)
-		,approxScanCacheCount(0)
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		,_approxScanCacheCount(0)
+		,_hotFieldCopyDepthCount(0)
+#endif /* OMR_GC_MODRON_SCAVENGER */	
 		,_activeValidator(NULL)
 		,_lastSyncPointReached(NULL)
 #if defined(OMR_GC_SEGREGATED_HEAP)
@@ -698,7 +704,10 @@ public:
 		,_slaveThreadCpuTimeNanos(0)
 		,_freeEntrySizeClassStats()
 		,_oolTraceAllocationBytes(0)
-		,approxScanCacheCount(0)
+#if defined(OMR_GC_MODRON_SCAVENGER)
+		,_approxScanCacheCount(0)
+		,_hotFieldCopyDepthCount(0)
+#endif /* OMR_GC_MODRON_SCAVENGER */
 		,_activeValidator(NULL)
 		,_lastSyncPointReached(NULL)
 #if defined(OMR_GC_SEGREGATED_HEAP)

--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -438,6 +438,7 @@ public:
 #if defined(OMR_GC_MODRON_SCAVENGER) || defined(OMR_GC_VLHGC)
 	enum ScavengerScanOrdering {
 		OMR_GC_SCAVENGER_SCANORDERING_BREADTH_FIRST = 0,
+		OMR_GC_SCAVENGER_SCANORDERING_DYNAMIC_BREADTH_FIRST,
 		OMR_GC_SCAVENGER_SCANORDERING_HIERARCHICAL,
 	};
 	ScavengerScanOrdering scavengerScanOrdering; /**< scan ordering in Scavenger */

--- a/gc/base/ObjectModelBase.hpp
+++ b/gc/base/ObjectModelBase.hpp
@@ -847,6 +847,18 @@ public:
 		return _delegate.getForwardedObjectSizeInBytes(forwardedHeader);
 	}
 
+	MMINLINE UDATA
+	getHotFieldOffset(MM_ForwardedHeader *forwardedHeader)
+	{
+		return _delegate.getHotFieldOffset(forwardedHeader);
+	}
+
+	MMINLINE UDATA
+	getHotFieldOffset2(MM_ForwardedHeader *forwardedHeader)
+	{
+		return _delegate.getHotFieldOffset2(forwardedHeader);
+	}
+
 	/**
 	 * Extract the flag bits from an unforwarded object. Flag bits are returned in the low-order byte of the returned value.
 	 *

--- a/gc/base/standard/Scavenger.hpp
+++ b/gc/base/standard/Scavenger.hpp
@@ -251,6 +251,8 @@ public:
 
 	MMINLINE omrobjectptr_t copy(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHeader);
 
+	MMINLINE void depthCopyHotFields(MM_EnvironmentStandard *env, MM_ForwardedHeader* forwardedHeader, omrobjectptr_t destinationObjectPtr);
+
 	MMINLINE void updateCopyScanCounts(MM_EnvironmentBase* env, uint64_t slotsScanned, uint64_t slotsCopied);
 	bool splitIndexableObjectScanner(MM_EnvironmentStandard *env, GC_ObjectScanner *objectScanner, uintptr_t startIndex, omrobjectptr_t *rememberedSetSlot);
 


### PR DESCRIPTION
Add a gc scan ordering feature that enables the copying
of a hot field marked by the JIT immediately after the
object containing the hot field is copied.

Issue: https://github.com/eclipse/openj9/issues/7552
Signed-off-by: Jonathan Oommen jon.oommen@gmail.com