### PR TITLE
WIP: AArch64: Load StartPC constant in OMRMemoryReference

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -58,7 +58,7 @@ static void loadRelocatableConstant(TR::Node *node,
 
    if (symbol->isStartPC())
       {
-      TR_UNIMPLEMENTED();
+      loadAddressConstant(cg, node, addr, reg, NULL, false, TR_AbsoluteMethodAddress);
       return;
       }
 


### PR DESCRIPTION
This commit adds code for loading StartPC constant.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>