### PR TITLE
Remove references to OpenJ9 private linkage

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -22,7 +22,6 @@
 #include <stdint.h>
 #include "arm/codegen/ARMInstruction.hpp"
 #ifdef J9_PROJECT_SPECIFC
-#include "arm/codegen/ARMPrivateLinkage.hpp"
 #include "arm/codegen/ARMRecompilation.hpp"
 #endif
 #include "arm/codegen/ARMSystemLinkage.hpp"

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -22,9 +22,6 @@
 #include "arm/codegen/Linkage.hpp"
 
 #include "arm/codegen/ARMInstruction.hpp"
-#ifdef J9_PROJECT_SPECIFIC
-#include "arm/codegen/ARMPrivateLinkage.hpp"
-#endif
 #include "arm/codegen/ARMSystemLinkage.hpp"
 #ifdef J9_PROJECT_SPECIFIC
 #include "codegen/CallSnippet.hpp"

--- a/compiler/x/i386/codegen/IA32SystemLinkage.hpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.hpp
@@ -53,26 +53,6 @@ class IA32SystemLinkage : public TR::X86SystemLinkage
    virtual uint32_t getAlignment(TR::DataType);
    };
 
-#if 0
-class IA32SystemLinkage : public TR::IA32PrivateLinkage
-   {
-   public:
-
-   IA32SystemLinkage(TR::CodeGenerator *cg);
-
-   virtual TR::Register *buildDirectDispatch(TR::Node *callNode, bool spillFPRegs);
-   virtual TR::Register *buildIndirectDispatch(TR::Node *callNode);
-   virtual TR::Register *buildAlloca(TR::Node *callNode);
-   virtual TR::Register *pushStructArg(TR::Node* child);
-   virtual void notifyHasalloca(){}
-
-   protected:
-
-   TR::Register *buildDispatch(TR::Node *callNode);
-
-   };
-#endif
-
 }
 
 #endif

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -1516,7 +1516,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *n
    TR::RegisterDependencyConditions  *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
    dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
    dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-   TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+   J9::IA32PrivateLinkage *linkage = static_cast<J9::IA32PrivateLinkage>(cg->getLinkage(TR_Private));
    TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
    TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
    TR::X86ImmSymInstruction  *instr =
@@ -1630,7 +1630,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *n
    dependencies->addPostCondition(firstRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
    dependencies->addPostCondition(secondRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
 
-   TR::IA32PrivateLinkage *linkage = TR::toIA32PrivateLinkage(cg->getLinkage(TR_Private));
+   J9::IA32PrivateLinkage *linkage = static_cast<J9::IA32PrivateLinkage>(cg->getLinkage(TR_Private));
    TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
    TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
    TR::X86ImmSymInstruction  *instr =

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -134,12 +134,10 @@
 #if J9_PROJECT_SPECIFIC
 #include "z/codegen/S390Recompilation.hpp"
 #include "z/codegen/S390Register.hpp"
-#include "z/codegen/J9S390PrivateLinkage.hpp"
 #endif
 
 class TR_IGNode;
 namespace TR { class DebugCounterBase; }
-namespace TR { class S390PrivateLinkage; }
 namespace TR { class SimpleRegex; }
 
 #define OPT_DETAILS "O^O CODE GENERATION: "
@@ -810,7 +808,6 @@ bool OMR::Z::CodeGenerator::prepareForGRA()
    }
 
 TR::Linkage * OMR::Z::CodeGenerator::getS390Linkage() {return (self()->getLinkage());}
-TR::S390PrivateLinkage * OMR::Z::CodeGenerator::getS390PrivateLinkage() {return TR::toS390PrivateLinkage(self()->getLinkage());}
 
 TR::RealRegister * OMR::Z::CodeGenerator::getStackPointerRealRegister(TR::Symbol *symbol)
    {

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -95,7 +95,6 @@ namespace TR { class S390ConstantInstructionSnippet; }
 namespace TR { class S390EyeCatcherDataSnippet; }
 namespace TR { class S390ImmInstruction; }
 class TR_S390OutOfLineCodeSection;
-namespace TR { class S390PrivateLinkage; }
 class TR_S390ScratchRegisterManager;
 namespace TR { class S390WritableDataSnippet; }
 class TR_StorageReference;
@@ -368,7 +367,6 @@ public:
 
 //Convenience accessor methods
    TR::Linkage *getS390Linkage();
-   TR::S390PrivateLinkage *getS390PrivateLinkage();
 
    TR::RealRegister *getStackPointerRealRegister(TR::Symbol *symbol = NULL);
    TR::RealRegister *getEntryPointRealRegister();

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -50,7 +50,6 @@ namespace OMR { typedef OMR::Z::Linkage LinkageConnector; }
 
 class TR_FrontEnd;
 namespace TR { class S390JNICallDataSnippet; }
-namespace TR { class S390PrivateLinkage; }
 namespace TR { class AutomaticSymbol; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
@@ -178,18 +177,6 @@ enum TR_S390LinkageConventions
  */
 #define TR_FirstSpecialLinkageIndex  0x10
 
-namespace TR {
-
-/**
- * Pseudo-safe downcast function, since all linkages must be S390 linkages
- */
-inline TR::S390PrivateLinkage *
-toS390PrivateLinkage(TR::Linkage * l)
-   {
-   return (TR::S390PrivateLinkage *) l;
-   }
-
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 //  TR::S390Linkage Definition
@@ -370,7 +357,7 @@ enum TR_DispatchType
    virtual bool isAggregateReturnedInRegistersCall(TR::Node *callNode) { return false; }
    virtual bool isAggregateReturnedInIntRegistersAndMemory(int32_t aggregateLenth)   { return false; }
    virtual bool isAggregateReturnedInRegistersAndMemoryCall(TR::Node *callNode) { return false; }
-   
+
    int32_t  isForceSaveIncomingParameters() { return _properties & ForceSaveIncomingParameters; }
    int32_t  isLongDoubleReturnedOnStorage() { return _properties & LongDoubleReturnedOnStorage; }
    int32_t  isLongDoublePassedOnStorage() { return _properties & LongDoublePassedOnStorage; }


### PR DESCRIPTION
J9 private linkage has been largely isolated to OpenJ9 and moved
into the J9 namespace.  Remove unused references in OMR and for
code guarded in project-specific macros reference the appropriate
private linkage class in the J9 namespace.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>