### PR TITLE
Fix compile error with Concurrent Scavenger enabled on macOS

### DIFF
--- a/gc/base/standard/ConcurrentScavengeTask.hpp
+++ b/gc/base/standard/ConcurrentScavengeTask.hpp
@@ -35,7 +35,6 @@ class MM_ConcurrentScavengeTask : public MM_ParallelScavengeTask
 {
 	/* Data Members */
 private:
-	uintptr_t const _bytesToScan;	/**< The number of bytes that this must scan before it will stop trying to do more work */
 	volatile uintptr_t _bytesScanned;	/**< The number of bytes scanned by this */
 protected:
 public:
@@ -69,10 +68,8 @@ public:
 			MM_Dispatcher *dispatcher,
 			MM_Scavenger *scavenger,
 			ConcurrentAction action,
-			uintptr_t bytesToScan,
 			MM_CycleState *cycleState) :
 		MM_ParallelScavengeTask(env, dispatcher, scavenger, cycleState)
-		, _bytesToScan(bytesToScan)
 		, _bytesScanned(0)
 		, _action(action)
 	{

--- a/gc/base/standard/Scavenger.cpp
+++ b/gc/base/standard/Scavenger.cpp
@@ -4821,7 +4821,7 @@ MM_Scavenger::scavengeRoots(MM_EnvironmentBase *env)
 {
 	Assert_MM_true(concurrent_state_roots == _concurrentState);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_ROOTS, UDATA_MAX, env->_cycleState);
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_ROOTS, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
 	return false;
@@ -4836,7 +4836,7 @@ MM_Scavenger::scavengeScan(MM_EnvironmentBase *envBase)
 
 	restoreMasterThreadTenureTLHRemainders(env);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, env->_cycleState);
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
 	return false;
@@ -4851,7 +4851,7 @@ MM_Scavenger::scavengeComplete(MM_EnvironmentBase *envBase)
 
 	restoreMasterThreadTenureTLHRemainders(env);
 
-	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_COMPLETE, UDATA_MAX, env->_cycleState);
+	MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_COMPLETE, env->_cycleState);
 	_dispatcher->run(env, &scavengeTask);
 
 	Assert_MM_true(_scavengeCacheFreeList.areAllCachesReturned());
@@ -5112,7 +5112,7 @@ MM_Scavenger::masterThreadConcurrentCollect(MM_EnvironmentBase *env)
 	if (concurrent_state_scan == _concurrentState) {
 		clearIncrementGCStats(env, false);
 
-		MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, UDATA_MAX, env->_cycleState);
+		MM_ConcurrentScavengeTask scavengeTask(env, _dispatcher, this, MM_ConcurrentScavengeTask::SCAVENGE_SCAN, env->_cycleState);
 		/* Concurrent background task will run with different (typically lower) number of threads. */
 		_dispatcher->run(env, &scavengeTask, _extensions->concurrentScavengerBackgroundThreads);
 


### PR DESCRIPTION
Removed unused private field `_bytesToScan` from `ConcurrentScavengeTask` to resolve:

```
/ConcurrentScavengeTask.hpp:38:18: error: private field '_bytesToScan' is not used [-Werror,-Wunused-private-field]
uintptr_t const _bytesToScan;   /**< The number of bytes that this must scan before it will stop trying to do more work */
```

Signed-off-by: Salman Rana <salman.rana@ibm.com>