### PR TITLE
Use CG query to check for guard merging support

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -299,6 +299,8 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    bool directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress);
 
+   bool supportsMergingGuards() {return false;}
+
    // OutOfLineCodeSection List functions
    TR::list<TR_ARM64OutOfLineCodeSection*> &getARM64OutOfLineCodeSectionList() {return _outOfLineCodeSectionList;}
 

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1061,6 +1061,14 @@ OMR::CodeGenerator::isGlobalVRF(TR_GlobalRegisterNumber n)
    }
 
 bool
+OMR::CodeGenerator::supportsMergingGuards()
+   {
+   return self()->getSupportsVirtualGuardNOPing() &&
+          self()->comp()->performVirtualGuardNOPing() &&
+          !self()->comp()->compileRelocatableCode();
+   }
+
+bool
 OMR::CodeGenerator::isGlobalFPR(TR_GlobalRegisterNumber n)
    {
    return !self()->isGlobalGPR(n);

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -541,7 +541,6 @@ class OMR_EXTENSIBLE CodeGenerator
    // Capabilities
    //
    bool supports32bitAiadd() {return true;}
-   bool supportsMergingGuards() {return false;}
 
    // --------------------------------------------------------------------------
    // Z only
@@ -1152,6 +1151,7 @@ class OMR_EXTENSIBLE CodeGenerator
    void apply64BitLoadLabelRelativeRelocation(TR::Instruction *, TR::LabelSymbol *);
    void apply32BitLabelRelativeRelocation(int32_t * cursor, TR::LabelSymbol *);
    void apply32BitLabelTableRelocation(int32_t * cursor, TR::LabelSymbol *);
+   bool supportsMergingGuards();
 
 
    bool needClassAndMethodPointerRelocations() { return false; }

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -242,6 +242,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool canTransformUnsafeCopyToArrayCopy() { return true; }
    bool canTransformUnsafeSetMemory();
+   bool supportsMergingGuards() {return false;}
 
    virtual bool supportsAESInstructions();
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1067,14 +1067,6 @@ OMR::X86::CodeGenerator::getSupportsBitPermute()
    }
 
 bool
-OMR::X86::CodeGenerator::supportsMergingGuards()
-   {
-   return self()->getSupportsVirtualGuardNOPing() &&
-          self()->comp()->performVirtualGuardNOPing() &&
-          self()->allowGuardMerging();
-   }
-
-bool
 OMR::X86::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
    {
    switch (symbol)

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -366,8 +366,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    virtual bool getSupportsBitPermute();
 
-   bool supportsMergingGuards();
-
    bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
 
    bool hasTMEvaluator()                       {return true;}
@@ -768,8 +766,6 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    flags32_t _flags;
 
    public:
-
-   bool allowGuardMerging() { return false; }
 
    bool enableBetterSpillPlacements()
       {

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -2113,14 +2113,6 @@ OMR::Z::CodeGenerator::StopUsingEscapedMemRefsRegisters(int32_t topOfMemRefStack
    }
 
 bool
-OMR::Z::CodeGenerator::supportsMergingGuards()
-   {
-   return self()->getSupportsVirtualGuardNOPing() &&
-          self()->comp()->performVirtualGuardNOPing() &&
-          !self()->comp()->compileRelocatableCode();
-   }
-
-bool
 OMR::Z::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
    {
    bool result = false;

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -284,8 +284,6 @@ public:
    void RemoveMemRefFromStack(TR::MemoryReference * mr);
    void StopUsingEscapedMemRefsRegisters(int32_t topOfMemRefStackBeforeEvaluation);
 
-   bool supportsMergingGuards();
-
    bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
 
    bool supportsDirectJNICallsForAOT() { return true;}


### PR DESCRIPTION
This commit refactors an x86 codegen query to the common
codegen such that it can be used by the Z codegen as well
inside the supportsMergingGuards() routine.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>