### PR TITLE
gtest: Do not reference temporaries past the expression that created them

### DIFF
--- a/third_party/gtest-1.8.0/src/gtest-typed-test.cc
+++ b/third_party/gtest-1.8.0/src/gtest-typed-test.cc
@@ -101,7 +101,7 @@ const char* TypedTestCasePState::VerifyRegisteredTestNames(
     }
   }
 
-  const std::string& errors_str = errors.GetString();
+  const std::string errors_str = errors.GetString();
   if (errors_str != "") {
     fprintf(stderr, "%s %s", FormatFileLocation(file, line).c_str(),
             errors_str.c_str());

--- a/third_party/gtest-1.8.0/src/gtest.cc
+++ b/third_party/gtest-1.8.0/src/gtest.cc
@@ -501,7 +501,7 @@ bool UnitTestOptions::MatchesFilter(
 // name and the test name.
 bool UnitTestOptions::FilterMatchesTest(const std::string &test_case_name,
                                         const std::string &test_name) {
-  const std::string& full_name = test_case_name + "." + test_name.c_str();
+  const std::string full_name = test_case_name + "." + test_name.c_str();
 
   // Split --gtest_filter at '-', if there is one, to separate into
   // positive filter and negative filter portions
@@ -1980,7 +1980,7 @@ std::string String::FormatByte(unsigned char value) {
 // Converts the buffer in a stringstream to an std::string, converting NUL
 // bytes to "\\0" along the way.
 std::string StringStreamToString(::std::stringstream* ss) {
-  const ::std::string& str = ss->str();
+  const ::std::string str = ss->str();
   const char* const start = str.c_str();
   const char* const end = start + str.length();
 
@@ -2858,7 +2858,7 @@ static std::string PrintTestPartResultToString(
 
 // Prints a TestPartResult.
 static void PrintTestPartResult(const TestPartResult& test_part_result) {
-  const std::string& result =
+  const std::string result =
       PrintTestPartResultToString(test_part_result);
   printf("%s\n", result.c_str());
   fflush(stdout);
@@ -3611,7 +3611,7 @@ void XmlUnitTestResultPrinter::OutputXmlAttribute(
     const std::string& element_name,
     const std::string& name,
     const std::string& value) {
-  const std::vector<std::string>& allowed_names =
+  const std::vector<std::string> allowed_names =
       GetReservedAttributesForElement(element_name);
 
   GTEST_CHECK_(std::find(allowed_names.begin(), allowed_names.end(), name) !=
@@ -4400,7 +4400,7 @@ void UnitTestImpl::SuppressTestEventsIfInSubprocess() {
 // Initializes event listeners performing XML output as specified by
 // UnitTestOptions. Must not be called before InitGoogleTest.
 void UnitTestImpl::ConfigureXmlOutput() {
-  const std::string& output_format = UnitTestOptions::GetOutputFormat();
+  const std::string output_format = UnitTestOptions::GetOutputFormat();
   if (output_format == "xml") {
     listeners()->SetDefaultXmlGenerator(new XmlUnitTestResultPrinter(
         UnitTestOptions::GetAbsolutePathToOutputFile().c_str()));
@@ -4802,7 +4802,7 @@ int UnitTestImpl::FilterTests(ReactionToSharding shard_tests) {
   int num_selected_tests = 0;
   for (size_t i = 0; i < test_cases_.size(); i++) {
     TestCase* const test_case = test_cases_[i];
-    const std::string &test_case_name = test_case->name();
+    const std::string test_case_name = test_case->name();
     test_case->set_should_run(false);
 
     for (size_t j = 0; j < test_case->test_info_list().size(); j++) {


### PR DESCRIPTION
This is an error in gtest, not in OMR.

This same error is repeated in a few places, causing different types of
bad behaviour on AIX, including breaking almost all logging and option
processing.

Rather than bind a const mytype& to a temporary result, copy the result
into a local, which ensures it is safe to access the value later in the
program.

When a reference is bound to a temporary value, that reference is
invalid when the value dies, at the end of the "full expression" that
created it. Using this reference to a temporary in a later expression
results in a kind of "use after destruction" error.

Fixes: #4537
Signed-off-by: Robert Young <rwy0717@gmail.com>