### PR TITLE
Add isRelocatable boolean to power's loadAddressConstant API

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1053,6 +1053,12 @@ OMR::CodeGenerator::getCodeLength() // cast explicitly
    }
 
 bool
+OMR::CodeGenerator::needRelocationsForLookupEvaluationData()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
 OMR::CodeGenerator::isGlobalVRF(TR_GlobalRegisterNumber n)
    {
    return self()->hasGlobalVRF() &&

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1156,6 +1156,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool needRelocationsForStatics() { return false; }
    bool needRelocationsForBodyInfoData() { return false; }
    bool needRelocationsForPersistentInfoData() { return false; }
+   bool needRelocationsForLookupEvaluationData();
 
    // --------------------------------------------------------------------------
    // Snippets

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3016,9 +3016,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          }
       else
          {
-         // the loadAddress routine here will eventually map down to TR_FixedSequence2 relo type. Might need to generate a query here that moves this JITServer
-         // check downstream.
-         if (cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation())
+         if (cg->needRelocationsForLookupEvaluationData())
             {
             loadAddressConstant(cg, node, address, addrRegister, true);
             generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, 0, 4, cg));
@@ -3315,9 +3313,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
          }
       else
          {
-         // the loadAddress routine here will eventually map down to TR_FixedSequence2 relo type. Might need to generate a query here that moves this JITServer
-         // check downstream.
-         loadAddressConstant(cg, node, address, addrRegister, cg->comp()->isOutOfProcessCompilation() || cg->comp()->isOutOfProcessCompilation());
+         loadAddressConstant(cg, node, address, addrRegister, cg->needRelocationsForLookupEvaluationData());
          }
       }
    else

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3018,12 +3018,12 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          {
          if (cg->needRelocationsForLookupEvaluationData())
             {
-            loadAddressConstant(cg, node, address, addrRegister, true);
+            loadAddressConstant(cg, true, node, address, addrRegister);
             generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, 0, 4, cg));
             }
          else
             {
-            loadAddressConstant(cg, node, cg->hiValue(address)<<16, addrRegister, false);
+            loadAddressConstant(cg, false, node, cg->hiValue(address)<<16, addrRegister);
             nextAddress = LO_VALUE((int32_t)address);
             if (isInt64)
                {
@@ -3313,7 +3313,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
          }
       else
          {
-         loadAddressConstant(cg, node, address, addrRegister, cg->needRelocationsForLookupEvaluationData());
+         loadAddressConstant(cg, cg->needRelocationsForLookupEvaluationData(), node, address, addrRegister);
          }
       }
    else

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -3021,9 +3021,9 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
 	 }
       else
 	 {
-         if (cg->comp()->compileRelocatableCode())
+         if (cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation())
             {
-            loadAddressConstant(cg, node, address, addrRegister);
+            loadAddressConstant(cg, node, address, addrRegister, NULL, false, -1, true);
             generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, dataRegister, new (cg->trHeapMemory()) TR::MemoryReference(addrRegister, 0, 4, cg));
             }
          else
@@ -3322,7 +3322,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
 	 }
       else
 	 {
-         loadAddressConstant(cg, node, address, addrRegister);
+         loadAddressConstant(cg, node, address, addrRegister, NULL, false, -1, cg->comp()->isOutOfProcessCompilation());
 	 }
       }
    else

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2752,7 +2752,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = self()->allocateRegister();
    TR::Register *counterReg = self()->allocateRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
@@ -2782,7 +2782,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = self()->allocateRegister();
    TR::Register *counterReg = self()->allocateRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
@@ -2822,7 +2822,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = srm.findOrCreateScratchRegister();
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
@@ -2843,7 +2843,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = srm.findOrCreateScratchRegister();
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2752,7 +2752,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = self()->allocateRegister();
    TR::Register *counterReg = self()->allocateRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
@@ -2782,7 +2782,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = self()->allocateRegister();
    TR::Register *counterReg = self()->allocateRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
@@ -2822,7 +2822,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = srm.findOrCreateScratchRegister();
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
@@ -2843,7 +2843,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = srm.findOrCreateScratchRegister();
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, cursor);
+   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->compileRelocatableCode(), cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -2752,7 +2752,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = self()->allocateRegister();
    TR::Register *counterReg = self()->allocateRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
@@ -2782,7 +2782,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = self()->allocateRegister();
    TR::Register *counterReg = self()->allocateRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);
@@ -2822,7 +2822,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = srm.findOrCreateScratchRegister();
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src1ImmInstruction(self(), TR::InstOpCode::addi, node, counterReg, counterReg, delta, cursor);
@@ -2843,7 +2843,7 @@ TR::Instruction *OMR::Power::CodeGenerator::generateDebugCounterBump(TR::Instruc
    TR::Register *addrReg = srm.findOrCreateScratchRegister();
    TR::Register *counterReg = srm.findOrCreateScratchRegister();
 
-   cursor = loadAddressConstant(self(), node, addr, addrReg, self()->comp()->compileRelocatableCode(), cursor);
+   cursor = loadAddressConstant(self(), self()->comp()->compileRelocatableCode(), node, addr, addrReg, cursor);
    cursor = generateTrg1MemInstruction(self(), TR::InstOpCode::lwz, node, counterReg,
                                        new (self()->trHeapMemory()) TR::MemoryReference(addrReg, 0, 4, self()), cursor);
    cursor = generateTrg1Src2Instruction(self(), TR::InstOpCode::add, node, counterReg, counterReg, deltaReg, cursor);

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -75,7 +75,16 @@ extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg,
                                     TR::Node        *node,
                                     intptrj_t         value,
                                     TR::Register    *targetRegister,
+                                    TR::Instruction *cursor=NULL,
+                                    bool            isPicSite=false,
+                                    int16_t         typeAddress = -1);
+
+
+extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg,
                                     bool            isRelocatable,
+                                    TR::Node        *node,
+                                    intptrj_t         value,
+                                    TR::Register    *targetRegister,
                                     TR::Instruction *cursor=NULL,
                                     bool            isPicSite=false,
                                     int16_t         typeAddress = -1);

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -75,10 +75,10 @@ extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg,
                                     TR::Node        *node,
                                     intptrj_t         value,
                                     TR::Register    *targetRegister,
+                                    bool            isRelocatable,
                                     TR::Instruction *cursor=NULL,
                                     bool            isPicSite=false,
-                                    int16_t         typeAddress = -1,
-                                    bool            isRelocatable = false);
+                                    int16_t         typeAddress = -1);
 
 extern TR::Instruction *loadActualConstant(TR::CodeGenerator *cg,
                                     TR::Node        *node,

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -77,7 +77,8 @@ extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg,
                                     TR::Register    *targetRegister,
                                     TR::Instruction *cursor=NULL,
                                     bool            isPicSite=false,
-                                    int16_t         typeAddress = -1);
+                                    int16_t         typeAddress = -1,
+                                    bool            isRelocatable = false);
 
 extern TR::Instruction *loadActualConstant(TR::CodeGenerator *cg,
                                     TR::Node        *node,

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -733,9 +733,9 @@ TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
       else
          {
          if (child->isMethodPointerConstant())
-            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->compileRelocatableCode(), NULL, false, TR_RamMethodSequence);
          else
-            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister);
+            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->compileRelocatableCode());
          }
       child->setRegister(pushRegister);
       }

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -733,9 +733,9 @@ TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
       else
          {
          if (child->isMethodPointerConstant())
-            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->compileRelocatableCode(), NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->comp()->compileRelocatableCode(), NULL, false, TR_RamMethodSequence);
          else
-            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->compileRelocatableCode());
+            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->comp()->compileRelocatableCode());
          }
       child->setRegister(pushRegister);
       }

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -733,9 +733,9 @@ TR::Register *OMR::Power::Linkage::pushAddressArg(TR::Node *child)
       else
          {
          if (child->isMethodPointerConstant())
-            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->comp()->compileRelocatableCode(), NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister, NULL, false, TR_RamMethodSequence);
          else
-            loadAddressConstant(self()->cg(), child, child->getAddress(), pushRegister, self()->cg()->comp()->compileRelocatableCode());
+            loadAddressConstant(self()->cg(), self()->cg()->comp()->compileRelocatableCode(), child, child->getAddress(), pushRegister);
          }
       child->setRegister(pushRegister);
       }

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1587,25 +1587,25 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          if (symbol->isDebugCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_DebugCounter);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_DebugCounter);
             return;
             }
          if (symbol->isCountForRecompile())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
+            loadAddressConstant(cg, nodeForSymbol, TR_CountForRecompile, reg, true, NULL, false, TR_GlobalValue);
             return;
             }
          else if (symbol->isRecompilationCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_BodyInfoAddressLoad);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_BodyInfoAddressLoad);
             return;
             }
          else if (symbol->isCompiledMethod())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_RamMethodSequence);
             return;
             }
          else if (symbol->isStartPC())
@@ -1618,13 +1618,13 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          else if (isStaticField && !ref->isUnresolved())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress, true);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_DataAddress);
             return;
             }
          else if (isClass && !ref->isUnresolved() && comp->getOption(TR_UseSymbolValidationManager))
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, (intptrj_t)ref, reg, NULL, false, TR_ClassAddress);
+            loadAddressConstant(cg, nodeForSymbol, (intptrj_t)ref, reg, true, NULL, false, TR_ClassAddress);
             return;
             }
          else
@@ -1687,25 +1687,25 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          if (symbol->isDebugCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_DebugCounter);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, comp->compileRelocatableCode(), NULL, false, TR_DebugCounter);
             return;
             }
          else if (symbol->isCountForRecompile())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
+            loadAddressConstant(cg, nodeForSymbol, TR_CountForRecompile, reg, comp->compileRelocatableCode(), NULL, false, TR_GlobalValue);
             return;
             }
          else if (symbol->isRecompilationCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 0, reg, NULL, false, TR_BodyInfoAddressLoad);
+            loadAddressConstant(cg, nodeForSymbol, 0, reg, comp->compileRelocatableCode(), NULL, false, TR_BodyInfoAddressLoad);
             return;
             }
          else if (symbol->isCompiledMethod())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 0, reg, NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(cg, nodeForSymbol, 0, reg, comp->compileRelocatableCode(), NULL, false, TR_RamMethodSequence);
             return;
             }
          else if (symbol->isStartPC())
@@ -1718,7 +1718,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          else if (isStaticField && !ref->isUnresolved())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, comp->compileRelocatableCode(), NULL, false, TR_DataAddress);
             return;
             }
          else if (ref->isUnresolved() || useUnresSnippetToAvoidRelo)

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1618,7 +1618,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          else if (isStaticField && !ref->isUnresolved())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress);
+            loadAddressConstant(cg, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress, true);
             return;
             }
          else if (isClass && !ref->isUnresolved() && comp->getOption(TR_UseSymbolValidationManager))

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1587,25 +1587,25 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          if (symbol->isDebugCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_DebugCounter);
+            loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_DebugCounter);
             return;
             }
          if (symbol->isCountForRecompile())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, TR_CountForRecompile, reg, true, NULL, false, TR_GlobalValue);
+            loadAddressConstant(cg, true, nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
             return;
             }
          else if (symbol->isRecompilationCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_BodyInfoAddressLoad);
+            loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_BodyInfoAddressLoad);
             return;
             }
          else if (symbol->isCompiledMethod())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RamMethodSequence);
             return;
             }
          else if (symbol->isStartPC())
@@ -1618,13 +1618,13 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          else if (isStaticField && !ref->isUnresolved())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, true, NULL, false, TR_DataAddress);
+            loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress);
             return;
             }
          else if (isClass && !ref->isUnresolved() && comp->getOption(TR_UseSymbolValidationManager))
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, (intptrj_t)ref, reg, true, NULL, false, TR_ClassAddress);
+            loadAddressConstant(cg, true, nodeForSymbol, (intptrj_t)ref, reg, NULL, false, TR_ClassAddress);
             return;
             }
          else
@@ -1687,25 +1687,25 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          if (symbol->isDebugCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, comp->compileRelocatableCode(), NULL, false, TR_DebugCounter);
+            loadAddressConstant(cg, comp->compileRelocatableCode(), nodeForSymbol, 1, reg, NULL, false, TR_DebugCounter);
             return;
             }
          else if (symbol->isCountForRecompile())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, TR_CountForRecompile, reg, comp->compileRelocatableCode(), NULL, false, TR_GlobalValue);
+            loadAddressConstant(cg, comp->compileRelocatableCode(), nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
             return;
             }
          else if (symbol->isRecompilationCounter())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 0, reg, comp->compileRelocatableCode(), NULL, false, TR_BodyInfoAddressLoad);
+            loadAddressConstant(cg, comp->compileRelocatableCode(), nodeForSymbol, 0, reg, NULL, false, TR_BodyInfoAddressLoad);
             return;
             }
          else if (symbol->isCompiledMethod())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 0, reg, comp->compileRelocatableCode(), NULL, false, TR_RamMethodSequence);
+            loadAddressConstant(cg, comp->compileRelocatableCode(), nodeForSymbol, 0, reg, NULL, false, TR_RamMethodSequence);
             return;
             }
          else if (symbol->isStartPC())
@@ -1718,7 +1718,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          else if (isStaticField && !ref->isUnresolved())
             {
             TR::Register *reg = _baseRegister = cg->allocateRegister();
-            loadAddressConstant(cg, nodeForSymbol, 1, reg, comp->compileRelocatableCode(), NULL, false, TR_DataAddress);
+            loadAddressConstant(cg, comp->compileRelocatableCode(), nodeForSymbol, 1, reg, NULL, false, TR_DataAddress);
             return;
             }
          else if (ref->isUnresolved() || useUnresSnippetToAvoidRelo)

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -125,7 +125,7 @@ loadAddressConstant(
       bool isPicSite,
       int16_t typeAddress)
    {
-   if (cg->comp()->compileRelocatableCode() || isRelocatable)
+   if (isRelocatable)
       return cg->loadAddressConstantFixed(node, value, trgReg, cursor, NULL, typeAddress);
 
    return loadActualConstant(cg, node, value, trgReg, cursor, isPicSite);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -117,15 +117,33 @@ TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node * 
 TR::Instruction *
 loadAddressConstant(
       TR::CodeGenerator *cg,
+      bool isRelocatable,
       TR::Node * node,
       intptrj_t value,
       TR::Register *trgReg,
-      bool isRelocatable,
       TR::Instruction *cursor,
       bool isPicSite,
       int16_t typeAddress)
    {
    if (isRelocatable)
+      return cg->loadAddressConstantFixed(node, value, trgReg, cursor, NULL, typeAddress);
+
+   return loadActualConstant(cg, node, value, trgReg, cursor, isPicSite);
+   }
+
+
+// loadAddressConstant could be merged with loadConstant 64-bit
+TR::Instruction *
+loadAddressConstant(
+      TR::CodeGenerator *cg,
+      TR::Node * node,
+      intptrj_t value,
+      TR::Register *trgReg,
+      TR::Instruction *cursor,
+      bool isPicSite,
+      int16_t typeAddress)
+   {
+   if (cg->comp()->compileRelocatableCode())
       return cg->loadAddressConstantFixed(node, value, trgReg, cursor, NULL, typeAddress);
 
    return loadActualConstant(cg, node, value, trgReg, cursor, isPicSite);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -120,10 +120,10 @@ loadAddressConstant(
       TR::Node * node,
       intptrj_t value,
       TR::Register *trgReg,
+      bool isRelocatable,
       TR::Instruction *cursor,
       bool isPicSite,
-      int16_t typeAddress,
-      bool isRelocatable)
+      int16_t typeAddress)
    {
    if (cg->comp()->compileRelocatableCode() || isRelocatable)
       return cg->loadAddressConstantFixed(node, value, trgReg, cursor, NULL, typeAddress);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -122,9 +122,10 @@ loadAddressConstant(
       TR::Register *trgReg,
       TR::Instruction *cursor,
       bool isPicSite,
-      int16_t typeAddress)
+      int16_t typeAddress,
+      bool isRelocatable)
    {
-   if (cg->comp()->compileRelocatableCode())
+   if (cg->comp()->compileRelocatableCode() || isRelocatable)
       return cg->loadAddressConstantFixed(node, value, trgReg, cursor, NULL, typeAddress);
 
    return loadActualConstant(cg, node, value, trgReg, cursor, isPicSite);


### PR DESCRIPTION
This PR overloads the `loadAddressConstant` API on Power. We add a new boolean which allows the consumer of this API to determine if relocatable code needs to be generated.

Once the commits are merged and have propagated into downstream projects, we will make the necessary API changes there and remove the old definition of the API since it will no longer be needed.