### PR TITLE
Use compiler-local target environment

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -79,7 +79,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
 
          TR_ASSERT_FATAL(jitToJitStart, "Unknown compiled method entry point.  Entry point should be available by now.");
 
-         TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange(jitToJitStart, (intptrj_t)cursor),
+         TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange(jitToJitStart, (intptrj_t)cursor),
                          "Target address is out of range");
 
          intptrj_t distance = jitToJitStart - (intptrj_t)cursor;
@@ -102,7 +102,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
                {
                destination = TR::CodeCacheManager::instance()->findHelperTrampoline(symRef->getReferenceNumber(), (void *)cursor);
 
-               TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange(destination, (intptrj_t)cursor),
+               TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange(destination, (intptrj_t)cursor),
                                "Target address is out of range");
                }
 
@@ -123,7 +123,7 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
             if (cg()->directCallRequiresTrampoline(destination, (intptrj_t)cursor))
                {
                destination = (intptrj_t)cg()->fe()->methodTrampolineLookup(cg()->comp(), symRef, (void *)cursor);
-               TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange(destination, (intptrj_t)cursor),
+               TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange(destination, (intptrj_t)cursor),
                                "Call target address is out of range");
                }
 

--- a/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
+++ b/compiler/aarch64/codegen/ARM64HelperCallSnippet.cpp
@@ -94,7 +94,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64HelperCallSnippet * snippet)
       {
       bufferPos += ARM64_INSTRUCTION_LENGTH;
       intptr_t restartLocation = (intptr_t)restartLabel->getCodeLocation();
-      if (TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange((intptrj_t)restartLocation, (intptrj_t)bufferPos))
+      if (comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange((intptrj_t)restartLocation, (intptrj_t)bufferPos))
          {
          printPrefix(pOutFile, NULL, bufferPos, 4);
          trfprintf(pOutFile, "b \t" POINTER_PRINTF_FORMAT "\t\t; Back to ", restartLocation);

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -495,6 +495,6 @@ bool
 OMR::ARM64::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
    {
    return
-      !TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange(targetAddress, sourceAddress) ||
+      !self()->comp()->target().cpu.isTargetWithinUnconditionalBranchImmediateRange(targetAddress, sourceAddress) ||
       self()->comp()->getOption(TR_StressTrampolines);
    }

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -333,7 +333,7 @@ OMR::ARM64::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeGenerator *c
 TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    if (op == TR::InstOpCode::vldrimms)
       {
@@ -399,7 +399,7 @@ OMR::ARM64::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       TR::TreeEvaluator::generateVFTMaskInstruction(cg, node, tempReg);
       }
 
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    if (needSync)
       {
       generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, 0xF); // dmb SY
@@ -448,7 +448,7 @@ OMR::ARM64::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *c
 TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
    {
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    TR::Node *valueChild;
 
    if (node->getOpCode().isIndirect())

--- a/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/aarch64/runtime/VirtualGuardRuntime.cpp
@@ -30,9 +30,6 @@ extern void arm64CodeSync(unsigned char *codeStart, unsigned int codeSize);
 
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinUnconditionalBranchImmediateRange((intptrj_t)destinationAddr, (intptrj_t)locationAddr),
-      "_patchVirtualGuard: Destination too far");
-
    int64_t distance = (int64_t)destinationAddr - (int64_t)locationAddr;
    *(uint32_t *)locationAddr = TR::InstOpCode::getOpCodeBinaryEncoding(TR::InstOpCode::b) | ((distance >> 2) & 0x3ffffff); /* imm26 */
    arm64CodeSync((unsigned char *)locationAddr, ARM64_INSTRUCTION_LENGTH);

--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -76,7 +76,7 @@ uint32_t encodeHelperBranch(bool isBranchAndLink, TR::SymbolReference *symRef, u
       {
       target = TR::CodeCacheManager::instance()->findHelperTrampoline(symRef->getReferenceNumber(), (void *)cursor);
 
-      TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinBranchImmediateRange(target, (intptrj_t)cursor),
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.isTargetWithinBranchImmediateRange(target, (intptrj_t)cursor),
                       "Target address is out of range");
       }
 
@@ -291,7 +291,7 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
             {
             int32_t imm = getSourceImmediate();
 
-            if (TR::Compiler->target.cpu.isTargetWithinBranchImmediateRange((intptrj_t)imm, (intptrj_t)cursor))
+            if (cg()->comp()->target().cpu.isTargetWithinBranchImmediateRange((intptrj_t)imm, (intptrj_t)cursor))
                {
                *(int32_t *)cursor |= encodeBranchDistance((uintptr_t)cursor, (uint32_t) imm);
                }
@@ -321,7 +321,7 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
                   // have to use the trampoline as the target and not the label
                   intptrj_t targetAddress = cg()->fe()->methodTrampolineLookup(comp, getSymbolReference(), (void *)cursor);
 
-                  TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinBranchImmediateRange(targetAddress, (intptrj_t)cursor),
+                  TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinBranchImmediateRange(targetAddress, (intptrj_t)cursor),
                                   "Target address is out of range");
 
                   *(int32_t *)cursor |= encodeBranchDistance((uintptr_t)cursor, (uintptr_t) targetAddress);
@@ -393,12 +393,12 @@ uint8_t *TR::ARMTrg1Src2Instruction::generateBinaryEncoding()
    if (std::find(comp->getStaticPICSites()->begin(), comp->getStaticPICSites()->end(), this) != comp->getStaticPICSites()->end())
       {
       TR::Node *node = getNode();
-      cg()->jitAddPicToPatchOnClassUnload((void *)(TR::Compiler->target.is64Bit()?node->getLongInt():node->getInt()), (void *)cursor);
+      cg()->jitAddPicToPatchOnClassUnload((void *)(cg()->comp()->target().is64Bit()?node->getLongInt():node->getInt()), (void *)cursor);
       }
    if (std::find(comp->getStaticMethodPICSites()->begin(), comp->getStaticMethodPICSites()->end(), this) != comp->getStaticMethodPICSites()->end())
       {
       TR::Node *node = getNode();
-      cg()->jitAddPicToPatchOnClassUnload((void *) (cg()->fe()->createResolvedMethod(cg()->trMemory(), (TR_OpaqueMethodBlock *) (TR::Compiler->target.is64Bit()?node->getLongInt():node->getInt()), comp->getCurrentMethod())->classOfMethod()), (void *)cursor);
+      cg()->jitAddPicToPatchOnClassUnload((void *) (cg()->fe()->createResolvedMethod(cg()->trMemory(), (TR_OpaqueMethodBlock *) (cg()->comp()->target().is64Bit()?node->getLongInt():node->getInt()), comp->getCurrentMethod())->classOfMethod()), (void *)cursor);
       }
 
    cursor += ARM_INSTRUCTION_LENGTH;

--- a/compiler/arm/codegen/BinaryEvaluator.cpp
+++ b/compiler/arm/codegen/BinaryEvaluator.cpp
@@ -279,7 +279,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGen
        secondChild->getRegister() == NULL)
       {
       TR::Register *src1Reg   = cg->evaluate(firstChild);
-      if (TR::Compiler->target.cpu.isBigEndian())
+      if (cg->comp()->target().cpu.isBigEndian())
          {
          longVal.x.highValue = secondChild->getLongIntLow();
          longVal.x.lowValue = secondChild->getLongIntHigh();
@@ -423,7 +423,7 @@ TR::Register *OMR::ARM::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeGen
    lowReg = cg->allocateRegister();
    trgReg = cg->allocateRegisterPair(lowReg, highReg);
 
-   if(TR::Compiler->target.cpu.isBigEndian())
+   if(cg->comp()->target().cpu.isBigEndian())
       {
       dependencies->addPreCondition(dd_lowReg, TR::RealRegister::gr1);
       dependencies->addPreCondition(dd_highReg, TR::RealRegister::gr0);
@@ -725,7 +725,7 @@ static TR::Register *ldivAndLRemHelper(TR::Node *node, bool isDivide, TR::CodeGe
    lowReg = cg->allocateRegister();
    trgReg = cg->allocateRegisterPair(lowReg, highReg);
 
-   if(TR::Compiler->target.cpu.isBigEndian())
+   if(cg->comp()->target().cpu.isBigEndian())
       {
       dependencies->addPreCondition(dd_lowReg, TR::RealRegister::gr1);
       dependencies->addPreCondition(dd_highReg, TR::RealRegister::gr0);

--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -93,7 +93,7 @@ int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
 
 bool TR::ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, TR::Instruction **q, bool remove)
    {
-   int32_t count = TR::Compiler->target.is64Bit()?4:2;
+   int32_t count = cg()->comp()->target().is64Bit()?4:2;
    ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
    TR::ARMConstant<intptrj_t>               *acursor=aiterator.getFirst();
    while (acursor != NULL)
@@ -320,7 +320,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
 	       // Register an unload assumption on the lower 32bit of the class constant.
 	       // The patching code thinks it's low bit tagging an instruction not a class pointer!!
                cg()->
-               jitAddPicToPatchOnClassUnload((void *)acursor->getConstantValue(), (void *)(codeCursor+((TR::Compiler->target.is64Bit())?4:0)) );
+               jitAddPicToPatchOnClassUnload((void *)acursor->getConstantValue(), (void *)(codeCursor+((cg()->comp()->target().is64Bit())?4:0)) );
                }
             }
 

--- a/compiler/arm/codegen/ConstantDataSnippet.cpp
+++ b/compiler/arm/codegen/ConstantDataSnippet.cpp
@@ -55,96 +55,36 @@ int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
 
    switch(type)
       {
-#if 0
-      case TR::Float:
-	 {
-	 ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
-         TR::ARMConstant<float>                 *fcursor=fiterator.getFirst();
-
-         fin.fvalue = *(float *)v;
-         while (fcursor != NULL)
-	    {
-            fex.fvalue = fcursor->getConstantValue();
-            if (fin.ivalue == fex.ivalue)
-               break;
-            fcursor = fiterator.getNext();
-	    }
-         if (fcursor == NULL)
-	    {
-            fcursor = new (_cg->trHeapMemory()) TR::ARMConstant<float>(_cg, fin.fvalue);
-            _floatConstants.add(fcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
-	       {
-               ret = TR_ARMTableOfConstants::lookUp(fin.fvalue, _cg);
-               fcursor->setTOCOffset(ret);
-	       }
-	    }
-         ret = fcursor->getTOCOffset();
-         if (TR::Compiler->target.is32Bit() || ret==PTOC_FULL_INDEX)
-            fcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
-         }
-         break;
-
-      case TR::Double:
-	 {
-	 ListIterator< TR::ARMConstant<double> > diterator(&_doubleConstants);
-         TR::ARMConstant<double>                *dcursor=diterator.getFirst();
-
-         din.dvalue = *(double *)v;
-         while (dcursor != NULL)
-	    {
-            dex.dvalue = dcursor->getConstantValue();
-            if (din.lvalue == dex.lvalue)
-               break;
-            dcursor = diterator.getNext();
-	    }
-         if (dcursor == NULL)
-	    {
-            dcursor = new (_cg->trHeapMemory()) TR::ARMConstant<double>(_cg, din.dvalue);
-            _doubleConstants.add(dcursor);
-            if (TR::Compiler->target.is64Bit() && !comp->getOption(TR_DisableTOC))
-	       {
-               ret = TR_ARMTableOfConstants::lookUp(din.dvalue, _cg);
-               dcursor->setTOCOffset(ret);
-	       }
-	    }
-         ret = dcursor->getTOCOffset();
-         if (TR::Compiler->target.is32Bit() || ret==PTOC_FULL_INDEX)
-            dcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
-         }
-         break;
-#endif
       case TR::Address:
-	 {
-	 ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
+         {
+         ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
          TR::ARMConstant<intptrj_t>                 *acursor=aiterator.getFirst();
 
          ain = *(intptrj_t *)v;
          while (acursor != NULL)
-	    {
-            aex = acursor->getConstantValue();
-            // if pointers require relocation, then not all pointers may be relocated for the same reason
-            //   so be conservative and do not combine them (e.g. HCR versus profiled inlined site enablement)
-            if (ain == aex &&
-                (!cg()->profiledPointersRequireRelocation() || acursor->getNode() == node))
-               break;
-            acursor = aiterator.getNext();
-	    }
+            {
+             aex = acursor->getConstantValue();
+             // if pointers require relocation, then not all pointers may be relocated for the same reason
+             //   so be conservative and do not combine them (e.g. HCR versus profiled inlined site enablement)
+             if (ain == aex &&
+                 (!cg()->profiledPointersRequireRelocation() || acursor->getNode() == node))
+                break;
+             acursor = aiterator.getNext();
+             }
          if (acursor && acursor->isUnloadablePicSite()!=isUnloadablePicSite)
             {
             TR_ASSERT(0, "Existing address constant does not have a matching unloadable state.\n" );
             acursor = NULL; // If asserts are turned off then we should just create a duplicate constant
             }
          if (acursor == NULL)
-	    {
+            {
             acursor = new (_cg->trHeapMemory()) TR::ARMConstant<intptrj_t>(_cg, ain, node, isUnloadablePicSite);
             _addressConstants.add(acursor);
-	    }
-         acursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
+            }
+            acursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
          }
          break;
       default:
-         //TR_ASSERT(0, "Only float and address constants are supported. Data type is %d.\n", type);
          TR_ASSERT(0, "Only address constants are supported. Data type is %d.\n", type);
       }
 
@@ -154,97 +94,6 @@ int32_t TR::ARMConstantDataSnippet::addConstantRequest(void              *v,
 bool TR::ARMConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, TR::Instruction **q, bool remove)
    {
    int32_t count = TR::Compiler->target.is64Bit()?4:2;
-#if 0
-   ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
-   TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
-
-   while (dcursor != NULL)
-      {
-      TR_Array<TR::Instruction *> &requestors = dcursor->getRequestors();
-      if (requestors.size() > 0)
-         {
-         for (int32_t i = 0; i < requestors.size(); i+=count)
-            {
-            if (count == 2)
-               {
-               if (requestors[i] == nibble || requestors[i+1] == nibble)
-                  {
-                  q[0] = requestors[i];
-                  q[1] = requestors[i+1];
-                  q[2] = NULL;
-                  q[3] = NULL;
-                  if (remove)
-                     {
-                     requestors.remove(i+1);
-                     requestors.remove(i);
-                     }
-                  return true;
-                  }
-               }
-            else // count == 4
-               {
-               int32_t j;
-               if (requestors[i] == nibble || requestors[i+1] == nibble || requestors[i+2] == nibble || requestors[i+3] == nibble)
-                  {
-                  for (j = 0; j < count; j++)
-                      q[j] = requestors[i+j];
-                  if (remove)
-                     {
-                     for (j = count-1; j >= 0 ; j--)
-                         requestors.remove(i+j);
-                     }
-                  return true;
-                  }
-               }
-            }
-         }
-      dcursor = diterator.getNext();
-      }
-   ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
-   TR::ARMConstant<float>               *fcursor=fiterator.getFirst();
-   while (fcursor != NULL)
-      {
-      TR_Array<TR::Instruction *> &requestors = fcursor->getRequestors();
-      if (requestors.size() > 0)
-         {
-         for (int32_t i = 0; i < requestors.size(); i+=count)
-            {
-            if (count == 2)
-               {
-               if (requestors[i] == nibble || requestors[i+1] == nibble)
-                  {
-                  q[0] = requestors[i];
-                  q[1] = requestors[i+1];
-                  q[2] = NULL;
-                  q[3] = NULL;
-                  if (remove)
-                     {
-                     requestors.remove(i+1);
-                     requestors.remove(i);
-                     }
-                  return true;
-                  }
-               }
-            else // count == 4
-               {
-               int32_t j = 0;
-               if (requestors[i] == nibble || requestors[i+1] == nibble || requestors[i+2] == nibble || requestors[i+3] == nibble)
-                  {
-                  for (j = 0; j < count; j++)
-                      q[j] = requestors[i+j];
-                  if (remove)
-                     {
-                     for (j = count-1; j >= 0 ; j--)
-                         requestors.remove(i+j);
-                     }
-                  return true;
-                  }
-               }
-            }
-         }
-      fcursor = fiterator.getNext();
-      }
-#endif
    ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
    TR::ARMConstant<intptrj_t>               *acursor=aiterator.getFirst();
    while (acursor != NULL)
@@ -514,43 +363,7 @@ uint8_t *TR::ARMConstantDataSnippet::emitSnippetBody()
 
 uint32_t TR::ARMConstantDataSnippet::getLength()
    {
-#if 0
-   if (TR::Compiler->target.is64Bit())
-      {
-      ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
-      TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
-      ListIterator< TR::ARMConstant<float> >   fiterator(&_floatConstants);
-      TR::ARMConstant<float>                  *fcursor=fiterator.getFirst();
-      ListIterator< TR::ARMConstant<intptrj_t> >   aiterator(&_addressConstants);
-      TR::ARMConstant<intptrj_t>              *acursor=aiterator.getFirst();
-      uint32_t length=0;
-
-      while (dcursor!=NULL)
-	 {
-         if (dcursor->getRequestors().size() > 0)
-            length += 8;
-         dcursor = diterator.getNext();
-	 }
-
-      while (fcursor!=NULL)
-	 {
-         if (fcursor->getRequestors().size() > 0)
-            length += 4;
-         fcursor = fiterator.getNext();
-	 }
-     while (acursor!=NULL)
-	 {
-         if (acursor->getRequestors().size() > 0)
-            length += sizeof(intptrj_t);
-         acursor = aiterator.getNext();
-	 }
-      return length;
-      }
-   else
-      return _doubleConstants.getSize()*8 + _floatConstants.getSize()*4 + _addressConstants.getSize()*4;
-#else
-      return _addressConstants.getSize()*4;
-#endif
+   return _addressConstants.getSize()*4;
    }
 
 
@@ -567,33 +380,6 @@ void TR::ARMConstantDataSnippet::print(TR::FILE *outFile)
 
    trfprintf(outFile, "\n%08x\t\t\t\t\t; Constant Data", codeCursor-codeStart);
 
-#if 0
-   ListIterator< TR::ARMConstant<double> >  diterator(&_doubleConstants);
-   TR::ARMConstant<double>                 *dcursor=diterator.getFirst();
-   while (dcursor != NULL)
-      {
-      if (TR::Compiler->target.is32Bit() || dcursor->getRequestors().size()>0)
-	 {
-         trfprintf(outFile, "\n%08x %08x %08x\t\t; %16f Double", codeCursor-codeStart,
-                 *(int32_t *)codeCursor, *(int32_t *)(codeCursor+4), dcursor->getConstantValue());
-         codeCursor += 8;
-	 }
-      dcursor = diterator.getNext();
-      }
-
-   ListIterator< TR::ARMConstant<float> >  fiterator(&_floatConstants);
-   TR::ARMConstant<float>                 *fcursor=fiterator.getFirst();
-   while (fcursor != NULL)
-      {
-      if (TR::Compiler->target.is32Bit() || fcursor->getRequestors().size()>0)
-	 {
-         trfprintf(outFile, "\n%08x %08x\t\t; %16f Float", codeCursor-codeStart,
-                 *(int32_t *)codeCursor, fcursor->getConstantValue());
-         codeCursor += 4;
-	 }
-      fcursor = fiterator.getNext();
-      }
-#endif
    ListIterator< TR::ARMConstant<intptrj_t> >  aiterator(&_addressConstants);
    TR::ARMConstant<intptrj_t>                 *acursor=aiterator.getFirst();
    while (acursor != NULL)

--- a/compiler/arm/codegen/FPTreeEvaluator.cpp
+++ b/compiler/arm/codegen/FPTreeEvaluator.cpp
@@ -227,7 +227,7 @@ static TR::Register *callLong2DoubleHelper(TR::Node *node, TR::CodeGenerator *cg
 #endif
    TR::Register *doubleTrgReg = NULL;
 
-   if (TR::Compiler->target.cpu.isLittleEndian())
+   if (cg->comp()->target().cpu.isLittleEndian())
       {
       /* Little Endian */
       dependencies->addPreCondition(srcReg->getHighOrder(), TR::RealRegister::gr1);
@@ -313,7 +313,7 @@ static TR::Register *callLong2FloatHelper(TR::Node *node, TR::CodeGenerator *cg)
 #endif
    TR::Register *floatTrgReg = NULL;
 
-   if (TR::Compiler->target.cpu.isLittleEndian())
+   if (cg->comp()->target().cpu.isLittleEndian())
       {
       /* Little Endian */
       dependencies->addPreCondition(srcReg->getHighOrder(), TR::RealRegister::gr1);
@@ -422,7 +422,7 @@ static TR::Register *callDouble2LongHelper(TR::Node *node, TR::CodeGenerator *cg
       TR_ASSERT(0, "Unknown register type\n");
 #endif
 
-   if (TR::Compiler->target.cpu.isLittleEndian())
+   if (cg->comp()->target().cpu.isLittleEndian())
       {
       /* Little Endian */
 
@@ -514,7 +514,7 @@ static TR::Register *callFloat2LongHelper(TR::Node *node, TR::CodeGenerator *cg)
       TR_ASSERT(0, "Unknown register type\n");
 #endif
 
-   if (TR::Compiler->target.cpu.isLittleEndian())
+   if (cg->comp()->target().cpu.isLittleEndian())
       {
       /* Little Endian */
 #if defined(__ARM_PCS_VFP)
@@ -618,7 +618,7 @@ static TR::Register *callDoubleRemainderHelper(TR::Node *node, TR::CodeGenerator
          }
       }
 
-   if (TR::Compiler->target.cpu.isLittleEndian())
+   if (cg->comp()->target().cpu.isLittleEndian())
       {
       /* Little Endian */
 #if defined(__ARM_PCS_VFP)
@@ -914,9 +914,9 @@ TR::Register *OMR::ARM::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Code
       	 {
          lowReg  = cg->allocateRegister();
          highReg = cg->allocateRegister();
-         highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 0 : 4, 4, cg);
+         highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 0 : 4, 4, cg);
          generateTrg1MemInstruction(cg, ARMOp_ldr, node, highReg, highMem);
-         lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 4 : 0, 4, cg);
+         lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 4 : 0, 4, cg);
          generateTrg1MemInstruction(cg, ARMOp_ldr, node, lowReg, lowMem);
 
          highMem->decNodeReferenceCounts();
@@ -982,9 +982,9 @@ TR::Register *OMR::ARM::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Code
       TR::MemoryReference  *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 8, cg);
       lowReg  = cg->allocateRegister();
       highReg = cg->allocateRegister();
-      highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 0 : 4, 4, cg);
+      highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 0 : 4, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, highReg, highMem);
-      lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 4 : 0, 4, cg);
+      lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 4 : 0, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, lowReg, lowMem);
 
       highMem->decNodeReferenceCounts();
@@ -1105,7 +1105,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::CodeG
 
    // Place the constant
    //armCG(cg)->findOrCreateFloatConstant(&value, TR::Double, high, low);
-   if (TR::Compiler->target.cpu.isLittleEndian())
+   if (cg->comp()->target().cpu.isLittleEndian())
       {
       generateImmInstruction(cg, ARMOp_dd, node, (int32_t)i64);
       generateImmInstruction(cg, ARMOp_dd, node, (int32_t)((i64>>32) & 0xffffffff));
@@ -1202,9 +1202,9 @@ TR::Register *OMR::ARM::TreeEvaluator::floadEvaluator(TR::Node *node, TR::CodeGe
       trgReg = floatTrgReg;
       }
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP() && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    tempMR->decNodeReferenceCounts();
    node->setRegister(trgReg);
@@ -1249,9 +1249,9 @@ TR::Register *OMR::ARM::TreeEvaluator::dloadEvaluator(TR::Node *node, TR::CodeGe
       trgReg = doubleTrgReg;
       }
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP() && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    tempMR->decNodeReferenceCounts();
    node->setRegister(trgReg);
@@ -1264,9 +1264,9 @@ TR::Register *OMR::ARM::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::CodeG
    TR::Register *sourceReg = cg->evaluate(firstChild);
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP() && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    if (noFPRA)
       {
@@ -1320,9 +1320,9 @@ TR::Register *OMR::ARM::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeG
    TR::Register *sourceReg = cg->evaluate(firstChild);
    bool  isUnresolved = node->getSymbolReference()->isUnresolved();
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP() && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    if (noFPRA)
       {
@@ -1331,7 +1331,7 @@ TR::Register *OMR::ARM::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::CodeG
          // sourceReg is in general registers, mimic a lstore
          TR::MemoryReference *lowMR  = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
          TR::MemoryReference *highMR = new (cg->trHeapMemory()) TR::MemoryReference(*lowMR, 4, 4, cg);
-         if (TR::Compiler->target.cpu.isBigEndian())
+         if (cg->comp()->target().cpu.isBigEndian())
             {
             generateMemSrc1Instruction(cg, ARMOp_str, node, lowMR, sourceReg->getHighOrder());
             generateMemSrc1Instruction(cg, ARMOp_str, node, highMR, sourceReg->getLowOrder());
@@ -1391,9 +1391,9 @@ TR::Register *OMR::ARM::TreeEvaluator::ifstoreEvaluator(TR::Node *node, TR::Code
    TR::Register *sourceReg = cg->evaluate(secondChild);
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP() && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    if (noFPRA)
       {
@@ -1445,9 +1445,9 @@ TR::Register *OMR::ARM::TreeEvaluator::idstoreEvaluator(TR::Node *node, TR::Code
    TR::Node *secondChild = node->getSecondChild();
    TR::Register *sourceReg = cg->evaluate(secondChild);
 
-   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP() && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP() && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
 
    if (noFPRA)
@@ -1457,7 +1457,7 @@ TR::Register *OMR::ARM::TreeEvaluator::idstoreEvaluator(TR::Node *node, TR::Code
          // sourceReg is in general registers, mimic a lstore
          TR::MemoryReference *lowMR  = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
          TR::MemoryReference *highMR = new (cg->trHeapMemory()) TR::MemoryReference(*lowMR, 4, 4, cg);
-         if (TR::Compiler->target.cpu.isBigEndian())
+         if (cg->comp()->target().cpu.isBigEndian())
             {
             generateMemSrc1Instruction(cg, ARMOp_str, node, lowMR, sourceReg->getHighOrder());
             generateMemSrc1Instruction(cg, ARMOp_str, node, highMR, sourceReg->getLowOrder());
@@ -1882,7 +1882,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::iload || firstChild->getOpCodeValue() == TR::iloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use. Use flds to save the move
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -1935,7 +1935,7 @@ TR::Register *OMR::ARM::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::iload || firstChild->getOpCodeValue() == TR::iloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2007,7 +2007,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2dEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::fload || firstChild->getOpCodeValue() == TR::floadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2062,7 +2062,7 @@ TR::Register *OMR::ARM::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::fload || firstChild->getOpCodeValue() == TR::floadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2102,7 +2102,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2iEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::dload || firstChild->getOpCodeValue() == TR::dloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(firstChild, 4, cg);
@@ -2175,7 +2175,7 @@ TR::Register *OMR::ARM::TreeEvaluator::d2fEvaluator(TR::Node *node, TR::CodeGene
       (firstChild->getOpCodeValue() == TR::dload || firstChild->getOpCodeValue() == TR::dloadi) &&
       (firstChild->getNumChildren() > 0) &&
       (firstChild->getFirstChild()->getNumChildren() == 1) &&
-      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+      !(firstChild->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // Coming from memory, last use
       TR::Register *tempReg = cg->allocateRegister(TR_FPR);
@@ -2722,9 +2722,9 @@ TR::Register *OMR::ARM::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Code
       TR::MemoryReference  *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 8, cg);
       lowReg  = cg->allocateRegister();
       highReg = cg->allocateRegister();
-      highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 0 : 4, 4, cg);
+      highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 0 : 4, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, highReg, highMem);
-      lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 4 : 0, 4, cg);
+      lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 4 : 0, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, lowReg, lowMem);
 
       highMem->decNodeReferenceCounts();
@@ -2759,9 +2759,9 @@ TR::Register *OMR::ARM::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Code
       TR::MemoryReference  *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 8, cg);
       lowReg  = cg->allocateRegister();
       highReg = cg->allocateRegister();
-      highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 0 : 4, 4, cg);
+      highMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 0 : 4, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, highReg, highMem);
-      lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (TR::Compiler->target.cpu.isBigEndian()) ? 4 : 0, 4, cg);
+      lowMem = new (cg->trHeapMemory()) TR::MemoryReference(*tempMR, (cg->comp()->target().cpu.isBigEndian()) ? 4 : 0, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, lowReg, lowMem);
 
       highMem->decNodeReferenceCounts();

--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -90,13 +90,13 @@ OMR::ARM::CodeGenerator::CodeGenerator()
    _unlatchedRegisterList[0] = 0; // mark that list is empty
 
    _linkageProperties = &self()->getLinkage()->getProperties();
-   _linkageProperties->setEndianness(TR::Compiler->target.cpu.isBigEndian());
+   _linkageProperties->setEndianness(self()->comp()->target().cpu.isBigEndian());
 
    if (!self()->comp()->getOption(TR_FullSpeedDebug))
       self()->setSupportsDirectJNICalls();
    self()->setSupportsVirtualGuardNOPing();
 
-   if(TR::Compiler->target.isLinux())
+   if(self()->comp()->target().isLinux())
       {
       // only hardhat linux-arm builds have the required gcc soft libraries
       // that allow the vm to be compiled with -msoft-float.
@@ -157,7 +157,7 @@ OMR::ARM::CodeGenerator::CodeGenerator()
    self()->setSupportsJavaFloatSemantics();
    self()->setSupportsInliningOfTypeCoersionMethods();
 
-   if (TR::Compiler->target.isLinux())
+   if (self()->comp()->target().isLinux())
       {
       // On AIX and Linux, we are very far away from address
       // wrapping-around.
@@ -261,7 +261,7 @@ directToInterpreterHelper(TR::ResolvedMethodSymbol *methodSymbol, TR::CodeGenera
       case TR::Int32:
          return sync?TR_ARMicallVMprJavaSendStaticSync1:TR_ARMicallVMprJavaSendStatic1;
       case TR::Address:
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             return sync?TR_ARMicallVMprJavaSendStaticSyncJ:TR_ARMicallVMprJavaSendStaticJ;
          else
             return sync?TR_ARMicallVMprJavaSendStaticSync1:TR_ARMicallVMprJavaSendStatic1;
@@ -831,6 +831,6 @@ bool
 OMR::ARM::CodeGenerator::directCallRequiresTrampoline(intptrj_t targetAddress, intptrj_t sourceAddress)
    {
    return
-      !TR::Compiler->target.cpu.isTargetWithinBranchImmediateRange(targetAddress, sourceAddress) ||
+      !self()->comp()->target().cpu.isTargetWithinBranchImmediateRange(targetAddress, sourceAddress) ||
       self()->comp()->getOption(TR_StressTrampolines);
    }

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -498,7 +498,7 @@ int32_t OMR::ARM::Linkage::buildARMLinkageArgs(TR::Node                         
    bool isHelper  = (conventions == TR_Helper);
    bool isVirtual = (isVirtualOrJNI && conventions == TR_Private);
    bool isSystem  = (conventions == TR_System);
-   bool bigEndian = TR::Compiler->target.cpu.isBigEndian();
+   bool bigEndian = self()->comp()->target().cpu.isBigEndian();
    int32_t   i;
    int32_t   totalSize = 0;
    uint32_t  numIntegerArgs = 0;

--- a/compiler/arm/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/arm/codegen/OMRTreeEvaluator.cpp
@@ -327,7 +327,7 @@ TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node * node, int
 TR::Register *OMR::ARM::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    tempReg = cg->allocateRegister();
    if (node->getSymbolReference()->getSymbol()->isInternalPointer())
@@ -340,9 +340,9 @@ TR::Register *OMR::ARM::TreeEvaluator::iloadEvaluator(TR::Node *node, TR::CodeGe
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 4, cg);
    generateTrg1MemInstruction(cg, ARMOp_ldr, node, tempReg, tempMR);
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    tempMR->decNodeReferenceCounts();
 
@@ -432,7 +432,7 @@ TR::Register *OMR::ARM::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGe
       }
 
    TR::Register *tempReg;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    if (!node->getSymbolReference()->getSymbol()->isInternalPointer())
       {
@@ -459,9 +459,9 @@ TR::Register *OMR::ARM::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGe
       }
 #endif
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    tempMR->decNodeReferenceCounts();
 
@@ -475,10 +475,10 @@ TR::Register *OMR::ARM::TreeEvaluator::lloadEvaluator(TR::Node *node, TR::CodeGe
    TR::Register           *highReg = cg->allocateRegister();
    TR::RegisterPair       *trgReg = cg->allocateRegisterPair(lowReg, highReg);
    TR::Compilation *comp = cg->comp();
-   bool bigEndian = TR::Compiler->target.cpu.isBigEndian();
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool bigEndian = cg->comp()->target().cpu.isBigEndian();
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 8, cg);
       TR::SymbolReference *vrlRef = comp->getSymRefTab()->findOrCreateVolatileReadLongSymbolRef(comp->getMethodSymbol());
@@ -534,11 +534,11 @@ TR::Register *OMR::ARM::TreeEvaluator::commonLoadEvaluator(TR::Node *node,  TR_A
    {
    TR::Register *tempReg = node->setRegister(cg->allocateRegister());
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    generateTrg1MemInstruction(cg, memToRegOp, node, tempReg, tempMR);
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    tempMR->decNodeReferenceCounts();
    return tempReg;
@@ -552,7 +552,7 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::Code
    TR::Node                *firstChild = node->getFirstChild();
    TR::Register            *sourceRegister;
    bool killSource = false;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    if (firstChild->getReferenceCount() > 1 && firstChild->getRegister() != NULL)
       {
@@ -570,9 +570,9 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::Code
    else
       sourceRegister = cg->evaluate(firstChild);
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
 
    generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, sourceRegister);
@@ -598,7 +598,7 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Cod
    TR::Node                *secondChild = node->getSecondChild();
    TR::Register            *sourceRegister;
    bool killSource = false;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    /* comp->useCompressedPointers() is false for 32bit environment, leaving the compressed pointer support unimplemented. */
    if (secondChild->getReferenceCount() > 1 && secondChild->getRegister() != NULL)
@@ -617,9 +617,9 @@ TR::Register *OMR::ARM::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Cod
    else
       sourceRegister = cg->evaluate(secondChild);
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
 
    generateMemSrc1Instruction(cg, ARMOp_str, node, tempMR, sourceRegister);
@@ -652,11 +652,11 @@ TR::Register *OMR::ARM::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR::CodeG
       {
       valueChild = node->getFirstChild();
       }
-   bool bigEndian = TR::Compiler->target.cpu.isBigEndian();
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool bigEndian = cg->comp()->target().cpu.isBigEndian();
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    TR::Register *valueReg = cg->evaluate(valueChild);
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
       TR::Register           *addrReg  = cg->allocateRegister();
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, 8, cg);
@@ -718,7 +718,7 @@ TR::Register *OMR::ARM::TreeEvaluator::istoreEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::ARM::TreeEvaluator::commonStoreEvaluator(TR::Node *node, TR_ARMOpCodes memToRegOp, int32_t memSize, TR::CodeGenerator *cg)
    {
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    TR::Node *valueChild;
    if (node->getOpCode().isIndirect())
       {
@@ -729,14 +729,14 @@ TR::Register *OMR::ARM::TreeEvaluator::commonStoreEvaluator(TR::Node *node, TR_A
       valueChild = node->getFirstChild();
       }
 
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb_st, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb_st, node);
       }
    generateMemSrc1Instruction(cg, memToRegOp, node, tempMR, cg->evaluate(valueChild));
-   if (needSync && TR::Compiler->target.cpu.id() != TR_DefaultARMProcessor)
+   if (needSync && cg->comp()->target().cpu.id() != TR_DefaultARMProcessor)
       {
-      generateInstruction(cg, (TR::Compiler->target.cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
+      generateInstruction(cg, (cg->comp()->target().cpu.id() == TR_ARMv6) ? ARMOp_dmb_v6 : ARMOp_dmb, node);
       }
    valueChild->decReferenceCount();
    tempMR->decNodeReferenceCounts();
@@ -1429,7 +1429,7 @@ TR::Register *OMR::ARM::TreeEvaluator::conversionAnalyser(TR::Node          *nod
    if (child->getReferenceCount() == 1 && child->getRegister() == NULL && child->getOpCode().isMemoryReference())
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, dstBits >> 3, cg);
-      if (TR::Compiler->target.cpu.isBigEndian() && node->getSize() < child->getSize())
+      if (cg->comp()->target().cpu.isBigEndian() && node->getSize() < child->getSize())
          {
          tempMR->addToOffset(node, child->getSize() - (dstBits>>3), cg);
          }
@@ -1454,7 +1454,7 @@ static void generateSignOrZeroExtend(TR::Node *node, TR::Register *dst, TR::Regi
    {
    TR_ARMOpCodes opcode = ARMOp_bad;
 
-   if (TR::Compiler->target.cpu.id() >= TR_ARMv6)
+   if (cg->comp()->target().cpu.id() >= TR_ARMv6)
       {
       // sxtb/sxth/uxtb/uxth instructions are unavailable in ARMv5 and older
       if (needSignExtend)

--- a/compiler/arm/codegen/UnaryEvaluator.cpp
+++ b/compiler/arm/codegen/UnaryEvaluator.cpp
@@ -266,7 +266,7 @@ TR::Register *OMR::ARM::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGene
       {
       trgReg = cg->allocateRegister();
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
-      if (TR::Compiler->target.cpu.isBigEndian())
+      if (cg->comp()->target().cpu.isBigEndian())
          tempMR->addToOffset(node, 4, cg);
       generateTrg1MemInstruction(cg, ARMOp_ldr, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts();

--- a/compiler/arm/runtime/VirtualGuardRuntime.cpp
+++ b/compiler/arm/runtime/VirtualGuardRuntime.cpp
@@ -28,9 +28,6 @@ extern void armCodeSync(uint8_t *, uint32_t);
 
 extern "C" void _patchVirtualGuard(uint8_t *locationAddr, uint8_t *destinationAddr, int32_t smpFlag)
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinBranchImmediateRange((intptrj_t)destinationAddr, (intptrj_t)locationAddr),
-                   "_patchVirtualGuard: Destination too far");
-
    // B instruction
    //
    int32_t newInstr = 0xEA000000 | encodeBranchDistance((uint32_t)locationAddr, (uint32_t)destinationAddr);

--- a/compiler/codegen/CodeGenGC.cpp
+++ b/compiler/codegen/CodeGenGC.cpp
@@ -288,7 +288,7 @@ OMR::CodeGenerator::buildGCMapForInstruction(TR::Instruction *instr)
          // skip it.  The occupied flag is not accurate in this case because we
          // did not free the spill and therefore did not clear the flag.
          //
-         if ((TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isZ()) && (*location)->getMaxSpillDepth() == 0  && comp->cg()->isOutOfLineHotPath())
+         if ((self()->comp()->target().cpu.isPower() || self()->comp()->target().cpu.isZ()) && (*location)->getMaxSpillDepth() == 0  && comp->cg()->isOutOfLineHotPath())
             {
             if (self()->getDebug())
                traceMsg(comp, "\nSkipping GC map [%p] index %d (%s) for instruction [%p] in OOL hot path because it has already been reverse spilled.\n",

--- a/compiler/codegen/CodeGenRA.cpp
+++ b/compiler/codegen/CodeGenRA.cpp
@@ -133,7 +133,7 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
                {
                registerPressure--;
                if ((node->getType().isInt64()) &&
-                   TR::Compiler->target.is32Bit())
+                   self()->comp()->target().is32Bit())
                   registerPressure--;
                }
 
@@ -229,7 +229,7 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
                   {
                   registerPressure++;
                   if ((node->getType().isInt64()) &&
-                      TR::Compiler->target.is32Bit())
+                      self()->comp()->target().is32Bit())
                      registerPressure++;
                   }
                }
@@ -247,7 +247,7 @@ OMR::CodeGenerator::estimateRegisterPressure(TR::Node *node, int32_t &registerPr
             //
             if (highRegisterPressureOpCode ||
                 ((node->getType().isInt64()) &&
-                 TR::Compiler->target.is32Bit() &&
+                 self()->comp()->target().is32Bit() &&
                  (node->getOpCode().isMul() ||
                   node->getOpCode().isDiv() ||
                   node->getOpCode().isRem() ||
@@ -1177,7 +1177,7 @@ OMR::CodeGenerator::pickRegister(TR_RegisterCandidate     *rc,
          {
          TR_GlobalRegisterNumber lowRegisterNumber = bvi.getNextElement();
 
-         if (TR::Compiler->target.is32Bit() && rc->getDataType() == TR::Int64)
+         if (self()->comp()->target().is32Bit() && rc->getDataType() == TR::Int64)
             highRegisterNumber = bvi.getNextElement();
          else
             highRegisterNumber = -1;
@@ -2192,9 +2192,9 @@ bool OMR::CodeGenerator::isLoadAlreadyAssignedOnEntry(TR::Node *node,  TR_Regist
 uint8_t OMR::CodeGenerator::gprCount(TR::DataType type,int32_t size)
    {
    if (type.isAggregate())
-      return (TR::Compiler->target.is32Bit() && !self()->use64BitRegsOn32Bit() && size > 4 && size <=  8) ? 2 : 1;
+      return (self()->comp()->target().is32Bit() && !self()->use64BitRegsOn32Bit() && size > 4 && size <=  8) ? 2 : 1;
 
-   return (type.isInt64() && TR::Compiler->target.is32Bit() && !self()->use64BitRegsOn32Bit())? 2 : (type.isIntegral() || type.isAddress())? 1 : 0;
+   return (type.isInt64() && self()->comp()->target().is32Bit() && !self()->use64BitRegsOn32Bit())? 2 : (type.isIntegral() || type.isAddress())? 1 : 0;
    }
 
 TR::CodeGenerator::TR_SimulatedNodeState &

--- a/compiler/codegen/LiveRegister.hpp
+++ b/compiler/codegen/LiveRegister.hpp
@@ -79,7 +79,7 @@ public:
    uint32_t setAssociation(TR_RegisterMask realRegMask, TR::Compilation * c)
 #endif
       {
-      if (TR::Compiler->target.cpu.isX86())
+      if (c->target().cpu.isX86())
          _association &= 0x80000000;
       else
          _association = 0;
@@ -98,7 +98,7 @@ public:
       {
       if (realRegMask && (_association & realRegMask))
          {
-         if (TR::Compiler->target.cpu.isX86())
+         if (compilation->target().cpu.isX86())
             _association &= 0x80000000;
          else
             _association = 0;

--- a/compiler/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/codegen/OMRCodeGenPhase.cpp
@@ -213,7 +213,7 @@ OMR::CodeGenPhase::performProcessRelocationsPhase(TR::CodeGenerator * cg, TR::Co
      TR::SimpleRegex * regex = comp->getOptions()->getSlipTrap();
      if (regex && TR::SimpleRegex::match(regex, comp->getCurrentMethod()))
         {
-        if (TR::Compiler->target.is64Bit())
+        if (cg->comp()->target().is64Bit())
         {
         setDllSlip((char*)cg->getCodeStart(),(char*)cg->getCodeStart()+cg->getCodeLength(),"SLIPDLL64", comp);
         }

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -815,7 +815,7 @@ bool
 OMR::CodeGenerator::use64BitRegsOn32Bit()
    {
 #ifdef TR_TARGET_S390
-   return TR::Compiler->target.is32Bit();
+   return self()->comp()->target().is32Bit();
 #else
    return false;
 #endif // TR_TARGET_S390
@@ -1836,7 +1836,7 @@ OMR::CodeGenerator::isMemoryUpdate(TR::Node *node)
    // effect of swapping children of commutative operations in order to expose the
    // opportunity.
    //
-   if (TR::Compiler->target.cpu.isX86() && valueChild->getOpCode().isMul())
+   if (self()->comp()->target().cpu.isX86() && valueChild->getOpCode().isMul())
       {
       return false;
       }
@@ -2692,7 +2692,7 @@ OMR::CodeGenerator::canNullChkBeImplicit(TR::Node *node, bool doChecks)
    TR::Node *firstChild = node->getFirstChild();
    TR::ILOpCode &opCode = firstChild->getOpCode();
 
-   if (opCode.isLoadVar() || (TR::Compiler->target.is64Bit() && opCode.getOpCodeValue() == TR::l2i))
+   if (opCode.isLoadVar() || (self()->comp()->target().is64Bit() && opCode.getOpCodeValue() == TR::l2i))
       {
       TR::SymbolReference *symRef = NULL;
 
@@ -3084,7 +3084,7 @@ bool OMR::CodeGenerator::AddArtificiallyInflatedNodeToStack(TR::Node * n)
 bool
 OMR::CodeGenerator::constantAddressesCanChangeSize(TR::Node *node)
    {
-   if (!self()->comp()->compileRelocatableCode() || TR::Compiler->target.is32Bit() || node==NULL)
+   if (!self()->comp()->compileRelocatableCode() || self()->comp()->target().is32Bit() || node==NULL)
       return false;
 
    if (node->getOpCodeValue() == TR::aconst && (node->isClassPointerConstant() || node->isMethodPointerConstant()))

--- a/compiler/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/codegen/OMRTreeEvaluator.cpp
@@ -397,7 +397,7 @@ TR_GlobalRegisterNumber
 OMR::TreeEvaluator::getHighGlobalRegisterNumberIfAny(TR::Node *node, TR::CodeGenerator *cg)
    {
     //No need for register pairs in 64-bit mode
-    if (TR::Compiler->target.is64Bit())
+    if (cg->comp()->target().is64Bit())
         return -1;
 
     //if the node itself doesn't have a type (e.g passthrough) we assume it has a child with a type

--- a/compiler/codegen/PreInstructionSelection.cpp
+++ b/compiler/codegen/PreInstructionSelection.cpp
@@ -66,7 +66,7 @@ OMR::CodeGenerator::setUpStackSizeForCallNode(TR::Node *node)
       {
       int32_t roundedSize = node->getChild(i)->getRoundedSize();
 
-      if (TR::Compiler->target.is64Bit() && node->getChild(i)->getDataType() != TR::Address)
+      if (self()->comp()->target().is64Bit() && node->getChild(i)->getDataType() != TR::Address)
          {
          currentArgSize += roundedSize * 2;
          }

--- a/compiler/codegen/Relocation.cpp
+++ b/compiler/codegen/Relocation.cpp
@@ -358,7 +358,7 @@ uint8_t TR::ExternalOrderedPair32BitRelocation::collectModifier()
    uint8_t * updateLocation2;
    TR_ExternalRelocationTargetKind kind = getTargetKind();
 
-   if (TR::Compiler->target.cpu.isPower() &&
+   if (comp->target().cpu.isPower() &&
           (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethod || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress || kind == TR_DebugCounter))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();
@@ -390,7 +390,7 @@ void TR::ExternalOrderedPair32BitRelocation::apply(TR::CodeGenerator *codeGen)
    TR::IteratedExternalRelocation *rec = getRelocationRecord();
    uint8_t *codeStart = (uint8_t *)comp->getRelocatableMethodCodeStart();
    TR_ExternalRelocationTargetKind kind = getRelocationRecord()->getTargetKind();
-   if (TR::Compiler->target.cpu.isPower() &&
+   if (comp->target().cpu.isPower() &&
       (kind == TR_ArrayCopyHelper || kind == TR_ArrayCopyToc || kind == TR_RamMethodSequence || kind == TR_GlobalValue || kind == TR_BodyInfoAddressLoad || kind == TR_DataAddress || kind == TR_DebugCounter))
       {
       TR::Instruction *instr = (TR::Instruction *)getUpdateLocation();

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -379,7 +379,7 @@ OMR::Compilation::Compilation(
       {
       if(self()->getMethodHotness() <= warm)
          {
-         if (!TR::Compiler->target.cpu.isPower()) // Temporarily exclude PPC due to perf regression
+         if (!self()->target().cpu.isPower()) // Temporarily exclude PPC due to perf regression
             self()->setOption(TR_DisableInternalPointers);
          }
       }

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -294,6 +294,7 @@ OMR::Compilation::Compilation(
    _gpuPtxCount(0),
    _bitVectorPool(self()),
    _typeLayoutMap((LayoutComparator()), LayoutAllocator(self()->region())),
+   _target(TR::Compiler->target),
    _tlsManager(*self())
    {
 

--- a/compiler/compile/OMRCompilation.hpp
+++ b/compiler/compile/OMRCompilation.hpp
@@ -1071,6 +1071,16 @@ public:
     */
    const TR::TypeLayout* typeLayout(TR_OpaqueClassBlock * clazz);
 
+   /**
+    * \brief
+    *    Returns a copy of the target env singleton that has been specialized
+    *    for the current compilation
+    *
+    * \return
+    *    reference to the copy of the target env
+    */
+   TR::Environment& target() { return _target; }
+
 private:
    void resetVisitCounts(vcount_t, TR::ResolvedMethodSymbol *);
    int16_t restoreInlineDepthUntil(int32_t stopIndex, TR_ByteCodeInfo &currentInfo);
@@ -1286,6 +1296,8 @@ private:
    typedef std::less<TR_OpaqueClassBlock*> LayoutComparator;
    typedef std::map<TR_OpaqueClassBlock *, const TR::TypeLayout *, LayoutComparator, LayoutAllocator> TypeLayoutMap;
    TypeLayoutMap _typeLayoutMap;
+
+   TR::Environment _target;
 
    /*
     * This must be last

--- a/compiler/compile/VirtualGuard.cpp
+++ b/compiler/compile/VirtualGuard.cpp
@@ -190,7 +190,7 @@ TR_VirtualGuard::createBreakpointGuardNode
    TR::Node * flagBit = NULL;
    TR::Node *guard = NULL;
    TR::Node * zero = NULL;
-   if (TR::Compiler->target.is64Bit())
+   if (comp->target().is64Bit())
       {
       flagBit = TR::Node::create(callNode, TR::lconst, 0, 0);
       flagBit->setLongInt(comp->fej9()->offsetOfMethodIsBreakpointedBit());
@@ -291,7 +291,7 @@ TR_VirtualGuard::createNonoverriddenGuard
    TR::SymbolReference * addressSymRef = symRefTab->createIsOverriddenSymbolRef(calleeSymbol);
 
    TR::Node * guard = NULL;
-   if (TR::Compiler->target.is64Bit())
+   if (comp->target().is64Bit())
       {
       TR::Node * load = TR::Node::createWithSymRef(callNode, TR::lload, 0, addressSymRef);
       TR::Node * flagBit = TR::Node::create(callNode, TR::lconst, 0, 0);

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -467,9 +467,9 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
                case TR::com_ibm_dataaccess_DecimalData_setflags:
                   if (!(
 #ifdef TR_TARGET_S390
-                     TR::Compiler->target.cpu.getSupportsDecimalFloatingPointFacility() ||
+                     comp->target().cpu.getSupportsDecimalFloatingPointFacility() ||
 #endif
-                      TR::Compiler->target.cpu.supportsDecimalFloatingPoint()) ||
+                      comp->target().cpu.supportsDecimalFloatingPoint()) ||
                       comp->getOption(TR_DisableDFP))
                      return NULL;
 #endif //J9_PROJECT_SPECIFIC

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1569,7 +1569,7 @@ OMR::Node::createAddConstantToAddress(TR::Node * addr, intptr_t value, TR::Node 
 
    if (value == 0) return addr;
 
-   if (TR::Compiler->target.is64Bit())
+   if (TR::comp()->target().is64Bit())
       {
       TR::Node *lconst = TR::Node::lconst(parentOfNewNode, (int64_t)value);
       ret = TR::Node::create(parentOfNewNode, TR::aladd, 2);
@@ -3701,7 +3701,7 @@ TR::Node *
 OMR::Node::createLongIfNeeded()
    {
    TR::Compilation * comp = TR::comp();
-   bool usingAladd = TR::Compiler->target.is64Bit();
+   bool usingAladd = comp->target().is64Bit();
    TR::Node *retNode = NULL;
 
    if (usingAladd)
@@ -4295,7 +4295,7 @@ OMR::Node::countChildren(TR::ILOpCodes opcode)
 bool
 OMR::Node::requiresRegisterPair(TR::Compilation *comp)
    {
-   return (self()->getType().isInt64() && TR::Compiler->target.is32Bit() && !comp->cg()->use64BitRegsOn32Bit());
+   return (self()->getType().isInt64() && comp->target().is32Bit() && !comp->cg()->use64BitRegsOn32Bit());
    }
 
 
@@ -4567,7 +4567,7 @@ OMR::Node::get64bitIntegralValue()
    else if (type.isInt64())
       return self()->getLongInt();
    else if (type.isAddress())
-      return self()->getAddress(); //TR::Compiler->target.is64Bit() ? getUnsignedLongInt() : getUnsignedInt();
+      return self()->getAddress();
    else
       {
       TR_ASSERT(false, "Must be an integral or address but it is type %s on node %p\n", self()->getDataType().toString(), self());
@@ -4592,7 +4592,7 @@ OMR::Node::set64bitIntegralValue(int64_t value)
       self()->setLongInt(value);
    else if (type.isAddress())
       {
-      if (TR::Compiler->target.is64Bit())
+      if (TR::comp()->target().is64Bit())
          self()->setLongInt(value);
       else
          self()->setInt((int32_t)value);
@@ -4617,7 +4617,7 @@ OMR::Node::get64bitIntegralValueAsUnsigned()
    else if (type.isInt64())
       return self()->getUnsignedLongInt();
    else if (type.isAddress())
-      return TR::Compiler->target.is64Bit() ? self()->getUnsignedLongInt() : self()->getUnsignedInt();
+      return TR::comp()->target().is64Bit() ? self()->getUnsignedLongInt() : self()->getUnsignedInt();
    else
       {
       TR_ASSERT(false, "Must be an integral or address but it is type %s", self()->getDataType().toString());

--- a/compiler/il/OMRNode_inlines.hpp
+++ b/compiler/il/OMRNode_inlines.hpp
@@ -632,7 +632,7 @@ OMR::Node::setAddress(uint64_t a)
    TR_ASSERT(self()->getOpCodeValue() == TR::aconst,"TR::Node::setAddress: used for a non aconst node");
    self()->freeExtensionIfExists();
 
-   if (TR::Compiler->target.is32Bit())
+   if (TR::comp()->target().is32Bit())
       a = a & 0x00000000ffffffff;
 
    return (uint64_t)(_unionBase._constValue = (int64_t)a);
@@ -670,7 +670,7 @@ OMR::Node::getIntegerNodeValue()
    TR::ILOpCodes opcode = self()->getOpCodeValue();
    if (opcode == TR::aconst)
       {
-      if (TR::Compiler->target.is64Bit())
+      if (comp->target().is64Bit())
          opcode = TR::lconst;
       else
          opcode = TR::iconst;

--- a/compiler/optimizer/DeadTreesElimination.cpp
+++ b/compiler/optimizer/DeadTreesElimination.cpp
@@ -96,7 +96,7 @@ static bool fixUpTree(TR::Node *node, TR::TreeTop *treeTop, TR::NodeChecklist &v
    // fold it into if statment and save jump instruction
    if (node->getOpCodeValue() == TR::arraycmp &&
       !node->isArrayCmpLen() &&
-      TR::Compiler->target.cpu.isX86())
+      opt->comp()->target().cpu.isX86())
       {
       anchorArrayCmp = false;
       }

--- a/compiler/optimizer/GeneralLoopUnroller.cpp
+++ b/compiler/optimizer/GeneralLoopUnroller.cpp
@@ -93,7 +93,7 @@ static TR::ILOpCodes getConstOpCode(TR::DataType type)
       case TR::Int16: return TR::sconst;
       case TR::Int32: return TR::iconst;
       case TR::Int64: return TR::lconst;
-      case TR::Address: return TR::Compiler->target.is64Bit() ? TR::lconst : TR::iconst;
+      case TR::Address: return TR::comp()->target().is64Bit() ? TR::lconst : TR::iconst;
       default:
          TR_ASSERT(false, "unsupported type");
          return TR::iconst;

--- a/compiler/optimizer/GlobalRegisterAllocator.cpp
+++ b/compiler/optimizer/GlobalRegisterAllocator.cpp
@@ -473,7 +473,7 @@ TR_GlobalRegisterAllocator::perform()
       _temp2 = new (trStackMemory()) TR_BitVector(_origSymRefCount, trMemory(), stackAlloc);
 
 
-      if (TR::Compiler->target.is64Bit() &&
+      if (comp()->target().is64Bit() &&
           optimizer()->getUseDefInfo())
          {
          _temp = new (trStackMemory()) TR_BitVector(optimizer()->getUseDefInfo()->getNumDefNodes(), trMemory(), stackAlloc);
@@ -3060,7 +3060,7 @@ TR_GlobalRegister::createStoreToRegister(TR::TreeTop * prevTreeTop, TR::Node *no
    if (NULL != doit)
       enableSignExtGRA = true;
 
-   if (TR::Compiler->target.cpu.isZ())
+   if (comp->target().cpu.isZ())
       {
       enableSignExtGRA = true;
       static char *doit2 = feGetEnv("TR_NSIGNEXTGRA");
@@ -3068,7 +3068,7 @@ TR_GlobalRegister::createStoreToRegister(TR::TreeTop * prevTreeTop, TR::Node *no
          enableSignExtGRA = false;
       }
 
-   if (TR::Compiler->target.is64Bit() &&
+   if (comp->target().is64Bit() &&
        (store->getOpCodeValue() == TR::iRegStore) &&
        gra->candidateCouldNeedSignExtension(rc->getSymbolReference()->getReferenceNumber()) &&
        enableSignExtGRA)
@@ -3883,7 +3883,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
    if (NULL != doit)
       enableSignExtGRA = true;
 
-   if (TR::Compiler->target.cpu.isZ())
+   if (comp()->target().cpu.isZ())
       {
       enableSignExtGRA = true;
       static char *doit2 = feGetEnv("TR_NSIGNEXTGRA");
@@ -3902,7 +3902,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
    if (node->getOpCode().isLoadVarDirect() && node->getSymbolReference()->getSymbol()->isAuto())
       {
       TR_UseDefInfo *info = optimizer()->getUseDefInfo();
-      if (TR::Compiler->target.is64Bit() && info &&
+      if (comp()->target().is64Bit() && info &&
           (parent->getOpCodeValue() == TR::i2l) && node->isNonNegative() && enableSignExtGRA)
          {
          node->setSkipSignExtension(true);
@@ -4012,7 +4012,7 @@ TR_GlobalRegisterAllocator::markAutosUsedIn(
                }
             else
                {
-               if (TR::Compiler->target.cpu.isZ() &&
+               if (comp()->target().cpu.isZ() &&
                    rc->getSymbolReference()->getSymbol()->getDataType() == TR::Address &&
                    parent &&
                    (((parent->getOpCode().isStoreIndirect() ||
@@ -4316,7 +4316,7 @@ TR_GlobalRegisterAllocator::createStoresForSignExt(
    if (NULL != doit)
       enableSignExtGRA = true;
 
-   if (TR::Compiler->target.cpu.isZ())
+   if (comp()->target().cpu.isZ())
       {
       enableSignExtGRA = true;
       static char *doit2 = feGetEnv("TR_NSIGNEXTGRA");
@@ -4620,7 +4620,7 @@ TR_LiveRangeSplitter::splitLiveRanges(TR_StructureSubGraphNode *structureNode)
 #endif
                                   );
                   int32_t numRegsForCandidate = 1;
-                  if ((symRef->getSymbol()->getType().isInt64() && TR::Compiler->target.is32Bit())
+                  if ((symRef->getSymbol()->getType().isInt64() && comp()->target().is32Bit())
 #ifdef J9_PROJECT_SPECIFIC
                       || symRef->getSymbol()->getType().isLongDouble()
 #endif

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -102,7 +102,7 @@ int32_t TR_LoopStrider::perform()
    //if (!cg()->supportsInternalPointers())
    //   return 0;
    //
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    static char *disableSignExtn = feGetEnv("TR_disableSelIndVar");
@@ -240,7 +240,7 @@ int32_t TR_LoopStrider::detectCanonicalizedPredictableLoops(TR_Structure *loopSt
    {
    // (64-bit)
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    TR_RegionStructure *regionStructure = loopStructure->asRegion();
@@ -1895,7 +1895,7 @@ bool TR_LoopStrider::examineTreeForInductionVariableUse(TR::Block *loopInvariant
    static const char *onlyConstStride = feGetEnv("TR_onlyConstStride");
 
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                       true : false;
 
    bool seenInductionVariableComputation = false;
@@ -2386,7 +2386,7 @@ TR::Node *TR_LoopStrider::placeInitializationTreeInLoopInvariantBlock(TR_BlockSt
       TR::SymbolReferenceTable *symRefTab)
    {
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
    //
    // Place the initialization tree for the derived induction variable
@@ -2634,7 +2634,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
 
 TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructure *loopInvariantBlock, TR::SymbolReference *inductionVarSymRef, TR::SymbolReference *newSymbolReference, int32_t k, TR::SymbolReferenceTable *symRefTab, TR::Node *placeHolderNode, TR::Node *newLoad, TR::TreeTop *insertionTreeTop, TR::Node *constNode, bool isAddition)
    {
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    //traceMsg(comp(), "For new sym ref %d _constNode is %x (value %d)\n", newSymbolReference->getReferenceNumber(), constNode, constNode->getInt());
@@ -2828,7 +2828,7 @@ TR::Node *TR_LoopStrider::placeNewInductionVariableIncrementTree(TR_BlockStructu
 int32_t TR_LoopStrider::findNewInductionVariable(TR::Node *node, TR::SymbolReference **symRef, bool hasAdditiveTerm, int32_t internalPointerParentSymbol)
    {
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
 
@@ -2991,7 +2991,7 @@ void TR_LoopStrider::identifyExpressionsLinearInInductionVariables(TR_Structure 
 bool TR_LoopStrider::identifyExpressionLinearInInductionVariable(TR::Node *node, vcount_t visitCount)
    {
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    if (node->getVisitCount() == visitCount)
@@ -3195,7 +3195,7 @@ TR::Node *TR_LoopStrider::setUsesLoadUsedInLoopIncrement(TR::Node *node, int32_t
 TR::Node *TR_LoopStrider::isExpressionLinearInInductionVariable(TR::Node *node, int32_t k)
    {
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    TR::Node *returnedNode = NULL;
@@ -3379,7 +3379,7 @@ bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlo
 bool TR_LoopStrider::reassociateAndHoistComputations(TR::Block *loopInvariantBlock, TR::Node *parent, int32_t childNum, TR::Node *node, vcount_t visitCount)
    {
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    bool reassociatedComputation = false;
@@ -4213,7 +4213,7 @@ void TR_LoopStrider::detectLoopsForIndVarConversion(
    {
 
    // 64-bit
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    // Stress mode: choose to replace *every* possible candidate 32-bit IV with
@@ -4562,7 +4562,7 @@ void TR_LoopStrider::morphExpressionsLinearInInductionVariable(TR_Structure *str
 bool TR_LoopStrider::morphExpressionLinearInInductionVariable(TR::Node *parent, int32_t childNum, TR::Node *node, vcount_t visitCount)
    {
    // for aladds
-   bool usingAladd = (TR::Compiler->target.is64Bit()) ?
+   bool usingAladd = (comp()->target().is64Bit()) ?
                      true : false;
 
    bool examineChildren = true;
@@ -7693,9 +7693,9 @@ void TR_IVTypeTransformer::changeIVTypeFromAddrToInt(TR_RegionStructure *natLoop
    auto baseStoreTT = TR::TreeTop::create(cm,
          TR::Node::createStore(_baseSymRef, TR::Node::createWithSymRef(TR::aload, 0, _addrSymRef)));
    _intIdxSymRef = cm->getSymRefTab()->createTemporary(cm->getMethodSymbol(),
-         TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32);
+         comp()->target().is64Bit() ? TR::Int64 : TR::Int32);
    auto intIdxStoreTT = TR::TreeTop::create(cm, TR::Node::createStore(_intIdxSymRef,
-         TR::Compiler->target.is64Bit() ? TR::Node::lconst(0) : TR::Node::iconst(0)));
+         comp()->target().is64Bit() ? TR::Node::lconst(0) : TR::Node::iconst(0)));
 
    // Just insert base address copy store in the preheader block. Note that canonicalizer is required.
    preheaderBlock->getEntry()->insertAfter(baseStoreTT);
@@ -7705,9 +7705,9 @@ void TR_IVTypeTransformer::changeIVTypeFromAddrToInt(TR_RegionStructure *natLoop
    if (!performTransformation(cm, "%s Adding int increment tree\n", optDetailString()))
       return;
    auto intIncrementTT = TR::TreeTop::create(cm, TR::Node::createStore(_intIdxSymRef,
-         TR::Node::create(TR::Compiler->target.is64Bit() ? TR::ladd : TR::iadd, 2,
+         TR::Node::create(comp()->target().is64Bit() ? TR::ladd : TR::iadd, 2,
                TR::Node::createLoad(_intIdxSymRef),
-               TR::Compiler->target.is64Bit() ? TR::Node::lconst(increment) : TR::Node::iconst(increment))));
+               comp()->target().is64Bit() ? TR::Node::lconst(increment) : TR::Node::iconst(increment))));
    astoreTT->insertAfter(intIncrementTT);
 
    // Modify the back-edge
@@ -7735,14 +7735,14 @@ void TR_IVTypeTransformer::changeIVTypeFromAddrToInt(TR_RegionStructure *natLoop
       return;
       itTT->insertAfter(TR::TreeTop::create(cm, TR::Node::create(TR::treetop, 1, intNodeForBackEdgeTest)));
       }
-   auto a2intOp = TR::ILOpCode::getProperConversion(TR::Address, TR::Compiler->target.is64Bit() ?
+   auto a2intOp = TR::ILOpCode::getProperConversion(TR::Address, comp()->target().is64Bit() ?
          TR::Int64 : TR::Int32, false);
    TR::Node *newIf;
    if (astoreNode->getSymbolReference() == firstChildSymRef) // Match if children to original backedgeIf children
       {
-      newIf = TR::Node::createif(getIntegralIfOpCode(backEdgeIfNode->getOpCodeValue(), TR::Compiler->target.is64Bit()),
+      newIf = TR::Node::createif(getIntegralIfOpCode(backEdgeIfNode->getOpCodeValue(), comp()->target().is64Bit()),
          intNodeForBackEdgeTest,
-         TR::Node::create(TR::Compiler->target.is64Bit() ? TR::lsub : TR::isub, 2,
+         TR::Node::create(comp()->target().is64Bit() ? TR::lsub : TR::isub, 2,
             TR::Node::create(a2intOp, 1, cmpChildWithEndAddr),
             TR::Node::create(a2intOp, 1,
                TR::Node::createLoad(_baseSymRef))),
@@ -7750,8 +7750,8 @@ void TR_IVTypeTransformer::changeIVTypeFromAddrToInt(TR_RegionStructure *natLoop
       }
    else
       {
-      newIf = TR::Node::createif(getIntegralIfOpCode(backEdgeIfNode->getOpCodeValue(), TR::Compiler->target.is64Bit()),
-         TR::Node::create(TR::Compiler->target.is64Bit() ? TR::lsub : TR::isub, 2,
+      newIf = TR::Node::createif(getIntegralIfOpCode(backEdgeIfNode->getOpCodeValue(), comp()->target().is64Bit()),
+         TR::Node::create(comp()->target().is64Bit() ? TR::lsub : TR::isub, 2,
             TR::Node::create(a2intOp, 1, cmpChildWithEndAddr),
             TR::Node::create(a2intOp, 1,
                TR::Node::createLoad(_baseSymRef))),
@@ -7863,7 +7863,7 @@ void TR_IVTypeTransformer::replaceAloadWithBaseIndexInSubtree(TR::Node *node)
        performTransformation(comp(), "%s Replacing n%in aload with base int-index form\n",
              optDetailString(), child->getGlobalIndex()))
       {
-      auto arrayRef = TR::Node::recreateWithoutProperties(child, TR::Compiler->target.is64Bit() ? TR::aladd : TR::aiadd, 2,
+      auto arrayRef = TR::Node::recreateWithoutProperties(child, comp()->target().is64Bit() ? TR::aladd : TR::aiadd, 2,
             TR::Node::createLoad(_baseSymRef),
             TR::Node::createLoad(_intIdxSymRef));
       }

--- a/compiler/optimizer/LoadExtensions.cpp
+++ b/compiler/optimizer/LoadExtensions.cpp
@@ -138,7 +138,7 @@ const bool TR_LoadExtensions::canSkipConversion(TR::Node* conversion, TR::Node* 
          conversion->getSize() > child->getSize() &&
 
          // Ensure we do not use register pairs for 64-bit loads on 32-bit platforms
-         (TR::Compiler->target.is64Bit() || comp()->cg()->use64BitRegsOn32Bit() || conversion->getSize() != 8) &&
+         (comp()->target().is64Bit() || comp()->cg()->use64BitRegsOn32Bit() || conversion->getSize() != 8) &&
 
          // Ensure the conversion matches our preferred extension on the load
          ((loadPrefersSignExtension && loadPrefersSignExtension == conversionOpCode.isSignExtension()) ||
@@ -365,7 +365,7 @@ void TR_LoadExtensions::flagPreferredLoadExtensions(TR::Node* parent)
             TR::ILOpCode& childOpCode = child->getOpCode();
 
             if (childOpCode.isLoadReg()
-               && !(parent->getSize() > 4 && TR::Compiler->target.is32Bit())
+               && !(parent->getSize() > 4 && comp()->target().is32Bit())
                && excludedNodes->count(parent) == 0)
                {
                TR::Node* useRegLoad = child;

--- a/compiler/optimizer/LocalAnticipatability.cpp
+++ b/compiler/optimizer/LocalAnticipatability.cpp
@@ -818,7 +818,7 @@ bool TR_LocalAnticipatability::adjustInfoForAddressAdd(TR::Node *node, TR::Node 
       if (killedExpressions->get(child->getLocalIndex()))
          {
          if (trace())
-            (TR::Compiler->target.is64Bit()
+            (comp()->target().is64Bit()
              ) ?
                traceMsg(comp(), "\n330Definition #%d (aladd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber())
                : traceMsg(comp(), "\n330Definition #%d (aiadd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber());
@@ -839,7 +839,7 @@ bool TR_LocalAnticipatability::adjustInfoForAddressAdd(TR::Node *node, TR::Node 
                   !storeNodes->get(child->getLocalIndex()))))
                {
                if (trace())
-                  (TR::Compiler->target.is64Bit()
+                  (comp()->target().is64Bit()
                    ) ?
                   traceMsg(comp(), "\n330Definition #%d (aladd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber())
                   : traceMsg(comp(), "\n330Definition #%d (aiadd) is NOT locally anticipatable in block_%d because of child\n", node->getLocalIndex(),block->getNumber());

--- a/compiler/optimizer/LocalDeadStoreElimination.cpp
+++ b/compiler/optimizer/LocalDeadStoreElimination.cpp
@@ -959,7 +959,7 @@ void TR::LocalDeadStoreElimination::eliminateDeadObjectInitializations()
                 int32_t offset = -1;
                 if (storeNode->getFirstChild()->getOpCode().isArrayRef())
                    {
-                   if (TR::Compiler->target.is64Bit())
+                   if (comp()->target().is64Bit())
                       {
                       if (storeNode->getFirstChild()->getSecondChild()->getLongInt() > INT_MAX)
                          removableZeroStore = false;

--- a/compiler/optimizer/LocalLiveRangeReducer.cpp
+++ b/compiler/optimizer/LocalLiveRangeReducer.cpp
@@ -69,7 +69,7 @@ void TR_LocalLiveRangeReduction::postPerformOnBlocks()
 
 int32_t TR_LocalLiveRangeReduction::perform()
    {
-   if (TR::Compiler->target.cpu.isZ())
+   if (comp()->target().cpu.isZ())
       return false;
 
    TR::TreeTop * exitTT, * nextTT;
@@ -491,7 +491,7 @@ bool TR_LocalLiveRangeReduction::isAnySymInDefinedOrUsedBy(TR_TreeRefInfo *curre
       return true;
       }
 
-   if (TR::Compiler->target.cpu.isPower() && opCode.getOpCodeValue() == TR::allocationFence)
+   if (comp()->target().cpu.isPower() && opCode.getOpCodeValue() == TR::allocationFence)
       {
       // Can't move allocations past flushes
       if (movingNode->getOpCodeValue() == TR::treetop &&
@@ -561,7 +561,7 @@ bool TR_LocalLiveRangeReduction::isAnySymInDefinedOrUsedBy(TR_TreeRefInfo *curre
             return true;
             }
 
-    	 else if (TR::Compiler->target.is64Bit() &&
+       else if (comp()->target().is64Bit() &&
     		  movingNode->getOpCode().isBndCheck() &&
     		  ((opCode.getOpCodeValue() == TR::i2l) || (opCode.getOpCodeValue() == TR::iu2l)) &&
     		  !child->isNonNegative())

--- a/compiler/optimizer/LocalOpts.cpp
+++ b/compiler/optimizer/LocalOpts.cpp
@@ -5148,7 +5148,7 @@ bool TR_Rematerialization::examineNode(TR::TreeTop *treeTop, TR::Node *parent, T
 
 
     int32_t numRegisters = 0;
-    if (TR::Compiler->target.is32Bit())
+    if (comp()->target().is32Bit())
        {
        ListIterator<TR::Node> nodesIt(&(state->_currentlyCommonedNodes));
        TR::Node *commonedNode = NULL;

--- a/compiler/optimizer/LocalTransparency.cpp
+++ b/compiler/optimizer/LocalTransparency.cpp
@@ -869,7 +869,7 @@ void TR_LocalTransparency::adjustInfoForAddressAdd(TR::Node *node, TR::Node *chi
                _transparencyInfo[i]->reset(node->getLocalIndex());
                if (trace())
                   {
-                  if (TR::Compiler->target.is64Bit())
+                  if (comp()->target().is64Bit())
                      traceMsg(comp(), "Expression %d killed by symRef #%d because grandchild (child of aladd) %d is already killed by the symRef\n", node->getLocalIndex(), i, child->getLocalIndex());
                   else
                      traceMsg(comp(), "Expression %d killed by symRef #%d because grandchild (child of aiadd) %d is already killed by the symRef\n", node->getLocalIndex(), i, child->getLocalIndex());

--- a/compiler/optimizer/LoopReducer.cpp
+++ b/compiler/optimizer/LoopReducer.cpp
@@ -786,7 +786,7 @@ TR_ArrayLoop::updateIndVarStore(TR_ParentOfChildNode * indVarNode, TR::Node * in
    //
    TR::Node * incMul = NULL;
    TR::Node * imul = NULL;
-   if (TR::Compiler->target.is64Bit())
+   if (comp()->target().is64Bit())
       {
       incMul = TR::Node::create(_finalNode, TR::lconst);
       incMul->setLongInt(endInc);
@@ -1053,8 +1053,8 @@ TR_LoopReducer::generateArraycopy(TR_InductionVariable * indVar, TR::Block * loo
       TR::Node *src = loadAddr;
       TR::Node *dst = storeAddr;
       intptrj_t offset;
-      TR::ILOpCodes op_add   = TR::Compiler->target.is64Bit() ? TR::aladd : TR::aiadd;
-      TR::ILOpCodes op_const = TR::Compiler->target.is64Bit() ? TR::lconst : TR::iconst;
+      TR::ILOpCodes op_add   = comp()->target().is64Bit() ? TR::aladd : TR::aiadd;
+      TR::ILOpCodes op_const = comp()->target().is64Bit() ? TR::lconst : TR::iconst;
 
       offset = arraycopyLoop.getStoreNode()->getSymbolReference()->getOffset();
       if (offset != 0)
@@ -1254,8 +1254,8 @@ TR_LoopReducer::generateArrayset(TR_InductionVariable * indVar, TR::Block * loop
 
    TR::Node *dst = storeNode->getFirstChild();
    intptrj_t offset;
-   TR::ILOpCodes op_add   = TR::Compiler->target.is64Bit() ? TR::aladd : TR::aiadd;
-   TR::ILOpCodes op_const = TR::Compiler->target.is64Bit() ? TR::lconst : TR::iconst;
+   TR::ILOpCodes op_add   = comp()->target().is64Bit() ? TR::aladd : TR::aiadd;
+   TR::ILOpCodes op_const = comp()->target().is64Bit() ? TR::lconst : TR::iconst;
    offset = storeNode->getSymbolReference()->getOffset();
    if (offset != 0)
       dst = TR::Node::create(op_add, 2, dst, TR::Node::create(dst, op_const, 0, offset));
@@ -3003,7 +3003,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
    TR::TreeTop * branchNewOldExit = branchNewOldBlock->getExit();
 
    TR::Node * tableNode = arraytranslateLoop.getTableNode()->duplicateTree();
-   if (tableNode->getType().isInt64() && TR::Compiler->target.is32Bit())
+   if (tableNode->getType().isInt64() && comp()->target().is32Bit())
       {
       TR::Node * shrunkTableNode = TR::Node::create(TR::l2i, 1, tableNode);
       tableNode = shrunkTableNode;
@@ -3071,7 +3071,7 @@ TR_LoopReducer::generateArraytranslate(TR_RegionStructure * whileLoop, TR_Induct
       TR::Node * compareNode = NULL;
       if (arraytranslateLoop.tableBackedByRawStorage())
          {
-         if (TR::Compiler->target.is64Bit())
+         if (comp()->target().is64Bit())
             {
             TR::Node * zeroNode = TR::Node::create(loadNode, TR::lconst);
             zeroNode->setLongInt(0);
@@ -3770,7 +3770,7 @@ TR_LoopReducer::generateByteToCharArraycopy(TR_InductionVariable * byteIndVar, T
    TR::TreeTop * arrayStoreTree = loopHeader->getFirstRealTreeTop();
    TR::Node * storeNode = arrayStoreTree->getNode();
 
-   TR_ByteToCharArraycopy arraycopyLoop(comp(), charIndVar, byteIndVar, TR::Compiler->target.cpu.isBigEndian());
+   TR_ByteToCharArraycopy arraycopyLoop(comp(), charIndVar, byteIndVar, comp()->target().cpu.isBigEndian());
 
    if (!arraycopyLoop.checkArrayStore(storeNode))
       {
@@ -4019,7 +4019,7 @@ TR_LoopReducer::generateCharToByteArraycopy(TR_InductionVariable * byteIndVar, T
    lowStoreNode = lowArrayStoreTree->getNode();
    nextTreeTop = lowArrayStoreTree->getNextTreeTop();
 
-   TR_CharToByteArraycopy arraycopyLoop(comp(), charIndVar, byteIndVar, TR::Compiler->target.cpu.isBigEndian());
+   TR_CharToByteArraycopy arraycopyLoop(comp(), charIndVar, byteIndVar, comp()->target().cpu.isBigEndian());
 
    if (!arraycopyLoop.checkArrayStores(highStoreNode, lowStoreNode))
       {

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -6279,7 +6279,7 @@ void TR_LoopVersioner::RemoveSpineCheck::improveLoop()
    //          i
    //       iconst strideShift
 
-   bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
+   bool is64BitTarget = comp()->target().is64Bit() ? true : false;
    TR::DataType type =  spineCheckNode->getChild(0)->getDataType();
    uint32_t elementSize = TR::Symbol::convertTypeToSize(type);
    if (comp()->useCompressedPointers() && (type == TR::Address))
@@ -7942,7 +7942,7 @@ bool TR_LoopVersioner::depsForLoopEntryPrep(
             TR::Node *vftLoad = TR::Node::createWithSymRef(TR::aloadi, 1, 1, node->getFirstChild(), comp()->getSymRefTab()->findOrCreateVftSymbolRef());
             //TR::Node *componentTypeLoad = TR::Node::create(TR::aloadi, 1, vftLoad, comp()->getSymRefTab()->findOrCreateArrayComponentTypeSymbolRef());
             TR::Node *classFlag = NULL;
-            if (TR::Compiler->target.is32Bit())
+            if (comp()->target().is32Bit())
                {
                classFlag = TR::Node::createWithSymRef(TR::iloadi, 1, 1, vftLoad, comp()->getSymRefTab()->findOrCreateClassAndDepthFlagsSymbolRef());
                }

--- a/compiler/optimizer/OMROptimizationManager.cpp
+++ b/compiler/optimizer/OMROptimizationManager.cpp
@@ -114,7 +114,7 @@ OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFact
          break;
       case OMR::tacticalGlobalRegisterAllocator:
          _flags.set(requiresStructure);
-         if (self()->comp()->getMethodHotness() >= hot && TR::Compiler->target.is64Bit())
+         if (self()->comp()->getMethodHotness() >= hot && o->comp()->target().is64Bit())
             _flags.set(requiresLocalsUseDefInfo | doesNotRequireLoadsAsDefs);
          break;
       case OMR::loopInversion:
@@ -180,7 +180,7 @@ OMR::OptimizationManager::OptimizationManager(TR::Optimizer *o, OptimizationFact
       case OMR::loopStrider:
          _flags.set(requiresStructure);
          // get UseDefInfo for sign-extension elimination on 64-bit
-         if (TR::Compiler->target.is64Bit())
+         if (o->comp()->target().is64Bit())
             _flags.set(requiresLocalsUseDefInfo | doesNotRequireLoadsAsDefs);
          break;
       case OMR::profiledNodeVersioning:

--- a/compiler/optimizer/OMRTransformUtil.cpp
+++ b/compiler/optimizer/OMRTransformUtil.cpp
@@ -117,8 +117,8 @@ OMR::TransformUtil::scalarizeArrayCopy(
    // abort if this requirement is not met.
    // TODO: also need to check if the first two children are aload nodes
    bool cannot_use_load_store_long = false;
-   if (TR::Compiler->target.cpu.isPower())
-      if (dataType == TR::Int64 && TR::Compiler->target.is64Bit())
+   if (comp->target().cpu.isPower())
+      if (dataType == TR::Int64 && comp->target().is64Bit())
          {
          TR::Node * firstChild = node->getFirstChild();
          if (firstChild->getNumChildren() == 2)

--- a/compiler/optimizer/OMRValuePropagation.cpp
+++ b/compiler/optimizer/OMRValuePropagation.cpp
@@ -5343,7 +5343,7 @@ int64_t TR::ArraycopyTransformation::arraycopyHighFrequencySpecificLength(TR::No
    const float MIN_ARRAYCOPY_FREQ_FOR_SPECIALIZATION = 0.7f;
    if (comp()->getRecompilationInfo())
       {
-      if (TR::Compiler->target.is64Bit())
+      if (comp()->target().is64Bit())
          {
          TR_LongValueInfo *valueInfo = static_cast<TR_LongValueInfo*>(TR_ValueProfileInfoManager::getProfiledValueInfo(arrayCopyNode, comp(), LongValueInfo));
          if (valueInfo && valueInfo->getTopProbability() > MIN_ARRAYCOPY_FREQ_FOR_SPECIALIZATION)
@@ -5367,7 +5367,7 @@ int64_t TR::ArraycopyTransformation::arraycopyHighFrequencySpecificLength(TR::No
 
 TR::TreeTop* TR::ArraycopyTransformation::createPointerCompareNode(TR::Node* node, TR::SymbolReference* srcRef, TR::SymbolReference* dstRef)
    {
-   bool is64Bit = TR::Compiler->target.is64Bit();
+   bool is64Bit = comp()->target().is64Bit();
    TR::Node* cmp;
    TR::Node* src; // = TR::Node::createLoad(node, srcRef);
    if (srcRef)
@@ -5399,7 +5399,7 @@ TR::TreeTop* TR::ArraycopyTransformation::createPointerCompareNode(TR::Node* nod
 
 TR::TreeTop* TR::ArraycopyTransformation::createRangeCompareNode(TR::Node* node, TR::SymbolReference* srcRef, TR::SymbolReference* dstRef, TR::SymbolReference* lenRef)
    {
-   bool is64Bit = TR::Compiler->target.is64Bit();
+   bool is64Bit = comp()->target().is64Bit();
    TR::Node* cmp;
    TR::Node* src; // = TR::Node::createLoad(node, srcRef);
    if (srcRef)
@@ -5587,7 +5587,7 @@ TR::TreeTop* TR::ArraycopyTransformation::tryToSpecializeForLength(TR::TreeTop *
 
 static TR::Node *addressSizedConst(TR::Compilation *comp, TR::Node *n, intptrj_t val)
    {
-   TR::Node *node = TR::Compiler->target.is64Bit()? TR::Node::lconst(n, val) : TR::Node::iconst(n, val);
+   TR::Node *node = comp->target().is64Bit()? TR::Node::lconst(n, val) : TR::Node::iconst(n, val);
    if (node->getOpCodeValue() == TR::lconst)
       node->setLongInt(val);
    return node;

--- a/compiler/optimizer/PrefetchInsertion.cpp
+++ b/compiler/optimizer/PrefetchInsertion.cpp
@@ -256,7 +256,7 @@ void TR_PrefetchInsertion::insertPrefetchInstructions()
 #endif
 
          static char * disablePrefetchStore = feGetEnv("TR_DISABLEPrefetchStore");
-         typeNode = TR::Node::iconst(addressNode, (TR::Compiler->target.cpu.isZ() && foundStore && !disablePrefetchStore) ?
+         typeNode = TR::Node::iconst(addressNode, (comp()->target().cpu.isZ() && foundStore && !disablePrefetchStore) ?
                                                             (int32_t)PrefetchStore :
                                                             (int32_t)PrefetchLoad);
 

--- a/compiler/optimizer/RegDepCopyRemoval.cpp
+++ b/compiler/optimizer/RegDepCopyRemoval.cpp
@@ -108,7 +108,7 @@ const char *
 TR::RegDepCopyRemoval::registerName(TR_GlobalRegisterNumber reg)
    {
    // this defaultSize only works for GPRs
-   TR_RegisterSizes defaultSize = TR::Compiler->target.is64Bit() ? TR_DoubleWordReg : TR_WordReg;
+   TR_RegisterSizes defaultSize = comp()->target().is64Bit() ? TR_DoubleWordReg : TR_WordReg;
    return comp()->getDebug()->getGlobalRegisterName(reg, defaultSize);
    }
 

--- a/compiler/optimizer/RegisterCandidate.cpp
+++ b/compiler/optimizer/RegisterCandidate.cpp
@@ -554,7 +554,7 @@ bool findLoadNearStartOfBlock(TR::Block *block, TR::SymbolReference *ref)
 bool TR_RegisterCandidates::aliasesPreventAllocation(TR::Compilation *comp, TR::SymbolReference *symRef)
   {
 
-  if (!symRef->getSymbol()->isAutoOrParm() && !(TR::Compiler->target.cpu.isZ() && TR::Compiler->target.isLinux()) ) return true;
+  if (!symRef->getSymbol()->isAutoOrParm() && !(comp->target().cpu.isZ() && comp->target().isLinux()) ) return true;
 
   TR::SparseBitVector use_def_aliases(comp->allocator());
   symRef->getUseDefAliases(false).getAliases(use_def_aliases);
@@ -695,13 +695,13 @@ bool TR_RegisterCandidate::rcNeeds2Regs(TR::Compilation *comp)
    {
    if(getType().isAggregate())
       {
-      if ( (TR::Compiler->target.is32Bit() && !comp->cg()->use64BitRegsOn32Bit() && getSymbol()->getSize() > 4) || (getSymbol()->getSize() > 8 ) )
+      if ( (comp->target().is32Bit() && !comp->cg()->use64BitRegsOn32Bit() && getSymbol()->getSize() > 4) || (getSymbol()->getSize() > 8 ) )
          return true;
       else
          return false;
       }
    else
-      return ((getType().isInt64() && TR::Compiler->target.is32Bit() && !comp->cg()->use64BitRegsOn32Bit())
+      return ((getType().isInt64() && comp->target().is32Bit() && !comp->cg()->use64BitRegsOn32Bit())
 #ifdef J9_PROJECT_SPECIFIC
               || getType().isLongDouble()
 #endif
@@ -1851,7 +1851,7 @@ TR_RegisterCandidates::reprioritizeCandidates(
          {
          if ((!onlyReprioritizeLongs ||
               (rc->getType().isInt64() &&
-               TR::Compiler->target.is32Bit())) &&
+               comp->target().is32Bit())) &&
              ((reprioritizeFP && isFPCandidate) ||
               (!reprioritizeFP && !isFPCandidate)))
             {
@@ -2566,7 +2566,7 @@ TR_RegisterCandidates::assign(TR::Block ** cfgBlocks, int32_t numberOfBlocks, in
          {
          if (trace)
             traceMsg(comp(),"Leaving candidate because it has vector type but no global vector registers provided\n");
-         TR_ASSERT(!TR::Compiler->target.cpu.isZ(),"ed : debug : Should never get here for vector GRA on z");
+         TR_ASSERT(!comp()->target().cpu.isZ(),"ed : debug : Should never get here for vector GRA on z");
          continue;
          }
 

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -759,7 +759,7 @@ bool reduceLongOpToIntegerOp(OMR::ValuePropagation *vp, TR::Node *node, TR::VPCo
    // Adding this check because it is likely suboptimal on machines where you can use long registers to convert things to integers and insert conversion trees.
    // Conversion trees are not free.
    // LoadExtensions (and other codegen peepholes) should in theory catch uneeded conversions (like widening) as described in the case below on 64 bit platforms.
-   if (TR::Compiler->target.is64Bit() || vp->comp()->cg()->use64BitRegsOn32Bit())
+   if (vp->comp()->target().is64Bit() || vp->comp()->cg()->use64BitRegsOn32Bit())
       return false;
 
 
@@ -1169,7 +1169,7 @@ TR::Node *constrainAnyIntLoad(OMR::ValuePropagation *vp, TR::Node *node)
                {
                TR::VPConstString *constString = baseVPConstraint->getClassType()->asConstString();
 
-               uintptrj_t offset = TR::Compiler->target.is64Bit() ? (uintptrj_t)index->getUnsignedLongInt() : (uintptrj_t)index->getUnsignedInt();
+               uintptrj_t offset = vp->comp()->target().is64Bit() ? (uintptrj_t)index->getUnsignedLongInt() : (uintptrj_t)index->getUnsignedInt();
                uintptrj_t chIdx = (offset - (uintptrj_t)TR::Compiler->om.contiguousArrayHeaderSizeInBytes()) / 2;
                uint16_t ch = constString->charAt(chIdx, vp->comp());
                if (ch != 0)
@@ -1195,7 +1195,7 @@ TR::Node *constrainAnyIntLoad(OMR::ValuePropagation *vp, TR::Node *node)
                   if (constrainAnyIntLoadCriticalSection.hasVMAccess())
                      {
                      uintptrj_t arrayObj = knot->getPointer(idx);
-                     uintptrj_t offset = TR::Compiler->target.is64Bit()
+                     uintptrj_t offset = vp->comp()->target().is64Bit()
                                          ? (uintptrj_t)index->getUnsignedLongInt() : (uintptrj_t)index->getUnsignedInt();
                      uintptrj_t lengthInElements = TR::Compiler->om.getArrayLengthInElements(vp->comp(), arrayObj);
                      TR::DataType elementType = kobj->getPrimitiveArrayDataType();
@@ -1921,7 +1921,7 @@ static TR::Node *findArrayLengthNode(OMR::ValuePropagation *vp, TR::Node *node, 
 static TR::Node *findArrayIndexNode(OMR::ValuePropagation *vp, TR::Node *node, int32_t stride)
   {
   TR::Node *offset = node->getSecondChild();
-  bool usingAladd = (TR::Compiler->target.is64Bit()
+  bool usingAladd = (vp->comp()->target().is64Bit()
                      ) ?
           true : false;
 

--- a/compiler/optimizer/ValuePropagationCommon.cpp
+++ b/compiler/optimizer/ValuePropagationCommon.cpp
@@ -858,7 +858,7 @@ void OMR::ValuePropagation::removeArrayCopyNode(TR::TreeTop *arraycopyTree)
 TR::Node * createHdrSizeNode(TR::Compilation *comp, TR::Node *n)
    {
    TR::Node *hdrSize = NULL;
-   if (TR::Compiler->target.is64Bit())
+   if (comp->target().is64Bit())
       {
       hdrSize = TR::Node::create(n, TR::lconst);
       hdrSize->setLongInt((int64_t)TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
@@ -871,7 +871,7 @@ TR::Node * createHdrSizeNode(TR::Compilation *comp, TR::Node *n)
 
 TR::Node* generateLenForArrayCopy(TR::Compilation *comp, int32_t elementSize, TR::Node *stride,TR::Node *srcObjNode,TR::Node *copyLenNode,TR::Node *n)
    {
-   bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
+   bool is64BitTarget = comp->target().is64Bit() ? true : false;
 
    TR::Node *len = NULL;
    if (elementSize == 1)
@@ -991,7 +991,7 @@ bool OMR::ValuePropagation::transformUnsafeCopyMemoryCall(TR::Node *arraycopyNod
          copyLenLow  = copyLenConstraint   ? copyLenConstraint->getLowInt() : TR::getMinSigned<TR::Int32>();
          copyLenHigh = copyLenConstraint   ? copyLenConstraint->getHighInt() : TR::getMaxSigned<TR::Int32>();
 
-         if (TR::Compiler->target.is64Bit())
+         if (comp()->target().is64Bit())
             {
             src  = TR::Node::create(TR::aladd, 2, src, srcOffset);
             dest = TR::Node::create(TR::aladd, 2, dest, destOffset);
@@ -1034,7 +1034,7 @@ bool OMR::ValuePropagation::transformUnsafeCopyMemoryCall(TR::Node *arraycopyNod
 
 void OMR::ValuePropagation::transformArrayCopyCall(TR::Node *node)
    {
-   bool is64BitTarget = TR::Compiler->target.is64Bit();
+   bool is64BitTarget = comp()->target().is64Bit();
 
    // Check to see if this is a call to java/lang/System.arraycopy
    if (!node->isArrayCopyCall())
@@ -1968,7 +1968,7 @@ TR::Node *generateArrayAddressTree(
    TR::Node *hdrSize)
    {
 
-   bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
+   bool is64BitTarget = comp->target().is64Bit() ? true : false;
 
    TR::Node *array;
 
@@ -2206,7 +2206,7 @@ TR::TreeTop *createStoresForArraycopyChildren(TR::Compilation *comp, TR::TreeTop
 void OMR::ValuePropagation::generateArrayTranslateNode(TR::TreeTop *callTree,TR::TreeTop *arrayTranslateTree, TR::SymbolReference *srcRef, TR::SymbolReference *dstRef, TR::SymbolReference *srcOffRef, TR::SymbolReference *dstOffRef, TR::SymbolReference *lenRef,TR::SymbolReference *tableRef, bool hasTable )
    {
 
-   bool is64BitTarget = TR::Compiler->target.is64Bit();
+   bool is64BitTarget = comp()->target().is64Bit();
    TR::Node* callNode = callTree->getNode()->getFirstChild();
    TR::MethodSymbol *symbol = callNode->getSymbol()->castToMethodSymbol();
    const TR::RecognizedMethod rm = symbol->getRecognizedMethod();
@@ -2557,7 +2557,7 @@ TR::TreeTop *OMR::ValuePropagation::buildSameLeafTest(TR::Node *offset,TR::Node 
    TR::Node *ifNode;
    TR::Node *child1 = NULL, *child2 = NULL;
 
-   bool is64BitTarget = TR::Compiler->target.is64Bit();
+   bool is64BitTarget = comp()->target().is64Bit();
 
    child1 = TR::Node::create(is64BitTarget ? TR::lshr : TR::ishr, 2, offset, spineShiftNode);
    child2 = TR::Node::create(is64BitTarget ? TR::ladd : TR::iadd, 2, offset, len);
@@ -2573,7 +2573,7 @@ TR::TreeTop *OMR::ValuePropagation::buildSameLeafTest(TR::Node *offset,TR::Node 
 
 TR::Node *generateArrayletAddressTree(TR::Compilation* comp, TR::Node *vcallNode, TR::DataType type, TR::Node *off,TR::Node *obj, TR::Node *spineShiftNode,TR::Node *shiftNode, TR::Node *strideShiftNode, TR::Node *hdrSize)
    {
-   bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
+   bool is64BitTarget = comp->target().is64Bit() ? true : false;
 
    uint32_t elementSize = TR::Symbol::convertTypeToSize(type);
    if (comp->useCompressedPointers() && (type == TR::Address))
@@ -3149,7 +3149,7 @@ void OMR::ValuePropagation::transformRealTimeArrayCopy(TR_RealTimeArrayCopy *rtA
          }
 
       TR::Node *fragmentParent = TR::Node::createWithSymRef(vcallNode, TR::aload, 0, comp()->getSymRefTab()->findOrCreateFragmentParentSymbolRef());
-      if (TR::Compiler->target.is64Bit())
+      if (comp()->target().is64Bit())
          {
          TR::Node *globalFragment = TR::Node::createWithSymRef(TR::lloadi, 1, 1, fragmentParent, comp()->getSymRefTab()->findOrCreateGlobalFragmentSymbolRef());
          ifTree = TR::TreeTop::create(comp(), TR::Node::createif(TR::iflcmpne, globalFragment,TR::Node::create(vcallNode, TR::lconst, 0, 0)));
@@ -3535,8 +3535,8 @@ void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR:
          comp()->getSymRefTab()->methodSymRefFromName(
             comp()->getMethodSymbol(),
             "com/ibm/jit/JITHelpers",
-            const_cast<char*>(TR::Compiler->target.is64Bit() ? "unsafeObjectShallowCopy64" : "unsafeObjectShallowCopy32"),
-            const_cast<char*>(TR::Compiler->target.is64Bit() ? "(Ljava/lang/Object;Ljava/lang/Object;J)V" : "(Ljava/lang/Object;Ljava/lang/Object;I)V"),
+            const_cast<char*>(comp()->target().is64Bit() ? "unsafeObjectShallowCopy64" : "unsafeObjectShallowCopy32"),
+            const_cast<char*>(comp()->target().is64Bit() ? "(Ljava/lang/Object;Ljava/lang/Object;J)V" : "(Ljava/lang/Object;Ljava/lang/Object;I)V"),
             TR::MethodSymbol::Static);
    TR::Node *getHelpers = TR::Node::createWithSymRef(callNode, TR::acall, 0, helperAccessor);
    callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(callNode, TR::treetop, 1, getHelpers)));
@@ -3544,7 +3544,7 @@ void OMR::ValuePropagation::transformObjectCloneCall(TR::TreeTop *callTree, OMR:
    objCopy->setAndIncChild(0, getHelpers);
    objCopy->setAndIncChild(1, objNode);
    objCopy->setAndIncChild(2, callNode);
-   objCopy->setAndIncChild(3, TR::Node::create(callNode, (TR::Compiler->target.is64Bit() ? TR::a2l : TR::a2i), 1, loadaddr));
+   objCopy->setAndIncChild(3, TR::Node::create(callNode, (comp()->target().is64Bit() ? TR::a2l : TR::a2i), 1, loadaddr));
 
    callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(callNode, TR::treetop, 1, callNode)));
    callTree->insertBefore(TR::TreeTop::create(comp(), TR::Node::create(callNode, TR::treetop, 1, objCopy)));
@@ -3640,15 +3640,15 @@ void OMR::ValuePropagation::transformArrayCloneCall(TR::TreeTop *callTree, OMR::
    newArray->setIsNonNull(true);
 
    int32_t elementSize = TR::Compiler->om.getSizeOfArrayElement(newArray);
-   TR::Node *lengthInBytes = TR::Compiler->target.is64Bit() ?
+   TR::Node *lengthInBytes = comp()->target().is64Bit() ?
       TR::Node::create(callNode, TR::lmul, 2, TR::Node::create(callNode, TR::i2l, 1, lenNode), TR::Node::lconst(lenNode, elementSize)) :
       TR::Node::create(callNode, TR::imul, 2, lenNode, TR::Node::iconst(lenNode, elementSize));
 
 
-   TR::Node *srcStart = TR::Compiler->target.is64Bit() ?
+   TR::Node *srcStart = comp()->target().is64Bit() ?
       TR::Node::create(callNode, TR::aladd, 2, objNode, TR::Node::lconst(objNode, TR::Compiler->om.contiguousArrayHeaderSizeInBytes())) :
       TR::Node::create(callNode, TR::aiadd, 2, objNode, TR::Node::iconst(objNode, TR::Compiler->om.contiguousArrayHeaderSizeInBytes()));
-   TR::Node *destStart = TR::Compiler->target.is64Bit() ?
+   TR::Node *destStart = comp()->target().is64Bit() ?
       TR::Node::create(callNode, TR::aladd, 2, newArray, TR::Node::lconst(newArray, TR::Compiler->om.contiguousArrayHeaderSizeInBytes())) :
       TR::Node::create(callNode, TR::aiadd, 2, newArray, TR::Node::iconst(newArray, TR::Compiler->om.contiguousArrayHeaderSizeInBytes()));
    TR::Node *arraycopy = NULL;
@@ -3713,7 +3713,6 @@ void OMR::ValuePropagation::transformConverterCall(TR::TreeTop *callTree)
    if (!performTransformation(comp(), "%sChanging call %s [%p] to %s \n", OPT_DETAILS, callNode->getOpCode().getName(), callNode, transformedTargetName(rm)))
       return;
 
-   //bool is64BitTarget = TR::Compiler->target.is64Bit() ? true : false;
    TR::CFG *cfg = comp()->getFlowGraph();
 
     //dup call
@@ -3860,7 +3859,7 @@ void OMR::ValuePropagation::transformConverterCall(TR::TreeTop *callTree)
    TR::TreeTop *ifTreed = TR::TreeTop::create(comp(), TR::Node::createif(TR::ifacmpeq, TR::Node::createLoad(callNode, dstRef), TR::Node::aconst(callNode,0)));
    createAndInsertTestBlock(comp(), ifTreed, callTree, origCallBlock, slowArraytranslateBlock);
 
-   if (TR::Compiler->target.cpu.isZ())
+   if (comp()->target().cpu.isZ())
       {
       // Task 110060:
       //

--- a/compiler/p/codegen/BinaryEvaluator.cpp
+++ b/compiler/p/codegen/BinaryEvaluator.cpp
@@ -204,7 +204,7 @@ TR::Register *OMR::Power::TreeEvaluator::iaddEvaluator(TR::Node *node, TR::CodeG
 
    TR::Node *firstChild = node->getFirstChild();
 
-  if (TR::Compiler->target.cpu.id() >= TR_PPCp9 &&
+  if (cg->comp()->target().cpu.id() >= TR_PPCp9 &&
       firstChild->getOpCodeValue() == TR::imul &&
       firstChild->getReferenceCount() == 1 &&
       firstChild->getRegister() == NULL)
@@ -447,7 +447,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
    bool setsOrReadsCC = NEED_CC(node) || (node->getOpCodeValue() == TR::luaddc);
    TR::InstOpCode::Mnemonic regToRegOpCode = TR::InstOpCode::addc;
 
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       {
       if (!setsOrReadsCC && (secondOp == TR::lconst || secondOp == TR::luconst) &&
           secondChild->getRegister() == NULL)
@@ -509,7 +509,7 @@ TR::Register *OMR::Power::TreeEvaluator::laddEvaluator(TR::Node *node, TR::CodeG
          return trgReg;
          }
 
-      if (TR::Compiler->target.cpu.id() >= TR_PPCp9 &&
+      if (cg->comp()->target().cpu.id() >= TR_PPCp9 &&
           !setsOrReadsCC &&
           (node->getOpCodeValue() == TR::ladd || node->getOpCodeValue() == TR::aladd) &&
           firstChild->getOpCodeValue() == TR::lmul &&
@@ -690,7 +690,7 @@ TR::Register *OMR::Power::TreeEvaluator::isubEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::asubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lsubEvaluator(node, cg);
    else
       return TR::TreeEvaluator::isubEvaluator(node, cg);
@@ -838,7 +838,7 @@ TR::Register *lsub64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
 // also handles lusub
 TR::Register *OMR::Power::TreeEvaluator::lsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
      return lsub64Evaluator(node, cg);
 
    TR::Node     *firstChild     = node->getFirstChild();
@@ -1234,7 +1234,7 @@ OMR::Power::TreeEvaluator::dualMulEvaluator(TR::Node * node, TR::CodeGenerator *
          lmulNode = NULL;
          }
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
          {
          return TR::TreeEvaluator::dualMulHelper64(node, lmulNode, lumulhNode, cg);
          }
@@ -1255,7 +1255,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulEvaluator(TR::Node *node, TR::CodeG
       return TR::TreeEvaluator::dualMulEvaluator(node, cg);
       }
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *trgReg;
       if (secondChild->getOpCodeValue() == TR::lconst || secondChild->getOpCodeValue() == TR::luconst)
@@ -1490,7 +1490,7 @@ TR::Register *OMR::Power::TreeEvaluator::lmulhEvaluator(TR::Node *node, TR::Code
 
    // lmulh is generated for constant ldiv and the second child is the magic number
    // assume magic number is usually a large odd number with little optimization opportunity
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *src1Reg = cg->evaluate(firstChild);
       TR::Register *trgReg = cg->allocateRegister();
@@ -1624,7 +1624,7 @@ static TR::Register *signedIntegerDivisionOrRemainderAnalyser(TR::Node          
             generateTrg1Src1Instruction(cg, TR::InstOpCode::neg, node, trgReg, trgReg);
          }
       }
-   else if (TR::Compiler->target.cpu.id() >= TR_PPCp9 && isRemainder)
+   else if (cg->comp()->target().cpu.id() >= TR_PPCp9 && isRemainder)
       {
       if (divisorReg == NULL)
          divisorReg = cg->evaluate(node->getSecondChild());
@@ -1800,14 +1800,14 @@ static TR::Register *signedLongDivisionOrRemainderAnalyser(TR::Node *node, TR::C
 
       if (divisor > 0)
          {
-         if(TR::Compiler->target.is64Bit())
+         if(cg->comp()->target().is64Bit())
             generateShiftRightLogicalImmediateLong(cg, node, temp4Reg, dividendReg, 63);
          else
             generateShiftRightLogicalImmediate(cg, node, temp4Reg, dividendReg, 31);
          }
       else
          {
-         if(TR::Compiler->target.is64Bit())
+         if(cg->comp()->target().is64Bit())
             generateShiftRightLogicalImmediateLong(cg, node, temp4Reg, temp3Reg, 63);
          else
             generateShiftRightLogicalImmediate(cg, node, temp4Reg, temp3Reg, 31);
@@ -2081,7 +2081,7 @@ strengthReducingLongDivideOrRemainder32BitMode(TR::Node *node,      TR::CodeGene
 
          if (isRemainder)
             {
-            if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+            if (cg->comp()->target().cpu.id() >= TR_PPCp9)
                {
                generateTrg1Src2Instruction(cg, TR::InstOpCode::moduw, node, dr_l, dd_l, dr_l);
                }
@@ -2102,7 +2102,7 @@ strengthReducingLongDivideOrRemainder32BitMode(TR::Node *node,      TR::CodeGene
 
    TR_RuntimeHelper helper;
 
-   if (TR::Compiler->target.cpu.id() >= TR_PPCp7 && !isDivisorImpossible32Bit)
+   if (cg->comp()->target().cpu.id() >= TR_PPCp7 && !isDivisorImpossible32Bit)
       helper = isSignedOp ? TR_PPClongDivideEP : TR_PPCunsignedLongDivideEP;
    else
       helper = isSignedOp ? TR_PPClongDivide : TR_PPCunsignedLongDivide;
@@ -2119,7 +2119,7 @@ strengthReducingLongDivideOrRemainder32BitMode(TR::Node *node,      TR::CodeGene
 TR::Register *OMR::Power::TreeEvaluator::ldivEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return ldiv64Evaluator(node, cg);
 
    TR::Register *dd_lowReg, *dr_lowReg;
@@ -2157,7 +2157,7 @@ TR::Register *OMR::Power::TreeEvaluator::iremEvaluator(TR::Node *node, TR::CodeG
          {
          TR::Register *divisorReg = cg->evaluate(secondChild);
          trgReg = cg->allocateRegister();
-         if(TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if(cg->comp()->target().cpu.id() >= TR_PPCp9)
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::modsw, node, trgReg, dividendReg, divisorReg);
             }
@@ -2213,7 +2213,7 @@ TR::Register *OMR::Power::TreeEvaluator::iremEvaluator(TR::Node *node, TR::CodeG
             generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, doneLabel, condReg);
             cg->stopUsingRegister(condReg);
             }
-         if(TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if(cg->comp()->target().cpu.id() >= TR_PPCp9)
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::modsw, node, trgReg, dividendReg, divisorReg);
             }
@@ -2253,7 +2253,7 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
          {
          TR::Register *divisorReg = cg->evaluate(secondChild);
          trgReg = cg->allocateRegister();
-         if(TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if(cg->comp()->target().cpu.id() >= TR_PPCp9)
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::modsd, node, trgReg, dividendReg, divisorReg);
             }
@@ -2309,7 +2309,7 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
             generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, doneLabel, condReg);
             cg->stopUsingRegister(condReg);
             }
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp9)
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::modsd, node, trgReg, dividendReg, divisorReg);
             }
@@ -2331,7 +2331,7 @@ TR::Register *lrem64Evaluator(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register *OMR::Power::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return lrem64Evaluator(node, cg);
 
    TR::Register *dd_lowReg, *dr_lowReg;
@@ -2353,7 +2353,7 @@ TR::Register *OMR::Power::TreeEvaluator::lremEvaluator(TR::Node *node, TR::CodeG
 static bool isPower9Extswsli(TR::CodeGenerator *cg, TR::Node *node)
    {
    static bool disableExtswsli = feGetEnv("TR_DisableExtswsli");
-   if (disableExtswsli || TR::Compiler->target.cpu.id() < TR_PPCp9)
+   if (disableExtswsli || cg->comp()->target().cpu.id() < TR_PPCp9)
       return false;
 
    TR::Node *lhs = node->getFirstChild();
@@ -2609,7 +2609,7 @@ TR::Register *OMR::Power::TreeEvaluator::ishlEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::lshlEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return integerShiftLeft(node, 8, cg);
    else
       return lshl32Evaluator(node, cg);
@@ -2993,7 +2993,7 @@ TR::Register *OMR::Power::TreeEvaluator::iushrEvaluator(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::lshrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return integerShiftRight(node, 8, false, cg);
    else
       return lshr32Evaluator(node, false, cg);
@@ -3001,7 +3001,7 @@ TR::Register *OMR::Power::TreeEvaluator::lshrEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::lushrEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return integerShiftRight(node, 8, true, cg);
    else
       return lshr32Evaluator(node, true, cg);
@@ -3034,7 +3034,7 @@ TR::Register *OMR::Power::TreeEvaluator::irolEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::lrolEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.is64Bit(), "lrol is not currently supported on ppc32");
+   TR_ASSERT_FATAL(cg->comp()->target().is64Bit(), "lrol is not currently supported on ppc32");
 
    TR::Node *firstChild = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
@@ -3206,7 +3206,7 @@ TR::Register *OMR::Power::TreeEvaluator::landEvaluator(TR::Node *node, TR::CodeG
    TR::Register *trgReg  = NULL;
    TR::ILOpCodes secondOp = secondChild->getOpCodeValue();
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *src1Reg = cg->evaluate(firstChild);
       trgReg  = cg->allocateRegister();
@@ -3272,7 +3272,7 @@ static inline TR::Register *lorTypeEvaluator(TR::Node *node,
    TR::Node     *firstChild  = node->getFirstChild();
    TR::ILOpCodes  secondOp = secondChild->getOpCodeValue();
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if ((secondOp == TR::lconst || secondOp == TR::luconst) &&
          secondChild->getRegister() == NULL)
@@ -3381,7 +3381,7 @@ TR::Register *OMR::Power::TreeEvaluator::lorEvaluator(TR::Node *node, TR::CodeGe
 
    if ((node->getFirstChild()->isHighWordZero() || node->getSecondChild()->isHighWordZero()) &&
        !((secondOp == TR::lconst || secondOp == TR::luconst) && node->getSecondChild()->getRegister() == NULL) &&
-       !(TR::Compiler->target.is64Bit()))
+       !(cg->comp()->target().is64Bit()))
       {
       return carrylessLongEvaluatorWithAnalyser(node, cg,
                                                     TR::InstOpCode::OR,
@@ -3400,7 +3400,7 @@ TR::Register *OMR::Power::TreeEvaluator::lxorEvaluator(TR::Node *node, TR::CodeG
 
    if ((node->getFirstChild()->isHighWordZero() || node->getSecondChild()->isHighWordZero()) &&
        !((secondOp == TR::lconst || secondOp == TR::luconst) && node->getSecondChild()->getRegister() == NULL) &&
-       !(TR::Compiler->target.is64Bit()))
+       !(cg->comp()->target().is64Bit()))
       {
       return carrylessLongEvaluatorWithAnalyser(node, cg,
                                                     TR::InstOpCode::XOR,
@@ -3509,7 +3509,7 @@ TR::Register *OMR::Power::TreeEvaluator::lxfrsEvaluator(TR::Node *node, TR::Code
    TR::Register *tmp2Reg  = cg->allocateRegister();
    TR::Register  *trgReg;
 
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       {
       TR::Register *lowReg  = cg->allocateRegister();
       TR::Register *highReg = cg->allocateRegister();

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -84,7 +84,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg);
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::iflucmpltEvaluator(node, cg);
    else
       return TR::TreeEvaluator::ifiucmpltEvaluator(node, cg);
@@ -92,7 +92,7 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpltEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::iflucmpgeEvaluator(node, cg);
    else
       return TR::TreeEvaluator::ifiucmpgeEvaluator(node, cg);
@@ -100,7 +100,7 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpgeEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::iflucmpgtEvaluator(node, cg);
    else
       return TR::TreeEvaluator::ifiucmpgtEvaluator(node, cg);
@@ -108,7 +108,7 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpgtEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::iflucmpleEvaluator(node, cg);
    else
       return TR::TreeEvaluator::ifiucmpleEvaluator(node, cg);
@@ -116,7 +116,7 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpleEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::Power::TreeEvaluator::acmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lucmpltEvaluator(node, cg);
    else
       return TR::TreeEvaluator::iucmpltEvaluator(node, cg);
@@ -124,7 +124,7 @@ TR::Register *OMR::Power::TreeEvaluator::acmpltEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::acmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lucmpgeEvaluator(node, cg);
    else
       return TR::TreeEvaluator::iucmpgeEvaluator(node, cg);
@@ -132,7 +132,7 @@ TR::Register *OMR::Power::TreeEvaluator::acmpgeEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::acmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lucmpgtEvaluator(node, cg);
    else
       return TR::TreeEvaluator::iucmpgtEvaluator(node, cg);
@@ -140,7 +140,7 @@ TR::Register *OMR::Power::TreeEvaluator::acmpgtEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::acmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lucmpleEvaluator(node, cg);
    else
       return TR::TreeEvaluator::iucmpleEvaluator(node, cg);
@@ -269,7 +269,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::Mne
       TR::Node *thirdChild = node->getChild(2);
       TR_ASSERT(thirdChild->getOpCodeValue() == TR::GlRegDeps, "The third child of a compare is assumed to be a TR::GlRegDeps, but wasn't");
       cg->evaluate(thirdChild);
-      if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+      if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
          generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                generateRegisterDependencyConditions(cg, thirdChild, 0));
       else
@@ -279,7 +279,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareIntsForOrder(TR::InstOpCode::Mne
       }
    else
       {
-      if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+      if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
          generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
       else
          generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -448,14 +448,14 @@ static TR::Register *compareLongsForOrderWithAnalyser(TR::InstOpCode::Mnemonic b
       generateLabelInstruction(cg, TR::InstOpCode::label, node, label1);
       if (deps)
          {
-         if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
             generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, destinationLabel, condReg, deps);
          else
             generateDepConditionalBranchInstruction(cg, branchOp, node, destinationLabel, condReg, deps);
          }
       else
          {
-         if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
             generateConditionalBranchInstruction(cg, branchOp, likeliness, node, destinationLabel, condReg);
          else
             generateConditionalBranchInstruction(cg, branchOp, node, destinationLabel, condReg);
@@ -510,7 +510,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
       {
       value = secondChild->get64bitIntegralValue();
       }
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       src1Reg = cg->evaluate(firstChild);
       if (secondChild->getOpCode().isLoadConst() &&
@@ -535,7 +535,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
          TR::Node *thirdChild = node->getChild(2);
          TR_ASSERT(thirdChild->getOpCodeValue() == TR::GlRegDeps, "The third child of a compare is assumed to be a TR::GlRegDeps, but wasn't");
          cg->evaluate(thirdChild);
-         if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
             generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                   generateRegisterDependencyConditions(cg, thirdChild, 0));
          else
@@ -545,7 +545,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForOrder(TR::InstOpCode::Mn
          }
       else
          {
-         if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
             generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
          else
             generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -685,7 +685,7 @@ TR::Register *OMR::Power::TreeEvaluator::lreturnEvaluator(TR::Node *node, TR::Co
    TR::Register *returnRegister = cg->evaluate(node->getFirstChild());
    const TR::PPCLinkageProperties &linkageProperties = cg->getProperties();
    TR::RegisterDependencyConditions *dependencies;
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::RealRegister::RegNum machineReturnRegister =
                    linkageProperties.getIntegerReturnRegister();
@@ -867,7 +867,7 @@ static TR::InstOpCode::Mnemonic cmp2cmp(TR::ILOpCodes op, TR::CodeGenerator *cg)
        case TR::lcmpge:
        case TR::lcmpgt:
        case TR::lcmple:
-          return TR::Compiler->target.is64Bit() ? TR::InstOpCode::cmp8 : TR::InstOpCode::cmp4;
+          return cg->comp()->target().is64Bit() ? TR::InstOpCode::cmp8 : TR::InstOpCode::cmp4;
        case TR::lucmplt:
        case TR::lucmpge:
        case TR::lucmpgt:
@@ -878,7 +878,7 @@ static TR::InstOpCode::Mnemonic cmp2cmp(TR::ILOpCodes op, TR::CodeGenerator *cg)
        case TR::acmpge:
        case TR::acmpgt:
        case TR::acmple:
-          return TR::Compiler->target.is64Bit() ? TR::InstOpCode::cmpl8 : TR::InstOpCode::cmpl4;
+          return cg->comp()->target().is64Bit() ? TR::InstOpCode::cmpl8 : TR::InstOpCode::cmpl4;
        default:
        TR_ASSERT(false, "assertion failure");
        }
@@ -918,7 +918,7 @@ static TR::InstOpCode::Mnemonic cmp2cmpi(TR::ILOpCodes op, TR::CodeGenerator *cg
        case TR::lcmpge:
        case TR::lcmpgt:
        case TR::lcmple:
-          return TR::Compiler->target.is64Bit() ? TR::InstOpCode::cmpi8 : TR::InstOpCode::cmpi4;
+          return cg->comp()->target().is64Bit() ? TR::InstOpCode::cmpi8 : TR::InstOpCode::cmpi4;
        case TR::lucmplt:
        case TR::lucmpge:
        case TR::lucmpgt:
@@ -929,7 +929,7 @@ static TR::InstOpCode::Mnemonic cmp2cmpi(TR::ILOpCodes op, TR::CodeGenerator *cg
        case TR::acmpge:
        case TR::acmpgt:
        case TR::acmple:
-          return TR::Compiler->target.is64Bit() ? TR::InstOpCode::cmpli8 : TR::InstOpCode::cmpli4;
+          return cg->comp()->target().is64Bit() ? TR::InstOpCode::cmpli8 : TR::InstOpCode::cmpli4;
        default:
        TR_ASSERT(false, "assertion failure");
        }
@@ -940,7 +940,7 @@ static TR::InstOpCode::Mnemonic cmp2cmpi(TR::ILOpCodes op, TR::CodeGenerator *cg
 TR::Register *OMR::Power::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::DataType type = node->getType();
-   bool two_reg = (TR::Compiler->target.is32Bit()) && type.getDataType() == TR::Int64;
+   bool two_reg = (cg->comp()->target().is32Bit()) && type.getDataType() == TR::Int64;
    TR::Register *resultReg = two_reg ?
                             cg->allocateRegisterPair(cg->allocateRegister(),cg->allocateRegister()) :
                             (type.getDataType() == TR::Float ?
@@ -961,7 +961,7 @@ TR::Register *OMR::Power::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::C
    if (firstChild->getOpCode().isBooleanCompare() &&
        firstChild->getRegister() == NULL &&
        firstChild->getReferenceCount() == 1 &&
-       !(firstChild->getFirstChild()->getType().isInt64() && TR::Compiler->target.is32Bit()))
+       !(firstChild->getFirstChild()->getType().isInt64() && cg->comp()->target().is32Bit()))
       {
       //This is now either 64 bit only.
       // (cmp1Reg [branch_opcode] cmp2Reg) ? trueReg : falseReg;
@@ -1333,7 +1333,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
        {
        TR::Node *thirdChild = node->getChild(2);
        cg->evaluate(thirdChild);
-       if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+       if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
           generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                 generateRegisterDependencyConditions(cg, thirdChild, 0));
        else
@@ -1344,7 +1344,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
        }
     else
        {
-       if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+       if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
           generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
        else
           generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -1426,7 +1426,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::Node *node,
 
 TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode::Mnemonic branchOp, TR::LabelSymbol *dstLabel, TR::Node *node, TR::CodeGenerator *cg, bool isHint, bool likeliness)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (virtualGuardHelper(node, cg))
          return NULL;
@@ -1438,7 +1438,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode:
 
    //Peephole to not compare top half of operands if shifted by more than 32
    //Useful for our implementation of BigDecimal.compareTo()
-   if (!disableCompareToOpt && TR::Compiler->target.is32Bit() &&
+   if (!disableCompareToOpt && cg->comp()->target().is32Bit() &&
        firstChild->getOpCodeValue() == TR::lshr && secondChild->getOpCodeValue() == TR::lshr &&
        firstChild->getReferenceCount() == 1 && secondChild->getReferenceCount() == 1)
       {
@@ -1490,7 +1490,7 @@ TR::Register *OMR::Power::TreeEvaluator::compareLongsForEquality(TR::InstOpCode:
    bool isSigned = !node->getOpCode().isUnsignedCompare();
    TR::Compilation *comp = cg->comp();
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
 
 #ifdef J9_PROJECT_SPECIFIC
@@ -1539,7 +1539,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
          {
          thirdChild = node->getChild(2);
          cg->evaluate(thirdChild);
-         if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
             generateDepConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg,
                   generateRegisterDependencyConditions(cg, thirdChild, 0));
          else
@@ -1549,7 +1549,7 @@ if (cg->profiledPointersRequireRelocation() && secondChild->getOpCodeValue() == 
          }
       else
          {
-         if (isHint && TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (isHint && cg->comp()->target().cpu.id() >= TR_PPCgp)
             generateConditionalBranchInstruction(cg, branchOp, likeliness, node, dstLabel, condReg);
          else
             generateConditionalBranchInstruction(cg, branchOp, node, dstLabel, condReg);
@@ -1663,7 +1663,7 @@ TR::Register *OMR::Power::TreeEvaluator::iflucmpleEvaluator(TR::Node *node, TR::
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Node::recreate(node, TR::iflcmpeq);
       TR::TreeEvaluator::iflcmpeqEvaluator(node, cg);
@@ -1679,7 +1679,7 @@ TR::Register *OMR::Power::TreeEvaluator::ifacmpeqEvaluator(TR::Node *node, TR::C
 
 TR::Register *OMR::Power::TreeEvaluator::ifacmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Node::recreate(node, TR::iflcmpne);
       TR::TreeEvaluator::iflcmpeqEvaluator(node, cg);
@@ -1783,7 +1783,7 @@ TR::Register *OMR::Power::TreeEvaluator::icmpneEvaluator(TR::Node *node, TR::Cod
       }
    // 64-bit needs sign extensions if we use the subf/addic/subfe sequence.
    // therefore, we prefer the subf/cntlzw/rlwinm/xori sequence
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateTrg1Src1Instruction(cg, TR::InstOpCode::cntlzw, node, temp2Reg, temp1Reg);
       generateShiftRightLogicalImmediate(cg, node, temp2Reg, temp2Reg, 5);
@@ -2090,7 +2090,7 @@ TR::Register *OMR::Power::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::Co
 // also handles acmpeq in 64-bit mode
 TR::Register *OMR::Power::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       {
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmp4, TR::InstOpCode::beq, node,cg);
       }
@@ -2151,7 +2151,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::Cod
 // also handles acmpne in 64-bit mode
 TR::Register *OMR::Power::TreeEvaluator::lcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       {
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmp4, TR::InstOpCode::bne, node, cg);
       }
@@ -2202,7 +2202,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpneEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::lcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmp4, TR::InstOpCode::blt, node, cg);
 
    TR::Node     *firstChild   = node->getFirstChild();
@@ -2253,7 +2253,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpltEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::lcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmp4, TR::InstOpCode::ble, node, cg);
 
    TR::Node     *firstChild   = node->getFirstChild();
@@ -2302,7 +2302,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpleEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::lcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
      return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmp4, TR::InstOpCode::bge, node, cg);
 
    TR::Node     *firstChild   = node->getFirstChild();
@@ -2356,7 +2356,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpgeEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::lcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmp4, TR::InstOpCode::bgt, node, cg);
 
    TR::Node     *firstChild   = node->getFirstChild();
@@ -2411,7 +2411,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpgtEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::lucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmpl4, TR::InstOpCode::blt, node, cg);
 
    TR::Node *firstChild  = node->getFirstChild();
@@ -2430,7 +2430,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpltEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::lucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmpl4, TR::InstOpCode::ble, node, cg);
 
    TR::Node *firstChild  = node->getFirstChild();
@@ -2449,7 +2449,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpleEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::lucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
      return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmpl4, TR::InstOpCode::bge, node, cg);
 
    TR::Node *firstChild  = node->getFirstChild();
@@ -2468,7 +2468,7 @@ TR::Register *OMR::Power::TreeEvaluator::lucmpgeEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::lucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       return compareLongAndSetOrderedBoolean(TR::InstOpCode::cmpl4, TR::InstOpCode::bgt, node, cg);
 
    TR::Node *firstChild  = node->getFirstChild();
@@ -2493,11 +2493,11 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
    TR::Node     *secondChild = node->getSecondChild();
    TR::Register *temp1Reg, *temp2Reg, *temp3Reg;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (secondChild->getOpCode().isLoadConst() && secondChild->getLongInt()==0)
          {
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp9)
             {
             TR::Register *condReg = cg->allocateRegister(TR_CCR);
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi8, node, condReg, src1Reg, 0);
@@ -2518,7 +2518,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
       else
          {
          TR::Register *src2Reg = cg->evaluate(secondChild);
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp9)
             {
             TR::Register *condReg = cg->allocateRegister(TR_CCR);
             generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp8, node, condReg, src1Reg, src2Reg);
@@ -2588,7 +2588,7 @@ TR::Register *OMR::Power::TreeEvaluator::lcmpEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::acmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lcmpeqEvaluator(node, cg);
    else
       return TR::TreeEvaluator::icmpeqEvaluator(node, cg);
@@ -2596,7 +2596,7 @@ TR::Register *OMR::Power::TreeEvaluator::acmpeqEvaluator(TR::Node *node, TR::Cod
 
 TR::Register *OMR::Power::TreeEvaluator::acmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::lcmpneEvaluator(node, cg);
    else
       return TR::TreeEvaluator::icmpneEvaluator(node, cg);
@@ -2725,7 +2725,7 @@ static void lookupScheme1(TR::Node *node, bool unbalanced, bool fromTableEval, T
    int32_t      total = node->getNumChildren();
    TR::Register *selector = cg->evaluate(node->getFirstChild());
    bool         isInt64 = false;
-   bool two_reg = (TR::Compiler->target.is32Bit()) && isInt64;
+   bool two_reg = (cg->comp()->target().is32Bit()) && isInt64;
    TR::Register *cndRegister = cg->allocateRegister(TR_CCR);
    TR::RegisterDependencyConditions *acond, *bcond, *conditions = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(3, 3, cg->trMemory());
    TR::Node     *secondChild = node->getSecondChild();
@@ -2755,7 +2755,7 @@ static void lookupScheme1(TR::Node *node, bool unbalanced, bool fromTableEval, T
       if (isInt64)
          {
          int64_t value = child->getCaseConstant();
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi8, node, cndRegister, selector, value);
             }
@@ -2806,7 +2806,7 @@ static void lookupScheme2(TR::Node *node, bool unbalanced, bool fromTableEval, T
    TR::Register *valRegister = NULL;
 
    bool         isInt64 = false;
-   bool two_reg = (TR::Compiler->target.is32Bit()) && isInt64;
+   bool two_reg = (cg->comp()->target().is32Bit()) && isInt64;
    TR::LabelSymbol *toDefaultLabel = NULL;
    if ( two_reg )
       {
@@ -2873,7 +2873,7 @@ static void lookupScheme2(TR::Node *node, bool unbalanced, bool fromTableEval, T
 
       if (isInt64)
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp8, node, cndRegister, selector, valRegister);
             }
@@ -2940,7 +2940,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
    int64_t     *dataTable64 = NULL;
    bool        isInt64 = false;
    TR::Compilation *comp = cg->comp();
-   bool        two_reg = isInt64 && TR::Compiler->target.is32Bit();
+   bool        two_reg = isInt64 && cg->comp()->target().is32Bit();
    if (isInt64)
       {
       dataTableSize *=2;
@@ -2967,7 +2967,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
    TR::Node     *secondChild = node->getSecondChild();
 
    TR::addDependency(conditions, addrRegister, TR::RealRegister::NoReg, TR_GPR, cg);
-   if (isInt64 && TR::Compiler->target.is64Bit())
+   if (isInt64 && cg->comp()->target().is64Bit())
       {
       TR::addDependency(conditions, dataRegister->getHighOrder(), TR::RealRegister::NoReg, TR_GPR, cg);
       TR::addDependency(conditions, dataRegister->getLowOrder(), TR::RealRegister::NoReg, TR_GPR, cg);
@@ -2991,7 +2991,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
       acond = acond->clone(cg, generateRegisterDependencyConditions(cg, secondChild->getFirstChild(), 0));
       }
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, cg);
 
@@ -3112,7 +3112,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
       TR::Node *child = node->getChild(ii);
       if (isInt64)
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateTrg1Src2Instruction(cg, TR::InstOpCode::cmp8, node, cndRegister, selector, dataRegister);
             }
@@ -3149,7 +3149,7 @@ static void lookupScheme3(TR::Node *node, bool unbalanced, TR::CodeGenerator *cg
          {
          if (isInt64)
             {
-            if (TR::Compiler->target.is64Bit())
+            if (cg->comp()->target().is64Bit())
                {
                if (nextAddress >= 32760)
                   {
@@ -3224,7 +3224,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
    int32_t  numberOfEntries = total - 2;
    size_t  dataTableSize = numberOfEntries * sizeof(int);
    bool        isInt64 = false;
-   bool        two_reg = isInt64 && TR::Compiler->target.is32Bit();
+   bool        two_reg = isInt64 && cg->comp()->target().is32Bit();
    int32_t *dataTable = NULL;
    int64_t *dataTable64 = NULL;
    intptrj_t  address = NULL;
@@ -3293,7 +3293,7 @@ static void lookupScheme4(TR::Node *node, TR::CodeGenerator *cg)
 
    loadConstant(cg, node, (numberOfEntries-1)<<2, highRegister);
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, cg);
 
@@ -3480,7 +3480,7 @@ TR::Register *OMR::Power::TreeEvaluator::tableEvaluator(TR::Node *node, TR::Code
       }
 
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          int32_t offset = TR_PPCTableOfConstants::allocateChunk(1, cg);
 
@@ -3551,7 +3551,7 @@ OMR::Power::TreeEvaluator::generateNullTestInstructions(
 
    if (cg->getHasResumableTrapHandler())
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          gcPoint = generateSrc1Instruction(cg, TR::InstOpCode::tdeqi, node, trgReg, NULLVALUE);
       else
          gcPoint = generateSrc1Instruction(cg, TR::InstOpCode::tweqi, node, trgReg, NULLVALUE);
@@ -3578,11 +3578,11 @@ OMR::Power::TreeEvaluator::generateNullTestInstructions(
 
       // trampoline kills gr11
       TR::addDependency(conditions, jumpReg, TR::RealRegister::gr11, TR_GPR, cg);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli8, node, condReg, trgReg, NULLVALUE);
       else
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpli4, node, condReg, trgReg, NULLVALUE);
-      if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+      if (cg->comp()->target().cpu.id() >= TR_PPCgp)
          // use PPC AS branch hint
          gcPoint = generateDepConditionalBranchInstruction(cg, TR::InstOpCode::beql, PPCOpProp_BranchUnlikely, node, snippetLabel, condReg, conditions);
       else
@@ -3685,11 +3685,11 @@ TR::Register *OMR::Power::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::Co
       {
       TR::Register *value = cg->evaluate(node->getFirstChild());
       TR::Register *condReg = cg->allocateRegister(TR_CCR);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi8, node, condReg, value, 0);
       else
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, condReg, value, 0);
-      if (TR::Compiler->target.cpu.id() >= TR_PPCgp) // Use PPC AS branch hint.
+      if (cg->comp()->target().cpu.id() >= TR_PPCgp) // Use PPC AS branch hint.
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, node, slowPathLabel, condReg);
       else
          generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, node, slowPathLabel, condReg);
@@ -3781,7 +3781,7 @@ static TR::Register *generateMaxMin(TR::Node *node, TR::CodeGenerator *cg, bool 
    TR::DataType type = child->getType();
    TR::InstOpCode::Mnemonic move_op = type.isIntegral() ? TR::InstOpCode::mr : TR::InstOpCode::fmr;
    TR::InstOpCode::Mnemonic cmp_op;
-   bool two_reg = (TR::Compiler->target.is32Bit() && type.isInt64());
+   bool two_reg = (cg->comp()->target().is32Bit() && type.isInt64());
    TR::Register *trgReg;
 
    switch (node->getOpCodeValue())

--- a/compiler/p/codegen/FPTreeEvaluator.cpp
+++ b/compiler/p/codegen/FPTreeEvaluator.cpp
@@ -88,7 +88,7 @@ TR::Register *OMR::Power::TreeEvaluator::ibits2fEvaluator(TR::Node *node, TR::Co
       }
    else
       {
-      generateMvFprGprInstructions(cg, node, gprSp2fpr, TR::Compiler->target.is64Bit(),target, cg->evaluate(child));
+      generateMvFprGprInstructions(cg, node, gprSp2fpr, cg->comp()->target().is64Bit(),target, cg->evaluate(child));
       cg->decReferenceCount(child);
       }
 
@@ -116,8 +116,8 @@ TR::Register *OMR::Power::TreeEvaluator::fbits2iEvaluator(TR::Node *node, TR::Co
       }
    else
       {
-      floatReg = TR::Compiler->target.cpu.id() >= TR_PPCp8 ? cg->gprClobberEvaluate(child) : cg->evaluate(child);
-      generateMvFprGprInstructions(cg, node, fpr2gprSp, TR::Compiler->target.is64Bit(),target, floatReg);
+      floatReg = cg->comp()->target().cpu.id() >= TR_PPCp8 ? cg->gprClobberEvaluate(child) : cg->evaluate(child);
+      generateMvFprGprInstructions(cg, node, fpr2gprSp, cg->comp()->target().is64Bit(),target, floatReg);
       childEval = floatReg == child->getRegister();
       cg->decReferenceCount(child);
       }
@@ -165,7 +165,7 @@ TR::Register *OMR::Power::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 8, cg);
 #ifdef J9_PROJECT_SPECIFIC
-      if (child->getOpCodeValue() == TR::irlload && TR::Compiler->target.is64Bit())        // 64-bit only
+      if (child->getOpCodeValue() == TR::irlload && cg->comp()->target().is64Bit())        // 64-bit only
          {
          TR::Register     *tmpReg = cg->allocateRegister();
          tempMR->forceIndexedForm(child, cg);
@@ -173,7 +173,7 @@ TR::Register *OMR::Power::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
          generateMvFprGprInstructions(cg, node, gpr2fprHost64, true, target, tmpReg);
          cg->stopUsingRegister(tmpReg);
          }
-      else if (child->getOpCodeValue() == TR::irlload && TR::Compiler->target.is32Bit())   // 32-bit
+      else if (child->getOpCodeValue() == TR::irlload && cg->comp()->target().is32Bit())   // 32-bit
          {
          TR::Register     *highReg = cg->allocateRegister();
          TR::Register     *lowReg = cg->allocateRegister();
@@ -199,12 +199,12 @@ TR::Register *OMR::Power::TreeEvaluator::lbits2dEvaluator(TR::Node *node, TR::Co
       }
    else
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateMvFprGprInstructions(cg, node, gpr2fprHost64, true, target, cg->evaluate(child));
       else
          {
          TR::Register *longReg = cg->evaluate(child);
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, target, longReg->getHighOrder(), longReg->getLowOrder(), tmp1);
@@ -237,7 +237,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
       doubleReg = cg->allocateRegister(TR_FPR);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lfd, node, doubleReg, tempMR);
 
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          lReg  = cg->allocateRegister();
          TR::MemoryReference  *tempMR2 = new (cg->trHeapMemory()) TR::MemoryReference(node, *tempMR, 0, 8, cg);
@@ -264,7 +264,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
       {
       doubleReg = cg->evaluate(child);
 
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          lReg  = cg->allocateRegister();
          generateMvFprGprInstructions(cg, node, fpr2gprHost64, true, lReg, doubleReg);
@@ -273,7 +273,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
          {
          highReg = cg->allocateRegister();
          lowReg = cg->allocateRegister();
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, fpr2gprHost32, false, highReg, lowReg, doubleReg, tmp1);
@@ -295,10 +295,10 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
       TR::LabelSymbol *nanNormalizeStartLabel = generateLabelSymbol(cg);
       TR::LabelSymbol *nanNormalizeEndLabel = generateLabelSymbol(cg);
 
-      uint16_t numDeps = TR::Compiler->target.is64Bit() ? 2 : 3;
+      uint16_t numDeps = cg->comp()->target().is64Bit() ? 2 : 3;
       TR::RegisterDependencyConditions *deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numDeps, numDeps, cg->trMemory());
       TR::addDependency(deps, condReg, TR::RealRegister::NoReg, TR_CCR, cg);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          TR::addDependency(deps, lReg, TR::RealRegister::NoReg, TR_GPR, cg);
          }
@@ -311,7 +311,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
       generateTrg1Src2Instruction(cg, TR::InstOpCode::fcmpu, node, condReg, doubleReg, doubleReg);
       generateLabelInstruction(cg, TR::InstOpCode::label, node, nanNormalizeStartLabel);
       generateConditionalBranchInstruction(cg, TR::InstOpCode::beq, PPCOpProp_BranchLikely, node, nanNormalizeEndLabel, condReg);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          loadConstant(cg, node, (int64_t)CONSTANT64(0x7ff8000000000000), lReg);
          }
@@ -328,7 +328,7 @@ TR::Register *OMR::Power::TreeEvaluator::dbits2lEvaluator(TR::Node *node, TR::Co
    if (!childEval)
       cg->stopUsingRegister(doubleReg);
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       node->setRegister(lReg);
       return lReg;
@@ -350,7 +350,7 @@ static TR::Register *fconstHandler(TR::Node *node, TR::CodeGenerator *cg, float 
    TR::Compilation *comp = cg->comp();
 
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       offset = cg->findOrCreateFloatConstant(&value, TR::Float, NULL, NULL, NULL, NULL);
       if (offset != PTOC_FULL_INDEX)
@@ -369,15 +369,15 @@ static TR::Register *fconstHandler(TR::Node *node, TR::CodeGenerator *cg, float 
          }
       }
 
-   if (TR::Compiler->target.is32Bit() || offset==PTOC_FULL_INDEX)
+   if (cg->comp()->target().is32Bit() || offset==PTOC_FULL_INDEX)
       {
       srcRegister = cg->allocateRegister();
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempReg = cg->allocateRegister();
       fixedSeqMemAccess(cg, node, 0, q, trgRegister, srcRegister, TR::InstOpCode::lfs, 4, NULL, tempReg);
       cg->findOrCreateFloatConstant(&value, TR::Float, q[0], q[1], q[2], q[3]);
       cg->stopUsingRegister(srcRegister);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          cg->stopUsingRegister(tempReg);
       }
    node->setRegister(trgRegister);
@@ -425,7 +425,7 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
    TR::Instruction *q[4];
    int32_t            offset;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       offset = cg->findOrCreateFloatConstant(&value, TR::Double, NULL, NULL, NULL, NULL);
       if (offset != PTOC_FULL_INDEX)
@@ -453,14 +453,14 @@ TR::Register *OMR::Power::TreeEvaluator::dconstEvaluator(TR::Node *node, TR::Cod
          }
       }
 
-   if (TR::Compiler->target.is32Bit() || offset==PTOC_FULL_INDEX)
+   if (cg->comp()->target().is32Bit() || offset==PTOC_FULL_INDEX)
       {
       srcRegister = cg->allocateRegister(TR_GPR);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempReg = cg->allocateRegister(TR_GPR);
       fixedSeqMemAccess(cg, node, 0, q, trgRegister, srcRegister, opcode, 8, NULL, tempReg);
       cg->stopUsingRegister(srcRegister);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          cg->stopUsingRegister(tempReg);
       cg->findOrCreateFloatConstant(&value, TR::Double, q[0], q[1], q[2], q[3]);
       }
@@ -473,7 +473,7 @@ TR::Register *OMR::Power::TreeEvaluator::floadEvaluator(TR::Node *node, TR::Code
    {
    TR::Register *tempReg = node->setRegister(cg->allocateSinglePrecisionRegister());
    TR::MemoryReference *tempMR;
-   bool needSync= node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP();
+   bool needSync= node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP();
 
    // If the reference is volatile or potentially volatile, the layout needs to be
    // fixed for patching if it turns out to be not a volatile atfer all.
@@ -494,8 +494,8 @@ TR::Register *OMR::Power::TreeEvaluator::dloadHelper(TR::Node *node, TR::CodeGen
    {
    TR::Compilation *comp = cg->comp();
    TR::MemoryReference *tempMR;
-   bool needSync= node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP();
-   if (TR::Compiler->target.is32Bit() && needSync && !cg->is64BitProcessor())
+   bool needSync= node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP();
+   if (cg->comp()->target().is32Bit() && needSync && !cg->is64BitProcessor())
       {
       TR::Register *addrReg = cg->allocateRegister();
       TR::SymbolReference *vrlRef = comp->getSymRefTab()->findOrCreateVolatileReadDoubleSymbolRef(comp->getMethodSymbol());
@@ -646,7 +646,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       TR::Register *tempReg = cg->evaluate(child);
       TR::Register *resReg = cg->allocateRegister(TR_VRF);
 
-      if (!disableDirectMove && TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX())
+      if (!disableDirectMove && cg->comp()->target().cpu.id() >= TR_PPCp8 && cg->comp()->target().cpu.getPPCSupportsVSX())
          {
          generateMvFprGprInstructions(cg, node, gprLow2fpr, false, resReg, tempReg);
          generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::xxspltw, node, resReg, resReg, 0x1);
@@ -678,9 +678,9 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
       TR::Register *srcReg = cg->evaluate(child);
       TR::Register *trgReg = cg->allocateRegister(TR_VRF);
 
-      if (!disableDirectMove && TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.cpu.getPPCSupportsVSX())
+      if (!disableDirectMove && cg->comp()->target().cpu.id() >= TR_PPCp8 && cg->comp()->target().cpu.getPPCSupportsVSX())
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateMvFprGprInstructions(cg, node, gpr2fprHost64, false, trgReg, srcReg);
             generateTrg1Src2ImmInstruction(cg, TR::InstOpCode::xxpermdi, node, trgReg, trgReg, trgReg, 0x0);
@@ -698,7 +698,7 @@ TR::Register *OMR::Power::TreeEvaluator::vsplatsEvaluator(TR::Node *node, TR::Co
          TR::SymbolReference *temp   = cg->allocateLocalTemp(TR::Int64);
          TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, temp, 8, cg);
 
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateMemSrc1Instruction(cg, TR::InstOpCode::std, node, tempMR, srcReg);
             }
@@ -927,7 +927,7 @@ TR::Register *OMR::Power::TreeEvaluator::fstoreEvaluator(TR::Node *node, TR::Cod
 
    TR::Register *valueReg = cg->evaluate(child);
    TR::MemoryReference *tempMR;
-   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool    needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    // If the reference is volatile or potentially volatile, the layout needs to be
    // fixed for patching if it turns out to be not a volatile after all.
@@ -973,9 +973,9 @@ TR::Register* OMR::Power::TreeEvaluator::dstoreEvaluator(TR::Node *node, TR::Cod
 
 
    TR::Register *valueReg = cg->evaluate(child);
-   bool needSync= node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP();
+   bool needSync= node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP();
    TR::MemoryReference *tempMR;
-   if (TR::Compiler->target.is32Bit() && needSync && !cg->is64BitProcessor())
+   if (cg->comp()->target().is32Bit() && needSync && !cg->is64BitProcessor())
       {
       TR::Register *addrReg = cg->allocateRegister();
       TR::SymbolReference    *vrlRef = comp->getSymRefTab()->findOrCreateVolatileWriteDoubleSymbolRef(comp->getMethodSymbol());
@@ -1363,9 +1363,9 @@ TR::Register *OMR::Power::TreeEvaluator::int2dbl(TR::Node * node, TR::Register *
    TR::Register *trgReg     = cg->allocateRegister(TR_FPR);
    TR::Register *tempReg;
 
-   if (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && TR::Compiler->target.is64Bit()))
+   if (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && cg->comp()->target().is64Bit()))
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          if (node->getOpCodeValue() == TR::iu2f || node->getOpCodeValue() == TR::iu2d)
             {
@@ -1386,7 +1386,7 @@ TR::Register *OMR::Power::TreeEvaluator::int2dbl(TR::Node * node, TR::Register *
          }
       else
          {
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp6 && node->getOpCodeValue() != TR::iu2f && node->getOpCodeValue() != TR::iu2d)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp6 && node->getOpCodeValue() != TR::iu2f && node->getOpCodeValue() != TR::iu2d)
             generateMvFprGprInstructions(cg, node, gprLow2fpr, false, trgReg, srcReg);
          else
             {
@@ -1397,7 +1397,7 @@ TR::Register *OMR::Power::TreeEvaluator::int2dbl(TR::Node * node, TR::Register *
             else
                generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::srawi, node, tempReg, srcReg, 31);
 
-            if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
+            if (cg->comp()->target().cpu.id() >= TR_PPCp8)
                {
                TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
                generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, trgReg, tempReg, srcReg, tmp1);
@@ -1408,7 +1408,7 @@ TR::Register *OMR::Power::TreeEvaluator::int2dbl(TR::Node * node, TR::Register *
             cg->stopUsingRegister(tempReg);
             }
          }
-      if ((TR::Compiler->target.cpu.id() >= TR_PPCp7) &&
+      if ((cg->comp()->target().cpu.id() >= TR_PPCp7) &&
           (node->getOpCodeValue() == TR::i2f || node->getOpCodeValue() == TR::iu2f))
          {
          // Generate the code to produce the float result here, setting the register flag is done afterwards
@@ -1456,12 +1456,12 @@ TR::Register *OMR::Power::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGe
    TR::Register *tempReg;
    TR::Register *trgReg;
 
-   if (((TR::Compiler->target.cpu.id() >= TR_PPCp7 &&
+   if (((cg->comp()->target().cpu.id() >= TR_PPCp7 &&
        (node->getOpCodeValue() == TR::iu2f && (child->getOpCodeValue() == TR::iuload || child->getOpCodeValue() == TR::iuloadi))) ||
-       (TR::Compiler->target.cpu.id() >= TR_PPCp6 &&
+       (cg->comp()->target().cpu.id() >= TR_PPCp6 &&
        (node->getOpCodeValue() == TR::i2f && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi)))) &&
        child->getReferenceCount() == 1 && child->getRegister() == NULL &&
-       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
       tempMR->forceIndexedForm(node, cg);
@@ -1470,7 +1470,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2fEvaluator(TR::Node *node, TR::CodeGe
       if (node->getOpCodeValue() == TR::i2f)
          {
          generateTrg1MemInstruction(cg, TR::InstOpCode::lfiwax, node, tempReg, tempMR);
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp7)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp7)
             {
             generateTrg1Src1Instruction(cg, TR::InstOpCode::fcfids, node, trgReg, tempReg);
             }
@@ -1504,13 +1504,13 @@ TR::Register *OMR::Power::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGe
    TR::Node     *child      = node->getFirstChild();
    TR::Register *trgReg;
 
-   if (((TR::Compiler->target.cpu.id() >= TR_PPCp7 &&
+   if (((cg->comp()->target().cpu.id() >= TR_PPCp7 &&
        (node->getOpCodeValue() == TR::iu2d && (child->getOpCodeValue() == TR::iuload || child->getOpCodeValue() == TR::iuloadi))) ||
-       (TR::Compiler->target.cpu.id() >= TR_PPCp6 &&
+       (cg->comp()->target().cpu.id() >= TR_PPCp6 &&
        node->getOpCodeValue() == TR::i2d && (child->getOpCodeValue() == TR::iload || child->getOpCodeValue() == TR::iloadi))) &&
        child->getReferenceCount()==1 &&
        child->getRegister() == NULL &&
-       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       // possible TODO: if refcount > 1, do both load and lfiwax?
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
@@ -1545,13 +1545,13 @@ TR::Register *OMR::Power::TreeEvaluator::long2dbl(TR::Node *node, TR::CodeGenera
    TR::Register *trgReg     = cg->allocateRegister(TR_FPR);
 
 
-   if (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && TR::Compiler->target.is64Bit()))
+   if (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && cg->comp()->target().is64Bit()))
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateMvFprGprInstructions(cg, node, gpr2fprHost64, false, trgReg, srcReg);
       else
          {
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, trgReg, srcReg->getHighOrder(), srcReg->getLowOrder(), tmp1);
@@ -1605,14 +1605,14 @@ TR::Register *OMR::Power::TreeEvaluator::long2float(TR::Node *node, TR::CodeGene
    TR::Register *srcReg  = cg->evaluate(child);
    TR::Register *trgReg     = cg->allocateSinglePrecisionRegister(TR_FPR);
 
-   if (TR::Compiler->target.cpu.id() >= TR_PPCp7 &&
-      (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && TR::Compiler->target.is64Bit())))
+   if (cg->comp()->target().cpu.id() >= TR_PPCp7 &&
+      (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && cg->comp()->target().is64Bit())))
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateMvFprGprInstructions(cg, node, gpr2fprHost64, false, trgReg, srcReg);
       else
          {
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
+         if (cg->comp()->target().cpu.id() >= TR_PPCp8)
             {
             TR::Register * tmp1 = cg->allocateRegister(TR_FPR);
             generateMvFprGprInstructions(cg, node, gpr2fprHost32, false, trgReg, srcReg->getHighOrder(), srcReg->getLowOrder(), tmp1);
@@ -1623,7 +1623,7 @@ TR::Register *OMR::Power::TreeEvaluator::long2float(TR::Node *node, TR::CodeGene
          }
       generateTrg1Src1Instruction(cg, TR::InstOpCode::fcfids, node, trgReg, trgReg);
       }
-   else if (TR::Compiler->target.is64Bit())
+   else if (cg->comp()->target().is64Bit())
       {
       TR::Register *src;
       TR::RegisterDependencyConditions *dependencies = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(8, 8, cg->trMemory());
@@ -1693,12 +1693,12 @@ TR::Register *OMR::Power::TreeEvaluator::l2fEvaluator(TR::Node *node, TR::CodeGe
    {
    TR::Register *trgReg;
    TR::Node     *child      = node->getFirstChild();
-   if (TR::Compiler->target.cpu.id() >= TR_PPCp7 &&
+   if (cg->comp()->target().cpu.id() >= TR_PPCp7 &&
        node->getOpCodeValue() == TR::l2f &&
        (child->getOpCodeValue() == TR::lload || child->getOpCodeValue() == TR::lloadi) &&
        child->getReferenceCount()==1 &&
        child->getRegister() == NULL &&
-       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
       tempMR->forceIndexedForm(node, cg);
@@ -1722,12 +1722,12 @@ TR::Register *OMR::Power::TreeEvaluator::l2dEvaluator(TR::Node *node, TR::CodeGe
    TR::Register *trgReg;
    TR::Node     *child      = node->getFirstChild();
    if (
-       TR::Compiler->target.cpu.id() >= TR_PPCp7 &&
+       cg->comp()->target().cpu.id() >= TR_PPCp7 &&
        node->getOpCodeValue() == TR::l2d &&
        (child->getOpCodeValue() == TR::lload || child->getOpCodeValue() == TR::lloadi) &&
        child->getReferenceCount()==1 &&
        child->getRegister() == NULL &&
-       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP()))
+       !(child->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP()))
       {
          TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
          tempMR->forceIndexedForm(node, cg);
@@ -1853,13 +1853,13 @@ TR::Register *OMR::Power::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGe
    TR::Register *sourceReg  = cg->evaluate(child);
    TR::Register *trgReg;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       trgReg     = cg->allocateRegister();
    else
       trgReg     = cg->allocateRegisterPair(cg->allocateRegister(),
                                                  cg->allocateRegister());
 
-   if (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && TR::Compiler->target.is64Bit()))
+   if (cg->is64BitProcessor() || (cg->comp()->compileRelocatableCode() && cg->comp()->target().is64Bit()))
       {
       TR::Register *condReg = cg->allocateRegister(TR_CCR);
       TR::Register *tempReg = (node->getOpCodeValue() == TR::f2l) ? cg->allocateSinglePrecisionRegister() :  cg->allocateRegister(TR_FPR);
@@ -1867,7 +1867,7 @@ TR::Register *OMR::Power::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGe
          generateControlFlowInstruction(cg, TR::InstOpCode::d2l, node);
       cfop->addTargetRegister(condReg);
       cfop->addTargetRegister(tempReg);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          cfop->addTargetRegister(trgReg);
       else
          {
@@ -2029,7 +2029,7 @@ TR::Register *OMR::Power::TreeEvaluator::dcmpneEvaluator(TR::Node *node, TR::Cod
 TR::Register *OMR::Power::TreeEvaluator::dcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    int64_t imm = 0;
-   if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+   if (cg->comp()->target().cpu.id() >= TR_PPCp9)
       {
       imm = (TR::RealRegister::CRCC_GT <<  TR::RealRegister::pos_RT | TR::RealRegister::CRCC_LT <<  TR::RealRegister::pos_RA | TR::RealRegister::CRCC_LT << TR::RealRegister::pos_RB);
       }
@@ -2278,7 +2278,7 @@ static TR::Register *compareFloatAndSetOrderedBoolean(TR::InstOpCode::Mnemonic b
       cfop->addTargetRegister(trgReg);
       cfop->addSourceRegister(src1Reg);
       cfop->addSourceRegister(src2Reg);
-      if (TR::Compiler->target.cpu.id() >= TR_PPCp9 && branchOp2 == TR::InstOpCode::bad && imm != 0)
+      if (cg->comp()->target().cpu.id() >= TR_PPCp9 && branchOp2 == TR::InstOpCode::bad && imm != 0)
          {
          cfop->addSourceImmediate(imm);
          }

--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -62,8 +62,8 @@ TR::Instruction *generateMvFprGprInstructions(TR::CodeGenerator *cg, TR::Node *n
    {
    TR::MemoryReference *tempMRStore1, *tempMRStore2, *tempMRLoad1, *tempMRLoad2;
    static bool disableDirectMove = feGetEnv("TR_disableDirectMove") ? true : false;
-   bool checkp8DirectMove = TR::Compiler->target.cpu.id() >= TR_PPCp8 && !disableDirectMove && TR::Compiler->target.cpu.getPPCSupportsVSX();
-   bool isLittleEndian = TR::Compiler->target.cpu.isLittleEndian();
+   bool checkp8DirectMove = cg->comp()->target().cpu.id() >= TR_PPCp8 && !disableDirectMove && cg->comp()->target().cpu.getPPCSupportsVSX();
+   bool isLittleEndian = cg->comp()->target().cpu.isLittleEndian();
 
    // it's fine if reg3 and reg2 are assigned in modes they are not used
    // what we want to avoid is them being NULL when we need to use them
@@ -166,7 +166,7 @@ TR::Instruction *generateMvFprGprInstructions(TR::CodeGenerator *cg, TR::Node *n
       else if (mode == gprLow2fpr)
          cursor = generateMemSrc1Instruction(cg, TR::InstOpCode::stw, node, tempMRStore1, reg1, cursor);
 
-      if ((nonops == false) && (TR::Compiler->target.cpu.id() >= TR_PPCgp))
+      if ((nonops == false) && (cg->comp()->target().cpu.id() >= TR_PPCgp))
          {
     	 // Insert 3 nops to break up the load/stores into separate groupings,
     	 // thus preventing a costly stall
@@ -208,7 +208,7 @@ TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
 
 TR::Instruction *generateAlignmentNopInstruction(TR::CodeGenerator *cg, TR::Node * n, uint32_t alignment, TR::Instruction *preced)
    {
-   auto op = TR::Compiler->target.cpu.id() >= TR_PPCp6 ? TR::InstOpCode::genop : TR::InstOpCode::nop;
+   auto op = cg->comp()->target().cpu.id() >= TR_PPCp6 ? TR::InstOpCode::genop : TR::InstOpCode::nop;
 
    if (preced)
       return new (cg->trHeapMemory()) TR::PPCAlignmentNopInstruction(op, n, alignment, preced, cg);
@@ -385,7 +385,7 @@ TR::Instruction *generateDepConditionalBranchInstruction(TR::CodeGenerator *cg, 
 TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
    TR::Register *treg, TR::Register *s1reg, intptrj_t imm, TR::Instruction *preced)
    {
-   if (TR::Compiler->target.cpu.id() == TR_PPCp6 && TR::InstOpCode(op).isCompare())
+   if (cg->comp()->target().cpu.id() == TR_PPCp6 && TR::InstOpCode(op).isCompare())
       treg->resetFlippedCCR();
    if (preced)
       return new (cg->trHeapMemory()) TR::PPCTrg1Src1ImmInstruction(op, n, treg, s1reg, imm, preced, cg);
@@ -395,7 +395,7 @@ TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstO
 TR::Instruction *generateTrg1Src1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
    TR::Register *treg, TR::Register *s1reg, TR::Register *cr0reg, int32_t imm, TR::Instruction *preced)
    {
-   if (TR::Compiler->target.cpu.id() == TR_PPCp6)
+   if (cg->comp()->target().cpu.id() == TR_PPCp6)
       cr0reg->resetFlippedCCR();
    if (preced)
       return new (cg->trHeapMemory()) TR::PPCTrg1Src1ImmInstruction(op, n,treg, s1reg, cr0reg, imm, preced, cg);
@@ -450,7 +450,7 @@ TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCo
    {
    TR::Compilation * comp = cg->comp();
    static bool disableFlipCompare = feGetEnv("TR_DisableFlipCompare") != NULL;
-   if (!disableFlipCompare && TR::Compiler->target.cpu.id() == TR_PPCp6 &&
+   if (!disableFlipCompare && cg->comp()->target().cpu.id() == TR_PPCp6 &&
        TR::InstOpCode(op).isCompare() &&
        n->getOpCode().isBranch() && n->getOpCode().isBooleanCompare())
       {
@@ -476,7 +476,7 @@ TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCo
 TR::Instruction *generateTrg1Src2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
    TR::Register *treg, TR::Register *s1reg, TR::Register *s2reg, TR::Register *cr0Reg, TR::Instruction *preced)
    {
-   if (TR::Compiler->target.cpu.id() == TR_PPCp6)
+   if (cg->comp()->target().cpu.id() == TR_PPCp6)
       cr0Reg->resetFlippedCCR();
    return new (cg->trHeapMemory()) TR::PPCTrg1Src2Instruction(op, n, treg, s1reg, s2reg, cr0Reg, preced, cg);
    }
@@ -508,7 +508,7 @@ TR::Instruction *generateTrg1Src1Imm2Instruction(TR::CodeGenerator *cg, TR::Inst
 TR::Instruction *generateTrg1Src1Imm2Instruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
    TR::Register *trgReg, TR::Register *srcReg, TR::Register *cr0reg, int32_t imm1, int64_t imm2, TR::Instruction *preced)
    {
-   if (TR::Compiler->target.cpu.id() == TR_PPCp6)
+   if (cg->comp()->target().cpu.id() == TR_PPCp6)
       cr0reg->resetFlippedCCR();
    if (preced)
       return new (cg->trHeapMemory()) TR::PPCTrg1Src1Imm2Instruction(op, n, trgReg, srcReg, cr0reg, imm1, imm2, preced, cg);
@@ -683,11 +683,11 @@ void generateZeroExtendInstruction(TR::Node *node,
                                    int32_t bitsInTarget,
                                    TR::CodeGenerator *cg)
    {
-   TR_ASSERT((TR::Compiler->target.is64Bit() && bitsInTarget > 0 && bitsInTarget < 64) ||
-          (TR::Compiler->target.is32Bit() && bitsInTarget > 0 && bitsInTarget < 32),
+   TR_ASSERT((cg->comp()->target().is64Bit() && bitsInTarget > 0 && bitsInTarget < 64) ||
+          (cg->comp()->target().is32Bit() && bitsInTarget > 0 && bitsInTarget < 32),
           "invalid zero extension requested");
    int64_t mask = (uint64_t)(CONSTANT64(0xffffFFFFffffFFFF)) >> (64 - bitsInTarget);
-   generateTrg1Src1Imm2Instruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::rldicl : TR::InstOpCode::rlwinm, node, trgReg, srcReg, 0, mask);
+   generateTrg1Src1Imm2Instruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::rldicl : TR::InstOpCode::rlwinm, node, trgReg, srcReg, 0, mask);
    }
 
 void generateSignExtendInstruction(TR::Node *node,

--- a/compiler/p/codegen/OMRConstantDataSnippet.cpp
+++ b/compiler/p/codegen/OMRConstantDataSnippet.cpp
@@ -81,14 +81,14 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             fcursor = new (_cg->trHeapMemory()) PPCConstant<float>(_cg, fin.fvalue);
             _floatConstants.add(fcursor);
-            if (TR::Compiler->target.is64Bit())
+            if (comp->target().is64Bit())
                {
                ret = TR_PPCTableOfConstants::lookUp(fin.fvalue, _cg);
                }
             fcursor->setTOCOffset(ret);
             }
          ret = fcursor->getTOCOffset();
-         if (TR::Compiler->target.is32Bit() || ret==PTOC_FULL_INDEX)
+         if (comp->target().is32Bit() || ret==PTOC_FULL_INDEX)
             fcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
          }
          break;
@@ -110,14 +110,14 @@ int32_t OMR::ConstantDataSnippet::addConstantRequest(void              *v,
             {
             dcursor = new (_cg->trHeapMemory()) PPCConstant<double>(_cg, din.dvalue);
             _doubleConstants.add(dcursor);
-            if (TR::Compiler->target.is64Bit())
+            if (comp->target().is64Bit())
                {
                ret = TR_PPCTableOfConstants::lookUp(din.dvalue, _cg);
                }
             dcursor->setTOCOffset(ret);
             }
          ret = dcursor->getTOCOffset();
-         if (TR::Compiler->target.is32Bit() || ret==PTOC_FULL_INDEX)
+         if (comp->target().is32Bit() || ret==PTOC_FULL_INDEX)
             dcursor->addValueRequest(nibble0, nibble1, nibble2, nibble3);
          }
          break;
@@ -164,7 +164,7 @@ bool OMR::ConstantDataSnippet::getRequestorsFromNibble(TR::Instruction* nibble, 
    {
    ListIterator< PPCConstant<double> >  diterator(&_doubleConstants);
    PPCConstant<double>                 *dcursor=diterator.getFirst();
-   int32_t count = TR::Compiler->target.is64Bit()?4:2;
+   int32_t count = cg()->comp()->target().is64Bit()?4:2;
 
    while (dcursor != NULL)
       {
@@ -421,7 +421,7 @@ OMR::ConstantDataSnippet::emitAddressConstant(
          // Register an unload assumption on the lower 32bit of the class constant.
          // The patching code thinks it's low bit tagging an instruction not a class pointer!!
          cg()->
-         jitAddPicToPatchOnClassUnload((void *)acursor->getConstantValue(), (void *)(codeCursor+((TR::Compiler->target.is64Bit())?4:0)) );
+         jitAddPicToPatchOnClassUnload((void *)acursor->getConstantValue(), (void *)(codeCursor+((cg()->comp()->target().is64Bit())?4:0)) );
          }
       }
 
@@ -481,7 +481,7 @@ uint8_t *OMR::ConstantDataSnippet::emitSnippetBody()
    int32_t size, count;
 
    setSnippetBinaryStart(codeCursor);
-   count = TR::Compiler->target.is64Bit()?4:2;
+   count = cg()->comp()->target().is64Bit()?4:2;
 
    // Align cursor to 8 bytes alignment
    codeCursor = (uint8_t *)((intptr_t)(codeCursor+7) & ~7);
@@ -563,7 +563,7 @@ void OMR::ConstantDataSnippet::print(TR::FILE *outFile)
    PPCConstant<double>                 *dcursor=diterator.getFirst();
    while (dcursor != NULL)
       {
-      if (TR::Compiler->target.is32Bit() || dcursor->getRequestors().size()>0)
+      if (cg()->comp()->target().is32Bit() || dcursor->getRequestors().size()>0)
          {
          trfprintf(outFile, "\n%08x %08x %08x\t\t; %16f Double", codeCursor-codeStart,
                  *(int32_t *)codeCursor, *(int32_t *)(codeCursor+4), dcursor->getConstantValue());
@@ -576,7 +576,7 @@ void OMR::ConstantDataSnippet::print(TR::FILE *outFile)
    PPCConstant<float>                 *fcursor=fiterator.getFirst();
    while (fcursor != NULL)
       {
-      if (TR::Compiler->target.is32Bit() || fcursor->getRequestors().size()>0)
+      if (cg()->comp()->target().is32Bit() || fcursor->getRequestors().size()>0)
          {
          trfprintf(outFile, "\n%08x %08x\t\t; %16f Float", codeCursor-codeStart,
                  *(int32_t *)codeCursor, fcursor->getConstantValue());

--- a/compiler/p/codegen/OMRInstruction.cpp
+++ b/compiler/p/codegen/OMRInstruction.cpp
@@ -231,7 +231,7 @@ uint8_t *TR::PPCDepImmSymInstruction::generateBinaryEncoding()
                }
             }
 
-         TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(targetAddress, (intptrj_t)cursor),
+         TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinIFormBranchRange(targetAddress, (intptrj_t)cursor),
                          "Target address is out of range");
 
          distance = targetAddress - (intptrj_t)cursor;

--- a/compiler/p/codegen/OMRLinkage.cpp
+++ b/compiler/p/codegen/OMRLinkage.cpp
@@ -138,7 +138,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
          {
          TR::DataType type = paramCursor->getType();
          TR::RealRegister::RegNum regNum;
-         bool twoRegs = (TR::Compiler->target.is32Bit() && type.isInt64() && lri < properties.getNumIntArgRegs()-1);
+         bool twoRegs = (self()->comp()->target().is32Bit() && type.isInt64() && lri < properties.getNumIntArgRegs()-1);
 
          if (!type.isFloatingPoint())
             {
@@ -173,7 +173,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
          if (!paramCursor->isReferencedParameter() && !paramCursor->isParmHasToBeOnStack()) continue;
 
          TR::RealRegister::RegNum regNum;
-         bool twoRegs = (TR::Compiler->target.is32Bit() && type.isInt64() && lri < properties.getNumIntArgRegs()-1);
+         bool twoRegs = (self()->comp()->target().is32Bit() && type.isInt64() && lri < properties.getNumIntArgRegs()-1);
 
          if (type.isFloatingPoint())
             regNum = properties.getFloatArgumentRegister(lri);
@@ -260,7 +260,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   }
                }
 
-            if (TR::Compiler->target.is32Bit() && type.isInt64())
+            if (self()->comp()->target().is32Bit() && type.isInt64())
                {
                int32_t aiLow = paramCursor->getAssignedLowGlobalRegisterIndex();
 
@@ -337,7 +337,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   {
                   busyMoves[0][busyIndex] = offset;
                   busyMoves[1][busyIndex] = ai;
-                  if (TR::Compiler->target.is64Bit())
+                  if (self()->comp()->target().is64Bit())
                      busyMoves[2][busyIndex] = 2;
                   else
                      busyMoves[2][busyIndex] = 1;
@@ -345,7 +345,7 @@ TR::Instruction *OMR::Power::Linkage::saveArguments(TR::Instruction *cursor, boo
                   }
                break;
             case TR::Int64:
-               if (TR::Compiler->target.is64Bit())
+               if (self()->comp()->target().is64Bit())
                   {
                   if (freeScratchable.isSet(ai))
                      {
@@ -545,7 +545,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                   numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               if (TR::Compiler->target.is64Bit())
+               if (self()->comp()->target().is64Bit())
                   cursor = generateTrg1MemInstruction(self()->cg(), TR::InstOpCode::ld, firstNode, argRegister,
                         new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()), cursor);
                else
@@ -560,7 +560,7 @@ TR::Instruction *OMR::Power::Linkage::loadUpArguments(TR::Instruction *cursor)
                      }
                   }
                }
-            if (TR::Compiler->target.is64Bit())
+            if (self()->comp()->target().is64Bit())
                numIntArgs++;
             else
                numIntArgs+=2;
@@ -647,7 +647,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                   numIntArgs<properties.getNumIntArgRegs())
                {
                argRegister = machine->getRealRegister(properties.getIntegerArgumentRegister(numIntArgs));
-               if (TR::Compiler->target.is64Bit())
+               if (self()->comp()->target().is64Bit())
                   cursor = generateMemSrc1Instruction(self()->cg(),TR::InstOpCode::Op_st, firstNode,
                         new (self()->trHeapMemory()) TR::MemoryReference(stackPtr, offset, 8, self()->cg()),
                         argRegister, cursor);
@@ -665,7 +665,7 @@ TR::Instruction *OMR::Power::Linkage::flushArguments(TR::Instruction *cursor)
                      }
                   }
                }
-            if (TR::Compiler->target.is64Bit())
+            if (self()->comp()->target().is64Bit())
                numIntArgs++;
             else
                numIntArgs+=2;
@@ -759,7 +759,7 @@ TR::Register *OMR::Power::Linkage::pushLongArg(TR::Node *child)
    TR::Register *pushRegister = NULL;
    if (child->getRegister() == NULL && child->getOpCode().isLoadConst())
       {
-      if (TR::Compiler->target.is64Bit())
+      if (self()->comp()->target().is64Bit())
          {
          pushRegister = self()->cg()->allocateRegister();
          loadConstant(self()->cg(), child, child->getLongInt(), pushRegister);
@@ -823,7 +823,7 @@ TR_ReturnInfo OMR::Power::Linkage::getReturnInfoFromReturnType(TR::DataType retu
       case TR::Int64:
          return TR_LongReturn;
       case TR::Address:
-         return TR::Compiler->target.is64Bit() ? TR_ObjectReturn : TR_IntReturn;
+         return self()->comp()->target().is64Bit() ? TR_ObjectReturn : TR_IntReturn;
       case TR::Float:
          return TR_FloatReturn;
       case TR::Double:

--- a/compiler/p/codegen/OMRMachine.cpp
+++ b/compiler/p/codegen/OMRMachine.cpp
@@ -201,7 +201,7 @@ void OMR::Power::Machine::initREGAssociations()
    // Power8/SAR:  confine to the smallest set of registers we can get away, because map cache
    // Others:      neutral --- take Power6 way for now
 
-   int rollingAllocator = !(TR::Compiler->target.cpu.id() == TR_PPCp8);
+   int rollingAllocator = !(self()->cg()->comp()->target().cpu.id() == TR_PPCp8);
 
 
    _inUseFPREnd = rollingAllocator?lastFPRv:0;
@@ -279,7 +279,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
    // For FPR/VSR/VRF
    if (rk == TR_FPR || rk == TR_VSX_SCALAR || rk == TR_VSX_VECTOR || rk == TR_VRF)
       {
-      int rollingAllocator = !(TR::Compiler->target.cpu.id() == TR_PPCp8);
+      int rollingAllocator = !(self()->cg()->comp()->target().cpu.id() == TR_PPCp8);
 
       // Find the best in the used FPR set so far
       int i, idx;
@@ -395,7 +395,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
          iNew = interference & currentReg;
 
          //Inject interference for last four assignments to prevent write-after-write dependancy in same p6 dispatch group.
-         if(rk == TR_GPR && (TR::Compiler->target.cpu.id() == TR_PPCp6))
+         if(rk == TR_GPR && (self()->cg()->comp()->target().cpu.id() == TR_PPCp6))
             {
             if (_lastGPRAssigned != -1)
                iNew |= currentReg & _lastGPRAssigned;
@@ -421,7 +421,7 @@ TR::RealRegister *OMR::Power::Machine::findBestFreeRegister(TR::Instruction *cur
             }
          }
       //Track the last four registers used for use in above interference injection.
-      if ((rk == TR_GPR) && (freeRegister != NULL) && (TR::Compiler->target.cpu.id() == TR_PPCp6))
+      if ((rk == TR_GPR) && (freeRegister != NULL) && (self()->cg()->comp()->target().cpu.id() == TR_PPCp6))
          {
          _4thLastGPRAssigned = _3rdLastGPRAssigned;
          _3rdLastGPRAssigned = _2ndLastGPRAssigned;
@@ -837,7 +837,7 @@ TR::RealRegister *OMR::Power::Machine::freeBestRegister(TR::Instruction     *cur
          // Until stack frame is 16-byte aligned, we cannot use VMX load/store here
          // So, we use VSX load/store instead as a work-around
 
-         TR_ASSERT(TR::Compiler->target.cpu.getPPCSupportsVSX(), "VSX support not enabled");
+         TR_ASSERT(self()->cg()->comp()->target().cpu.getPPCSupportsVSX(), "VSX support not enabled");
 
          tempIndexRegister = self()->findBestFreeRegister(currentInstruction, TR_GPR);
          if (tempIndexRegister  == NULL)
@@ -1081,7 +1081,7 @@ TR::RealRegister *OMR::Power::Machine::reverseSpillState(TR::Instruction      *c
          // Until stack frame is 16-byte aligned, we cannot use VMX load/store here
          // So, we use VSX load/store instead as a work-around
 
-         TR_ASSERT(TR::Compiler->target.cpu.getPPCSupportsVSX(), "VSX support not enabled");
+         TR_ASSERT(self()->cg()->comp()->target().cpu.getPPCSupportsVSX(), "VSX support not enabled");
 
          tempIndexRegister  = self()->findBestFreeRegister(currentInstruction, TR_GPR);
          if (tempIndexRegister  == NULL)
@@ -1192,7 +1192,7 @@ void OMR::Power::Machine::coerceRegisterAssignment(TR::Instruction              
 				   (currentAssignedRegister!=NULL && currentAssignedRegister->getKind()==ctv_rk);
 
       // RegisterExchange: GPR/VRF have xor op always, and only CCR has no xor after P6
-      bool needTemp = !((ctv_rk == TR_GPR) || (ctv_rk == TR_VRF) || (TR::Compiler->target.cpu.getPPCSupportsVSX() && ctv_rk!=TR_CCR));
+      bool needTemp = !((ctv_rk == TR_GPR) || (ctv_rk == TR_VRF) || (self()->cg()->comp()->target().cpu.getPPCSupportsVSX() && ctv_rk!=TR_CCR));
 
       if (targetRegister->getState() == TR::RealRegister::Blocked)
          {
@@ -1778,7 +1778,7 @@ static void registerCopy(TR::Instruction     *precedingInstruction,
    TR::Instruction *instr = NULL;
 
    // Go for performance, disregarding the dirty SP de-normal condition
-   bool useVSXLogical = TR::Compiler->target.cpu.getPPCSupportsVSX();
+   bool useVSXLogical = cg->comp()->target().cpu.getPPCSupportsVSX();
    switch (rk)
       {
       case TR_GPR:

--- a/compiler/p/codegen/PPCAOTRelocation.cpp
+++ b/compiler/p/codegen/PPCAOTRelocation.cpp
@@ -66,7 +66,7 @@ void TR::PPCPairedLabelAbsoluteRelocation::apply(TR::CodeGenerator *cg)
    {
    intptrj_t p = (intptrj_t)getLabel()->getCodeLocation();
 
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       {
       _instr1->updateImmediateField(cg->hiValue(p) & 0x0000ffff);
       _instr2->updateImmediateField(LO_VALUE(p) & 0x0000ffff);

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -545,7 +545,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src1Imm2Instruction * instr)
    print(pOutFile, instr->getSource1Register(), TR_WordReg);
 
    lmask = instr->getLongMask();
-   if (TR::Compiler->target.is64Bit())
+   if (instr->cg()->comp()->target().is64Bit())
       trfprintf(pOutFile, ", " POINTER_PRINTF_FORMAT ", " POINTER_PRINTF_FORMAT, instr->getSourceImmediate(), lmask);
    else
       trfprintf(pOutFile, ", " POINTER_PRINTF_FORMAT ", 0x%x", instr->getSourceImmediate(), (uint32_t)lmask);
@@ -594,7 +594,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::PPCTrg1Src2ImmInstruction * instr)
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
    lmask = instr->getLongMask();
-   if (TR::Compiler->target.is64Bit())
+   if (instr->cg()->comp()->target().is64Bit())
       trfprintf(pOutFile, ", " POINTER_PRINTF_FORMAT, lmask);
    else
       trfprintf(pOutFile, ", 0x%x", (uint32_t)lmask);

--- a/compiler/p/codegen/PPCHelperCallSnippet.cpp
+++ b/compiler/p/codegen/PPCHelperCallSnippet.cpp
@@ -107,7 +107,7 @@ uint8_t *TR::PPCHelperCallSnippet::genHelperCall(uint8_t *buffer)
       {
       helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(getDestination()->getReferenceNumber(), (void *)buffer);
 
-      TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinIFormBranchRange(helperAddress, (intptrj_t)buffer),
+      TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinIFormBranchRange(helperAddress, (intptrj_t)buffer),
                       "Helper address is out of range");
       }
 

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1048,7 +1048,7 @@ TR::PPCTrg1MemInstruction::PPCTrg1MemInstruction(
 
 bool TR::PPCTrg1MemInstruction::encodeMutexHint()
    {
-   return TR::Compiler->target.cpu.id() >= TR_PPCp6 && (getOpCodeValue() == TR::InstOpCode::lwarx || getOpCodeValue() == TR::InstOpCode::ldarx);
+   return cg()->comp()->target().cpu.id() >= TR_PPCp6 && (getOpCodeValue() == TR::InstOpCode::lwarx || getOpCodeValue() == TR::InstOpCode::ldarx);
    }
 
 
@@ -1318,7 +1318,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
          break;
       case TR::InstOpCode::setbool:
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp9 && getCmpOpValue() == TR::InstOpCode::fcmpu && (getOpCode2Value() == TR::InstOpCode::blt || getOpCode2Value() ==  TR::InstOpCode::bgt))
+         if (cg()->comp()->target().cpu.id() >= TR_PPCp9 && getCmpOpValue() == TR::InstOpCode::fcmpu && (getOpCode2Value() == TR::InstOpCode::blt || getOpCode2Value() ==  TR::InstOpCode::bgt))
             {
 
             /* Used with: dcmpgt, dcmplt, fcmpgt and fcmplt*/
@@ -1388,7 +1388,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
       case TR::InstOpCode::idiv:
          cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(1), -1, cursor));
          cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::neg, currentNode, getTargetRegister(1), getSourceRegister(0), cursor));
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCgp)
             // use PPC AS branch hint
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, currentNode, label2, getTargetRegister(0), cursor));
          else
@@ -1399,12 +1399,12 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
       case TR::InstOpCode::irem:
          cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(1), -1, cursor));
          cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(1), 0, cursor));
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCgp)
             // use PPC AS branch hint
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, currentNode, label2, getTargetRegister(0), cursor));
          else
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, currentNode, label2, getTargetRegister(0), cursor));
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCp9)
             {
             cg()->traceRAInstruction(cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::modsw, currentNode, getTargetRegister(1), getSourceRegister(0), getSourceRegister(1), cursor));
             }
@@ -1419,7 +1419,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
       case TR::InstOpCode::ldiv:
          cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi8, currentNode, getTargetRegister(0), getSourceRegister(1), -1, cursor));
          cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::neg, currentNode, getTargetRegister(1), getSourceRegister(0), cursor));
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCgp)
             // use PPC AS branch hint
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, currentNode, label2, getTargetRegister(0), cursor));
          else
@@ -1430,12 +1430,12 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
       case TR::InstOpCode::lrem:
          cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi8, currentNode, getTargetRegister(0), getSourceRegister(1), -1, cursor));
          cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(1), 0, cursor));
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCgp)
             // use PPC AS branch hint
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, PPCOpProp_BranchUnlikely, currentNode, label2, getTargetRegister(0), cursor));
          else
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::beq, currentNode, label2, getTargetRegister(0), cursor));
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp9)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCp9)
             {
             cg()->traceRAInstruction(cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::modsd, currentNode, getTargetRegister(1), getSourceRegister(0), getSourceRegister(1), cursor));
             }
@@ -1452,19 +1452,19 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::fctiwz, currentNode, getTargetRegister(1), getSourceRegister(0), cursor));
          cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(2), 0, cursor));
 
-         if (TR::Compiler->target.cpu.id() < TR_PPCp8)
+         if (cg()->comp()->target().cpu.id() < TR_PPCp8)
             {
             tempMR = new (cg()->trHeapMemory()) TR::MemoryReference(cg()->getStackPointerRegister(), -8, 8, cg());
             cg()->traceRAInstruction(cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, currentNode, tempMR, getTargetRegister(1), cursor));
             }
 
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCgp)
             // use PPC AS branch hint
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, PPCOpProp_BranchUnlikely, currentNode, label2, getTargetRegister(0), cursor));
          else
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
 
-         if (TR::Compiler->target.cpu.id() >= TR_PPCp8)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCp8)
             cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::mfvsrwz, currentNode, getTargetRegister(2), getTargetRegister(1), cursor));
          else
             cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, currentNode, getTargetRegister(2), new (cg()->trHeapMemory()) TR::MemoryReference(currentNode, *tempMR, 4, 4, cg()), cursor));
@@ -1475,28 +1475,28 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          cg()->traceRAInstruction(cursor = generateTrg1Src2Instruction(cg(), TR::InstOpCode::fcmpu, currentNode, getTargetRegister(0), getSourceRegister(0), getSourceRegister(0), cursor));
          cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::fctidz, currentNode, getTargetRegister(1), getSourceRegister(0), cursor));
 
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(2), 0, cursor));
          else
             {
             cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(2), 0, cursor));
             cg()->traceRAInstruction(cursor = generateTrg1ImmInstruction(cg(), TR::InstOpCode::li, currentNode, getTargetRegister(3), 0, cursor));
             }
-         if (TR::Compiler->target.cpu.id() < TR_PPCp8 || TR::Compiler->target.is32Bit())
+         if (cg()->comp()->target().cpu.id() < TR_PPCp8 || cg()->comp()->target().is32Bit())
             {
             tempMR = new (cg()->trHeapMemory()) TR::MemoryReference(cg()->getStackPointerRegister(), -8, 8, cg());
             cg()->traceRAInstruction(cursor = generateMemSrc1Instruction(cg(), TR::InstOpCode::stfd, currentNode, tempMR, getTargetRegister(1), cursor));
             }
 
-         if (TR::Compiler->target.cpu.id() >= TR_PPCgp)
+         if (cg()->comp()->target().cpu.id() >= TR_PPCgp)
             // use PPC AS branch hint
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, PPCOpProp_BranchUnlikely, currentNode, label2, getTargetRegister(0), cursor));
          else
             cg()->traceRAInstruction(cursor = generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, currentNode, label2, getTargetRegister(0), cursor));
 
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             {
-            if (TR::Compiler->target.cpu.id() >= TR_PPCp8 && TR::Compiler->target.is64Bit())
+            if (cg()->comp()->target().cpu.id() >= TR_PPCp8 && cg()->comp()->target().is64Bit())
                cg()->traceRAInstruction(cursor = generateTrg1Src1Instruction(cg(), TR::InstOpCode::mfvsrd, currentNode, getTargetRegister(2), getTargetRegister(1), cursor));
             else
                cg()->traceRAInstruction(cursor = generateTrg1MemInstruction(cg(), TR::InstOpCode::ld, currentNode, getTargetRegister(2), tempMR, cursor));

--- a/compiler/p/codegen/PPCSystemLinkage.cpp
+++ b/compiler/p/codegen/PPCSystemLinkage.cpp
@@ -75,7 +75,7 @@ mappedOffsetToFirstLocal(
    TR::Machine *machine = cg->machine();
 
    uint32_t min_arg_area = machine->getLinkRegisterKilled() ?
-                               (TR::Compiler->target.is64Bit() ? 8*8 : 8*4)
+                               (cg->comp()->target().is64Bit() ? 8*8 : 8*4)
                                : 0;
 
    uint32_t offset = linkage.getOffsetToFirstLocal() +
@@ -105,7 +105,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    _properties._registerFlags[TR::RealRegister::gr10] = IntegerArgument;
    _properties._registerFlags[TR::RealRegister::gr11] = 0;
    _properties._registerFlags[TR::RealRegister::gr12] = 0;
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       _properties._registerFlags[TR::RealRegister::gr13] = Preserved|PPC_Reserved; // system
    else
       _properties._registerFlags[TR::RealRegister::gr13] = Preserved;
@@ -123,7 +123,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    _properties._registerFlags[TR::RealRegister::fp7]   = FloatArgument;
    _properties._registerFlags[TR::RealRegister::fp8]   = FloatArgument;
 
-   if (TR::Compiler->target.is64Bit() || TR::Compiler->target.isAIX())
+   if (cg->comp()->target().is64Bit() || cg->comp()->target().isAIX())
       {
       _properties._registerFlags[TR::RealRegister::fp9]   = FloatArgument;
       _properties._registerFlags[TR::RealRegister::fp10]  = FloatArgument;
@@ -161,7 +161,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
 
    _properties._numIntegerArgumentRegisters  = 8;
    _properties._firstIntegerArgumentRegister = 0;
-   if (TR::Compiler->target.is64Bit() || TR::Compiler->target.isAIX())
+   if (cg->comp()->target().is64Bit() || cg->comp()->target().isAIX())
       _properties._numFloatArgumentRegisters    = 13;
    else
       _properties._numFloatArgumentRegisters    = 8;
@@ -193,7 +193,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    _properties._argumentRegisters[15] = TR::RealRegister::fp7;
    _properties._argumentRegisters[16] = TR::RealRegister::fp8;
 
-   if (TR::Compiler->target.is64Bit() || TR::Compiler->target.isAIX())
+   if (cg->comp()->target().is64Bit() || cg->comp()->target().isAIX())
        {
        _properties._argumentRegisters[17] = TR::RealRegister::fp9;
        _properties._argumentRegisters[18] = TR::RealRegister::fp10;
@@ -215,7 +215,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    _properties._returnRegisters[5]  = TR::RealRegister::fp4;
    _properties._returnRegisters[6]  = TR::RealRegister::vsr34;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       _properties._numAllocatableIntegerRegisters          = 29; // 64
       _properties._firstAllocatableFloatArgumentRegister   = 42; // 64
@@ -228,7 +228,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
       _properties._lastAllocatableFloatVolatileRegister    = 43; // 32
       }
 
-   if (TR::Compiler->target.is32Bit() && TR::Compiler->target.isAIX())
+   if (cg->comp()->target().is32Bit() && cg->comp()->target().isAIX())
       _properties._firstAllocatableIntegerArgumentRegister = 9;  // aix 32 only
    else
       _properties._firstAllocatableIntegerArgumentRegister = 8;
@@ -240,7 +240,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    i = 0;
    _properties._allocationOrder[i++] = TR::RealRegister::gr12;
 
-   if (TR::Compiler->target.is32Bit() && TR::Compiler->target.isAIX())
+   if (cg->comp()->target().is32Bit() && cg->comp()->target().isAIX())
       _properties._allocationOrder[i++] = TR::RealRegister::gr11;
 
    _properties._allocationOrder[i++] = TR::RealRegister::gr10;
@@ -252,7 +252,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    _properties._allocationOrder[i++] = TR::RealRegister::gr4;
    _properties._allocationOrder[i++] = TR::RealRegister::gr3;
 
-   if (TR::Compiler->target.is64Bit() || !TR::Compiler->target.isAIX())
+   if (cg->comp()->target().is64Bit() || !cg->comp()->target().isAIX())
       _properties._allocationOrder[i++] = TR::RealRegister::gr11;
 
    _properties._allocationOrder[i++] = TR::RealRegister::gr0;
@@ -275,7 +275,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    _properties._allocationOrder[i++] = TR::RealRegister::gr15;
    _properties._allocationOrder[i++] = TR::RealRegister::gr14;
 
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       _properties._allocationOrder[i++] = TR::RealRegister::gr13;
 
    _properties._allocationOrder[i++] = TR::RealRegister::fp0;
@@ -330,9 +330,9 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
    // Note: FPRs 14-31 are preserved, however if you use them as vector registers you must
    // assume the additional 64 bits are volatile because the callee will only preserve
    // the FPR portion and the additional 64 bits will be undefined after the callee returns.
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
-      bool isBE = TR::Compiler->target.cpu.isBigEndian();
+      bool isBE = cg->comp()->target().cpu.isBigEndian();
 
       // Volatile GPR (0,2-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
       _properties._numberOfDependencyGPRegisters = 12 + 14 + 5 + 20 + 18;
@@ -341,7 +341,7 @@ TR::PPCSystemLinkage::PPCSystemLinkage(TR::CodeGenerator *cg)
       }
    else
       {
-      if (TR::Compiler->target.isAIX())
+      if (cg->comp()->target().isAIX())
          {
          // Volatile GPR (0,2-12) + FPR (0-13) + CCR (0-1,5-7) + VR (0-19) + FPR (14-31) if used as vector
          _properties._numberOfDependencyGPRegisters = 12 + 14 + 5 + 20 + 18;
@@ -658,7 +658,7 @@ TR::PPCSystemLinkage::createPrologue(
 
    if (savedFirst <= TR::RealRegister::LastGPR)
       {
-      if (TR::Compiler->target.cpu.id() == TR_PPCgp || TR::Compiler->target.is64Bit() ||
+      if (cg()->comp()->target().cpu.id() == TR_PPCgp || cg()->comp()->target().is64Bit() ||
           (!comp()->getOption(TR_OptimizeForSpace) &&
            TR::RealRegister::LastGPR - savedFirst <= 3))
          for (regIndex=TR::RealRegister::LastGPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
@@ -761,7 +761,7 @@ TR::PPCSystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    if (savedFirst <= TR::RealRegister::LastGPR)
       {
-      if (TR::Compiler->target.cpu.id() == TR_PPCgp || TR::Compiler->target.is64Bit() ||
+      if (cg()->comp()->target().cpu.id() == TR_PPCgp || cg()->comp()->target().is64Bit() ||
           (!comp()->getOption(TR_OptimizeForSpace) &&
            TR::RealRegister::LastGPR - savedFirst <= 3))
          for (regIndex=TR::RealRegister::LastGPR; regIndex>=savedFirst; regIndex=(TR::RealRegister::RegNum)((uint32_t)regIndex-1))
@@ -832,7 +832,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
    TR::Symbol * callSymbol = callNode->getSymbolReference()->getSymbol();
 
    uint32_t firstArgumentChild = callNode->getFirstArgumentIndex();
-   bool aix_style_linkage = (TR::Compiler->target.isAIX() || (TR::Compiler->target.is64Bit() && TR::Compiler->target.isLinux()));
+   bool aix_style_linkage = (cg()->comp()->target().isAIX() || (cg()->comp()->target().is64Bit() && cg()->comp()->target().isLinux()));
 
    /* Step 1 - figure out how many arguments are going to be spilled to memory i.e. not in registers */
    for (i = firstArgumentChild; i < callNode->getNumChildren(); i++)
@@ -849,7 +849,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
             numIntegerArgs++;
             break;
          case TR::Int64:
-            if (TR::Compiler->target.is64Bit())
+            if (cg()->comp()->target().is64Bit())
                {
                if (numIntegerArgs >= properties.getNumIntArgRegs())
                   memArgs++;
@@ -891,7 +891,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
          case TR::Double:
             if (aix_style_linkage)
                {
-               if (TR::Compiler->target.is64Bit())
+               if (cg()->comp()->target().is64Bit())
                   {
                   if (numIntegerArgs >= properties.getNumIntArgRegs())
                      memArgs++;
@@ -989,7 +989,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                   dependencies->addPreCondition(argRegister, TR::RealRegister::gr3);
                   dependencies->addPostCondition(resultReg, TR::RealRegister::gr3);
                   }
-               else if (TR::Compiler->target.is32Bit() && numIntegerArgs == 1 && resType.isInt64())
+               else if (cg()->comp()->target().is32Bit() && numIntegerArgs == 1 && resType.isInt64())
                   {
                   TR::Register *resultReg = cg()->allocateRegister();
                   dependencies->addPreCondition(argRegister, TR::RealRegister::gr4);
@@ -1025,7 +1025,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                {
                if (!cg()->canClobberNodesRegister(child, 0))
                   {
-                  if (TR::Compiler->target.is64Bit())
+                  if (cg()->comp()->target().is64Bit())
                      {
                      tempRegister = cg()->allocateRegister();
                      generateTrg1Src1Instruction(cg(), TR::InstOpCode::mr, callNode, tempRegister, argRegister);
@@ -1047,13 +1047,13 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                      resultReg = cg()->allocateCollectedReferenceRegister();
                   else
                      resultReg = cg()->allocateRegister();
-                  if (TR::Compiler->target.is64Bit())
+                  if (cg()->comp()->target().is64Bit())
                      dependencies->addPreCondition(argRegister, TR::RealRegister::gr3);
                   else
                      dependencies->addPreCondition(argRegister->getRegisterPair()->getHighOrder(), TR::RealRegister::gr3);
                   dependencies->addPostCondition(resultReg, TR::RealRegister::gr3);
                   }
-               else if (TR::Compiler->target.is32Bit() && numIntegerArgs == 1 && resType.isInt64())
+               else if (cg()->comp()->target().is32Bit() && numIntegerArgs == 1 && resType.isInt64())
                   {
                   TR::Register *resultReg = cg()->allocateRegister();
                   dependencies->addPreCondition(argRegister, TR::RealRegister::gr4);
@@ -1061,12 +1061,12 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                   }
                else
                   {
-                  if (TR::Compiler->target.is64Bit())
+                  if (cg()->comp()->target().is64Bit())
                      TR::addDependency(dependencies, argRegister, properties.getIntegerArgumentRegister(numIntegerArgs), TR_GPR, cg());
                   else
                      TR::addDependency(dependencies, argRegister->getRegisterPair()->getHighOrder(), properties.getIntegerArgumentRegister(numIntegerArgs), TR_GPR, cg());
                   }
-               if (TR::Compiler->target.is32Bit())
+               if (cg()->comp()->target().is32Bit())
                   {
                   if (numIntegerArgs < properties.getNumIntArgRegs()-1)
                      {
@@ -1095,7 +1095,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                }
             else // numIntegerArgs >= properties.getNumIntArgRegs()
                {
-               if (TR::Compiler->target.is64Bit())
+               if (cg()->comp()->target().is64Bit())
                   {
                   mref = getOutgoingArgumentMemRef(argSize, argRegister, TR::InstOpCode::std, pushToMemory[argIndex++], TR::Compiler->om.sizeofReferenceAddress());
                   }
@@ -1170,7 +1170,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                   }
                else // numIntegerArgs >= properties.getNumIntArgRegs()
                   {
-                  if (TR::Compiler->target.is64Bit() && TR::Compiler->target.isLinux())
+                  if (cg()->comp()->target().is64Bit() && cg()->comp()->target().isLinux())
                      {
                      mref = getOutgoingArgumentMemRef(argSize+4, argReg, TR::InstOpCode::stfs, pushToMemory[argIndex++], 4);
                      }
@@ -1244,7 +1244,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                   else
                      TR::addDependency(dependencies, NULL, properties.getIntegerArgumentRegister(numIntegerArgs), TR_GPR, cg());
 
-                  if (TR::Compiler->target.is32Bit())
+                  if (cg()->comp()->target().is32Bit())
                      {
                      if ((numIntegerArgs+1) < properties.getNumIntArgRegs())
                         TR::addDependency(dependencies, NULL, properties.getIntegerArgumentRegister(numIntegerArgs+1), TR_GPR, cg());
@@ -1259,7 +1259,7 @@ int32_t TR::PPCSystemLinkage::buildArgs(TR::Node *callNode,
                   mref = getOutgoingArgumentMemRef(argSize, argReg, TR::InstOpCode::stfd, pushToMemory[argIndex++], 8);
                   }
 
-               numIntegerArgs += TR::Compiler->target.is64Bit()?1:2;
+               numIntegerArgs += cg()->comp()->target().is64Bit()?1:2;
                }
             numFloatArgs++;
             if (aix_style_linkage)
@@ -1397,7 +1397,7 @@ void TR::PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
    TR::Instruction             *gcPoint;
    TR::MethodSymbol               *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
    TR::ResolvedMethodSymbol        *sym = callSymbol->getResolvedMethodSymbol();
-   bool aix_style_linkage = (TR::Compiler->target.isAIX() || (TR::Compiler->target.is64Bit() && TR::Compiler->target.isLinux()));
+   bool aix_style_linkage = (cg()->comp()->target().isAIX() || (cg()->comp()->target().is64Bit() && cg()->comp()->target().isLinux()));
    int32_t                        refNum = callSymRef->getReferenceNumber();
 
    //This is not JIT pseudo TOC, but jit-module system TOC.
@@ -1407,7 +1407,7 @@ void TR::PPCSystemLinkage::buildDirectCall(TR::Node *callNode,
          //Implies TOC needs to be restored (ie not 32bit ppc-linux-be)
          //This is wrong with regard to where system TOC is restored from, but happens to be right for JIT
          //for the time being.
-         if(TR::Compiler->target.cpu.isBigEndian())
+         if(cg()->comp()->target().cpu.isBigEndian())
             {
 #if !defined(JITTEST)
             TR::TreeEvaluator::restoreTOCRegister(callNode, cg(), dependencies);
@@ -1463,7 +1463,7 @@ TR::Register *TR::PPCSystemLinkage::buildDirectDispatch(TR::Node *callNode)
          break;
       case TR::lcall:
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             returnRegister = dependencies->searchPostConditionRegister(
                                 pp.getLongReturnRegister());
          else
@@ -1506,7 +1506,7 @@ void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                        
                                                TR::RegisterDependencyConditions *dependencies,
                                                uint32_t                            sizeOfArguments)
    {
-   bool aix_style_linkage = (TR::Compiler->target.isAIX() || (TR::Compiler->target.is64Bit() && TR::Compiler->target.isLinux()));
+   bool aix_style_linkage = (cg()->comp()->target().isAIX() || (cg()->comp()->target().is64Bit() && cg()->comp()->target().isLinux()));
    TR_ASSERT(callNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->isComputed(), "system linkage only supports computed indirect call for now %p\n", callNode);
    //We do not support Linux 32bit.
    if(!aix_style_linkage)
@@ -1540,10 +1540,10 @@ void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                        
    cg()->evaluate(callNode->getChild(0));
    cg()->decReferenceCount(callNode->getChild(0));
 
-   int32_t callerSaveTOCOffset = (TR::Compiler->target.cpu.isBigEndian() ? 5 : 3) *  TR::Compiler->om.sizeofReferenceAddress();
+   int32_t callerSaveTOCOffset = (cg()->comp()->target().cpu.isBigEndian() ? 5 : 3) *  TR::Compiler->om.sizeofReferenceAddress();
 
    TR::Register *targetRegister;
-   if (TR::Compiler->target.cpu.isBigEndian())
+   if (cg()->comp()->target().cpu.isBigEndian())
       {
       // load target from FD
       generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, gr0, new (trHeapMemory()) TR::MemoryReference(callNode->getChild(0)->getRegister(), 0, TR::Compiler->om.sizeofReferenceAddress(), cg()));
@@ -1559,7 +1559,7 @@ void TR::PPCSystemLinkage::buildVirtualDispatch(TR::Node                        
 
    generateSrc1Instruction(cg(), TR::InstOpCode::mtctr, callNode, targetRegister, 0);
 
-   if (TR::Compiler->target.cpu.isBigEndian())
+   if (cg()->comp()->target().cpu.isBigEndian())
       generateTrg1MemInstruction(cg(),TR::InstOpCode::Op_load, callNode, grTOCReg, new (trHeapMemory()) TR::MemoryReference(callNode->getChild(0)->getRegister(), TR::Compiler->om.sizeofReferenceAddress(), TR::Compiler->om.sizeofReferenceAddress(), cg()));
 
    generateDepInstruction(cg(), TR::InstOpCode::bctrl, callNode, dependencies);
@@ -1594,7 +1594,7 @@ TR::Register *TR::PPCSystemLinkage::buildIndirectDispatch(TR::Node *callNode)
          break;
       case TR::lcalli:
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             returnRegister = dependencies->searchPostConditionRegister(
                                 pp.getLongReturnRegister());
          else
@@ -1665,7 +1665,7 @@ void TR::PPCSystemLinkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSy
                {
                index = numIntArgs;
                }
-            if (TR::Compiler->target.is64Bit())
+            if (cg()->comp()->target().is64Bit())
                numIntArgs ++;
             else
                numIntArgs += 2;

--- a/compiler/p/codegen/PPCTableOfConstants.cpp
+++ b/compiler/p/codegen/PPCTableOfConstants.cpp
@@ -368,7 +368,7 @@ TR_PPCTableOfConstants::lookUp(int32_t val, struct TR_tocHashEntry *tmplate, int
       case TR_FLAG_tocFloatKey:
          hash[idx]._fKey = tmplate->_fKey;
          uintptrj_t slotValue;
-         if (TR::Compiler->target.cpu.isBigEndian())
+         if (comp->target().cpu.isBigEndian())
             slotValue = (*offsetInSlot == 0)?(((uintptrj_t)hash[idx]._fKey)<<32):(getTOCSlot(rval*sizeof(intptrj_t))|hash[idx]._fKey);
          else
             slotValue = (*offsetInSlot == 0)?((uintptrj_t)hash[idx]._fKey):(getTOCSlot(rval*sizeof(intptrj_t))|(((uintptrj_t)hash[idx]._fKey)<<32));

--- a/compiler/p/codegen/TreeEvaluatorVMX.cpp
+++ b/compiler/p/codegen/TreeEvaluatorVMX.cpp
@@ -87,7 +87,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                doubleword = (halfword << 48) | (halfword << 32) | (halfword << 16) | halfword;
                }
             fillReg = cg->allocateRegister();
-            if (dofastPath && TR::Compiler->target.is64Bit())
+            if (dofastPath && cg->comp()->target().is64Bit())
                {
                generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, fillReg, halfword);
                generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwimi, node, fillReg, fillReg,  16, 0xffff0000);
@@ -108,7 +108,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                doubleword = (halfword << 48) | (halfword << 32) | (halfword << 16) | halfword;
                }
             fillReg = cg->allocateRegister();
-            if (dofastPath && TR::Compiler->target.is64Bit())
+            if (dofastPath && cg->comp()->target().is64Bit())
                {
                generateTrg1ImmInstruction(cg, TR::InstOpCode::li, node, fillReg, halfword);
                generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwimi, node, fillReg, fillReg,  16, 0xffff0000);
@@ -130,7 +130,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                }
             fillReg = cg->allocateRegister();
             loadConstant(cg, node, ((int32_t)word), fillReg);
-            if (dofastPath && TR::Compiler->target.is64Bit())
+            if (dofastPath && cg->comp()->target().is64Bit())
                generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rldimi, node, fillReg, fillReg,  32, 0xffffffff00000000ULL);
             }
             break;
@@ -143,7 +143,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                   fp1Reg = cg->evaluate(fillNode);
                fillReg = cg->allocateRegister();
                }
-            else if (TR::Compiler->target.is64Bit())  //long: 64 bit target
+            else if (cg->comp()->target().is64Bit())  //long: 64 bit target
                fillReg = cg->evaluate(fillNode);
             else                           //long: 32 bit target
                {
@@ -160,7 +160,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
       if (fillNode->getDataType() != TR::Double && dofastPath)
          {
          fp1Reg = cg->allocateRegister(TR_FPR);
-         if (TR::Compiler->target.is32Bit())
+         if (cg->comp()->target().is32Bit())
             {
             fixedSeqMemAccess(cg, node, 0, q, fp1Reg, tempReg, TR::InstOpCode::lfd, 8, NULL, tempReg);
             cg->findOrCreateFloatConstant(&doubleword, TR::Double, q[0], q[1], q[2], q[3]);
@@ -195,7 +195,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
                {
                fp1Reg = cg->evaluate(fillNode);
                }
-            else if (TR::Compiler->target.is64Bit())
+            else if (cg->comp()->target().is64Bit())
                {
                fp1Reg = cg->allocateRegister();
                fillReg = cg->evaluate(fillNode);
@@ -289,7 +289,7 @@ TR::Register *OMR::Power::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::C
 
       TR::InstOpCode::Mnemonic dblStoreOp = TR::InstOpCode::stfd;
       TR::Register *dblFillReg= fp1Reg;
-      if (TR::Compiler->target.is64Bit() && fillNode->getDataType() != TR::Double)
+      if (cg->comp()->target().is64Bit() && fillNode->getDataType() != TR::Double)
          {
          dblStoreOp = TR::InstOpCode::std;
          dblFillReg = fillReg;

--- a/compiler/p/codegen/UnaryEvaluator.cpp
+++ b/compiler/p/codegen/UnaryEvaluator.cpp
@@ -70,7 +70,7 @@ TR::Register *OMR::Power::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::Cod
    bool isProfiledPointerConstant = node->isClassPointerConstant() || node->isMethodPointerConstant();
 
    // use data snippet only on class pointers when HCR is enabled
-   intptrj_t address = TR::Compiler->target.is64Bit()? node->getLongInt(): node->getInt();
+   intptrj_t address = cg->comp()->target().is64Bit()? node->getLongInt(): node->getInt();
    if (isClass && cg->wantToPatchClassPointer((TR_OpaqueClassBlock*)address, node) ||
        isProfiledPointerConstant && cg->profiledPointersRequireRelocation())
       {
@@ -91,7 +91,7 @@ TR::Register *OMR::Power::TreeEvaluator::aconstEvaluator(TR::Node *node, TR::Cod
 TR::Register *OMR::Power::TreeEvaluator::lconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *tempReg = node->setRegister(cg->allocateRegister());
       loadConstant(cg, node, node->getLongInt(), tempReg);
@@ -136,7 +136,7 @@ TR::Register *OMR::Power::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::lnegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       return TR::TreeEvaluator::inegEvaluator(node, cg);
       }
@@ -177,7 +177,7 @@ TR::Register *OMR::Power::TreeEvaluator::iabsEvaluator(TR::Node *node, TR::CodeG
 TR::Register *OMR::Power::TreeEvaluator::labsEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *trgReg = cg->allocateRegister();
       TR::Register *tmpReg = cg->allocateRegister();
@@ -269,7 +269,7 @@ TR::Register *OMR::Power::TreeEvaluator::b2iEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::b2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::b2lEvaluator(node, cg);
    else
       return TR::TreeEvaluator::b2iEvaluator(node, cg);
@@ -343,7 +343,7 @@ TR::Register *OMR::Power::TreeEvaluator::s2iEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::b2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *child  = node->getFirstChild();
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *trgReg = cg->allocateRegister();
       generateTrg1Src1Instruction(cg, TR::InstOpCode::extsb, node, trgReg, cg->evaluate(child));
@@ -368,7 +368,7 @@ TR::Register *OMR::Power::TreeEvaluator::b2lEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::s2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *child = node->getFirstChild();
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::extsw;
       TR::ILOpCodes  nodeOpCode = node->getOpCodeValue();
@@ -404,7 +404,7 @@ TR::Register *OMR::Power::TreeEvaluator::s2lEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *child  = node->getFirstChild();
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (node->getOpCodeValue() == TR::iu2l && child && child->getReferenceCount() == 1 && !child->getRegister() &&
           (child->getOpCodeValue() == TR::iloadi || child->getOpCodeValue() == TR::iload))
@@ -445,7 +445,7 @@ TR::Register *OMR::Power::TreeEvaluator::iu2lEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::su2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::iu2lEvaluator(node, cg);
    else
       return TR::TreeEvaluator::s2iEvaluator(node, cg);
@@ -477,7 +477,7 @@ TR::Register *OMR::Power::TreeEvaluator::su2iEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::s2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::s2lEvaluator(node, cg);
    else
       return TR::TreeEvaluator::s2iEvaluator(node, cg);
@@ -504,7 +504,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2cEvaluator(TR::Node *node, TR::CodeGe
        child->getRegister() == NULL)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?2:0, cg);
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?2:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       }
@@ -521,13 +521,13 @@ TR::Register *OMR::Power::TreeEvaluator::i2sEvaluator(TR::Node *node, TR::CodeGe
    TR::Node *child  = node->getFirstChild();
    TR::Register *trgReg = cg->allocateRegister();
 
-   if (TR::Compiler->target.cpu.id() != TR_PPCp6 &&  // avoid algebraic loads on P6
+   if (cg->comp()->target().cpu.id() != TR_PPCp6 &&  // avoid algebraic loads on P6
        child->getReferenceCount() == 1 &&
        child->getOpCode().isMemoryReference() &&
        child->getRegister() == NULL)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?2:0, cg);
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?2:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       generateTrg1Src1Instruction(cg, TR::InstOpCode::extsh, node, trgReg, trgReg);
       tempMR->decNodeReferenceCounts(cg);
@@ -543,7 +543,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2sEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::i2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::s2lEvaluator(node, cg);
    else
       return TR::TreeEvaluator::passThroughEvaluator(node, cg);
@@ -551,7 +551,7 @@ TR::Register *OMR::Power::TreeEvaluator::i2aEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::iu2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::iu2lEvaluator(node, cg);
    else
       return TR::TreeEvaluator::passThroughEvaluator(node, cg);
@@ -567,7 +567,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2bEvaluator(TR::Node *node, TR::CodeGe
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 1, cg);
       trgReg = cg->allocateRegister();
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?7:0, cg);
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?7:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
       node->setRegister(trgReg);
       tempMR->decNodeReferenceCounts(cg);
@@ -577,7 +577,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2bEvaluator(TR::Node *node, TR::CodeGe
       TR::Register *temp = cg->evaluate(child);
       if (child->getReferenceCount() == 1 || !cg->useClobberEvaluate())
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             trgReg = temp;
          else // 32 bit target
             trgReg = temp->getLowOrder();
@@ -585,7 +585,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2bEvaluator(TR::Node *node, TR::CodeGe
       else
          {
          trgReg = cg->allocateRegister();
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, trgReg, temp);
 	 else
             generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, trgReg, temp->getLowOrder());
@@ -606,14 +606,14 @@ TR::Register *OMR::Power::TreeEvaluator::l2buEvaluator(TR::Node *node, TR::CodeG
        child->getOpCode().isMemoryReference() && (child->getRegister() == NULL))
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 1, cg);
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?7:0, cg);
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?7:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lbz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       }
    else
       {
       TR::Register *tempReg;
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempReg = cg->evaluate(child);
       else // 32 bit target
          tempReg = cg->evaluate(child)->getLowOrder();
@@ -637,13 +637,13 @@ TR::Register *OMR::Power::TreeEvaluator::l2cEvaluator(TR::Node *node, TR::CodeGe
        child->getOpCode().isMemoryReference() && (temp == NULL))
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?6:0, cg);
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?6:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       }
    else
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rldicl, node, trgReg, cg->evaluate(child), 0, CONSTANT64(0x000000000000ffff));
       else // 32 bit target
          generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwinm, node, trgReg, cg->evaluate(child)->getLowOrder(), 0, 0xffff);
@@ -663,8 +663,8 @@ TR::Register *OMR::Power::TreeEvaluator::l2sEvaluator(TR::Node *node, TR::CodeGe
        child->getRegister() == NULL)
       {
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 2, cg);
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?6:0, cg);
-      if (TR::Compiler->target.cpu.id() == TR_PPCp6)  // avoid algebraic loads on P6
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?6:0, cg);
+      if (cg->comp()->target().cpu.id() == TR_PPCp6)  // avoid algebraic loads on P6
          {
          generateTrg1MemInstruction(cg, TR::InstOpCode::lhz, node, trgReg, tempMR);
          generateTrg1Src1Instruction(cg, TR::InstOpCode::extsh, node, trgReg, trgReg);
@@ -675,7 +675,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2sEvaluator(TR::Node *node, TR::CodeGe
       }
    else
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateTrg1Src1Instruction(cg, TR::InstOpCode::extsh, node, trgReg, cg->evaluate(child));
       else // 32 bit target
          generateTrg1Src1Instruction(cg, TR::InstOpCode::extsh, node, trgReg, cg->evaluate(child)->getLowOrder());
@@ -696,7 +696,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGe
       {
       trgReg = cg->allocateRegister();
       TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(child, 4, cg);
-      tempMR->addToOffset(node, TR::Compiler->target.cpu.isBigEndian()?4:0, cg);
+      tempMR->addToOffset(node, cg->comp()->target().cpu.isBigEndian()?4:0, cg);
       generateTrg1MemInstruction(cg, TR::InstOpCode::lwz, node, trgReg, tempMR);
       tempMR->decNodeReferenceCounts(cg);
       node->setRegister(trgReg);
@@ -706,7 +706,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGe
       temp = cg->evaluate(child);
       if (child->getReferenceCount() == 1 || !cg->useClobberEvaluate())
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             trgReg = temp;
          else // 32 bit target
             trgReg = temp->getLowOrder();
@@ -714,7 +714,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGe
       else
          {
          trgReg = cg->allocateRegister();
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, trgReg, temp);
 	 else
             generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, trgReg, temp->getLowOrder());
@@ -728,7 +728,7 @@ TR::Register *OMR::Power::TreeEvaluator::l2iEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *OMR::Power::TreeEvaluator::l2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       // -J9JIT_COMPRESSED_POINTER-
       //
@@ -784,7 +784,7 @@ TR::Register *OMR::Power::TreeEvaluator::su2lEvaluator(TR::Node *node, TR::CodeG
    {
    TR::Node *child  = node->getFirstChild();
    TR::Register *sourceRegister = NULL;
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       TR::Register *trgReg = cg->allocateRegister();
       TR::Register *temp;
@@ -873,7 +873,7 @@ TR::Register *OMR::Power::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeG
    TR::Node *child  = node->getFirstChild();
    TR::Register *trgReg;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (child->getOpCode().isMemoryReference())
          {
@@ -910,7 +910,7 @@ TR::Register *OMR::Power::TreeEvaluator::bu2lEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::bu2aEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::bu2lEvaluator(node, cg);
    else
       return TR::TreeEvaluator::bu2iEvaluator(node, cg);
@@ -918,7 +918,7 @@ TR::Register *OMR::Power::TreeEvaluator::bu2aEvaluator(TR::Node *node, TR::CodeG
 
 TR::Register *OMR::Power::TreeEvaluator::a2iEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::l2iEvaluator(node, cg);
    else
       return TR::TreeEvaluator::passThroughEvaluator(node, cg);
@@ -926,7 +926,7 @@ TR::Register *OMR::Power::TreeEvaluator::a2iEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::a2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::passThroughEvaluator(node, cg);
    else
       return TR::TreeEvaluator::iu2lEvaluator(node, cg);
@@ -934,7 +934,7 @@ TR::Register *OMR::Power::TreeEvaluator::a2lEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::a2bEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::l2bEvaluator(node, cg);
    else
       return TR::TreeEvaluator::i2bEvaluator(node, cg);
@@ -942,7 +942,7 @@ TR::Register *OMR::Power::TreeEvaluator::a2bEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *OMR::Power::TreeEvaluator::a2sEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       return TR::TreeEvaluator::l2sEvaluator(node, cg);
    else
       return TR::TreeEvaluator::i2sEvaluator(node, cg);

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -747,12 +747,12 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction *instr, uint8_t *curso
 
       // Print machine code in bytes on X86, in words on PPC,ARM,ARM64
       // Stop if we try to run over the buffer.
-      if (TR::Compiler->target.cpu.isX86())
+      if (_comp->target().cpu.isX86())
          {
          for (int i = 0; i < size && p1 - p0 + 3 < prefixWidth; i++, p1 += 3)
             sprintf(p1, " %02x", *cursor++);
          }
-      else if (TR::Compiler->target.cpu.isPower() || TR::Compiler->target.cpu.isARM() || TR::Compiler->target.cpu.isARM64())
+      else if (_comp->target().cpu.isPower() || _comp->target().cpu.isARM() || _comp->target().cpu.isARM64())
          {
          for (int i = 0; i < size && p1 - p0 + 9 < prefixWidth; i += 4, p1 += 9, cursor += 4)
             sprintf(p1, " %08x", *((uint32_t *)cursor));
@@ -833,7 +833,7 @@ TR_Debug::printSnippetLabel(TR::FILE *pOutFile, TR::LabelSymbol *label, uint8_t 
    trfprintf(pOutFile, ":");
    if (comment1)
       {
-      trfprintf(pOutFile, "\t\t%c %s", (TR::Compiler->target.cpu.isX86() && TR::Compiler->target.isLinux()) ? '#' : ';', comment1);
+      trfprintf(pOutFile, "\t\t%c %s", (_comp->target().cpu.isX86() && _comp->target().isLinux()) ? '#' : ';', comment1);
       if (comment2)
          trfprintf(pOutFile, " (%s)", comment2);
       }
@@ -2545,7 +2545,7 @@ TR_Debug::dumpMethodInstrs(TR::FILE *pOutFile, const char *title, bool dumpTrees
            crtLineNo = lastLineNoPrinted;
            }
 
-        bool printEveryLine = TR::Compiler->target.cpu.isZ() && TR::Compiler->target.isLinux();
+        bool printEveryLine = _comp->target().cpu.isZ() && _comp->target().isLinux();
         // Emit .line directive if there was change in line number, or source file or
         // inlined method state since last time
         if ((crtLineNo != -1) &&
@@ -2560,7 +2560,7 @@ TR_Debug::dumpMethodInstrs(TR::FILE *pOutFile, const char *title, bool dumpTrees
 
            int32_t lno;
 
-           if (TR::Compiler->target.cpu.isZ() && TR::Compiler->target.isLinux())
+           if (_comp->target().cpu.isZ() && _comp->target().isLinux())
               {
               lno = crtLineNo - 1;
               }
@@ -2597,7 +2597,7 @@ TR_Debug::dumpMethodInstrs(TR::FILE *pOutFile, const char *title, bool dumpTrees
          printS390OOLSequences(pOutFile);
 #endif
 #elif defined(TR_TARGET_X86)
-      if (TR::Compiler->target.cpu.isX86())
+      if (_comp->target().cpu.isX86())
          printX86OOLSequences(pOutFile);
 #endif
 
@@ -2773,7 +2773,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * inst, const char *title)
       return;
 
 #if defined(TR_TARGET_X86)
-   if (TR::Compiler->target.cpu.isX86())
+   if (_comp->target().cpu.isX86())
       {
       printx(pOutFile, inst);
       return;
@@ -2781,7 +2781,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * inst, const char *title)
 #endif
 
 #if defined(TR_TARGET_POWER)
-   if (TR::Compiler->target.cpu.isPower())
+   if (_comp->target().cpu.isPower())
       {
       print(pOutFile, inst);
       return;
@@ -2789,7 +2789,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * inst, const char *title)
 #endif
 
 #if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM())
+   if (_comp->target().cpu.isARM())
       {
       print(pOutFile, inst);
       return;
@@ -2797,7 +2797,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * inst, const char *title)
 #endif
 
 #if defined(TR_TARGET_ARM64)
-   if (TR::Compiler->target.cpu.isARM64())
+   if (_comp->target().cpu.isARM64())
       {
       print(pOutFile, inst);
       return;
@@ -2805,7 +2805,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * inst, const char *title)
 #endif
 
 #if defined(TR_TARGET_S390)
-   if (TR::Compiler->target.cpu.isZ())
+   if (_comp->target().cpu.isZ())
       {
       printz(pOutFile, inst, title);
       return;
@@ -2821,7 +2821,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::GCRegisterMap * map)
       return;
 
 #if defined(TR_TARGET_X86)
-   if (TR::Compiler->target.cpu.isX86())
+   if (_comp->target().cpu.isX86())
       {
       printX86GCRegisterMap(pOutFile, map);
       return;
@@ -2829,7 +2829,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::GCRegisterMap * map)
 #endif
 
 #if defined(TR_TARGET_POWER)
-   if (TR::Compiler->target.cpu.isPower())
+   if (_comp->target().cpu.isPower())
       {
       printPPCGCRegisterMap(pOutFile, map);
       return;
@@ -2837,7 +2837,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::GCRegisterMap * map)
 #endif
 
 #if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM())
+   if (_comp->target().cpu.isARM())
       {
       printARMGCRegisterMap(pOutFile, map);
       return;
@@ -2845,7 +2845,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::GCRegisterMap * map)
 #endif
 
 #if defined(TR_TARGET_S390)
-   if (TR::Compiler->target.cpu.isZ())
+   if (_comp->target().cpu.isZ())
       {
       printS390GCRegisterMap(pOutFile, map);
       return;
@@ -2853,7 +2853,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::GCRegisterMap * map)
 #endif
 
 #if defined(TR_TARGET_ARM64)
-   if (TR::Compiler->target.cpu.isARM64())
+   if (_comp->target().cpu.isARM64())
       {
       printARM64GCRegisterMap(pOutFile, map);
       return;
@@ -2900,15 +2900,15 @@ const char *
 TR_Debug::getName(TR::Snippet *snippet)
    {
 #if defined(TR_TARGET_X86)
-   if (TR::Compiler->target.cpu.isX86())
+   if (_comp->target().cpu.isX86())
       return getNamex(snippet);
 #endif
 #if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM())
+   if (_comp->target().cpu.isARM())
       return getNamea(snippet);
 #endif
 #if defined(TR_TARGET_ARM64)
-   if (TR::Compiler->target.cpu.isARM64())
+   if (_comp->target().cpu.isARM64())
       return getNamea64(snippet);
 #endif
    return "<unknown snippet>"; // TODO: Return a more informative name
@@ -2918,35 +2918,35 @@ void
 TR_Debug::print(TR::FILE *pOutFile, TR::Snippet * snippet)
    {
 #if defined(TR_TARGET_X86)
-   if (TR::Compiler->target.cpu.isX86())
+   if (_comp->target().cpu.isX86())
       {
       printx(pOutFile, snippet);
       return;
       }
 #endif
 #if defined(TR_TARGET_POWER)
-   if (TR::Compiler->target.cpu.isPower())
+   if (_comp->target().cpu.isPower())
       {
       printp(pOutFile, snippet);
       return;
       }
 #endif
 #if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM())
+   if (_comp->target().cpu.isARM())
       {
       printa(pOutFile, snippet);
       return;
       }
 #endif
 #if defined(TR_TARGET_S390)
-   if (TR::Compiler->target.cpu.isZ())
+   if (_comp->target().cpu.isZ())
       {
       printz(pOutFile, (TR::Snippet *)snippet);
       return;
       }
 #endif
 #if defined(TR_TARGET_ARM64)
-   if (TR::Compiler->target.cpu.isARM64())
+   if (_comp->target().cpu.isARM64())
       {
       printa64(pOutFile, snippet);
       return;
@@ -2985,23 +2985,23 @@ TR_Debug::getName(TR::Register *reg, TR_RegisterSizes size)
    if (reg->getRealRegister())
       {
 #if defined(TR_TARGET_X86)
-      if (TR::Compiler->target.cpu.isX86())
+      if (_comp->target().cpu.isX86())
          return getName((TR::RealRegister *)reg, size);
 #endif
 #if defined(TR_TARGET_POWER)
-      if (TR::Compiler->target.cpu.isPower())
+      if (_comp->target().cpu.isPower())
          return getName((TR::RealRegister *)reg, size);
 #endif
 #if defined(TR_TARGET_ARM)
-      if (TR::Compiler->target.cpu.isARM())
+      if (_comp->target().cpu.isARM())
          return getName((TR::RealRegister *)reg, size);
 #endif
 #if defined(TR_TARGET_S390)
-      if (TR::Compiler->target.cpu.isZ())
+      if (_comp->target().cpu.isZ())
          return getName(toRealRegister(reg), size);
 #endif
 #if defined(TR_TARGET_ARM64)
-      if (TR::Compiler->target.cpu.isARM64())
+      if (_comp->target().cpu.isARM64())
          return getName((TR::RealRegister *)reg, size);
 #endif
       TR_ASSERT(0, "TR_Debug::getName() ==> unknown target platform for given real register\n");
@@ -3070,19 +3070,19 @@ const char *TR_Debug::getGlobalRegisterName(TR_GlobalRegisterNumber regNum, TR_R
    {
    uint32_t realRegNum = _comp->cg()->getGlobalRegister(regNum);
 #if defined(TR_TARGET_X86)
-   if (TR::Compiler->target.cpu.isX86())
+   if (_comp->target().cpu.isX86())
       return getName(realRegNum, size);
 #endif
 #if defined(TR_TARGET_POWER)
-   if (TR::Compiler->target.cpu.isPower())
+   if (_comp->target().cpu.isPower())
       return getPPCRegisterName(realRegNum);
 #endif
 #if defined(TR_TARGET_S390)
-   if (TR::Compiler->target.cpu.isZ())
+   if (_comp->target().cpu.isZ())
       return getS390RegisterName(realRegNum);
 #endif
 #if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM())
+   if (_comp->target().cpu.isARM())
       return getName(realRegNum, size);
 #endif
    return "???";
@@ -3141,7 +3141,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Register * reg, TR_RegisterSizes size)
    if (pOutFile == NULL)
       return;
 #if defined(TR_TARGET_S390)
-   if (reg == NULL && TR::Compiler->target.cpu.isZ()) // zero based ptr
+   if (reg == NULL && _comp->target().cpu.isZ()) // zero based ptr
       {
       trfprintf(pOutFile, "%s", "GPR0");
       return;
@@ -3151,35 +3151,35 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Register * reg, TR_RegisterSizes size)
    if (reg->getRealRegister())
       {
 #if defined(TR_TARGET_X86)
-      if (TR::Compiler->target.cpu.isX86())
+      if (_comp->target().cpu.isX86())
          {
          print(pOutFile, (TR::RealRegister *)reg, size);
          return;
          }
 #endif
 #if defined(TR_TARGET_POWER)
-      if (TR::Compiler->target.cpu.isPower())
+      if (_comp->target().cpu.isPower())
          {
          print(pOutFile, (TR::RealRegister *)reg, size);
          return;
          }
 #endif
 #if defined(TR_TARGET_ARM)
-      if (TR::Compiler->target.cpu.isARM())
+      if (_comp->target().cpu.isARM())
          {
          print(pOutFile, (TR::RealRegister *)reg, size);
          return;
          }
 #endif
 #if defined(TR_TARGET_S390)
-      if (TR::Compiler->target.cpu.isZ())
+      if (_comp->target().cpu.isZ())
          {
          print(pOutFile, toRealRegister(reg), size);
          return;
          }
 #endif
 #if defined(TR_TARGET_ARM64)
-      if (TR::Compiler->target.cpu.isARM64())
+      if (_comp->target().cpu.isARM64())
          {
          print(pOutFile, (TR::RealRegister *)reg, size);
          return;
@@ -3318,7 +3318,7 @@ TR_Debug::printGPRegisterStatus(TR::FILE *pOutFile, OMR::MachineConnector *machi
    if (pOutFile == NULL)
       return;
 #if defined(TR_TARGET_S390)
-   if (TR::Compiler->target.cpu.isZ())
+   if (_comp->target().cpu.isZ())
       {
       printGPRegisterStatus(pOutFile, (TR::Machine *)machine);
       return;
@@ -3331,7 +3331,7 @@ TR_Debug::printFPRegisterStatus(TR::FILE *pOutFile, OMR::MachineConnector *machi
    if (pOutFile == NULL)
       return;
 #if defined(TR_TARGET_S390)
-   if (TR::Compiler->target.cpu.isZ())
+   if (_comp->target().cpu.isZ())
       {
       printFPRegisterStatus(pOutFile, (TR::Machine *)machine);
       return;
@@ -3778,7 +3778,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          }
       }
 #ifdef TR_TARGET_X86
-   else if ((TR::Compiler->target.cpu.isI386() || TR::Compiler->target.cpu.isAMD64()) && !inDebugExtension())
+   else if ((_comp->target().cpu.isI386() || _comp->target().cpu.isAMD64()) && !inDebugExtension())
       {
       if (index < TR_LXRH)
          {
@@ -3822,7 +3822,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
             case TR_outlinedPrologue_8preserved:         return "outlinedPrologue_8preserved";
             }
          }
-      else if (TR::Compiler->target.cpu.isI386())
+      else if (_comp->target().cpu.isI386())
          {
          switch (index)
             {
@@ -3883,7 +3883,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          }
       }
 #elif defined (TR_TARGET_POWER)
-   else if (TR::Compiler->target.cpu.isPower() && !inDebugExtension())
+   else if (_comp->target().cpu.isPower() && !inDebugExtension())
       {
       switch (index)
          {
@@ -4000,7 +4000,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          }
       }
 #elif defined (TR_TARGET_S390)
-   else if (TR::Compiler->target.cpu.isZ() && !inDebugExtension())
+   else if (_comp->target().cpu.isZ() && !inDebugExtension())
       {
       switch (index)
          {
@@ -4097,7 +4097,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          }
       }
 #elif defined (TR_TARGET_ARM)
-   else if (TR::Compiler->target.cpu.isARM() && !inDebugExtension())
+   else if (_comp->target().cpu.isARM() && !inDebugExtension())
       {
       switch (index)
          {
@@ -4231,7 +4231,7 @@ TR_Debug::getRuntimeHelperName(int32_t index)
          }
       }
 #elif defined (TR_TARGET_ARM64)
-   else if (TR::Compiler->target.cpu.isARM64() && !inDebugExtension())
+   else if (_comp->target().cpu.isARM64() && !inDebugExtension())
       {
       switch (index)
          {

--- a/compiler/ras/DebugCounter.cpp
+++ b/compiler/ras/DebugCounter.cpp
@@ -58,7 +58,7 @@ void
 TR::DebugCounter::prependDebugCounterBump(TR::Compilation *comp, TR::TreeTop *nextTreeTop, TR::DebugCounterBase *counter, int32_t delta)
    {
    // Use long operations in 64 bit platforms and int operations in 32 bit platforms
-   if (TR::Compiler->target.is64Bit())
+   if (comp->target().is64Bit())
       {
       prependDebugCounterBump(comp, nextTreeTop, counter, TR::Node::lconst(nextTreeTop->getNode(), delta));
       }
@@ -284,9 +284,9 @@ const char *TR::DebugCounter::debugCounterBucketName(TR::Compilation *comp, int3
 TR::Node *TR::DebugCounterBase::createBumpCounterNode(TR::Compilation *comp, TR::Node *deltaNode)
    {
    TR::SymbolReference *symref = getBumpCountSymRef(comp);
-   TR::Node *load = TR::Node::createWithSymRef(deltaNode, TR::Compiler->target.is64Bit() ? TR::lload : TR::iload, 0, symref);
-   TR::Node *add = TR::Node::create(TR::Compiler->target.is64Bit() ? TR::ladd : TR::iadd, 2, load, deltaNode);
-   TR::Node *store = TR::Node::createWithSymRef(TR::Compiler->target.is64Bit() ? TR::lstore : TR::istore, 1, 1, add, symref);
+   TR::Node *load = TR::Node::createWithSymRef(deltaNode, comp->target().is64Bit() ? TR::lload : TR::iload, 0, symref);
+   TR::Node *add = TR::Node::create(comp->target().is64Bit() ? TR::ladd : TR::iadd, 2, load, deltaNode);
+   TR::Node *store = TR::Node::createWithSymRef(comp->target().is64Bit() ? TR::lstore : TR::istore, 1, 1, add, symref);
 
    if (comp->compileRelocatableCode())
       comp->mapStaticAddressToCounter(symref, this);
@@ -319,7 +319,7 @@ TR::DebugCounterBase::finalizeReloData(TR::Compilation *comp, TR::Node *node, ui
 
 TR::SymbolReference *TR::DebugCounter::getBumpCountSymRef(TR::Compilation *comp)
    {
-   TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateCounterSymRef(const_cast<char*>(_name), TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32, &_bumpCount);
+   TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateCounterSymRef(const_cast<char*>(_name), comp->target().is64Bit() ? TR::Int64 : TR::Int32, &_bumpCount);
    symRef->getSymbol()->setIsDebugCounter();
    return symRef;
    }

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1720,7 +1720,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
    else if (!inDebugExtension() &&
             (node->getOpCode().isLoadReg() || node->getOpCode().isStoreReg()) )
       {
-      if ((node->getType().isInt64() && TR::Compiler->target.is32Bit() && !_comp->cg()->use64BitRegsOn32Bit()))
+      if ((node->getType().isInt64() && _comp->target().is32Bit() && !_comp->cg()->use64BitRegsOn32Bit()))
          output.append(" %s:%s ", getGlobalRegisterName(node->getHighGlobalRegisterNumber()), getGlobalRegisterName(node->getLowGlobalRegisterNumber()));
       else
          output.append(" %s ", getGlobalRegisterName(node->getGlobalRegisterNumber()));
@@ -1743,7 +1743,7 @@ TR_Debug::printNodeInfo(TR::Node * node, TR_PrettyPrinterString& output, bool pr
          else if (t == TR::Int32) size = TR_WordReg;
          else                    size = TR_DoubleWordReg;
          if ((node->getFirstChild()->getType().isInt64() &&
-              TR::Compiler->target.is32Bit()))
+              _comp->target().is32Bit()))
             output.append(" %s:%s ",
                           getGlobalRegisterName(node->getHighGlobalRegisterNumber(), size),
                           getGlobalRegisterName(node->getLowGlobalRegisterNumber(), size));

--- a/compiler/riscv/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/riscv/codegen/ControlFlowEvaluator.cpp
@@ -390,7 +390,7 @@ OMR::RV::TreeEvaluator::iucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return icmpeqEvaluator(node, cg);
    }
 
@@ -398,63 +398,63 @@ OMR::RV::TreeEvaluator::lcmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return icmpneEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return icmpltEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return icmpgeEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return icmpgtEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lcmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return icmpleEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lucmpltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return iucmpltEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lucmpgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return iucmpgeEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lucmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return iucmpgtEvaluator(node, cg);
    }
 
 TR::Register *
 OMR::RV::TreeEvaluator::lucmpleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "RV32 not yet supported");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "RV32 not yet supported");
    return iucmpleEvaluator(node, cg);
    }
 

--- a/compiler/riscv/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.cpp
@@ -125,7 +125,7 @@ OMR::RV::TreeEvaluator::badILOpEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *commonLoadEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
    {
    TR::Register *tempReg;
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
 
    if (op == TR::InstOpCode::_flw)
       {
@@ -190,7 +190,7 @@ OMR::RV::TreeEvaluator::aloadEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 
    /*
     * Enable this part when dmb instruction becomes available
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    if (needSync)
       {
       generateInstruction(cg, TR::InstOpCode::dmb, node);
@@ -239,7 +239,7 @@ OMR::RV::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *commonStoreEvaluator(TR::Node *node, TR::InstOpCode::Mnemonic op, int32_t memSize, TR::CodeGenerator *cg)
    {
    TR::MemoryReference *tempMR = new (cg->trHeapMemory()) TR::MemoryReference(node, memSize, cg);
-   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && TR::Compiler->target.isSMP());
+   bool needSync = (node->getSymbolReference()->getSymbol()->isSyncVolatile() && cg->comp()->target().isSMP());
    TR::Node *valueChild;
 
    if (node->getOpCode().isIndirect())

--- a/compiler/runtime/Trampoline.cpp
+++ b/compiler/runtime/Trampoline.cpp
@@ -531,75 +531,44 @@ void s390zLinux64CodeCacheParameters(int32_t *trampolineSize, void **callBacks, 
 void setupCodeCacheParameters(int32_t *trampolineSize, OMR::CodeCacheCodeGenCallbacks *callBacks, int32_t * numHelpers, int32_t *CCPreLoadedCodeSize)
    {
 #if defined(TR_TARGET_POWER)
-   if (TR::Compiler->target.cpu.isPower())
-      {
       ppcCodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
       return;
-      }
 #endif
 
 #if defined(TR_TARGET_X86) && defined(TR_TARGET_32BIT)
-   if (TR::Compiler->target.cpu.isI386())
-      {
       ia32CodeCacheParameters(trampolineSize, callBacks, numHelpers, CCPreLoadedCodeSize);
       return;
-      }
 #endif
 
 #if defined(TR_TARGET_X86) && defined(TR_TARGET_64BIT)
-   if (TR::Compiler->target.cpu.isAMD64())
-      {
       amd64CodeCacheParameters(trampolineSize, callBacks, numHelpers, CCPreLoadedCodeSize);
       return;
-      }
 #endif
 
 #if defined(TR_TARGET_ARM)
-   if (TR::Compiler->target.cpu.isARM())
-      {
       armCodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
       return;
-      }
 #endif
 
 #if defined(TR_TARGET_ARM64)
-   if (TR::Compiler->target.cpu.isARM64())
-      {
       arm64CodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
       return;
-      }
 #endif
 
 #if defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && defined(J9ZOS390)
-   // zOS 31 code cache support.
-   if (TR::Compiler->target.cpu.isZ())
-      {
       s390zOS31CodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
-      }
 #endif
 
 #if defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && defined(J9ZOS390)
-   // zOS 64 code cache support.
-   if (TR::Compiler->target.cpu.isZ())
-      {
       s390zOS64CodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
-      }
 #endif
 
 #if defined(TR_TARGET_S390) && !defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
-   // zLinux 31 code cache support.
-   if (TR::Compiler->target.cpu.isZ())
-      {
       s390zLinux31CodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
-      }
 #endif
 
 #if defined(TR_TARGET_S390) && defined(TR_TARGET_64BIT) && !defined(J9ZOS390)
-   // zLinux 64 code cache support.
-   if (TR::Compiler->target.cpu.isZ())
-      {
       s390zLinux64CodeCacheParameters(trampolineSize, (void **)callBacks, numHelpers, CCPreLoadedCodeSize);
-      }
 #endif
    }
 

--- a/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/amd64/codegen/OMRCodeGenerator.cpp
@@ -125,7 +125,7 @@ OMR::X86::AMD64::CodeGenerator::CodeGenerator() :
 TR::Register *
 OMR::X86::AMD64::CodeGenerator::longClobberEvaluate(TR::Node *node)
    {
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "assertion failure");
+   TR_ASSERT(self()->comp()->target().is64Bit(), "assertion failure");
    TR_ASSERT(node->getOpCode().is8Byte() || node->getOpCode().isRef(), "assertion failure");
    return self()->gprClobberEvaluate(node, MOV8RegReg);
    }

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -592,7 +592,7 @@ OMR::X86::AMD64::MemoryReference::generateBinaryEncoding(
       // addressLoadInstruction's node should be that of containingInstruction
       //
       addressLoadInstruction->setNode(_baseNode ? _baseNode : containingInstruction->getNode());
-      if (TR::Compiler->target.isSMP() && self()->getUnresolvedDataSnippet())
+      if (cg->comp()->target().isSMP() && self()->getUnresolvedDataSnippet())
          {
          // Also adjust the node of the TR::X86PatchableCodeAlignmentInstruction
          //

--- a/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/x/codegen/BinaryCommutativeAnalyser.cpp
@@ -929,7 +929,9 @@ TR::Register *TR_X86BinaryCommutativeAnalyser::integerAddAnalyserImpl(TR::Node  
 //
 static bool isVolatileMemoryOperand(TR::Node *node)
    {
-   if (TR::Compiler->target.isSMP() && node->getOpCode().isMemoryReference())
+   TR::Compilation *comp = TR::comp();
+   TR_ASSERT_FATAL(comp, "isVolatileMemoryOperand should only be called during a compilation!");
+   if (comp->target().isSMP() && node->getOpCode().isMemoryReference())
       {
       TR_ASSERT(node->getSymbolReference(), "expecting a symbol reference\n");
       TR::Symbol *sym = node->getSymbolReference()->getSymbol();

--- a/compiler/x/codegen/BinaryEvaluator.cpp
+++ b/compiler/x/codegen/BinaryEvaluator.cpp
@@ -97,7 +97,7 @@ static void forceSize(TR::Node *node, TR::Register *reg, bool is64Bit, TR::CodeG
 inline TR::Register *evaluateAndForceSize(TR::Node *node, bool is64Bit, TR::CodeGenerator *cg)
    {
    TR::Register *reg = cg->evaluate(node);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       forceSize(node, reg, is64Bit, cg);
       }
@@ -967,7 +967,7 @@ TR::Register *OMR::X86::TreeEvaluator::baddEvaluator(TR::Node *node, TR::CodeGen
 
    // This comment has been tested on X86_32 and X86_64 Linux only, and has not been tested
    // on any Windows operating systems.
-   // TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 baddEvaluator not yet supported");
+   // TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 baddEvaluator not yet supported");
 
    // See if we can generate a direct memory operation. In this case there is no
    // target register generated and we return NULL to the caller (which should be
@@ -1093,7 +1093,7 @@ TR::Register *OMR::X86::TreeEvaluator::saddEvaluator(TR::Node *node, TR::CodeGen
 
    //This comment has been tested on X86_32 and X86_64 Linux only, and has not been tested
    //on any Windows operating systems.
-   //TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 baddEvaluator not yet supported");
+   //TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 baddEvaluator not yet supported");
 
    // See if we can generate a direct memory operation. In this case there is no
    // target register generated and we return NULL to the caller (which should be
@@ -1226,7 +1226,7 @@ TR::Register *OMR::X86::TreeEvaluator::caddEvaluator(TR::Node *node, TR::CodeGen
    bool                 oursIsTheOnlyMemRef = true;
    TR::Compilation     *comp                = cg->comp();
 
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 baddEvaluator not yet supported");
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 baddEvaluator not yet supported");
 
    // See if we can generate a direct memory operation. In this case there is no
    // target register generated and we return NULL to the caller (which should be
@@ -2715,7 +2715,7 @@ TR::X86RegInstruction  *OMR::X86::TreeEvaluator::generateRegisterShift(TR::Node 
                   diagnostic("shift: removed sign or zero extend to shift amount in memory in method %s\n",
                               comp->signature());
                }
-            else if (op != TR::l2i || TR::Compiler->target.is64Bit()) // cannot use a reigster pair as the shift amount
+            else if (op != TR::l2i || comp->target().is64Bit()) // cannot use a reigster pair as the shift amount
                {
                secondChild->decReferenceCount();
                secondChild = grandChild;
@@ -2826,7 +2826,7 @@ TR::X86MemInstruction  *OMR::X86::TreeEvaluator::generateMemoryShift(TR::Node *n
                if (reportShiftAmount)
                   diagnostic("shift: removed sign or zero extend to shift amount in memory in method %s\n", comp->signature());
                }
-            else if (op != TR::l2i || TR::Compiler->target.is64Bit())
+            else if (op != TR::l2i || comp->target().is64Bit())
                {
                secondChild->decReferenceCount();
                secondChild = grandChild;

--- a/compiler/x/codegen/DataSnippet.cpp
+++ b/compiler/x/codegen/DataSnippet.cpp
@@ -61,7 +61,7 @@ TR::X86DataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
                                   __FILE__, __LINE__, self()->getNode());
          }
 
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          if (!needRelocation)
             cg()->jitAddPicToPatchOnClassUnload((void*)-1, (void *) cursor);

--- a/compiler/x/codegen/DivideCheckSnippet.cpp
+++ b/compiler/x/codegen/DivideCheckSnippet.cpp
@@ -44,7 +44,7 @@ uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
 
    // CMP realDivisorReg, -1
    //
-   uint8_t rexPrefix = TR::Compiler->target.is64Bit() ? realDivisorReg->rexBits(TR::RealRegister::REX_B, false) : 0;
+   uint8_t rexPrefix = cg()->comp()->target().is64Bit() ? realDivisorReg->rexBits(TR::RealRegister::REX_B, false) : 0;
    buffer = TR_X86OpCode(CMPRegImms(_divOp.isLong())).binary(buffer, rexPrefix);
    realDivisorReg->setRMRegisterFieldInModRM(buffer-1);
    *buffer++ = -1;
@@ -58,7 +58,7 @@ uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
       {
       // MOV eax, realDividendReg
       //
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          uint8_t rexPrefix = realDividendReg->rexBits(TR::RealRegister::REX_R, false);
          if (_divOp.isLong())
@@ -76,7 +76,7 @@ uint8_t *TR::X86DivideCheckSnippet::emitSnippetBody()
       {
       // XOR edx, edx
       //
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          uint8_t rexPrefix = 0;
          if (_divOp.isLong())
@@ -110,7 +110,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86DivideCheckSnippet  * snippet) // TOD
 
    int32_t cmpSize = 6;
 #if defined(TR_TARGET_64BIT)
-   if (TR::Compiler->target.is64Bit())
+   if (comp()->target().is64Bit())
       {
       uint8_t rexPrefix = realDivisorReg->rexBits(TR::RealRegister::REX_B, false);
       if (isLong)
@@ -132,7 +132,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86DivideCheckSnippet  * snippet) // TOD
       {
       int32_t movSize = 2;
 #if defined(TR_TARGET_64BIT)
-      if (TR::Compiler->target.is64Bit())
+      if (comp()->target().is64Bit())
          {
          uint8_t rexPrefix = realDividendReg->rexBits(TR::RealRegister::REX_R, false);
          if (isLong)
@@ -169,7 +169,7 @@ uint32_t TR::X86DivideCheckSnippet::getLength(int32_t estimatedSnippetStart)
    uint32_t fixedLength = 6;
 
    TR::Machine *machine = cg()->machine();
-   if (TR::Compiler->target.is64Bit())
+   if (cg()->comp()->target().is64Bit())
       {
       uint8_t rexPrefix = realDivisorReg->rexBits(TR::RealRegister::REX_B, false);
       if (_divOp.isLong())
@@ -184,7 +184,7 @@ uint32_t TR::X86DivideCheckSnippet::getLength(int32_t estimatedSnippetStart)
    if (_divOp.isDiv() && realDividendReg->getRegisterNumber() != TR::RealRegister::eax)
       {
       fixedLength += 2;
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          uint8_t rexPrefix = realDividendReg->rexBits(TR::RealRegister::REX_R, false);
          if (_divOp.isLong())

--- a/compiler/x/codegen/FPTreeEvaluator.cpp
+++ b/compiler/x/codegen/FPTreeEvaluator.cpp
@@ -285,7 +285,7 @@ TR::Register *OMR::X86::TreeEvaluator::performFload(TR::Node *node, TR::MemoryRe
    TR::Instruction *instr;
    if (cg->useSSEForSinglePrecision())
       {
-      if (TR::Compiler->target.is64Bit() &&
+      if (cg->comp()->target().is64Bit() &&
           sourceMR->getSymbolReference().isUnresolved())
          {
          // The 64-bit mode XMM load instructions may be wider than 8-bytes (our patching
@@ -334,7 +334,7 @@ TR::Register *OMR::X86::TreeEvaluator::performDload(TR::Node *node, TR::MemoryRe
    TR::Instruction *instr;
    if (cg->useSSEForDoublePrecision())
       {
-      if (TR::Compiler->target.is64Bit() &&
+      if (cg->comp()->target().is64Bit() &&
           sourceMR->getSymbolReference().isUnresolved())
          {
          // The 64-bit load instructions may be wider than 8-bytes (our patching
@@ -407,7 +407,7 @@ TR::Register *OMR::X86::TreeEvaluator::floatingPointStoreEvaluator(TR::Node *nod
       {
       if (nodeIs64Bit)
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             TR::Register *floatConstReg = cg->allocateRegister(TR_GPR);
             if (valueChild->getLongInt() == 0)
@@ -454,7 +454,7 @@ TR::Register *OMR::X86::TreeEvaluator::floatingPointStoreEvaluator(TR::Node *nod
       TR::Register *sourceRegister = cg->evaluate(valueChild);
       if (sourceRegister->getKind() == TR_FPR)
          {
-         if (TR::Compiler->target.is64Bit() &&
+         if (cg->comp()->target().is64Bit() &&
             tempMR->getSymbolReference().isUnresolved())
             {
 
@@ -513,7 +513,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpReturnEvaluator(TR::Node *node, TR::Cod
    TR_ASSERT(returnRegister, "Return node's child should evaluate to a register");
    TR::Compilation *comp = cg->comp();
 
-   if (TR::Compiler->target.is32Bit() &&
+   if (cg->comp()->target().is32Bit() &&
        !cg->useSSEForDoublePrecision() &&
        returnRegister->getKind() == TR_FPR)
       {
@@ -787,7 +787,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpRemEvaluator(TR::Node *node, TR::CodeGe
       TR::Node *divisor = node->getSecondChild();
       TR::Node *dividend = node->getFirstChild();
 
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          // TODO: We should do this for IA32 eventually
          TR::SymbolReference *helperSymRef = cg->symRefTab()->findOrCreateRuntimeHelper(nodeIsDouble ? TR_AMD64doubleRemainder : TR_AMD64floatRemainder, false, false, false);
@@ -1022,7 +1022,7 @@ TR::Register *OMR::X86::TreeEvaluator::i2dEvaluator(TR::Node *node, TR::CodeGene
 TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::SymbolReference *helperSymRef, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 has enableSSE set, so it doesn't use this logic");
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 has enableSSE set, so it doesn't use this logic");
 
    TR::Node     *child     = node->getFirstChild();
    TR::Register *accReg    = 0;
@@ -1184,7 +1184,7 @@ TR::Register *OMR::X86::TreeEvaluator::fpConvertToInt(TR::Node *node, TR::Symbol
 TR::Register *OMR::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::SymbolReference *helperSymRef, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 doesn't use this logic");
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 doesn't use this logic");
 
    TR::Node *child = node->getFirstChild();
 
@@ -1392,7 +1392,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
             TR_ASSERT(0, "Unknown opcode value in f2iEvaluator");
             break;
          }
-      TR_ASSERT(TR::Compiler->target.is64Bit() || !longTarget, "Incorrect opcode value in f2iEvaluator");
+      TR_ASSERT(cg->comp()->target().is64Bit() || !longTarget, "Incorrect opcode value in f2iEvaluator");
 
       TR::TreeEvaluator::coerceFPOperandsToXMMRs(node, cg);
 
@@ -1406,7 +1406,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
       sourceRegister = cg->evaluate(child);
       if (sourceRegister->getKind() == TR_X87 && child->getReferenceCount() == 1)
          {
-         TR_ASSERT(TR::Compiler->target.is32Bit(), "assertion failure");
+         TR_ASSERT(cg->comp()->target().is32Bit(), "assertion failure");
          TR::MemoryReference  *tempMR = cg->machine()->getDummyLocalMR(TR::Float);
          generateFPMemRegInstruction(FSTMemReg, node, tempMR, sourceRegister, cg);
          generateRegMemInstruction(CVTTSS2SIReg4Mem,
@@ -1426,7 +1426,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
 
       if (longTarget)
          {
-         TR_ASSERT(TR::Compiler->target.is64Bit(), "We should only get here on AMD64");
+         TR_ASSERT(cg->comp()->target().is64Bit(), "We should only get here on AMD64");
          // We can't compare with 0x8000000000000000.
          // Instead, rotate left 1 bit and compare with 0x0000000000000001.
          generateRegInstruction(ROL8Reg1, node, targetRegister, cg);
@@ -1483,7 +1483,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
       }
    else
       {
-      TR_ASSERT(TR::Compiler->target.is32Bit(), "assertion failure");
+      TR_ASSERT(cg->comp()->target().is32Bit(), "assertion failure");
       return TR::TreeEvaluator::fpConvertToInt(node, cg->symRefTab()->findOrCreateRuntimeHelper(node->getOpCodeValue() == TR::f2i ? TR_IA32floatToInt : TR_IA32doubleToInt, false, false, false), cg);
       }
    }
@@ -1491,7 +1491,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGene
 
 TR::Register *OMR::X86::TreeEvaluator::f2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 uses f2iEvaluator for this");
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 uses f2iEvaluator for this");
    return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32floatToLong, false, false, false), cg);
    }
 
@@ -1558,7 +1558,7 @@ TR::Register *OMR::X86::TreeEvaluator::f2cEvaluator(TR::Node *node, TR::CodeGene
 
 TR::Register *OMR::X86::TreeEvaluator::d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 uses f2iEvaluator for this");
+   TR_ASSERT(cg->comp()->target().is32Bit(), "AMD64 uses f2iEvaluator for this");
 
    return TR::TreeEvaluator::fpConvertToLong(node, cg->symRefTab()->findOrCreateRuntimeHelper(TR_IA32doubleToLong, false, false, false), cg);
    }

--- a/compiler/x/codegen/HelperCallSnippet.cpp
+++ b/compiler/x/codegen/HelperCallSnippet.cpp
@@ -131,7 +131,7 @@ TR::X86HelperCallSnippet::addMetaDataForLoadAddrArg(
        && (!child->getSymbol()->isClassObject()
            || cg()->wantToPatchClassPointer((TR_OpaqueClassBlock*)sym->getStaticAddress(), buffer)))
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          cg()->jitAddPicToPatchOnClassRedefinition(((void *) (uintptrj_t)sym->getStaticAddress()), (void *) buffer);
       else
          cg()->jitAdd32BitPicToPatchOnClassRedefinition(((void *) (uintptrj_t)sym->getStaticAddress()), (void *) buffer);
@@ -146,7 +146,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
    //
    if (_stackPointerAdjustment < -128 || _stackPointerAdjustment > 127)
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          *buffer++ = 0x48; // Rex
          }
@@ -157,7 +157,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
       }
    else if (_stackPointerAdjustment != 0)
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          *buffer++ = 0x48; // Rex
          }
@@ -169,7 +169,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
    if (_callNode)
       {
       if(!debug("amd64unimplemented"))
-         TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 genHelperCall with _callNode not yet implemented");
+         TR_ASSERT(cg()->comp()->target().is32Bit(), "AMD64 genHelperCall with _callNode not yet implemented");
       int32_t i = 0;
 
       if (_offset != -1)
@@ -266,7 +266,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
 
    // Insert alignment padding if the instruction might be patched dynamically.
    //
-   if (_alignCallDisplacementForPatching && TR::Compiler->target.isSMP())
+   if (_alignCallDisplacementForPatching && cg()->comp()->target().isSMP())
       {
       uintptrj_t mod = (uintptrj_t)(buffer) % cg()->getInstructionPatchAlignmentBoundary();
       mod = cg()->getInstructionPatchAlignmentBoundary() - mod;
@@ -298,7 +298,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
    //
    if (_stackPointerAdjustment < -128 || _stackPointerAdjustment > 127)
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          *buffer++ = 0x48; // Rex
          }
@@ -309,7 +309,7 @@ uint8_t *TR::X86HelperCallSnippet::genHelperCall(uint8_t *buffer)
       }
    else if (_stackPointerAdjustment != 0)
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg()->comp()->target().is64Bit())
          {
          *buffer++ = 0x48; // Rex
          }
@@ -342,9 +342,9 @@ TR_Debug::printBody(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet, uin
 
    if (snippet->getStackPointerAdjustment() != 0)
       {
-      uint8_t size = 5 + (TR::Compiler->target.is64Bit()? 1 : 0);
+      uint8_t size = 5 + (comp()->target().is64Bit()? 1 : 0);
       printPrefix(pOutFile, NULL, bufferPos, size);
-      trfprintf(pOutFile, "add \t%s, %d\t\t\t%s Temporarily deallocate stack frame", TR::Compiler->target.is64Bit()? "rsp":"esp", snippet->getStackPointerAdjustment(),
+      trfprintf(pOutFile, "add \t%s, %d\t\t\t%s Temporarily deallocate stack frame", comp()->target().is64Bit()? "rsp":"esp", snippet->getStackPointerAdjustment(),
                     commentString());
       bufferPos += size;
       }
@@ -415,9 +415,9 @@ TR_Debug::printBody(TR::FILE *pOutFile, TR::X86HelperCallSnippet  * snippet, uin
 
    if (snippet->getStackPointerAdjustment() != 0)
       {
-      uint8_t size = 5 + (TR::Compiler->target.is64Bit()? 1 : 0);
+      uint8_t size = 5 + (comp()->target().is64Bit()? 1 : 0);
       printPrefix(pOutFile, NULL, bufferPos, size);
-      trfprintf(pOutFile, "sub \t%s, %d\t\t\t%s Reallocate stack frame", TR::Compiler->target.is64Bit()? "rsp":"esp", snippet->getStackPointerAdjustment(),
+      trfprintf(pOutFile, "sub \t%s, %d\t\t\t%s Reallocate stack frame", comp()->target().is64Bit()? "rsp":"esp", snippet->getStackPointerAdjustment(),
                     commentString());
       bufferPos += size;
       }
@@ -474,7 +474,7 @@ uint32_t TR::X86HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
 
    // Conservatively assume that 4 NOPs might be required for alignment.
    //
-   if (_alignCallDisplacementForPatching && TR::Compiler->target.isSMP())
+   if (_alignCallDisplacementForPatching && cg()->comp()->target().isSMP())
       {
       length += 4;
       }
@@ -495,7 +495,7 @@ int32_t TR::X86HelperCallSnippet::branchDisplacementToHelper(
       {
       helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(helper->getReferenceNumber(), (void *)(callInstructionAddress+1));
 
-      TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinRIPRange(helperAddress, nextInstructionAddress),
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.isTargetWithinRIPRange(helperAddress, nextInstructionAddress),
                       "Local helper trampoline should be reachable directly");
       }
 

--- a/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
+++ b/compiler/x/codegen/IntegerMultiplyDecomposer.cpp
@@ -43,7 +43,7 @@ namespace TR { class Register; }
 // This is duplicated from TR::TreeEvaluator
 inline bool getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::Compiler->target.is64Bit() && node->getSize() > 4;
+   return cg->comp()->target().is64Bit() && node->getSize() > 4;
    }
 
 // tempRegArray is an array of temporary registers

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -109,7 +109,7 @@ namespace TR { class RegisterDependencyConditions; }
 
 TR_X86ProcessorInfo OMR::X86::CodeGenerator::_targetProcessorInfo;
 
-void TR_X86ProcessorInfo::initialize()
+void TR_X86ProcessorInfo::initialize(TR::CodeGenerator *cg)
    {
    // For now, we only convert the feature bits into a flags32_t, for easier querying.
    // To retrieve other information, the VM functions can be called directly.
@@ -206,7 +206,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    {
 
    bool supportsSSE2 = false;
-   _targetProcessorInfo.initialize();
+   _targetProcessorInfo.initialize(self());
 
    // Pick a padding table
    //

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -532,7 +532,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    int32_t arrayInitMinimumNumberOfBytes()
       {
-      if (TR::Compiler->target.is64Bit()) return 12;
+      if (OMR::X86::CodeGenerator::comp()->target().is64Bit()) return 12;
       return 8;
       }
 

--- a/compiler/x/codegen/OMRCodeGenerator.hpp
+++ b/compiler/x/codegen/OMRCodeGenerator.hpp
@@ -223,7 +223,7 @@ private:
 
    friend class OMR::X86::CodeGenerator;
 
-   void initialize();
+   void initialize(TR::CodeGenerator *cg);
 
    /**
     * @brief testFlag Ensures that the feature being tested for exists in the mask

--- a/compiler/x/codegen/OMRInstruction.cpp
+++ b/compiler/x/codegen/OMRInstruction.cpp
@@ -83,7 +83,7 @@ OMR::X86::Instruction::initialize(TR::CodeGenerator *cg, TR::RegisterDependencyC
 
 void OMR::X86::Instruction::assumeValidInstruction()
    {
-   TR_ASSERT(!(TR::Compiler->target.is64Bit() && self()->getOpCode().isIA32Only()), "Cannot use invalid AMD64 instructions");
+   TR_ASSERT(!(self()->cg()->comp()->target().is64Bit() && self()->getOpCode().isIA32Only()), "Cannot use invalid AMD64 instructions");
    }
 
 bool OMR::X86::Instruction::isRegRegMove()
@@ -345,7 +345,7 @@ OMR::X86::Instruction::rexRepeatCount()
 
 void TR_X86OpCode::trackUpperBitsOnReg(TR::Register *reg, TR::CodeGenerator *cg)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (clearsUpperBits())
          {

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -466,14 +466,14 @@ void OMR::X86::Linkage::mapIncomingParms(TR::ResolvedMethodSymbol *method)
       for (; parmCursor; parmCursor = parameterIterator.getNext())
          {
          if (!debug("amd64unimplemented"))
-         TR_ASSERT(TR::Compiler->target.is32Bit(), "Right-to-left not yet implemented on AMD64");
+         TR_ASSERT(self()->comp()->target().is32Bit(), "Right-to-left not yet implemented on AMD64");
          parmCursor->setParameterOffset(currentOffset);
          currentOffset += parmCursor->getRoundedSize();
          }
       }
    else
       {
-      TR_ASSERT(TR::Compiler->target.is32Bit(), "This code is IA32-specific");
+      TR_ASSERT(self()->comp()->target().is32Bit(), "This code is IA32-specific");
       // TODO:AMD64: This code deosn't need to support 8-byte slots; put it back the way it was
       uint8_t parmSlotShift = self()->getProperties().getParmSlotShift();
       int32_t topOfParameterArea = (method->getNumParameterSlots() << parmSlotShift) + offsetToFirstParm;
@@ -510,7 +510,7 @@ void OMR::X86::Linkage::mapSingleAutomatic(TR::AutomaticSymbol *p,
    stackIndex -= size;
    // align stack-allocated objects that don't have GC map index > 0
    // and are referenced through a register
-   if (p->isLocalObject() && TR::Compiler->target.is64Bit())
+   if (p->isLocalObject() && self()->comp()->target().is64Bit())
       {
       if (p->getGCMapIndex() == -1)
          self()->alignLocalObjectWithoutCollectedFields(stackIndex);

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -775,6 +775,12 @@ OMR::X86::Linkage::paramMovType(TR::ParameterSymbol *param)
    return self()->movType(param->getDataType());
    }
 
+TR::Environment&
+OMR::X86::Linkage::getTargetFromComp()
+   {
+   return TR::comp()->target();
+   }
+
 
 TR_X86OpCodes OMR::X86::Linkage::_movOpcodes[NumMovOperandTypes][NumMovDataTypes] =
    {

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -360,7 +360,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
          case TR::Int64:
             return TR_MovDataTypes::Int8;
          case TR::Address:
-            return TR::Compiler->target.is64Bit() ? TR_MovDataTypes::Int8 : TR_MovDataTypes::Int4;
+            return OMR::X86::Linkage::getTargetFromComp().is64Bit() ? TR_MovDataTypes::Int8 : TR_MovDataTypes::Int4;
          default:
             return Int4;
          }
@@ -373,7 +373,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
       switch(reg->getKind())
          {
          case TR_GPR:
-            return TR::Compiler->target.is64Bit() ? TR_MovDataTypes::Int8 : TR_MovDataTypes::Int4;
+            return OMR::X86::Linkage::getTargetFromComp().is64Bit() ? TR_MovDataTypes::Int8 : TR_MovDataTypes::Int4;
          case TR_FPR:
             return Float8;
          default:
@@ -384,7 +384,7 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
 
    static inline TR_X86OpCodes movOpcodes(TR_MovOperandTypes operandType, TR_MovDataTypes dataType)
       {
-      TR_ASSERT(TR::Compiler->target.is64Bit() || dataType != TR_MovDataTypes::Int8, "MOV Int8 should not occur on X86-32");
+      TR_ASSERT(OMR::X86::Linkage::getTargetFromComp().is64Bit() || dataType != TR_MovDataTypes::Int8, "MOV Int8 should not occur on X86-32");
       return _movOpcodes[operandType][dataType];
       }
 
@@ -427,6 +427,8 @@ class OMR_EXTENSIBLE Linkage : public OMR::Linkage
    virtual void setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol *method) { }
 
    private:
+
+   static TR::Environment& getTargetFromComp();
 
    static TR_X86OpCodes _movOpcodes[NumMovOperandTypes][NumMovDataTypes];
    uint8_t              _minimumFirstInstructionSize;

--- a/compiler/x/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/codegen/OMRMemoryReference.cpp
@@ -476,7 +476,7 @@ OMR::X86::MemoryReference::getStrideForNode(
       if (node->getSecondChild()->getOpCode().isLoadConst())
          {
          int32_t multiplier;
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             multiplier = (int32_t)node->getSecondChild()->getLongInt();
          else
             multiplier = node->getSecondChild()->getInt();
@@ -782,7 +782,7 @@ OMR::X86::MemoryReference::evaluate(TR::Node * node, TR::CodeGenerator * cg, TR:
          {
          //Node is already positive and zero extended
          }
-      else if (TR::Compiler->target.is64Bit())
+      else if (cg->comp()->target().is64Bit())
          {
          //Sign extension in the 64-bit case
          TR::Instruction *instr = NULL;
@@ -1324,7 +1324,7 @@ OMR::X86::MemoryReference::addMetaDataForCodeAddress(
 
             if (label != NULL)
                {
-               if (TR::Compiler->target.is64Bit())
+               if (cg->comp()->target().is64Bit())
                   {
                   // Assume the snippet is in RIP range
                   // TODO:AMD64: Would it be cleaner to have some kind of "isRelative" flag rather than "is64BitTarget"?
@@ -1576,7 +1576,7 @@ OMR::X86::MemoryReference::generateBinaryEncoding(
 
             if (label != NULL)
                {
-               if (TR::Compiler->target.is64Bit())
+               if (cg->comp()->target().is64Bit())
                   {
                   // This cast is ok because we only need the low 32 bits of the address
                   // *(int32_t *)cursor = -(int32_t)(intptrj_t)(cursor+4);
@@ -1759,7 +1759,7 @@ void rematerializeAddressAdds(
 
          if (debug("traceInstructionSelection"))
             {
-            if (TR::Compiler->target.is64Bit())
+            if (cg->comp()->target().is64Bit())
                diagnostic("\nRematerializing aladd [" POINTER_PRINTF_FORMAT "] with [" POINTER_PRINTF_FORMAT "] at [" POINTER_PRINTF_FORMAT "]",
                         tempNode, subTree, rootLoadOrStore);
             else
@@ -1841,7 +1841,7 @@ generateX86MemoryReference(TR::MemoryReference  & mr, intptrj_t n, TR::CodeGener
 TR::MemoryReference  *
 generateX86MemoryReference(TR::MemoryReference& mr, intptrj_t n, TR_ScratchRegisterManager *srm, TR::CodeGenerator *cg)
    {
-   if(TR::Compiler->target.is64Bit())
+   if(cg->comp()->target().is64Bit())
       return new (cg->trHeapMemory()) TR::MemoryReference(mr, n, cg, srm);
    else
       return new (cg->trHeapMemory()) TR::MemoryReference(mr, n, cg);

--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -57,7 +57,7 @@
 
 // TODO:AMD64: IA32 FPR GRA currently interferes XMM GRA in a somewhat
 // confusing way that doesn't occur on AMD64.
-#define XMM_GPRS_USE_DISTINCT_NUMBERS (TR::Compiler->target.is64Bit())
+#define XMM_GPRS_USE_DISTINCT_NUMBERS(cg) (cg->comp()->target().is64Bit())
 
 static void generateRegcopyDebugCounter(TR::CodeGenerator *cg, const char *category)
    {
@@ -127,7 +127,7 @@ OMR::X86::RegisterDependencyConditions::RegisterDependencyConditions(
       TR_GlobalRegisterNumber  highGlobalRegNum = child->getHighGlobalRegisterNumber();
 
       TR::RealRegister::RegNum realRegNum = TR::RealRegister::NoReg, realHighRegNum = TR::RealRegister::NoReg;
-      if (globalReg->getKind() == TR_GPR || globalReg->getKind() == TR_VRF || XMM_GPRS_USE_DISTINCT_NUMBERS)
+      if (globalReg->getKind() == TR_GPR || globalReg->getKind() == TR_VRF || XMM_GPRS_USE_DISTINCT_NUMBERS(cg))
          {
          realRegNum = (TR::RealRegister::RegNum) cg->getGlobalRegister(globalRegNum);
 

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -140,7 +140,7 @@ TR::Instruction *OMR::X86::TreeEvaluator::compareGPMemoryToImmediate(TR::Node   
    {
    // On IA32, this is called to do half of an 8-byte compare, so even though
    // the node is 64 bit, we should do a 32-bit compare
-   bool is64Bit = TR::Compiler->target.is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
+   bool is64Bit = cg->comp()->target().is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
    TR_X86OpCodes cmpOp = (value >= -128 && value <= 127) ? CMPMemImms(is64Bit) : CMPMemImm4(is64Bit);
    TR::Instruction *instr = generateMemImmInstruction(cmpOp, node, mr, value, cg);
    cg->setImplicitExceptionPoint(instr);
@@ -154,7 +154,7 @@ void OMR::X86::TreeEvaluator::compareGPRegisterToImmediate(TR::Node          *no
    {
    // On IA32, this is called to do half of an 8-byte compare, so even though
    // the node is 64 bit, we should do a 32-bit compare
-   bool is64Bit = TR::Compiler->target.is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
+   bool is64Bit = cg->comp()->target().is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
    TR_X86OpCodes cmpOp = (value >= -128 && value <= 127) ? CMPRegImms(is64Bit) : CMPRegImm4(is64Bit);
    generateRegImmInstruction(cmpOp, node, cmpRegister, value, cg);
    }
@@ -166,7 +166,7 @@ void OMR::X86::TreeEvaluator::compareGPRegisterToImmediateForEquality(TR::Node  
    {
    // On IA32, this is called to do half of an 8-byte compare, so even though
    // the node is 64 bit, we should do a 32-bit compare
-   bool is64Bit = TR::Compiler->target.is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
+   bool is64Bit = cg->comp()->target().is64Bit()? TR::TreeEvaluator::getNodeIs64Bit(node->getFirstChild(), cg) : false;
    TR_X86OpCodes cmpOp = (value >= -128 && value <= 127) ? CMPRegImms(is64Bit) : CMPRegImm4(is64Bit);
    if (value==0)
       generateRegRegInstruction(TESTRegReg(is64Bit), node, cmpRegister, cmpRegister, cg);
@@ -197,7 +197,7 @@ TR::Instruction *OMR::X86::TreeEvaluator::insertLoadConstant(TR::Node           
    bool is64Bit = false;
 
    int opsRow = type;
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (type == TR_RematerializableAddress)
          {
@@ -395,7 +395,7 @@ TR::Register *OMR::X86::TreeEvaluator::loadConstant(TR::Node * node, intptrj_t v
    if (cg->enableRematerialisation())
       {
       if (node && node->getOpCode().hasSymbolReference() && node->getSymbol() && node->getSymbol()->isClassObject())
-         (TR::Compiler->om.generateCompressedObjectHeaders() || TR::Compiler->target.is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
+         (TR::Compiler->om.generateCompressedObjectHeaders() || cg->comp()->target().is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
 
       setDiscardableIfPossible(type, targetRegister, node, instr, value, cg);
       }
@@ -425,7 +425,7 @@ OMR::X86::TreeEvaluator::insertLoadMemory(
       };
 
    TR_X86OpCodes opCode = ops[type];
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       if (type == TR_RematerializableAddress)
          {
@@ -497,7 +497,7 @@ void OMR::X86::TreeEvaluator::padUnresolvedDataReferences(
 
    TR::Compilation *comp = cg->comp();
    uint8_t padBytes = 0;
-   if (TR::Compiler->target.is32Bit())
+   if (cg->comp()->target().is32Bit())
       padBytes = 2; // needs at least 2 bytes as we are patching 8 bytes at a time
    else
       {
@@ -538,7 +538,7 @@ OMR::X86::TreeEvaluator::loadMemory(
    if (cg->enableRematerialisation())
       {
       if (node && node->getOpCode().hasSymbolReference() && node->getSymbol() && node->getSymbol()->isClassObject())
-         (TR::Compiler->om.generateCompressedObjectHeaders() || TR::Compiler->target.is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
+         (TR::Compiler->om.generateCompressedObjectHeaders() || cg->comp()->target().is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
 
       setDiscardableIfPossible(type, targetRegister, node, instr, sourceMR, cg);
       }
@@ -944,7 +944,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
            valueChild->getOpCodeValue() == TR::l2b))
          {
          valueChild = valueChild->getFirstChild();
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             translatedReg = cg->evaluate(valueChild);
          else
             translatedReg = cg->evaluate(valueChild)->getLowOrder();
@@ -1038,7 +1038,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerStoreEvaluator(TR::Node *node, TR:
                   case TR::Address:
                        {
                      if (node && node->getOpCode().hasSymbolReference() && node->getSymbol() && node->getSymbol()->isClassObject())
-                        (TR::Compiler->om.generateCompressedObjectHeaders() || TR::Compiler->target.is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
+                        (TR::Compiler->om.generateCompressedObjectHeaders() || cg->comp()->target().is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
                      else
                         type = TR_RematerializableAddress;
 
@@ -1506,7 +1506,7 @@ void OMR::X86::TreeEvaluator::genArithmeticInstructionsForOverflowCHK(TR::Node *
    TR::Node *operand2 = node->getThirdChild();
    //it is fine that nodeIs64Bit is false for long operand on 32bits platform because
    //the analyzers below don't use *op* in this case anyways
-   bool nodeIs64Bit = TR::Compiler->target.is32Bit()? false: TR::TreeEvaluator::getNodeIs64Bit(operand1, cg);
+   bool nodeIs64Bit = cg->comp()->target().is32Bit()? false: TR::TreeEvaluator::getNodeIs64Bit(operand1, cg);
    switch (node->getOverflowCheckOperation())
       {
       //add group
@@ -1542,7 +1542,7 @@ void OMR::X86::TreeEvaluator::genArithmeticInstructionsForOverflowCHK(TR::Node *
          // Therefore the usual way of only detecting the OF for the last instruction of sequence won't work for this case.
          // The implementation needs to detect OF flags after all the instructions involving higher parts of the registers for
          // both operands and intermediate results.
-         TR_ASSERT(TR::Compiler->target.is64Bit(), "overflowCHK for lmul on 32 bits is not currently supported\n");
+         TR_ASSERT(cg->comp()->target().is64Bit(), "overflowCHK for lmul on 32 bits is not currently supported\n");
          op = IMULRegReg(nodeIs64Bit);
          break;
       default:
@@ -1575,7 +1575,7 @@ void OMR::X86::TreeEvaluator::genArithmeticInstructionsForOverflowCHK(TR::Node *
             addMulAnalyser.integerAddAnalyserWithExplicitOperands(node, operand1, operand2, op, BADIA32Op, needsEflags);
             break;
          case TR::ladd:
-            TR::Compiler->target.is32Bit() ? addMulAnalyser.longAddAnalyserWithExplicitOperands(node, operand1, operand2)
+            cg->comp()->target().is32Bit() ? addMulAnalyser.longAddAnalyserWithExplicitOperands(node, operand1, operand2)
                                            : addMulAnalyser.integerAddAnalyserWithExplicitOperands(node, operand1, operand2, op, BADIA32Op, needsEflags);
             break;
          // sub group
@@ -1587,7 +1587,7 @@ void OMR::X86::TreeEvaluator::genArithmeticInstructionsForOverflowCHK(TR::Node *
             subAnalyser.integerSubtractAnalyserWithExplicitOperands(node, operand1, operand2, op, BADIA32Op, MOV4RegReg, needsEflags);
             break;
          case TR::lsub:
-            TR::Compiler->target.is32Bit() ? subAnalyser.longSubtractAnalyserWithExplicitOperands(node, operand1, operand2)
+            cg->comp()->target().is32Bit() ? subAnalyser.longSubtractAnalyserWithExplicitOperands(node, operand1, operand2)
                                            : subAnalyser.integerSubtractAnalyserWithExplicitOperands(node, operand1, operand2, op, BADIA32Op, MOV8RegReg, needsEflags);
             break;
          // mul group
@@ -2246,7 +2246,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
    bool isShortConstArrayWithDirection = false;
    bool isShortConstArrayWithoutDirection = false;
    uint32_t size;
-   if (sizeNode->getOpCode().isLoadConst() && TR::Compiler->target.is64Bit() && optimizeForConstantLengthArrayCopy)
+   if (sizeNode->getOpCode().isLoadConst() && cg->comp()->target().is64Bit() && optimizeForConstantLengthArrayCopy)
       {
       size = TR::TreeEvaluator::integerConstNodeValue(sizeNode, cg);
       if ((node->isForwardArrayCopy() || node->isBackwardArrayCopy()) && !ignoreDirectionForConstantLengthArrayCopy)
@@ -2273,11 +2273,11 @@ TR::Register *OMR::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Co
       {
       bool isSize64Bit = TR::TreeEvaluator::getNodeIs64Bit(sizeNode, cg);
       TR::Register* sizeReg = cg->gprClobberEvaluate(sizeNode, MOVRegReg(isSize64Bit));
-      if (TR::Compiler->target.is64Bit() && !isSize64Bit)
+      if (cg->comp()->target().is64Bit() && !isSize64Bit)
          {
          generateRegRegInstruction(MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
          }
-      if (elementSize == 8 && TR::Compiler->target.is32Bit())
+      if (elementSize == 8 && cg->comp()->target().is32Bit())
          {
          arrayCopy64BitPrimitiveOnIA32(node, dstReg, srcReg, sizeReg, cg);
          }
@@ -2356,16 +2356,16 @@ TR::Register *OMR::X86::TreeEvaluator::arraytranslateEvaluator(TR::Node *node, T
       TR_ASSERT(!node->isTargetByteArrayTranslate(), "Both source and target are byte for array translate");
       if (arraytranslateOT)
       {
-         helper = TR::Compiler->target.is64Bit() ? TR_AMD64arrayTranslateTROT : TR_IA32arrayTranslateTROT;
+         helper = cg->comp()->target().is64Bit() ? TR_AMD64arrayTranslateTROT : TR_IA32arrayTranslateTROT;
          dependencies->addPostCondition(termCharReg, TR::RealRegister::edx, cg);
       }
       else
-         helper = TR::Compiler->target.is64Bit() ? TR_AMD64arrayTranslateTROTNoBreak : TR_IA32arrayTranslateTROTNoBreak;
+         helper = cg->comp()->target().is64Bit() ? TR_AMD64arrayTranslateTROTNoBreak : TR_IA32arrayTranslateTROTNoBreak;
       }
    else
       {
       TR_ASSERT(node->isTargetByteArrayTranslate(), "Both source and target are word for array translate");
-      helper = TR::Compiler->target.is64Bit() ? TR_AMD64arrayTranslateTRTO : TR_IA32arrayTranslateTRTO;
+      helper = cg->comp()->target().is64Bit() ? TR_AMD64arrayTranslateTRTO : TR_IA32arrayTranslateTRTO;
       dependencies->addPostCondition(termCharReg, TR::RealRegister::edx, cg);
       }
    dependencies->stopAddingConditions();
@@ -2712,7 +2712,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
    TR::Node* valueNode    = node->getChild(1); // Value
    TR::Node* sizeNode     = node->getChild(2); // Size
 
-   TR::Register* addressReg = TR::TreeEvaluator::intOrLongClobberEvaluate(addressNode, TR::Compiler->target.is64Bit(), cg);
+   TR::Register* addressReg = TR::TreeEvaluator::intOrLongClobberEvaluate(addressNode, cg->comp()->target().is64Bit(), cg);
    uintptrj_t size;
    bool isSizeConst = false;
    bool isValueZero = false;
@@ -2721,7 +2721,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
    bool isShortConstantArrayWithZero = false;
 
    static bool isConstArraysetEnabled = (NULL == feGetEnv("TR_DisableConstArrayset"));
-   if (isConstArraysetEnabled && cg->getX86ProcessorInfo().supportsSSSE3() && TR::Compiler->target.is64Bit())
+   if (isConstArraysetEnabled && cg->getX86ProcessorInfo().supportsSSSE3() && cg->comp()->target().is64Bit())
       {
       if (valueNode->getOpCode().isLoadConst() && !valueNode->getOpCode().isFloat() && !valueNode->getOpCode().isDouble())
          {
@@ -2782,11 +2782,11 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
       TR::Register* valueReg = cg->evaluate(valueNode);
 
       // Zero-extend array size if passed in as 32-bit on 64-bit architecture
-      if (TR::Compiler->target.is64Bit() && !TR::TreeEvaluator::getNodeIs64Bit(sizeNode, cg))
+      if (cg->comp()->target().is64Bit() && !TR::TreeEvaluator::getNodeIs64Bit(sizeNode, cg))
          {
          generateRegRegInstruction(MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
          }
-      if (elementSize == 8 && TR::Compiler->target.is32Bit())
+      if (elementSize == 8 && cg->comp()->target().is32Bit())
          {
          arraySet64BitPrimitiveOnIA32(node, addressReg, valueReg, sizeReg, cg);
          }
@@ -2807,7 +2807,7 @@ TR::Register *OMR::X86::TreeEvaluator::arraysetEvaluator(TR::Node *node, TR::Cod
 bool OMR::X86::TreeEvaluator::constNodeValueIs32BitSigned(TR::Node *node, intptrj_t *value, TR::CodeGenerator *cg)
    {
    *value = TR::TreeEvaluator::integerConstNodeValue(node, cg);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       return IS_32BIT_SIGNED(*value);
       }
@@ -2830,8 +2830,8 @@ bool OMR::X86::TreeEvaluator::getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *
     * not a hinderance, because 64-bit code on IA32 uses register pairs and other
     * things that are totally different from their 32-bit counterparts.
     */
-   TR_ASSERT(TR::Compiler->target.is64Bit() || node->getSize() <= 4, "64-bit nodes on 32-bit platforms shouldn't use getNodeIs64Bit");
-   return TR::Compiler->target.is64Bit() && node->getSize() > 4;
+   TR_ASSERT(cg->comp()->target().is64Bit() || node->getSize() <= 4, "64-bit nodes on 32-bit platforms shouldn't use getNodeIs64Bit");
+   return cg->comp()->target().is64Bit() && node->getSize() > 4;
    }
 
 intptrj_t OMR::X86::TreeEvaluator::integerConstNodeValue(TR::Node *node, TR::CodeGenerator *cg)
@@ -2962,7 +2962,7 @@ static TR::Register * inlineSinglePrecisionSQRT(TR::Node *node, TR::CodeGenerato
  */
 static TR::Register* inlineAtomicMemoryUpdate(TR::Node* node, TR_X86OpCodes op, TR::CodeGenerator* cg)
    {
-   TR_ASSERT((!TR_X86OpCode(op).hasLongSource() && !TR_X86OpCode(op).hasLongTarget()) || TR::Compiler->target.is64Bit(), "64-bit instruction not supported on IA32");
+   TR_ASSERT((!TR_X86OpCode(op).hasLongSource() && !TR_X86OpCode(op).hasLongTarget()) || cg->comp()->target().is64Bit(), "64-bit instruction not supported on IA32");
    TR::Register* address = cg->evaluate(node->getChild(0));
    TR::Register* value   = cg->gprClobberEvaluate(node->getChild(1), MOVRegReg());
 
@@ -2988,7 +2988,7 @@ static TR::Register* inlineAtomicMemoryUpdate(TR::Node* node, TR_X86OpCodes op, 
  */
 static TR::Register* inline64BitAtomicCompareAndMemoryUpdateOn32Bit(TR::Node* node, bool returnValue, TR::CodeGenerator* cg)
    {
-   TR_ASSERT(TR::Compiler->target.is32Bit(), "32-bit only");
+   TR_ASSERT(cg->comp()->target().is32Bit(), "32-bit only");
    TR::Register* address  = cg->evaluate(node->getChild(0));
    TR::Register* oldvalue = cg->longClobberEvaluate(node->getChild(1));
    TR::Register* newvalue = cg->evaluate(node->getChild(2));
@@ -3037,7 +3037,7 @@ static TR::Register* inline64BitAtomicCompareAndMemoryUpdateOn32Bit(TR::Node* no
 static TR::Register* inlineAtomicCompareAndMemoryUpdate(TR::Node* node, bool returnValue, TR::CodeGenerator* cg)
    {
    bool isNode64Bit = node->getChild(1)->getDataType().isInt64();
-   if (TR::Compiler->target.is32Bit() && isNode64Bit)
+   if (cg->comp()->target().is32Bit() && isNode64Bit)
       {
       return inline64BitAtomicCompareAndMemoryUpdateOn32Bit(node, returnValue, cg);
       }
@@ -3254,7 +3254,7 @@ TR::Register *OMR::X86::TreeEvaluator::generateLEAForLoadAddr(TR::Node *node,
        TR_RematerializableTypes type;
 
        if (node && node->getOpCode().hasSymbolReference() && node->getSymbol() && node->getSymbol()->isClassObject())
-          (TR::Compiler->om.generateCompressedObjectHeaders() || TR::Compiler->target.is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
+          (TR::Compiler->om.generateCompressedObjectHeaders() || cg->comp()->target().is32Bit()) ? type = TR_RematerializableInt : type = TR_RematerializableLong;
        else
           type = TR_RematerializableAddress;
 
@@ -3272,7 +3272,7 @@ TR::Register *OMR::X86::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::Cod
    // for loadaddr, directly allocated register according to its symRef, since memRef only represents symRef
    TR::Register *targetRegister = TR::TreeEvaluator::generateLEAForLoadAddr(node, memRef, symRef, cg, false);
 
-   if (symRef->isUnresolved() && TR::Compiler->target.is32Bit())
+   if (symRef->isUnresolved() && cg->comp()->target().is32Bit())
       {
       TR::TreeEvaluator::padUnresolvedDataReferences(node, memRef->getSymbolReference(), cg);
       }
@@ -3325,7 +3325,7 @@ TR::Register *OMR::X86::TreeEvaluator::integerRegLoadEvaluator(TR::Node *node, T
    // Everything that can put a value in a global reg (iRegStore, method parameters)
    // zeroes out the upper bits.
    //
-   if (TR::Compiler->target.is64Bit() && node->getOpCodeValue()==TR::iRegLoad && performTransformation(comp, "TREE EVALUATION: setUpperBitsAreZero on iRegLoad %s\n", cg->getDebug()->getName(node)))
+   if (cg->comp()->target().is64Bit() && node->getOpCodeValue()==TR::iRegLoad && performTransformation(comp, "TREE EVALUATION: setUpperBitsAreZero on iRegLoad %s\n", cg->getDebug()->getName(node)))
       globalReg->setUpperBitsAreZero();
 
    return globalReg;
@@ -3337,7 +3337,7 @@ TR::Register *OMR::X86::TreeEvaluator::iRegStoreEvaluator(TR::Node *node, TR::Co
    TR::Node *child = node->getFirstChild();
    TR::Register *globalReg = cg->evaluate(child);
 
-   if (TR::Compiler->target.is64Bit() && node->getDataType() == TR::Int32)
+   if (cg->comp()->target().is64Bit() && node->getDataType() == TR::Int32)
       {
       // We disregard needsSignExtension here intentionally.  By always zero-extending
       // at iRegStores, we are free to setUpperBitsAreZero at every iRegLoad, and lots
@@ -3721,7 +3721,7 @@ OMR::X86::TreeEvaluator::icmpsetEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       generateRegisterDependencyConditions((uint8_t)1, (uint8_t)1, cg);
    deps->addPreCondition (compareReg, TR::RealRegister::eax, cg);
    deps->addPostCondition(compareReg, TR::RealRegister::eax, cg);
-   generateMemRegInstruction(TR::Compiler->target.isSMP() ? LCMPXCHGMemReg(nodeIs64Bit) : CMPXCHGMemReg(nodeIs64Bit), node, memRef, replaceReg, deps, cg);
+   generateMemRegInstruction(cg->comp()->target().isSMP() ? LCMPXCHGMemReg(nodeIs64Bit) : CMPXCHGMemReg(nodeIs64Bit), node, memRef, replaceReg, deps, cg);
 
    cg->stopUsingRegister(compareReg);
 

--- a/compiler/x/codegen/OMRX86Instruction.cpp
+++ b/compiler/x/codegen/OMRX86Instruction.cpp
@@ -1498,7 +1498,7 @@ void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, in
       TR::Register *indexReg = mr->getIndexRegister();
       TR::Register *addressReg = NULL;
 
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          addressReg = mr->getAddressRegister();
 
 
@@ -1527,7 +1527,7 @@ void insertUnresolvedReferenceInstructionMemoryBarrier(TR::CodeGenerator *cg, in
          addressReg = NULL;
          baseReg = anotherMr->getBaseRegister();
          indexReg = anotherMr->getIndexRegister();
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             addressReg = anotherMr->getAddressRegister();
 
          if (baseReg && baseReg->getKind() != TR_X87)
@@ -3386,7 +3386,7 @@ void TR::X86FPCompareEvalInstruction::assignRegisters(TR_RegisterKinds kindsToBe
          case TR::fcmpg:
          case TR::dcmpl:
          case TR::dcmpg:
-            TR_ASSERT(TR::Compiler->target.is32Bit(), "AMD64 doesn't support SAHF");
+            TR_ASSERT(cg()->comp()->target().is32Bit(), "AMD64 doesn't support SAHF");
             cursor = new (cg()->trHeapMemory()) TR::Instruction(SAHF, cursor, cg());
             break;
 

--- a/compiler/x/codegen/OMRX86Instruction.hpp
+++ b/compiler/x/codegen/OMRX86Instruction.hpp
@@ -1424,7 +1424,7 @@ class X86MemInstruction : public TR::Instruction
          padUnresolvedReferenceInstruction(this, mr, cg);
          }
 
-      if (!cg->comp()->getOption(TR_DisableNewX86VolatileSupport) && TR::Compiler->target.is32Bit())
+      if (!cg->comp()->getOption(TR_DisableNewX86VolatileSupport) && cg->comp()->target().is32Bit())
          {
          int32_t barrier = memoryBarrierRequired(this->getOpCode(), mr, cg, true);
 
@@ -1465,7 +1465,7 @@ class X86MemInstruction : public TR::Instruction
          padUnresolvedReferenceInstruction(this, p, cg);
          }
 
-      if (!cg->comp()->getOption(TR_DisableNewX86VolatileSupport) && TR::Compiler->target.is32Bit())
+      if (!cg->comp()->getOption(TR_DisableNewX86VolatileSupport) && cg->comp()->target().is32Bit())
          {
          int32_t barrier = memoryBarrierRequired(this->getOpCode(), p, cg, true);
 
@@ -1898,7 +1898,7 @@ class X86RegMemInstruction : public TR::X86RegInstruction
          padUnresolvedReferenceInstruction(this, p, cg);
          }
 
-      if (!cg->comp()->getOption(TR_DisableNewX86VolatileSupport) && TR::Compiler->target.is32Bit())
+      if (!cg->comp()->getOption(TR_DisableNewX86VolatileSupport) && cg->comp()->target().is32Bit())
          {
          int32_t barrier = memoryBarrierRequired(this->getOpCode(), p, cg, true);
 

--- a/compiler/x/codegen/SIMDTreeEvaluator.cpp
+++ b/compiler/x/codegen/SIMDTreeEvaluator.cpp
@@ -138,7 +138,7 @@ TR::Register* OMR::X86::TreeEvaluator::SIMDsplatsEvaluator(TR::Node* node, TR::C
          generateRegRegImmInstruction(PSHUFDRegRegImm1, node, resultReg, resultReg, 0x00, cg); // 00 00 00 00 shuffle xxxA to AAAA
          break;
       case TR::VectorInt64:
-         if (TR::Compiler->target.is32Bit())
+         if (cg->comp()->target().is32Bit())
             {
             TR::Register* tempVectorReg = cg->allocateRegister(TR_VRF);
             generateRegRegInstruction(MOVDRegReg4, node, tempVectorReg, childReg->getHighOrder(), cg);
@@ -194,7 +194,7 @@ TR::Register* OMR::X86::TreeEvaluator::SIMDgetvelemEvaluator(TR::Node* node, TR:
          break;
       case TR::VectorInt64:
          elementCount = 2;
-         if (TR::Compiler->target.is32Bit())
+         if (cg->comp()->target().is32Bit())
             {
             lowResReg = cg->allocateRegister();
             highResReg = cg->allocateRegister();
@@ -302,7 +302,7 @@ TR::Register* OMR::X86::TreeEvaluator::SIMDgetvelemEvaluator(TR::Node* node, TR:
 
          if (TR::VectorInt64 == firstChild->getDataType())
             {
-            if (TR::Compiler->target.is32Bit())
+            if (cg->comp()->target().is32Bit())
                {
                generateRegRegInstruction(MOVDReg4Reg, node, lowResReg, dstReg, cg);
                generateRegRegImmInstruction(PSHUFDRegRegImm1, node, dstReg, srcVectorReg, (0 == elem) ? 0x03 : 0x01, cg);

--- a/compiler/x/codegen/SubtractAnalyser.cpp
+++ b/compiler/x/codegen/SubtractAnalyser.cpp
@@ -236,7 +236,8 @@ TR::Register* TR_X86SubtractAnalyser::integerSubtractAnalyserImpl(TR::Node     *
 //
 static bool isVolatileMemoryOperand(TR::Node *node)
    {
-   if (TR::Compiler->target.isSMP() && node->getOpCode().isMemoryReference())
+   TR::Compilation *comp = TR::comp();
+   if (comp->target().isSMP() && node->getOpCode().isMemoryReference())
       {
       TR_ASSERT(node->getSymbolReference(), "expecting a symbol reference\n");
       TR::Symbol *sym = node->getSymbolReference()->getSymbol();

--- a/compiler/x/codegen/X86Debug.cpp
+++ b/compiler/x/codegen/X86Debug.cpp
@@ -860,7 +860,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86ImmSymInstruction  * instr)
    intptr_t targetAddress = 0;
 
    //  64 bit always gets the targetAddress from the symRef
-   if(TR::Compiler->target.is64Bit())
+   if(_comp->target().is64Bit())
       {
       // new code patching might have a call to a snippet label, which is not a method
       if(!sym->isLabel())
@@ -1475,7 +1475,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
       "dword",    // TR_FloatReg
       "qword" };  // TR_DoubleReg
 
-   TR_RegisterSizes addressSize = (TR::Compiler->target.cpu.isAMD64() ? TR_DoubleWordReg : TR_WordReg);
+   TR_RegisterSizes addressSize = (_comp->target().cpu.isAMD64() ? TR_DoubleWordReg : TR_WordReg);
    bool hasTerm = false;
    bool hasPrecedingTerm = false;
    trfprintf(pOutFile, "%s ptr [", typeSpecifier[operandSize]);
@@ -1556,14 +1556,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::MemoryReference  * mr, TR_RegisterSizes 
          if (disp)
             {
             trfprintf(pOutFile, " : ");
-            printHexConstant(pOutFile, disp, TR::Compiler->target.is64Bit() ? 16 : 8, false);
+            printHexConstant(pOutFile, disp, _comp->target().is64Bit() ? 16 : 8, false);
             }
          }
       else if (disp)
          {
          printHexConstant(pOutFile,
-                          TR::Compiler->target.is64Bit() ? disp : (uint32_t)disp,
-                          TR::Compiler->target.is64Bit() ? 16 : 8,
+                          _comp->target().is64Bit() ? disp : (uint32_t)disp,
+                          _comp->target().is64Bit() ? 16 : 8,
                           true);
          }
       else if (cds)
@@ -1632,8 +1632,8 @@ int32_t
 TR_Debug::printHexConstant(TR::FILE *pOutFile, int64_t value, int8_t width, bool padWithZeros)
    {
    // we probably need to revisit generateMasmListingSyntax
-   const char *prefix = TR::Compiler->target.isLinux() ? "0x" : (_cg->generateMasmListingSyntax() ? "0" : "0x");
-   const char *suffix = TR::Compiler->target.isLinux() ? "" : (_cg->generateMasmListingSyntax() ? "h" : "");
+   const char *prefix = _comp->target().isLinux() ? "0x" : (_cg->generateMasmListingSyntax() ? "0" : "0x");
+   const char *suffix = _comp->target().isLinux() ? "" : (_cg->generateMasmListingSyntax() ? "h" : "");
 
    if (padWithZeros)
       trfprintf(pOutFile, "%s%0*llx%s", prefix, width, value, suffix);
@@ -2169,7 +2169,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::X86CallSnippet  * snippet)
 
    printSnippetLabel(pOutFile, snippet->getSnippetLabel(), bufferPos, getName(snippet));
 
-   if (TR::Compiler->target.is64Bit())
+   if (_comp->target().is64Bit())
       {
       int32_t   count;
       int32_t   size = 0;
@@ -2407,7 +2407,7 @@ TR_Debug::getOpCodeName(TR_X86OpCode  * opCode)
 const char *
 TR_Debug::getMnemonicName(TR_X86OpCode  * opCode)
    {
-   if (TR::Compiler->target.isLinux())
+   if (_comp->target().isLinux())
       {
       int32_t o = opCode->getOpCodeValue();
       if (o == (int32_t) DQImm64) return dqString();

--- a/compiler/x/codegen/X86FPConversionSnippet.cpp
+++ b/compiler/x/codegen/X86FPConversionSnippet.cpp
@@ -67,7 +67,7 @@ uint8_t *TR::X86FPConversionSnippet::emitCallToConversionHelper(uint8_t *buffer)
       {
       helperAddress = TR::CodeCacheManager::instance()->findHelperTrampoline(getHelperSymRef()->getReferenceNumber(), (void *)buffer);
 
-      TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinRIPRange(helperAddress, nextInstructionAddress),
+      TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinRIPRange(helperAddress, nextInstructionAddress),
                       "Local helper trampoline must be reachable directly");
       }
    *(int32_t *)buffer = (int32_t)(helperAddress - nextInstructionAddress);

--- a/compiler/x/codegen/X86SystemLinkage.cpp
+++ b/compiler/x/codegen/X86SystemLinkage.cpp
@@ -516,7 +516,7 @@ TR::X86SystemLinkage::createPrologue(TR::Instruction *cursor)
 
    // Allocate the stack frame
    //
-   const int32_t singleWordSize = TR::Compiler->target.is32Bit() ? 4 : 8;
+   const int32_t singleWordSize = cg()->comp()->target().is32Bit() ? 4 : 8;
    if (allocSize == 0)
       {
       // No need to do anything
@@ -706,7 +706,7 @@ TR::X86SystemLinkage::createEpilogue(TR::Instruction *cursor)
 
    // Deallocate the stack frame
    //
-   const int32_t singleWordSize = TR::Compiler->target.is32Bit() ? 4 : 8;
+   const int32_t singleWordSize = comp()->target().is32Bit() ? 4 : 8;
    if (_properties.getAlwaysDedicateFramePointerRegister())
       {
       // Restore stack pointer from frame pointer
@@ -875,7 +875,7 @@ TR::X86SystemLinkage::layoutTypeOnStack(
          dataCursor += 8;
          break;
       case TR::Address:
-         dataCursor += TR::Compiler->target.is32Bit() ? 4 : 8;
+         dataCursor += comp()->target().is32Bit() ? 4 : 8;
          break;
       case TR::Aggregate:
       default:

--- a/compiler/x/i386/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/i386/codegen/OMRCodeGenerator.cpp
@@ -74,7 +74,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
    self()->setSupportsDoubleWordCAS();
    self()->setSupportsDoubleWordSet();
 
-   if (TR::Compiler->target.isWindows())
+   if (self()->comp()->target().isWindows())
       {
       if (self()->comp()->getOption(TR_DisableTraps))
          {
@@ -92,7 +92,7 @@ OMR::X86::I386::CodeGenerator::CodeGenerator() :
       self()->setJNILinkageCalleeCleanup();
       self()->setRealVMThreadRegister(self()->machine()->getRealRegister(TR::RealRegister::ebp));
       }
-   else if (TR::Compiler->target.isLinux())
+   else if (self()->comp()->target().isLinux())
       {
       if (self()->comp()->getOption(TR_DisableTraps))
          {

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -490,7 +490,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
                generateRegRegInstruction(MOV4RegReg, node, ecxReg, valueReg->getHighOrder(), cg);
 
                TR::MemoryReference  *cmpxchgMR = generateX86MemoryReference(node, cg);
-               generateMemInstruction (TR::Compiler->target.isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, cmpxchgMR, deps, cg);
+               generateMemInstruction (cg->comp()->target().isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, cmpxchgMR, deps, cg);
 
                cg->stopUsingRegister(eaxReg);
                cg->stopUsingRegister(edxReg);
@@ -498,7 +498,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
                cg->stopUsingRegister(ebxReg);
                }
             }
-         else if(symRef && symRef->isUnresolved() && symRef->getSymbol()->isVolatile() && (!comp->getOption(TR_DisableNewX86VolatileSupport) && TR::Compiler->target.is32Bit()) )
+         else if(symRef && symRef->isUnresolved() && symRef->getSymbol()->isVolatile() && (!comp->getOption(TR_DisableNewX86VolatileSupport) && cg->comp()->target().is32Bit()) )
             {
             TR_ASSERT( cg->getX86ProcessorInfo().supportsCMPXCHG8BInstruction(), "Assumption of support of the CMPXCHG8B instruction failed in lstoreEvaluator()" );
             eaxReg = cg->allocateRegister();
@@ -527,7 +527,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::lstoreEvaluator(TR::Node *node, TR:
             highMR->setProcessAsLongVolatileHigh();
 
             TR::MemoryReference  *cmpxchgMR = generateX86MemoryReference(node, cg);
-            generateMemInstruction (TR::Compiler->target.isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, cmpxchgMR, deps, cg);
+            generateMemInstruction (cg->comp()->target().isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, cmpxchgMR, deps, cg);
 
             cg->stopUsingRegister(eaxReg);
             cg->stopUsingRegister(edxReg);
@@ -3169,7 +3169,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::performLload(TR::Node *node, TR::Me
 
          generateRegRegInstruction (MOV4RegReg, node, ecxReg, highRegister, cg);
          generateRegRegInstruction (MOV4RegReg, node, ebxReg, lowRegister, cg);
-         generateMemInstruction ( TR::Compiler->target.isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, sourceMR, deps, cg);
+         generateMemInstruction ( cg->comp()->target().isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, sourceMR, deps, cg);
 
          cg->stopUsingRegister(ecxReg);
          cg->stopUsingRegister(ebxReg);
@@ -3756,7 +3756,7 @@ OMR::X86::I386::TreeEvaluator::lcmpsetEvaluator(TR::Node *node, TR::CodeGenerato
    deps->addPostCondition(compareReg->getLowOrder(),  TR::RealRegister::eax, cg);
    deps->addPostCondition(replaceReg->getHighOrder(), TR::RealRegister::ecx, cg);
    deps->addPostCondition(replaceReg->getLowOrder(),  TR::RealRegister::ebx, cg);
-   generateMemInstruction(TR::Compiler->target.isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, memRef, deps, cg);
+   generateMemInstruction(cg->comp()->target().isSMP() ? LCMPXCHG8BMem : CMPXCHG8BMem, node, memRef, deps, cg);
 
    cg->stopUsingRegister(compareReg);
 

--- a/compiler/z/codegen/BinaryAnalyser.cpp
+++ b/compiler/z/codegen/BinaryAnalyser.cpp
@@ -172,7 +172,7 @@ TR_S390BinaryAnalyser::genericAnalyser(TR::Node * root,
 
       bool done = false;
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+      if (cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
          {
          if (getBinaryReg3Reg2() || secondRegister != NULL)
             {
@@ -311,7 +311,7 @@ TR_S390BinaryAnalyser::longSubtractAnalyser(TR::Node * root)
    /**  Attempt to use SGH to subtract halfword (64 <- 16).
     * The second child is a halfword from memory */
    bool is16BitMemory2Operand = false;
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14) &&
+   if (cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z14) &&
        secondChild->getOpCodeValue() == TR::s2l &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
        secondChild->isSingleRefUnevaluated() &&

--- a/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
+++ b/compiler/z/codegen/BinaryCommutativeAnalyser.cpp
@@ -212,7 +212,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
           }
       }
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg()->comp()->target().is64Bit())
       {
       if (firstChild->getOpCodeValue() == TR::l2i && firstChild->getReferenceCount() == 1 &&
           firstChild->getRegister() == NULL && nonClobberingDestination)
@@ -246,7 +246,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
    bool isLoadNodeNested = false;
 
    // TODO: add MH and MHY here; outside of the z14 if check.
-   if(TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14))
+   if(cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z14))
       {
       bool isSetReg2Mem1 = false;
 
@@ -340,7 +340,7 @@ TR_S390BinaryCommutativeAnalyser::genericAnalyser(TR::Node * root, TR::InstOpCod
          }
       else
          {
-         if(TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14))
+         if(cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z14))
             {
             // Check for multiplications on z14
             TR::InstOpCode::Mnemonic z14OpCode = TR::InstOpCode::BAD;
@@ -666,9 +666,9 @@ bool
 TR_S390BinaryCommutativeAnalyser::conversionIsRemoved(TR::Node * root, TR::Node * &child)
    {
    if (((root->getDataType() == TR::Int64 && child->getOpCodeValue() == TR::a2l &&
-         TR::Compiler->target.is64Bit()) ||
+         cg()->comp()->target().is64Bit()) ||
         (root->getDataType() == TR::Int32 && child->getOpCodeValue() == TR::a2i &&
-       TR::Compiler->target.is32Bit()))  &&
+       cg()->comp()->target().is32Bit()))  &&
        child->getFirstChild()->getOpCodeValue() == TR::aloadi &&
        child->getFirstChild()->getRegister() == NULL &&
        child->getFirstChild()->getReferenceCount() == 1 &&
@@ -739,7 +739,7 @@ TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOp
       }
 
    /**  Attempt to use AGH to add halfworf from memory */
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14) &&
+   if (cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z14) &&
        secondChild->getOpCodeValue() == TR::s2l &&
        secondChild->getFirstChild()->getOpCodeValue() == TR::sloadi &&
        secondChild->isSingleRefUnevaluated() &&
@@ -791,7 +791,7 @@ TR_S390BinaryCommutativeAnalyser::integerAddAnalyser(TR::Node * root, TR::InstOp
       TR::Register * tempReg = root->setRegister(allocateAddSubRegister(root, firstRegister));
       bool done = false;
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+      if (cg()->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
          {
          if (regToRegOpCode == TR::InstOpCode::AR)
             {

--- a/compiler/z/codegen/CallSnippet.cpp
+++ b/compiler/z/codegen/CallSnippet.cpp
@@ -96,7 +96,7 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
          case TR::Int32:
             if (!rightToLeft)
                {
-               offset -= TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset -= cg->comp()->target().is64Bit() ? 8 : 4;
                }
             if (intArgNum < linkage->getNumIntegerArgumentRegisters())
                {
@@ -107,13 +107,13 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
 
             if (rightToLeft)
                {
-               offset += TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset += cg->comp()->target().is64Bit() ? 8 : 4;
                }
             break;
          case TR::Address:
             if (!rightToLeft)
                {
-               offset -= TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset -= cg->comp()->target().is64Bit() ? 8 : 4;
                }
             if (intArgNum < linkage->getNumIntegerArgumentRegisters())
                {
@@ -124,18 +124,18 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
 
             if (rightToLeft)
                {
-               offset += TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset += cg->comp()->target().is64Bit() ? 8 : 4;
                }
             break;
 
          case TR::Int64:
             if (!rightToLeft)
                {
-               offset -= (TR::Compiler->target.is64Bit() ? 16 : 8);
+               offset -= (cg->comp()->target().is64Bit() ? 16 : 8);
                }
             if (intArgNum < linkage->getNumIntegerArgumentRegisters())
                {
-               if (TR::Compiler->target.is64Bit())
+               if (cg->comp()->target().is64Bit())
                   {
                   buffer = storeArgumentItem(TR::InstOpCode::STG, buffer,
                               machine->getRealRegister(linkage->getIntegerArgumentRegister(intArgNum)), offset, cg);
@@ -151,17 +151,17 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
                      }
                   }
                }
-            intArgNum += TR::Compiler->target.is64Bit() ? 1 : 2;
+            intArgNum += cg->comp()->target().is64Bit() ? 1 : 2;
             if (rightToLeft)
                {
-               offset += TR::Compiler->target.is64Bit() ? 16 : 8;
+               offset += cg->comp()->target().is64Bit() ? 16 : 8;
                }
             break;
 
          case TR::Float:
             if (!rightToLeft)
                {
-               offset -= TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset -= cg->comp()->target().is64Bit() ? 8 : 4;
                }
             if (floatArgNum < linkage->getNumFloatArgumentRegisters())
                {
@@ -171,14 +171,14 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
             floatArgNum++;
             if (rightToLeft)
                {
-               offset += TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset += cg->comp()->target().is64Bit() ? 8 : 4;
                }
             break;
 
          case TR::Double:
             if (!rightToLeft)
                {
-               offset -= TR::Compiler->target.is64Bit() ? 16 : 8;
+               offset -= cg->comp()->target().is64Bit() ? 16 : 8;
                }
             if (floatArgNum < linkage->getNumFloatArgumentRegisters())
                {
@@ -188,7 +188,7 @@ TR::S390CallSnippet::S390flushArgumentsToStack(uint8_t * buffer, TR::Node * call
             floatArgNum++;
             if (rightToLeft)
                {
-               offset += TR::Compiler->target.is64Bit() ? 16 : 8;
+               offset += cg->comp()->target().is64Bit() ? 16 : 8;
                }
             break;
          }
@@ -232,12 +232,12 @@ TR::S390CallSnippet::instructionCountForArguments(TR::Node * callNode, TR::CodeG
             if (intArgNum < linkage->getNumIntegerArgumentRegisters())
                {
                count += TR::InstOpCode::getInstructionLength(TR::InstOpCode::getLoadOpCode());
-               if ((TR::Compiler->target.is32Bit()) && intArgNum < linkage->getNumIntegerArgumentRegisters() - 1)
+               if ((cg->comp()->target().is32Bit()) && intArgNum < linkage->getNumIntegerArgumentRegisters() - 1)
                   {
                   count += TR::InstOpCode::getInstructionLength(TR::InstOpCode::getLoadOpCode());
                   }
                }
-            intArgNum += TR::Compiler->target.is64Bit() ? 1 : 2;
+            intArgNum += cg->comp()->target().is64Bit() ? 1 : 2;
             break;
          case TR::Float:
             if (floatArgNum < linkage->getNumFloatArgumentRegisters())
@@ -305,7 +305,7 @@ TR::S390CallSnippet::getHelper(TR::MethodSymbol * methodSymbol, TR::DataType typ
             break;
 
          case TR::Address:
-            if (TR::Compiler->target.is64Bit())
+            if (cg->comp()->target().is64Bit())
                {
                if (synchronised)
                   {
@@ -492,7 +492,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390CallSnippet * snippet)
                   }
                break;
             case TR::Address:
-            if (TR::Compiler->target.is64Bit())
+            if (_comp->target().is64Bit())
                {
                if (synchronised)
                   {
@@ -559,14 +559,14 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390CallSnippet * snippet)
 
    if (snippet->getKind() == TR::Snippet::IsUnresolvedCall)
       {
-      int lengthOfLoad = (TR::Compiler->target.is64Bit())?6:4;
+      int lengthOfLoad = (_comp->target().is64Bit())?6:4;
 
       printPrefix(pOutFile, NULL, bufferPos, 6);
       trfprintf(pOutFile, "LARL \tGPR14, *+%d <%p>\t# Start of Data Const.",
                         8 + lengthOfLoad + padbytes,
                         bufferPos + 8 + lengthOfLoad + padbytes);
       bufferPos += 6;
-      if (TR::Compiler->target.is64Bit())
+      if (_comp->target().is64Bit())
          {
          printPrefix(pOutFile, NULL, bufferPos, 6);
          trfprintf(pOutFile, "LG  \tGPR_EP, 0(,GPR14)");

--- a/compiler/z/codegen/ConstantDataSnippet.cpp
+++ b/compiler/z/codegen/ConstantDataSnippet.cpp
@@ -164,7 +164,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
 
       case TR_HelperAddress:
          AOTcgDiag1(comp, "add TR_AbsoluteHelperAddress cursor=%x\n", cursor);
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor), TR_AbsoluteHelperAddress, cg()),
                                 __FILE__, __LINE__, getNode());
@@ -179,7 +179,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
       case TR_AbsoluteMethodAddress:
       case TR_BodyInfoAddress:
          AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             {
             cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor, (uint8_t *) *((uint64_t*) cursor),
                   (TR_ExternalRelocationTargetKind) reloType, cg()),
@@ -226,7 +226,7 @@ TR::S390ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
             uint8_t * targetAdress2 = NULL;
             if (getNode()->getOpCodeValue() != TR::aconst)
                {
-               if (TR::Compiler->target.is64Bit())
+               if (cg()->comp()->target().is64Bit())
                   targetAdress2 = (uint8_t *) *((uint64_t*) cursor);
                else
                   targetAdress2 = (uint8_t *) *((uintptrj_t*) cursor);

--- a/compiler/z/codegen/FPTreeEvaluator.cpp
+++ b/compiler/z/codegen/FPTreeEvaluator.cpp
@@ -71,7 +71,7 @@
 
 static TR::InstOpCode::Mnemonic getIntToFloatLogicalConversion(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic convertOpCode)
    {
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       switch(convertOpCode)
          {
@@ -112,7 +112,7 @@ static TR::InstOpCode::Mnemonic getIntToFloatLogicalConversion(TR::CodeGenerator
  */
 static TR::InstOpCode::Mnemonic getFloatToIntLogicalConversion(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic convertOpCode)
    {
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       switch(convertOpCode)
          {
@@ -185,11 +185,11 @@ unaryEvaluator(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic
 inline void
 genLogicalConversionForInt(TR::Node * node, TR::CodeGenerator * cg, TR::Register * targetRegister, int8_t shift_amount)
    {
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::zEC12))
       {
       generateRIEInstruction(cg, TR::InstOpCode::RISBGN, node, targetRegister, targetRegister, shift_amount, (int8_t)(63|0x80), 0);
       }
-   else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+   else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
       {
       generateRIEInstruction(cg, TR::InstOpCode::RISBG, node, targetRegister, targetRegister, shift_amount, (int8_t)(63|0x80), 0);
       }
@@ -1071,7 +1071,7 @@ OMR::Z::TreeEvaluator::ibits2fEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * targetReg = cg->allocateRegister(TR_FPR);
    TR::Register * sourceReg;
    sourceReg = cg->evaluate(firstChild);
-   if (TR::Compiler->target.cpu.getSupportsFloatingPointExtensionFacility() && !disabled)
+   if (cg->comp()->target().cpu.getSupportsFloatingPointExtensionFacility() && !disabled)
       {
       TR::Register *tempreg;
       tempreg = cg->allocateRegister();
@@ -1112,7 +1112,7 @@ OMR::Z::TreeEvaluator::lbits2dEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * sourceReg;
    TR::Node * firstChild = node->getFirstChild();
    TR::Compilation *comp = cg->comp();
-   if((TR::Compiler->target.cpu.getSupportsFloatingPointExtensionFacility()) && (!disabled))
+   if((cg->comp()->target().cpu.getSupportsFloatingPointExtensionFacility()) && (!disabled))
       {
       sourceReg = cg->evaluate(firstChild);
       TR::Register * targetReg = cg->allocateRegister(TR_FPR);
@@ -1175,7 +1175,7 @@ l2dHelper64(TR::Node * node, TR::CodeGenerator * cg)
    TR::Register * longRegister = cg->evaluate(firstChild);
    TR::Register * targetFloatRegister = cg->allocateRegister(TR_FPR);
 
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196) && node->getOpCodeValue() == TR::lu2d)
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196) && node->getOpCodeValue() == TR::lu2d)
       {
       generateRRFInstruction(cg, TR::InstOpCode::CDLGBR, node, targetFloatRegister, longRegister, (uint8_t)0x0, (uint8_t)0x0);
       cg->decReferenceCount(firstChild);

--- a/compiler/z/codegen/InstOpCode.cpp
+++ b/compiler/z/codegen/InstOpCode.cpp
@@ -301,252 +301,252 @@ OMR::Z::InstOpCode::getEquivalentLongDisplacementMnemonic(TR::InstOpCode::Mnemon
    }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadOnConditionRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LOCGR : TR::InstOpCode::LOCR; }
+OMR::Z::InstOpCode::getLoadOnConditionRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LOCGR : TR::InstOpCode::LOCR; }
 
 TR::InstOpCode::Mnemonic
 OMR::Z::InstOpCode::getLoadAddressOpCode() { return 0 ? TR::InstOpCode::LAE : TR::InstOpCode::LA; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LG : TR::InstOpCode::L; }
+OMR::Z::InstOpCode::getLoadOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LG : TR::InstOpCode::L; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadAndMaskOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LZRG : TR::InstOpCode::LZRF; }
+OMR::Z::InstOpCode::getLoadAndMaskOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LZRG : TR::InstOpCode::LZRF; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getExtendedLoadOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LG : TR::InstOpCode::LY; }
+OMR::Z::InstOpCode::getExtendedLoadOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LG : TR::InstOpCode::LY; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR; }
+OMR::Z::InstOpCode::getLoadRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadTestRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LTGR : TR::InstOpCode::LTR; }
+OMR::Z::InstOpCode::getLoadTestRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LTGR : TR::InstOpCode::LTR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadComplementOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LCGR : TR::InstOpCode::LCR; }
+OMR::Z::InstOpCode::getLoadComplementOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LCGR : TR::InstOpCode::LCR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadHalfWordOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGH : TR::InstOpCode::LH; }
+OMR::Z::InstOpCode::getLoadHalfWordOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LGH : TR::InstOpCode::LH; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadHalfWordImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI; }
+OMR::Z::InstOpCode::getLoadHalfWordImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LGHI : TR::InstOpCode::LHI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadPositiveOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LPGR : TR::InstOpCode::LPR; }
+OMR::Z::InstOpCode::getLoadPositiveOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LPGR : TR::InstOpCode::LPR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadMultipleOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LMG : TR::InstOpCode::LM; }
+OMR::Z::InstOpCode::getLoadMultipleOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LMG : TR::InstOpCode::LM; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadNegativeOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LNGR : TR::InstOpCode::LNR; }
+OMR::Z::InstOpCode::getLoadNegativeOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LNGR : TR::InstOpCode::LNR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadAndTrapOpCode() { return TR::Compiler->target.is64Bit()? TR::InstOpCode::LGAT : TR::InstOpCode::LAT; }
+OMR::Z::InstOpCode::getLoadAndTrapOpCode() { return TR::comp()->target().is64Bit()? TR::InstOpCode::LGAT : TR::InstOpCode::LAT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getExtendedStoreOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::STG : TR::InstOpCode::STY; }
+OMR::Z::InstOpCode::getExtendedStoreOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::STG : TR::InstOpCode::STY; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getStoreOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::STG : TR::InstOpCode::ST; }
+OMR::Z::InstOpCode::getStoreOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::STG : TR::InstOpCode::ST; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getStoreMultipleOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::STMG : TR::InstOpCode::STM; }
+OMR::Z::InstOpCode::getStoreMultipleOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::STMG : TR::InstOpCode::STM; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpHalfWordImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGHI : TR::InstOpCode::CHI; }
+OMR::Z::InstOpCode::getCmpHalfWordImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGHI : TR::InstOpCode::CHI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpHalfWordImmToMemOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGHSI : TR::InstOpCode::CHSI; }
+OMR::Z::InstOpCode::getCmpHalfWordImmToMemOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGHSI : TR::InstOpCode::CHSI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAndRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::NGR : TR::InstOpCode::NR; }
+OMR::Z::InstOpCode::getAndRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::NGR : TR::InstOpCode::NR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAndOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::NG : TR::InstOpCode::N; }
+OMR::Z::InstOpCode::getAndOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::NG : TR::InstOpCode::N; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getBranchOnCountOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::BCTG : TR::InstOpCode::BCT; }
+OMR::Z::InstOpCode::getBranchOnCountOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::BCTG : TR::InstOpCode::BCT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AG : TR::InstOpCode::A; }
+OMR::Z::InstOpCode::getAddOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AG : TR::InstOpCode::A; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGR : TR::InstOpCode::AR; }
+OMR::Z::InstOpCode::getAddRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AGR : TR::InstOpCode::AR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGRK : TR::InstOpCode::ARK; }
+OMR::Z::InstOpCode::getAddThreeRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AGRK : TR::InstOpCode::ARK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddLogicalThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGRK : TR::InstOpCode::ALRK; }
+OMR::Z::InstOpCode::getAddLogicalThreeRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::ALGRK : TR::InstOpCode::ALRK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddLogicalImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGFI : TR::InstOpCode::ALFI; }
+OMR::Z::InstOpCode::getAddLogicalImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::ALGFI : TR::InstOpCode::ALFI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddLogicalRegRegImmediateOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGHSIK : TR::InstOpCode::ALHSIK; }
+OMR::Z::InstOpCode::getAddLogicalRegRegImmediateOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::ALGHSIK : TR::InstOpCode::ALHSIK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubstractOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SG : TR::InstOpCode::S; }
+OMR::Z::InstOpCode::getSubstractOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SG : TR::InstOpCode::S; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubstractRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SGR : TR::InstOpCode::SR; }
+OMR::Z::InstOpCode::getSubstractRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SGR : TR::InstOpCode::SR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubtractThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SGRK : TR::InstOpCode::SRK; }
+OMR::Z::InstOpCode::getSubtractThreeRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SGRK : TR::InstOpCode::SRK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubtractLogicalThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SLGRK : TR::InstOpCode::SLRK; }
+OMR::Z::InstOpCode::getSubtractLogicalThreeRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SLGRK : TR::InstOpCode::SLRK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubtractLogicalImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SLGFI : TR::InstOpCode::SLFI; }
+OMR::Z::InstOpCode::getSubtractLogicalImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SLGFI : TR::InstOpCode::SLFI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getMultiplySingleOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::MSG : TR::InstOpCode::MS; }
+OMR::Z::InstOpCode::getMultiplySingleOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::MSG : TR::InstOpCode::MS; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getMultiplySingleRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::MSGR : TR::InstOpCode::MSR; }
+OMR::Z::InstOpCode::getMultiplySingleRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::MSGR : TR::InstOpCode::MSR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getOrOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::OG : TR::InstOpCode::O; }
+OMR::Z::InstOpCode::getOrOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::OG : TR::InstOpCode::O; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getOrRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::OGR : TR::InstOpCode::OR; }
+OMR::Z::InstOpCode::getOrRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::OGR : TR::InstOpCode::OR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getOrThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::OGRK : TR::InstOpCode::ORK; }
+OMR::Z::InstOpCode::getOrThreeRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::OGRK : TR::InstOpCode::ORK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getXOROpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::XG : TR::InstOpCode::X; }
+OMR::Z::InstOpCode::getXOROpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::XG : TR::InstOpCode::X; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getXORRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::XGR : TR::InstOpCode::XR; }
+OMR::Z::InstOpCode::getXORRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::XGR : TR::InstOpCode::XR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getXORThreeRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::XGRK : TR::InstOpCode::XRK; }
+OMR::Z::InstOpCode::getXORThreeRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::XGRK : TR::InstOpCode::XRK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGRT : TR::InstOpCode::CRT; }
+OMR::Z::InstOpCode::getCmpTrapOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGRT : TR::InstOpCode::CRT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGFI : TR::InstOpCode::CFI; }
+OMR::Z::InstOpCode::getCmpImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGFI : TR::InstOpCode::CFI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpImmTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGIT : TR::InstOpCode::CIT; }
+OMR::Z::InstOpCode::getCmpImmTrapOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGIT : TR::InstOpCode::CIT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpImmBranchRelOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGIJ : TR::InstOpCode::CIJ; }
+OMR::Z::InstOpCode::getCmpImmBranchRelOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGIJ : TR::InstOpCode::CIJ; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGRT : TR::InstOpCode::CLRT; }
+OMR::Z::InstOpCode::getCmpLogicalTrapOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLGRT : TR::InstOpCode::CLRT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalImmTrapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGIT : TR::InstOpCode::CLFIT; }
+OMR::Z::InstOpCode::getCmpLogicalImmTrapOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLGIT : TR::InstOpCode::CLFIT; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CG : TR::InstOpCode::C; }
+OMR::Z::InstOpCode::getCmpOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CG : TR::InstOpCode::C; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGR : TR::InstOpCode::CR; }
+OMR::Z::InstOpCode::getCmpRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGR : TR::InstOpCode::CR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLG : TR::InstOpCode::CL; }
+OMR::Z::InstOpCode::getCmpLogicalOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLG : TR::InstOpCode::CL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGR : TR::InstOpCode::CLR; }
+OMR::Z::InstOpCode::getCmpLogicalRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLGR : TR::InstOpCode::CLR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpAndSwapOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CSG : TR::InstOpCode::CS; }
+OMR::Z::InstOpCode::getCmpAndSwapOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CSG : TR::InstOpCode::CS; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGFI : TR::InstOpCode::CLFI; }
+OMR::Z::InstOpCode::getCmpLogicalImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLGFI : TR::InstOpCode::CLFI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getShiftLeftLogicalSingleOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SLLG : TR::InstOpCode::SLL; }
+OMR::Z::InstOpCode::getShiftLeftLogicalSingleOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SLLG : TR::InstOpCode::SLL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getShiftRightLogicalSingleOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SRLG : TR::InstOpCode::SRL; }
+OMR::Z::InstOpCode::getShiftRightLogicalSingleOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SRLG : TR::InstOpCode::SRL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddHalfWordImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI; }
+OMR::Z::InstOpCode::getAddHalfWordImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddHalfWordImmDistinctOperandOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGHIK : TR::InstOpCode::AHIK; }
+OMR::Z::InstOpCode::getAddHalfWordImmDistinctOperandOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AGHIK : TR::InstOpCode::AHIK; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddLogicalOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALG : TR::InstOpCode::AL; }
+OMR::Z::InstOpCode::getAddLogicalOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::ALG : TR::InstOpCode::AL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddLogicalRegOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGR : TR::InstOpCode::ALR; }
+OMR::Z::InstOpCode::getAddLogicalRegOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::ALGR : TR::InstOpCode::ALR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getBranchOnIndexHighOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::BXHG : TR::InstOpCode::BXH; }
+OMR::Z::InstOpCode::getBranchOnIndexHighOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::BXHG : TR::InstOpCode::BXH; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getBranchOnIndexEqOrLowOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::BXLEG : TR::InstOpCode::BXLE; }
+OMR::Z::InstOpCode::getBranchOnIndexEqOrLowOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::BXLEG : TR::InstOpCode::BXLE; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getBranchRelIndexHighOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::BRXHG : TR::InstOpCode::BRXH; }
+OMR::Z::InstOpCode::getBranchRelIndexHighOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::BRXHG : TR::InstOpCode::BRXH; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getBranchRelIndexEqOrLowOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::BRXLG : TR::InstOpCode::BRXLE; }
+OMR::Z::InstOpCode::getBranchRelIndexEqOrLowOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::BRXLG : TR::InstOpCode::BRXLE; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGF : TR::InstOpCode::L; }
+OMR::Z::InstOpCode::getLoadWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LGF : TR::InstOpCode::L; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGFR : TR::InstOpCode::LR; }
+OMR::Z::InstOpCode::getLoadRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LGFR : TR::InstOpCode::LR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadTestRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LTGFR : TR::InstOpCode::LTR; }
+OMR::Z::InstOpCode::getLoadTestRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LTGFR : TR::InstOpCode::LTR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGF : TR::InstOpCode::A; }
+OMR::Z::InstOpCode::getAddWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AGF : TR::InstOpCode::A; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getAddRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGFR : TR::InstOpCode::AR; }
+OMR::Z::InstOpCode::getAddRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::AGFR : TR::InstOpCode::AR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubstractWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SGF : TR::InstOpCode::S; }
+OMR::Z::InstOpCode::getSubstractWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SGF : TR::InstOpCode::S; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubStractRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SGFR : TR::InstOpCode::SR; }
+OMR::Z::InstOpCode::getSubStractRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SGFR : TR::InstOpCode::SR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGF : TR::InstOpCode::C; }
+OMR::Z::InstOpCode::getCmpWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGF : TR::InstOpCode::C; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGFR : TR::InstOpCode::CR; }
+OMR::Z::InstOpCode::getCmpRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGFR : TR::InstOpCode::CR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpRegAndBranchRelOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGRJ : TR::InstOpCode::CRJ; }
+OMR::Z::InstOpCode::getCmpRegAndBranchRelOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CGRJ : TR::InstOpCode::CRJ; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGF : TR::InstOpCode::CL; }
+OMR::Z::InstOpCode::getCmpLogicalWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLGF : TR::InstOpCode::CL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getCmpLogicalRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::CLGFR : TR::InstOpCode::CLR; }
+OMR::Z::InstOpCode::getCmpLogicalRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::CLGFR : TR::InstOpCode::CLR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadComplementRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LCGFR : TR::InstOpCode::LCR; }
+OMR::Z::InstOpCode::getLoadComplementRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LCGFR : TR::InstOpCode::LCR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadPositiveRegWidenOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LPGFR : TR::InstOpCode::LPR; }
+OMR::Z::InstOpCode::getLoadPositiveRegWidenOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LPGFR : TR::InstOpCode::LPR; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getSubtractWithBorrowOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::SLBGR : TR::InstOpCode::SLBR; }
+OMR::Z::InstOpCode::getSubtractWithBorrowOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::SLBGR : TR::InstOpCode::SLBR; }
 
 /*  Golden Eagle instructions   */
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadTestOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LTG : TR::InstOpCode::LT; }
+OMR::Z::InstOpCode::getLoadTestOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LTG : TR::InstOpCode::LT; }
 
 /*  z6 instructions             */
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getStoreRelativeLongOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::STGRL : TR::InstOpCode::STRL; }
+OMR::Z::InstOpCode::getStoreRelativeLongOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::STGRL : TR::InstOpCode::STRL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getLoadRelativeLongOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGRL : TR::InstOpCode::LRL; }
+OMR::Z::InstOpCode::getLoadRelativeLongOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::LGRL : TR::InstOpCode::LRL; }
 
 TR::InstOpCode::Mnemonic
-OMR::Z::InstOpCode::getMoveHalfWordImmOpCode() { return TR::Compiler->target.is64Bit() ? TR::InstOpCode::MVGHI : TR::InstOpCode::MVHI; }
+OMR::Z::InstOpCode::getMoveHalfWordImmOpCode() { return TR::comp()->target().is64Bit() ? TR::InstOpCode::MVGHI : TR::InstOpCode::MVHI; }
 
 
 TR::InstOpCode::Mnemonic
@@ -554,7 +554,7 @@ OMR::Z::InstOpCode::getLoadRegOpCodeFromNode(TR::CodeGenerator *cg, TR::Node *no
    {
    if (node->getType().isAddress())
       {
-      return TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR;
+      return cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR;
       }
 
    return node->getType().isInt64() ? TR::InstOpCode::LGR : TR::InstOpCode::LR;

--- a/compiler/z/codegen/OMRCodeGenPhase.cpp
+++ b/compiler/z/codegen/OMRCodeGenPhase.cpp
@@ -41,7 +41,7 @@
 void
 OMR::Z::CodeGenPhase::performMarkLoadAsZeroOrSignExtensionPhase(TR::CodeGenerator * cg, TR::CodeGenPhase * phase)
    {
-   if (TR::Compiler->target.cpu.isZ() && cg->getOptimizationPhaseIsComplete())
+   if (cg->comp()->target().cpu.isZ() && cg->getOptimizationPhaseIsComplete())
       {
       TR::Compilation* comp = cg->comp();
       TR::OptimizationManager *manager = comp->getOptimizer()->getOptimization(OMR::loadExtensions);

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -261,7 +261,7 @@ public:
 
    bool canTransformUnsafeCopyToArrayCopy();
    bool supportsInliningOfIsInstance();
-   bool supports32bitAiadd() {return TR::Compiler->target.is64Bit();}
+   bool supports32bitAiadd() {return OMR::Z::CodeGenerator::comp()->target().is64Bit();}
 
    void addPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet, TR::list<TR_OpaqueClassBlock*> * PICSlist);
    TR::list<TR_OpaqueClassBlock*> * getPICsListForInterfaceSnippet(TR::S390ConstantDataSnippet * ifcSnippet);
@@ -297,7 +297,7 @@ public:
 
    bool supportsLengthMinusOneForMemoryOpts() {return true;}
 
-   bool codegenSupportsLoadlessBNDCheck() {return TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12);}
+   bool codegenSupportsLoadlessBNDCheck() {return OMR::Z::CodeGenerator::comp()->target().cpu.getSupportsArch(TR::CPU::zEC12);}
    TR::Register *evaluateLengthMinusOneForMemoryOps(TR::Node *,  bool , bool &lenMinusOne);
 
    virtual TR_GlobalRegisterNumber getGlobalRegisterNumber(uint32_t realRegNum);

--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -86,7 +86,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator* cg, TR::InstOpCode::Mnemonic
    OMR::Instruction(cg, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.getSupportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.getSupportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
 
    self()->initialize();
    }
@@ -96,7 +96,7 @@ OMR::Z::Instruction::Instruction(TR::CodeGenerator*cg, TR::Instruction* precedin
    OMR::Instruction(cg, precedingInstruction, op, node),
    CTOR_INITIALIZER_LIST
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.getSupportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.getSupportsArch(_opcode.getMinimumALS()), "Processor detected does not support instruction %s\n", _opcode.getMnemonicName());
 
    self()->initialize(precedingInstruction, true);
    }
@@ -960,7 +960,7 @@ OMR::Z::Instruction::useTargetRegister(TR::Register* reg)
    self()->useRegister(reg);
 
    if (reg->getKind() == TR_GPR && (_opcode.is64bit() || _opcode.is32to64bit() ||
-         (TR::Compiler->target.is64Bit() &&
+         (comp->target().is64Bit() &&
             (self()->getOpCodeValue() == TR::InstOpCode::LA ||
              self()->getOpCodeValue() == TR::InstOpCode::LAY ||
              self()->getOpCodeValue() == TR::InstOpCode::LARL ||

--- a/compiler/z/codegen/OMRLinkage.cpp
+++ b/compiler/z/codegen/OMRLinkage.cpp
@@ -492,10 +492,10 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                 || type.getDataType() == TR::DecimalDouble
 #endif
                 )
-                count = (TR::Compiler->target.is64Bit()) ? 1 : 2;
+                count = (self()->cg()->comp()->target().is64Bit()) ? 1 : 2;
 #ifdef J9_PROJECT_SPECIFIC
             else if (type.isLongDouble())
-                count = (TR::Compiler->target.is64Bit()) ? 2 : 4;
+                count = (self()->cg()->comp()->target().is64Bit()) ? 2 : 4;
 #endif
             else
                 count = 1;
@@ -512,7 +512,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
             }
          else
             {
-            numIntArgs += (type.isInt64() && TR::Compiler->target.is32Bit()) ? 2 : 1;
+            numIntArgs += (type.isInt64() && self()->cg()->comp()->target().is32Bit()) ? 2 : 1;
             }
          }
       }
@@ -533,7 +533,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 
       // Treat GPR6 special on zLinux.  It is a linkage register but also preserved.
       // If it has no global reg number, locate it on local save area instead of register save area
-      if (TR::Compiler->target.isLinux() &&
+      if (self()->cg()->comp()->target().isLinux() &&
           (lri > 0 && ai < 0 && (self()->getPreserved(REGNUM(lri + 3)) || dtype.isVector())))
           paramCursor->setParmHasToBeOnStack();
 
@@ -572,7 +572,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
             loadOpCode = TR::InstOpCode::L;
             break;
          case 8:
-            if (TR::Compiler->target.is64Bit())
+            if (self()->cg()->comp()->target().is64Bit())
                {
                storeOpCode = TR::InstOpCode::STG;
                loadOpCode = TR::InstOpCode::LG;
@@ -625,12 +625,12 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                }
 #endif
             }
-         else if(TR::Compiler->target.isLinux() && dtype == TR::Aggregate)
+         else if(self()->cg()->comp()->target().isLinux() && dtype == TR::Aggregate)
            {
            TR_ASSERT( paramCursor->getSize()<=8, "Only aggregates of size 8 bytes or less are passed in registers");
            regNum = self()->getIntegerArgumentRegister(lri);
            lastFreeIntArgIndex = lri + 1;
-           if(TR::Compiler->target.is32Bit() && paramCursor->getSize() > 4)
+           if(self()->cg()->comp()->target().is32Bit() && paramCursor->getSize() > 4)
              {
              fullLong = true;   // On 31 bit this larger aggregate will be treated like a 64 bit long
              lastFreeIntArgIndex++;
@@ -646,7 +646,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                regNum = self()->getIntegerArgumentRegister(lri);
 
             lastFreeIntArgIndex = lri + 1;
-            if (fullLong && TR::Compiler->target.is32Bit())
+            if (fullLong && self()->cg()->comp()->target().is32Bit())
                {
                lastFreeIntArgIndex++;
                }
@@ -661,7 +661,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
              (!unconditionalSave || (unconditionalSave && dtype != TR::Address)) )
             {
             freeScratchable.set(regNum);
-            if (fullLong && TR::Compiler->target.is32Bit())
+            if (fullLong && self()->cg()->comp()->target().is32Bit())
                {
                freeScratchable.set(regNum + 1);
                }
@@ -732,7 +732,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 
                   if (secondStore &&
                       fullLong &&
-                      TR::Compiler->target.is32Bit())
+                      self()->cg()->comp()->target().is32Bit())
                      {
                      if (genBinary)
                         {
@@ -865,7 +865,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
             // Or we have long reg on 31bir, so we need to build the 64bit register from the two
             // arguments (reg + reg) or (reg + mem)
             // also need to take care of longdouble/complex types which takes 2 or more slots
-            if (regNum != ai || (dtype == TR::Int64 && TR::Compiler->target.is32Bit()))
+            if (regNum != ai || (dtype == TR::Int64 && self()->cg()->comp()->target().is32Bit()))
                {
                //  Global register is available as scratch reg, so make the move
                //
@@ -903,7 +903,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
 #endif
                   else
                      {
-                     if (dtype == TR::Int64 && TR::Compiler->target.is32Bit())
+                     if (dtype == TR::Int64 && self()->cg()->comp()->target().is32Bit())
                         {
                         cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::SLLG, firstNode, self()->getRealRegister(REGNUM(ai)),
                                     self()->getRealRegister(regNum), 32, (TR::Instruction *) cursor);
@@ -952,7 +952,7 @@ OMR::Z::Linkage::saveArguments(void * cursor, bool genBinary, bool InPreProlog, 
                   // We have to handle the high and low word.  We use two entries
                   // in the busyMoves to represent high and low word.
                   //
-                  if (dtype == TR::Int64 && TR::Compiler->target.is32Bit())
+                  if (dtype == TR::Int64 && self()->cg()->comp()->target().is32Bit())
                      {
                      if (fullLong)
                         {
@@ -1368,7 +1368,7 @@ OMR::Z::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * met
                {
                index = numIntArgs;
                }
-            numIntArgs += (TR::Compiler->target.is64Bit() ? 1 : 2);
+            numIntArgs += (self()->cg()->comp()->target().is64Bit() ? 1 : 2);
             break;
          case TR::Float:
 #ifdef J9_PROJECT_SPECIFIC
@@ -1391,7 +1391,7 @@ OMR::Z::Linkage::setParameterLinkageRegisterIndex(TR::ResolvedMethodSymbol * met
             break;
          case TR::DecimalLongDouble:
             // On zLinux Long Double is passed in memory using a pointer to buffer
-            if(TR::Compiler->target.isLinux())
+            if(self()->cg()->comp()->target().isLinux())
                {
                if(numIntArgs < self()->getNumIntegerArgumentRegisters())
                   index = numIntArgs++;
@@ -1449,7 +1449,7 @@ OMR::Z::Linkage::getOpCodeForLinkage(TR::Node * child, bool isStore, bool isRegR
        switch (child->getDataType())
          {
          case TR::Int64:
-            if (TR::Compiler->target.is32Bit())
+            if (self()->cg()->comp()->target().is32Bit())
                return (isStore)? TR::InstOpCode::STM : (isRegReg)? TR::InstOpCode::LR : TR::InstOpCode::LM;
             else
                return (isStore)? TR::InstOpCode::STG : (isRegReg)? TR::InstOpCode::LGR : TR::InstOpCode::LG;
@@ -1460,12 +1460,12 @@ OMR::Z::Linkage::getOpCodeForLinkage(TR::Node * child, bool isStore, bool isRegR
          case TR::Int8:
          case TR::Int16:
          case TR::Int32:
-            if (TR::Compiler->target.is32Bit())
+            if (self()->cg()->comp()->target().is32Bit())
               return (isStore)? TR::InstOpCode::ST : (isRegReg)? TR::InstOpCode::LR : TR::InstOpCode::L;
             else
               return (isStore)? (isWiden)? TR::InstOpCode::STG : TR::InstOpCode::ST : (isRegReg)? (isWiden)? TR::InstOpCode::LGFR : TR::InstOpCode::LGR : (isWiden)? TR::InstOpCode::LGF: TR::InstOpCode::L;
          case TR::Aggregate: // can get here for aggregates with register size
-            if (TR::Compiler->target.is32Bit())
+            if (self()->cg()->comp()->target().is32Bit())
               return (isStore)? TR::InstOpCode::ST : (isRegReg)? TR::InstOpCode::LR : TR::InstOpCode::L;
             else
               return (isStore)? TR::InstOpCode::STG : (isRegReg)? TR::InstOpCode::LGR : TR::InstOpCode::LG;
@@ -1520,7 +1520,7 @@ OMR::Z::Linkage::copyArgRegister(TR::Node * callNode, TR::Node * child, TR::Regi
 
    TR_Debug * debugObj = self()->cg()->getDebug();
    char * REG_PARAM = "LR=Reg_param";
-   if (TR::Compiler->target.is32Bit() && child->getDataType() == TR::Int64 && !argRegister->getRegisterPair())
+   if (self()->cg()->comp()->target().is32Bit() && child->getDataType() == TR::Int64 && !argRegister->getRegisterPair())
       {
       TR::Register * tempRegH = self()->cg()->allocateRegister();
       TR::Register * tempRegL = self()->cg()->allocateRegister();
@@ -1703,7 +1703,7 @@ OMR::Z::Linkage::pushArg(TR::Node * callNode, TR::Node * child, int32_t numInteg
    {
    TR::DataType argType = child->getType();
    TR::DataType argDataType = argType.getDataType();
-   int8_t regSize = (TR::Compiler->target.is64Bit())? 8:4;
+   int8_t regSize = (self()->cg()->comp()->target().is64Bit())? 8:4;
    int8_t argSize = 0;
 
    if (argType.isInt64()
@@ -1722,7 +1722,7 @@ OMR::Z::Linkage::pushArg(TR::Node * callNode, TR::Node * child, int32_t numInteg
    else
        argSize += regSize;
 
-   if (TR::Compiler->target.is32Bit() && argType.isInt64())
+   if (self()->cg()->comp()->target().is32Bit() && argType.isInt64())
       return self()->pushLongArg32(callNode, child, numIntegerArgs,  numFloatArgs, stackOffsetPtr, dependencies, argRegister);
 
    bool isStoreArg = self()->isAllParmsOnStack();
@@ -2005,7 +2005,7 @@ OMR::Z::Linkage::loadIntArgumentsFromStack(TR::Node *callNode, TR::RegisterDepen
          TR::MemoryReference * argMemRef = generateS390MemoryReference(stackRegister, stackOffset , self()->cg());
          TR::InstOpCode::Mnemonic loadOp = TR::InstOpCode::getLoadOpCode();
 #ifdef J9_PROJECT_SPECIFIC
-         if (argType == TR::DecimalFloat && TR::Compiler->target.is64Bit()) // special case for DecFloat on 64bit
+         if (argType == TR::DecimalFloat && self()->cg()->comp()->target().is64Bit()) // special case for DecFloat on 64bit
             loadOp = TR::InstOpCode::LLGF;
 #endif
 
@@ -2199,7 +2199,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
             numIntegerArgs++;
             break;
          case TR::Int64:
-            if (TR::Compiler->target.is32Bit())
+            if (self()->cg()->comp()->target().is32Bit())
                {
                argRegister = self()->pushLongArg32(callNode, child, numIntegerArgs, numFloatArgs, &stackOffset, dependencies);
                numIntegerArgs += 2;
@@ -2239,7 +2239,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
                {
                if (numIntegerArgs < self()->getNumIntegerArgumentRegisters())
                   {
-                  numIntegerArgs += (TR::Compiler->target.is64Bit()) ? 1 : 2;
+                  numIntegerArgs += (self()->cg()->comp()->target().is64Bit()) ? 1 : 2;
                   }
                }
             break;
@@ -2259,7 +2259,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
                {
                if (numIntegerArgs < self()->getNumIntegerArgumentRegisters())
                   {
-                  numIntegerArgs += (TR::Compiler->target.is64Bit()) ? 2 : 4;
+                  numIntegerArgs += (self()->cg()->comp()->target().is64Bit()) ? 2 : 4;
                   }
                }
             break;
@@ -2342,7 +2342,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
             }
 #endif
          case TR::Int64:
-            if (TR::Compiler->target.is32Bit())
+            if (self()->cg()->comp()->target().is32Bit())
                {
                //In this case, private and system linkage use same regs for return value
                TR::Register * resultRegLow = self()->cg()->allocateRegister();
@@ -2383,7 +2383,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
 
    // In zLinux, GPR6 may be used for param passing, in this case, we need to kill it
    // so kill GPR6 if used in preDeps and is not in postDeps
-  if (TR::Compiler->target.isLinux())
+  if (self()->cg()->comp()->target().isLinux())
      {
      TR::Register * gpr6Reg= dependencies->searchPreConditionRegister(TR::RealRegister::GPR6);
      if (gpr6Reg)
@@ -2425,7 +2425,7 @@ OMR::Z::Linkage::buildArgs(TR::Node * callNode, TR::RegisterDependencyConditions
 
    // spill all high regs
    //
-   if (TR::Compiler->target.is32Bit())
+   if (self()->cg()->comp()->target().is32Bit())
       {
       TR::Register *reg = self()->cg()->allocateRegister();
 
@@ -2553,7 +2553,7 @@ OMR::Z::Linkage::killAndAssignRegister(int64_t killMask, TR::RegisterDependencyC
       if (isDummy)
          {
          (*virtualRegPtr)->setPlaceholderReg();
-         if (TR::Compiler->target.is64Bit() && regNum <= TR::RealRegister::LastGPR)
+         if (self()->cg()->comp()->target().is64Bit() && regNum <= TR::RealRegister::LastGPR)
             {
             (*virtualRegPtr)->setIs64BitReg(true);
             }
@@ -2642,7 +2642,7 @@ OMR::Z::Linkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_DispatchType
    self()->comp()->setHasNativeCall();
 
 
-   if (!TR::Compiler->target.isZOS())
+   if (!self()->cg()->comp()->target().isZOS())
       {
       TR::Register * parm3VirtualRegister = NULL;
       killMask = self()->killAndAssignRegister(killMask, deps, &parm3VirtualRegister, TR::RealRegister::GPR4, self()->cg(), true);
@@ -2652,7 +2652,7 @@ OMR::Z::Linkage::setupRegisterDepForLinkage(TR::Node * callNode, TR_DispatchType
 
    if (dispatchType == TR_SystemDispatch)
      {
-     if (!TR::Compiler->target.isZOS())
+     if (!self()->cg()->comp()->target().isZOS())
        killMask = self()->killAndAssignRegister(killMask, deps, methodAddressReg, TR::RealRegister::GPR14, self()->cg(), true);
      }
    }
@@ -2899,7 +2899,7 @@ OMR::Z::Linkage::restorePreservedRegs(TR::RealRegister::RegNum firstUsedReg,
    TR::Instruction * cursor, TR::Node * nextNode, TR::RealRegister * spReg, TR::MemoryReference * rsa,
    TR::RealRegister::RegNum spRealReg)
    {
-   bool break64 = TR::Compiler->target.is64Bit() && self()->comp()->getOption(TR_Enable39064Epilogue);
+   bool break64 = self()->cg()->comp()->target().is64Bit() && self()->comp()->getOption(TR_Enable39064Epilogue);
 
    // restoring preserved regs is unavoidable in Java due to GC object moves
 
@@ -2953,7 +2953,7 @@ OMR::Z::Linkage::restorePreservedRegs(TR::RealRegister::RegNum firstUsedReg,
       }
 
    // 64-bit non-optimized CASE AND 32-bit shorter LMG case
-   else if ((TR::Compiler->target.is64Bit() && !break64) ||
+   else if ((self()->cg()->comp()->target().is64Bit() && !break64) ||
             ((newFirstUsedReg+1) %2 == 0))
       {
       cursor = generateRSInstruction(self()->cg(), TR::InstOpCode::getLoadMultipleOpCode(), nextNode,

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -409,7 +409,7 @@ boundNext(TR::Instruction * currentInstruction, int32_t realNum, TR::Register * 
 uint8_t
 OMR::Z::Machine::getGPRSize()
    {
-   return TR::Compiler->target.is64Bit() ? 8 : 4;
+   return self()->cg()->comp()->target().is64Bit() ? 8 : 4;
    }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3794,7 +3794,7 @@ OMR::Z::Machine::initializeGlobalRegisterTable()
       }
 
    p = self()->addGlobalRegLater(linkage->getMethodMetaDataRegister(), p);
-   if (TR::Compiler->target.isZOS())
+   if (self()->cg()->comp()->target().isZOS())
       {
       p = self()->addGlobalRegLater(self()->cg()->getS390Linkage()->getStackPointerRegister(), p);
       }

--- a/compiler/z/codegen/OMRMemoryReference.cpp
+++ b/compiler/z/codegen/OMRMemoryReference.cpp
@@ -556,7 +556,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
             {
             uintptrj_t staticAddressValue = (uintptrj_t) symbol->getStaticSymbol()->getStaticAddress();
             TR::S390ConstantDataSnippet * targetsnippet;
-            if (TR::Compiler->target.is64Bit())
+            if (cg->comp()->target().is64Bit())
                {
                targetsnippet = cg->findOrCreate8ByteConstant(0, staticAddressValue);
                }
@@ -596,7 +596,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Node * rootLoadOrStore, TR::CodeGen
                {
                // Storing to the symbol reference
                TR::Register * tempReg;
-               if (TR::Compiler->target.is64Bit())
+               if (cg->comp()->target().is64Bit())
                   tempReg = cg->allocateRegister();
                else
                   tempReg = cg->allocateRegister();
@@ -858,7 +858,7 @@ OMR::Z::MemoryReference::MemoryReference(TR::Snippet * s, TR::CodeGenerator * cg
       {
       if (cg->isLiteralPoolOnDemandOn())
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             self()->setBaseRegister(cg->allocateRegister(), cg);
          else
             self()->setBaseRegister(cg->allocateRegister(), cg);
@@ -1147,7 +1147,7 @@ OMR::Z::MemoryReference::bookKeepingRegisterUses(TR::Instruction * instr, TR::Co
       _baseRegister->setIsUsedInMemRef();
       // Set addressing register to 64 bit data
       // but be careful of instructions using X type operand to specify something else other then memory
-      if(TR::Compiler->target.is64Bit() && (instr->getOpCode().isLoad() || instr->getOpCode().isStore() ||
+      if(cg->comp()->target().is64Bit() && (instr->getOpCode().isLoad() || instr->getOpCode().isStore() ||
                                  instr->getOpCodeValue() == TR::InstOpCode::LA || instr->getOpCodeValue() == TR::InstOpCode::LARL ||
                                  instr->getOpCodeValue() == TR::InstOpCode::LAY || instr->getOpCodeValue() == TR::InstOpCode::LAE ||
                                  instr->getOpCodeValue() == TR::InstOpCode::LAEY) )
@@ -1159,7 +1159,7 @@ OMR::Z::MemoryReference::bookKeepingRegisterUses(TR::Instruction * instr, TR::Co
       {
       instr->useRegister(_indexRegister);
       _indexRegister->setIsUsedInMemRef();
-      if(TR::Compiler->target.is64Bit() && (instr->getOpCode().isLoad() || instr->getOpCode().isStore() ||
+      if(cg->comp()->target().is64Bit() && (instr->getOpCode().isLoad() || instr->getOpCode().isStore() ||
                                  instr->getOpCodeValue() == TR::InstOpCode::LA || instr->getOpCodeValue() == TR::InstOpCode::LARL ||
                                  instr->getOpCodeValue() == TR::InstOpCode::LAY || instr->getOpCodeValue() == TR::InstOpCode::LAE ||
                                  instr->getOpCodeValue() == TR::InstOpCode::LAEY) )
@@ -1333,7 +1333,7 @@ OMR::Z::MemoryReference::populateAddTree(TR::Node * subTree, TR::CodeGenerator *
       // catch the pattern of aiadd on iaload <base> / isub of <expression> and -<constant> and
       // convert it into LA Rx,<constant>(R<expression>,R<base>)
       //
-      bool usingAladd = (TR::Compiler->target.is64Bit()) ? true : false;
+      bool usingAladd = (cg->comp()->target().is64Bit()) ? true : false;
 
       TR::Node * firstSubChild = integerChild->getFirstChild();
       TR::Node * secondSubChild = integerChild->getSecondChild();
@@ -1851,7 +1851,7 @@ OMR::Z::MemoryReference::populateMemoryReference(TR::Node * subTree, TR::CodeGen
          }
       else if (subTree->getOpCodeValue() == TR::aconst)
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             _offset += subTree->getLongInt();
             }
@@ -1918,7 +1918,7 @@ OMR::Z::MemoryReference::consolidateRegisters(TR::Node * node, TR::CodeGenerator
       {
       if (node && node->isInternalPointer() && node->getPinningArrayPointer())
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             tempTargetRegister = cg->allocateRegister();
          else
             tempTargetRegister = cg->allocateRegister();
@@ -1933,7 +1933,7 @@ OMR::Z::MemoryReference::consolidateRegisters(TR::Node * node, TR::CodeGenerator
       }
    else
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempTargetRegister = cg->allocateRegister();
       else
          tempTargetRegister = cg->allocateRegister();
@@ -2099,7 +2099,7 @@ OMR::Z::MemoryReference::enforce4KDisplacementLimit(TR::Node * node, TR::CodeGen
        !self()->isAdjustedForLongDisplacement())
       {
       TR::Register * tempTargetRegister = NULL;
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempTargetRegister = cg->allocateRegister();
       else
          tempTargetRegister = cg->allocateRegister();
@@ -2169,7 +2169,7 @@ OMR::Z::MemoryReference::enforceDisplacementLimit(TR::Node * node, TR::CodeGener
       {
       TR_ASSERT( node,"node should be non-null for enforceDisplacementLimit\n");
       TR::Register * tempTargetRegister;
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempTargetRegister = cg->allocateRegister();
       else
          tempTargetRegister = cg->allocateRegister();
@@ -2222,7 +2222,7 @@ OMR::Z::MemoryReference::eliminateNegativeDisplacement(TR::Node * node, TR::Code
       {
 
       TR::Register * tempTargetRegister;
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempTargetRegister = cg->allocateRegister();
       else
          tempTargetRegister = cg->allocateRegister();
@@ -2271,7 +2271,7 @@ OMR::Z::MemoryReference::separateIndexRegister(TR::Node * node, TR::CodeGenerato
          return preced;
          }
       TR::Register * tempTargetRegister = NULL;
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          tempTargetRegister = cg->allocateRegister();
       else
          tempTargetRegister = cg->allocateRegister();
@@ -2415,7 +2415,7 @@ OMR::Z::MemoryReference::assignRegisters(TR::Instruction * currentInstruction, T
 bool
 OMR::Z::MemoryReference::needsAdjustDisp(TR::Instruction * instr, OMR::Z::MemoryReference * mRef, TR::CodeGenerator * cg)
    {
-   TR_ASSERT( TR::Compiler->target.is64Bit(), "needsAdjustDisp() call is for 64bit code-gen only");
+   TR_ASSERT( cg->comp()->target().is64Bit(), "needsAdjustDisp() call is for 64bit code-gen only");
 
    TR::SymbolReference * symRef = mRef->getSymbolReference();
    TR::Compilation *comp = cg->comp();
@@ -2497,7 +2497,7 @@ OMR::Z::MemoryReference::estimateBinaryLength(int32_t  currentEstimate, TR::Code
    else
       {
       length = instr->getOpCode().getInstructionLength();
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          // most pessimistic case has LGHI/SLLG/LA/SLLG/LA + LA
          // LGHI/SLLG/LA/SLLG/LA + LA (4+6+4+6+4+4)
@@ -2779,7 +2779,7 @@ OMR::Z::MemoryReference::calcDisplacement(uint8_t * cursor, TR::Instruction * in
       if (symbol->isRegisterMappedSymbol())
          {
          disp += symbol->castToRegisterMappedSymbol()->getOffset();
-         if (TR::Compiler->target.is64Bit() && TR::MemoryReference::needsAdjustDisp(instr, this, cg) && !self()->getDispAdjusted())
+         if (cg->comp()->target().is64Bit() && TR::MemoryReference::needsAdjustDisp(instr, this, cg) && !self()->getDispAdjusted())
             {
             disp += 4;
             }
@@ -2808,7 +2808,7 @@ generateImmToRegister(TR::CodeGenerator * cg, TR::Node * node, TR::Register * ta
       low  = (value & 0xfff);
       cursor = generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node,  // LHI Rscrtch, (value>>12)&0xFFFF
                       targetRegister, (high&0xFFFF), cursor);
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
         {
         cursor = generateRSInstruction(cg, TR::InstOpCode::SLLG,
                    node, targetRegister, targetRegister, 12, cursor); // SLLG Rscrtch,Rscrtch,12
@@ -2831,7 +2831,7 @@ generateImmToRegister(TR::CodeGenerator * cg, TR::Node * node, TR::Register * ta
                                      ((value >> 24) & 0xff),
                                      cursor);  // LHI Rscrtch,value>>24&0xFF
       // now shift that left by 12 bits
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          cursor = generateRSInstruction(cg,
                                         TR::InstOpCode::SLLG,
@@ -2856,7 +2856,7 @@ generateImmToRegister(TR::CodeGenerator * cg, TR::Node * node, TR::Register * ta
                                      generateS390MemoryReference(targetRegister, ((value >> 12) & 0xfff), cg),
                                      cursor);         // LA  Rscrtch, value&0xFFF(,Rscrtch)
       // now shift those 20 bits left by 12 bits
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          cursor = generateRSInstruction(cg,
                                         TR::InstOpCode::SLLG,
@@ -3002,7 +3002,7 @@ OMR::Z::MemoryReference::generateBinaryEncoding(uint8_t * cursor, TR::CodeGenera
             else
                {
                scratchReg  = instr->assignBestSpillRegister2();
-               if (TR::Compiler->target.is64Bit())
+               if (cg->comp()->target().is64Bit())
                   offsetToLongDispSlot += 8;
                else
                   offsetToLongDispSlot += 4;
@@ -3235,7 +3235,7 @@ OMR::Z::MemoryReference::generateBinaryEncodingTouchUpForLongDisp(uint8_t *curso
          scratchReg = instr->getLocalLocalSpillReg2();
          if (!scratchReg)
             scratchReg = instr->assignBestSpillRegister2();
-         if(TR::Compiler->target.is64Bit())
+         if(cg->comp()->target().is64Bit())
             offsetToLongDispSlot += 8;
          else
             offsetToLongDispSlot += 4;

--- a/compiler/z/codegen/OMRSnippet.cpp
+++ b/compiler/z/codegen/OMRSnippet.cpp
@@ -106,7 +106,7 @@ OMR::Z::Snippet::generatePICBinary(TR::CodeGenerator * cg, uint8_t * cursor, TR:
       cursor += sizeof(int32_t);
 
       // L/LG  rEP, 0(r14)
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          *(int32_t *) cursor = 0xe300e000 + (rEP << 20);           // LG  rEP, 0(r14)
          cursor += sizeof(int32_t);
@@ -151,7 +151,7 @@ OMR::Z::Snippet::generatePICBinary(TR::CodeGenerator * cg, uint8_t * cursor, TR:
          }
 #endif
 
-      TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinBranchRelativeRILRange(destAddr, instructionStartAddress),
+      TR_ASSERT_FATAL(cg->comp()->target().cpu.isTargetWithinBranchRelativeRILRange(destAddr, instructionStartAddress),
                       "Helper Call is not reachable.");
       self()->setSnippetDestAddr(destAddr);
 
@@ -170,7 +170,7 @@ OMR::Z::Snippet::generatePICBinary(TR::CodeGenerator * cg, uint8_t * cursor, TR:
 uint32_t
 OMR::Z::Snippet::getPICBinaryLength(TR::CodeGenerator * cg)
    {
-   int32_t lengthOfLoad = (TR::Compiler->target.is64Bit())?6:4;
+   int32_t lengthOfLoad = (cg->comp()->target().is64Bit())?6:4;
 
    if (self()->getKind() == TR::Snippet::IsUnresolvedCall)
       return 6 + lengthOfLoad + 2; // LARL + L/LG + BCR

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -234,7 +234,7 @@ genLoadLongConstant(TR::CodeGenerator * cg, TR::Node * node, int64_t value, TR::
    //disable LARL for AOT for easier relocation
    //cannot safely generate LARL for longs on 31-bit
    else if (cg->canUseRelativeLongInstructions(value) &&
-            TR::Compiler->target.is64Bit() && !(comp->compileRelocatableCode()))
+            comp->target().is64Bit() && !(comp->compileRelocatableCode()))
       {
       cursor = generateRILInstruction(cg, TR::InstOpCode::LARL, node, targetRegister, reinterpret_cast<void*>(value), cursor);
       }
@@ -301,7 +301,7 @@ genLoadAddressConstant(TR::CodeGenerator * cg, TR::Node * node, uintptrj_t value
       return unloadableConstInstr;
       }
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       return genLoadLongConstant(cg, node, (uint64_t) value, targetRegister, cursor, cond, base);
       }
@@ -339,7 +339,7 @@ generateLoad32BitConstant(TR::CodeGenerator * cg, TR::Node * constExpr)
          break;
       case TR::Address:
          tempReg = cg->allocateRegister();
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             genLoadLongConstant(cg, constExpr, constExpr->getLongInt(), tempReg);
             }
@@ -444,7 +444,7 @@ TR::Instruction *multiply31Reduction(TR::CodeGenerator * cg, TR::Node * node,
          {
          if (targetRegister != sourceRegister)
             {
-            if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+            if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
                {
                cursor = generateRSInstruction(cg, TR::InstOpCode::SLLK, node, targetRegister, sourceRegister, shiftValue, preced);
                }
@@ -472,7 +472,7 @@ TR::Instruction *multiply31Reduction(TR::CodeGenerator * cg, TR::Node * node,
    // We also need to disable the optimization in the tree simplifier -- see overloaded
    // method, TR_S390CodeGenerator::mulDecompositionCostIsJustified()
 
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+   if (!cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
       {
       return cursor;
       }
@@ -1078,7 +1078,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
             {
             immOp = TR::InstOpCode::MGHI;
             }
-         else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && value >= GE_MIN_IMMEDIATE_VAL && value <= GE_MAX_IMMEDIATE_VAL)
+         else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && value >= GE_MIN_IMMEDIATE_VAL && value <= GE_MAX_IMMEDIATE_VAL)
             {
             ei_immOp = TR::InstOpCode::MSGFI;
             }
@@ -1109,7 +1109,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,  TR::InstOpCode::Mnemonic memOp, TR::N
             {
             immOp = TR::InstOpCode::MHI;
             }
-         else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && memOp == TR::InstOpCode::MS)
+         else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && memOp == TR::InstOpCode::MS)
             {
             ei_immOp = TR::InstOpCode::MSFI;
             }
@@ -1205,7 +1205,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,
    // in 32bit target.  Currently we only handle long constant for 32bit target for
    // bitwise instructions.
    // NOTE: You can only get in here if bitwiseOpNeedsLiteralFromPool() return false.
-   if (TR::Compiler->target.is32Bit() &&
+   if (cg->comp()->target().is32Bit() &&
         (memOp == TR::InstOpCode::N || memOp == TR::InstOpCode::O || memOp == TR::InstOpCode::X))
       {
       TR_ASSERT( sourceRegister->getRegisterPair(), "Long value in 32-bit target must be in a register pair : OpCode %s\n", memOp);
@@ -1356,7 +1356,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,
             {
             immOp = TR::InstOpCode::MGHI;
             }
-         else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && value >= GE_MIN_IMMEDIATE_VAL && value <= GE_MAX_IMMEDIATE_VAL)
+         else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && value >= GE_MIN_IMMEDIATE_VAL && value <= GE_MAX_IMMEDIATE_VAL)
             {
             ei_immOp = TR::InstOpCode::MSGFI;
             }
@@ -1390,7 +1390,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,
             {
             ei_immOp = TR::InstOpCode::CGFI;
             }
-         else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+         else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
             {
             memOp = TR::InstOpCode::CGRL;
             }
@@ -1400,7 +1400,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,
             {
             ei_immOp = TR::InstOpCode::CLGFI;
             }
-         else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+         else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
             {
             memOp = TR::InstOpCode::CLGRL;
             }
@@ -1414,7 +1414,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,
             {
             ei_immOp = TR::InstOpCode::LLILF;
             }
-         else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+         else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
             {
             memOp = TR::InstOpCode::LGRL;
             }
@@ -1476,7 +1476,7 @@ generateS390ImmOp(TR::CodeGenerator * cg,
       }
    else
       {
-      if (TR::Compiler->target.is32Bit() && memOp != TR::InstOpCode::MLG)
+      if (cg->comp()->target().is32Bit() && memOp != TR::InstOpCode::MLG)
          {
          TR_ASSERT(!targetRegister->getRegisterPair(), "This instruction is for 64bit target only, it should not take a register pair.\n");
          }
@@ -2069,7 +2069,7 @@ tryGenerateSIComparisons(TR::Node *node, TR::Node *constNode, TR::Node *otherNod
    else if (operandSize == 2 || operandSize == 4 || operandSize == 8) // we can use the SIL form compares
       {
       // 16-bit immediates and these instructions are only avaialble on z10 and up
-      if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+      if (!cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
          {
          return 0;
          }
@@ -2398,7 +2398,7 @@ tryGenerateCLCForComparison(TR::Node *node, TR::CodeGenerator *cg)
 
    if (operand1IsVFTSymbol || operand2IsVFTSymbol)
       {
-      if (TR::Compiler->target.is64Bit() && (cg->isCompressedClassPointerOfObjectHeader(operand1) || cg->isCompressedClassPointerOfObjectHeader(operand2)))
+      if (cg->comp()->target().is64Bit() && (cg->isCompressedClassPointerOfObjectHeader(operand1) || cg->isCompressedClassPointerOfObjectHeader(operand2)))
          numOfBytesToCompare = 4; //getSize() currently return wrong value in compressedrefs
 
       numOfBytesToCompare--;
@@ -2734,7 +2734,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
    if (dataType == TR::Address)
       {
       isUnsignedCmp = true;
-      if(TR::Compiler->target.is64Bit() && !cg->isCompressedClassPointerOfObjectHeader(firstChild))
+      if(cg->comp()->target().is64Bit() && !cg->isCompressedClassPointerOfObjectHeader(firstChild))
          {
          dataType = TR::Int64;
          }
@@ -2829,12 +2829,12 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
           !isUnsignedCmp &&
           !nonConstNode->getOpCode().isDouble() &&
           getIntegralValue(constNode) == 0 &&
-          (!nonConstNode->isExtendedTo64BitAtSource() || TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) ))
+          (!nonConstNode->isExtendedTo64BitAtSource() || cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) ))
          {
          TR::SymbolReference * symRef = nonConstNode->getSymbolReference();
          TR::Symbol * symbol = symRef->getSymbol();
-         bool useLTG = (TR::Compiler->target.is64Bit() && (constType == TR::Int64 || constType == TR::Address)) ||
-                       (TR::Compiler->target.is32Bit() && (constType == TR::Int64));
+         bool useLTG = (cg->comp()->target().is64Bit() && (constType == TR::Int64 || constType == TR::Address)) ||
+                       (cg->comp()->target().is32Bit() && (constType == TR::Int64));
 
          if (nonConstNode->getDataType() == TR::Address &&
              !symbol->isInternalPointer() &&
@@ -2851,7 +2851,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
          TR::MemoryReference * tempMR = generateS390MemoryReference(nonConstNode, cg);
          bool mustExtend = !useLTG && nonConstNode->isExtendedTo64BitAtSource();
 
-         if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && mustExtend)
+         if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && mustExtend)
             {
             if (isUnsignedCmp)
                {
@@ -2883,8 +2883,8 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
             }
          else
             {
-            TR_ASSERT(  TR::Compiler->target.is32Bit(), "ICM can be used for 32bit code-gen only!");
-            if (TR::Compiler->target.is32Bit() && (constType == TR::Int64))
+            TR_ASSERT(  cg->comp()->target().is32Bit(), "ICM can be used for 32bit code-gen only!");
+            if (cg->comp()->target().is32Bit() && (constType == TR::Int64))
                {
                generateRXInstruction(cg, TR::InstOpCode::LG, nonConstNode, testRegister, tempMR);
                if (branchTarget != NULL)
@@ -2991,7 +2991,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
          bool isAddress = constType == TR::Address;
          if (constType == TR::Address)
             {
-            constType = (TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32);
+            constType = (cg->comp()->target().is64Bit() ? TR::Int64 : TR::Int32);
             isUnsignedCmp = true;
             }
 
@@ -3146,7 +3146,7 @@ generateS390CompareAndBranchOpsHelper(TR::Node * node, TR::CodeGenerator * cg, T
       if (childType == TR::Address)
          {
          isUnsignedCmp = true;
-         if (TR::Compiler->target.is64Bit() && !cg->isCompressedClassPointerOfObjectHeader(secondChild))
+         if (cg->comp()->target().is64Bit() && !cg->isCompressedClassPointerOfObjectHeader(secondChild))
             {
             childType = TR::Int64;
             }
@@ -3358,7 +3358,7 @@ getOpCodeIfSuitableForCompareAndBranch(TR::CodeGenerator * cg, TR::Node * node, 
    bool isUnsignedCmp = node->getOpCode().isUnsignedCompare();
    if (dataType == TR::Address)
       {
-      dataType = (TR::Compiler->target.is64Bit() ? TR::Int64 : TR::Int32);
+      dataType = (cg->comp()->target().is64Bit() ? TR::Int64 : TR::Int32);
       isUnsignedCmp = true;
       }
 
@@ -4001,7 +4001,7 @@ containsValidOpCodesForConditionalMoves(TR::Node* node, TR::CodeGenerator* cg)
       // On 32-bit platforms, we should not generate a STM/LM on condition.
       if (!node->getType().isInt64() && !node->getType().isAddress() && !node->getType().isInt32())
          return false;
-      if (TR::Compiler->target.is32Bit() && node->getType().isInt64())
+      if (cg->comp()->target().is32Bit() && node->getType().isInt64())
          return false;
       if (node->useSignExtensionMode() || (node->getOpCode().isLoad() && node->isLoadAndTest()))
          return false;
@@ -4235,7 +4235,7 @@ generateS390CompareBranch(TR::Node * node, TR::CodeGenerator * cg, TR::InstOpCod
    bool isLoadOrStoreOnConditionCandidateFallthrough  = false;
 
    // Determine if successor blocks maybe candidates for conditional load/stores/moves
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       canadidateLoadStoreConditionalBlock = checkForCandidateBlockForConditionalLoadAndStores(node, cg, cg->getCurrentBlock(), &isLoadOrStoreOnConditionCandidateFallthrough);
       if (canadidateLoadStoreConditionalBlock)
@@ -4574,7 +4574,7 @@ OMR::Z::TreeEvaluator::extendCastEvaluator(TR::Node * node, TR::CodeGenerator * 
    TR::Compilation *comp = cg->comp();
 
    childRegister = targetRegister = cg->evaluate(firstChild);
-   if (numberOfExtendBits == 32 && targetRegister->getRegisterPair() != NULL) //&& TR::Compiler->target.is32Bit()
+   if (numberOfExtendBits == 32 && targetRegister->getRegisterPair() != NULL) //&& cg->comp()->target().is32Bit()
       // if were using the register pairs (i.e. force64bit() might have been set), just throw away the top
       targetRegister = targetRegister->getLowOrder();
 
@@ -4805,7 +4805,7 @@ bool relativeLongLoadHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Registe
    TR::SymbolReference * symRef = node->getSymbolReference();
    TR::Symbol * symbol = symRef->getSymbol();
 
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) &&
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) &&
        symbol->isStatic() &&
        !symRef->isUnresolved() &&
        !cg->comp()->compileRelocatableCode() &&
@@ -4816,7 +4816,7 @@ bool relativeLongLoadHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Registe
       uintptrj_t staticAddress = (uintptrj_t)symRef->getSymbol()->getStaticSymbol()->getStaticAddress();
 
       TR::InstOpCode::Mnemonic op = TR::InstOpCode::BAD;
-      if (node->getType().isInt32() || (!(TR::Compiler->target.is64Bit()) && node->getType().isAddress() ))
+      if (node->getType().isInt32() || (!(cg->comp()->target().is64Bit()) && node->getType().isAddress() ))
          {
          op = TR::InstOpCode::LRL;
 
@@ -4838,8 +4838,8 @@ bool relativeLongLoadHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Registe
       TR_ASSERT(op != TR::InstOpCode::BAD, "Bad opcode selection in relative load helper!\n");
 
       if ((!disableFORCELRL || cg->canUseRelativeLongInstructions(staticAddress)) &&
-           ((TR::Compiler->target.is32Bit() && (staticAddress&0x3) == 0)  ||
-             (TR::Compiler->target.is64Bit() && (staticAddress&0x7) == 0)
+           ((cg->comp()->target().is32Bit() && (staticAddress&0x3) == 0)  ||
+             (cg->comp()->target().is64Bit() && (staticAddress&0x7) == 0)
            )
          )
          {
@@ -4849,7 +4849,7 @@ bool relativeLongLoadHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Registe
             }
          else
             {
-            if (TR::Compiler->target.is64Bit())
+            if (cg->comp()->target().is64Bit())
                {
                // On 64bit we could end up having to transform the LGRL into LLILF/LG.
                // We would not be able to handle GRP0 in this case
@@ -4910,7 +4910,7 @@ iloadHelper(TR::Node * node, TR::CodeGenerator * cg, TR::MemoryReference * tempM
       {
       bool mustExtend = node->isExtendedTo64BitAtSource();
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && mustExtend)
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && mustExtend)
          {
          if (node->isZeroExtendedTo64BitAtSource())
             {
@@ -5148,7 +5148,7 @@ bool relativeLongStoreHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Node *
    TR::SymbolReference * symRef = node->getSymbolReference();
    TR::Symbol * symbol = symRef->getSymbol();
 
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) &&
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) &&
        symbol->isStatic() &&
        !symRef->isUnresolved() &&
        !cg->comp()->compileRelocatableCode() &&
@@ -5161,8 +5161,8 @@ bool relativeLongStoreHelper(TR::CodeGenerator * cg, TR::Node * node, TR::Node *
 
       TR::Register * sourceRegister = cg->evaluate(valueChild);
 
-      if ((TR::Compiler->target.is32Bit() && (staticAddress&0x3) == 0)  ||
-           (TR::Compiler->target.is64Bit() && (staticAddress&0x7) == 0)
+      if ((cg->comp()->target().is32Bit() && (staticAddress&0x3) == 0)  ||
+           (cg->comp()->target().is64Bit() && (staticAddress&0x7) == 0)
          )
          {
          generateRILInstruction(cg, op, node, sourceRegister, symRef, reinterpret_cast<void*>(staticAddress));
@@ -5240,7 +5240,7 @@ bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGenerator * 
    TR::Compilation *comp = cg->comp();
 
    // All the immediates that use this require non reversed instructions
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || isReversed || cg->getConditionalMovesEvaluationMode())
+   if (!cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) || isReversed || cg->getConditionalMovesEvaluationMode())
       {
       return true;
       }
@@ -5255,7 +5255,7 @@ bool storeHelperImmediateInstruction(TR::Node * valueChild, TR::CodeGenerator * 
          {
          int64_t tmp;
          case TR::Address:
-            if (TR::Compiler->target.is32Bit())
+            if (cg->comp()->target().is32Bit())
                {
                imm = (uintptrj_t)valueChild->getAddress();
                if ((imm <= MIN_IMMEDIATE_VAL) || (imm >= MAX_IMMEDIATE_VAL))
@@ -5460,7 +5460,7 @@ sstoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
       else
          {
          sourceRegister = cg->gprClobberEvaluate(valueChild);
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             generateRSInstruction(cg, TR::InstOpCode::SRLG, node, sourceRegister, sourceRegister, 48);
          else
             generateRSInstruction(cg, TR::InstOpCode::SRL, node, sourceRegister, 16);
@@ -5615,7 +5615,7 @@ istoreHelper(TR::Node * node, TR::CodeGenerator * cg, bool isReversed)
          }
       else
          {
-         if (valueChild->getDataType() != TR::Aggregate || TR::Compiler->target.is32Bit())
+         if (valueChild->getDataType() != TR::Aggregate || cg->comp()->target().is32Bit())
             sourceRegister = cg->evaluate(valueChild);
          else
             {
@@ -5910,7 +5910,7 @@ TR::Register *
 OMR::Z::TreeEvaluator::aladdEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Compilation *comp = cg->comp();
-   TR_ASSERT(TR::Compiler->target.is64Bit(), "aladd should not be seen on 32-bit");
+   TR_ASSERT(cg->comp()->target().is64Bit(), "aladd should not be seen on 32-bit");
 
    TR::Register * targetRegister = cg->allocateRegister();
 
@@ -6283,7 +6283,7 @@ OMR::Z::TreeEvaluator::bstoreEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       else
          {
          sourceRegister = cg->gprClobberEvaluate(valueChild);
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             generateRSInstruction(cg, TR::InstOpCode::SRLG, node, sourceRegister, sourceRegister, 56);
          else
             generateRSInstruction(cg, TR::InstOpCode::SRL, node, sourceRegister, 24);
@@ -6507,12 +6507,12 @@ OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg,
    TR::LabelSymbol *cFlowRegionStart = generateLabelSymbol(cg);
    TR::LabelSymbol *cFlowRegionEnd = generateLabelSymbol(cg);
 
-   TR::InstOpCode::Mnemonic subOp = TR::Compiler->target.is64Bit() ? TR::InstOpCode::SGR : TR::InstOpCode::SR;
-   TR::InstOpCode::Mnemonic addOp = TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGR : TR::InstOpCode::AR;
+   TR::InstOpCode::Mnemonic subOp = cg->comp()->target().is64Bit() ? TR::InstOpCode::SGR : TR::InstOpCode::SR;
+   TR::InstOpCode::Mnemonic addOp = cg->comp()->target().is64Bit() ? TR::InstOpCode::AGR : TR::InstOpCode::AR;
 
    // check if 0 to skip below instructions
    generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, outReg, outReg);
-   generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGHI : TR::InstOpCode::CHI, node, inReg, 0);
+   generateRIInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::CGHI : TR::InstOpCode::CHI, node, inReg, 0);
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, cFlowRegionStart);
    cFlowRegionStart->setStartInternalControlFlow();
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRE, node, cFlowRegionEnd);
@@ -6524,7 +6524,7 @@ OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg,
 
    // x -= (x >> 1) & 0x555555555
    generateRSInstruction(cg, TR::InstOpCode::SRLG, node, outReg, inReg, 1);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
      generateS390ImmOp(cg, TR::InstOpCode::N, node, outReg, outReg, (int64_t) 0x5555555555555555, regDeps);
    else
      generateS390ImmOp(cg, TR::InstOpCode::N, node, outReg, outReg, (int32_t) 0x55555555, regDeps);
@@ -6532,7 +6532,7 @@ OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg,
 
    // x = (x & 0x33333333) + ((x >> 2) & 0x33333333)
    generateRSInstruction(cg, TR::InstOpCode::SRLG, node, outReg, inReg, 2);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateS390ImmOp(cg, TR::InstOpCode::N, node, outReg, outReg, (int64_t) 0x3333333333333333, regDeps);
       generateS390ImmOp(cg, TR::InstOpCode::N, node, inReg, inReg, (int64_t) 0x3333333333333333, regDeps);
@@ -6547,7 +6547,7 @@ OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg,
    // x = (x + (x >> 4)) & 0x0f0f0f0f
    generateRSInstruction(cg, TR::InstOpCode::SRLG, node, outReg, inReg, 4);
    generateRRInstruction(cg, addOp, node, inReg, outReg);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
      generateS390ImmOp(cg, TR::InstOpCode::N, node, inReg, inReg, (int64_t) 0x0f0f0f0f0f0f0f0f, regDeps);
    else
      generateS390ImmOp(cg, TR::InstOpCode::N, node, inReg, inReg, (int32_t) 0x0f0f0f0f, regDeps);
@@ -6565,7 +6565,7 @@ OMR::Z::TreeEvaluator::z990PopCountHelper(TR::Node *node, TR::CodeGenerator *cg,
    generateRRInstruction(cg, addOp, node, outReg, inReg);
 
    // x = x & 0x7f
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
      generateS390ImmOp(cg, TR::InstOpCode::N, node, outReg, outReg, (int64_t) 0x000000000000007f, regDeps);
    else
      generateS390ImmOp(cg, TR::InstOpCode::N, node, outReg, outReg, (int32_t) 0x0000007f, regDeps);
@@ -6745,7 +6745,7 @@ TR::Register *getConditionCode(TR::Node *node, TR::CodeGenerator *cg, TR::Regist
       }
 
    generateRRInstruction(cg, TR::InstOpCode::IPM, node, programRegister, programRegister);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateRRInstruction(cg, TR::InstOpCode::LLGTR, node, programRegister, programRegister);
       generateRSInstruction(cg, TR::InstOpCode::SRLG, node, programRegister, programRegister, 28);
@@ -8043,7 +8043,7 @@ inlineP256Multiply(TR::Node * node, TR::CodeGenerator * cg)
    bool disableSIMDP256 = NULL != disableECCSIMD || comp->getOption(TR_Randomize) && cg->randomizer.randomBoolean();
    bool disableMLGRP256 = NULL != disableECCMLGR || comp->getOption(TR_Randomize) && cg->randomizer.randomBoolean();
 
-   if (!disableVMSL && TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14) && cg->getSupportsVectorRegisters())
+   if (!disableVMSL && cg->comp()->target().cpu.getSupportsArch(TR::CPU::z14) && cg->getSupportsVectorRegisters())
       return inlineVMSL256Multiply(node, cg);
    if (disableECCKarat==NULL && cg->getSupportsVectorRegisters())
       return inlineSIMDP256Multiply(node, cg);
@@ -8938,7 +8938,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
          }
       else
          {
-         needs64BitOpCode =  TR::Compiler->target.is64Bit();
+         needs64BitOpCode =  cg->comp()->target().is64Bit();
          }
 
       if (maxLenIn256)
@@ -9047,7 +9047,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
 
             //cFlowRegionEnd = generateLabelSymbol(cg);
 
-            generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LTGR : TR::InstOpCode::LTR, node, lengthReg, lengthReg);
+            generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LTGR : TR::InstOpCode::LTR, node, lengthReg, lengthReg);
 
             //The following test may not be necessary as TR::InstOpCode::CLCLU/TR::InstOpCode::CLCLE does not care zero legth case?
             if (isFoldedIf)
@@ -9065,12 +9065,12 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
 
             if(isWideChar)
                {
-               if(TR::Compiler->target.is64Bit())
+               if(cg->comp()->target().is64Bit())
                   generateRSInstruction(cg, TR::InstOpCode::SLLG, node, lengthReg, lengthReg, 1);
                else
                   generateRSInstruction(cg, TR::InstOpCode::SLL, node, lengthReg, 1);
                }
-            generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, lengthCopyReg, lengthReg);
+            generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, lengthCopyReg, lengthReg);
 
             TR::LabelSymbol *continueLabel = generateLabelSymbol(cg);
             generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, continueLabel);
@@ -9146,7 +9146,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
 
             TR::LabelSymbol * EXTargetLabel;
 
-            if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
+            if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
                {
                // Inline the EXRL target so it is always in the instruction cache
                generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, EXTargetLabel = generateLabelSymbol(cg));
@@ -9183,7 +9183,7 @@ OMR::Z::TreeEvaluator::arraycmpHelper(TR::Node *node,
             source1MemRef= generateS390MemoryReference(source1Reg, 0, cg);
             source2MemRef= generateS390MemoryReference(source2Reg, 0, cg);
 
-            if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
+            if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
                {
                cursor = new (cg->trHeapMemory()) TR::S390RILInstruction(TR::InstOpCode::EXRL, node, lengthReg, EXTargetLabel, cg);
                }
@@ -9536,7 +9536,7 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
       litpool->setUnresolvedDataSnippet(uds);
 
       TR::S390RILInstruction * lrlInstr = NULL;
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
          {
          lrlInstr = static_cast<TR::S390RILInstruction *>(generateRILInstruction(cg, TR::InstOpCode::getLoadRelativeLongOpCode(), node, targetRegister, reinterpret_cast<void*>(0xBABE), 0));
          uds->setDataReferenceInstruction(lrlInstr);
@@ -10205,7 +10205,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
       // For chars, scale the index and array/search length by 2 (size of char) to convert into bytes.
       if (elementChar)
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateRSInstruction(cg, TR::InstOpCode::SLLG, node, indexReg, indexReg, 1);
             generateRSInstruction(cg, TR::InstOpCode::SLLG, node, alenReg, alenReg, 1);
@@ -10324,7 +10324,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
 
          // Index into helper table - Each entry in table is 16 bytes.
          //   Actual index to helper table is the remaining length (8-byte) * 16.
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             generateShiftAndKeepSelected64Bit(node, cg, tmpReg, tmpReg, 52, 59, 4, true, false);
          else
             generateShiftAndKeepSelected31Bit(node, cg, tmpReg, tmpReg, 20, 27, 4, true, false);
@@ -10525,7 +10525,7 @@ OMR::Z::TreeEvaluator::arraytranslateAndTestEvaluator(TR::Node * node, TR::CodeG
       if (elementChar)
          {
          // Scale the result index from bytes to char.
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             generateRSInstruction(cg, TR::InstOpCode::SRLG, node, indexReg, indexReg, 1);
             }
@@ -10608,7 +10608,7 @@ OMR::Z::TreeEvaluator::arraytranslateEvaluator(TR::Node * node, TR::CodeGenerato
       {
       // We need to copy the final length to resultReg, so that we can calculate
       // number of elements translated after TRXX.
-      if (TR::Compiler->target.is64Bit() && !(inputLengthNode->getOpCode().isLong()))
+      if (cg->comp()->target().is64Bit() && !(inputLengthNode->getOpCode().isLong()))
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, resultReg, inputLenReg);
       else
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, resultReg, inputLenReg);
@@ -10618,7 +10618,7 @@ OMR::Z::TreeEvaluator::arraytranslateEvaluator(TR::Node * node, TR::CodeGenerato
    if (node->isByteToByteTranslate() || node->isByteToCharTranslate())
       {
       opCode = (node->isByteToByteTranslate())?TR::InstOpCode::TROO:TR::InstOpCode::TROT;
-      if (!isLengthConstant && TR::Compiler->target.is64Bit() && !(inputLengthNode->getOpCode().isLong())) // need to ensure this value is sign extended as well
+      if (!isLengthConstant && cg->comp()->target().is64Bit() && !(inputLengthNode->getOpCode().isLong())) // need to ensure this value is sign extended as well
             generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, inputLenReg, resultReg);
       }
    else
@@ -10628,7 +10628,7 @@ OMR::Z::TreeEvaluator::arraytranslateEvaluator(TR::Node * node, TR::CodeGenerato
 
       if (!isLengthConstant)
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg->comp()->target().is64Bit())
             {
             if (!(inputLengthNode->getOpCode().isLong()))
                generateRSInstruction(cg, TR::InstOpCode::SLLG, node, inputLenReg, resultReg, 1);  // resultReg is sign extended above.
@@ -10725,7 +10725,7 @@ OMR::Z::TreeEvaluator::arraytranslateEvaluator(TR::Node * node, TR::CodeGenerato
 
    if (opCode == TR::InstOpCode::TRTO || opCode == TR::InstOpCode::TRTT)
       {
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          generateRSInstruction(cg, TR::InstOpCode::SRLG, node, inputLenReg, inputLenReg, 1);
       else
          generateRSInstruction(cg, TR::InstOpCode::SRL, node, inputLenReg, 1);
@@ -10814,7 +10814,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
 
    if (constType == TR::Address)
       {
-      bool refs64 = TR::Compiler->target.is64Bit() && !comp->useCompressedPointers();
+      bool refs64 = cg->comp()->target().is64Bit() && !comp->useCompressedPointers();
       constType = (refs64 ? TR::Int64 : TR::Int32);
       }
 
@@ -11136,7 +11136,7 @@ OMR::Z::TreeEvaluator::arraysetEvaluator(TR::Node * node, TR::CodeGenerator * cg
             }
          else
             {
-            if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+            if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
                {
                generateRSInstruction(cg, TR::InstOpCode::SRAK, node, itersReg, elemsRegister, 6);
                }
@@ -11337,7 +11337,7 @@ OMR::Z::TreeEvaluator::generateLoadAndStoreForArrayCopy(TR::Node *node, TR::Code
             generateRXInstruction(cg, TR::InstOpCode::STG, node, workReg, dstMemRef);
          break;
       case TR::Address:
-         if (TR::Compiler->target.is64Bit() && !cg->comp()->useCompressedPointers())
+         if (cg->comp()->target().is64Bit() && !cg->comp()->useCompressedPointers())
             {
             if (needsGuardedLoad)
                {
@@ -11393,7 +11393,7 @@ OMR::Z::TreeEvaluator::generateMemToMemElementCopy(TR::Node *node, TR::CodeGener
    deps->addPostCondition(endReg, TR::RealRegister::LegalOddOfPair);
    deps->addPostCondition(brxReg, TR::RealRegister::EvenOddPair);
    TR::DataType elementType = node->getArrayCopyElementType();
-   int32_t elementSize = (elementType == TR::Address && TR::Compiler->target.is64Bit() && cg->comp()->useCompressedPointers()) ? 4 : TR::DataType::getSize(elementType);
+   int32_t elementSize = (elementType == TR::Address && cg->comp()->target().is64Bit() && cg->comp()->useCompressedPointers()) ? 4 : TR::DataType::getSize(elementType);
    TR::Instruction *cursor = NULL;
    TR_Debug *debug = cg->getDebug();
 #define iComment(str) if (debug) debug->addInstructionComment(cursor, (str));
@@ -11508,7 +11508,7 @@ OMR::Z::TreeEvaluator::forwardArrayCopySequenceGenerator(TR::Node *node, TR::Cod
                                        generateS390MemoryReference(byteDstReg, 0, cg),
                                        generateS390MemoryReference(byteSrcReg, 0, cg));
       generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, exrlInstructionLabel);
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !cg->comp()->getOption(TR_DisableInlineEXTarget))
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && !cg->comp()->getOption(TR_DisableInlineEXTarget))
          {
          generateRILInstruction(cg, TR::InstOpCode::EXRL, node, byteLenReg, exrlTargetLabel);
          }
@@ -11531,7 +11531,7 @@ OMR::Z::TreeEvaluator::backwardArrayCopySequenceGenerator(TR::Node *node, TR::Co
    TR::RegisterDependencyConditions *deps = NULL;
    bool genStartICFLabel = node->isBackwardArrayCopy() && byteLenNode->getOpCode().isLoadConst();
 
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z15))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z15))
       {
       TR::Register* loopIterReg = srm->findOrCreateScratchRegister();
 
@@ -11831,7 +11831,7 @@ OMR::Z::TreeEvaluator::aRegLoadEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR::Machine *machine = cg->machine();
 
    // GRA needs to tell LRA about the register type
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       globalReg->setIs64BitReg(true);
       }
@@ -11926,7 +11926,7 @@ OMR::Z::TreeEvaluator::iRegStoreEvaluator(TR::Node * node, TR::CodeGenerator * c
        !cg->comp()->compileRelocatableCode())
       {
       needsLGFR = false;
-      if (TR::Compiler->target.is64Bit())
+      if (cg->comp()->target().is64Bit())
          {
          useLGHI = true;
          }
@@ -12061,7 +12061,7 @@ OMR::Z::TreeEvaluator::long2StringEvaluator(TR::Node * node, TR::CodeGenerator *
    TR::Register * workReg = cg->evaluate(node->getChild(3));
    TR::Register * raReg = cg->allocateRegister();
    TR_ASSERT( inputNode->getDataType() == TR::Int64 || inputNode->getDataType() == TR::Int32, "error");
-   TR_ASSERT( !isLong || TR::Compiler->target.is64Bit(), "Not supported");
+   TR_ASSERT( !isLong || cg->comp()->target().is64Bit(), "Not supported");
 
    TR::Instruction *cursor;
 
@@ -12233,7 +12233,7 @@ OMR::Z::TreeEvaluator::bitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg
    // Use z14's VBPERM instruction if possible. (Note: VBPERM supports permutation on arrays
    // of up to size 16, and beats the performance of the loop unrolling technique used above
    // for arrays with size greater than the bitPermuteConstantUnrollThreshold constant defined above)
-   else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z14) &&
+   else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z14) &&
          isLoadConst  &&
          arrayLen <= 16 )
       {
@@ -12604,7 +12604,7 @@ TR::Register *OMR::Z::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::CodeG
    TR::Compilation *comp = cg->comp();
 
    static char * disablePrefetch = feGetEnv("TR_DisablePrefetch");
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || disablePrefetch)
+   if (!cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) || disablePrefetch)
       {
       cg->recursivelyDecReferenceCount(firstChild);
       cg->recursivelyDecReferenceCount(secondChild);
@@ -12955,14 +12955,14 @@ arraycmpWithPadHelper::arraycmpWithPadHelper(TR::Node *n,
 void arraycmpWithPadHelper::setupCLCLandCLCLE()
    {
    source1LenReg = cg->gprClobberEvaluate(source1LenNode);
-   if ((source1LenNode->getSize()) <= 4 && TR::Compiler->target.is64Bit())
+   if ((source1LenNode->getSize()) <= 4 && cg->comp()->target().is64Bit())
       {
       // Cleanup the high order part of the reg
       generateRRInstruction(cg, TR::InstOpCode::LLGFR, node, source1LenReg, source1LenReg);
       }
 
    source2LenReg = cg->gprClobberEvaluate(source2LenNode);
-   if ((source2LenNode->getSize()) <= 4 && TR::Compiler->target.is64Bit())
+   if ((source2LenNode->getSize()) <= 4 && cg->comp()->target().is64Bit())
       {
       // Cleanup the high order part of the reg
       generateRRInstruction(cg, TR::InstOpCode::LLGFR, node, source2LenReg, source2LenReg);
@@ -12998,7 +12998,7 @@ void arraycmpWithPadHelper::setupConstCLCL()
 TR::Register *arraycmpWithPadHelper::generateConstCLCL()
    {
    uint32_t lenPad = ((uint32_t)source2Len & 0x00FFFFFF) | ((uint32_t)CLCLpaddingChar << 24);
-   if(TR::Compiler->target.is64Bit())
+   if(cg->comp()->target().is64Bit())
       genLoadLongConstant(cg, node, lenPad, source2LenReg);
    else
       generateLoad32BitConstant(cg, node, lenPad, source2LenReg, true);
@@ -13029,9 +13029,9 @@ TR::Register *arraycmpWithPadHelper::generateConstCLCL()
 
 TR::Register *arraycmpWithPadHelper::generateCLCL()
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
          {
          generateRIEInstruction(cg, TR::InstOpCode::ROSBG, node, source2LenReg, paddingReg, 32, 39, 24);
          }
@@ -13249,19 +13249,19 @@ void arraycmpWithPadHelper::generateVarCLCSetup()
       regDeps->addPostCondition(countReg, TR::RealRegister::AssignAny);
       regDeps->addPostCondition(paddingPosReg, TR::RealRegister::AssignAny);
 
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, countReg, source1LenReg);
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, paddingPosReg, source2Reg);
-      if (TR::Compiler->target.is64Bit())
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, countReg, source1LenReg);
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, paddingPosReg, source2Reg);
+      if (cg->comp()->target().is64Bit())
          genLoadLongConstant(cg, node, 2, paddingUnequalRetValReg);
       else
          generateLoad32BitConstant(cg, node, 2, paddingUnequalRetValReg, true);
 
       TR::LabelSymbol *doneAssignLabel = generateLabelSymbol(cg);
-      generateS390CompareAndBranchInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::CGR : TR::InstOpCode::CR, node, source2LenReg, source1LenReg, TR::InstOpCode::COND_BHR, doneAssignLabel);
+      generateS390CompareAndBranchInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::CGR : TR::InstOpCode::CR, node, source2LenReg, source1LenReg, TR::InstOpCode::COND_BHR, doneAssignLabel);
 
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, countReg, source2LenReg);
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, paddingPosReg, source1Reg);
-      if(TR::Compiler->target.is64Bit())
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, countReg, source2LenReg);
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, paddingPosReg, source1Reg);
+      if(cg->comp()->target().is64Bit())
          genLoadLongConstant(cg, node, 1, paddingUnequalRetValReg);
       else
          generateLoad32BitConstant(cg, node, 1, paddingUnequalRetValReg, true);
@@ -13270,26 +13270,26 @@ void arraycmpWithPadHelper::generateVarCLCSetup()
       cursor->setDependencyConditions(regDeps);
 
       paddingLenReg = cg->allocateRegister();
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::SLGR : TR::InstOpCode::SLR, node, source1LenReg, source2LenReg);
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LPGR : TR::InstOpCode::LPR, node, paddingLenReg, source1LenReg);
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::SLGR : TR::InstOpCode::SLR, node, source1LenReg, source2LenReg);
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LPGR : TR::InstOpCode::LPR, node, paddingLenReg, source1LenReg);
       if(isUTF16)
          {
-         if(TR::Compiler->target.is64Bit())
+         if(cg->comp()->target().is64Bit())
             generateRSInstruction(cg, TR::InstOpCode::SRLG, node, paddingLenReg, paddingLenReg, 1);
          else
             generateRSInstruction(cg, TR::InstOpCode::SRL, node, paddingLenReg, 1);
          }
-      generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::ALGR : TR::InstOpCode::ALR, node, paddingPosReg, countReg);
+      generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::ALGR : TR::InstOpCode::ALR, node, paddingPosReg, countReg);
 
       retValReg = cg->allocateRegister();
-      if(TR::Compiler->target.is64Bit())
+      if(cg->comp()->target().is64Bit())
          genLoadLongConstant(cg, node, 0, retValReg);
       else
          generateLoad32BitConstant(cg, node, 0, retValReg, true);
       }
 
    loopCountReg = cg->allocateRegister();
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateRSInstruction(cg, TR::InstOpCode::SRLG, node, loopCountReg, countReg, 8);
       }
@@ -13386,7 +13386,7 @@ void arraycmpWithPadHelper::generateVarCLCMainLoop()
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, loopStartLabel);
 
-   generateS390BranchInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, loopCountReg, loopTopLabel);
+   generateS390BranchInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, loopCountReg, loopTopLabel);
    cg->stopUsingRegister(loopCountReg);
    }
 
@@ -13428,7 +13428,7 @@ void arraycmpWithPadHelper::generateVarCLCRemainder()
    // this compare and branch will work because we'd only get here if the CC was 0
    // if we skip, we're setting it to 0 again (no change)
    // otherwise we're setting it properly with a CLC
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateS390ImmOp(cg, TR::InstOpCode::NG, node, countReg, countReg, (int64_t)0xFF);
 
@@ -13441,7 +13441,7 @@ void arraycmpWithPadHelper::generateVarCLCRemainder()
       generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::C, node, countReg, (int32_t)0, TR::InstOpCode::COND_BE, isFoldedIf ? unequalLabel : cmpDoneLabel, false, false);
       }
 
-   generateRIInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI, node, countReg, -1);
+   generateRIInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI, node, countReg, -1);
 
    TR::MemoryReference *pos1Ref;
    if (!isAddr1Const)
@@ -13487,7 +13487,7 @@ TR::Register* arraycmpWithPadHelper::generateCLCUnequal()
       }
 
    generateRRInstruction(cg, TR::InstOpCode::IPM, node, retValReg, retValReg);
-   if(TR::Compiler->target.is64Bit())
+   if(cg->comp()->target().is64Bit())
       {
       generateRRInstruction(cg, TR::InstOpCode::LLGTR, node, retValReg, retValReg);
       generateRSInstruction(cg, TR::InstOpCode::SRLG, node, retValReg, retValReg, 28);
@@ -13717,7 +13717,7 @@ void arraycmpWithPadHelper::generateConstCLCPaddingLoop()
       generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK6, node, paddingUnequalLabel);
       }
 
-   if(TR::Compiler->target.is64Bit())
+   if(cg->comp()->target().is64Bit())
       genLoadLongConstant(cg, node, 0, retValReg);
    else
       generateLoad32BitConstant(cg, node, 0, retValReg, true);
@@ -13726,7 +13726,7 @@ void arraycmpWithPadHelper::generateConstCLCPaddingLoop()
    //IPM
    generateRRInstruction(cg, TR::InstOpCode::IPM, node, retValReg, retValReg);
    //SRL(G)
-   if(TR::Compiler->target.is64Bit())
+   if(cg->comp()->target().is64Bit())
       {
       generateRRInstruction(cg, TR::InstOpCode::LLGTR, node, retValReg, retValReg);
       generateRSInstruction(cg, TR::InstOpCode::SRLG, node, retValReg, retValReg, 28);
@@ -13768,12 +13768,12 @@ void arraycmpWithPadHelper::generateVarCLCPaddingLoop()
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, loopStartLabel);
 
-   generateS390BranchInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, paddingLenReg, loopTopLabel);
+   generateS390BranchInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::BRCTG : TR::InstOpCode::BRCT, node, paddingLenReg, loopTopLabel);
 
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK15, node, doneLabel); //if we finish the loop, then everything is equal and we're done
 
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, node, paddingUnequalLabel);
-   generateRRInstruction(cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, retValReg, paddingUnequalRetValReg);
+   generateRRInstruction(cg, cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR, node, retValReg, paddingUnequalRetValReg);
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_MASK15, node, doneLabel);
 
    cg->stopUsingRegister(paddingReg);
@@ -14041,7 +14041,7 @@ TR::Register* arraycmpWithPadHelper::generate()
 
    if (isAddr1Const)
       {
-      if(TR::Compiler->target.is64Bit())
+      if(cg->comp()->target().is64Bit())
          {
          source1Reg = cg->allocateRegister();
          genLoadLongConstant(cg, node, addr1Const, source1Reg);
@@ -14055,7 +14055,7 @@ TR::Register* arraycmpWithPadHelper::generate()
 
    if (isAddr2Const)
       {
-      if(TR::Compiler->target.is64Bit())
+      if(cg->comp()->target().is64Bit())
          {
          source2Reg = cg->allocateRegister();
          genLoadLongConstant(cg, node, addr2Const, source2Reg);
@@ -14122,7 +14122,7 @@ TR::Register *OMR::Z::TreeEvaluator::integerNumberOfTrailingZeros(TR::Node *node
 
 TR::Register *OMR::Z::TreeEvaluator::integerBitCount(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z15), "TR::popcnt IL only supported on z15+");
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.getSupportsArch(TR::CPU::z15), "TR::popcnt IL only supported on z15+");
 
    TR::Register* resultReg = cg->allocateRegister();
    TR::Register* valueReg = cg->gprClobberEvaluate(node->getChild(0));
@@ -14648,7 +14648,7 @@ OMR::Z::TreeEvaluator::arraytranslateDecodeSIMDEvaluator(TR::Node * node, TR::Co
       inputLen = cg->gprClobberEvaluate(inputLenNode, true);
 
       // Sign extend the value if needed
-      if (TR::Compiler->target.is64Bit() && !(inputLenNode->getOpCode().isLong()))
+      if (cg->comp()->target().is64Bit() && !(inputLenNode->getOpCode().isLong()))
          {
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, inputLen,   inputLen);
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, inputLen16, inputLen);
@@ -14926,7 +14926,7 @@ OMR::Z::TreeEvaluator::arraytranslateEncodeSIMDEvaluator(TR::Node * node, TR::Co
       inputLen = cg->gprClobberEvaluate(inputLenNode, true);
 
       // Sign extend the value if needed
-      if (TR::Compiler->target.is64Bit() && !(inputLenNode->getOpCode().isLong()))
+      if (cg->comp()->target().is64Bit() && !(inputLenNode->getOpCode().isLong()))
          {
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, inputLen,   inputLen);
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, inputLen16, inputLen);
@@ -15235,7 +15235,7 @@ inlineStringHashCode(TR::Node* node, TR::CodeGenerator* cg, bool isCompressed)
    TR::Register* registerIndex = cg->gprClobberEvaluate(nodeIndex);
    TR::Register* registerCount = cg->gprClobberEvaluate(nodeCount);
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, registerIndex, registerIndex);
       generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, registerCount, registerCount);
@@ -15453,7 +15453,7 @@ inlineUTF16BEEncodeSIMD(TR::Node *node, TR::CodeGenerator *cg)
       generateRSInstruction(cg, TR::InstOpCode::getShiftLeftLogicalSingleOpCode(), node, inputLen, inputLen, 1);
 
       // Sign extend the value if needed
-      if (TR::Compiler->target.is64Bit() && !(inputLenNode->getOpCode().isLong()))
+      if (cg->comp()->target().is64Bit() && !(inputLenNode->getOpCode().isLong()))
          {
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, inputLen,   inputLen);
          generateRRInstruction(cg, TR::InstOpCode::getLoadRegWidenOpCode(), node, inputLen16, inputLen);
@@ -15886,7 +15886,7 @@ OMR::Z::TreeEvaluator::arraycmpSIMDHelper(TR::Node *node,
             {
             // Return -1 or 1 based off the condition code of VFENE
             generateRRInstruction(cg, TR::InstOpCode::IPM, node, resultReg, resultReg);
-            if (TR::Compiler->target.is64Bit())
+            if (cg->comp()->target().is64Bit())
                {
                generateRSInstruction(cg, TR::InstOpCode::SLLG, node, resultReg, resultReg, 34);
                generateRSInstruction(cg, TR::InstOpCode::SRAG, node, resultReg, resultReg, 64-2);
@@ -16609,7 +16609,7 @@ OMR::Z::TreeEvaluator::vrandEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    // last element index. mask4=0,1,2,3 -> last element index=15,7,3,1
    TR::MemoryReference *extractIndexMR = generateS390MemoryReference((1 << (4 - mask4)) - 1, cg);
 
-   TR::Register *resultReg = (TR::Compiler->target.is32Bit() && mask4 == 3) ? cg->allocateRegister() : cg->allocateRegister();
+   TR::Register *resultReg = (cg->comp()->target().is32Bit() && mask4 == 3) ? cg->allocateRegister() : cg->allocateRegister();
    generateVRScInstruction(cg, TR::InstOpCode::VLGV, node, resultReg, workReg, extractIndexMR, mask4);
 
    cg->stopUsingRegister(workReg);
@@ -16814,11 +16814,11 @@ OMR::Z::TreeEvaluator::getvelemEvaluator(TR::Node *node, TR::CodeGenerator *cg)
       }
    else if (dt == TR::VectorInt16 && !isUnsigned)
       {
-      generateRRInstruction(cg, (TR::Compiler->target.is64Bit()) ? TR::InstOpCode::LGHR : TR::InstOpCode::LHR, node, returnReg, returnReg);
+      generateRRInstruction(cg, (cg->comp()->target().is64Bit()) ? TR::InstOpCode::LGHR : TR::InstOpCode::LHR, node, returnReg, returnReg);
       }
    else if (dt == TR::VectorInt8 && !isUnsigned)
       {
-      generateRRInstruction(cg, (TR::Compiler->target.is64Bit()) ? TR::InstOpCode::LGBR : TR::InstOpCode::LBR, node, returnReg, returnReg);
+      generateRRInstruction(cg, (cg->comp()->target().is64Bit()) ? TR::InstOpCode::LGBR : TR::InstOpCode::LBR, node, returnReg, returnReg);
       }
 
    cg->stopUsingRegister(vectorReg);
@@ -17010,7 +17010,7 @@ OMR::Z::TreeEvaluator::genLoadForObjectHeadersMasked(TR::CodeGenerator *cg, TR::
 TR::Register*
 OMR::Z::TreeEvaluator::intrinsicAtomicAdd(TR::Node* node, TR::CodeGenerator* cg)
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196), "Atomic add intrinsics are only supported z196+");
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196), "Atomic add intrinsics are only supported z196+");
 
    TR::Node* addressNode = node->getChild(0);
    TR::Node* valueNode = node->getChild(1);
@@ -17041,7 +17041,7 @@ OMR::Z::TreeEvaluator::intrinsicAtomicAdd(TR::Node* node, TR::CodeGenerator* cg)
 TR::Register*
 OMR::Z::TreeEvaluator::intrinsicAtomicFetchAndAdd(TR::Node* node, TR::CodeGenerator* cg)
    {
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196), "Atomic add intrinsics are only supported z196+");
+   TR_ASSERT_FATAL(cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196), "Atomic add intrinsics are only supported z196+");
 
    TR::Node* addressNode = node->getChild(0);
    TR::Node* valueNode = node->getChild(1);

--- a/compiler/z/codegen/OpMemToMem.cpp
+++ b/compiler/z/codegen/OpMemToMem.cpp
@@ -80,7 +80,7 @@ TR::Instruction *
 MemToMemVarLenMacroOp::generateLoop()
    {
    TR::Compilation *comp = _cg->comp();
-   bool needs64BitOpCode = TR::Compiler->target.is64Bit();
+   bool needs64BitOpCode = comp->target().is64Bit();
 
    if (useEXForRemainder())
       {
@@ -144,7 +144,7 @@ MemToMemVarLenMacroOp::generateLoop()
       }
    else
       {
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+      if (_cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
          {
          generateRSInstruction(_cg, TR::InstOpCode::SRAK, _rootNode, _itersReg, _regLen, 8);
          }
@@ -168,7 +168,7 @@ MemToMemVarLenMacroOp::generateLoop()
 
    generateS390BranchInstruction(_cg, TR::InstOpCode::BRCT, _rootNode, _itersReg, topOfLoop);
 
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
+   if (_cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
       {
       if (useEXForRemainder())
          {
@@ -400,7 +400,7 @@ MemToMemConstLenMacroOp::generateLoop()
    if (_itersReg == NULL)
       _itersReg = (_tmpReg == NULL ? _cg->allocateRegister() : _tmpReg);
 
-   if (TR::Compiler->target.is64Bit())
+   if (_cg->comp()->target().is64Bit())
       cursor = genLoadLongConstant(_cg, _rootNode, largeCopies, _itersReg, cursor, NULL, NULL);
    else
       cursor = generateLoad32BitConstant(_cg, _rootNode, largeCopies, _itersReg, true, cursor, NULL, NULL);
@@ -525,7 +525,7 @@ MemInitConstLenMacroOp::generateLoop()
    if (_itersReg == NULL)
       _itersReg = (_tmpReg == NULL ? _cg->allocateRegister() : _tmpReg);
 
-   if (TR::Compiler->target.is64Bit())
+   if (_cg->comp()->target().is64Bit())
       cursor = genLoadLongConstant(_cg, _rootNode, largeCopies, _itersReg, cursor, NULL, NULL);
    else
       cursor = generateLoad32BitConstant(_cg, _rootNode, largeCopies, _itersReg, true, cursor, NULL, NULL);
@@ -971,7 +971,7 @@ MemToMemVarLenMacroOp::generateRemainder()
 
       TR::Instruction* cursor = NULL;
 
-      if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || comp->getOption(TR_DisableInlineEXTarget))
+      if (!_cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) || comp->getOption(TR_DisableInlineEXTarget))
          {
          cursor = generateInstruction(0, 1);
          }
@@ -991,7 +991,7 @@ MemToMemVarLenMacroOp::generateRemainder()
         }
 
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
+      if (_cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && !comp->getOption(TR_DisableInlineEXTarget))
          {
          TR_ASSERT(_EXTargetLabel != NULL, "Assert: EXTarget label must not be NULL");
 
@@ -1018,7 +1018,7 @@ MemToMemVarLenMacroOp::generateRemainder()
    else
       {
       TR::LabelSymbol *remainderDoneLabel = generateLabelSymbol(_cg);
-      if (TR::Compiler->target.is64Bit())
+      if (_cg->comp()->target().is64Bit())
          generateShiftAndKeepSelected64Bit(_rootNode, _cg, _regLen, _regLen, 52, 59, 4, true, false);
       else
          generateShiftAndKeepSelected31Bit(_rootNode, _cg, _regLen, _regLen, 20, 27, 4, true, false);
@@ -1043,7 +1043,7 @@ MemInitVarLenMacroOp::generateRemainder()
       {
       // can't use generateS390ImmOp as it may generate a temporary register
       // which wouldn't have a dependency
-      if(TR::Compiler->target.is64Bit())
+      if(_cg->comp()->target().is64Bit())
          {
          generateRILInstruction(_cg, TR::InstOpCode::NILF, _rootNode, _regLen, 0xFF);
          generateRILInstruction(_cg, TR::InstOpCode::NIHF, _rootNode, _regLen, 0);
@@ -1059,13 +1059,13 @@ MemInitVarLenMacroOp::generateRemainder()
       if (!_doneLabel)
          _doneLabel  = generateLabelSymbol(_cg);
 
-      if(TR::Compiler->target.is64Bit())
+      if(_cg->comp()->target().is64Bit())
          generateS390CompareAndBranchInstruction(_cg, TR::InstOpCode::CG, _rootNode, _regLen, (int32_t)0, TR::InstOpCode::COND_BNH, _doneLabel, false, false);
       else
          generateS390CompareAndBranchInstruction(_cg, TR::InstOpCode::C, _rootNode, _regLen, (int32_t)0, TR::InstOpCode::COND_BNH, _doneLabel, false, false);
 
       if (_firstByteInitialized)
-         generateRIInstruction(_cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI, _rootNode, _regLen, -1);
+         generateRIInstruction(_cg, _cg->comp()->target().is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI, _rootNode, _regLen, -1);
 
       TR::Instruction * MVCInstr = generateSS1Instruction(_cg, TR::InstOpCode::MVC, _rootNode, 0,
                new (_cg->trHeapMemory()) TR::MemoryReference(_dstReg, 1, _cg),
@@ -1087,7 +1087,7 @@ MemInitVarLenMacroOp::generateRemainder()
       {
       //Need to compensate the length as the first byte has been set in generateLoop
       //and check if there is a remainder.
-      generateRIInstruction(_cg, TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI, _rootNode, _regLen, -1);
+      generateRIInstruction(_cg, _cg->comp()->target().is64Bit() ? TR::InstOpCode::AGHI : TR::InstOpCode::AHI, _rootNode, _regLen, -1);
 
       if (!_doneLabel)
          _doneLabel  = generateLabelSymbol(_cg);
@@ -1126,7 +1126,7 @@ MemClearVarLenMacroOp::generateRemainder()
       return MemToMemVarLenMacroOp::generateRemainder();
       }
 
-   if(TR::Compiler->target.is64Bit())
+   if(_cg->comp()->target().is64Bit())
       {
       cursor = generateS390ImmOp(_cg, TR::InstOpCode::NG, _rootNode, _regLen, _regLen, (int64_t)0xFF);
       generateS390CompareAndBranchInstruction(_cg, TR::InstOpCode::CG, _rootNode, _regLen, (int32_t)0, TR::InstOpCode::COND_BL, _doneLabel, false, false);
@@ -1243,7 +1243,7 @@ MemClearConstLenMacroOp::generateInstruction(int32_t offset, int64_t length, TR:
       // For lengths of 1, 2, 4 and 8, the XC sequence is suboptimal, as they require
       // 2 cycles to execute.  If MVI / MVHHI / MVHI / MVGHI are supported, we should
       // generate those instead.
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && length <= 8 && TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(length))
+      if (_cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && length <= 8 && TR::TreeEvaluator::checkPositiveOrNegativePowerOfTwo(length))
          {
          switch(length)
             {
@@ -1594,7 +1594,7 @@ generateCmpSignResult(TR::CodeGenerator * cg, TR::Node * rootNode, TR::Register 
 #if USE_IPM_FORARRAYCMPSIGN
    generateS390LabelInstruction(cg, TR::InstOpCode::LABEL, rootNode, falseLabel);
    generateRRInstruction(cg, TR::InstOpCode::IPM, rootNode, resultReg, resultReg);
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       generateRSInstruction(cg, TR::InstOpCode::SLLG, rootNode, resultReg, resultReg, 34);
       generateRSInstruction(cg, TR::InstOpCode::SRAG, rootNode, resultReg, resultReg, 64-2);
@@ -1746,7 +1746,7 @@ MemToMemTypedVarLenMacroOp::shiftSize()
          return 3;
          break;
       default:
-         if (TR::Compiler->target.is64Bit())
+         if (_cg->comp()->target().is64Bit())
             return 3;
          else
             return 2;
@@ -1774,7 +1774,7 @@ MemToMemTypedVarLenMacroOp::strideSize()
          return 8;
          break;
       default:
-         if (TR::Compiler->target.is64Bit() && !comp->useCompressedPointers())
+         if (comp->target().is64Bit() && !comp->useCompressedPointers())
             return 8;
          else
             return 4;
@@ -1972,7 +1972,7 @@ MemCpyVarLenTypedMacroOp::generateInstruction()
          cursor = generateRXInstruction(_cg, TR::InstOpCode::STG, _dstNode, _workReg, dstMR);
          break;
       case TR::Address:
-         if (TR::Compiler->target.is64Bit() && !comp->useCompressedPointers())
+         if (_cg->comp()->target().is64Bit() && !comp->useCompressedPointers())
             {
             if (_needsGuardedLoad)
                {
@@ -2377,9 +2377,9 @@ MemCpyAtomicMacroOp::generateLoop()
       if (_trace)
          traceMsg(comp, "MemCpyAtomicMacroOp: unknown type routine\n");
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+      if (comp->target().cpu.getSupportsArch(TR::CPU::z196))
          {
-         auto mnemonic = TR::Compiler->target.is64Bit() ? TR::InstOpCode::OGRK : TR::InstOpCode::ORK;
+         auto mnemonic = comp->target().is64Bit() ? TR::InstOpCode::OGRK : TR::InstOpCode::ORK;
 
          cursor = generateRRRInstruction(_cg, mnemonic, _srcNode, _alignedReg, _srcReg, _startReg);
          }
@@ -2448,9 +2448,9 @@ MemCpyAtomicMacroOp::generateLoop()
          traceMsg(comp, "MemCpyAtomicMacroOp: aligned loop\n");
       if (_destType == TR::Int16)
          {
-         if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+         if (comp->target().cpu.getSupportsArch(TR::CPU::z196))
             {
-            auto mnemonic = TR::Compiler->target.is64Bit() ? TR::InstOpCode::NGRK : TR::InstOpCode::NRK;
+            auto mnemonic = comp->target().is64Bit() ? TR::InstOpCode::NGRK : TR::InstOpCode::NRK;
 
             cursor = generateRRRInstruction(_cg, mnemonic, _srcNode, _alignedReg, _srcReg, _startReg);
             }
@@ -2473,9 +2473,9 @@ MemCpyAtomicMacroOp::generateLoop()
          cursor = generateS390BranchInstruction(_cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, _srcNode, remainderLabel);
          }
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+      if (_cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
          {
-         auto mnemonic = TR::Compiler->target.is64Bit() ? TR::InstOpCode::AGRK : TR::InstOpCode::ARK;
+         auto mnemonic = _cg->comp()->target().is64Bit() ? TR::InstOpCode::AGRK : TR::InstOpCode::ARK;
 
          cursor = generateRRRInstruction(_cg, mnemonic, _srcNode, _alignedReg, _srcReg, _startReg);
          }

--- a/compiler/z/codegen/S390Debug.cpp
+++ b/compiler/z/codegen/S390Debug.cpp
@@ -1215,7 +1215,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390RILInstruction * instr)
          int32_t offsetInHalfWords =(int32_t) (*((int32_t *)(cursor+2)));
          intptrj_t offset = ((intptrj_t)offsetInHalfWords) * 2;
          intptrj_t targetAddress = (intptrj_t)cursor + offset;
-         if (TR::Compiler->target.is32Bit())
+         if (_comp->target().is32Bit())
             targetAddress &= 0x7FFFFFFF;
 
          if (offsetInHalfWords<0)
@@ -1762,7 +1762,7 @@ TR_Debug::print(TR::FILE *pOutFile, TR::S390MIIInstruction * instr)
       offsetInHalfWords = offsetInHalfWords >> 8;
       intptrj_t offset = ((intptrj_t)offsetInHalfWords) * 2;
       intptrj_t targetAddress = (intptrj_t)cursor + offset;
-      if (TR::Compiler->target.is32Bit())
+      if (_comp->target().is32Bit())
          targetAddress &= 0x7FFFFFFF;
       if (offsetInHalfWords<0)
          trfprintf(pOutFile, ", targetAddr=0x%p (offset=-0x%p)", targetAddress, -offset);
@@ -2338,11 +2338,11 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
          case TR::Address:
             if (!privateLinkage->getRightToLeft())
                {
-               offset -= TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset -= _comp->target().is64Bit() ? 8 : 4;
                }
             if (intArgNum < privateLinkage->getNumIntegerArgumentRegisters())
                {
-               if (TR::Compiler->target.is64Bit() && child->getDataType() == TR::Address)
+               if (_comp->target().is64Bit() && child->getDataType() == TR::Address)
                   {
                   printPrefix(pOutFile, NULL, bufferPos, 6);
                   trfprintf(pOutFile, "STG  \t");
@@ -2358,7 +2358,7 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                print(pOutFile, stackPtr);
                trfprintf(pOutFile, ")");
 
-               if (TR::Compiler->target.is64Bit() && child->getDataType() == TR::Address)
+               if (_comp->target().is64Bit() && child->getDataType() == TR::Address)
                   {
                   bufferPos += 6;
                   }
@@ -2370,18 +2370,18 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
             intArgNum++;
             if (privateLinkage->getRightToLeft())
                {
-               offset -= TR::Compiler->target.is64Bit() ? 8 : 4;
+               offset -= _comp->target().is64Bit() ? 8 : 4;
                }
             break;
 
          case TR::Int64:
             if (!privateLinkage->getRightToLeft())
                {
-               offset -= (TR::Compiler->target.is64Bit() ? 16 : 8);
+               offset -= (_comp->target().is64Bit() ? 16 : 8);
                }
             if (intArgNum < privateLinkage->getNumIntegerArgumentRegisters())
                {
-               if (TR::Compiler->target.is64Bit())
+               if (_comp->target().is64Bit())
                   {
                   printPrefix(pOutFile, NULL, bufferPos, 6);
                   trfprintf(pOutFile, "STG  \t");
@@ -2414,10 +2414,10 @@ TR_Debug::printS390ArgumentsFlush(TR::FILE *pOutFile, TR::Node * node, uint8_t *
                      }
                   }
                }
-            intArgNum += TR::Compiler->target.is64Bit() ? 1 : 2;
+            intArgNum += _comp->target().is64Bit() ? 1 : 2;
             if (privateLinkage->getRightToLeft())
                {
-               offset += TR::Compiler->target.is64Bit() ? 16 : 8;
+               offset += _comp->target().is64Bit() ? 16 : 8;
                }
             break;
 

--- a/compiler/z/codegen/S390GenerateInstructions.cpp
+++ b/compiler/z/codegen/S390GenerateInstructions.cpp
@@ -323,7 +323,7 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
    if( !cg->comp()->getOption(TR_DisableCompareAndBranchInstruction) &&
            !needsCC &&
            replacementOpCode != TR::InstOpCode::BAD &&
-           TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12))
+           cg->comp()->target().cpu.getSupportsArch(TR::CPU::zEC12))
       {
       // generate a compare and branch.
       returnInstruction = (TR::S390RIEInstruction *)generateRIEInstruction(cg, replacementOpCode, node, first, second, branchDestination, bc);
@@ -419,7 +419,7 @@ generateS390CompareAndBranchInstruction(TR::CodeGenerator * cg,
    if( !cg->comp()->getOption(TR_DisableCompareAndBranchInstruction) &&
            !needsCC &&
            replacementOpCode != TR::InstOpCode::BAD &&
-           TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12))
+           cg->comp()->target().cpu.getSupportsArch(TR::CPU::zEC12))
       {
       cursor = (TR::S390RIEInstruction *)generateRIEInstruction(cg, replacementOpCode, node, first, (int8_t) second, branchDestination, bc, preced);
       }
@@ -2067,13 +2067,13 @@ TR::Instruction *
 generateShiftRightImmediate(TR::CodeGenerator *cg, TR::Node *node, TR::Register *trgReg, TR::Register *srcReg, int32_t imm, TR::Instruction *preced)
    {
    TR::Instruction *instr = NULL;
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       instr = generateRSInstruction(cg, TR::InstOpCode::SRAG, node, trgReg, srcReg, imm, preced);
       }
    else
       {
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
          {
          instr = generateRSInstruction(cg, TR::InstOpCode::SRAK, node, trgReg, srcReg, imm, preced);
          }
@@ -2315,7 +2315,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    TR::S390RILInstruction *LRLinst = 0;
    if (cg->isLiteralPoolOnDemandOn() && (base == 0))
       {
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && op == TR::InstOpCode::L)
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && op == TR::InstOpCode::L)
          {
          targetsnippet = cg->findOrCreate4ByteConstant(node, imm);
          LRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LRL, node, treg, targetsnippet, 0);
@@ -2388,7 +2388,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
    TR::Instruction * cursor;
    TR::Compilation *comp = cg->comp();
 
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
       {
       if (op == TR::InstOpCode::LG || op == TR::InstOpCode::L)
          {
@@ -2421,7 +2421,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       {
       base = NULL;
       }
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       dataref = generateS390MemoryReference((int64_t)imm, TR::Int64, cg, base, node);
       }
@@ -2531,7 +2531,7 @@ generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op
       }
    else if (cg->isLiteralPoolOnDemandOn() && (base == 0))
       {
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) && op == TR::InstOpCode::LG)
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10) && op == TR::InstOpCode::LG)
          {
          targetsnippet = cg->findOrCreate8ByteConstant(node, imm);
          LGRLinst = (TR::S390RILInstruction *) generateRILInstruction(cg, TR::InstOpCode::LGRL, node, treg, targetsnippet, 0);
@@ -2606,7 +2606,7 @@ TR::Instruction *
 generateRegLitRefInstruction(TR::CodeGenerator * cg, TR::InstOpCode::Mnemonic op, TR::Node * node, TR::Register * treg, uintptrj_t imm,
                              TR::RegisterDependencyConditions * cond, TR::Instruction * preced, TR::Register * base, bool isPICCandidate)
    {
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       return generateRegLitRefInstruction(cg, op, node, treg, (int64_t) imm, cond, preced, base, isPICCandidate);
       }
@@ -2934,7 +2934,7 @@ generateSerializationInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Inst
    {
    // BCR R15, 0 is the defacto serialization instruction on Z, however on z196, a fast serialization
    // facilty was added, and hence BCR R14, 0 is preferred
-   TR::InstOpCode::S390BranchCondition cond = TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196) ? TR::InstOpCode::COND_MASK14 : TR::InstOpCode::COND_MASK15;
+   TR::InstOpCode::S390BranchCondition cond = cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196) ? TR::InstOpCode::COND_MASK14 : TR::InstOpCode::COND_MASK15;
 
    // We needed some special handling in TR::Instruction::assignRegisterNoDependencies
    // to recognize real register GPR0 being passed in.
@@ -3048,11 +3048,11 @@ void generateShiftAndKeepSelected64Bit(TR::Node * node, TR::CodeGenerator *cg,
                                        TR::Register * aFirstRegister, TR::Register * aSecondRegister,
                                        int aFromBit, int aToBit, int aShiftAmount, bool aClearOtherBits, bool aSetConditionCode)
    {
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12) && !aSetConditionCode)
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::zEC12) && !aSetConditionCode)
       {
       generateRIEInstruction(cg, TR::InstOpCode::RISBGN, node, aFirstRegister, aSecondRegister, aFromBit, aToBit|(aClearOtherBits ? 0x80 : 0x00), aShiftAmount);
       }
-   else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+   else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
       {
       generateRIEInstruction(cg, TR::InstOpCode::RISBG, node, aFirstRegister, aSecondRegister, aFromBit, aToBit|(aClearOtherBits ? 0x80 : 0x00), aShiftAmount);
       }
@@ -3073,7 +3073,7 @@ generateShiftAndKeepSelected31Bit(TR::Node * node, TR::CodeGenerator *cg,
                                   TR::Register * aFirstRegister, TR::Register * aSecondRegister,
                                   int aFromBit, int aToBit, int aShiftAmount, bool aClearOtherBits, bool aSetConditionCode)
    {
-   if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       generateRIEInstruction(cg, TR::InstOpCode::RISBLG, node, aFirstRegister, aSecondRegister, aFromBit, aToBit|(aClearOtherBits ? 0x80 : 0x00), aShiftAmount);
       }

--- a/compiler/z/codegen/S390HelperCallSnippet.cpp
+++ b/compiler/z/codegen/S390HelperCallSnippet.cpp
@@ -129,7 +129,7 @@ TR::S390HelperCallSnippet::emitSnippetBody()
       }
 #endif
 
-   TR_ASSERT_FATAL(TR::Compiler->target.cpu.isTargetWithinBranchRelativeRILRange(destAddr, branchInstructionStartAddress),
+   TR_ASSERT_FATAL(cg()->comp()->target().cpu.isTargetWithinBranchRelativeRILRange(destAddr, branchInstructionStartAddress),
                    "Helper Call is not reachable.");
    this->setSnippetDestAddr(destAddr);
 

--- a/compiler/z/codegen/S390OutOfLineCodeSection.cpp
+++ b/compiler/z/codegen/S390OutOfLineCodeSection.cpp
@@ -52,7 +52,7 @@ TR_S390OutOfLineCodeSection::TR_S390OutOfLineCodeSection(TR::Node  *callNode,
                                                  TR::LabelSymbol    *restartLabel,
                                                  TR::CodeGenerator *cg) :
                                                  TR_OutOfLineCodeSection(callNode,callOp,targetReg,entryLabel,restartLabel,cg),
-                                                   _targetRegMovOpcode(TR::Compiler->target.is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR)
+                                                   _targetRegMovOpcode(cg->comp()->target().is64Bit() ? TR::InstOpCode::LGR : TR::InstOpCode::LR)
    {
    // isPreparedForDirectJNI also checks if the node is a call
    if(callNode->isPreparedForDirectJNI())

--- a/compiler/z/codegen/S390Peephole.cpp
+++ b/compiler/z/codegen/S390Peephole.cpp
@@ -439,7 +439,7 @@ TR_S390PostRAPeephole::AGIReduction()
    // We can switch the _cursor to instruction to LA if:
    // 1. The opcode is LGR
    // 2. The target is 64-bit (because LA sets the upppermost bit to 0 on 31-bit)
-   attemptLA &= _cursor->getOpCodeValue() == TR::InstOpCode::LGR && TR::Compiler->target.is64Bit();
+   attemptLA &= _cursor->getOpCodeValue() == TR::InstOpCode::LGR && comp()->target().is64Bit();
    if (attemptLA)
       {
       // in order to switch the instruction to LA, we check to see that
@@ -790,7 +790,7 @@ TR_S390PostRAPeephole::seekRegInFutureMemRef(int32_t maxWindowSize, TR::Register
 bool
 TR_S390PostRAPeephole::removeMergedNullCHK()
    {
-      if (TR::Compiler->target.isZOS())
+      if (comp()->target().isZOS())
         {
         // CLT cannot do the job in zOS because in zOS it is legal to read low memory address (like 0x000000, literally NULL),
         // and CLT will read the low memory address legally (in this case NULL) to compare it with the other operand.
@@ -1285,7 +1285,7 @@ TR_S390PostRAPeephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branc
    bool disabled = comp()->getOption(TR_DisableZ13) || comp()->getOption(TR_DisableZ13LoadImmediateOnCond);
 
    // This optimization relies on hardware instructions introduced in z13
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z13) || disabled)
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z13) || disabled)
       return false;
 
    TR::S390RIEInstruction* branchInst = static_cast<TR::S390RIEInstruction*> (_cursor);
@@ -1354,7 +1354,7 @@ TR_S390PostRAPeephole::ConditionalBranchReduction(TR::InstOpCode::Mnemonic branc
 bool
 TR_S390PostRAPeephole::CompareAndBranchReduction()
    {
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z10))
       return false;
 
    bool branchTakenPerformReduction = false;
@@ -1453,7 +1453,7 @@ TR_S390PostRAPeephole::LoadAndMaskReduction(TR::InstOpCode::Mnemonic LZOpCode)
    bool disabled = comp()->getOption(TR_DisableZ13) || comp()->getOption(TR_DisableZ13LoadAndMask);
 
    // This optimization relies on hardware instructions introduced in z13
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z13) || disabled)
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z13) || disabled)
       return false;
 
    if (_cursor->getNext()->getOpCodeValue() == TR::InstOpCode::NILL)
@@ -1570,7 +1570,7 @@ bool
 TR_S390PostRAPeephole::trueCompEliminationForCompare()
    {
    // z10 specific
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z10) || comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       return false;
       }
@@ -1709,7 +1709,7 @@ bool
 TR_S390PostRAPeephole::trueCompEliminationForCompareAndBranch()
    {
    // z10 specific
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z10) || comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       return false;
       }
@@ -1850,7 +1850,7 @@ TR_S390PostRAPeephole::trueCompEliminationForCompareAndBranch()
 bool
 TR_S390PostRAPeephole::trueCompEliminationForLoadComp()
    {
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10) || TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z10) || comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       return false;
       }
@@ -2331,7 +2331,7 @@ TR_S390PostRAPeephole::attemptZ7distinctOperants()
 
    TR::Instruction * instr = _cursor;
 
-   if (!TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z196))
+   if (!comp()->target().cpu.getSupportsArch(TR::CPU::z196))
       {
       return false;
       }
@@ -2619,10 +2619,10 @@ TR_S390PostRAPeephole::reloadLiteralPoolRegisterForCatchBlock()
    // This causes a failure when we come back to a catch block because the register context will not be preserved.
    // Hence, we can not assume that R6 will still contain the lit pool register and hence need to reload it.
 
-   bool isZ10 = TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10);
+   bool isZ10 = comp()->target().cpu.getSupportsArch(TR::CPU::z10);
 
    // we only need to reload literal pool for Java on older z architecture on zos when on demand literal pool is off
-   if ( TR::Compiler->target.isZOS() && !isZ10 && !_cg->isLiteralPoolOnDemandOn())
+   if ( comp()->target().isZOS() && !isZ10 && !_cg->isLiteralPoolOnDemandOn())
       {
       // check to make sure that we actually need to use the literal pool register
       TR::Snippet * firstSnippet = _cg->getFirstSnippet();
@@ -2851,7 +2851,7 @@ TR_S390PostRAPeephole::perform()
             {
             static char * disableEXRLDispatch = feGetEnv("TR_DisableEXRLDispatch");
 
-            if (_cursor->isOutOfLineEX() && !comp()->getCurrentBlock()->isCold() && !(bool)disableEXRLDispatch && TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+            if (_cursor->isOutOfLineEX() && !comp()->getCurrentBlock()->isCold() && !(bool)disableEXRLDispatch && comp()->target().cpu.getSupportsArch(TR::CPU::z10))
                inlineEXtarget();
             break;
             }
@@ -2921,7 +2921,7 @@ TR_S390PostRAPeephole::perform()
             }
          case TR::InstOpCode::CGIT:
             {
-            if (TR::Compiler->target.is64Bit() && !removeMergedNullCHK())
+            if (comp()->target().is64Bit() && !removeMergedNullCHK())
                {
                if (comp()->getOption(TR_TraceCG))
                   printInst();

--- a/compiler/z/codegen/SystemLinkage.cpp
+++ b/compiler/z/codegen/SystemLinkage.cpp
@@ -305,10 +305,10 @@ TR::SystemLinkage::mapStack(TR::ResolvedMethodSymbol * method, uint32_t stackInd
       }
 
    // Map slot for long displacement
-   if (TR::Compiler->target.isLinux())
+   if (comp()->target().isLinux())
       {
       // Linux on Z has a special reserved slot in the linkage convention
-      setOffsetToLongDispSlot(TR::Compiler->target.is64Bit() ? 8 : 4);
+      setOffsetToLongDispSlot(comp()->target().is64Bit() ? 8 : 4);
       }
    else
       {

--- a/compiler/z/codegen/SystemLinkageLinux.cpp
+++ b/compiler/z/codegen/SystemLinkageLinux.cpp
@@ -83,7 +83,7 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
    {
    setProperties(FirstParmAtFixedOffset);
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       setProperty(NeedsWidening);
       setProperty(PadFloatParms);
@@ -102,7 +102,7 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
                                                                 // This possibly assumes that we don't shuffle the return address register around elsewhere
    setRegisterFlag(TR::RealRegister::GPR15, Preserved);
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       setRegisterFlag(TR::RealRegister::FPR8, Preserved);
       setRegisterFlag(TR::RealRegister::FPR9, Preserved);
@@ -152,7 +152,7 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
    setFloatArgumentRegister(0, TR::RealRegister::FPR0);
    setFloatArgumentRegister(1, TR::RealRegister::FPR2);
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       setFloatArgumentRegister(2, TR::RealRegister::FPR4);
       setFloatArgumentRegister(3, TR::RealRegister::FPR6);
@@ -212,7 +212,7 @@ TR::S390zLinuxSystemLinkage::S390zLinuxSystemLinkage(TR::CodeGenerator* cg)
    // x'1c0' see ICST_PAR in tpf/icstk.h
    setOffsetToFirstParm(448);
 #else
-   if (TR::Compiler->target.is64Bit())
+   if (cg->comp()->target().is64Bit())
       {
       setOffsetToRegSaveArea(16);
       setGPRSaveAreaBeginOffset(48);
@@ -383,7 +383,7 @@ TR::S390zLinuxSystemLinkage::callNativeFunction(TR::Node * callNode,
       case TR::lcall:
       case TR::lcalli:
          {
-         if (TR::Compiler->target.is64Bit())
+         if (cg()->comp()->target().is64Bit())
             {
             returnRegister = deps->searchPostConditionRegister(getIntegerReturnRegister());
             }
@@ -474,7 +474,7 @@ TR::S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, 
       switch (parmCursor->getDataType())
          {
          case TR::Int64:
-            if(TR::Compiler->target.is32Bit())
+            if(cg()->comp()->target().is32Bit())
                {
                //make sure that we can fit the entire value in registers, not half in registers half on the stack
                if((numIntegerArgs + 2) <= getNumIntegerArgumentRegisters())
@@ -521,7 +521,7 @@ TR::S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, 
                   {
                   if (numIntegerArgs < getNumIntegerArgumentRegisters())
                      {
-                     numIntegerArgs += (TR::Compiler->target.is64Bit()) ? 1 : 2;
+                     numIntegerArgs += (cg()->comp()->target().is64Bit()) ? 1 : 2;
                      }
                   }
             break;
@@ -570,7 +570,7 @@ TR::S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, 
          parmCursor->setParameterOffset(parmCursor->getParameterOffset() + gprSize - parmCursor->getSize());
          }
 
-      if (TR::Compiler->target.is64Bit() && parmCursor->getType().isAddress() && (parmCursor->getSize()==4))
+      if (cg()->comp()->target().is64Bit() && parmCursor->getType().isAddress() && (parmCursor->getSize()==4))
          {
          // This is a 31-bit pointer parameter. It's real location is +4 bytes from the start of the
          // 8-byte parm slot. Since ptr31 parms are passed as 64-bit values, the prologue code has the
@@ -591,8 +591,8 @@ TR::S390zLinuxSystemLinkage::initParamOffset(TR::ResolvedMethodSymbol * method, 
 int32_t
 TR::S390zLinuxSystemLinkage::getRegisterSaveOffset(TR::RealRegister::RegNum srcReg)
    {
-   int32_t gpr2Offset = TR::Compiler->target.is64Bit() ? 16 : 8;
-   int32_t fpr0Offset = TR::Compiler->target.is64Bit() ? 128 : 64;
+   int32_t gpr2Offset = cg()->comp()->target().is64Bit() ? 16 : 8;
+   int32_t fpr0Offset = cg()->comp()->target().is64Bit() ? 128 : 64;
    switch(srcReg)
       {
       case TR::RealRegister::FPR0: return fpr0Offset;

--- a/compiler/z/codegen/TranslateEvaluator.cpp
+++ b/compiler/z/codegen/TranslateEvaluator.cpp
@@ -130,7 +130,7 @@ TR::Register *inlineTrtEvaluator(
    TR::Register *r1Reg = cg->allocateRegister();
    TR::Register *r2Reg = cg->allocateRegister();
 
-   if (packR2 && !TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+   if (packR2 && !cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
       {
       generateRRInstruction(cg, TR::InstOpCode::XR, node, r2Reg, r2Reg);
       }
@@ -158,7 +158,7 @@ TR::Register *inlineTrtEvaluator(
       cg->decReferenceCount(lengthNode);
       }
 
-   if ((opCode == TR::InstOpCode::TRTR) && (TR::Compiler->target.is32Bit()))
+   if ((opCode == TR::InstOpCode::TRTR) && (cg->comp()->target().is32Bit()))
       {
       TR::MemoryReference *r1BitClearRef = generateS390MemoryReference(r1Reg, 0, cg);
       TR::Instruction *cursor = generateRXInstruction(cg, TR::InstOpCode::LA, node, r1Reg, r1BitClearRef);
@@ -169,11 +169,11 @@ TR::Register *inlineTrtEvaluator(
       {
       TR::Register *conditionCodeReg = getConditionCode(node, cg);
 
-      if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::zEC12))
+      if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::zEC12))
          {
          generateRIEInstruction(cg, TR::InstOpCode::RISBGN, node,  conditionCodeReg, r2Reg, 48, 55, 8);
          }
-      else if (TR::Compiler->target.cpu.getSupportsArch(TR::CPU::z10))
+      else if (cg->comp()->target().cpu.getSupportsArch(TR::CPU::z10))
          {
          generateRIEInstruction(cg, TR::InstOpCode::RISBG, node,  conditionCodeReg, r2Reg, 48, 55, 8);
          }

--- a/compiler/z/codegen/UnaryEvaluator.cpp
+++ b/compiler/z/codegen/UnaryEvaluator.cpp
@@ -187,7 +187,7 @@ OMR::Z::TreeEvaluator::iabsEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 #endif
    else if (node->getOpCodeValue() == TR::iabs)
       opCode = TR::InstOpCode::getLoadPositiveRegWidenOpCode();
-   else if (TR::Compiler->target.is64Bit())
+   else if (cg->comp()->target().is64Bit())
       opCode = TR::InstOpCode::LPGR;
    else
       TR_ASSERT( 0,"labs for 32 bit not implemented yet");

--- a/compiler/z/codegen/snippet/PPA1Snippet.cpp
+++ b/compiler/z/codegen/snippet/PPA1Snippet.cpp
@@ -59,7 +59,7 @@ TR::PPA1Snippet::emitSnippetBody()
 
    uint8_t flags1 = 0x00;
 
-   if (TR::Compiler->target.is64Bit())
+   if (cg()->comp()->target().is64Bit())
       {
       flags1 |= 0x80;
       }

--- a/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.cpp
+++ b/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.cpp
@@ -35,7 +35,7 @@ uint32_t TR::XPLINKCallDescriptorSnippet::generateCallDescriptorValue(TR::S390zO
    {
    uint32_t result = 0;
 
-   if (TR::Compiler->target.is32Bit())
+   if (linkage->cg()->comp()->target().is32Bit())
       {
       uint32_t returnValueAdjust = 0;
 


### PR DESCRIPTION
Issue: #4518

Note, this PR hasn't removed all uses of the global `TR::CompilerEnv->target`, see https://github.com/eclipse/omr/issues/4518#issuecomment-554478912