### PR TITLE
Turn CUDA off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,23 +64,6 @@ set(OMR_INSTALL_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE PATH "Installation dir
 set(OMR_INSTALL_DATA_DIR ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME} CACHE PATH "Installation directory for data files")
 
 ###
-### CUDA Support
-###
-
-if (OMR_ENV_DATA64)
-	find_package(Threads)
-	if(Threads_FOUND)
-		# Threads mush be found before we can look for CUDA.
-		# FindCuda will error out if Threads is missing, even though CUDA itself is optional.
-		find_package(CUDA)
-	else()
-		set(CUDA_FOUND OFF CACHE BOOL "CUDA is disabled (threads not found)")
-	endif()
-else()
-	set(CUDA_FOUND OFF CACHE BOOL "CUDA is disabled")
-endif()
-
-###
 ### Versions and stuff
 ###
 

--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64
@@ -34,7 +34,7 @@ pipeline {
 
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..'''
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DOMR_OPT_CUDA=ON -DOMR_CUDA_HOME=/usr/local/cuda ..'''
 
                         echo 'Compile...'
                         sh '''make -j4'''

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64
@@ -20,7 +20,7 @@ pipeline {
                     
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake ..''' 
+                        sh '''cmake -Wdev -C../cmake/caches/Travis.cmake -DOMR_OPT_CUDA=ON -DOMR_CUDA_HOME=/usr/local/cuda ..'''
                        
                         echo 'Compile...'
                         sh '''make -j4'''

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -202,6 +202,6 @@ set(OMR_NOTIFY_POLICY_CONTROL OFF CACHE BOOL "TODO: Document")
 
 set(OMR_ENV_GCC OFF CACHE BOOL "TODO: Document")
 
-set(OMR_OPT_CUDA ${CUDA_FOUND} CACHE BOOL "Enable CUDA support in OMR")
+set(OMR_OPT_CUDA OFF CACHE BOOL "Enable CUDA support in OMR. See also: OMR_CUDA_HOME in FindOmrCuda.cmake")
 
 set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GNU or Clang")

--- a/cmake/modules/FindOmrCuda.cmake
+++ b/cmake/modules/FindOmrCuda.cmake
@@ -1,0 +1,72 @@
+###############################################################################
+# Copyright (c) 2019, 2020 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at http://eclipse.org/legal/epl-2.0
+# or the Apache License, Version 2.0 which accompanies this distribution
+# and is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception [1] and GNU General Public
+# License, version 2 with the OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+#############################################################################
+
+# This module locates a minimal set of cuda headers, required by the OMR_OPT_CUDA flag.
+# This module will search for CUDA resources in only one directory. The variables tested, in order of preference, are:
+#
+# 1. The cmake variable OMR_CUDA_HOME, if set.
+# 2. The cmake variable CUDA_HOME, if set.
+# 3. The environment variable CUDA_HOME, if set.
+#
+
+include(FindPackageHandleStandardArgs)
+
+set(OMR_CUDA_HOME "NOTFOUND" CACHE PATH "Path to the CUDA SDK. Takes precedence over CUDA_HOME in OMR.")
+set(OmrCuda_INCLUDE_DIRS "OmrCuda_INCLUDE_DIRS-NOTFOUND")
+
+if(OmrCuda_FIND_REQUIRED)
+	set(error_level FATAL_ERROR)
+else()
+	set(error_level WARNING)
+endif()
+
+# Establish which directory we are searching in
+
+set(OmrCuda_SEARCH_DIR "")
+
+if(OMR_CUDA_HOME)
+	set(OmrCuda_SEARCH_DIR "${OMR_CUDA_HOME}")
+elseif(CUDA_HOME)
+	set(OmrCuda_SEARCH_DIR "${CUDA_HOME}")
+elseif(ENV{CUDA_HOME})
+	set(OmrCuda_SEARCH_DIR "$ENV{CUDA_HOME}")
+else()
+	message(${error_level} "CUDA support requested, but OMR_CUDA_HOME/CUDA_HOME are not set.")
+endif()
+
+# Try to locate the main CUDA include directory by finding cuda.h
+
+find_path(OmrCuda_INCLUDE_DIR
+	NAMES cuda.h
+	PATHS ${OmrCuda_SEARCH_DIR}
+	PATH_SUFFIXES include Headers
+	DOC "The CUDA include directory"
+	NO_DEFAULT_PATH
+)
+
+find_package_handle_standard_args(OmrCuda
+	DEFAULT_MSG
+	OmrCuda_INCLUDE_DIR
+)
+
+if(OmrCuda_FOUND)
+	set(OmrCuda_INCLUDE_DIRS "${OmrCuda_INCLUDE_DIR}")
+endif()

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -22,7 +22,11 @@
 
 include(OmrFindFiles)
 
-if (OMR_HOST_OS STREQUAL "zos")
+if(OMR_OPT_CUDA)
+	find_package(OmrCuda REQUIRED)
+endif()
+
+if(OMR_HOST_OS STREQUAL "zos")
 	include(OmrMetalC)
 endif()
 
@@ -44,10 +48,10 @@ target_include_directories(omrport_obj
 		$<TARGET_PROPERTY:omr_base,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-if (OMR_OPT_CUDA)
+if(OMR_OPT_CUDA)
 	target_include_directories(omrport_obj
 		PRIVATE
-			${CUDA_INCLUDE_DIRS}
+			${OmrCuda_INCLUDE_DIRS}
 	)
 endif()
 


### PR DESCRIPTION
* Stop automatically enabling OMR_OPT_CUDA, so a user has to specifically opt-in for CUDA support.
* Stop using the built-in FindCUDA package, because it requires a complete installation of CUDA. We only need a small subset of the CUDA SDK.
* Enable OMR_OPT_CUDA explicitly in X86-64 builds