### PR TITLE
Remove Flex/Bison from AppVeyor and Travis

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,9 +30,6 @@ environment:
   TEST_RESULT_DIR: '%APPVEYOR_BUILD_FOLDER%\test_results'
   GTEST_OUTPUT: 'xml:%TEST_RESULT_DIR%\'
 
-install:
-  - cinst winflexbison
-
 before_build:
   - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
   - set PATH=C:\Python37;%PATH%

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ matrix:
       addons:
         apt:
           packages:
-            - bison
             - clang-3.8
             - libclang-3.8-dev
             - llvm-3.8


### PR DESCRIPTION
With the merge of #4345 we no longer depend on Flex and Bison being
installed for our testing. AppVeyor seems to be broken at the moment in
that checksums are failing when installing this package. We fix the
issue by removing the dependency as it is no longer needed.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>