### PR TITLE
Change CAS code & memory barrier for RISC-V in OMR (part6/cas)

### DIFF
--- a/include_core/omrutilbase.h
+++ b/include_core/omrutilbase.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -158,6 +158,36 @@ J9CAS8Helper(volatile uint64_t *addr, uint32_t compareLo, uint32_t compareHi, ui
 
 #endif /* !OMR_ENV_DATA64 && (AIXPPC || LINUXPPC) */
 
+
+#if defined(__riscv)
+/* ---------------- cas32helper.s ---------------- */
+/**
+ * @brief Perform a compare and swap of a 32-bit value.
+ *
+ * @param[in] addr          The address of the memory address
+ * @param[in] compareValue  The value to be compared
+ * @param[in] swapValue     The new value to be swapped to the specified memory address
+ *
+ * @return  The old value read from addr
+ */
+uint32_t
+RiscvCAS32Helper(volatile uint32_t *addr, uint32_t compareValue, uint32_t swapValue);
+
+/* ---------------- cas64helper.s ---------------- */
+#if defined(OMR_ENV_DATA64)
+/**
+ * @brief Perform a compare and swap of a 64-bit value on a 64-bit system.
+ *
+ * @param[in] addr          The address of the memory address
+ * @param[in] compareValue  The value to be compared
+ * @param[in] swapValue     The new value to be swapped to the specified memory address
+ *
+ * @return  The old value read from addr
+ */
+uint64_t
+RiscvCAS64Helper(volatile uint64_t *addr, uint64_t compareValue, uint64_t swapValue);
+#endif /* OMR_ENV_DATA64 */
+#endif /* __riscv */
 
 /* ---------------- gettimebase.c ---------------- */
 

--- a/util/omrutil/CMakeLists.txt
+++ b/util/omrutil/CMakeLists.txt
@@ -116,6 +116,20 @@ if(OMR_ARCH_POWER)
 	endif()
 endif()
 
+if(OMR_ARCH_RISCV)
+	if(OMR_HOST_OS STREQUAL linux)
+		list(APPEND OBJECTS cas32helper.s)
+		list(APPEND VPATH unix/linux/riscv/32)
+		target_include_directories(omrutil_obj PRIVATE unix/linux/riscv/32)
+
+		if(OMR_ENV_DATA64)
+			list(APPEND OBJECTS cas64helper.s)
+			list(APPEND VPATH unix/linux/riscv/64)
+			target_include_directories(omrutil_obj PRIVATE unix/linux/riscv/64)
+		endif()
+	endif()
+endif()
+
 list(APPEND OBJECTS
 	AtomicFunctions.cpp
 	argscan.c

--- a/util/omrutil/makefile
+++ b/util/omrutil/makefile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2015 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -74,6 +74,17 @@ ifeq (ppc,$(OMR_HOST_ARCH))
       vpath cas8help.s unix/linux/ppc/32
     else
       vpath cas8help.s unix/aix/32
+    endif
+  endif
+endif
+
+ifeq (riscv,$(OMR_HOST_ARCH))
+  ifeq (linux,$(OMR_HOST_OS))
+    OBJECTS += cas32helper$(OBJEXT)
+    vpath cas32helper.s unix/linux/riscv/32
+    ifeq (1,$(OMR_ENV_DATA64))
+      OBJECTS += cas64helper$(OBJEXT)
+      vpath cas64helper.s unix/linux/riscv/64
     endif
   endif
 endif

--- a/util/omrutil/unix/linux/riscv/32/cas32helper.s
+++ b/util/omrutil/unix/linux/riscv/32/cas32helper.s
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright (c) 2019, 2019 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+	.file	"cas32helper.s"
+	.option nopic
+	.text
+
+# Prototype: uint32_t RiscvCAS32Helper(volatile uint32_t *addr, uint32_t compareValue, uint32_t swapValue);
+# Defined in: #Args: 3
+	.align	2
+	.globl	RiscvCAS32Helper
+	.type	RiscvCAS32Helper, @function
+RiscvCAS32Helper:
+	addi	sp,sp,-32
+	sd	s0,24(sp)
+	addi	s0,sp,32
+	sd	a0,-24(s0)
+	mv	a5,a1
+	mv	a4,a2
+	sw	a5,-28(s0)
+	mv	a5,a4
+	sw	a5,-32(s0)
+	ld	a5,-24(s0)
+	lw	a4,-28(s0)
+	lw	a3,-32(s0)
+	fence iorw,ow
+retry:
+	lr.w.aq a2,0(a5)
+	bne a2,a4,fail
+	sc.w.aqrl a1,a3,0(a5)
+	bnez a1,retry
+fail:
+	sext.w	a5,a2
+	mv	a0,a5
+	ld	s0,24(sp)
+	addi	sp,sp,32
+	jr	ra
+	.size	RiscvCAS32Helper, .-RiscvCAS32Helper

--- a/util/omrutil/unix/linux/riscv/64/cas64helper.s
+++ b/util/omrutil/unix/linux/riscv/64/cas64helper.s
@@ -1,0 +1,54 @@
+###############################################################################
+# Copyright (c) 2019, 2019 IBM Corp. and others
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] http://openjdk.java.net/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+###############################################################################
+
+	.file	"cas64helper.s"
+	.option nopic
+	.text
+
+# Prototype: uint64_t RiscvCAS64Helper(volatile uint64_t *addr, uint64_t compareValue, uint64_t swapValue);
+# Defined in: #Args: 3
+	.align	2
+	.globl	RiscvCAS64Helper
+	.type	RiscvCAS64Helper, @function
+RiscvCAS64Helper:
+	addi	sp,sp,-48
+	sd	s0,40(sp)
+	addi	s0,sp,48
+	sd	a0,-24(s0)
+	sd	a1,-32(s0)
+	sd	a2,-40(s0)
+	ld	a5,-24(s0)
+	ld	a4,-32(s0)
+	ld	a3,-40(s0)
+	fence iorw,ow
+retry:
+	lr.d.aq a2,0(a5)
+	bne a2,a4,fail
+	sc.d.aqrl a1,a3,0(a5)
+	bnez a1,retry
+fail:
+	mv	a5,a2
+	mv	a0,a5
+	ld	s0,40(sp)
+	addi	sp,sp,48
+	jr	ra
+	.size	RiscvCAS64Helper, .-RiscvCAS64Helper


### PR DESCRIPTION
The changes mainly include the code for CAS-specific
functions as well as memory barrier on RISC-V.

Issue: #4426

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>