### PR TITLE
AArch64: Implement ARM64Trg1MemSrc1Instruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -511,6 +511,26 @@ int32_t TR::ARM64MemSrc1Instruction::estimateBinaryLength(int32_t currentEstimat
    return(currentEstimate + getEstimatedBinaryLength());
    }
 
+uint8_t *TR::ARM64Trg1MemSrc1Instruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   cursor = getMemoryReference()->generateBinaryEncoding(this, cursor, cg());
+   setBinaryLength(cursor - instructionStart);
+   setBinaryEncoding(instructionStart);
+   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
+   return cursor;
+   }
+
+int32_t TR::ARM64Trg1MemSrc1Instruction::estimateBinaryLength(int32_t currentEstimate)
+   {
+   setEstimatedBinaryLength(getMemoryReference()->estimateBinaryLength(getOpCodeValue()));
+   return currentEstimate + getEstimatedBinaryLength();
+   }
+
 uint8_t *TR::ARM64Src1Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -592,6 +592,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsMemSrc1:
          print(pOutFile, (TR::ARM64MemSrc1Instruction *)instr);
          break;
+      case OMR::Instruction::IsTrg1MemSrc1:
+         print(pOutFile, (TR::ARM64Trg1MemSrc1Instruction *)instr);
+         break;
       case OMR::Instruction::IsSrc1:
          print(pOutFile, (TR::ARM64Src1Instruction *)instr);
          break;
@@ -1093,6 +1096,20 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64MemSrc1Instruction *instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
 
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getMemoryReference());
+
+   printMemoryReferenceComment(pOutFile, instr->getMemoryReference());
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1MemSrc1Instruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getMemoryReference());
 

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -2483,6 +2483,137 @@ class ARM64MemSrc1Instruction : public ARM64MemInstruction
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);
    };
 
+// for "store exclusive" instructions such as stxrx/stxrw
+class ARM64Trg1MemSrc1Instruction : public ARM64Trg1MemInstruction
+   {
+   TR::Register *_source1Register;
+
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] mr : memory reference
+    * @param[in] sreg : source register
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1MemSrc1Instruction(TR::InstOpCode::Mnemonic op,
+                               TR::Node *node,
+                               TR::Register *treg,
+                               TR::MemoryReference *mr,
+                               TR::Register *sreg, TR::CodeGenerator *cg)
+      : ARM64Trg1MemInstruction(op, node, treg, mr, cg), _source1Register(sreg)
+      {
+      useRegister(sreg);
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] mr : memory reference
+    * @param[in] sreg : source register
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1MemSrc1Instruction(TR::InstOpCode::Mnemonic op,
+                               TR::Node *node,
+                               TR::Register *treg,
+                               TR::MemoryReference *mr,
+                               TR::Register *sreg,
+                               TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1MemInstruction(op, node, treg, mr, precedingInstruction, cg), _source1Register(sreg)
+      {
+      useRegister(sreg);
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsTrg1MemSrc1; }
+
+   /**
+    * @brief Gets source register
+    * @return source register
+    */
+   TR::Register *getSource1Register() {return _source1Register;}
+   /**
+    * @brief Sets source register
+    * @param[in] sr : source register
+    * @return source register
+    */
+   TR::Register *setSource1Register(TR::Register *sr) {return (_source1Register = sr);}
+
+   virtual TR::Snippet *getSnippetForGC() {return getMemoryReference()->getUnresolvedSnippet();}
+
+   /**
+    * @brief Sets target register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertTargetRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *target = toRealRegister(getTargetRegister());
+      target->setRegisterFieldRS(instruction);
+      }
+
+   /**
+    * @brief Sets source register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertSource1Register(uint32_t *instruction)
+      {
+      TR::RealRegister *source1 = toRealRegister(_source1Register);
+      source1->setRegisterFieldRT(instruction);
+      }
+
+   /**
+    * @brief Answers whether this instruction references the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction references the virtual register
+    */
+   virtual bool refsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction uses the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction uses the virtual register
+    */
+   virtual bool usesRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given virtual register
+    * @param[in] reg : virtual register
+    * @return true when the instruction defines the virtual register
+    */
+   virtual bool defsRegister(TR::Register *reg);
+   /**
+    * @brief Answers whether this instruction defines the given real register
+    * @param[in] reg : real register
+    * @return true when the instruction defines the real register
+    */
+   virtual bool defsRealRegister(TR::Register *reg);
+   /**
+    * @brief Assigns registers
+    * @param[in] kindToBeAssigned : register kind
+    */
+   virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+
+   /**
+    * @brief Estimates binary length
+    * @param[in] currentEstimate : current estimated length
+    * @return estimated binary length
+    */
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
+   };
+
 class ARM64Src1Instruction : public TR::Instruction
    {
    TR::Register *_source1Register;

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -232,6 +232,14 @@ TR::Instruction *generateMemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCod
    return new (cg->trHeapMemory()) TR::ARM64MemSrc1Instruction(op, node, mr, sreg, cg);
    }
 
+TR::Instruction *generateTrg1MemSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
+   TR::Register *treg, TR::MemoryReference *mr, TR::Register *sreg, TR::Instruction *preced)
+   {
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1MemSrc1Instruction(op, node, treg, mr, sreg, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1MemSrc1Instruction(op, node, treg, mr, sreg, cg);
+   }
+
 TR::Instruction *generateSrc1Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
    TR::Register *s1reg, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -505,6 +505,26 @@ TR::Instruction *generateMemSrc1Instruction(
                    TR::Instruction *preced = NULL);
 
 /*
+ * @brief Generates "store exclusive" instruction
+ * @param[in] cg : CodeGenerator
+ * @param[in] op : instruction opcode
+ * @param[in] node : node
+ * @param[in] treg : target register
+ * @param[in] mr : memory reference
+ * @param[in] sreg : source register
+ * @param[in] preced : preceding instruction
+ * @return generated instruction
+ */
+TR::Instruction *generateTrg1MemSrc1Instruction(
+                   TR::CodeGenerator *cg,
+                   TR::InstOpCode::Mnemonic op,
+                   TR::Node *node,
+                   TR::Register *treg,
+                   TR::MemoryReference *mr,
+                   TR::Register *sreg,
+                   TR::Instruction *preced = NULL);
+
+/*
  * @brief Generates src1 instruction
  * @param[in] cg : CodeGenerator
  * @param[in] op : instruction opcode

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -46,6 +46,7 @@
             IsTrg1Src2Extended,
             IsTrg1Src3,
       IsTrg1Mem,
+         IsTrg1MemSrc1,
    IsMem,
       IsMemSrc1,
    IsSrc1,

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -715,6 +715,13 @@ static bool isImm12OffsetInstruction(uint32_t enc)
    return ((enc & 0x3b200000) == 0x39000000);
    }
 
+/* load/store exclusive */
+static bool isExclusiveMemAccessInstruction(TR::InstOpCode::Mnemonic op)
+   {
+   return (op == TR::InstOpCode::ldxrx || op == TR::InstOpCode::ldxrw ||
+           op == TR::InstOpCode::stxrx || op == TR::InstOpCode::stxrw);
+   }
+
 
 uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *currentInstruction, uint8_t *cursor, TR::CodeGenerator *cg)
    {
@@ -801,9 +808,14 @@ uint8_t *OMR::ARM64::MemoryReference::generateBinaryEncoding(TR::Instruction *cu
                   TR_ASSERT(false, "Offset is too large for specified instruction.");
                   }
                }
+            else if (isExclusiveMemAccessInstruction(op.getMnemonic()))
+               {
+               TR_ASSERT(displacement == 0, "Offset must be zero for specified instruction.");
+               cursor += ARM64_INSTRUCTION_LENGTH;
+               }
             else
                {
-               /* Register pair, literal, exclusive instructions to be supported */
+               /* Register pair, literal instructions to be supported */
                TR_UNIMPLEMENTED();
                }
             }
@@ -882,9 +894,13 @@ uint32_t OMR::ARM64::MemoryReference::estimateBinaryLength(TR::InstOpCode op)
                   TR_ASSERT(false, "Offset is too large for specified instruction.");
                   }
                }
+            else if (isExclusiveMemAccessInstruction(op.getMnemonic()))
+               {
+               return ARM64_INSTRUCTION_LENGTH;
+               }
             else
                {
-               /* Register pair, literal, exclusive instructions to be supported */
+               /* Register pair, literal instructions to be supported */
                TR_UNIMPLEMENTED();
                }
             }

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -352,6 +352,7 @@ namespace TR { class ARM64Trg1Src3Instruction; }
 namespace TR { class ARM64Trg1MemInstruction; }
 namespace TR { class ARM64MemInstruction; }
 namespace TR { class ARM64MemSrc1Instruction; }
+namespace TR { class ARM64Trg1MemSrc1Instruction; }
 namespace TR { class ARM64Src1Instruction; }
 namespace TR { class ARM64Src2Instruction; }
 namespace TR { class ARM64HelperCallSnippet; }
@@ -1105,6 +1106,7 @@ public:
    void print(TR::FILE *, TR::ARM64Trg1MemInstruction *);
    void print(TR::FILE *, TR::ARM64MemInstruction *);
    void print(TR::FILE *, TR::ARM64MemSrc1Instruction *);
+   void print(TR::FILE *, TR::ARM64Trg1MemSrc1Instruction *);
    void print(TR::FILE *, TR::ARM64Src1Instruction *);
    void print(TR::FILE *, TR::ARM64Src2Instruction *);
 #ifdef J9_PROJECT_SPECIFIC


### PR DESCRIPTION
This commit implements ARM64Trg1MemSrc1Instruction, for generating
AArch64 "store exclusive" instructions.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>