### PR TITLE
MCS Locks: Part 1

### DIFF
--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -252,6 +252,13 @@ typedef struct J9ThreadMonitorTracing {
 #define J9_ABSTRACT_MONITOR_FIELDS_7
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) && defined(OMR_THR_THREE_TIER_LOCKING) */
 
+#if defined(OMR_THR_MCS_LOCKS)
+#define J9_ABSTRACT_MONITOR_FIELDS_8 \
+	omrthread_mcs_node_t volatile queueTail;
+#else /* defined(OMR_THR_MCS_LOCKS) */
+#define J9_ABSTRACT_MONITOR_FIELDS_8
+#endif /* defined(OMR_THR_MCS_LOCKS) */
+
 #define J9_ABSTRACT_MONITOR_FIELDS \
 	J9_ABSTRACT_MONITOR_FIELDS_1 \
 	J9_ABSTRACT_MONITOR_FIELDS_2 \
@@ -259,8 +266,8 @@ typedef struct J9ThreadMonitorTracing {
 	J9_ABSTRACT_MONITOR_FIELDS_4 \
 	J9_ABSTRACT_MONITOR_FIELDS_5 \
 	J9_ABSTRACT_MONITOR_FIELDS_6 \
-	J9_ABSTRACT_MONITOR_FIELDS_7
-
+	J9_ABSTRACT_MONITOR_FIELDS_7 \
+	J9_ABSTRACT_MONITOR_FIELDS_8
 
 /*
  * @ddr_namespace: map_to_type=J9ThreadAbstractMonitor

--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -84,6 +84,60 @@ typedef struct J9ThreadCustomSpinOptions {
 } J9ThreadCustomSpinOptions;
 #endif /* OMR_THR_CUSTOM_SPIN_OPTIONS */
 
+#if defined(OMR_THR_MCS_LOCKS)
+/* Cache align MCS nodes in the pool (OMRThreadMCSNodes->pool). */
+#define OMRTHREAD_MCS_NODE_ALIGNMENT 64
+
+/* Initialize pool (OMRThreadMCSNodes->pool) with minimum 10 MCS nodes. */
+#define OMRTHREAD_MIN_MCS_NODES 10
+
+/* Possible states of the OMRThreadMCSNode->blocked field. */
+#define OMRTHREAD_MCS_THREAD_BLOCKED 1
+#define OMRTHREAD_MCS_THREAD_ACQUIRE 0
+
+/* OMRThreadMCSNode: MCS node
+ * - thread: owner of the MCS node.
+ * - monitor: associated with the MCS node.
+ * - stackNext: pointer to the next MCS node in the stack (thread property).
+ * - queueNext: pointer to the next MCS node in the queue (lock property).
+ * - blocked:
+ *   1) OMRTHREAD_MCS_THREAD_BLOCKED - thread cannot own the lock.
+ *   2) OMRTHREAD_MCS_THREAD_ACQUIRE - thread can own the lock.
+ */
+typedef struct OMRThreadMCSNode *omrthread_mcs_node_t;
+typedef struct OMRThreadMCSNode {
+	omrthread_t thread;
+	omrthread_monitor_t monitor;
+	omrthread_mcs_node_t stackNext;
+	omrthread_mcs_node_t volatile queueNext;
+	volatile uintptr_t blocked;
+} OMRThreadMCSNode;
+
+/* OMRThreadMCSNodes: contains a set of MCS nodes for the thread.
+ * - stackHead: pointer to the head of the stack.
+ * - pool: J9Pool of MCS nodes,
+ *         cache aligned -> OMRTHREAD_MCS_NODE_ALIGNMENT,
+ *         minimum number of elements -> OMRTHREAD_MIN_MCS_NODES.
+ *
+ * A thread can enter multiple critical sections in a chained manner.
+ * Example:
+ *    monitor1->enter() {
+ *       critical_section1() {
+ *          monitor2->enter() {
+ *             critical_section2() {
+ *
+ * The stack (LIFO) records the MCS node <-> monitor mapping for a thread.
+ *
+ * The pool provides MCS nodes to a thread if it acquires multiple monitors
+ * one after the other.
+ */
+typedef struct OMRThreadMCSNodes *omrthread_mcs_nodes_t;
+typedef struct OMRThreadMCSNodes {
+	omrthread_mcs_node_t stackHead;
+	struct J9Pool *pool;
+} OMRThreadMCSNodes;
+#endif /* defined(OMR_THR_MCS_LOCKS) */
+
 typedef struct J9ThreadTracing {
 #if defined(OMR_THR_JLM_HOLD_TIMES)
 	uintptr_t pause_count;

--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -173,10 +173,18 @@ typedef struct J9ThreadTracing {
     uintptr_t lockedmonitorcount; \
     omrthread_os_errno_t os_errno;
 
+#if defined(OMR_THR_MCS_LOCKS)
+#define J9_ABSTRACT_THREAD_FIELDS_4 \
+	omrthread_mcs_nodes_t mcsNodes;
+#else /* defined(OMR_THR_MCS_LOCKS) */
+#define J9_ABSTRACT_THREAD_FIELDS_4
+#endif /* defined(OMR_THR_MCS_LOCKS) */
+
 #define J9_ABSTRACT_THREAD_FIELDS \
 	J9_ABSTRACT_THREAD_FIELDS_1 \
 	J9_ABSTRACT_THREAD_FIELDS_2 \
-	J9_ABSTRACT_THREAD_FIELDS_3
+	J9_ABSTRACT_THREAD_FIELDS_3 \
+	J9_ABSTRACT_THREAD_FIELDS_4
 
 typedef struct J9ThreadMonitorTracing {
 	char *monitor_name;

--- a/thread/common/threaddef.h
+++ b/thread/common/threaddef.h
@@ -98,6 +98,23 @@ intptr_t omrthread_spinlock_acquire(omrthread_t self, omrthread_monitor_t monito
 intptr_t omrthread_spinlock_acquire_no_spin(omrthread_t self, omrthread_monitor_t monitor);
 uintptr_t omrthread_spinlock_swapState(omrthread_monitor_t monitor, uintptr_t newState);
 
+#if defined(OMR_THR_MCS_LOCKS)
+intptr_t
+omrthread_mcs_lock(omrthread_t self, omrthread_monitor_t monitor, omrthread_mcs_node_t mcsNode, BOOLEAN retry);
+
+intptr_t
+omrthread_mcs_trylock(omrthread_t self, omrthread_monitor_t monitor, omrthread_mcs_node_t mcsNode);
+
+omrthread_t
+omrthread_mcs_unlock(omrthread_t self, omrthread_monitor_t monitor);
+
+omrthread_mcs_node_t
+omrthread_mcs_node_allocate(omrthread_t self);
+
+void
+omrthread_mcs_node_free(omrthread_t self, omrthread_mcs_node_t mcsNode);
+#endif /* defined(OMR_THR_MCS_LOCKS) */
+
 /*
  * constants for profiling
  */

--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -26,6 +26,7 @@ extern "C" {
 
 #include "thrtypes.h"
 #include "threaddef.h"
+#include "ut_j9thr.h"
 
 void
 omrthread_monitor_pin(omrthread_monitor_t monitor, omrthread_t self)
@@ -194,6 +195,91 @@ omrthread_spinlock_swapState(omrthread_monitor_t monitor, uintptr_t newState)
 	}
 	return oldState;
 }
+
+#if defined(OMR_THR_MCS_LOCKS)
+/**
+ * Acquire the MCS lock.
+ *
+ * @param[in] self the current omrthread_t
+ * @param[in] monitor the monitor to be acquired
+ * @param[in] mcsNode the MCS node belonging to self
+ * @param[in] retry specifies if a MCS node is reused in which case the MCS lock queue
+ * and MCS node characteristics should not be updated. Only spinning should be performed
+ * against mcsNode->blocked.
+ *
+ * @return 0 on success, -1 on failure
+ */
+intptr_t
+omrthread_mcs_lock(omrthread_t self, omrthread_monitor_t monitor, omrthread_mcs_node_t mcsNode, BOOLEAN retry)
+{
+	/* Unimplemented. */
+	Assert_THR_true(FALSE);
+	return -1;
+}
+
+/**
+ * Try to acquire the MCS lock.
+ *
+ * @param[in] self the current omrthread_t
+ * @param[in] monitor the monitor to be acquired
+ * @param[in] mcsNode the MCS node belonging to self
+ *
+ * @return 0 on success, -1 on failure
+ */
+intptr_t
+omrthread_mcs_trylock(omrthread_t self, omrthread_monitor_t monitor, omrthread_mcs_node_t mcsNode)
+{
+	/* Unimplemented. */
+	Assert_THR_true(FALSE);
+	return -1;
+}
+
+/**
+ * Unlock the MCS lock.
+ *
+ * @param[in] self the current omrthread_t
+ * @param[in] monitor the monitor to be released
+ *
+ * @return the next thread which will acquire the lock
+ */
+omrthread_t
+omrthread_mcs_unlock(omrthread_t self, omrthread_monitor_t monitor)
+{
+	/* Unimplemented. */
+	Assert_THR_true(FALSE);
+	return NULL;
+}
+
+/**
+ * Allocate memory and get an instance of OMRThreadMCSNode.
+ *
+ * @param[in] self the current omrthread_t
+ *
+ * @return a pointer to a new OMRThreadMCSNode on success and NULL on failure
+ */
+omrthread_mcs_node_t
+omrthread_mcs_node_allocate(omrthread_t self)
+{
+	/* Unimplemented. */
+	Assert_THR_true(FALSE);
+	return NULL;
+}
+
+/**
+ * Free memory and return the instance of OMRThreadMCSNode.
+ *
+ * @param[in] self the current omrthread_t
+ * @param[in] mcsNode the MCS node belonging to self
+ *
+ * @return void
+ */
+void
+omrthread_mcs_node_free(omrthread_t self, omrthread_mcs_node_t mcsNode)
+{
+	/* Unimplemented. */
+	Assert_THR_true(FALSE);
+}
+#endif /* defined(OMR_THR_MCS_LOCKS) */
 
 #endif /* OMR_THR_THREE_TIER_LOCKING */
 


### PR DESCRIPTION
1) Add new data structures and macros for implementing MCS locks.
2) Add a field to a store a OMRThreadMCSNodes pointer in J9Thread.
3) Add a field to store a pointer to the MCS queue tail in J9ThreadMonitor.
4) Add function prototypes for the MCS lock API.
5) Add function stubs with description for the MCS lock API.
6) [DONT MERGE] Enable the OMR_THR_MCS_LOCKS flag to verify compilation.

Will remove 6) after it is verified that the code compiles properly through the pull request build jobs.

Related: #4086.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>