### PR TITLE
Adding `dsqrtEvaluator` on X86

### DIFF
--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -710,7 +710,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::fnint
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dnint
    TR::TreeEvaluator::fpSqrtEvaluator,                                 // TR::fsqrt
-   TR::TreeEvaluator::fpSqrtEvaluator,                                 // TR::dsqrt
+   TR::TreeEvaluator::dsqrtEvaluator,                                  // TR::dsqrt
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::getstack
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::dealloca
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::ishfl

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -722,6 +722,19 @@ TR::Register *OMR::X86::TreeEvaluator::fpSqrtEvaluator(TR::Node *node, TR::CodeG
    return result;
    }
 
+TR::Register *OMR::X86::TreeEvaluator::dsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   TR::Node *operand = node->getFirstChild();
+   TR::Register *opRegister = cg->evaluate(operand);
+   TR::Register *targetRegister = cg->allocateRegister(TR_FPR);
+
+   generateRegRegInstruction(SQRTSDRegReg, node, targetRegister, opRegister, cg);
+   
+   node->setRegister(targetRegister);
+   cg->decReferenceCount(operand);
+   return targetRegister;
+   }
+
 TR::Register *OMR::X86::TreeEvaluator::faddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    return TR::TreeEvaluator::fpBinaryArithmeticEvaluator(node, true, cg);

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -280,6 +280,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *fpReturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fpRemEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *fpSqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *dsqrtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    // routines for floating point values that can fit in one GPR
    static TR::Register *floatingPointStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/env/OMRCPU.cpp
+++ b/compiler/x/env/OMRCPU.cpp
@@ -109,6 +109,12 @@ OMR::X86::CPU::getX86ProcessorFeatureFlags8()
    }
 
 bool
+OMR::X86::CPU::getSupportsHardwareSQRT()
+   {
+   return true;
+   }
+
+bool
 OMR::X86::CPU::testOSForSSESupport()
    {
    return false;

--- a/compiler/x/env/OMRCPU.hpp
+++ b/compiler/x/env/OMRCPU.hpp
@@ -62,6 +62,8 @@ public:
    uint32_t getX86ProcessorFeatureFlags2();
    uint32_t getX86ProcessorFeatureFlags8();
 
+   bool getSupportsHardwareSQRT();
+
    bool testOSForSSESupport();
 
 


### PR DESCRIPTION
Adding X86's version of `getSupportsHardwareSQRT()` function and make it return `true` value. So that X86 will be able to reduce `StrictMath.sqrt()` and `Math.sqrt()` function to `dsqrt` in `recognizedCallTransformer`. 

Also, on X86, there is a function `inlineMathSQRT()` which previously handles the call to `StrictMath.sqrt()` and `Math.sqrt()`. X86 specially handled the constant case in `inlineMathSQRT()`. In `dsqrtEvaluator`, I didn't include the constant handling, because the constant case will be handled in `treeSimplification` (i.e. reducing `dsqrt` to `dconst`). Following is the trace log I generated from my own test case[1] using the jvm which includes the newly added `dsqrtEvaluator` and having `inlineMathSQRT` removed:

- Post Inlining Trees: for testsqrt.sq(D)D (Trees before `treeSimplification`)
```
n1n       BBStart <block_2>                                                                   [0x7eff1d5e5370] bci=[-1,0,17] rc=0 vc=14 vn=- li=- udi=- nc=0
n42n      treetop                                                                             [0x7eff1d5e6040] bci=[-1,3,17] rc=0 vc=14 vn=- li=- udi=- nc=1
n9n         aladd                                                                             [0x7eff1d5e55f0] bci=[-1,3,17] rc=1 vc=14 vn=- li=- udi=- nc=2
n7n           aconst 0x964300 (java/lang/StrictMath.class) (classPointerConstant sharedMemory )  [0x7eff1d5e5550] bci=[-1,3,17] rc=1 vc=14 vn=- li=- udi=- nc=0 flg=0x10000
n8n           lconst 48                                                                       [0x7eff1d5e55a0] bci=[-1,3,17] rc=1 vc=14 vn=- li=- udi=- nc=0
n43n      treetop                                                                             [0x7eff1d5e6090] bci=[-1,0,17] rc=0 vc=14 vn=- li=- udi=- nc=1
n3n         dconst 42.25 [0x4045200000000000]                                                 [0x7eff1d5e5410] bci=[-1,0,17] rc=2 vc=14 vn=- li=- udi=- nc=0
n10n      dstore  <auto slot 2>[#360  Auto] [flags 0x6 0x0 ]                                  [0x7eff1d5e5640] bci=[-1,6,17] rc=0 vc=14 vn=- li=- udi=- nc=1
n6n         dsqrt ()                                                                          [0x7eff1d5e5500] bci=[-1,3,17] rc=1 vc=14 vn=- li=- udi=- nc=1 flg=0x40000
n3n           ==>dconst 42.25 [0x4045200000000000]
n15n      NULLCHK on n11n [#31]                                                               [0x7eff1d5e57d0] bci=[-1,11,21] rc=0 vc=14 vn=- li=- udi=- nc=1
n14n        calli  java/io/PrintStream.println(D)V[#364  virtual Method -240] [flags 0x500 0x0 ] ()  [0x7eff1d5e5780] bci=[-1,11,21] rc=1 vc=15 vn=- li=- udi=- nc=3 flg=0x20
n13n          aloadi  <vft-symbol>[#295  Shadow] [flags 0x18607 0x0 ]                         [0x7eff1d5e5730] bci=[-1,11,21] rc=1 vc=14 vn=- li=- udi=- nc=1
n11n            aload  java/lang/System.out Ljava/io/PrintStream;[#361  final Static] [flags 0x20307 0x0 ]  [0x7eff1d5e5690] bci=[-1,7,21] rc=2 vc=14 vn=- li=- udi=- nc=0
n11n          ==>aload
n12n          dload  <auto slot 2>[#360  Auto] [flags 0x6 0x0 ]                               [0x7eff1d5e56e0] bci=[-1,10,21] rc=1 vc=14 vn=- li=- udi=- nc=0
n17n      dreturn                                                                             [0x7eff1d5e5870] bci=[-1,15,22] rc=0 vc=14 vn=- li=- udi=- nc=1
n16n        dload  <auto slot 2>[#360  Auto] [flags 0x6 0x0 ]                                 [0x7eff1d5e5820] bci=[-1,14,22] rc=1 vc=14 vn=- li=- udi=- nc=0
n2n       BBEnd </block_2> =====                                                              [0x7eff1d5e53c0] bci=[-1,15,22] rc=0 vc=14 vn=- li=- udi=- nc=0
```

- Trees after `treeSimplification`: for testsqrt.sq(D)D
```
n1n       BBStart <block_2>                                                                   [0x7eff1d5e5370] bci=[-1,0,17] rc=0 vc=22 vn=- li=- udi=- nc=0
n42n      treetop                                                                             [0x7eff1d5e6040] bci=[-1,3,17] rc=0 vc=22 vn=- li=- udi=- nc=1
n9n         aladd                                                                             [0x7eff1d5e55f0] bci=[-1,3,17] rc=1 vc=22 vn=- li=- udi=- nc=2
n7n           aconst 0x964300 (java/lang/StrictMath.class) (classPointerConstant sharedMemory )  [0x7eff1d5e5550] bci=[-1,3,17] rc=1 vc=22 vn=- li=- udi=- nc=0 flg=0x10000
n8n           lconst 48 (highWordZero )                                                       [0x7eff1d5e55a0] bci=[-1,3,17] rc=1 vc=22 vn=- li=- udi=- nc=0 flg=0x4000
n43n      treetop                                                                             [0x7eff1d5e6090] bci=[-1,0,17] rc=0 vc=22 vn=- li=- udi=- nc=1
n3n         dconst 42.25 [0x4045200000000000]                                                 [0x7eff1d5e5410] bci=[-1,0,17] rc=1 vc=22 vn=- li=- udi=- nc=0
n10n      dstore  <auto slot 2>[#360  Auto] [flags 0x6 0x0 ]                                  [0x7eff1d5e5640] bci=[-1,6,17] rc=0 vc=22 vn=- li=- udi=- nc=1
n6n         dconst 6.5 [0x401a000000000000] ()                                                [0x7eff1d5e5500] bci=[-1,3,17] rc=1 vc=22 vn=- li=- udi=- nc=0 flg=0x40000
n15n      NULLCHK on n11n [#31]                                                               [0x7eff1d5e57d0] bci=[-1,11,21] rc=0 vc=22 vn=- li=- udi=- nc=1
n14n        calli  java/io/PrintStream.println(D)V[#364  virtual Method -240] [flags 0x500 0x0 ] ()  [0x7eff1d5e5780] bci=[-1,11,21] rc=1 vc=22 vn=- li=- udi=- nc=3 flg=0x20
n13n          aloadi  <vft-symbol>[#295  Shadow] [flags 0x18607 0x0 ]                         [0x7eff1d5e5730] bci=[-1,11,21] rc=1 vc=22 vn=- li=- udi=- nc=1
n11n            aload  java/lang/System.out Ljava/io/PrintStream;[#361  final Static] [flags 0x20307 0x0 ] (X>=0 sharedMemory )  [0x7eff1d5e5690] bci=[-1,7,21] rc=2 vc=22 vn=- li=- udi=- nc=0 flg=0x100
n11n          ==>aload
n12n          dload  <auto slot 2>[#360  Auto] [flags 0x6 0x0 ]                               [0x7eff1d5e56e0] bci=[-1,10,21] rc=1 vc=22 vn=- li=- udi=- nc=0
n17n      dreturn                                                                             [0x7eff1d5e5870] bci=[-1,15,22] rc=0 vc=22 vn=- li=- udi=- nc=1
n16n        dload  <auto slot 2>[#360  Auto] [flags 0x6 0x0 ]                                 [0x7eff1d5e5820] bci=[-1,14,22] rc=1 vc=22 vn=- li=- udi=- nc=0
n2n       BBEnd </block_2> =====                                                              [0x7eff1d5e53c0] bci=[-1,15,22] rc=0 vc=22 vn=- li=- udi=- nc=0
```

[1] test case I used to generate the log:
```
public class testsqrt {
    public static void main(String[] args) 
      {
      double total = 0;
      for (int i = 0; i < 5; i++)
         total += sq();
      System.out.println(total);
     [}](url)

    public static double sq()
       {
       double res = StrictMath.sqrt(42.25);
       System.out.println(res);
       return res;
      }
}

