### PR TITLE
Fix typo in ARM TreeEvaluatorTable

### DIFF
--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -723,7 +723,7 @@
    TR::TreeEvaluator::checkcastEvaluator,     // TR::checkcast
    TR::TreeEvaluator::checkcastAndNULLCHKEvaluator,     // TR::checkcastAndNULLCHK
    TR::TreeEvaluator::newObjectEvaluator,   // TR::New
-   TR::TreeEvaluator::unImpOptEvaluator,    // TR::newvalue (should be lowered before evaluation)
+   TR::TreeEvaluator::unImpOpEvaluator,    // TR::newvalue (should be lowered before evaluation)
    TR::TreeEvaluator::newArrayEvaluator,    // TR::newarray
    TR::TreeEvaluator::anewArrayEvaluator,   // TR::anewarray
    TR::TreeEvaluator::newObjectEvaluator,   // TR::variableNew


### PR DESCRIPTION
Signed-off-by: Daryl Maier <maier@ca.ibm.com>