### PR TITLE
Disable ExpandInstructionsPhase on codegens that don't use it

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1274,17 +1274,6 @@ OMR::CodeGenerator::removeUnusedLocals()
    self()->comp()->getMethodSymbol()->removeUnusedLocals();
    }
 
-
-void
-OMR::CodeGenerator::expandInstructions()
-   {
-   for (TR::Instruction *instr = self()->getFirstInstruction(); instr; instr = instr->getNext())
-      {
-      instr = instr->expandInstruction();
-      }
-   }
-
-
 bool OMR::CodeGenerator::areAssignableGPRsScarce()
    {
    int32_t threshold = 13;

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -428,7 +428,7 @@ class OMR_EXTENSIBLE CodeGenerator
    void spillLiveReferencesToTemps(TR::TreeTop *insertionTree, std::list<TR::SymbolReference*, TR::typed_allocator<TR::SymbolReference*, TR::Allocator> >::iterator firstAvailableSpillTemp);
    void needSpillTemp(TR_LiveReference * cursor, TR::Node*parent, TR::TreeTop *treeTop);
 
-   void expandInstructions();
+   void expandInstructions() {}
 
    friend void OMR::CodeGenPhase::performEmitSnippetsPhase(TR::CodeGenerator*, TR::CodeGenPhase *);
    friend void OMR::CodeGenPhase::performCleanUpFlagsPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase);

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1663,6 +1663,15 @@ OMR::Power::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    return linkage;
    }
 
+void
+OMR::Power::CodeGenerator::expandInstructions()
+   {
+   for (TR::Instruction *instr = self()->getFirstInstruction(); instr; instr = instr->getNext())
+      {
+      instr = instr->expandInstruction();
+      }
+   }
+
 void OMR::Power::CodeGenerator::generateBinaryEncodingPrologue(
       TR_PPCBinaryEncodingData *data)
    {

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -178,6 +178,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    void doRegisterAssignment(TR_RegisterKinds kindsToAssign);
    void doBinaryEncoding();
    void doPeephole();
+   void expandInstructions();
    virtual TR_RegisterPressureSummary *calculateRegisterPressure();
    void deleteInst(TR::Instruction* old);
    TR::Instruction *generateNop(TR::Node *n, TR::Instruction *preced = 0, TR_NOPKind nopKind=TR_NOPStandard);


### PR DESCRIPTION
Previously, ExpandInstructionsPhase would iterate over every instruction
and call a virtual method on each, even if the codegen in question
wasn't making use of it. Since only the Power codegen currently has
plans to make immediate use of this phase, other codegens do not need to
be doing this. To avoid performing unnecessary work, expandInstructions
is now stubbed out on all codegens other than Power.

Signed-off-by: Ben Thomas <ben@benthomas.ca>