### PR TITLE
Remove side effects in assert statements

### DIFF
--- a/fvtest/tril/examples/incordec/main.cpp
+++ b/fvtest/tril/examples/incordec/main.cpp
@@ -22,14 +22,20 @@
 #include "default_compiler.hpp"
 #include "Jit.hpp"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
 
 typedef int32_t (IncOrDecFunction)(int32_t*);
 
 int main(int argc, char const * const * const argv) {
     assert(argc == 2);
-    assert(initializeJit());
+
+   bool initialized = initializeJit();
+   if (!initialized) {
+        fprintf(stderr, "FAIL: could not initialize JIT\n");
+        exit(-1);
+    }
 
     // parse the input Tril file
     FILE* inputFile = fopen(argv[1], "r");
@@ -42,7 +48,13 @@ int main(int argc, char const * const * const argv) {
 
     // assume that the file contians a single method and compile it
     Tril::DefaultCompiler incordecCompiler(trees);
-    assert(incordecCompiler.compile() == 0);
+
+    int32_t result = incordecCompiler.compile();
+    if (result != 0) {
+       printf("Failed to compile\n");
+       exit(-2);
+    }
+
     auto incordec = incordecCompiler.getEntryPoint<IncOrDecFunction*>();
 
     int32_t value = 1;

--- a/fvtest/tril/examples/mandelbrot/main.cpp
+++ b/fvtest/tril/examples/mandelbrot/main.cpp
@@ -30,7 +30,12 @@ typedef void (MandelbrotFunction) (int32_t, int32_t, int32_t*);
 
 int main(int argc, char const * const * const argv) {
     assert(argc == 2);
-    assert(initializeJit());
+
+   bool initialized = initializeJit();
+   if (!initialized) {
+        fprintf(stderr, "FAIL: could not initialize JIT\n");
+        exit(-1);
+    }
 
     // parse the input Tril file
     FILE* inputFile = fopen(argv[1], "r");
@@ -43,7 +48,13 @@ int main(int argc, char const * const * const argv) {
 
     // assume that the file contians a single method and compile it
     Tril::DefaultCompiler mandelbrotCompiler(trees);
-    assert(mandelbrotCompiler.compile() == 0);
+
+    int32_t rc = mandelbrotCompiler.compile();
+    if (rc != 0) {
+      fprintf(stderr,"FAIL: compilation error %d\n", rc);
+      exit(-2);
+    }
+
     auto mandelbrot = mandelbrotCompiler.getEntryPoint<MandelbrotFunction*>();
 
     const auto size = 80;                   // number of rows/columns in the output table

--- a/jitbuilder/release/cpp/samples/Union.cpp
+++ b/jitbuilder/release/cpp/samples/Union.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -161,7 +161,12 @@ template <typename Function>
 static Function assert_compile(OMR::JitBuilder::MethodBuilder* m)
    {
    void* entry;
-   assert(0 == compileMethodBuilder(m, &entry));
+   int32_t rc = compileMethodBuilder(m, &entry);
+   if (rc != 0)
+      {
+      fprintf(stderr, "FAIL: could not compile MethodBuilder\n");
+      exit(-1);
+      }
    return (Function)entry;
    }
 
@@ -169,7 +174,12 @@ int
 main()
    {
    std::cout << "Step 1: initialize JIT\n";
-   assert(initializeJit());
+   bool initialized = initializeJit();
+   if (!initialized)
+      {
+      fprintf(stderr, "FAIL: could not initialize JIT\n");
+      exit(-1);
+      }
 
    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When compiling in release mode, we compile with `-DNDEBUG`.  When this
happens any statements inside of asserts are not run.  We must
initialize the jit outside of the assert.

Signed-off-by: Andrew Young <youngar17@gmail.com>