### PR TITLE
Improved code generation for compare and branch instructions

### DIFF
--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6686,12 +6686,12 @@ inlineTrailingZerosQuadWordAtATime(
    cursor = generateS390LabelInstruction (cg, TR::InstOpCode::LABEL, node, LabelProcessNext8Bytes);                                                            iComment("====== core loop ======");
    LabelProcessNext8Bytes->setStartInternalControlFlow();
 
-   cursor = generateRXInstruction        (cg, TR::InstOpCode::getLoadOpCode(), node, rInput, generateS390MemoryReference(rInputByteArray, rOffset, 0, cg));  iComment("next double-word");
-   cursor = generateRIEInstruction       (cg, is64 ? TR::InstOpCode::CGIJ : TR::InstOpCode::CIJ, node, rInput, (int8_t) 0x0, cFlowRegionEnd, TR::InstOpCode::COND_BNE);     iComment("byte is non-zero?");
-   cursor = generateRXInstruction        (cg, TR::InstOpCode::getLoadOpCode(), node, rInput, generateS390MemoryReference(rInputByteArray, rOffset, 8, cg));  iComment("next double-word");
-   cursor = generateRIEInstruction       (cg, is64 ? TR::InstOpCode::CGIJ : TR::InstOpCode::CIJ, node, rInput, (int8_t) 0x0, cFlowRegionEnd, TR::InstOpCode::COND_BNE);     iComment("byte is non-zero?");
-   cursor = generateRXInstruction        (cg, TR::InstOpCode::LAY, node, rOffset, generateS390MemoryReference(rOffset, -16, cg));
-   cursor = generateS390BranchInstruction(cg, is64 ?TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, rBranchCounter, LabelProcessNext8Bytes);
+   cursor = generateRXInstruction                  (cg, TR::InstOpCode::getLoadOpCode(), node, rInput, generateS390MemoryReference(rInputByteArray, rOffset, 0, cg));  iComment("next double-word");
+   cursor = generateS390CompareAndBranchInstruction(cg, is64 ? TR::InstOpCode::CG : TR::InstOpCode::C, node, rInput, static_cast<int32_t>(0x0), TR::InstOpCode::COND_BNE, cFlowRegionEnd);     iComment("byte is non-zero?");
+   cursor = generateRXInstruction                  (cg, TR::InstOpCode::getLoadOpCode(), node, rInput, generateS390MemoryReference(rInputByteArray, rOffset, 8, cg));  iComment("next double-word");
+   cursor = generateS390CompareAndBranchInstruction(cg, is64 ? TR::InstOpCode::CG : TR::InstOpCode::C, node, rInput, static_cast<int32_t>(0x0), TR::InstOpCode::COND_BNE, cFlowRegionEnd);     iComment("byte is non-zero?");
+   cursor = generateRXInstruction                  (cg, TR::InstOpCode::LAY, node, rOffset, generateS390MemoryReference(rOffset, -16, cg));
+   cursor = generateS390BranchInstruction          (cg, is64 ?TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, rBranchCounter, LabelProcessNext8Bytes);
 
    // doneLabel : we get here in 3 cases: i. if no trailing non-zeros were found ii. if trailing non-zero was found in core-loop iii. if trailing non-zero was found in residue processing
    cursor = generateS390LabelInstruction (cg, TR::InstOpCode::LABEL, node, cFlowRegionEnd, regDeps);

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6687,9 +6687,9 @@ inlineTrailingZerosQuadWordAtATime(
    LabelProcessNext8Bytes->setStartInternalControlFlow();
 
    cursor = generateRXInstruction                  (cg, TR::InstOpCode::getLoadOpCode(), node, rInput, generateS390MemoryReference(rInputByteArray, rOffset, 0, cg));  iComment("next double-word");
-   cursor = generateS390CompareAndBranchInstruction(cg, is64 ? TR::InstOpCode::CG : TR::InstOpCode::C, node, rInput, static_cast<int32_t>(0x0), TR::InstOpCode::COND_BNE, cFlowRegionEnd);     iComment("byte is non-zero?");
+   cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, rInput, 0x0, TR::InstOpCode::COND_BNE, cFlowRegionEnd);     iComment("byte is non-zero?");
    cursor = generateRXInstruction                  (cg, TR::InstOpCode::getLoadOpCode(), node, rInput, generateS390MemoryReference(rInputByteArray, rOffset, 8, cg));  iComment("next double-word");
-   cursor = generateS390CompareAndBranchInstruction(cg, is64 ? TR::InstOpCode::CG : TR::InstOpCode::C, node, rInput, static_cast<int32_t>(0x0), TR::InstOpCode::COND_BNE, cFlowRegionEnd);     iComment("byte is non-zero?");
+   cursor = generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpOpCode(), node, rInput, 0x0, TR::InstOpCode::COND_BNE, cFlowRegionEnd);     iComment("byte is non-zero?");
    cursor = generateRXInstruction                  (cg, TR::InstOpCode::LAY, node, rOffset, generateS390MemoryReference(rOffset, -16, cg));
    cursor = generateS390BranchInstruction          (cg, is64 ?TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, rBranchCounter, LabelProcessNext8Bytes);
 


### PR DESCRIPTION
Code generation for all compare and branch instructions has been
consolidated into `generateS390CompareAndBranchInstruction()` API.
Instructions consolidated in this commit are `CIJ` and `CGIJ`.

This is allows for compare and branch instruction optimizations to be
applied through a common point. In addition to that, all compare and
branch instructions can now be to be disabled through
`Xjit:disableCompareAndBranch`.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>