### PR TITLE
Break unneeded class dependencies on OMRLinkage

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -30,6 +30,7 @@
 #include "env/StackMemoryRegion.hpp"
 #include "il/AutomaticSymbol.hpp"
 #include "il/Node_inlines.hpp"
+#include "il/ParameterSymbol.hpp"
 
 
 TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -35,20 +35,19 @@ namespace OMR { typedef OMR::ARM64::Linkage LinkageConnector; }
 
 #include <stddef.h>
 #include <stdint.h>
-#include "codegen/CodeGenerator.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"
-#include "codegen/RegisterDependency.hpp"
 #include "env/TRMemory.hpp"
 
-class TR_FrontEnd;
 namespace TR { class AutomaticSymbol; }
+namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
 namespace TR { class MemoryReference; }
 namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
+namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
 
 namespace TR {

--- a/compiler/arm/codegen/ARMSystemLinkage.cpp
+++ b/compiler/arm/codegen/ARMSystemLinkage.cpp
@@ -24,6 +24,7 @@
 #include "il/MethodSymbol.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
+#include "il/ParameterSymbol.hpp"
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/RegisterMappedSymbol.hpp"
 #include "il/StaticSymbol.hpp"

--- a/compiler/arm/codegen/OMRLinkage.cpp
+++ b/compiler/arm/codegen/OMRLinkage.cpp
@@ -43,6 +43,7 @@
 #include "il/MethodSymbol.hpp"
 #include "il/Node.hpp"
 #include "il/Node_inlines.hpp"
+#include "il/ParameterSymbol.hpp"
 #include "il/RegisterMappedSymbol.hpp"
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/StaticSymbol.hpp"

--- a/compiler/arm/codegen/OMRLinkage.hpp
+++ b/compiler/arm/codegen/OMRLinkage.hpp
@@ -33,16 +33,17 @@ namespace OMR { typedef OMR::ARM::Linkage LinkageConnector; }
 #endif
 
 #include "compiler/codegen/OMRLinkage.hpp"
-
+#include "codegen/ARMOps.hpp"
+#include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/RealRegister.hpp"
-#include "codegen/RegisterDependency.hpp"
 #include "infra/Annotations.hpp"
-#ifdef J9_PROJECT_SPECIFIC
-#include "runtime/RuntimeAssumptions.hpp"
-#endif
 
 namespace TR { class CodeGenerator; }
+namespace TR { class Instruction; }
+namespace TR { class MemoryReference; }
+namespace TR { class Node; }
 namespace TR { class Register; }
+namespace TR { class RegisterDependencyConditions; }
 
 namespace TR {
 

--- a/compiler/codegen/OMRLinkage.hpp
+++ b/compiler/codegen/OMRLinkage.hpp
@@ -31,9 +31,6 @@ namespace OMR { class Linkage; }
 namespace OMR { typedef OMR::Linkage LinkageConnector; }
 #endif
 
-#include "infra/List.hpp"
-#include "il/ParameterSymbol.hpp"
-
 #include <stddef.h>
 #include <stdint.h>
 #include "codegen/RegisterConstants.hpp"

--- a/compiler/p/codegen/OMRLinkage.hpp
+++ b/compiler/p/codegen/OMRLinkage.hpp
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef OMR_Power_LINKAGE_INCL
-#define OMR_Power_LINKAGE_INCL
+#ifndef OMR_POWER_LINKAGE_INCL
+#define OMR_POWER_LINKAGE_INCL
 
 /*
  * The following #define and typedef must appear before any #includes in this file
@@ -35,22 +35,22 @@ namespace OMR { typedef OMR::Power::Linkage LinkageConnector; }
 
 #include <stddef.h>
 #include <stdint.h>
-#include "codegen/CodeGenerator.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/RealRegister.hpp"
-#include "codegen/Register.hpp"
 #include "codegen/RegisterConstants.hpp"
-#include "codegen/RegisterDependency.hpp"
+#include "compile/CompilationTypes.hpp"
 #include "env/TRMemory.hpp"
 #include "infra/Annotations.hpp"
 
-class TR_FrontEnd;
 namespace TR { class AutomaticSymbol; }
+namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
 namespace TR { class MemoryReference; }
 namespace TR { class Node; }
 namespace TR { class ParameterSymbol; }
+namespace TR { class Register; }
+namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
 template <class T> class List;
 

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.hpp
@@ -25,6 +25,7 @@
 #include "x/codegen/X86SystemLinkage.hpp"
 
 #include <stdint.h>
+#include "codegen/Machine.hpp"
 #include "codegen/Register.hpp"
 #include "il/DataTypes.hpp"
 

--- a/compiler/x/codegen/OMRLinkage.cpp
+++ b/compiler/x/codegen/OMRLinkage.cpp
@@ -31,6 +31,7 @@
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
 #include "codegen/LiveRegister.hpp"
+#include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"

--- a/compiler/x/codegen/OMRLinkage.hpp
+++ b/compiler/x/codegen/OMRLinkage.hpp
@@ -36,14 +36,12 @@ namespace OMR { typedef OMR::X86::Linkage LinkageConnector; }
 #include <algorithm>
 #include <stddef.h>
 #include <stdint.h>
-#include "codegen/CodeGenerator.hpp"
-#include "codegen/Machine.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/Register.hpp"
 #include "codegen/RegisterConstants.hpp"
+#include "env/CompilerEnv.hpp"
 #include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
-#include "il/ParameterSymbol.hpp"
 #include "infra/Annotations.hpp"
 #include "infra/Assert.hpp"
 #include "x/codegen/X86Ops.hpp"
@@ -75,10 +73,12 @@ namespace OMR { typedef OMR::X86::Linkage LinkageConnector; }
 
 class TR_FrontEnd;
 namespace TR { class AutomaticSymbol; }
+namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
 namespace TR { class MethodSymbol; }
 namespace TR { class Node; }
+namespace TR { class ParameterSymbol; }
 namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
 

--- a/compiler/x/i386/codegen/IA32SystemLinkage.hpp
+++ b/compiler/x/i386/codegen/IA32SystemLinkage.hpp
@@ -25,6 +25,7 @@
 #include "x/codegen/X86SystemLinkage.hpp"
 
 #include <stdint.h>
+#include "codegen/Machine.hpp"
 #include "codegen/Register.hpp"
 #include "il/DataTypes.hpp"
 

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -35,22 +35,17 @@ namespace OMR { typedef OMR::Z::Linkage LinkageConnector; }
 
 #include <stddef.h>
 #include <stdint.h>
-#include "codegen/CodeGenerator.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/LinkageConventionsEnum.hpp"
-#include "codegen/Machine.hpp"
 #include "codegen/RealRegister.hpp"
 #include "codegen/RegisterConstants.hpp"
-#include "codegen/Snippet.hpp"
 #include "env/TRMemory.hpp"
 #include "il/DataTypes.hpp"
 #include "infra/Assert.hpp"
 
-#include "codegen/RegisterDependency.hpp"
-
-class TR_FrontEnd;
 namespace TR { class S390JNICallDataSnippet; }
 namespace TR { class AutomaticSymbol; }
+namespace TR { class CodeGenerator; }
 namespace TR { class Compilation; }
 namespace TR { class Instruction; }
 namespace TR { class MemoryReference; }
@@ -59,6 +54,7 @@ namespace TR { class ParameterSymbol; }
 namespace TR { class Register; }
 namespace TR { class RegisterDependencyConditions; }
 namespace TR { class ResolvedMethodSymbol; }
+namespace TR { class Snippet; }
 namespace TR { class Symbol; }
 namespace TR { class SymbolReference; }
 namespace TR { class SystemLinkage; }

--- a/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.cpp
+++ b/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.cpp
@@ -19,10 +19,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "codegen/CodeGenerator.hpp"
+#include "codegen/Instruction.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
+#include "codegen/Relocation.hpp"
 #include "codegen/SystemLinkagezOS.hpp"
 #include "codegen/snippet/XPLINKCallDescriptorSnippet.hpp"
+#include "env/CompilerEnv.hpp"
+#include "il/DataTypes.hpp"
+#include "il/Node.hpp"
 #include "OMR/Bytes.hpp"
 
 uint32_t TR::XPLINKCallDescriptorSnippet::generateCallDescriptorValue(TR::S390zOSSystemLinkage* linkage, TR::Node* callNode)
@@ -48,7 +54,7 @@ uint32_t TR::XPLINKCallDescriptorSnippet::generateCallDescriptorValue(TR::S390zO
          XPLINK_RVA_RETURN_COMPLEX16       = 0x0E,
          XPLINK_RVA_RETURN_AGGREGATE       = 0x10,
          };
-      
+
       TR::DataType dataType = callNode->getDataType();
 
       switch (dataType)

--- a/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.hpp
+++ b/compiler/z/codegen/snippet/XPLINKCallDescriptorSnippet.hpp
@@ -23,12 +23,10 @@
 #define OMR_Z_SNIPPET_XPLINKCALLDESCRIPTORSNIPPET_INCL
 
 #include <stdint.h>
+#include "codegen/ConstantDataSnippet.hpp"
 
-#include "codegen/CodeGenerator.hpp"
-#include "codegen/Instruction.hpp"
-#include "codegen/Relocation.hpp"
-#include "codegen/Snippet.hpp"
-
+namespace TR { class CodeGenerator; }
+namespace TR { class Node; }
 namespace TR { class S390zOSSystemLinkage; }
 
 namespace TR {
@@ -36,7 +34,7 @@ namespace TR {
 /** \brief
  *
  *  Represents the XPLINK Call Descriptor snippet which is created only on 31-bit targets when:
- *  
+ *
  *  1. The call site is so far removed from the Entry Point Marker of the function that its offset cannot be contained
  *     in the space available in the call NOP descriptor following the call site.
  *
@@ -74,7 +72,7 @@ class XPLINKCallDescriptorSnippet : public TR::S390ConstantDataSnippet
    virtual uint8_t* emitSnippetBody();
 
    private:
-   
+
    TR::S390zOSSystemLinkage* _linkage;
    uint32_t _callDescriptorValue;
    };


### PR DESCRIPTION
Do not include unnecessary header files to prevent downstream breakages.

Introduce include directives and forward declarations as appropriate to
compensate for removing header files from the extensible OMRLinkage.hpp

Signed-off-by: Daryl Maier <maier@ca.ibm.com>