### PR TITLE
AArch64: Implement PrefetchEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -839,6 +839,26 @@ OMR::ARM64::TreeEvaluator::passThroughEvaluator(TR::Node *node, TR::CodeGenerato
    return trgReg;
    }
 
+TR::Register *
+OMR::ARM64::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR_ASSERT(node->getNumChildren() == 4, "TR::Prefetch should contain 4 child nodes");
+
+   TR::Compilation *comp = cg->comp();
+   TR::Node *firstChild = node->getFirstChild();
+   TR::Node *secondChild = node->getChild(1);
+   TR::Node *sizeChild = node->getChild(2);
+   TR::Node *typeChild = node->getChild(3);
+
+   // Do nothing for now
+
+   cg->recursivelyDecReferenceCount(firstChild);
+   cg->recursivelyDecReferenceCount(secondChild);
+   cg->recursivelyDecReferenceCount(sizeChild);
+   cg->recursivelyDecReferenceCount(typeChild);
+   return NULL;
+   }
+
 TR::Instruction *
 OMR::ARM64::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *dstReg, TR::Register *srcReg, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -773,4 +773,4 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sbitpermuteEvaluator ,	// TR::sbitpermute
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::ibitpermuteEvaluator ,	// TR::ibitpermute
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lbitpermuteEvaluator ,	// TR::lbitpermute
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::PrefetchEvaluator, 		// TR::Prefetch
+    TR::TreeEvaluator::PrefetchEvaluator,		// TR::Prefetch

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2624,6 +2624,11 @@ OMR::Options::jitPreProcess()
          _disabledOptimizations[prefetchInsertion] = true;
          }
 
+#if defined(TR_HOST_ARM64)
+      // Prefetch is not supported on ARM64 yet
+      _disabledOptimizations[prefetchInsertion] = true;
+#endif
+
       self()->setOption(TR_DisableThunkTupleJ2I); // JSR292:TODO: Figure out how to do this without confusing startPCIfAlreadyCompiled
 
       self()->setOption(TR_DisableSeparateInitFromAlloc);


### PR DESCRIPTION
This commit implements a PrefetchEvaluator for AArch64.
It does not generate "PRFM" instructions yet.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>