### PR TITLE
Migrate processor/feature detection from OpenJ9 to OMR Part 1

### DIFF
--- a/fvtest/porttest/si.cpp
+++ b/fvtest/porttest/si.cpp
@@ -2343,3 +2343,34 @@ TEST(PortSysinfoTest, sysinfo_cgroup_get_memlimit)
 	reportTestExit(OMRPORTLIB, testName);
 	return;
 }
+
+/**
+ * Test GetProcessorDescription.
+ */
+TEST(PortSysinfoTest, GetProcessorDescription)
+{
+	OMRPORT_ACCESS_FROM_OMRPORT(portTestEnv->getPortLibrary());
+	OMRProcessorDesc desc;
+
+	ASSERT_NE(omrsysinfo_get_processor_description(&desc), -1);
+
+#if defined(J9X86) || defined(J9HAMMER)
+	ASSERT_GE(desc.processor, OMR_PROCESSOR_X86_UNKNOWN);
+	ASSERT_GE(desc.physicalProcessor, OMR_PROCESSOR_X86_UNKNOWN);
+#elif defined(AIXPPC) || defined(LINUXPPC)
+	ASSERT_GE(desc.processor, OMR_PROCESSOR_PPC_UNKNOWN);
+	ASSERT_LT(desc.processor, OMR_PROCESSOR_X86_UNKNOWN);
+	ASSERT_GE(desc.physicalProcessor, OMR_PROCESSOR_PPC_UNKNOWN);
+	ASSERT_LT(desc.physicalProcessor, OMR_PROCESSOR_X86_UNKNOWN);
+#elif defined(S390) || defined(J9ZOS390)
+	ASSERT_GE(desc.processor, OMR_PROCESSOR_S390_UNKNOWN);
+	ASSERT_LT(desc.processor, OMR_PROCESSOR_PPC_UNKNOWN);
+	ASSERT_GE(desc.physicalProcessor, OMR_PROCESSOR_S390_UNKNOWN);
+	ASSERT_LT(desc.physicalProcessor, OMR_PROCESSOR_PPC_UNKNOWN);
+#endif
+	
+	for (int i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE * 32; i++) {
+		BOOLEAN feature = omrsysinfo_processor_has_feature(&desc, i);
+		ASSERT_TRUE(feature == TRUE || feature == FALSE);
+	}
+}

--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1161,6 +1161,314 @@ typedef struct OMROSKernelInfo {
 #define OMR_CGROUP_SUBSYSTEM_CPUSET ((uint64_t)0x4)
 #define OMR_CGROUP_SUBSYSTEM_ALL (OMR_CGROUP_SUBSYSTEM_CPU | OMR_CGROUP_SUBSYSTEM_MEMORY | OMR_CGROUP_SUBSYSTEM_CPUSET)
 
+
+/* List of all processors that are currently supported by OMR's processor detection */
+
+typedef enum OMRProcessorArchitecture {
+
+	OMR_PROCESSOR_UNDEFINED,
+
+	OMR_PROCESSOR_S390_UNKNOWN,
+	OMR_PROCESSOR_S390_GP6,
+	OMR_PROCESSOR_S390_GP7,
+	OMR_PROCESSOR_S390_GP8,
+	OMR_PROCESSOR_S390_GP9,
+	OMR_PROCESSOR_S390_GP10,
+	OMR_PROCESSOR_S390_GP11,
+	OMR_PROCESSOR_S390_GP12,
+	OMR_PROCESSOR_S390_GP13,
+	OMR_PROCESSOR_S390_GP14,
+
+	OMR_PROCESSOR_PPC_UNKNOWN,
+	OMR_PROCESSOR_PPC_7XX,
+	OMR_PROCESSOR_PPC_GP,
+	OMR_PROCESSOR_PPC_GR,
+	OMR_PROCESSOR_PPC_NSTAR,
+	OMR_PROCESSOR_PPC_PULSAR,
+	OMR_PROCESSOR_PPC_PWR403,
+	OMR_PROCESSOR_PPC_PWR405,
+	OMR_PROCESSOR_PPC_PWR440,
+	OMR_PROCESSOR_PPC_PWR601,
+	OMR_PROCESSOR_PPC_PWR602,
+	OMR_PROCESSOR_PPC_PWR603,
+	OMR_PROCESSOR_PPC_PWR604,
+	OMR_PROCESSOR_PPC_PWR620,
+	OMR_PROCESSOR_PPC_PWR630,
+	OMR_PROCESSOR_PPC_RIOS1,
+	OMR_PROCESSOR_PPC_RIOS2,
+	OMR_PROCESSOR_PPC_P6,
+	OMR_PROCESSOR_PPC_P7,
+	OMR_PROCESSOR_PPC_P8,
+	OMR_PROCESSOR_PPC_P9,
+
+	OMR_PROCESSOR_X86_UNKNOWN,
+	OMR_PROCESSOR_X86_INTELPENTIUM,
+	OMR_PROCESSOR_X86_INTELP6,
+	OMR_PROCESSOR_X86_INTELPENTIUM4,
+	OMR_PROCESSOR_X86_INTELCORE2,
+	OMR_PROCESSOR_X86_INTELTULSA,
+	OMR_PROCESSOR_X86_INTELNEHALEM,
+	OMR_PROCESSOR_X86_INTELWESTMERE,
+	OMR_PROCESSOR_X86_INTELSANDYBRIDGE,
+	OMR_PROCESSOR_X86_INTELHASWELL,
+	OMR_PROCESSOR_X86_AMDK5,
+	OMR_PROCESSOR_X86_AMDK6,
+	OMR_PROCESSOR_X86_AMDATHLONDURON,
+	OMR_PROCESSOR_X86_AMDOPTERON,
+
+	OMR_PROCESSOR_DUMMY = 0x40000000 /* force wide enums */
+
+} OMRProcessorArchitecture;
+
+/* Holds processor type and features used with j9sysinfo_get_processor_description
+ * and j9sysinfo_processor_has_feature
+ */
+#define OMRPORT_SYSINFO_FEATURES_SIZE 5
+typedef struct OMRProcessorDesc {
+	OMRProcessorArchitecture processor;
+	OMRProcessorArchitecture physicalProcessor;
+	uint32_t features[OMRPORT_SYSINFO_FEATURES_SIZE];
+} OMRProcessorDesc;
+
+/* PowerPC features
+ * Auxiliary Vector Hardware Capability (AT_HWCAP) features for PowerPC.
+ */
+#define OMRPORT_PPC_FEATURE_32                    31 /* 32-bit mode.  */
+#define OMRPORT_PPC_FEATURE_64                    30 /* 64-bit mode.  */
+#define OMRPORT_PPC_FEATURE_601_INSTR             29 /* 601 chip, Old POWER ISA.  */
+#define OMRPORT_PPC_FEATURE_HAS_ALTIVEC           28 /* SIMD/Vector Unit.  */
+#define OMRPORT_PPC_FEATURE_HAS_FPU               27 /* Floating Point Unit.  */
+#define OMRPORT_PPC_FEATURE_HAS_MMU               26 /* Memory Management Unit.  */
+#define OMRPORT_PPC_FEATURE_HAS_4xxMAC            25 /* 4xx Multiply Accumulator.  */
+#define OMRPORT_PPC_FEATURE_UNIFIED_CACHE         24 /* Unified I/D cache.  */
+#define OMRPORT_PPC_FEATURE_HAS_SPE               23 /* Signal Processing ext.  */
+#define OMRPORT_PPC_FEATURE_HAS_EFP_SINGLE        22 /* SPE Float.  */
+#define OMRPORT_PPC_FEATURE_HAS_EFP_DOUBLE        21 /* SPE Double.  */
+#define OMRPORT_PPC_FEATURE_NO_TB                 20 /* 601/403gx have no timebase.  */
+#define OMRPORT_PPC_FEATURE_POWER4                19 /* POWER4 ISA 2.01.  */
+#define OMRPORT_PPC_FEATURE_POWER5                18 /* POWER5 ISA 2.02.  */
+#define OMRPORT_PPC_FEATURE_POWER5_PLUS           17 /* POWER5+ ISA 2.03.  */
+#define OMRPORT_PPC_FEATURE_CELL_BE               16 /* CELL Broadband Engine */
+#define OMRPORT_PPC_FEATURE_BOOKE                 15 /* ISA Embedded Category.  */
+#define OMRPORT_PPC_FEATURE_SMT                   14 /* Simultaneous Multi-Threading.  */
+#define OMRPORT_PPC_FEATURE_ICACHE_SNOOP          13
+#define OMRPORT_PPC_FEATURE_ARCH_2_05             12 /* ISA 2.05.  */
+#define OMRPORT_PPC_FEATURE_PA6T                  11 /* PA Semi 6T Core.  */
+#define OMRPORT_PPC_FEATURE_HAS_DFP               10 /* Decimal FP Unit.  */
+#define OMRPORT_PPC_FEATURE_POWER6_EXT             9 /* P6 + mffgpr/mftgpr.  */
+#define OMRPORT_PPC_FEATURE_ARCH_2_06              8 /* ISA 2.06.  */
+#define OMRPORT_PPC_FEATURE_HAS_VSX                7 /* P7 Vector Scalar Extension.  */
+#define OMRPORT_PPC_FEATURE_PSERIES_PERFMON_COMPAT 6 /* Has ISA >= 2.05 PMU basic subset support.  */
+#define OMRPORT_PPC_FEATURE_TRUE_LE                1 /* Processor in true Little Endian mode.  */
+#define OMRPORT_PPC_FEATURE_PPC_LE                 0 /* Processor emulates Little Endian Mode.  */
+
+#define OMRPORT_PPC_FEATURE_ARCH_2_07             32 + 31
+#define OMRPORT_PPC_FEATURE_HTM                   32 + 30
+#define OMRPORT_PPC_FEATURE_DSCR                  32 + 29
+#define OMRPORT_PPC_FEATURE_EBB                   32 + 28
+#define OMRPORT_PPC_FEATURE_ISEL                  32 + 27
+#define OMRPORT_PPC_FEATURE_TAR                   32 + 26
+
+/* s390 features
+ * z/Architecture Principles of Operation 4-69
+ * STORE FACILITY LIST EXTENDED (STFLE)
+ */
+#define OMRPORT_S390_FEATURE_ESAN3      0 /* STFLE bit 0 */
+#define OMRPORT_S390_FEATURE_ZARCH      1 /* STFLE bit 2 */
+#define OMRPORT_S390_FEATURE_STFLE      2 /* STFLE bit 7 */
+#define OMRPORT_S390_FEATURE_MSA        3 /* STFLE bit 17 */
+#define OMRPORT_S390_FEATURE_DFP        6 /* STFLE bit 42 & 44 */
+#define OMRPORT_S390_FEATURE_HPAGE      7
+#define OMRPORT_S390_FEATURE_TE        10 /* STFLE bit 50 & 73 */
+#define OMRPORT_S390_FEATURE_MSA_EXTENSION3                      11 /* STFLE bit 76 */
+#define OMRPORT_S390_FEATURE_MSA_EXTENSION4                      12 /* STFLE bit 77 */
+
+#define OMRPORT_S390_FEATURE_COMPARE_AND_SWAP_AND_STORE          32 + 0  /* STFLE bit 32 */
+#define OMRPORT_S390_FEATURE_COMPARE_AND_SWAP_AND_STORE2         32 + 1  /* STFLE bit 33 */
+#define OMRPORT_S390_FEATURE_EXECUTE_EXTENSIONS                  32 + 3  /* STFLE bit 35 */
+#define OMRPORT_S390_FEATURE_FPE                                 32 + 9  /* STFLE bit 41 */
+
+#define OMRPORT_S390_FEATURE_RI            64 + 0 /* STFLE bit 64 */
+
+/* z990 facilities */
+
+/* STFLE bit 19 - Long-displacement facility */
+#define OMRPORT_S390_FEATURE_LONG_DISPLACEMENT 19
+
+/* z9 facilities */
+
+/* STFLE bit 21 - Extended-immediate facility */
+#define OMRPORT_S390_FEATURE_EXTENDED_IMMEDIATE 21
+
+/* STFLE bit 22 - Extended-translation facility 3 */
+#define OMRPORT_S390_FEATURE_EXTENDED_TRANSLATION_3 22
+
+/* STFLE bit 30 - ETF3-enhancement facility */
+#define OMRPORT_S390_FEATURE_ETF3_ENHANCEMENT 30
+
+/* z10 facilities */
+
+/* STFLE bit 34 - General-instructions-extension facility */
+#define OMRPORT_S390_FEATURE_GENERAL_INSTRUCTIONS_EXTENSIONS 34
+
+/* z196 facilities */
+
+/* STFLE bit 45 - High-word facility */
+#define OMRPORT_S390_FEATURE_HIGH_WORD 45
+
+/* STFLE bit 45 - Load/store-on-condition facility 1 */
+#define OMRPORT_S390_FEATURE_LOAD_STORE_ON_CONDITION_1 45
+
+/* zEC12 facilities */
+
+/* STFLE bit 49 - Miscellaneous-instruction-extension facility */
+#define OMRPORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION 49
+
+/* z13 facilities */
+
+/* STFLE bit 53 - Load/store-on-condition facility 2 */
+#define OMRPORT_S390_FEATURE_LOAD_STORE_ON_CONDITION_2 53
+
+/* STFLE bit 53 - Load-and-zero-rightmost-byte facility */
+#define OMRPORT_S390_FEATURE_LOAD_AND_ZERO_RIGHTMOST_BYTE 53
+
+/* STFLE bit 129 - Vector facility */
+#define OMRPORT_S390_FEATURE_VECTOR_FACILITY 129
+
+/* z14 facilities */
+
+/* STFLE bit 58 - Miscellaneous-instruction-extensions facility 2 */
+#define OMRPORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_2 58
+
+/* STFLE bit 59 - Semaphore-assist facility */
+#define OMRPORT_S390_FEATURE_SEMAPHORE_ASSIST 59
+
+/* STFLE bit 131 - Side-effect-access facility */
+#define OMRPORT_S390_FEATURE_SIDE_EFFECT_ACCESS 131
+
+/* STFLE bit 133 - Guarded-storage facility */
+#define OMRPORT_S390_FEATURE_GUARDED_STORAGE 133
+
+/* STFLE bit 134 - Vector packed decimal facility */
+#define OMRPORT_S390_FEATURE_VECTOR_PACKED_DECIMAL 134
+
+/* STFLE bit 135 - Vector enhancements facility 1 */
+#define OMRPORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_1 135
+
+/* STFLE bit 146 - Message-security-assist-extension-8 facility */
+#define OMRPORT_S390_FEATURE_MSA_EXTENSION_8 146
+
+/* STFLE bit 57 - Message-security-assist-extension-5 facility */
+#define OMRPORT_S390_FEATURE_MSA_EXTENSION_5 57
+
+/* z15 facilities */
+
+/* STFLE bit 61 - Miscellaneous-instruction-extensions facility 3 */ 
+#define OMRPORT_S390_FEATURE_MISCELLANEOUS_INSTRUCTION_EXTENSION_3 61
+
+/* STFLE bit 148 - Vector enhancements facility 2 */
+#define OMRPORT_S390_FEATURE_VECTOR_FACILITY_ENHANCEMENT_2 148
+
+/* STFLE bit 152 - Vector packed decimal enhancement facility */
+#define OMRPORT_S390_FEATURE_VECTOR_PACKED_DECIMAL_ENHANCEMENT_FACILITY 152
+
+
+/*  Linux on Z features
+ *  Auxiliary Vector Hardware Capability (AT_HWCAP) features for Linux on Z.
+ *  Obtained from: https://github.com/torvalds/linux/blob/050cdc6c9501abcd64720b8cc3e7941efee9547d/arch/s390/include/asm/elf.h#L94-L109.
+ *  If new facility support is required, then it must be defined there (and here), before we can check for it consistently.
+ *
+ *  The linux kernel will use the defines in the above link to set HWCAP features. This is done inside "setup_hwcaps(void)" routine found
+ *  in arch/s390/kernel/setup.c in the linux kernel source tree.
+ */
+#define OMRPORT_HWCAP_S390_ESAN3     0x1
+#define OMRPORT_HWCAP_S390_ZARCH     0x2
+#define OMRPORT_HWCAP_S390_STFLE     0x4
+#define OMRPORT_HWCAP_S390_MSA       0x8
+#define OMRPORT_HWCAP_S390_LDISP     0x10
+#define OMRPORT_HWCAP_S390_EIMM      0x20
+#define OMRPORT_HWCAP_S390_DFP       0x40
+#define OMRPORT_HWCAP_S390_HPAGE     0x80
+#define OMRPORT_HWCAP_S390_ETF3EH    0x100
+#define OMRPORT_HWCAP_S390_HIGH_GPRS 0x200
+#define OMRPORT_HWCAP_S390_TE        0x400
+#define OMRPORT_HWCAP_S390_VXRS      0x800
+#define OMRPORT_HWCAP_S390_VXRS_BCD  0x1000
+#define OMRPORT_HWCAP_S390_VXRS_EXT  0x2000
+#define OMRPORT_HWCAP_S390_GS        0x4000
+
+/* x86 features
+ * INTEL INSTRUCTION SET REFERENCE, A-M
+ * 3-170 Vol. 2A Table 3-21. More on Feature Information Returned in the EDX Register
+ */
+#define OMRPORT_X86_FEATURE_FPU     0 /* Floating Point Unit On-Chip. */
+#define OMRPORT_X86_FEATURE_VME     1 /* Virtual 8086 Mode Enhancements. */
+#define OMRPORT_X86_FEATURE_DE      2 /* DE Debugging Extensions. */
+#define OMRPORT_X86_FEATURE_PSE     3 /* Page Size Extension. */
+#define OMRPORT_X86_FEATURE_TSC     4 /* Time Stamp Counter. */
+#define OMRPORT_X86_FEATURE_MSR     5 /* Model Specific Registers RDMSR and WRMSR Instructions. */
+#define OMRPORT_X86_FEATURE_PAE     6 /* Physical Address Extension. */
+#define OMRPORT_X86_FEATURE_MCE     7 /* Machine Check Exception. */
+#define OMRPORT_X86_FEATURE_CX8     8 /* Compare-and-exchange 8 bytes (64 bits) instruction */
+#define OMRPORT_X86_FEATURE_APIC    9 /* APIC On-Chip. */
+#define OMRPORT_X86_FEATURE_10     10 /* Reserved */
+#define OMRPORT_X86_FEATURE_SEP    11 /* SYSENTER and SYSEXIT Instructions. */
+#define OMRPORT_X86_FEATURE_MTRR   12 /* Memory Type Range Registers. */
+#define OMRPORT_X86_FEATURE_PGE    13 /* Page Global Bit. */
+#define OMRPORT_X86_FEATURE_MCA    14 /* Machine Check Architecture. */
+#define OMRPORT_X86_FEATURE_CMOV   15 /* Conditional Move Instructions. */
+#define OMRPORT_X86_FEATURE_PAT    16 /* Page Attribute Table. */
+#define OMRPORT_X86_FEATURE_PSE_36 17 /* 36-Bit Page Size Extension. */
+#define OMRPORT_X86_FEATURE_PSN    18 /* Processor Serial Number. */
+#define OMRPORT_X86_FEATURE_CLFSH  19 /* CLFLUSH Instruction. */
+#define OMRPORT_X86_FEATURE_20     20 /* Reserved */
+#define OMRPORT_X86_FEATURE_DS     21 /* Debug Store. */
+#define OMRPORT_X86_FEATURE_ACPI   22 /* Thermal Monitor and Software Controlled Clock Facilities. */
+#define OMRPORT_X86_FEATURE_MMX    23 /* Intel MMX Technology. */
+#define OMRPORT_X86_FEATURE_FXSR   24 /* FXSAVE and FXRSTOR Instructions. */
+#define OMRPORT_X86_FEATURE_SSE    25 /* The processor supports the SSE extensions. */
+#define OMRPORT_X86_FEATURE_SSE2   26 /* The processor supports the SSE2 extensions. */
+#define OMRPORT_X86_FEATURE_SS     27 /* Self Snoop. */
+#define OMRPORT_X86_FEATURE_HTT    28 /* Hyper Threading. */
+#define OMRPORT_X86_FEATURE_TM     29 /* Thermal Monitor. */
+#define OMRPORT_X86_FEATURE_30     30 /* Reserved */
+#define OMRPORT_X86_FEATURE_PBE    31 /* Pending Break Enable. */
+
+/* INTEL INSTRUCTION SET REFERENCE, A-M
+ * Vol. 2A 3-167 Table 3-20. Feature Information Returned in the ECX Register
+ */
+#define OMRPORT_X86_FEATURE_SSE3         32 + 0 /* Streaming SIMD Extensions 3 */
+#define OMRPORT_X86_FEATURE_PCLMULQDQ    32 + 1 /* PCLMULQDQ. */
+#define OMRPORT_X86_FEATURE_DTES64       32 + 2 /* 64-bit DS Area. */
+#define OMRPORT_X86_FEATURE_MONITOR      32 + 3 /* MONITOR/MWAIT. */
+#define OMRPORT_X86_FEATURE_DS_CPL       32 + 4 /* CPL Qualified Debug Store. */
+#define OMRPORT_X86_FEATURE_VMX          32 + 5 /* Virtual Machine Extensions. */
+#define OMRPORT_X86_FEATURE_SMX          32 + 6 /* Safer Mode Extensions. */
+#define OMRPORT_X86_FEATURE_EIST         32 + 7 /* Enhanced Intel SpeedStep technology. */
+#define OMRPORT_X86_FEATURE_TM2          32 + 8 /* Thermal Monitor 2. */
+#define OMRPORT_X86_FEATURE_SSSE3        32 + 9 /* Supplemental Streaming SIMD Extensions 3 */
+#define OMRPORT_X86_FEATURE_CNXT_ID      32 + 10 /* L1 Context ID. */
+#define OMRPORT_X86_FEATURE_11           32 + 11 /* Reserved */
+#define OMRPORT_X86_FEATURE_FMA          32 + 12 /* FMA extensions using YMM state. */
+#define OMRPORT_X86_FEATURE_CMPXCHG16B   32 + 13 /* CMPXCHG16B Available. */
+#define OMRPORT_X86_FEATURE_XTPR         32 + 14 /* xTPR Update Control. */
+#define OMRPORT_X86_FEATURE_PDCM         32 + 15 /* Perfmon and Debug Capability. */
+#define OMRPORT_X86_FEATURE_16           32 + 16 /* Reserved. */
+#define OMRPORT_X86_FEATURE_PCID         32 + 17 /* Process-context identifiers. */
+#define OMRPORT_X86_FEATURE_DCA          32 + 18 /* Processor supports the ability to prefetch data from a memory mapped device. */
+#define OMRPORT_X86_FEATURE_SSE4_1       32 + 19 /* Processor supports SSE4.1. */
+#define OMRPORT_X86_FEATURE_SSE4_2       32 + 20 /* Processor supports SSE4.2. */
+#define OMRPORT_X86_FEATURE_X2APIC       32 + 21 /* Processor supports x2APIC feature. */
+#define OMRPORT_X86_FEATURE_MOVBE        32 + 22 /* Processor supports MOVBE instruction. */
+#define OMRPORT_X86_FEATURE_POPCNT       32 + 23 /* Processor supports the POPCNT instruction. */
+#define OMRPORT_X86_FEATURE_TSC_DEADLINE 32 + 24 /* Processor's local APIC timer supports one-shot operation using a TSC deadline value. */
+#define OMRPORT_X86_FEATURE_AESNI        32 + 25 /* Processor supports the AESNI instruction extensions. */
+#define OMRPORT_X86_FEATURE_XSAVE        32 + 26 /* Processor supports the XSAVE/XRSTOR processor extended states. */
+#define OMRPORT_X86_FEATURE_OSXSAVE      32 + 27 /* OS has enabled XSETBV/XGETBV instructions to access XCR0, and support for processor extended state management using XSAVE/XRSTOR. */
+#define OMRPORT_X86_FEATURE_AVX          32 + 28 /* Processor supports the AVX instruction extensions. */
+#define OMRPORT_X86_FEATURE_F16C         32 + 29 /* 16-bit floating-point conversion instructions. */
+#define OMRPORT_X86_FEATURE_RDRAND       32 + 30 /* Processor supports RDRAND instruction. */
+
 struct OMRPortLibrary;
 typedef struct J9Heap J9Heap;
 
@@ -1242,6 +1550,10 @@ typedef struct OMRPortLibrary {
 	intptr_t (*sysinfo_get_env)(struct OMRPortLibrary *portLibrary, const char *envVar, char *infoString, uintptr_t bufSize) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_CPU_architecture "omrsysinfo_get_CPU_architecture"*/
 	const char *(*sysinfo_get_CPU_architecture)(struct OMRPortLibrary *portLibrary) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_get_processor_description "omrsysinfo_get_processor_description"*/
+	intptr_t  ( *sysinfo_get_processor_description)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc) ;
+	/** see @ref omrsysinfo.c::omrsysinfo_processor_has_feature "omrsysinfo_processor_has_feature"*/
+	BOOLEAN  ( *sysinfo_processor_has_feature)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_OS_type "omrsysinfo_get_OS_type"*/
 	const char *(*sysinfo_get_OS_type)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_executable_name "omrsysinfo_get_executable_name"*/
@@ -1945,6 +2257,8 @@ extern J9_CFUNC int32_t omrport_getVersion(struct OMRPortLibrary *portLibrary);
 #define omrsysinfo_get_OS_version() privateOmrPortLibrary->sysinfo_get_OS_version(privateOmrPortLibrary)
 #define omrsysinfo_get_env(param1,param2,param3) privateOmrPortLibrary->sysinfo_get_env(privateOmrPortLibrary, (param1), (param2), (param3))
 #define omrsysinfo_get_CPU_architecture() privateOmrPortLibrary->sysinfo_get_CPU_architecture(privateOmrPortLibrary)
+#define omrsysinfo_get_processor_description(param1) privateOmrPortLibrary->sysinfo_get_processor_description(privateOmrPortLibrary,param1)
+#define omrsysinfo_processor_has_feature(param1,param2) privateOmrPortLibrary->sysinfo_processor_has_feature(privateOmrPortLibrary,param1,param2)
 #define omrsysinfo_get_OS_type() privateOmrPortLibrary->sysinfo_get_OS_type(privateOmrPortLibrary)
 #define omrsysinfo_get_executable_name(param1,param2) privateOmrPortLibrary->sysinfo_get_executable_name(privateOmrPortLibrary, (param1), (param2))
 #define omrsysinfo_get_username(param1,param2) privateOmrPortLibrary->sysinfo_get_username(privateOmrPortLibrary, (param1), (param2))

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -193,9 +193,7 @@ list(APPEND OBJECTS
 	omrsysinfo.c
 )
 
-if(OMR_HOST_OS STREQUAL zos)
-	list(APPEND OBJECTS omrsysinfo_helpers.c)
-endif()
+list(APPEND OBJECTS omrsysinfo_helpers.c)
 
 list(APPEND OBJECTS omrsyslog.c)
 

--- a/port/common/omrport.c
+++ b/port/common/omrport.c
@@ -72,6 +72,8 @@ static OMRPortLibrary MasterPortLibraryTable = {
 	omrsysinfo_get_OS_version, /* sysinfo_get_OS_version */
 	omrsysinfo_get_env, /* sysinfo_get_env */
 	omrsysinfo_get_CPU_architecture, /* sysinfo_get_CPU_architecture */
+	omrsysinfo_get_processor_description, /* omrsysinfo_get_processor_description */
+	omrsysinfo_processor_has_feature, /* omrsysinfo_processor_has_feature */
 	omrsysinfo_get_OS_type, /* sysinfo_get_OS_type */
 	omrsysinfo_get_executable_name, /* sysinfo_get_executable_name */
 	omrsysinfo_get_username, /* sysinfo_get_username */

--- a/port/common/omrport.tdf
+++ b/port/common/omrport.tdf
@@ -1101,3 +1101,9 @@ TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_parseFirstA
 TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_parseDashFailed Group=mem Overhead=1 Level=5 NoEnv Template="findAvailableMemoryBlockNoMalloc parser failed to get dash from line (%s)"
 TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_parseSecondAddressFailed Group=mem Overhead=1 Level=5 NoEnv Template="findAvailableMemoryBlockNoMalloc parser failed to get second address from line (%s)"
 TraceException=Trc_PRT_vmem_omrvmem_findAvailableMemoryBlockNoMalloc_addressesMismatch Group=mem Overhead=1 Level=5 NoEnv Template="findAvailableMemoryBlockNoMalloc parser found addresses mismatch from line (%s)"
+
+TraceEntry=Trc_PRT_sysinfo_get_processor_description_Entered Group=j9sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_processor_description: desc = %p"
+TraceExit=Trc_PRT_sysinfo_get_processor_description_Exit Group=j9sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_get_processor_description: returning with %zd"
+
+TraceEntry=Trc_PRT_sysinfo_processor_has_feature_Entered Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_has_feature: desc = %p, feature = %d"
+TraceExit=Trc_PRT_sysinfo_processor_has_feature_Exit Group=sysinfo Overhead=1 Level=5 NoEnv Template="sysinfo_processor_has_feature: returning with %zu."

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -89,6 +89,42 @@ omrsysinfo_get_CPU_architecture(struct OMRPortLibrary *portLibrary)
 	return "unknown";
 #endif
 }
+
+/**
+ * Determine CPU type and features.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[out] desc pointer to the struct that will contain the CPU type and features.
+ *              - desc will still be initialized if there is a failure.
+ *
+ * @return 0 on success, -1 on failure
+ */
+intptr_t
+omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
+{
+	Trc_PRT_sysinfo_get_processor_description_Entered(desc);
+	intptr_t rc = OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
+	Trc_PRT_sysinfo_get_processor_description_Exit(rc);
+	return rc;
+}
+
+/**
+ * Determine if a CPU feature is present.
+ *
+ * @param[in] portLibrary The port library.
+ * @param[in] desc The struct that will contain the CPU type and features.
+ * @param[in] feature The feature to check (see j9port.h for list of features J9PORT_{PPC,S390,PPC}_FEATURE_*)
+ *
+ * @return TRUE if feature is present, FALSE otherwise.
+ */
+BOOLEAN
+omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature)
+{
+	Trc_PRT_sysinfo_processor_has_feature_Entered(desc, feature);
+	BOOLEAN rc = FALSE;
+	Trc_PRT_sysinfo_processor_has_feature_Exit((uintptr_t)rc);
+	return rc;
+}
 /**
  * Query the operating system for environment variables.
  *

--- a/port/common/omrsysinfo_helpers.c
+++ b/port/common/omrsysinfo_helpers.c
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/**
+ * @file
+ * @ingroup Port
+ * @brief System information
+ */
+
+#include "omrsysinfo_helpers.h"
+ 
+#include "omrport.h"
+#include "omrporterror.h"
+#include "portnls.h"
+
+#include <string.h>
+#if defined(WIN32)
+#include <intrin.h>
+#endif /* defined(WIN32) */
+
+/* defines for the CPUID instruction */
+#define CPUID_VENDOR_INFO                   0
+#define CPUID_FAMILY_INFO                   1
+
+#define CPUID_VENDOR_INTEL                  "GenuineIntel"
+#define CPUID_VENDOR_AMD                    "AuthenticAMD"
+#define CPUID_VENDOR_LENGTH                 12
+
+#define CPUID_SIGNATURE_FAMILY              0x00000F00
+#define CPUID_SIGNATURE_MODEL               0x000000F0
+#define CPUID_SIGNATURE_EXTENDEDMODEL       0x000F0000
+
+#define CPUID_SIGNATURE_FAMILY_SHIFT        8
+#define CPUID_SIGNATURE_MODEL_SHIFT         4
+#define CPUID_SIGNATURE_EXTENDEDMODEL_SHIFT 12
+
+#define CPUID_FAMILYCODE_INTELPENTIUM       0x05
+#define CPUID_FAMILYCODE_INTELCORE          0x06
+#define CPUID_FAMILYCODE_INTELPENTIUM4      0x0F
+
+#define CPUID_MODELCODE_INTELHASWELL        0x3A
+#define CPUID_MODELCODE_SANDYBRIDGE         0x2A
+#define CPUID_MODELCODE_INTELWESTMERE       0x25
+#define CPUID_MODELCODE_INTELNEHALEM        0x1E
+#define CPUID_MODELCODE_INTELCORE2          0x0F
+
+#define CPUID_FAMILYCODE_AMDKSERIES         0x05
+#define CPUID_FAMILYCODE_AMDATHLON          0x06
+#define CPUID_FAMILYCODE_AMDOPTERON         0x0F
+
+#define CPUID_MODELCODE_AMDK5               0x04
+
+/**
+ * @internal
+ * Populates OMRProcessorDesc *desc on Windows and Linux (x86)
+ *
+ * @param[in] desc pointer to the struct that will contain the CPU type and features.
+ *
+ * @return 0 on success, -1 on failure
+ */
+intptr_t
+getX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
+{
+	uint32_t CPUInfo[4] = {0};
+	char vendor[12];
+	uint32_t familyCode = 0;
+	uint32_t processorSignature = 0;
+
+	desc->processor = OMR_PROCESSOR_X86_UNKNOWN;
+
+	/* vendor */
+	getX86CPUID(CPUID_VENDOR_INFO, CPUInfo);
+	memcpy(vendor + 0, &CPUInfo[1], sizeof(uint32_t));
+	memcpy(vendor + 4, &CPUInfo[3], sizeof(uint32_t));
+	memcpy(vendor + 8, &CPUInfo[2], sizeof(uint32_t));
+
+	/* family and model */
+	getX86CPUID(CPUID_FAMILY_INFO, CPUInfo);
+	processorSignature = CPUInfo[0];
+	familyCode = (processorSignature & CPUID_SIGNATURE_FAMILY) >> CPUID_SIGNATURE_FAMILY_SHIFT;
+	if (0 == strncmp(vendor, CPUID_VENDOR_INTEL, CPUID_VENDOR_LENGTH)) {
+		switch (familyCode) {
+		case CPUID_FAMILYCODE_INTELPENTIUM:
+			desc->processor = OMR_PROCESSOR_X86_INTELPENTIUM;
+			break;
+		case CPUID_FAMILYCODE_INTELCORE:
+		{
+			uint32_t modelCode  = (processorSignature & CPUID_SIGNATURE_MODEL) >> CPUID_SIGNATURE_MODEL_SHIFT;
+			uint32_t extendedModelCode = (processorSignature & CPUID_SIGNATURE_EXTENDEDMODEL) >> CPUID_SIGNATURE_EXTENDEDMODEL_SHIFT;
+			uint32_t totalModelCode = modelCode + extendedModelCode;
+
+			if (totalModelCode > CPUID_MODELCODE_INTELHASWELL) {
+				desc->processor = OMR_PROCESSOR_X86_INTELHASWELL;
+			} else if (totalModelCode >= CPUID_MODELCODE_SANDYBRIDGE) {
+				desc->processor = OMR_PROCESSOR_X86_INTELSANDYBRIDGE;
+			} else if (totalModelCode >= CPUID_MODELCODE_INTELWESTMERE) {
+				desc->processor = OMR_PROCESSOR_X86_INTELWESTMERE;
+			} else if (totalModelCode >= CPUID_MODELCODE_INTELNEHALEM) {
+				desc->processor = OMR_PROCESSOR_X86_INTELNEHALEM;
+			} else if (totalModelCode == CPUID_MODELCODE_INTELCORE2) {
+				desc->processor = OMR_PROCESSOR_X86_INTELCORE2;
+			} else {
+				desc->processor = OMR_PROCESSOR_X86_INTELP6;
+			}
+			break;
+		}
+		case CPUID_FAMILYCODE_INTELPENTIUM4:
+			desc->processor = OMR_PROCESSOR_X86_INTELPENTIUM4;
+			break;
+		}
+	} else if (0 == strncmp(vendor, CPUID_VENDOR_AMD, CPUID_VENDOR_LENGTH)) {
+		switch (familyCode) {
+		case CPUID_FAMILYCODE_AMDKSERIES:
+		{
+			uint32_t modelCode  = (processorSignature & CPUID_SIGNATURE_FAMILY) >> CPUID_SIGNATURE_MODEL_SHIFT;
+			if (modelCode < CPUID_MODELCODE_AMDK5) {
+				desc->processor = OMR_PROCESSOR_X86_AMDK5;
+			}
+			desc->processor = OMR_PROCESSOR_X86_AMDK6;
+			break;
+		}
+		case CPUID_FAMILYCODE_AMDATHLON:
+			desc->processor = OMR_PROCESSOR_X86_AMDATHLONDURON;
+			break;
+		case CPUID_FAMILYCODE_AMDOPTERON:
+			desc->processor = OMR_PROCESSOR_X86_AMDOPTERON;
+			break;
+		}
+	}
+
+	desc->physicalProcessor = desc->processor;
+
+	/* features */
+	desc->features[0] = CPUInfo[3];
+	desc->features[1] = CPUInfo[2];
+	desc->features[2] = 0; /* reserved for future expansion */
+
+	return 0;
+}
+
+/**
+ * Assembly code to get the register data from CPUID instruction
+ * This function executes the CPUID instruction based on which we can detect
+ * if the environment is virtualized or not, and also get the Hypervisor Vendor
+ * Name based on the same instruction. The leaf value specifies what information
+ * to return.
+ *
+ * @param[in] 	leaf The leaf value to the CPUID instruction.
+ * @param[out]	cpuInfo 	Reference to the an integer array which holds the data
+ *                          of EAX,EBX,ECX and EDX registers.
+ *              cpuInfo[0]  To hold the EAX register data, value in this register at
+ *                          the time of CPUID tells what information to return
+ *                          EAX=0x1,returns the processor Info and feature bits
+ *                          in EBX,ECX,EDX registers.
+ *                          EAX=0x40000000 returns the Hypervisor Vendor Names
+ *                          in the EBX,ECX,EDX registers.
+ *              cpuInfo[1]  For EAX = 0x40000000 hold first 4 characters of the
+ *                          Hypervisor Vendor String
+ *              cpuInfo[2]  For EAX = 0x1, the 31st bit of ECX tells if its
+ *                          running on Hypervisor or not,For EAX = 0x40000000 holds the second
+ *                          4 characters of the the Hypervisor Vendor String
+ *              cpuInfo[3]  For EAX = 0x40000000 hold the last 4 characters of the
+ *                          Hypervisor Vendor String
+ *
+ */
+
+void
+getX86CPUID(uint32_t leaf, uint32_t *cpuInfo)
+{
+	cpuInfo[0] = leaf;
+
+/* Implemented for x86 & x86_64 bit platforms */
+#if defined(WIN32)
+	/* Specific CPUID instruction available in Windows */
+	__cpuid(cpuInfo, cpuInfo[0]);
+
+#elif defined(LINUX) || defined(OSX)
+#if defined(J9X86)
+	__asm volatile
+	("mov %%ebx, %%edi;"
+			"cpuid;"
+			"mov %%ebx, %%esi;"
+			"mov %%edi, %%ebx;"
+			:"+a" (cpuInfo[0]), "=S" (cpuInfo[1]), "=c" (cpuInfo[2]), "=d" (cpuInfo[3])
+			 : :"edi");
+
+#elif defined(J9HAMMER)
+  __asm volatile(
+     "cpuid;"
+     :"+a" (cpuInfo[0]), "=b" (cpuInfo[1]), "=c" (cpuInfo[2]), "=d" (cpuInfo[3])
+        );
+#endif
+#endif
+}

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+/**
+ * @file
+ * @ingroup Port
+ * @brief System information
+ */
+
+#ifndef SYSINFOHELPERS_H_
+#define SYSINFOHELPERS_H_
+
+#include "omrport.h"
+
+extern void
+getX86CPUID(uint32_t leaf, uint32_t *cpuInfo);
+
+extern intptr_t
+getX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
+
+#endif /* SYSINFOHELPERS_H_ */

--- a/port/linuxs390/omrsysinfo_helpers.h
+++ b/port/linuxs390/omrsysinfo_helpers.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -20,20 +20,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMRSYSINFO_HELPERS_H_
-#define OMRSYSINFO_HELPERS_H_
+/**
+ * @file
+ * @ingroup Port
+ * @brief sysinfo helpers
+ */
+#ifndef SYSINFO_HELPERS_H_
+#define SYSINFO_HELPERS_H_
 
 #include "omrport.h"
-
-#define J9BYTES_PER_PAGE            4096		/* Size of main storage frame/virtual storage page/auxiliary storage slot */
-
-#if defined(__cplusplus)
-extern "C" {
-#endif /* __cplusplus */
-
-/**
-* End of portion extracted from the header "//'SYS1.SIEAHDR.H(IWMQVSH)'".
-*/
 
 /**
  * Retrieve z/Architecture facility bits.
@@ -45,26 +40,4 @@ extern "C" {
  */
 extern int getstfle(int lastDoubleWord, uint64_t *bits);
 
-/**
- * Function retrieves and populates memory usage statistics on a z/OS platform.
- * @param [in] portLibrary The Port Library Handle.
- * @param[out] memInfo     Pointer to J9MemoryInfo struct which we populate with memory usage.
- * @return                 0 on success; negative value on failure.
- */
-int32_t
-retrieveZOSMemoryStats(struct OMRPortLibrary *portLibrary, struct J9MemoryInfo *memInfo);
-
-/**
- * Function retrieves and populates processor usage statistics on a z/OS platform.
- * @param [in] portLibrary The Port Library Handle.
- * @param[out] procInfo    Pointer to J9ProcessorInfos struct that we populate with processor usage.
- * @return                 0 on success; negative value on failure.
- */
-int32_t
-retrieveZOSProcessorStats(struct OMRPortLibrary *portLibrary, struct J9ProcessorInfos *procInfo);
-
-#if defined(__cplusplus)
-} /* extern "C" */
-#endif
-
-#endif /* OMRSYSINFO_HELPERS_H_ */
+#endif /* SYSINFO_HELPERS_H_ */

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -473,6 +473,10 @@ extern J9_CFUNC uintptr_t
 omrsysinfo_get_number_CPUs_by_type(struct OMRPortLibrary *portLibrary, uintptr_t type);
 extern J9_CFUNC const char *
 omrsysinfo_get_CPU_architecture(struct OMRPortLibrary *portLibrary);
+extern J9_CFUNC intptr_t
+omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
+extern J9_CFUNC BOOLEAN
+omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature);
 extern J9_CFUNC const char *
 omrsysinfo_get_OS_version(struct OMRPortLibrary *portLibrary);
 extern J9_CFUNC int32_t

--- a/port/port_objects.mk
+++ b/port/port_objects.mk
@@ -150,9 +150,7 @@ endif
 OBJECTS += omrsl
 OBJECTS += omrstr
 OBJECTS += omrsysinfo
-ifeq (zos,$(OMR_HOST_OS))
-  OBJECTS += omrsysinfo_helpers
-endif
+OBJECTS += omrsysinfo_helpers
 OBJECTS += omrsyslog
 ifeq (win,$(OMR_HOST_OS))
   OBJECTS += omrsyslogmessages.res

--- a/port/unix_include/omrportpg.h
+++ b/port/unix_include/omrportpg.h
@@ -52,6 +52,17 @@ typedef struct J9PortNodeMask {
 } J9PortNodeMask;
 #endif
 
+typedef struct OMRSTFLEFacilities {
+	uint64_t dw1;
+	uint64_t dw2;
+	uint64_t dw3;
+} OMRSTFLEFacilities;
+
+typedef struct OMRSTFLECache {
+	uintptr_t lastDoubleWord;
+	OMRSTFLEFacilities facilities;
+} OMRSTFLECache;
+
 typedef struct OMRPortPlatformGlobals {
 	uintptr_t numa_platform_supports_numa;
 	uintptr_t numa_platform_interleave_memory;
@@ -91,6 +102,7 @@ typedef struct OMRPortPlatformGlobals {
 	uintptr_t performFullMemorySearch; /**< Always perform full range memory search even smart address can not be established */
 	BOOLEAN syscallNotAllowed; /**< Assigned True if the mempolicy syscall is failed due to security opts (Can be seen in case of docker) */
 #endif /* defined(LINUX) */
+	OMRSTFLECache stfleCache;
 } OMRPortPlatformGlobals;
 
 
@@ -139,6 +151,8 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_numaSyscallNotAllowed (portLibrary->portGlobals->platformGlobals.syscallNotAllowed)
 #define PPG_performFullMemorySearch (portLibrary->portGlobals->platformGlobals.performFullMemorySearch)
 #endif /* defined(LINUX) */
+
+#define PPG_stfleCache (portLibrary->portGlobals->platformGlobals.stfleCache)
 
 #endif /* omrportpg_h */
 

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -44,6 +44,7 @@
 #include "omrportpg.h"
 #include "omrportptb.h"
 #include "ut_omrport.h"
+#include "omrsysinfo_helpers.h"
 
 static int32_t copyEnvToBuffer(struct OMRPortLibrary *portLibrary, void *args);
 
@@ -88,6 +89,38 @@ omrsysinfo_get_CPU_architecture(struct OMRPortLibrary *portLibrary)
 #else
 	return "unknown";
 #endif
+}
+
+intptr_t
+omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
+{
+	intptr_t rc = -1;
+	Trc_PRT_sysinfo_get_processor_description_Entered(desc);
+	
+	if (NULL != desc) {
+		memset(desc, 0, sizeof(OMRProcessorDesc));
+		rc = getX86Description(portLibrary, desc);
+	}
+	
+	Trc_PRT_sysinfo_get_processor_description_Exit(rc);
+	return rc;
+}
+
+BOOLEAN
+omrsysinfo_processor_has_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature)
+{
+	BOOLEAN rc = FALSE;
+	Trc_PRT_sysinfo_processor_has_feature_Entered(desc, feature);
+
+	if ((NULL != desc) && (feature < (OMRPORT_SYSINFO_OS_FEATURES_SIZE * 32))) {
+		uint32_t featureIndex = feature / 32;
+		uint32_t featureShift = feature % 32;
+
+		rc = OMR_ARE_ALL_BITS_SET(desc->features[featureIndex], 1 << featureShift);
+	}
+
+	Trc_PRT_sysinfo_processor_has_feature_Exit((uintptr_t)rc);
+	return rc;
 }
 
 #define ENVVAR_VALUE_BUFFER_LENGTH 512

--- a/port/zos390/omrportpg.h
+++ b/port/zos390/omrportpg.h
@@ -48,6 +48,17 @@
 #define TTOKEN_BUF_SZ                   16
 #endif /* defined(OMR_ENV_DATA64) */
 
+typedef struct OMRSTFLEFacilities {
+	uint64_t dw1;
+	uint64_t dw2;
+	uint64_t dw3;
+} OMRSTFLEFacilities;
+
+typedef struct OMRSTFLECache {
+	uintptr_t lastDoubleWord;
+	OMRSTFLEFacilities facilities;
+} OMRSTFLECache;
+
 typedef struct OMRPortPlatformGlobals {
 	char *si_osType;
 	char *si_osVersion;
@@ -68,6 +79,7 @@ typedef struct OMRPortPlatformGlobals {
 	MUTEX globalConverterMutex[UNCACHED_ICONV_DESCRIPTOR];
 	uintptr_t systemLoggingFlags;
 	char *si_executableName;
+	OMRSTFLECache stfleCache;
 #if defined(OMR_ENV_DATA64)
 	char iptTtoken[TTOKEN_BUF_SZ];
 #endif /* defined(OMR_ENV_DATA64) */
@@ -92,5 +104,7 @@ typedef struct OMRPortPlatformGlobals {
 
 #define PPG_si_executableName (portLibrary->portGlobals->platformGlobals.si_executableName)
 #define PPG_ipt_ttoken (portLibrary->portGlobals->platformGlobals.iptTtoken)
+
+#define PPG_stfleCache (portLibrary->portGlobals->platformGlobals.stfleCache)
 
 #endif /* omrportpg_h */


### PR DESCRIPTION
OpenJ9 port library has processor and feature detections that can be sunk down to OMR. This can be divided into 4 steps:
1: Creation of processor and feature detection in OMR (from OpenJ9).
2: Implementation of the new feature throughout out OMR.
3: Implementation of the new feature throughout OpenJ9.
4: Deletion of the processor detection in OpenJ9 port library.

This PR serves to implement step 1 of the list above. This PR includes the following:

- Move and rename necessary port library macros from OpenJ9 to OMR's `omrport.h` (Commit 1)
- Move and implement processor/feature detection for windows systems[WIP] (Commit 2)
- Move and implement processor/feature detection for unix systems (x86, Power, AIX, Z) (Commit 3)
- Move and test the respective port tests that helps verify that processor detection works (Commit 4)

Issue: #4339