### PR TITLE
MCS Lock (Part 3): Implement the MCS lock API

### DIFF
--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -424,9 +424,10 @@ lockReleased:
 omrthread_mcs_node_t
 omrthread_mcs_node_allocate(omrthread_t self)
 {
-	/* Unimplemented. */
-	Assert_THR_true(FALSE);
-	return NULL;
+	/* An instance of J9Pool is used per thread to manage memory for a thread's
+	 * MCS nodes.
+	 */
+	return (omrthread_mcs_node_t)pool_newElement(self->mcsNodes->pool);
 }
 
 /**

--- a/thread/common/threadhelpers.cpp
+++ b/thread/common/threadhelpers.cpp
@@ -441,8 +441,17 @@ omrthread_mcs_node_allocate(omrthread_t self)
 void
 omrthread_mcs_node_free(omrthread_t self, omrthread_mcs_node_t mcsNode)
 {
-	/* Unimplemented. */
-	Assert_THR_true(FALSE);
+#if defined(THREAD_ASSERTS)
+	ASSERT(mcsNode != NULL);
+#endif /* defined(THREAD_ASSERTS) */
+
+	/* Clear the fields of the mcsNode. */
+	mcsNode->stackNext = NULL;
+	mcsNode->queueNext = NULL;
+	mcsNode->thread = NULL;
+	mcsNode->blocked = OMRTHREAD_MCS_THREAD_BLOCKED;
+
+	pool_removeElement(self->mcsNodes->pool, mcsNode);
 }
 #endif /* defined(OMR_THR_MCS_LOCKS) */
 


### PR DESCRIPTION
The implementation is added for the following functions:
1. omrthread_mcs_lock
2. omrthread_mcs_trylock
3. omrthread_mcs_unlock
4. omrthread_mcs_node_allocate
5. omrthread_mcs_node_free

A. [DONT MERGE] Enable the OMR_THR_MCS_LOCKS flag to verify compilation.

Will remove A) after it is verified that the code compiles properly through the pull request build jobs.

Related: #4086.

Dependent on #4508. Will require a rebase once #4508 is merged.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>