### PR TITLE
AArch64: Add types for ARM64 to TRMemory

### DIFF
--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -56,7 +56,7 @@ namespace TR {
 class ARM64MemoryArgument
    {
    public:
-   // @@ TR_ALLOC(TR_Memory::ARM64MemoryArgument)
+   TR_ALLOC(TR_Memory::ARM64MemoryArgument)
 
    TR::Register *argRegister;
    TR::MemoryReference *argMemory;

--- a/compiler/env/TRMemory.cpp
+++ b/compiler/env/TRMemory.cpp
@@ -145,6 +145,10 @@ const char * objectName[] =
    "ARMConstant",
    "ARMConstantDataSnippet",
 
+   // ARM64 types
+   "ARM64Relocation",
+   "ARM64MemoryArgument",
+
    "BlockCloner",
    "BlockFrequencyInfo",
    "ByteCodeIterator",

--- a/compiler/env/TRMemory.hpp
+++ b/compiler/env/TRMemory.hpp
@@ -292,6 +292,10 @@ public:
       ARMConstant,
       ARMConstantDataSnippet,
 
+      // ARM64 types
+      ARM64Relocation,
+      ARM64MemoryArgument,
+
       BlockCloner,
       BlockFrequencyInfo,
       ByteCodeIterator,


### PR DESCRIPTION
This commit adds some types for ARM64 to TRMemory.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>