### PR TITLE
Peephole optimizations for BNDCHK evaluator on Z

### DIFF
--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -1349,29 +1349,96 @@ TR_S390PostRAPeephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branc
 
 
 /**
- * Catch the pattern where an CR/BRC can be converted
- *    CR R1,R2
- *    BRC  Mask, Lable
+ * Catch the pattern where an CLR/BRC can be converted
+ *    CLR R1, R2
+ *    BRC Mask, Lable
  * Can be replaced with
- *    CRJ  R1,R2,Lable
+ *    CLRJ R1, R2, Lable, Mask
  */
 bool
 TR_S390PostRAPeephole::CompareAndBranchReduction()
    {
-   bool performed = false;
+   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+      return false;
 
-   TR::Instruction *current = _cursor;
-   TR::Instruction *next = _cursor->getNext();
-   TR::InstOpCode::Mnemonic curOpCode = current->getOpCodeValue();
-   TR::InstOpCode::Mnemonic nextOpCode = next->getOpCodeValue();
-   if ((curOpCode == TR::InstOpCode::CR || curOpCode == TR::InstOpCode::CGR || curOpCode == TR::InstOpCode::CGFR)
-      && (nextOpCode == TR::InstOpCode::BRC || nextOpCode == TR::InstOpCode::BRCL))
+   bool branchTakenPerformReduction = false;
+   bool fallThroughPerformReduction = false;
+
+   if (_cursor->getOpCodeValue() == TR::InstOpCode::CLR
+       && _cursor->getNext()->getOpCodeValue() == TR::InstOpCode::BRC)
       {
-      printf("Finding CR + BRC\n");
-      printf("method=%s\n", comp()->signature());
-      }
+      TR::Instruction *clrInstruction = _cursor;
+      TR::Instruction *brcInstruction = _cursor->getNext();
+      TR::LabelSymbol *labelSymbol = brcInstruction->getLabelSymbol();
 
-   return performed;
+      /* Conditions for reduction
+       * - Branch target is a snippet
+       *    - we only need to check if CC is consumed in fall through case
+       * - Else: branch target is not a snippet
+       *    - we need to check if CC is consumed in both branch taken
+       *      and fall through case
+       */
+      if (labelSymbol->getSnippet())
+         {
+         branchTakenPerformReduction = true;
+         }
+      else
+         {
+         // check branch taken case for condition code usage
+         TR::Instruction* branchInstruction = labelSymbol->getInstruction();
+         for (auto branchTakenInstIndex = 0; branchTakenInstIndex < 5 && NULL != branchInstruction; ++branchTakenInstIndex)
+            {
+            if (branchInstruction->getOpCode().readsCC())
+               {
+               break;
+               }
+            // CC is set before it is read (ordering of the if checks matter)
+            if (branchInstruction->getOpCode().setsCC() || TR::BBEnd == branchInstruction->getNode()->getOpCodeValue())
+               {
+               branchTakenPerformReduction = true;
+               break;
+               }
+            branchInstruction = branchInstruction->getNext();
+            }
+         }
+      // check fall through case for condition code usage
+      TR::Instruction* fallThroughInstruction = brcInstruction->getNext();
+      for (auto fallThroughInstIndex = 0; fallThroughInstIndex < 5 && NULL != fallThroughInstruction; ++fallThroughInstIndex)
+         {
+         if (fallThroughInstruction->getOpCode().readsCC())
+            {
+            break;
+            }
+         // CC is set before it is read (ordering of the if checks matter)
+         if (fallThroughInstruction->getOpCode().setsCC() || TR::BBEnd == fallThroughInstruction->getNode()->getOpCodeValue())
+            {
+            fallThroughPerformReduction = true;
+            break;
+            }
+         fallThroughInstruction = fallThroughInstruction->getNext();
+         }
+
+      if (fallThroughPerformReduction
+         && branchTakenPerformReduction
+         && performTransformation(comp(), "O^O S390 PEEPHOLE: Transforming CLR [%p] and BRC [%p] to CLRJ\n", clrInstruction, brcInstruction))
+         {
+         TR_ASSERT_FATAL(clrInstruction->getNumRegisterOperands() == 2, "Number of register operands was not 2: %d\n", clrInstruction->getNumRegisterOperands());
+
+         TR::Instruction *clrjInstruction = generateRIEInstruction(
+            _cg,
+            TR::InstOpCode::CLRJ,
+            clrInstruction->getNode(),
+            clrInstruction->getRegisterOperand(1),
+            clrInstruction->getRegisterOperand(2),
+            labelSymbol,
+            static_cast<TR::S390BranchInstruction*>(brcInstruction)->getBranchCondition(),
+            clrInstruction->getPrev()
+         );
+         _cg->replaceInst(clrInstruction, clrjInstruction);
+         _cg->deleteInst(brcInstruction);
+         }
+      }
+   return fallThroughPerformReduction && branchTakenPerformReduction;
    }
 
 /**
@@ -2898,6 +2965,16 @@ TR_S390PostRAPeephole::perform()
          case TR::InstOpCode::CRT:
          case TR::InstOpCode::CGFR:
          case TR::InstOpCode::CGRT:
+         case TR::InstOpCode::CLR:
+            {
+            CompareAndBranchReduction();
+            trueCompEliminationForCompareAndBranch();
+
+            if (comp()->getOption(TR_TraceCG))
+               printInst();
+
+            break;
+            }
          case TR::InstOpCode::CLRB:
          case TR::InstOpCode::CLRJ:
          case TR::InstOpCode::CLRT:


### PR DESCRIPTION
- `CLR` and `BRC` instructions are reduced to `CLRJ`
- The reduction happens only if one of the following conditions are met
    1. Branch target is a snippet, or
    2. Condition code is not used by the next 5 instructions, or
    3. Condition code is set by an instruction in that 5 instruction window

Closes: eclipse/openj9#4384

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>