### PR TITLE
MCS Lock (Part 2): Initialize structures for the MCS lock

### DIFF
--- a/include_core/omrthread_generated.h
+++ b/include_core/omrthread_generated.h
@@ -362,6 +362,10 @@ typedef struct J9AbstractThread {
 #define J9THREAD_ERR_INVALID_ATTACH_ATTR			24
 #define J9THREAD_ERR_CANT_ALLOC_ATTACH_ATTR			25
 
+#if defined(OMR_THR_MCS_LOCKS)
+#define OMRTHREAD_ERR_CANT_ALLOC_MCS_NODES 26 /* Error initializing J9Thread->mcsNodes. */
+#endif /* defined(OMR_THR_MCS_LOCKS) */
+
 /* Bit flag indicating that os_errno is set. This flag must not interfere with the sign bit. */
 #define J9THREAD_ERR_OS_ERRNO_SET  0x40000000
 #define J9THREAD_INVALID_OS_ERRNO  -1

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -3552,6 +3552,10 @@ monitor_free(omrthread_library_t lib, omrthread_monitor_t monitor)
 		monitor->flags = J9THREAD_MONITOR_MUTEX_UNINITIALIZED;
 	}
 
+#if defined(OMR_THR_MCS_LOCKS)
+	monitor->queueTail = NULL;
+#endif /* defined(OMR_THR_MCS_LOCKS) */
+
 	lib->monitor_pool->next_free = monitor;
 }
 
@@ -3589,6 +3593,10 @@ monitor_free_nolock(omrthread_library_t lib, omrthread_t thread, omrthread_monit
 			monitor->flags = J9THREAD_MONITOR_MUTEX_UNINITIALIZED;
 		}
 	}
+
+#if defined(OMR_THR_MCS_LOCKS)
+	monitor->queueTail = NULL;
+#endif /* defined(OMR_THR_MCS_LOCKS) */
 
 	if (0 == thread->destroyed_monitor_head) {
 		thread->destroyed_monitor_tail = monitor;
@@ -3670,6 +3678,10 @@ monitor_init(omrthread_monitor_t monitor, uintptr_t flags, omrthread_library_t l
 			monitor->name = (char *)name;
 		}
 	}
+
+#if defined(OMR_THR_MCS_LOCKS)
+ 	monitor->queueTail = NULL;
+#endif /* defined(OMR_THR_MCS_LOCKS) */
 
 	return 0;
 }


### PR DESCRIPTION
1) Add code to allocate and free OMRThreadMCSNodes.
2) Initialize J9Thread->mcsNodes.
3) Initialize and reset J9ThreadMonitor->queueTail.
4) [DONT MERGE] Enable the OMR_THR_MCS_LOCKS flag to verify compilation.

Will remove 4) after it is verified that the code compiles properly through the pull request build jobs.

Related: #4086.

Dependent on #4484. Will require a rebase once #4484 is merged.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>