### PR TITLE
Rename disableTOCForConsts option and disable TOC when the opti…

### DIFF
--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -73,7 +73,7 @@ int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
 	    {
             fcursor = new (_cg->trHeapMemory()) TR::ARMConstant<float>(_cg, fin.fvalue);
             _floatConstants.add(fcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOCForConsts))
+            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
 	       {
                ret = TR_ARMTableOfConstants::lookUp(fin.fvalue, _cg);
                fcursor->setTOCOffset(ret);
@@ -102,7 +102,7 @@ int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
 	    {
             dcursor = new (_cg->trHeapMemory()) TR::ARMConstant<double>(_cg, din.dvalue);
             _doubleConstants.add(dcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOCForConsts))
+            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
 	       {
                ret = TR_ARMTableOfConstants::lookUp(din.dvalue, _cg);
                dcursor->setTOCOffset(ret);

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -539,7 +539,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableTLE",                         "O\tdisable transactional lock elision", SET_OPTION_BIT(TR_DisableTLE), "F"},
    {"disableTlhPrefetch",                 "O\tdisable software prefetch on allocation", SET_OPTION_BIT(TR_DisableTLHPrefetch), "F"},
    {"disableTM",                          "O\tdisable transactional memory support", SET_OPTION_BIT(TR_DisableTM), "F"},
-   {"disableTOC",                         "O\tdisable use of the Table of Contents (TOC) on relevant architectures", SET_OPTION_BIT(TR_DisableTOC), "F"},
+   {"disableTOC",                         "O\tdisable use of the Table of Constants (TOC) on relevant architectures", SET_OPTION_BIT(TR_DisableTOC), "F"},
    {"disableTraceRegDeps",                "O\tdisable printing of register dependancies for each instruction in trace file",              SET_OPTION_BIT(TR_DisableTraceRegDeps), "F"},
    {"disableTraps",                       "C\tdisable trap instructions",                       SET_OPTION_BIT(TR_DisableTraps), "F"},
    {"disableTreeCleansing",               "O\tdisable tree cleansing",                         TR::Options::disableOptimization, treesCleansing, 0, "P"},

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -539,7 +539,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableTLE",                         "O\tdisable transactional lock elision", SET_OPTION_BIT(TR_DisableTLE), "F"},
    {"disableTlhPrefetch",                 "O\tdisable software prefetch on allocation", SET_OPTION_BIT(TR_DisableTLHPrefetch), "F"},
    {"disableTM",                          "O\tdisable transactional memory support", SET_OPTION_BIT(TR_DisableTM), "F"},
-   {"disableTOCForConsts",                "O\tdisable use of the TOC for constants and floats materialization", SET_OPTION_BIT(TR_DisableTOCForConsts), "F"},
+   {"disableTOC",                         "O\tdisable use of the Table of Contents (TOC) on relevant architectures", SET_OPTION_BIT(TR_DisableTOC), "F"},
    {"disableTraceRegDeps",                "O\tdisable printing of register dependancies for each instruction in trace file",              SET_OPTION_BIT(TR_DisableTraceRegDeps), "F"},
    {"disableTraps",                       "C\tdisable trap instructions",                       SET_OPTION_BIT(TR_DisableTraps), "F"},
    {"disableTreeCleansing",               "O\tdisable tree cleansing",                         TR::Options::disableOptimization, treesCleansing, 0, "P"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -322,7 +322,7 @@ enum TR_CompilationOptions
    TR_TurnOffSelectiveNoOptServerIfNoStartupHint = 0x01000000 + 7,
    TR_TraceDominators                     = 0x02000000 + 7,
    TR_EnableHCR                           = 0x04000000 + 7, // enable hot code replacement
-   TR_DisableTOCForConsts                 = 0x08000000 + 7,
+   TR_DisableTOC                          = 0x08000000 + 7,
    TR_UseLowPriorityQueueDuringCLP        = 0x10000000 + 7,
    TR_DisableVectorBCD                    = 0x20000000 + 7,
    // Available                           = 0x40000000 + 7,

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -81,7 +81,7 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             fcursor = new (_cg->trHeapMemory()) PPCConstant<float>(_cg, fin.fvalue);
             _floatConstants.add(fcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOCForConsts))
+            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
                {
                ret = TR_PPCTableOfConstants::lookUp(fin.fvalue, _cg);
                }
@@ -110,7 +110,7 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             dcursor = new (_cg->trHeapMemory()) PPCConstant<double>(_cg, din.dvalue);
             _doubleConstants.add(dcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOCForConsts))
+            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
                {
                ret = TR_PPCTableOfConstants::lookUp(din.dvalue, _cg);
                }

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -81,7 +81,7 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             fcursor = new (_cg->trHeapMemory()) PPCConstant<float>(_cg, fin.fvalue);
             _floatConstants.add(fcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
+            if (TR::Compiler->target.is64Bit())
                {
                ret = TR_PPCTableOfConstants::lookUp(fin.fvalue, _cg);
                }
@@ -110,7 +110,7 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             dcursor = new (_cg->trHeapMemory()) PPCConstant<double>(_cg, din.dvalue);
             _doubleConstants.add(dcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
+            if (TR::Compiler->target.is64Bit())
                {
                ret = TR_PPCTableOfConstants::lookUp(din.dvalue, _cg);
                }

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -199,7 +199,7 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
    int32_t offset = PTOC_FULL_INDEX;
 
    bool canUseTOC = (!TR::isJ9() || !isPicSite) &&
-                    !comp->getOption(TR_DisableTOCForConsts);
+                    !comp->getOption(TR_DisableTOC);
    if (canUseTOC && useTOC)
       offset = TR_PPCTableOfConstants::lookUp((int8_t *)&value, sizeof(int64_t), true, 0, cg);
 

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -198,8 +198,7 @@ TR::Instruction *loadConstant(TR::CodeGenerator *cg, TR::Node * node, int64_t va
 
    int32_t offset = PTOC_FULL_INDEX;
 
-   bool canUseTOC = (!TR::isJ9() || !isPicSite) &&
-                    !comp->getOption(TR_DisableTOC);
+   bool canUseTOC = (!TR::isJ9() || !isPicSite);
    if (canUseTOC && useTOC)
       offset = TR_PPCTableOfConstants::lookUp((int8_t *)&value, sizeof(int64_t), true, 0, cg);
 

--- a/compiler/p/codegen/PPCTableOfConstants.cpp
+++ b/compiler/p/codegen/PPCTableOfConstants.cpp
@@ -180,7 +180,7 @@ TR_PPCTableOfConstants::lookUp(int32_t val, struct TR_tocHashEntry *tmplate, int
    {
    TR::Compilation *comp = cg->comp();
 
-   if (comp->compileRelocatableCode() || (comp->getOption(TR_EnableHCR) && comp->getOption(TR_HCRPatchClassPointers)) || comp->getOption(TR_MimicInterpreterFrameShape))
+   if (comp->compileRelocatableCode() || comp->getOption(TR_DisableTOC) || (comp->getOption(TR_EnableHCR) && comp->getOption(TR_HCRPatchClassPointers)) || comp->getOption(TR_MimicInterpreterFrameShape))
       return PTOC_FULL_INDEX;
 
    if (comp->isOptServer())
@@ -391,7 +391,7 @@ int32_t TR_PPCTableOfConstants::lookUp(int8_t *name, int32_t len, bool isAddr, i
    struct TR_tocHashEntry localEntry;
    int32_t                val, offsetInSlot;
 
-   if (comp->compileRelocatableCode() || (comp->getOption(TR_EnableHCR) && comp->getOption(TR_HCRPatchClassPointers)))
+   if (comp->compileRelocatableCode() || comp->getOption(TR_DisableTOC) || (comp->getOption(TR_EnableHCR) && comp->getOption(TR_HCRPatchClassPointers)))
       return PTOC_FULL_INDEX;
 
    if (comp->isOptServer())
@@ -424,6 +424,9 @@ int32_t TR_PPCTableOfConstants::lookUp(double dvalue, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
 
+   if (comp->getOption(TR_DisableTOC))
+      return PTOC_FULL_INDEX;
+
    if (comp->isOptServer())
       {
       if (comp->getMethodHotness() < warm || comp->isDLT() || comp->isProfilingCompilation() || cg->getCurrentBlock()->isCold())
@@ -449,6 +452,9 @@ int32_t TR_PPCTableOfConstants::lookUp(double dvalue, TR::CodeGenerator *cg)
 int32_t TR_PPCTableOfConstants::lookUp(float fvalue, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
+
+   if (comp->getOption(TR_DisableTOC))
+      return PTOC_FULL_INDEX;
 
    if (comp->isOptServer())
       {
@@ -477,6 +483,9 @@ int32_t TR_PPCTableOfConstants::lookUp(float fvalue, TR::CodeGenerator *cg)
 int32_t TR_PPCTableOfConstants::lookUp(TR::SymbolReference *symRef, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
+
+   if (comp->getOption(TR_DisableTOC))
+      return PTOC_FULL_INDEX;
 
    if (comp->isOptServer())
       {
@@ -559,7 +568,7 @@ int32_t TR_PPCTableOfConstants::allocateChunk(uint32_t numEntries, TR::CodeGener
    {
    TR_PPCTableOfConstants *tocManagement = toPPCTableOfConstants(TR_PersistentMemory::getNonThreadSafePersistentInfo()->getPersistentTOC());
 
-   if (tocManagement == NULL || cg->comp()->compileRelocatableCode() || (cg->comp()->getOption(TR_EnableHCR) && cg->comp()->getOption(TR_HCRPatchClassPointers)))
+   if (tocManagement == NULL || cg->comp()->getOption(TR_DisableTOC) || cg->comp()->compileRelocatableCode() || (cg->comp()->getOption(TR_EnableHCR) && cg->comp()->getOption(TR_HCRPatchClassPointers)))
       return PTOC_FULL_INDEX;
 
    if (grabMonitor)


### PR DESCRIPTION
This PR renames the `disableTOCForConstants` option to just `disableTOC`, and then uses the option to prevent the PPC code generator from being able to generate TOC code.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>