### PR TITLE
Fix Typo of word instruction

### DIFF
--- a/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
@@ -1894,7 +1894,7 @@ void TR_X86BinaryCommutativeAnalyser::longMultiplyAnalyser(TR::Node *root)
       }
    else if (getCopyRegs())
       {
-      // Ah:Al=Al*Bl notation means that Ah:Al contains the result of the MUL instructon between Al and Bl
+      // Ah:Al=Al*Bl notation means that Ah:Al contains the result of the MUL instruction between Al and Bl
       //
       // both high zero: compute                               Ah:Al=Al*Bl            (clobber Ah,Al)
       // Ah zero:        compute Bh=Bh*Al,                     Ah:Al=Al*Bl, Ah=Ah+Bh  (clobber Ah,Al,Bh)

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -6164,7 +6164,7 @@ class S390EInstruction : public TR::Instruction
       }
 
    /**
-    * Following constructor is for PFPO instructino, where FPR0/FPR2 and GPR1 are target registers;
+    * Following constructor is for PFPO instruction, where FPR0/FPR2 and GPR1 are target registers;
     * FPR4/FPR6 and GPR0 are source registers;
     * they are implied by the opcode, purpose of adding these is to notify RA the reg use/def dependencies
     */


### PR DESCRIPTION
The word 'instruction' was spelled wrong in 2 omr files

Signed-off-by: Kishor Patil <patil@ca.ibm.com>