### PR TITLE
Change misc code for RISC-V in OMR (part5/misc)

### DIFF
--- a/include_core/ute_dataformat.h
+++ b/include_core/ute_dataformat.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2015 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -116,6 +116,7 @@ typedef enum {
 	UT_PIV,
 	UT_TREX,
 	UT_OPTERON,
+	UT_RV64G,
 	UT_SUBTYPE_FORCE_INTEGER = INT_MAX
 } UtSubtype;
 
@@ -145,6 +146,7 @@ typedef enum {
 	UT_IA64,
 	UT_S390X,
 	UT_AMD64,
+	UT_RISCV,
 	UT_ARCHITECTURE_FORCE_INTEGER = INT_MAX
 } UtArchitecture;
 

--- a/omrtrace/omrtracelog.cpp
+++ b/omrtrace/omrtracelog.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corp. and others
+ * Copyright (c) 1998, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1311,6 +1311,9 @@ getProcessorInfo(void)
 		} else if (strcmp(osarch, OMRPORT_ARCH_X86) == 0) {
 			ret->architecture = UT_X86;
 			ret->procInfo.subtype = UT_PIV;
+		} else if (0 == strcmp(osarch, OMRPORT_ARCH_RISCV)) {
+			ret->architecture = UT_RISCV;
+			ret->procInfo.subtype = UT_RV64G;
 		} else {
 			ret->architecture = UT_UNKNOWN;
 		}

--- a/thread/common/thrprof.c
+++ b/thread/common/thrprof.c
@@ -823,7 +823,7 @@ omrthread_get_process_times(omrthread_process_time_t *processTime)
 uint64_t
 omrthread_get_hires_clock(void)
 {
-#if defined(LINUX) && (defined(J9HAMMER) || defined(J9X86))
+#if defined(LINUX) && (defined(J9HAMMER) || defined(J9X86) || defined(RISCV64))
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)
 	struct timespec ts;
 	uint64_t hiresTime = 0;
@@ -833,7 +833,7 @@ omrthread_get_hires_clock(void)
 	}
 
 	return hiresTime;
-#elif defined(OMR_OS_WINDOWS) /* defined(LINUX) && (defined(J9HAMMER) || defined(J9X86)) */
+#elif defined(OMR_OS_WINDOWS) /* defined(LINUX) && (defined(J9HAMMER) || defined(J9X86) || defined(RISCV64)) */
 	LARGE_INTEGER i;
 
 	if (QueryPerformanceCounter(&i)) {

--- a/util/omrutil/gettimebase.c
+++ b/util/omrutil/gettimebase.c
@@ -26,7 +26,7 @@
 #include "omrcomp.h"
 #include "omrutilbase.h"
 
-#if defined(LINUX) && (defined(OMR_ARCH_ARM) || defined(OMR_ARCH_RISCV))
+#if defined(LINUX) && (defined(OMR_ARCH_ARM) || defined(OMR_ARCH_RISCV) || defined(RISCV64))
 #include <time.h>
 #endif
 
@@ -81,7 +81,7 @@ getTimebase(void)
 	asm("stck %0" : "=m" (tsc));
 #elif defined(J9ZOS390)
 	__stck(&tsc);
-#elif defined(LINUX) && (defined(OMR_ARCH_ARM) || defined(OMR_ARCH_RISCV))
+#elif defined(LINUX) && (defined(OMR_ARCH_ARM) || defined(OMR_ARCH_RISCV) || defined(RISCV64))
 	/* For now, use the system nano clock */
 #define J9TIME_NANOSECONDS_PER_SECOND	J9CONST_U64(1000000000)
 	struct timespec ts;


### PR DESCRIPTION
The changes mainly include miscellaneous code
to enable RISC-V 64bit from the OMR perspective.

Issue: eclipse#4426

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>