### PR TITLE
Concurrent GC Yield and Resume after CM VM Exclusive

### DIFF
--- a/gc/base/MasterGCThread.hpp
+++ b/gc/base/MasterGCThread.hpp
@@ -67,6 +67,7 @@ private:
 	MM_Collector *_collector; /**< The garbage collector */
 	bool _runAsImplicit; /**< if true, STW GC (via garbageCollect()) is executed with the master thread being the caller's thread, otherwise the request is passed to the explicit master thread */
 	bool _acquireVMAccessDuringConcurrent; /**< if true, (explicit) master GC thread holds VM access, while running concurrent phase of a GC cycle */
+	bool _concurrentResumable; /**< if true, a previously terminated concurrent phase (e.g. Concurrent Scavenger) is able to resume once vm access has been acquired again */
 
 /*
  * Function members
@@ -77,7 +78,7 @@ public:
 	 * Early initialize: montior creation
 	 * globalCollector[in] the global collector (typically the caller)
 	 */
-	bool initialize(MM_Collector *collector, bool runAsImplicit = false, bool acquireVMAccessDuringConcurrent = false);
+	bool initialize(MM_Collector *collector, bool runAsImplicit = false, bool acquireVMAccessDuringConcurrent = false, bool concurrentResumable = false);
 
 	/**
 	 * Teardown resources created by initialize

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -282,7 +282,7 @@ MM_Scavenger::initialize(MM_EnvironmentBase *env)
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)
 	if (_extensions->concurrentScavenger) {
-		if (!_masterGCThread.initialize(this, true, true)) {
+		if (!_masterGCThread.initialize(this, true, true, true)) {
 			return false;
 		}
 	}
@@ -5128,7 +5128,6 @@ MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 			} else {
 				/* Ran out of free space in allocate/survivor, or system/global GC */
 				getConcurrentPhaseStats()->_terminationRequestType = MM_ConcurrentPhaseStatsBase::terminationRequest_ByGC;
-				_concurrentState = concurrent_state_complete;
 			}
 			_shouldYield = false;
 		} else {


### PR DESCRIPTION
Previously, after terminating and yielding to an exclusive VM access request, Concurrent Scavenger would only resume if it yielded to an **external** request. However, CS should also resume after yielding to **internal GC request** CM init as this completely terminates CS and results in missed opportunity for CS to make progress.

- upon GC termination request, `_concurrentState` is no longer transitioned to `concurrent_state_complete`, it's left in scan state.

- Introduced `_concurrentResumable` configuration param for `MasterGCThread` which is set to true if the collector is resumable. (initialized to true for Scavenger, defaults to false for balanced)

Signed-off-by: Salman Rana <salman.rana@ibm.com>