### PR TITLE
AArch64: Set destination address in ARM64ImmSymInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -81,6 +81,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
 
          intptrj_t distance = jitToJitStart - (intptrj_t)cursor;
          insertImmediateField(toARM64Cursor(cursor), distance);
+         setAddrImmediate(jitToJitStart);
          }
       else if (label != NULL)
          {
@@ -104,6 +105,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
 
             intptrj_t distance = destination - (intptrj_t)cursor;
             insertImmediateField(toARM64Cursor(cursor), distance);
+            setAddrImmediate(destination);
 
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(
                                            cursor,

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -206,6 +206,12 @@ class ARM64ImmSymInstruction : public TR::Instruction
     * @return address immediate
     */
    uintptrj_t getAddrImmediate() { return _addrImmediate; }
+   /**
+    * @brief Sets address immediate
+    * @param[in] imm : address immediate
+    * @return address immediate
+    */
+   uintptrj_t setAddrImmediate(uintptrj_t imm) { return (_addrImmediate = imm); }
 
    /**
     * @brief Gets symbol reference


### PR DESCRIPTION
This commit adds code for setting the destination address of "bl"
instruction in ARM64ImmSymInstruction when possible, to improve the
readability of trace files.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>