### PR TITLE
Fixes two typos

### DIFF
--- a/compiler/p/codegen/OMRRegisterDependency.cpp
+++ b/compiler/p/codegen/OMRRegisterDependency.cpp
@@ -977,7 +977,7 @@ void TR_PPCRegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
          }
       }
 
-   // Assign all virtual regs that depend on a specfic real reg that is not free
+   // Assign all virtual regs that depend on a specific real reg that is not free
    for (i = 0; i < numberOfRegisters; i++)
       {
       virtReg          = _dependencies[i].getRegister();

--- a/run_configure.mk
+++ b/run_configure.mk
@@ -56,7 +56,7 @@ ifdef OMRGLUE
   CONFIG_INCL_DIR ?= $(firstword $(OMRGLUE))/configure_includes
 endif
 
-# If CONFIG_INCL_DIR is defined, we include platform specfic makefiles
+# If CONFIG_INCL_DIR is defined, we include platform specific makefiles
 # from that directory. These makefiles are expected to add extra configure
 # arguments to the variable CONFIGURE_ARGS.
 ifdef CONFIG_INCL_DIR


### PR DESCRIPTION
This change fixes two small typos of the word 'specific'

Signed-off-by: Pushkar Bettadpur <pushkar.bettadpur@gmail.com>