### PR TITLE
Add support of J9OS_I5 for ddrgen

### DIFF
--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -18,6 +18,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+#ifndef DWARFFUNCTIONS_HPP
+#define DWARFFUNCTIONS_HPP
 
 #include "ddr/config.hpp"
 
@@ -324,3 +326,5 @@ int dwarf_dieoffset(Dwarf_Die die, Dwarf_Off *dieOffset, Dwarf_Error *error);
 int dwarf_get_TAG_name(Dwarf_Half tag, const char **name);
 
 void setError(Dwarf_Error *error, Dwarf_Half num);
+
+#endif /*DWARFFUNCTIONS_HPP*/

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -73,8 +73,9 @@ public:
 
 	virtual DDR_RC startScan(OMRPortLibrary *portLibrary, Symbol_IR *ir,
 			vector<string> *debugFiles, const char *blacklistPath);
-
+	static const char * getScanFileName() { return scanFileName; }
 private:
+	static const char * scanFileName;
 	Dwarf_Signed _fileNameCount;
 	char **_fileNamesTable;
 	unordered_map<string, int> _anonymousEnumNames;

--- a/ddr/lib/ddr-scanner/dwarf/AixSymbolTableParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/AixSymbolTableParser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +22,7 @@
 #include "ddr/error.hpp"
 
 #include "ddr/scanner/dwarf/AixSymbolTableParser.hpp"
+#include "ddr/scanner/dwarf/DwarfScanner.hpp"
 
 /* Statics. */
 static die_map createdDies;
@@ -105,7 +106,6 @@ dwarf_init(int fd,
 	int ret = DW_DLV_OK;
 	FILE *fp = NULL;
 	char buffer[50000];
-	char filepath[100] = {'\0'};
 	Dwarf_CU_Context::_firstCU = NULL;
 	Dwarf_CU_Context::_currentCU = NULL;
 	refNumber = 1;
@@ -114,13 +114,10 @@ dwarf_init(int fd,
 	ret = populateBuiltInTypeDies(error);
 	populateAttributeReferences();
 
-	/* Get the path of the file descriptor. */
-	sprintf(filepath, "/proc/%d/fd/%d", getpid(), fd);
-
 	/* Call dump to get the symbol table. */
 	if (DW_DLV_OK == ret) {
 		stringstream ss;
-		ss << "dump -tvXany " << filepath << " 2>&1";
+		ss << "dump -tvXany " << DwarfScanner::getScanFileName() << " 2>&1";
 		fp = popen(ss.str().c_str(), "r");
 		if (NULL == fp) {
 			ret = DW_DLV_ERROR;

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -64,6 +64,8 @@ public:
 	virtual DDR_RC visitUnion(UnionUDT *type) const;
 };
 
+const char * DwarfScanner::scanFileName = NULL;
+
 DwarfScanner::DwarfScanner()
 	: _fileNameCount(0), _fileNamesTable(NULL), _ir(NULL), _debug(NULL)
 {
@@ -1563,6 +1565,7 @@ DwarfScanner::scanFile(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *f
 		Dwarf_Handler errhand = 0;
 		Dwarf_Ptr errarg = NULL;
 		intptr_t native_fd = omrfile_convert_omrfile_fd_to_native_fd(fd);
+		DwarfScanner::scanFileName = filepath;
 		res = dwarf_init((int)native_fd, access, errhand, errarg, &_debug, &error);
 		if (DW_DLV_OK != res) {
 			ERRMSG("Failed to initialize libDwarf scanning %s: %s\nExiting...\n", filepath, dwarf_errmsg(error));
@@ -1597,6 +1600,7 @@ DwarfScanner::scanFile(OMRPortLibrary *portLibrary, Symbol_IR *ir, const char *f
 		omrfile_close(fd);
 	}
 
+	DwarfScanner::scanFileName = NULL;
 	DEBUGPRINTF("Start Scan Finished: Returning...");
 
 	return rc;


### PR DESCRIPTION
This is to enable ddrgen to work on IBM i. I have refined the code per suggestion from @keithc-ca . Please help to review and merge it. I didn't break any existing routines. thanks.

FYI @keithc-ca