### PR TITLE
Fix Bugs in splitPostGRA

### DIFF
--- a/compiler/il/OMRBlock.cpp
+++ b/compiler/il/OMRBlock.cpp
@@ -1165,17 +1165,22 @@ static TR::SymbolReference * createSymRefForNode(TR::Compilation *comp, TR::Reso
                {
                while (valueChild->getOpCode().isArrayRef())
                   valueChild = valueChild->getFirstChild();
-
-               if (valueChild->getOpCode().isLoadVarDirect() &&
-                     valueChild->getSymbolReference()->getSymbol()->isAuto())
+               // If the node we are uncommoning is internal pointer and while iterating a child we found a node that is not 
+               // Array Reference, There are only two possibilities.
+               // 1. It is  internal poiter which was commoned means could be stored into register or on temp slot. 
+               // 2. Itself is a pointer to array object.
+               TR::SymbolReference *valueChildSymRef = valueChild->getSymbolReference();
+               if (valueChildSymRef != NULL &&
+                  (valueChild->getOpCode().isLoadVarDirect() && valueChildSymRef->getSymbol()->isAuto()) ||
+                  (valueChild->getOpCode().isLoadReg() && valueChildSymRef->getSymbol()->castToAutoSymbol()->isInternalPointer()))
                   {
-                  if (valueChild->getSymbolReference()->getSymbol()->castToAutoSymbol()->isInternalPointer())
+                  if (valueChildSymRef->getSymbol()->castToAutoSymbol()->isInternalPointer())
                      {
-                     pinningArray = valueChild->getSymbolReference()->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer();
+                     pinningArray = valueChildSymRef->getSymbol()->castToInternalPointerAutoSymbol()->getPinningArrayPointer();
                      }
                   else
                      {
-                     pinningArray = valueChild->getSymbolReference()->getSymbol()->castToAutoSymbol();
+                     pinningArray = valueChildSymRef->getSymbol()->castToAutoSymbol();
                      pinningArray->setPinningArrayPointer();
                      }
                   }
@@ -1413,6 +1418,10 @@ OMR::Block::splitPostGRA(TR::TreeTop * startOfNewBlock, TR::CFG *cfg, bool copyE
             TR::Node *regDeps = iter->getNode()->getNumChildren() > 0 ? iter->getNode()->getChild(0) : NULL;
             if (regDeps && regDeps->getOpCodeValue() == TR::GlRegDeps)
                {
+               // If the previous tree top of BBEnd contains branch, we need to make sure any regStore we add are added before that.
+               TR::TreeTop *prevTT = iter->getPrevTreeTop();
+               if (prevTT->getNode()->getOpCode().isBranch() || prevTT->getNode()->getOpCode().hasBranchChildren())
+                  iter = prevTT;
                gatherUnavailableRegisters(comp, regDeps, iter, nodeInfo, storeNodeInfo, &storeRegNodePostSplitPoint, unavailableRegisters);
                }
             }


### PR DESCRIPTION
In post GRA block splitter there are some issue which we found in tests.
This commits fixes following two issues.
1. While creating approprite symbol reference for to be uncommoned node to
   store on temp slot or global register, it checks if that node is representing
   internal pointer. In such case it needs get corresponding pinning array symref
   if already exists and need to mark created symref with it. In case if corresponding
   pinning array symref does not exist then it needs to find it and create new pinning
   array pointer symref. Issue was, it was only checking variable load nodes for already
   existing pinning array pointer symref while with splitting block after GRA, we can have
   regLoad node which already contains it.
2. Second issue we found was altering the Basic Block semantics and adding treetops
   in between branch treetop and BBEnd treetop in the Basic block.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>