### PR TITLE
Include correct concrete class header files

### DIFF
--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "arm/codegen/OMRLinkage.hpp"
+#include "arm/codegen/Linkage.hpp"
 
 #include "arm/codegen/ARMInstruction.hpp"
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRCodeGenerator.hpp" // IWYU pragma: keep
+#include "codegen/CodeGenerator.hpp" // IWYU pragma: keep
 
 #include <stdint.h>
 #include <string.h>

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -24,7 +24,7 @@
  * before actual code generation should go in this file.
  */
 
-#include "codegen/OMRCodeGenerator.hpp" // IWYU pragma: keep
+#include "codegen/CodeGenerator.hpp" // IWYU pragma: keep
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRCodeGenerator.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 #include <limits.h>
 #include <stdint.h>

--- a/compiler/codegen/NodeEvaluation.cpp
+++ b/compiler/codegen/NodeEvaluation.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRCodeGenerator.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 #include <limits.h>
 #include <stddef.h>

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -29,7 +29,7 @@
 #pragma csect(TEST,"OMRCGPhase#T")
 
 
-#include "codegen/OMRCodeGenPhase.hpp"
+#include "codegen/CodeGenPhase.hpp"
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -23,7 +23,7 @@
 #pragma csect(STATIC,"TRCGBase#S")
 #pragma csect(TEST,"TRCGBase#T")
 
-#include "codegen/OMRCodeGenerator.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 #include <limits.h>
 #include <stdarg.h>

--- a/compiler/codegen/OMRELFRelocationResolver.cpp
+++ b/compiler/codegen/OMRELFRelocationResolver.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRELFRelocationResolver.hpp"
+#include "codegen/ELFRelocationResolver.hpp"
 #include "infra/Assert.hpp"
 
 #if defined(LINUX)

--- a/compiler/codegen/OMRGCStackAtlas.cpp
+++ b/compiler/codegen/OMRGCStackAtlas.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRGCStackAtlas.hpp"
+#include "codegen/GCStackAtlas.hpp"
 
 #include <stdint.h>
 #include <string.h>

--- a/compiler/codegen/OMRInstOpCode.cpp
+++ b/compiler/codegen/OMRInstOpCode.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "compiler/codegen/OMRInstOpCode.hpp"
+#include "compiler/codegen/InstOpCode.hpp"
 
 uint8_t
 OMR::InstOpCode::length(Mnemonic m)

--- a/compiler/codegen/OMRMachine.cpp
+++ b/compiler/codegen/OMRMachine.cpp
@@ -29,7 +29,7 @@
 #pragma csect(TEST,"OMRMachine#T")
 
 
-#include "codegen/OMRMachine.hpp"
+#include "codegen/Machine.hpp"
 
 #include "codegen/Machine.hpp"
 #include "codegen/Machine_inlines.hpp"

--- a/compiler/codegen/OMRRealRegister.cpp
+++ b/compiler/codegen/OMRRealRegister.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRRealRegister.hpp"
+#include "codegen/RealRegister.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/codegen/OMRRegister.cpp
+++ b/compiler/codegen/OMRRegister.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRRegister.hpp"
+#include "codegen/Register.hpp"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -27,7 +27,7 @@
 #include "codegen/Register.hpp"
 #include "codegen/RegisterConstants.hpp"
 #include "codegen/RegisterRematerializationInfo.hpp"
-#include "codegen/OMRRealRegister.hpp"
+#include "codegen/RealRegister.hpp"
 #include "compile/Compilation.hpp"
 #include "ras/Debug.hpp"
 

--- a/compiler/codegen/OMRRegisterPair.cpp
+++ b/compiler/codegen/OMRRegisterPair.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRRegisterPair.hpp"
+#include "codegen/RegisterPair.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRTreeEvaluator.hpp"
+#include "codegen/TreeEvaluator.hpp"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/compiler/codegen/OMRUnresolvedDataSnippet.cpp
+++ b/compiler/codegen/OMRUnresolvedDataSnippet.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRUnresolvedDataSnippet.hpp"
+#include "codegen/UnresolvedDataSnippet.hpp"
 
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/UnresolvedDataSnippet.hpp"

--- a/compiler/codegen/PreInstructionSelection.cpp
+++ b/compiler/codegen/PreInstructionSelection.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRCodeGenerator.hpp"
+#include "codegen/CodeGenerator.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/compile/OMRAliasBuilder.cpp
+++ b/compiler/compile/OMRAliasBuilder.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "compile/OMRAliasBuilder.hpp"
+#include "compile/AliasBuilder.hpp"
 
 #include "compile/AliasBuilder.hpp"
 #include "compile/Compilation.hpp"

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "compile/OMRCompilation.hpp"
+#include "compile/Compilation.hpp"
 
 #include <limits.h>
 #include <math.h>

--- a/compiler/compile/TLSCompilationManager.cpp
+++ b/compiler/compile/TLSCompilationManager.cpp
@@ -21,7 +21,7 @@
 
 #include "compile/TLSCompilationManager.hpp"
 #include "infra/ThreadLocal.h"
-#include "compile/OMRCompilation.hpp"
+#include "compile/Compilation.hpp"
 
 TR::TLSCompilationManager::TLSCompilationManager(TR::Compilation &comp)
    {

--- a/compiler/env/FEBase.cpp
+++ b/compiler/env/FEBase.cpp
@@ -35,7 +35,7 @@
 #include "env/jittypes.h"
 #include "compile/CompilationException.hpp"
 #include "il/ILOps.hpp"
-#include "il/OMRILOps.hpp"
+#include "il/ILOps.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
 

--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "il/OMRBlock.hpp"
+#include "il/Block.hpp"
 
 #include <limits.h>
 #include <stdint.h>

--- a/compiler/il/OMRILOps.cpp
+++ b/compiler/il/OMRILOps.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "il/OMRILOps.hpp"
+#include "il/ILOps.hpp"
 
 #include <stdint.h>
 #include <stddef.h>

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "il/OMRNode.hpp"
+#include "il/Node.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/il/OMRSymbolReference.cpp
+++ b/compiler/il/OMRSymbolReference.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "il/OMRSymbolReference.hpp"
+#include "il/SymbolReference.hpp"
 
 #include <assert.h>
 #include <stdint.h>

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "infra/OMRCfg.hpp"
+#include "infra/Cfg.hpp"
 
 #include <algorithm>
 #include <limits.h>

--- a/compiler/infra/OMRMonitor.cpp
+++ b/compiler/infra/OMRMonitor.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "infra/OMRMonitor.hpp"
+#include "infra/Monitor.hpp"
 
 #include "env/CompilerEnv.hpp"
 #include "env/TRMemory.hpp"

--- a/compiler/optimizer/OMROptimization.cpp
+++ b/compiler/optimizer/OMROptimization.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "optimizer/OMROptimization.hpp"
+#include "optimizer/Optimization.hpp"
 
 
 #include <stddef.h>

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "optimizer/OMRValuePropagation.hpp"
+#include "optimizer/ValuePropagation.hpp"
 #include "optimizer/GlobalValuePropagation.hpp"
 
 #include <algorithm>

--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -46,7 +46,7 @@
 #include "ilgen/IlGenRequest.hpp"
 #include "ilgen/IlGeneratorMethodDetails.hpp"
 #include "optimizer/Optimization_inlines.hpp"
-#include "optimizer/OMRValuePropagation.hpp"
+#include "optimizer/ValuePropagation.hpp"
 
 #ifdef J9_PROJECT_SPECIFIC
 #include "env/PersistentCHTable.hpp"

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -76,7 +76,7 @@
 #include "optimizer/TransformUtil.hpp"
 #include "optimizer/UseDefInfo.hpp"
 #include "optimizer/VPConstraint.hpp"
-#include "optimizer/OMRValuePropagation.hpp"
+#include "optimizer/ValuePropagation.hpp"
 #include "ras/Debug.hpp"
 #include "ras/DebugCounter.hpp"
 #include "runtime/Runtime.hpp"

--- a/compiler/optimizer/VPHandlersCommon.cpp
+++ b/compiler/optimizer/VPHandlersCommon.cpp
@@ -40,7 +40,7 @@
 #include "infra/Assert.hpp"
 #include "infra/List.hpp"
 #include "optimizer/VPConstraint.hpp"
-#include "optimizer/OMRValuePropagation.hpp"
+#include "optimizer/ValuePropagation.hpp"
 #include "runtime/Runtime.hpp"
 #include "optimizer/TransformUtil.hpp"
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -79,7 +79,7 @@
 #include "optimizer/UseDefInfo.hpp"
 #include "optimizer/ValueNumberInfo.hpp"
 #include "optimizer/VPConstraint.hpp"
-#include "optimizer/OMRValuePropagation.hpp"
+#include "optimizer/ValuePropagation.hpp"
 #include "optimizer/LocalValuePropagation.hpp"
 #include "ras/Debug.hpp"
 #include "ras/DebugCounter.hpp"

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRLinkage.hpp"
+#include "codegen/Linkage.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/p/runtime/OMRCodeCacheConfig.cpp
+++ b/compiler/p/runtime/OMRCodeCacheConfig.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "p/runtime/OMRCodeCacheConfig.hpp"
+#include "p/runtime/CodeCacheConfig.hpp"
 #include "runtime/CodeCacheConfig.hpp"
 
 OMR::Power::CodeCacheConfig::CodeCacheConfig() : OMR::CodeCacheConfig()

--- a/compiler/runtime/OMRCodeCache.cpp
+++ b/compiler/runtime/OMRCodeCache.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "runtime/OMRCodeCache.hpp"
+#include "runtime/CodeCache.hpp"
 
 #include <algorithm>
 #include <stddef.h>

--- a/compiler/runtime/OMRCodeCacheManager.cpp
+++ b/compiler/runtime/OMRCodeCacheManager.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "runtime/OMRCodeCacheManager.hpp"
+#include "runtime/CodeCacheManager.hpp"
 
 #include <algorithm>
 #include <stddef.h>

--- a/compiler/runtime/OMRCodeMetaData.cpp
+++ b/compiler/runtime/OMRCodeMetaData.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "runtime/OMRCodeMetaData.hpp"
+#include "runtime/CodeMetaData.hpp"
 
 #include "compile/Compilation.hpp"
 #include "compile/ResolvedMethod.hpp"

--- a/compiler/runtime/OMRCodeMetaDataManager.cpp
+++ b/compiler/runtime/OMRCodeMetaDataManager.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "runtime/OMRCodeMetaDataManager.hpp"
+#include "runtime/CodeMetaDataManager.hpp"
 
 #include <stdint.h>
 #include <string.h>

--- a/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluator.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRTreeEvaluator.hpp"
+#include "codegen/TreeEvaluator.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "codegen/OMRLinkage.hpp"
+#include "codegen/Linkage.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -67,7 +67,7 @@
 #include "z/codegen/S390GenerateInstructions.hpp"
 #include "z/codegen/S390Instruction.hpp"
 #include "z/codegen/S390OutOfLineCodeSection.hpp"
-#include "z/codegen/OMRLinkage.hpp"
+#include "z/codegen/Linkage.hpp"
 
 static TR::InstOpCode::Mnemonic getIntToFloatLogicalConversion(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic convertOpCode)
    {

--- a/compiler/z/codegen/InstOpCodeTables.cpp
+++ b/compiler/z/codegen/InstOpCodeTables.cpp
@@ -19,6 +19,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "compiler/z/codegen/OMRInstOpCode.hpp"
+#include "compiler/z/codegen/InstOpCode.hpp"
 
 

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -26,7 +26,7 @@
 // See also S390Linkage2.cpp which contains more S390 Linkage
 // implementations (primarily System Linkage and derived classes).
 
-#include "codegen/OMRLinkage.hpp"
+#include "codegen/Linkage.hpp"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/compiler/z/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/z/runtime/VirtualGuardRuntime.cpp
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include "codegen/FrontEnd.hpp"
-#include "codegen/OMRMachine.hpp"
+#include "codegen/Machine.hpp"
 #include "compile/Compilation.hpp"
 #include "env/jittypes.h"
 #include "infra/Assert.hpp"


### PR DESCRIPTION
There exist many instances where we do not include the concrete implementation of the headerfile. Fix all instances where that was the case.

For the full list, refer to the Issue of this PR

Fixes #3973
