### PR TITLE
Forward format args to trace function in nonfatal assertion

### DIFF
--- a/compiler/infra/Assert.cpp
+++ b/compiler/infra/Assert.cpp
@@ -134,6 +134,12 @@ static void traceAssertionFailure(const char * file, int32_t line, const char *c
 
 namespace TR
    {
+   static void OMR_NORETURN va_fatal_assertion(const char *file, int line, const char *condition, const char *format, va_list ap)
+      {
+      traceAssertionFailure(file, line, condition, format, ap);
+      TR::trap();
+      }
+
    void assertion(const char *file, int line, const char *condition, const char *format, ...)
       {
       TR::Compilation *comp = TR::comp();
@@ -146,15 +152,17 @@ namespace TR
          if (comp->getOption(TR_SoftFailOnAssume))
             comp->failCompilation<TR::AssertionFailure>("Assertion Failure");
          }
-      fatal_assertion(file, line, condition, format);
+      va_list ap;
+      va_start(ap, format);
+      va_fatal_assertion(file, line, condition, format, ap);
+      va_end(ap);
       }
 
    void OMR_NORETURN fatal_assertion(const char *file, int line, const char *condition, const char *format, ...)
       {
       va_list ap;
       va_start(ap, format);
-      traceAssertionFailure(file, line, condition, format, ap);
+      va_fatal_assertion(file, line, condition, format, ap);
       va_end(ap);
-      TR::trap();
       }
    }


### PR DESCRIPTION
TR::Assertion is passing the format string, but not the variadic
arguments, to fatal assert. This is causing crashes in the printing
helper.

This commit introduces a new function, va_fatal_assertion, which accepts
a va_list argument. Both assertion and fatal_assertion call this helper.

Using this helper, the arguments should be forwarded along correctly to
the printing helper.

Fixes: #4423
Signed-off-by: Robert Young <rwy0717@gmail.com>