### PR TITLE
AArch64: Handle resolved class pointer in loadRelocatableConstant()

### DIFF
--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -84,6 +84,10 @@ static void loadRelocatableConstant(TR::Node *node,
          {
          loadAddressConstant(cg, GCRnode, 1, reg, NULL, false, TR_DataAddress);
          }
+      else if (isClass && !ref->isUnresolved())
+         {
+         loadAddressConstant(cg, GCRnode, (intptr_t)ref, reg, NULL, false, TR_ClassAddress);
+         }
       else
          {
          cg->addSnippet(mr->setUnresolvedSnippet(new (cg->trHeapMemory()) TR::UnresolvedDataSnippet(cg, node, ref, node->getOpCode().isStore(), false)));


### PR DESCRIPTION
This commit adds code to loadRelocatableConstant() in OMRMemoryReference
for AArch64, so that it can handle resolved class pointer.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>