### PR TITLE
Enable Tril and JitBuilder tests on AIX

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
+++ b/buildenv/jenkins/jobs/builds/Build-aix_ppc-64
@@ -36,7 +36,7 @@ pipeline {
                     
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_JIT=OFF -DOMR_JITBUILDER=OFF -DOMR_TEST_COMPILER=OFF -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..''' 
+                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
                        
                         echo 'Compile...'
                         sh '''make -j8'''

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-aix_ppc-64
@@ -22,7 +22,7 @@ pipeline {
                     
                     dir('build') {
                         echo 'Configure...'
-                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_JIT=OFF -DOMR_JITBUILDER=OFF -DOMR_TEST_COMPILER=OFF -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..''' 
+                        sh '''cmake -Wdev -DCMAKE_XL_CreateExportList="/usr/vac/bin/CreateExportList -X64" -DOMR_DDR=OFF -C../cmake/caches/Travis.cmake ..'''
                        
                         echo 'Compile...'
                         sh '''make -j4'''

--- a/cmake/modules/OmrCompilerSupport.cmake
+++ b/cmake/modules/OmrCompilerSupport.cmake
@@ -280,10 +280,14 @@ macro(set_tr_compile_options)
 		#  Prepend leading '-D' only if required
 		if(def MATCHES "^-D")
 			set(TR_ASM_FLAGS "${TR_ASM_FLAGS} ${def}")
+			list(APPEND SPP_FLAGS "${def}")
 		else()
 			set(TR_ASM_FLAGS "${TR_ASM_FLAGS} -D${def}")
+			list(APPEND SPP_FLAGS "-D${def}")
 		endif()
 	endforeach()
+
+	set(SPP_FLAGS ${SPP_FLAGS} PARENT_SCOPE)
 
 	# We need special handling on x86 because we could be gnu or NASM assembler
 	if(OMR_ARCH_X86)

--- a/compiler/infra/OMRMonitor.hpp
+++ b/compiler/infra/OMRMonitor.hpp
@@ -58,7 +58,7 @@ class Monitor
    char const *getName();
    bool init(char *name);
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) || defined(AIXPPC)
    // xlc cannot handle private delete operator
    public:
 #else

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -122,4 +122,6 @@ target_link_libraries(compilertest
 
 set_property(TARGET compilertest PROPERTY FOLDER fvtest)
 
-add_test(NAME CompilerTest COMMAND compilertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
+if (NOT OMR_HOST_OS STREQUAL "aix")
+	add_test(NAME CompilerTest COMMAND compilertest --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/compilertest-results.xml)
+endif()

--- a/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
+++ b/fvtest/compilertest/runtime/TestCodeCacheManager.cpp
@@ -79,7 +79,7 @@ TestCompiler::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
               codeCacheSizeToAllocate,
               PROT_READ | PROT_WRITE | PROT_EXEC,
               MAP_ANONYMOUS | MAP_PRIVATE,
-              0,
+              -1,
               0));
 #endif /* OMR_OS_WINDOWS */
    TR::CodeCacheMemorySegment *memSegment = (TR::CodeCacheMemorySegment *) ((size_t)memorySlab + codeCacheSizeToAllocate - sizeof(TR::CodeCacheMemorySegment));

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -44,7 +44,7 @@
 #include "tests/injectors/TernaryOpIlInjector.hpp"
 #include "tests/injectors/UnaryOpIlInjector.hpp"
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) || defined(AIXPPC)
 namespace std
 {
    using ::isnan;

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -320,6 +320,8 @@ TEST_P(Int16Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
         << "smul/sdiv not yet implemented on x86 (see Issue #4408)";
@@ -356,6 +358,8 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
         << "smul/sdiv not yet implemented on x86 (see Issue #4408)";
@@ -388,6 +392,8 @@ TEST_P(Int8Arithmetic, UsingConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
         << "bmul/bdiv not yet implemented on x86 (see Issue #4408)";
@@ -424,10 +430,10 @@ TEST_P(Int8Arithmetic, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
-
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
     SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
         << "bmul/bdiv not yet implemented on x86 (see Issue #4408)";
-        
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -25,7 +25,7 @@
 
 #include <cmath>
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) || defined(AIXPPC)
 namespace std
 {
    using ::isnan;

--- a/fvtest/compilertriltest/BitPermuteTest.cpp
+++ b/fvtest/compilertriltest/BitPermuteTest.cpp
@@ -343,6 +343,8 @@ TEST_P(sBitPermuteTest, ConstAddressLengthTest)
    std::string arch = omrsysinfo_get_CPU_architecture();
    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
       << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+   SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+      << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -383,6 +385,8 @@ TEST_P(sBitPermuteTest, ConstAddressTest)
    std::string arch = omrsysinfo_get_CPU_architecture();
    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
       << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+   SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+      << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -422,6 +426,8 @@ TEST_P(sBitPermuteTest, NoConstTest)
    std::string arch = omrsysinfo_get_CPU_architecture();
    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
       << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+   SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+      << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[16];
@@ -462,6 +468,8 @@ TEST_P(bBitPermuteTest, ConstAddressLengthTest)
    std::string arch = omrsysinfo_get_CPU_architecture();
    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
       << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+   SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+      << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];
@@ -502,6 +510,8 @@ TEST_P(bBitPermuteTest, ConstAddressTest)
    std::string arch = omrsysinfo_get_CPU_architecture();
    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
       << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+   SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+      << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];
@@ -541,6 +551,8 @@ TEST_P(bBitPermuteTest, NoConstTest)
    std::string arch = omrsysinfo_get_CPU_architecture();
    SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
       << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+   SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+      << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
    auto param = to_struct(GetParam());
 
    uint8_t maskedIndices[8];

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -339,6 +339,8 @@ TEST_P(Int8ShiftAndRotate, UsingRhsConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -369,6 +371,8 @@ TEST_P(Int8ShiftAndRotate, UsingLhsConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -399,6 +403,8 @@ TEST_P(Int8ShiftAndRotate, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -463,6 +469,8 @@ TEST_P(Int16ShiftAndRotate, UsingRhsConst) {
 
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -493,6 +501,8 @@ TEST_P(Int16ShiftAndRotate, UsingLhsConst) {
 
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -523,6 +533,8 @@ TEST_P(Int16ShiftAndRotate, UsingLoadParam) {
 
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -801,6 +813,8 @@ TEST_P(UInt8ShiftAndRotate, UsingRhsConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -831,6 +845,8 @@ TEST_P(UInt8ShiftAndRotate, UsingLhsConst) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -859,6 +875,8 @@ TEST_P(UInt8ShiftAndRotate, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -924,6 +942,8 @@ TEST_P(UInt16ShiftAndRotate, UsingRhsConst) {
 
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -954,6 +974,8 @@ TEST_P(UInt16ShiftAndRotate, UsingLhsConst) {
 
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -982,6 +1004,8 @@ TEST_P(UInt16ShiftAndRotate, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -1333,6 +1357,8 @@ TEST_P(UInt16MaskThenShift, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1373,6 +1399,8 @@ TEST_P(Int16MaskThenShift, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1413,6 +1441,8 @@ TEST_P(UInt8MaskThenShift, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),
@@ -1453,6 +1483,8 @@ TEST_P(Int8MaskThenShift, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     char inputTrees[300] = {0};
     std::snprintf(inputTrees, sizeof(inputTrees),

--- a/fvtest/compilertriltest/ShiftAndRotateTest.cpp
+++ b/fvtest/compilertriltest/ShiftAndRotateTest.cpp
@@ -206,7 +206,7 @@ TEST_P(Int64ShiftAndRotate, UsingConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %" PRId64 ")"
+        "        (lconst %" OMR_PRId64 ")"
         "        (iconst %d)))))",
         param.opcode.c_str(),
         param.lhs,
@@ -257,7 +257,7 @@ TEST_P(Int64ShiftAndRotate, UsingLhsConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %" PRId64 ")"
+        "        (lconst %" OMR_PRId64 ")"
         "        (iload parm=0)))))",
         param.opcode.c_str(),
         param.lhs);
@@ -670,7 +670,7 @@ TEST_P(UInt64ShiftAndRotate, UsingConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %" PRIu64 ")"
+        "        (lconst %" OMR_PRIu64 ")"
         "        (iconst %d)))))",
         param.opcode.c_str(),
         param.lhs,
@@ -721,7 +721,7 @@ TEST_P(UInt64ShiftAndRotate, UsingLhsConst) {
         "  (block"
         "    (lreturn"
         "      (%s"
-        "        (lconst %" PRIu64 ")"
+        "        (lconst %" OMR_PRIu64 ")"
         "        (iload parm=0)))))",
         param.opcode.c_str(),
         param.lhs);
@@ -1196,7 +1196,7 @@ TEST_P(UInt64MaskThenShift, UsingLoadParam) {
         "      (%s"
         "        (land"
         "          (lload parm=0)"
-        "          (lconst %" PRIu64 "))"
+        "          (lconst %" OMR_PRIu64 "))"
         "        (iconst %d)))))",
         param.opcode.c_str(),
         param.mask,
@@ -1231,7 +1231,7 @@ TEST_P(Int64MaskThenShift, UsingLoadParam) {
         "      (%s"
         "        (land"
         "          (lload parm=0)"
-        "          (lconst %" PRId64 "))"
+        "          (lconst %" OMR_PRId64 "))"
         "        (iconst %d)))))",
         param.opcode.c_str(),
         param.mask,

--- a/fvtest/compilertriltest/TernaryTest.cpp
+++ b/fvtest/compilertriltest/TernaryTest.cpp
@@ -417,6 +417,8 @@ TEST_P(ShortTernaryDoubleCompareTest, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, MissingImplementation)
         << "The Z code generator implementation is missing currently (see issue #3796)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = to_struct(GetParam());
 

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -103,6 +103,8 @@ TEST_P(Int8ToInt32, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -163,6 +165,8 @@ TEST_P(UInt8ToInt32, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -223,6 +227,8 @@ TEST_P(Int8ToInt64, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -283,6 +289,8 @@ TEST_P(UInt8ToInt64, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -343,6 +351,8 @@ TEST_P(Int16ToInt32, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -403,6 +413,8 @@ TEST_P(UInt16ToInt32, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -463,6 +475,8 @@ TEST_P(Int16ToInt64, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -523,6 +537,8 @@ TEST_P(UInt16ToInt64, UsingLoadParam) {
     std::string arch = omrsysinfo_get_CPU_architecture();
     SKIP_IF(OMRPORT_ARCH_S390 == arch || OMRPORT_ARCH_S390X == arch, KnownBug)
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
+    SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
+        << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
     auto param = TRTest::to_struct(GetParam());
 

--- a/fvtest/compilertriltest/TypeConversionTest.cpp
+++ b/fvtest/compilertriltest/TypeConversionTest.cpp
@@ -25,7 +25,7 @@
 
 #include <cmath>
 
-#if defined(J9ZOS390)
+#if defined(J9ZOS390) || defined(AIXPPC)
 namespace std
 {
    using ::isnan;

--- a/fvtest/omrGtestGlue/CMakeLists.txt
+++ b/fvtest/omrGtestGlue/CMakeLists.txt
@@ -60,7 +60,7 @@ if(NOT OMR_HOST_OS STREQUAL "win")
 endif()
 #target_link_libraries(omrGtest INTERFACE omrGtestGlue)
 
-if(OMR_HOST_OS STREQUAL "zos")
+if(OMR_HOST_OS STREQUAL "zos" OR OMR_HOST_OS STREQUAL "aix")
 	list(APPEND OMR_GTEST_DEFINITIONS
 		-DGTEST_ENV_HAS_STD_TUPLE_
 		-D__IBMCPP_TR1__

--- a/fvtest/tril/test/IlGenTest.cpp
+++ b/fvtest/tril/test/IlGenTest.cpp
@@ -40,6 +40,9 @@
 
 class IlGenTest : public Tril::Test::JitTest {};
 
+// This test is currently broken on AIX, since it is not valid to use the return value of
+// compileMethodFromDetails as a function pointer.
+#if !defined(AIXPPC)
 TEST_F(IlGenTest, Return3) {
     auto trees = parseString("(block (ireturn (iconst 3)))");
 
@@ -59,3 +62,4 @@ TEST_F(IlGenTest, Return3) {
     auto entry = reinterpret_cast<int32_t(*)(void)>(entry_point);
     ASSERT_EQ(3, entry()) << "Compiled body did not return expected value";
 }
+#endif

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -61,6 +61,14 @@ target_link_libraries(tril PUBLIC
 	${CMAKE_DL_LIBS}
 )
 
+#TODO  system thread library should be linked in a more generic way.
+if(NOT OMR_HOST_OS STREQUAL "win")
+	if(NOT OMR_HOST_OS STREQUAL "zos")
+		target_link_libraries(tril PUBLIC pthread)
+	endif()
+endif()
+
+
 add_executable(tril_dumper compiler.cpp)
 target_link_libraries(tril_dumper tril)
 

--- a/fvtest/tril/tril/method_compiler.hpp
+++ b/fvtest/tril/tril/method_compiler.hpp
@@ -77,11 +77,12 @@ class MethodCompiler {
          */
         template <typename T>
         T getEntryPoint() {
-#if !defined(J9ZOS390)
+#if !defined(J9ZOS390) && !defined(AIXPPC)
             static_assert( std::is_pointer<T>::value &&
                            std::is_function<typename std::remove_pointer<T>::type>::value,
                           "Attempted to get entry point using a non-function-pointer type.");
 #endif
+
             return reinterpret_cast<T>(_entry_point);
         }
 

--- a/jitbuilder/runtime/JBCodeCacheManager.cpp
+++ b/jitbuilder/runtime/JBCodeCacheManager.cpp
@@ -99,7 +99,7 @@ JitBuilder::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
               codeCacheSizeToAllocate,
               PROT_READ | PROT_WRITE | PROT_EXEC,
               MAP_ANONYMOUS | MAP_PRIVATE,
-              0,
+              -1,
               0));
    // keep the impact of this fix localized
    #if defined(NO_MAP_ANONYMOUS)

--- a/third_party/gtest-1.8.0/include/gtest/internal/gtest-port.h
+++ b/third_party/gtest-1.8.0/include/gtest/internal/gtest-port.h
@@ -690,10 +690,11 @@ struct _RTL_CRITICAL_SECTION;
 # elif GTEST_ENV_HAS_STD_TUPLE_
 #  include <tuple>
 
-#if defined(J9ZOS390)
-// On z/OS tuple is defined in the ::std::tr1 namespace as it is an extension
-// class since xlc does not support the full C++11 standard. As such we expose
-// the tuple class in the ::std namespace such that code below will work.
+#if defined(J9ZOS390) || defined(AIXPPC)
+// On z/OS and AIX, tuple is defined in the ::std::tr1 namespace as it is an
+// extension class since xlc does not support the full C++11 standard. As such,
+// we expose the tuple class in the ::std namespace such that code below will
+// work.
 namespace std
 {
 using ::std::tr1::get;


### PR DESCRIPTION
Previously, the AIX CI builds were explicitly not compiling nor testing the JIT component, as it turns out that the JIT would not compile correctly under CMake on AIX. This PR fixes some issues with the JIT CMake builds and makes it possible to run both Tril and JitBuilder tests on AIX through use of some similar hacks to what are currently used on z/OS.

As part of this, I've enabled the Tril and JitBuilder tests on our CI AIX builds in this PR. I'm not 100% sure if this will work, as I don't know whether the AIX CI machines have `lex` and `yacc` set up, which are required to compile Tril. If they don't, this PR can wait until #4345 lands, which will remove the dependency on these tools altogether.

FYI @gita-omr @zl-wang 