### PR TITLE
Change Dwarf_CU_Context files list from vector to map

### DIFF
--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -214,7 +214,7 @@ struct Dwarf_CU_Context
 	Dwarf_Unsigned _nextCUheaderOffset;
 	Dwarf_CU_Context *_nextCU;
 
-	static vector<string> _fileList;
+	static unordered_map<string, size_t> _fileId; /* key: file name, value: order added indexed at 0 */
 	static Dwarf_CU_Context *_firstCU;
 	static Dwarf_CU_Context *_currentCU;
 };

--- a/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
@@ -35,7 +35,7 @@ static const char * const _errmsgs[] = {
 	"DW_DLE_VMM (9) dwarf format/library version mismatch",
 };
 
-vector<string> Dwarf_CU_Context::_fileList;
+unordered_map<string, size_t> Dwarf_CU_Context::_fileId;
 unordered_map<Dwarf_Off, Dwarf_Die> Dwarf_Die_s::refMap;
 
 int
@@ -53,21 +53,19 @@ dwarf_srcfiles(Dwarf_Die die, char ***srcfiles, Dwarf_Signed *filecount, Dwarf_E
 		 * This implementation maintains the entire list through
 		 * all CU's, rather than just the current CU, for simplicity.
 		 */
-		*filecount = Dwarf_CU_Context::_fileList.size();
+		*filecount = Dwarf_CU_Context::_fileId.size();
 		*srcfiles = new char *[*filecount];
 		if (NULL == *srcfiles) {
 			ret = DW_DLV_ERROR;
 			setError(error, DW_DLE_MAF);
 		} else {
-			size_t index = 0;
-			for (str_vect::iterator it = Dwarf_CU_Context::_fileList.begin(); it != Dwarf_CU_Context::_fileList.end(); ++it) {
-				(*srcfiles)[index] = strdup(it->c_str());
-				if (NULL == (*srcfiles)[index]) {
+			for (unordered_map<string, size_t>::const_iterator it = Dwarf_CU_Context::_fileId.begin(); it != Dwarf_CU_Context::_fileId.end(); ++it) {
+				(*srcfiles)[it->second] = strdup(it->first.c_str());
+				if (NULL == (*srcfiles)[it->second]) {
 					ret = DW_DLV_ERROR;
 					setError(error, DW_DLE_MAF);
 					break;
 				}
-				index += 1;
 			}
 		}
 	}

--- a/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfParser.cpp
@@ -50,7 +50,7 @@ dwarf_finish(Dwarf_Debug dbg, Dwarf_Error *error)
 		delete Dwarf_CU_Context::_currentCU;
 		Dwarf_CU_Context::_currentCU = nextCU;
 	}
-	Dwarf_CU_Context::_fileList.clear();
+	Dwarf_CU_Context::_fileId.clear();
 	Dwarf_CU_Context::_currentCU = NULL;
 	Dwarf_CU_Context::_firstCU = NULL;
 	return DW_DLV_OK;
@@ -465,8 +465,12 @@ parseAttribute(char *line, Dwarf_Die *lastCreatedDie,
 					setError(error, DW_DLE_MAF);
 					newAttr->_udata = 0;
 				} else if (DW_TAG_unknown != (*lastCreatedDie)->_tag) {
-					Dwarf_CU_Context::_fileList.push_back(string(newAttr->_stringdata));
-					newAttr->_udata = Dwarf_CU_Context::_fileList.size();
+					string fileName = string(newAttr->_stringdata);
+					unordered_map<string, size_t>::const_iterator insertIt = Dwarf_CU_Context::_fileId.insert(make_pair(fileName, Dwarf_CU_Context::_fileId.size())).first;
+					/* whether the insert succeeded or not due to duplicates, the pair at the iterator will have the right index value */
+					newAttr->_udata = insertIt->second + 1; /* since this attribute is indexed at 1 */
+
+
 				}
 			} else if (DW_FORM_string == form) {
 				char *valueStart = line + span + 3;


### PR DESCRIPTION
The current dwarf parser for OSX does not actually prune duplicate file names,
which leads to wasted time parsing the file name list later on. Switching the
container for the file names from list to map would allow us to remove the
duplicate file names from the list and thus improve the performance of ddrgen.
On AIX, we keep a separate set for this purpose and this change would also do
away with that. We need a map instead of a set so that dwarf_srcfiles returns
the file list in the correct order indicated by the DW_AT_decl_file attribute.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse/omr/issues/4498

On my personal machine it takes around 2 minutes on OpenJ9 source after the change, compared to around 6 minutes beforehand.

![Screen Shot 2019-10-28 at 12 25 45 PM](https://user-images.githubusercontent.com/32070971/67704163-fe5fb900-f98a-11e9-9d61-1cdc77f38727.png)
From the profiler, it looks like a large part of the remaining time is spent in parsing the output of `dwarfdump` on OSX, which would explain the remaining difference in runtime compared to Linux. `libdwarf` on Linux parses the debug files directly while on AIX and OSX we create a textual dump and parse that.

fyi: @keithc-ca 