### PR TITLE
AArch64: Provide thresholds for arrayTranslate/arrayTranslateAndTest

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -302,6 +302,11 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    // OutOfLineCodeSection List functions
    TR::list<TR_ARM64OutOfLineCodeSection*> &getARM64OutOfLineCodeSectionList() {return _outOfLineCodeSectionList;}
 
+   // We need to provide an implementation to avoid an unimplemented assert. See issue #4446.
+   int32_t arrayTranslateMinimumNumberOfElements(bool isByteSource, bool isByteTarget) { return 8; }
+   // We need to provide an implementation to avoid an unimplemented assert. See issue #4446.
+   int32_t arrayTranslateAndTestMinimumNumberOfIterations() { return 8; }
+
    private:
 
    enum // flags


### PR DESCRIPTION
This commit adds arrayTranslateMinimumNumberOfElements and
arrayTranslateAndTestMinimumNumberOfIterations to aarch64 codegen to
avoid hitting assert.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>