### PR TITLE
AArch64: Set first instruction to block in BBStartEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -777,10 +777,15 @@ OMR::ARM64::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::CodeGenerator *c
       child->decReferenceCount();
       }
 
-   if (node->getLabel() != NULL)
+   TR::LabelSymbol *labelSym = node->getLabel();
+   if (!labelSym)
       {
-      node->getLabel()->setInstruction(generateLabelInstruction(cg, TR::InstOpCode::label, node, node->getLabel(), deps));
+      labelSym = generateLabelSymbol(cg);
+      node->setLabel(labelSym);
       }
+   TR::Instruction *labelInst = generateLabelInstruction(cg, TR::InstOpCode::label, node, labelSym, deps);
+   labelSym->setInstruction(labelInst);
+   block->setFirstInstruction(labelInst);
 
    TR::Node *fenceNode = TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC);
    TR::Instruction *fence = generateAdminInstruction(cg, TR::InstOpCode::fence, node, fenceNode);


### PR DESCRIPTION
Set first instruction to the block of the node in BBStartEvaluator in order to avoid
crash in `J9::CodeGenerator::generateCatchBlockBBStartPrologue`.
https://github.com/eclipse/openj9/blob/c91114a70f3b59d29c747a9ffe2a0a736a86546e/runtime/compiler/codegen/J9CodeGenerator.cpp#L4634

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>