### PR TITLE
Compact trigger adjustment

### DIFF
--- a/gc/base/GCExtensionsBase.hpp
+++ b/gc/base/GCExtensionsBase.hpp
@@ -1427,7 +1427,7 @@ public:
 		, heapAlignment(HEAP_ALIGNMENT)
 		, absoluteMinimumOldSubSpaceSize(MINIMUM_OLD_SPACE_SIZE)
 		, absoluteMinimumNewSubSpaceSize(MINIMUM_NEW_SPACE_SIZE)
-		, darkMatterCompactThreshold((float)0.40)
+		, darkMatterCompactThreshold((float)0.15)
 		, parSweepChunkSize(0)
 		, heapExpansionMinimumSize(1024 * 1024)
 		, heapExpansionMaximumSize(0)
@@ -1764,7 +1764,7 @@ public:
 		, idleMinimumFree(0)
 		, gcOnIdle(false)
 		, compactOnIdle(false)
-		, gcOnIdleCompactThreshold((float)0.25)
+		, gcOnIdleCompactThreshold((float)0.10)
 #endif /* defined(OMR_GC_IDLE_HEAP_MANAGER) */
 #if defined(OMR_VALGRIND_MEMCHECK)
 		, valgrindMempoolAddr(0)


### PR DESCRIPTION
Dark matter and paging compact triggers currently only compare potential
free memory gains vs current free memory (with aim to reduce Global GC
frequency). While trigger thresholds are set rather high, they can still
easily trigger with Tenure being fairly full.

To account for the cost of work by doing the compact, the gains are
not just compared with total free memory but with total heap size, too.

That alone would make the trigger way less probable to occur, so as a
compromise: the weight of total heap that account into the formula is
set to 50%, and thresholds are cut by a factor of 2 or so.

Signed-off-by: Aleksandar Micic <amicic@ca.ibm.com>