### PR TITLE
Add a new codegen phase for instruction expansion

### DIFF
--- a/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -34,6 +34,7 @@
     RegisterAssigningPhase,
     MapStackPhase,
     PeepholePhase,
+    ExpandInstructionsPhase,
 
     BinaryEncodingPhase,
     EmitSnippetsPhase,

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -561,6 +561,17 @@ OMR::CodeGenPhase::performInsertDebugCountersPhase(TR::CodeGenerator * cg, TR::C
    cg->insertDebugCounters();
    }
 
+void
+OMR::CodeGenPhase::performExpandInstructionsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
+   {
+   TR::Compilation * comp = cg->comp();
+   phase->reportPhase(ExpandInstructionsPhase);
+
+   cg->expandInstructions();
+
+   if (comp->getOption(TR_TraceCG))
+      comp->getDebug()->dumpMethodInstrs(comp->getOutFile(), "Post Instruction Expansion Instructions", false, true);
+   }
 
 const char *
 OMR::CodeGenPhase::getName()
@@ -608,6 +619,8 @@ OMR::CodeGenPhase::getName(PhaseValue phase)
 	 return "InsertDebugCountersPhase";
       case CleanUpFlagsPhase:
 	 return "CleanUpFlagsPhase";
+      case ExpandInstructionsPhase:
+         return "ExpandInstructionsPhase";
       default:
          TR_ASSERT(false, "TR::CodeGenPhase %d doesn't have a corresponding name.", phase);
          return NULL;

--- a/compiler/codegen/OMRCodeGenPhase.hpp
+++ b/compiler/codegen/OMRCodeGenPhase.hpp
@@ -98,6 +98,7 @@ class OMR_EXTENSIBLE CodeGenPhase
    static void performRemoveUnusedLocalsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase *);
    static void performCleanUpFlagsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase);
    static void performInsertDebugCountersPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase);
+   static void performExpandInstructionsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase);
 
    protected:
 

--- a/compiler/codegen/OMRCodeGenPhaseEnum.hpp
+++ b/compiler/codegen/OMRCodeGenPhaseEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,4 +42,5 @@
       InliningReportPhase, // all
       InsertDebugCountersPhase,
       CleanUpFlagsPhase,
-      LastOMRPhase = CleanUpFlagsPhase,
+      ExpandInstructionsPhase,
+      LastOMRPhase = ExpandInstructionsPhase,

--- a/compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
+++ b/compiler/codegen/OMRCodeGenPhaseFunctionTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -42,3 +42,4 @@
    TR::CodeGenPhase::performInliningReportPhase,                                             //InliningReportPhase
    TR::CodeGenPhase::performInsertDebugCountersPhase,
    TR::CodeGenPhase::performCleanUpFlagsPhase,
+   TR::CodeGenPhase::performExpandInstructionsPhase,

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1275,6 +1275,16 @@ OMR::CodeGenerator::removeUnusedLocals()
    }
 
 
+void
+OMR::CodeGenerator::expandInstructions()
+   {
+   for (TR::Instruction *instr = self()->getFirstInstruction(); instr; instr = instr->getNext())
+      {
+      instr = instr->expandInstruction();
+      }
+   }
+
+
 bool OMR::CodeGenerator::areAssignableGPRsScarce()
    {
    int32_t threshold = 13;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -428,6 +428,8 @@ class OMR_EXTENSIBLE CodeGenerator
    void spillLiveReferencesToTemps(TR::TreeTop *insertionTree, std::list<TR::SymbolReference*, TR::typed_allocator<TR::SymbolReference*, TR::Allocator> >::iterator firstAvailableSpillTemp);
    void needSpillTemp(TR_LiveReference * cursor, TR::Node*parent, TR::TreeTop *treeTop);
 
+   void expandInstructions();
+
    friend void OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator*, TR::CodeGenPhase *);
    friend void OMR::CodeGenPhase::performCleanUpFlagsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase);
 

--- a/compiler/codegen/OMRInstruction.hpp
+++ b/compiler/codegen/OMRInstruction.hpp
@@ -136,6 +136,14 @@ class OMR_EXTENSIBLE Instruction
     */
    virtual uint8_t *generateBinaryEncoding() = 0;
 
+   /**
+    * @brief Expand this instruction prior to binary encoding.
+    *
+    * @returns the last instruction in the expansion or this instruction if no expansion was
+    *          performed.
+    */
+   virtual TR::Instruction *expandInstruction() { return self(); }
+
    /*
     * Assign the specified register kind(s) on this instruction to real registers.
     */

--- a/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,6 +32,7 @@
     RegisterAssigningPhase,
     MapStackPhase,
     PeepholePhase,
+    ExpandInstructionsPhase,
 
     BinaryEncodingPhase,
     EmitSnippetsPhase,


### PR DESCRIPTION
Currently, there are many instances where a single TR::Instruction will
end up being binary encoded as multiple instructions. While there are
some cases which cannot be easily avoided, such as alignment using nops,
since they rely on information only available during binary encoding,
many do not require any such information. Performing these expansions
during binary encoding is more error-prone, requires the binary length
estimation functions to take such expansions into consideration, and
sometimes results in confusing mismatches between what a tracefile says
was emitted and what is seen during disassembly.

A better solution would be to expand these sequences into multiple
TR::Instruction objects and allow binary encoding of these to proceed as
normal. However, it is often not desirable for these sequences to be
present prior to other phases such as register allocation. To accomodate
this, a new codegen phase has been added immediately prior to binary
encoding which should be used to perform such expansion if it can be
done prior to binary encoding.

Signed-off-by: Ben Thomas <ben@benthomas.ca>