### PR TITLE
Fix the compile failure related to the lockExchange function on AIX

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -466,7 +466,7 @@ public:
 #if defined(__GNUC__)
 		return (uint64_t)__sync_lock_test_and_set(address, newValue);
 #elif defined(__xlC__) /* defined(__GNUC__) */
-		return (uint64_t)__fetch_and_swaplp((volatile long*)address, (long)newValue);
+		return (uint64_t)__fetch_and_swaplp((volatile unsigned long*)address, (unsigned long)newValue);
 #elif defined(_MSC_VER) /* defined(__GNUC__) */
 		return (uint64_t)_InterlockedExchange64((volatile __int64 *)address, (__int64)newValue);
 #else /* defined(__GNUC__) */
@@ -502,7 +502,7 @@ public:
 #if defined(__GNUC__)
 		return (uint32_t)__sync_lock_test_and_set(address, newValue);
 #elif defined(__xlC__) /* defined(__GNUC__) */
-		return (uint32_t)__fetch_and_swap((volatile int*)address, (int)newValue);
+		return (uint32_t)__fetch_and_swap((volatile unsigned int *)address, (unsigned int)newValue);
 #elif defined(_MSC_VER) /* defined(__GNUC__) */
 		return (uint32_t)_InterlockedExchange((volatile long *)address, (long)newValue);
 #else /* defined(__GNUC__) */


### PR DESCRIPTION
**Job failure:** https://ci.eclipse.org/omr/job/PullRequest-aix_ppc-64/1584/console.

**Details:**
1540-0256 (S) A parameter of type "volatile unsigned long *" cannot be
initialized with an expression of type "volatile long *".
1540-1205 (I) The error occurred while converting to parameter 1 of
"__fetch_and_swaplp(volatile unsigned long *, unsigned long)".

**Related:** https://github.com/eclipse/omr/pull/4469.

From the XLC AIX documentation,
```
Prototype:
unsigned int __fetch_and_swap (volatile unsigned int* addr, unsigned int val); 
unsigned long __fetch_and_swaplp (volatile unsigned long* addr, unsigned long val);
```

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>