### PR TITLE
AArch64: Add "nop" and "vgdnop" to ARM64Debug.cpp

### DIFF
--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -486,11 +486,13 @@ static const char *opCodeToNameMap[] =
    "fmaxd",
    "fmins",
    "fmind",
+   "nop",
    "proc",
    "fence",
    "return",
    "dd",
-   "label"
+   "label",
+   "vgdnop"
    };
 
 const char *


### PR DESCRIPTION
This commit adds "nop" and "vgdnop" instructions to ARM64Debug.cpp.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>