### PR TITLE
Fix argument info propagation in inlining

### DIFF
--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -549,6 +549,8 @@ class OMR_InlinerUtil : public TR::OptimizationUtil, public OMR_InlinerHelper
       virtual void adjustCallerWeightLimit(TR::ResolvedMethodSymbol *callSymbol, int &callerWeightLimit){ return; }
       virtual void adjustMethodByteCodeSizeThreshold(TR::ResolvedMethodSymbol *callSymbol, int &methodByteCodeSizeThreshold){ return; }
       virtual TR_PrexArgInfo *computePrexInfo(TR_CallTarget *target);
+      virtual TR_PrexArgInfo *computePrexInfo(TR_CallTarget *target, TR_PrexArgInfo *callerArgInfo);
+      virtual void clearArgInfoForNonInvariantArguments(TR_CallTarget *target, TR_InlinerTracer* tracer);
       virtual void collectCalleeMethodClassInfo(TR_ResolvedMethod *calleeMethod);
       /*
        * Implemented by down stream projects to request for certain optimizations based on \parm target

--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -701,6 +701,9 @@ class TR_InvariantArgumentPreexistence : public TR::Optimization
       void     setClassIsRefined()         { _classIsRefined = true; }
       bool     classIsRefined()            { return _classIsRefined; }
 
+      void     setClassIsPreexistent()         { _classIsPreexistent = true; }
+      bool     classIsPreexistent()            { return _classIsPreexistent; }
+
       void     setClass(TR_OpaqueClassBlock *clazz) { _clazz = clazz; }
       TR_OpaqueClassBlock *getClass() { return _clazz; }
 
@@ -717,12 +720,16 @@ class TR_InvariantArgumentPreexistence : public TR::Optimization
       bool     _classIsFixed;
       bool     _classIsCurrentlyFinal;
       bool     _classIsRefined;
+      bool     _classIsPreexistent;
       };
 
+   void traceIfEnabled(const char* format, ...);
    void processNode        (TR::Node *node, TR::TreeTop *treeTop, vcount_t visitCount);
    void processIndirectCall(TR::Node *node, TR::TreeTop *treeTop, vcount_t visitCount);
    void processIndirectLoad(TR::Node *node, TR::TreeTop *treeTop, vcount_t visitCount);
    bool convertCall(TR::Node *node, TR::TreeTop *treeTop);
+   bool devirtualizeVirtualCall(TR::Node *node, TR::TreeTop *treeTop, TR_OpaqueClassBlock* clazz);
+   TR_YesNoMaybe classIsCompatibleWithMethod(TR_OpaqueClassBlock* thisClazz, TR_ResolvedMethod* method);
 
    ParmInfo *getSuitableParmInfo(TR::Node *node);
 

--- a/compiler/optimizer/PreExistence.hpp
+++ b/compiler/optimizer/PreExistence.hpp
@@ -56,7 +56,7 @@ class TR_PrexArgument
       _profiledClazz(profiledClazz),
       _knownObjectIndex(TR::KnownObjectTable::UNKNOWN),
       _isTypeInfoForInlinedBody(false)
-      { }
+      { TR_ASSERT_FATAL(_classKind != ClassIsFixed || _class, "Fixed type must have a class"); }
 
    static const char *priorKnowledgeStrings[];
    static PrexKnowledgeLevel knowledgeLevel(TR_PrexArgument *pa);
@@ -118,6 +118,14 @@ class TR_PrexArgInfo
 
    static TR_PrexArgInfo* buildPrexArgInfoForMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
    void clearArgInfoForNonInvariantArguments(TR::ResolvedMethodSymbol* methodSymbol, TR_InlinerTracer* tracer);
+   /**
+    * \brief
+    *    Get arg info for arguments of callNode that are parameters of the caller
+    *
+    * \return
+    *    TR_PrexArgInfo contianing arg info for arguments from caller parameters
+    */
+   static TR_PrexArgInfo* argInfoFromCaller(TR::Node* callNode, TR_PrexArgInfo* callerArgInfo);
 #endif
 
    TR_ALLOC(TR_Memory::LocalOpts);


### PR DESCRIPTION
Invariant argument preexistence (IAP) stores argument type info in parm symbols. The problem with this is that most type information is site specific.

This PR will fix this issue by stop putting site specific information on parm symbols. The improved type information will be put on prex arg info which will be used by inliner.