### PR TITLE
WIP: Merge two tree walk passes into one

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -93,6 +93,7 @@
 #include "infra/Cfg.hpp"
 #include "infra/Flags.hpp"
 #include "infra/HashTab.hpp"
+#include "infra/ILWalk.hpp"
 #include "infra/Link.hpp"
 #include "infra/List.hpp"
 #include "infra/Stack.hpp"
@@ -439,18 +440,16 @@ OMR::CodeGenerator::setUpForInstructionSelection()
    // the _register and _label fields are unioned members of a node.  prepareNodeForInstructionSelection
    // zeros the _register field while the second for loop sets label fields on destination nodes.
    //
-   TR::TreeTop * tt=NULL, *prev = NULL;
+   //TR::TreeTop * tt=NULL, *prev = NULL;
 
-
-   for (tt = self()->comp()->getStartTree(); tt; tt = tt->getNextTreeTop())
+   for (TR::TreeTopIterator it(self()->comp()->getStartTree(), self()->comp()); it.currentNode(); it.stepForward())
+   //for (tt = self()->comp()->getStartTree(); tt; prev=tt, tt = tt->getNextTreeTop())
       {
-      self()->prepareNodeForInstructionSelection(tt->getNode());
-      }
+      TR::Node * node = it.currentNode();
 
-
-   for (tt = self()->comp()->getStartTree(); tt; prev=tt, tt = tt->getNextTreeTop())
-      {
-      TR::Node * node = tt->getNode();
+      // prepareNodeForInstructionSelection is called in a single walk of the treetops
+      // since the UnionA field _register is not affected by labeling nodes as was previously thought.
+      self()->prepareNodeForInstructionSelection(node);
 
       if ((node->getOpCodeValue() == TR::treetop) ||
           node->getOpCode().isAnchor() ||


### PR DESCRIPTION
Merge two independent (non-interfering) tree
walks into a single one in codegen/OMRCodeGenerator.

Signed-off-by: Batyr Nuryyev <nuryyev@ualberta.ca>