### PR TITLE
Make TR:Trap() work on release builds

### DIFF
--- a/compiler/infra/Assert.cpp
+++ b/compiler/infra/Assert.cpp
@@ -41,11 +41,7 @@
 void OMR_NORETURN TR::trap()
    {
    static char * noDebug = feGetEnv("TR_NoDebuggerBreakPoint");
-   if (noDebug)
-      {
-      exit(1337);
-      }
-   else
+   if (!noDebug)
       {
       static char *crashLogOnAssume = feGetEnv("TR_crashLogOnAssume");
       if (crashLogOnAssume)
@@ -55,23 +51,25 @@ void OMR_NORETURN TR::trap()
          }
 
 #ifdef _MSC_VER
-      static char *revertToDebugbreakWin = feGetEnv("TR_revertToDebugbreakWin");
 #ifdef DEBUG
       DebugBreak();
 #else
+      static char *revertToDebugbreakWin = feGetEnv("TR_revertToDebugbreakWin");
       if(revertToDebugbreakWin)
+         {
          DebugBreak();
+         }
       else
-         *(int*)(NULL) = 1;
-#endif
+         {
+         *(volatile int*)(0) = 1;
+         }
+#endif //ifdef DEBUG
 #else // of _MSC_VER
-
-      assert(0);
-
+      abort();
 #endif // ifdef _MSC_VER
       }
+   exit(1337);
    }
-
 
 static void traceAssertionFailure(const char * file, int32_t line, const char *condition, const char *s, va_list ap)
    {

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3213,7 +3213,7 @@ TR::Register *OMR::X86::TreeEvaluator::fenceEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      assert(0);
+      TR::trap();
       }
    return NULL;
    }


### PR DESCRIPTION
assert(0) does nothing on a release build, so abort() instead.

Use TR::trap() instead of assert(0) in OMRTreeEvaluator.