### PR TITLE
Rework MemoryReference::accessStaticItem in Power for JITServer

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1159,6 +1159,7 @@ class OMR_EXTENSIBLE CodeGenerator
    bool needRelocationsForBodyInfoData() { return false; }
    bool needRelocationsForPersistentInfoData() { return false; }
    bool needRelocationsForLookupEvaluationData();
+   bool needRelocationsForCurrentMethodPC() { return false; }
 
    // This query can be used if we need to decide whether data represented by TR_HelperAddress or TR_AbsoluteHelperAddress
    // relocation type needs a relocation record.

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1605,7 +1605,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RamMethodSequence);
          return;
          }
-      else if (symbol->isStartPC() && (cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation()))
+      else if (symbol->isStartPC() && cg->needRelocationsForCurrentMethodPC())
          {
          // use inSnippet, as the relocation mechanism is already set up there
          TR::Register *reg = _baseRegister = cg->allocateRegister();
@@ -1703,7 +1703,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, comp->compileRelocatableCode() || comp->isOutOfProcessCompilation(), nodeForSymbol, 0, reg, NULL, false, TR_RamMethodSequence);
          return;
          }
-      else if (symbol->isStartPC() && (ref->isUnresolved() || comp->compileRelocatableCode() || comp->isOutOfProcessCompilation()))
+      else if (symbol->isStartPC() && (ref->isUnresolved() || cg->needRelocationsForCurrentMethodPC()))
          {
          // use inSnippet, as the relocation mechanism is already set up there
          TR::Register *reg = _baseRegister = cg->allocateRegister();
@@ -1716,7 +1716,7 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_DataAddress);
          return;
          }
-      else if (refIsUnresolved || useUnresSnippetToAvoidRelo && (comp->compileRelocatableCode() || comp->isOutOfProcessCompilation()))
+      else if (refIsUnresolved || useUnresSnippetToAvoidRelo)
          {
          self()->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, isStore, false));
          cg->addSnippet(self()->getUnresolvedSnippet());

--- a/compiler/p/codegen/OMRMemoryReference.cpp
+++ b/compiler/p/codegen/OMRMemoryReference.cpp
@@ -1587,19 +1587,19 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_DebugCounter);
          return;
          }
-      if (symbol->isCountForRecompile() && (cg->needRelocationsForPersistentInfoData() || cg->needRelocationsForStatics()))
+      if (symbol->isCountForRecompile() && cg->needRelocationsForPersistentInfoData())
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
          loadAddressConstant(cg, true, nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
          return;
          }
-      else if (symbol->isRecompilationCounter() && (cg->needRelocationsForBodyInfoData() || cg->needRelocationsForStatics()))
+      else if (symbol->isRecompilationCounter() && cg->needRelocationsForBodyInfoData())
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_BodyInfoAddressLoad);
          return;
          }
-      else if (symbol->isCompiledMethod() && (cg->comp()->compileRelocatableCode() || cg->comp()->isOutOfProcessCompilation()))
+      else if (symbol->isCompiledMethod() && cg->needRelocationsForCurrentMethodPC())
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
          loadAddressConstant(cg, true, nodeForSymbol, 1, reg, NULL, false, TR_RamMethodSequence);
@@ -1685,22 +1685,22 @@ void OMR::Power::MemoryReference::accessStaticItem(TR::Node *node, TR::SymbolRef
          loadAddressConstant(cg, comp->compileRelocatableCode(), nodeForSymbol, 1, reg, NULL, false, TR_DebugCounter);
          return;
          }
-      else if ((refIsUnresolved || cg->needRelocationsForPersistentInfoData() || cg->needRelocationsForStatics()) && symbol->isCountForRecompile())
+      else if ((refIsUnresolved || cg->needRelocationsForPersistentInfoData()) && symbol->isCountForRecompile())
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
-         loadAddressConstant(cg, cg->needRelocationsForPersistentInfoData() || cg->needRelocationsForStatics(), nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
+         loadAddressConstant(cg, cg->needRelocationsForPersistentInfoData(), nodeForSymbol, TR_CountForRecompile, reg, NULL, false, TR_GlobalValue);
          return;
          }
-      else if ((refIsUnresolved || cg->needRelocationsForBodyInfoData() || cg->needRelocationsForStatics()) && symbol->isRecompilationCounter())
+      else if ((refIsUnresolved || cg->needRelocationsForBodyInfoData()) && symbol->isRecompilationCounter())
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
-         loadAddressConstant(cg, cg->needRelocationsForBodyInfoData() || cg->needRelocationsForStatics(), nodeForSymbol, 0, reg, NULL, false, TR_BodyInfoAddressLoad);
+         loadAddressConstant(cg, cg->needRelocationsForBodyInfoData(), nodeForSymbol, 0, reg, NULL, false, TR_BodyInfoAddressLoad);
          return;
          }
-      else if (symbol->isCompiledMethod() && (ref->isUnresolved() || comp->compileRelocatableCode() || comp->isOutOfProcessCompilation()))
+      else if (symbol->isCompiledMethod() && (ref->isUnresolved() || cg->needRelocationsForCurrentMethodPC()))
          {
          TR::Register *reg = _baseRegister = cg->allocateRegister();
-         loadAddressConstant(cg, comp->compileRelocatableCode() || comp->isOutOfProcessCompilation(), nodeForSymbol, 0, reg, NULL, false, TR_RamMethodSequence);
+         loadAddressConstant(cg, cg->needRelocationsForCurrentMethodPC(), nodeForSymbol, 0, reg, NULL, false, TR_RamMethodSequence);
          return;
          }
       else if (symbol->isStartPC() && (ref->isUnresolved() || cg->needRelocationsForCurrentMethodPC()))


### PR DESCRIPTION
In this PR we make the changes needed to use front end queries instead of `cg->compileRelocatableCode()` when deciding whether to generate relocatable code inside `accessStaticItem`. This allows us to generate relocatable code for remote compilations in a consumer project such as OpenJ9, because the appropriate front-end query can return the right answer depending on the mode of compilation.