### PR TITLE
Handle symref creation under relocatable compiles

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -958,7 +958,12 @@ OMR::SymbolReferenceTable::methodSymRefFromName(TR::ResolvedMethodSymbol * ownin
    //
 
    TR_OpaqueMethodBlock *method = fe()->getMethodFromName(className, methodName, methodSignature);
-   TR_ASSERT(method, "methodSymRefFromName: method must exist: %s.%s%s", className, methodName, methodSignature);
+
+   // It is possible for getMethodFromName to return NULL in relocatable compilations
+   if (!method && comp()->compileRelocatableCode())
+      comp()->failCompilation<TR::CompilationException>("Failed to get method %s.%s%s from name", className, methodName, methodSignature);
+
+   TR_ASSERT_FATAL(method, "methodSymRefFromName: method must exist: %s.%s%s", className, methodName, methodSignature);
    TR_ASSERT(kind != TR::MethodSymbol::Virtual, "methodSymRefFromName doesn't support virtual methods"); // Until we're able to look up vtable index
 
    // Note: we use cpIndex=-1 here so we don't end up getting back the original symref (which will not have the signature we want)


### PR DESCRIPTION
OMR::SymbolReferenceTable::methodSymRefFromName creates a method symref
using the value returned by fe()->getMethodFromName. However, it is
possible for the value to be NULL in relocatable compiles (for various
runtime specific reasons).

This PR handles the case where a NULL is returned.

Fixes: https://github.com/eclipse/openj9/issues/6511
Fixes: https://github.com/eclipse/openj9/issues/7273