### PR TITLE
Fix checkAndReplaceRotation 32/64 bit ambiguity

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -4656,7 +4656,13 @@ static bool checkAndReplaceRotation(TR::Node *node,TR::Block *block, TR::Simplif
 
    //traceMsg(TR::comp(), "Spot 2.5 correctLeftShiftAmount = %d mulConst = %d shiftConst = %d sizeof(T)*8 = %d\n",correctLeftShiftAmount,mulConst,shiftConst,sizeof(T)*8);
 
-   if ( (1 << correctLeftShiftAmount) != mulConst )      // Only a rotate if the const values add up to the size of the node type.  ie for ints, this better add up to 32
+   // We can only convert to a rotate if the calculated shift value (based on
+   // operand size) matches the constant from the multiply, specifically the
+   // constant must be 2^correctLeftShiftAmount.
+   // NB The following calculation of expectedMulConst goes to great lengths to
+   // avoid undefined behaviour that caused errors in earlier versions.
+   T expectedMulConst = correctLeftShiftAmount < static_cast<T>(sizeof(T) * 8) ? 1ULL << correctLeftShiftAmount : 0;
+   if (expectedMulConst != mulConst)
       return false;
 
    if (!performTransformation(s->comp(), "%sReduced or/xor/add in node [" POINTER_PRINTF_FORMAT "] to rol\n", s->optDetailString(), node))


### PR DESCRIPTION
checkAndReplaceRotation tests for pattern validity by comparing an expected
shift amount based on the size of the operand with the constant from the
multiply node:

```
if ( (1 << correctLeftShiftAmount) != mulConst )
      return false;
```

Unfortunately, the implicit int constant '1' allows the C++ compiler to ignore
the possibility of shift amounts>32 (undefined behaviour), resulting in 1<<n
giving the same answer as 1<<(n+32). This allowed the simplification to proceed
on a 64 bit operand with shift values that were only valid for 32 bit operands.

The shift has been updated with code crafted by Leonardo which allows the test
to correctly differentiate between 32 and 64 bit valid patterns.

Signed-off-by: James Kingdon <jkingdon@ca.ibm.com>