### PR TITLE
Update makefile scripts for RISC-V in OMR (part2/gc)

### DIFF
--- a/gc/base/makefile
+++ b/gc/base/makefile
@@ -44,7 +44,7 @@ MODULE_INCLUDES += vlhgc
 endif
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif

--- a/gc/base/standard/makefile
+++ b/gc/base/standard/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2015 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))
 MODULE_INCLUDES += ../../include ../../stats ../../structs ../../base $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif

--- a/gc/startup/makefile
+++ b/gc/startup/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))
 MODULE_INCLUDES += ../base ../base/standard ../include ../stats ../structs ../verbose $(top_srcdir)/omr/startup $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif

--- a/gc/stats/makefile
+++ b/gc/stats/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))
 MODULE_INCLUDES += ../include ../base ../structs $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif

--- a/gc/structs/makefile
+++ b/gc/structs/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))
 MODULE_INCLUDES += ../base ../stats ../include $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif

--- a/gc/verbose/handler_standard/makefile
+++ b/gc/verbose/handler_standard/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))
 MODULE_INCLUDES += ../../base ../../structs ../../stats ../../include ../../verbose $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif

--- a/gc/verbose/makefile
+++ b/gc/verbose/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -32,7 +32,7 @@ OBJECTS += $(patsubst %.c,%$(OBJEXT),$(wildcard *.c))
 MODULE_INCLUDES += ../base ../structs ../stats ../include ../verbose/handler_standard $(OMRGLUE_INCLUDES)
 
 ifeq (linux,$(OMR_HOST_OS))
-  ifeq (x86,$(OMR_HOST_ARCH))
+  ifneq (,$(filter x86 riscv,$(OMR_HOST_ARCH)))
     MODULE_CFLAGS += -funroll-loops
     MODULE_CXXFLAGS += -funroll-loops
   endif


### PR DESCRIPTION
The changes mainly include makefile scripts in the
GC directory to enable RISC-V 64bit from the OMR
perspective.

Issue: eclipse#4426

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>