### PR TITLE
Disable portion of Load Extension on Z

### DIFF
--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -62,7 +62,13 @@ TR_LoadExtensions::TR_LoadExtensions(TR::OptimizationManager *manager)
 
 int32_t TR_LoadExtensions::perform()
    {
-   if (comp()->getOptLevel() >= hot && !optimizer()->cantBuildGlobalsUseDefInfo())
+   static bool enableGRALoadExtensions = feGetEnv("TR_EnableGRALoadExtensions") != NULL;
+
+   // Make sure the UseDefInfo is set to NULL when GRA Load Extensions are disable.
+   if (!enableGRALoadExtensions)
+      optimizer()->setUseDefInfo(NULL);
+
+   if (comp()->getOptLevel() >= hot && !optimizer()->cantBuildGlobalsUseDefInfo() && enableGRALoadExtensions)
       {
       if (!comp()->getFlowGraph()->getStructure())
          {


### PR DESCRIPTION
Currently we are seeing issues with load extension on Z where we are using a full 64 Bit register for 32 Bit values assuming the value is extended load at the source. Disabling the portion of the Load Extensions which uses Global Use Def info to do the optimization.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>