### PR TITLE
AArch64: Change ARM64HelperCallSnippet to set GC Map to the branch instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
@@ -40,16 +40,8 @@ TR::ARM64HelperCallSnippet::emitSnippetBody()
       TR_ASSERT(constantIsSignedImm28(distance), "Trampoline too far away.");
       }
 
-   if (_restartLabel == NULL)
-      {
-      // b distance
-      *(int32_t *)cursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::b) | ((distance >> 2) & 0x3ffffff); // imm26
-      }
-   else
-      {
-      // bl distance
-      *(int32_t *)cursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::bl) | ((distance >> 2) & 0x3ffffff); // imm26
-      }
+   *(int32_t *)cursor = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::bl) | ((distance >> 2) & 0x3ffffff); // imm26
+
    cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                                cursor,
                                (uint8_t *)getDestination(),
@@ -95,8 +87,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64HelperCallSnippet * snippet)
       }
 
    printPrefix(pOutFile, NULL, bufferPos, 4);
-   trfprintf(pOutFile, "%s \t" POINTER_PRINTF_FORMAT "\t\t; %s%s",
-      (restartLabel != NULL) ? "bl" : "b", target, getName(snippet->getDestination()), info);
+   trfprintf(pOutFile, "bl \t" POINTER_PRINTF_FORMAT "\t\t; %s%s",
+      target, getName(snippet->getDestination()), info);
 
    if (restartLabel != NULL)
       {

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.hpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.hpp
@@ -48,7 +48,7 @@ class ARM64HelperCallSnippet : public TR::Snippet
                           TR::LabelSymbol      *snippetlab,
                           TR::SymbolReference  *helper,
                           TR::LabelSymbol      *restartLabel=NULL)
-      : TR::Snippet(cg, node, snippetlab, (restartLabel!=NULL && helper->canCauseGC())),
+      : TR::Snippet(cg, node, snippetlab, helper->canCauseGC()),
         _destination(helper),
         _restartLabel(restartLabel)
       {

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -31,6 +31,7 @@
 #include "codegen/Instruction.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RegisterDependency.hpp"
+#include "codegen/UnresolvedDataSnippet.hpp"
 #include "il/symbol/LabelSymbol.hpp"
 #include "infra/Assert.hpp"
 
@@ -233,6 +234,8 @@ class ARM64ImmSymInstruction : public TR::Instruction
     */
    TR::Snippet *setCallSnippet(TR::Snippet *s) { return (_snippet = s); }
 
+   virtual TR::Snippet *getSnippetForGC() {return _snippet;}
+
    /**
     * @brief Sets immediate field in binary encoding
     * @param[in] instruction : instruction cursor
@@ -338,6 +341,8 @@ class ARM64LabelInstruction : public TR::Instruction
       {
       return (_symbol = sym);
       }
+
+   virtual TR::Snippet *getSnippetForGC() {return getLabelSymbol()->getSnippet();}
 
    /**
     * @brief Sets immediate field in binary encoding
@@ -2204,6 +2209,8 @@ class ARM64Trg1MemInstruction : public ARM64Trg1Instruction
       return (_memoryReference = mr);
       }
 
+   virtual TR::Snippet *getSnippetForGC() {return getMemoryReference()->getUnresolvedSnippet();}
+
    /**
     * @brief Gets base register of memory reference
     * @return base register
@@ -2412,6 +2419,8 @@ class ARM64MemSrc1Instruction : public ARM64MemInstruction
     * @return source register
     */
    TR::Register *setSource1Register(TR::Register *sr) {return (_source1Register = sr);}
+
+   virtual TR::Snippet *getSnippetForGC() {return getMemoryReference()->getUnresolvedSnippet();}
 
    /**
     * @brief Sets source register in binary encoding

--- a/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/aarch64/codegen/ControlFlowEvaluator.cpp
@@ -513,11 +513,13 @@ evaluateNULLCHKWithPossibleResolve(TR::Node *node, bool needsResolve, TR::CodeGe
 
    // Only explicit test needed for now.
    TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
-   cg->addSnippet(new (cg->trHeapMemory()) TR::ARM64HelperCallSnippet(cg, node, snippetLabel, node->getSymbolReference(), NULL));
+   TR::Snippet *snippet = new (cg->trHeapMemory()) TR::ARM64HelperCallSnippet(cg, node, snippetLabel, node->getSymbolReference(), NULL);
+   cg->addSnippet(snippet);
    TR::Register *referenceReg = cg->evaluate(reference);
    TR::InstOpCode::Mnemonic compareOp = useCompressedPointers ? TR::InstOpCode::cbzw : TR::InstOpCode::cbzx;
    TR::Instruction *cbzInstruction = generateCompareBranchInstruction(cg, compareOp, node, referenceReg, snippetLabel, NULL);
    cbzInstruction->setNeedsGCMap(0xffffffff);
+   snippet->gcMap().setGCRegisterMask(0xffffffff);
 
    /*
     * If the first child is a load with a ref count of 1, just decrement the reference count on the child.


### PR DESCRIPTION

- This commit changes ARM64HelperCallSnippet to always use `bl` instruction
instead of `b`.
   - The mainline code which jumps to a helper call snippet does not use `bl` instruction because aarch64 instruction set does not have conditional branch-and-link instruction. Thus, we need to use `bl` instruction so that the stack walker can find the correct gc map.

- This commit also adds getSnippetForGC virtual function to instruction classes defined in ARM64Instruction.hpp

- This commit also changes the evaluator using ARM64HelperCallSnippet to set register mask to GC map of the snippet.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>