### PR TITLE
Cmake: Fix install of omr_ebcdic and omr_ascii targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,14 +108,8 @@ if(OMR_OS_ZOS)
 			INTERFACE
 				-DOMR_EBCDIC
 		)
-		install(TARGETS omr_ebcdic
-			EXPORT OmrTargets
-		)
 	else()
 		target_link_libraries(omr_base INTERFACE omr_ascii)
-		install(TARGETS omr_ascii
-			EXPORT OmrTargets
-		)
 	endif()
 endif()
 

--- a/cmake/modules/platform/os/zos.cmake
+++ b/cmake/modules/platform/os/zos.cmake
@@ -46,6 +46,10 @@ target_link_libraries(omr_ascii INTERFACE j9a2e)
 add_library(omr_ebcdic INTERFACE)
 target_compile_definitions(omr_ebcdic INTERFACE -DOMR_EBCDIC)
 
+install(TARGETS omr_ascii omr_ebcdic
+	EXPORT OmrTargets
+)
+
 macro(omr_os_global_setup)
 
 	# TODO: Move this out and after platform config.


### PR DESCRIPTION
The `install()` command needs to be called from the same directory that
defines the targets. The current code works because the top level
CMakeLists includes  zos.cmake (which defines the libraries). However
If a consumer of omr includes zos.cmake before calling add_subdirectory
on omr, the definition and installation commands will be in different
directories

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>