### PR TITLE
AArch64: Implement a path in loadaddrEvaluator()

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -520,7 +520,7 @@ OMR::ARM64::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::CodeGenerator *
             resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
             if (mref->hasDelayedOffset())
                {
-               TR_UNIMPLEMENTED();
+               generateTrg1MemInstruction(cg, TR::InstOpCode::addimmx, node, resultReg, mref);
                }
             else
                {


### PR DESCRIPTION
This commit implements an unimplemented path in loadaddrEvaluator().

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>