### PR TITLE
AArch64: Add VirtualGuardNOPInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -25,6 +25,7 @@
 #include "codegen/ARM64ConditionCode.hpp"
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/InstOpCode.hpp"
 #include "codegen/InstructionDelegate.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Relocation.hpp"
@@ -534,3 +535,73 @@ uint8_t *TR::ARM64Src2Instruction::generateBinaryEncoding()
    setBinaryEncoding(instructionStart);
    return cursor;
    }
+
+#ifdef J9_PROJECT_SPECIFIC
+uint8_t *TR::ARM64VirtualGuardNOPInstruction::generateBinaryEncoding()
+   {
+   uint8_t *cursor = cg()->getBinaryBufferCursor();
+   TR::LabelSymbol *label = getLabelSymbol();
+   int32_t length = 0;
+   TR::Instruction *guardForPatching = cg()->getVirtualGuardForPatching(this);
+
+   // a previous guard is patching to the same destination and we can recycle the patch
+   // point so setup the patching location to use this previous guard and generate no
+   // instructions ourselves
+   if ((guardForPatching != this) &&
+         // AOT needs an explicit nop, even if there are patchable instructions at this site because
+         // 1) Those instructions might have AOT data relocations (and therefore will be incorrectly patched again)
+         // 2) We might want to re-enable the code path and unpatch, in which case we would have to know what the old instruction was
+         !cg()->comp()->compileRelocatableCode())
+      {
+      _site->setLocation(guardForPatching->getBinaryEncoding());
+      setBinaryLength(0);
+      setBinaryEncoding(cursor);
+      if (label->getCodeLocation() == NULL)
+         {
+         cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
+         }
+      else
+         {
+         _site->setDestination(label->getCodeLocation());
+         }
+      cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
+      return cursor;
+      }
+
+   // We need to revisit this to improve it to support empty patching
+
+   _site->setLocation(cursor);
+   if (label->getCodeLocation() == NULL)
+      {
+      _site->setDestination(cursor);
+      cg()->addRelocation(new (cg()->trHeapMemory()) TR::LabelAbsoluteRelocation((uint8_t *) (&_site->getDestination()), label));
+
+#ifdef DEBUG
+   if (debug("traceVGNOP"))
+      printf("####> virtual location = %p, label (relocation) = %p\n", cursor, label);
+#endif
+      }
+   else
+      {
+       _site->setDestination(label->getCodeLocation());
+#ifdef DEBUG
+   if (debug("traceVGNOP"))
+      printf("####> virtual location = %p, label location = %p\n", cursor, label->getCodeLocation());
+#endif
+      }
+
+   setBinaryEncoding(cursor);
+   TR::InstOpCode opCode(TR::InstOpCode::nop);
+   opCode.copyBinaryToBuffer(cursor);
+   length = ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(length);
+   return cursor+length;
+   }
+
+int32_t TR::ARM64VirtualGuardNOPInstruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   // This is a conservative estimation for reserving NOP space.
+   setEstimatedBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   return currentEstimate+ARM64_INSTRUCTION_LENGTH;
+   }
+#endif

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -542,6 +542,11 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsCompareBranch:
          print(pOutFile, (TR::ARM64CompareBranchInstruction *)instr);
          break;
+#ifdef J9_PROJECT_SPECIFIC
+      case OMR::Instruction::IsVirtualGuardNOP:
+         print(pOutFile, (TR::ARM64VirtualGuardNOPInstruction *)instr);
+         break;
+#endif
       case OMR::Instruction::IsRegBranch:
          print(pOutFile, (TR::ARM64RegBranchInstruction *)instr);
          break;
@@ -680,6 +685,20 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64LabelInstruction *instr)
       print(pOutFile, instr->getDependencyConditions());
    trfflush(_comp->getOutFile());
    }
+
+#ifdef J9_PROJECT_SPECIFIC
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64VirtualGuardNOPInstruction * instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s Site:" POINTER_PRINTF_FORMAT ", ", getOpCodeName(&instr->getOpCode()), instr->getSite());
+   print(pOutFile, instr->getLabelSymbol());
+   printInstructionComment(pOutFile, 1, instr);
+   if (instr->getDependencyConditions())
+      print(pOutFile, instr->getDependencyConditions());
+   trfflush(pOutFile);
+   }
+#endif
 
 void
 TR_Debug::print(TR::FILE *pOutFile, TR::ARM64ConditionalBranchInstruction *instr)

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -35,6 +35,7 @@
 #include "il/LabelSymbol.hpp"
 #include "infra/Assert.hpp"
 
+class TR_VirtualGuardSite;
 namespace TR { class SymbolReference; }
 
 #define ARM64_INSTRUCTION_LENGTH 4
@@ -2805,6 +2806,45 @@ class ARM64ExceptionInstruction : public ARM64ImmInstruction
       }
 
    };
+
+#ifdef J9_PROJECT_SPECIFIC
+class ARM64VirtualGuardNOPInstruction : public TR::ARM64LabelInstruction
+   {
+   private:
+   TR_VirtualGuardSite *_site;
+
+   public:
+   ARM64VirtualGuardNOPInstruction(TR::Node                       *node,
+                                 TR_VirtualGuardSite              *site,
+                                 TR::RegisterDependencyConditions *cond,
+                                 TR::LabelSymbol                  *sym,
+                                 TR::CodeGenerator                *cg)
+      : TR::ARM64LabelInstruction(TR::InstOpCode::vgdnop, node, sym, cond, cg),
+        _site(site)
+      {
+      }
+
+   ARM64VirtualGuardNOPInstruction(TR::Node                       *node,
+                                 TR_VirtualGuardSite              *site,
+                                 TR::RegisterDependencyConditions *cond,
+                                 TR::LabelSymbol                  *sym,
+                                 TR::Instruction                  *precedingInstruction,
+                                 TR::CodeGenerator                *cg)
+      : TR::ARM64LabelInstruction(TR::InstOpCode::vgdnop, node, sym, cond, precedingInstruction, cg),
+        _site(site)
+      {
+      }
+
+   virtual Kind getKind() { return IsVirtualGuardNOP; }
+
+   void setSite(TR_VirtualGuardSite *site) { _site = site; }
+   TR_VirtualGuardSite * getSite() { return _site; }
+
+   virtual uint8_t *generateBinaryEncoding();
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
+   virtual bool     isVirtualGuardNOPInstruction() {return true;}
+   };
+#endif
 
 } // TR
 

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -473,3 +473,13 @@ TR::ARM64ExceptionInstruction *generateExceptionInstruction(TR::CodeGenerator *c
       return new (cg->trHeapMemory()) TR::ARM64ExceptionInstruction(op, node, imm, preced, cg);
    return new (cg->trHeapMemory()) TR::ARM64ExceptionInstruction(op, node, imm, cg);
    }
+
+#ifdef J9_PROJECT_SPECIFIC
+TR::Instruction *generateVirtualGuardNOPInstruction(TR::CodeGenerator *cg,  TR::Node *n, TR_VirtualGuardSite *site,
+   TR::RegisterDependencyConditions *cond, TR::LabelSymbol *sym, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64VirtualGuardNOPInstruction(n, site, cond, sym, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64VirtualGuardNOPInstruction(n, site, cond, sym, cg);
+   }
+#endif

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -788,4 +788,19 @@ TR::ARM64ExceptionInstruction *generateExceptionInstruction(
                   uint32_t imm,
                   TR::Instruction *preced = NULL);
 
+#ifdef J9_PROJECT_SPECIFIC
+/*
+ * @brief Generates virtual guard nop instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] node : node
+ * @param[in] site : virtual guard site
+ * @param[in] cond : register dependency condition
+ * @param[in] sym : label symbol
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateVirtualGuardNOPInstruction(TR::CodeGenerator *cg,  TR::Node *node, TR_VirtualGuardSite *site,
+   TR::RegisterDependencyConditions *cond, TR::LabelSymbol *sym, TR::Instruction *preced = NULL);
+
+#endif
 #endif

--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -467,11 +467,14 @@
 		fmaxd,                                                  	/* 0x1E604800	FMAX      	 */
 		fmins,                                                  	/* 0x1E205800	FMIN      	 */
 		fmind,                                                  	/* 0x1E605800	FMIN      	 */
+/* Hint instructions */
+		nop,                                                    	/* 0xD503201F   NOP          */
 /* Internal OpCodes */
 		proc,  // Entry to the method
 		fence, // Fence
 		retn,  // Return
 		dd,    // Define word
 		label, // Destination of a jump
-		ARM64LastOp = label,
+		vgdnop, // Virtual Guard NOP instruction
+		ARM64LastOp = vgdnop,
 		ARM64NumOpCodes = ARM64LastOp+1,

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -32,6 +32,7 @@
    IsLabel,
       IsConditionalBranch,
       IsCompareBranch,
+      IsVirtualGuardNOP,
    IsRegBranch,
    IsAdmin,
    IsTrg1,

--- a/compiler/aarch64/codegen/OpBinary.cpp
+++ b/compiler/aarch64/codegen/OpBinary.cpp
@@ -466,4 +466,5 @@ const OMR::ARM64::InstOpCode::OpCodeBinaryEntry OMR::ARM64::InstOpCode::binaryEn
 		0x1E604800,	/* FMAX      	fmaxd	 */
 		0x1E205800,	/* FMIN      	fmins	 */
 		0x1E605800,	/* FMIN      	fmind	 */
+		0xD503201F,	/* NOP          nop      */
 };

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -357,6 +357,8 @@ namespace TR { class ARM64Src2Instruction; }
 namespace TR { class ARM64HelperCallSnippet; }
 
 #ifdef J9_PROJECT_SPECIFIC
+namespace TR { class ARM64VirtualGuardNOPInstruction; }
+
 namespace TR { class ARM64InterfaceCallSnippet; }
 namespace TR { class ARM64StackCheckFailureSnippet; }
 namespace TR { class ARM64ForceRecompilationSnippet; }
@@ -1105,7 +1107,9 @@ public:
    void print(TR::FILE *, TR::ARM64MemSrc1Instruction *);
    void print(TR::FILE *, TR::ARM64Src1Instruction *);
    void print(TR::FILE *, TR::ARM64Src2Instruction *);
-
+#ifdef J9_PROJECT_SPECIFIC
+   void print(TR::FILE *, TR::ARM64VirtualGuardNOPInstruction *);
+#endif
    void print(TR::FILE *, TR::RealRegister *, TR_RegisterSizes size = TR_WordReg);
    void print(TR::FILE *, TR::RegisterDependency *);
    void print(TR::FILE *, TR::RegisterDependencyConditions *);


### PR DESCRIPTION
This commit adds `VirtualGuardNOPInstruction` to aarch64 codegen in order to add support for HCR.
https://github.com/eclipse/openj9/issues/6775


Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>