### PR TITLE
Register copy defect

### DIFF
--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -294,14 +294,6 @@ TR::Instruction *generateLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode:
    return new (cg->trHeapMemory()) TR::PPCLabelInstruction(op, n, sym, cg);
    }
 
-TR::Instruction *generateAlignedLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
-   TR::LabelSymbol *sym, int32_t alignment, TR::Instruction *preced)
-   {
-   if (preced)
-      return new (cg->trHeapMemory()) TR::PPCAlignedLabelInstruction(op, n, sym, alignment, preced, cg);
-   return new (cg->trHeapMemory()) TR::PPCAlignedLabelInstruction(op, n, sym, alignment, cg);
-   }
-
 TR::Instruction *generateDepLabelInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n,
    TR::LabelSymbol *sym, TR::RegisterDependencyConditions *cond, TR::Instruction *preced)
    {

--- a/compiler/p/codegen/GenerateInstructions.cpp
+++ b/compiler/p/codegen/GenerateInstructions.cpp
@@ -206,6 +206,15 @@ TR::Instruction *generateInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnem
    return new (cg->trHeapMemory()) TR::Instruction(op, n, cg);
    }
 
+TR::Instruction *generateAlignmentNopInstruction(TR::CodeGenerator *cg, TR::Node * n, uint32_t alignment, TR::Instruction *preced)
+   {
+   auto op = TR::Compiler->target.cpu.id() >= TR_PPCp6 ? TR::InstOpCode::genop : TR::InstOpCode::nop;
+
+   if (preced)
+      return new (cg->trHeapMemory()) TR::PPCAlignmentNopInstruction(op, n, alignment, preced, cg);
+   return new (cg->trHeapMemory()) TR::PPCAlignmentNopInstruction(op, n, alignment, cg);
+   }
+
 TR::Instruction *generateImmInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t imm,
                                        TR::Instruction *preced)
    {

--- a/compiler/p/codegen/GenerateOMRInstructions.hpp
+++ b/compiler/p/codegen/GenerateOMRInstructions.hpp
@@ -152,14 +152,6 @@ TR::Instruction *generateLabelInstruction(
                    TR::LabelSymbol *sym,
                    TR::Instruction *preced = 0);
 
-TR::Instruction *generateAlignedLabelInstruction(
-                   TR::CodeGenerator *cg,
-                   TR::InstOpCode::Mnemonic op,
-                   TR::Node * n,
-                   TR::LabelSymbol *sym,
-                   int32_t alignment,
-                   TR::Instruction *preced = 0);
-
 TR::Instruction *generateDepLabelInstruction(
                    TR::CodeGenerator      *cg,
                    TR::InstOpCode::Mnemonic                       op,

--- a/compiler/p/codegen/GenerateOMRInstructions.hpp
+++ b/compiler/p/codegen/GenerateOMRInstructions.hpp
@@ -66,6 +66,12 @@ TR::Instruction *generateInstruction(
                    TR::Node               *n,
                    TR::Instruction        *preced = 0);
 
+TR::Instruction *generateAlignmentNopInstruction(
+                   TR::CodeGenerator *cg,
+                   TR::Node *n,
+                   uint32_t alignment,
+                   TR::Instruction *preced = 0);
+
 TR::Instruction *generateImmInstruction(
                    TR::CodeGenerator      *cg,
                    TR::InstOpCode::Mnemonic          op,

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -1757,37 +1757,6 @@ void OMR::Power::CodeGenerator::doBinaryEncoding()
 
    while (data.cursorInstruction)
       {
-      if(data.cursorInstruction->isLabel())
-         {
-         if ((data.cursorInstruction)->isNopCandidate())
-            {
-            TR::Instruction *nop;
-            uintptrj_t uselessFetched = ((uintptrj_t)self()->getBinaryBufferCursor()/4)%8;
-
-            if (uselessFetched >= 8 - data.cursorInstruction->MAX_LOOP_ALIGN_NOPS())
-               {
-               if (TR::Compiler->target.cpu.id() >= TR_PPCp6)
-                  {
-                  nop = self()->generateNop(data.cursorInstruction->getNode(), data.cursorInstruction->getPrev(), TR_NOPEndGroup); // handles P6, P7
-                  nop->setNext(data.cursorInstruction);
-                  data.cursorInstruction = nop;
-                  uselessFetched++;
-                  }
-               for (; uselessFetched < 8; uselessFetched++)
-                  {
-                  nop = self()->generateNop(data.cursorInstruction->getNode(), data.cursorInstruction->getPrev(), TR_NOPStandard);
-                  nop->setNext(data.cursorInstruction);
-                  data.cursorInstruction = nop;
-                  }
-               skipLabel = true;
-               }
-            }
-         else
-            {
-            skipLabel = false;
-            }
-         }
-
       self()->setBinaryBufferCursor(data.cursorInstruction->generateBinaryEncoding());
 
       self()->addToAtlas(data.cursorInstruction);

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -5797,7 +5797,7 @@
 
    {
    /* .mnemonic    = */ OMR::InstOpCode::genop,
-   /* .name        = */ "nop",
+   /* .name        = */ "genop",
    /* .description =    "Group Ending NoOp (ori)", */
    /* .opcode      = */ 0x60000000,
    /* .format      = */ UNKNOWN_FORMAT,

--- a/compiler/p/codegen/OMRInstruction.cpp
+++ b/compiler/p/codegen/OMRInstruction.cpp
@@ -160,28 +160,6 @@ OMR::Power::Instruction::assignRegisters(TR_RegisterKinds kindToBeAssigned)
    }
 
 bool
-OMR::Power::Instruction::isNopCandidate()
-   {
-   return (self()->getNode() != NULL
-        && self()->getNode()->getOpCodeValue() == TR::BBStart
-        && self()->getNode()->getBlock() != NULL
-        && self()->getNode()->getBlock()->firstBlockInLoop()
-        && !self()->getNode()->getBlock()->isCold());
-   }
-
-int
-OMR::Power::Instruction::MAX_LOOP_ALIGN_NOPS()
-   {
-   static int LOCAL_MAX_LOOP_ALIGN_NOPS = -1;
-   if (LOCAL_MAX_LOOP_ALIGN_NOPS == -1)
-      {
-      static char *TR_LoopAlignNops = feGetEnv("TR_LoopAlignNops");
-      LOCAL_MAX_LOOP_ALIGN_NOPS = (TR_LoopAlignNops == NULL ? 7 : atoi(TR_LoopAlignNops));
-      }
-   return LOCAL_MAX_LOOP_ALIGN_NOPS;
-   }
-
-bool
 OMR::Power::Instruction::isBeginBlock()
    {
    return self()->getPrev()->getOpCodeValue() == TR::InstOpCode::label;

--- a/compiler/p/codegen/OMRInstruction.hpp
+++ b/compiler/p/codegen/OMRInstruction.hpp
@@ -162,11 +162,6 @@ class OMR_EXTENSIBLE Instruction : public OMR::Instruction
 
    virtual bool dependencyRefsRegister(TR::Register *reg);
 
-   virtual bool isNopCandidate();
-
-   //This function stores a env. variable and returns it upon call.
-   virtual int MAX_LOOP_ALIGN_NOPS();
-
    virtual TR::PPCDepImmInstruction *getPPCDepImmInstruction();
 
    virtual TR::PPCConditionalBranchInstruction *getPPCConditionalBranchInstruction();

--- a/compiler/p/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/p/codegen/OMRInstructionKindEnum.hpp
@@ -32,7 +32,6 @@
       IsDepImm,
          IsDepImmSym,
    IsLabel,
-      IsAlignedLabel,
       IsDepLabel,
          IsVirtualGuardNOP,
       IsConditionalBranch,

--- a/compiler/p/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/p/codegen/OMRInstructionKindEnum.hpp
@@ -25,6 +25,7 @@
  */
 
    IsNotExtended,
+   IsAlignmentNop,
    IsImm,
       IsSrc1,
    IsImm2,

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5675,6 +5675,9 @@ TR::Register *OMR::Power::TreeEvaluator::BBStartEvaluator(TR::Node *node, TR::Co
    TR::Instruction * fence = generateAdminInstruction(cg, TR::InstOpCode::fence, node,
                                TR::Node::createRelative32BitFenceNode(node, &block->getInstructionBoundaries()._startPC));
 
+   if (block->firstBlockInLoop() && !block->isCold())
+      generateAlignmentNopInstruction(cg, node, 32);
+
    TR::Instruction *labelInst = NULL;
 
    if (node->getLabel() != NULL)

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -206,44 +206,6 @@ static bool reversedConditionalBranchOpCode(TR::InstOpCode::Mnemonic op, TR::Ins
       }
    }
 
-uint8_t *TR::PPCAlignedLabelInstruction::generateBinaryEncoding()
-   {
-   uint8_t        *instructionStart = cg()->getBinaryBufferCursor();
-   TR::LabelSymbol *label            = getLabelSymbol();
-   uint8_t        *cursor           = instructionStart;
-   int32_t        alignment         = getAlignment();
-   int32_t        paddingNOPsNeeded = 0;
-
-   if ((alignment-1) & (intptr_t)cursor)
-      {
-      paddingNOPsNeeded = (alignment - ((alignment-1) & (intptr_t)cursor))/(PPC_INSTRUCTION_LENGTH);
-      }
-
-   if ((paddingNOPsNeeded > 0) ^ getFlipAlignmentDecision())
-      {
-      for (int32_t i = 0; i < paddingNOPsNeeded; i++)
-         {
-         TR::InstOpCode opCode(TR::InstOpCode::nop);
-         opCode.copyBinaryToBuffer(cursor);
-         cursor += PPC_INSTRUCTION_LENGTH;
-         }
-      }
-
-   label->setCodeLocation(cursor); // point past any NOPs to the following instruction
-   setBinaryLength(cursor - instructionStart);
-   cg()->addAccumulatedInstructionLengthError(getEstimatedBinaryLength() - getBinaryLength());
-   setBinaryEncoding(instructionStart);
-   return cursor;
-   }
-
-int32_t TR::PPCAlignedLabelInstruction::estimateBinaryLength(int32_t currentEstimate)
-   {
-   TR_ASSERT((getAlignment() % PPC_INSTRUCTION_LENGTH) == 0, "label alignment must be a multiple of the instruction length, alignment = %d", getAlignment());
-   TR_ASSERT(getOpCodeValue() == TR::InstOpCode::label, "AlignedLabel only supported for TR::InstOpCode::Label opcodes");
-   setEstimatedBinaryLength(getAlignment() - PPC_INSTRUCTION_LENGTH);
-   return currentEstimate + getEstimatedBinaryLength();
-   }
-
 uint8_t *TR::PPCConditionalBranchInstruction::generateBinaryEncoding()
    {
    uint8_t        *instructionStart = cg()->getBinaryBufferCursor();

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -186,14 +186,6 @@ uint8_t *TR::PPCLabelInstruction::generateBinaryEncoding()
 
 int32_t TR::PPCLabelInstruction::estimateBinaryLength(int32_t currentEstimate)
    {
-   int8_t loopAlignBytes = 0;
-   static int count=0;
-
-   if (isNopCandidate())
-      {
-	loopAlignBytes = MAX_LOOP_ALIGN_NOPS()*PPC_INSTRUCTION_LENGTH;
-      }
-
    if (getOpCode().isBranchOp())
       {
       setEstimatedBinaryLength(PPC_INSTRUCTION_LENGTH);
@@ -201,9 +193,9 @@ int32_t TR::PPCLabelInstruction::estimateBinaryLength(int32_t currentEstimate)
    else
       {
       setEstimatedBinaryLength(0);
-      getLabelSymbol()->setEstimatedCodeLocation(currentEstimate + loopAlignBytes);
+      getLabelSymbol()->setEstimatedCodeLocation(currentEstimate);
       }
-   return currentEstimate + getEstimatedBinaryLength() + loopAlignBytes;
+   return currentEstimate + getEstimatedBinaryLength();
    }
 static bool reversedConditionalBranchOpCode(TR::InstOpCode::Mnemonic op, TR::InstOpCode::Mnemonic *rop)
    {

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -109,6 +109,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * instr)
 
    switch (instr->getKind())
       {
+      case OMR::Instruction::IsAlignmentNop:
+         print(pOutFile, (TR::PPCAlignmentNopInstruction *)instr);
+         break;
       case OMR::Instruction::IsImm:
          print(pOutFile, (TR::PPCImmInstruction *)instr);
          break;
@@ -220,6 +223,14 @@ TR_Debug::printPrefix(TR::FILE *pOutFile, TR::Instruction * instr)
       }
    else
       trfprintf(pOutFile, "0 \t");
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::PPCAlignmentNopInstruction * instr)
+   {
+   printPrefix(pOutFile, instr);
+   trfprintf(pOutFile, "%s\t; Align to %u bytes", getOpCodeName(&instr->getOpCode()), instr->getAlignment());
+   trfflush(pOutFile);
    }
 
 void

--- a/compiler/p/codegen/PPCDebug.cpp
+++ b/compiler/p/codegen/PPCDebug.cpp
@@ -128,7 +128,6 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction * instr)
          print(pOutFile, (TR::PPCDepImmSymInstruction *)instr);
          break;
       case OMR::Instruction::IsLabel:
-      case OMR::Instruction::IsAlignedLabel:
          print(pOutFile, (TR::PPCLabelInstruction *)instr);
          break;
       case OMR::Instruction::IsDepLabel:
@@ -926,7 +925,6 @@ TR::Instruction* TR_Debug::getOutlinedTargetIfAny(TR::Instruction *instr)
    switch (instr->getKind())
       {
       case TR::Instruction::IsLabel:
-      case TR::Instruction::IsAlignedLabel:
       case TR::Instruction::IsDepLabel:
       case TR::Instruction::IsVirtualGuardNOP:
       case TR::Instruction::IsConditionalBranch:

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -61,6 +61,12 @@ class PPCAlignmentNopInstruction : public TR::Instruction
    {
    uint32_t _alignment;
 
+   void setAlignment(uint32_t alignment)
+      {
+      TR_ASSERT_FATAL((alignment % PPC_INSTRUCTION_LENGTH) == 0, "Alignment must be a multiple of the nop instruction length");
+      _alignment = alignment != 0 ? alignment : PPC_INSTRUCTION_LENGTH;
+      }
+
 public:
    PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::CodeGenerator *codeGen)
       : TR::Instruction(op, n, codeGen)
@@ -77,11 +83,6 @@ public:
    virtual Kind getKind() { return IsAlignmentNop; }
 
    uint32_t getAlignment() { return _alignment; }
-   void setAlignment(uint32_t alignment)
-      {
-      TR_ASSERT_FATAL((alignment % PPC_INSTRUCTION_LENGTH) == 0, "Alignment must be a multiple of the nop instruction length");
-      _alignment = alignment != 0 ? alignment : PPC_INSTRUCTION_LENGTH;
-      }
 
    virtual uint8_t *generateBinaryEncoding();
    virtual int32_t estimateBinaryLength(int32_t currentEstimate);

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -401,35 +401,6 @@ class PPCLabelInstruction : public TR::Instruction
    virtual void assignRegisters(TR_RegisterKinds kindToBeAssigned);
    };
 
-class PPCAlignedLabelInstruction : public PPCLabelInstruction
-   {
-   int32_t _alignment;
-   bool _flipAlignmentDecision;
-
-   public:
-
-   PPCAlignedLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::LabelSymbol *sym, int32_t align, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, codeGen), _alignment(align), _flipAlignmentDecision(false)
-      {}
-
-   PPCAlignedLabelInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, TR::LabelSymbol *sym, int32_t align,
-                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
-      : PPCLabelInstruction(op, n, sym, precedingInstruction, codeGen), _alignment(align), _flipAlignmentDecision(false)
-      {}
-
-   virtual Kind getKind() { return IsAlignedLabel; }
-
-   int32_t getAlignment() { return  _alignment;}
-   int32_t setAlignment(int32_t a) { return  (_alignment=a);}
-
-   bool getFlipAlignmentDecision() { return  _flipAlignmentDecision;}
-   bool setFlipAlignmentDecision(bool d) { return  (_flipAlignmentDecision=d);}
-
-   virtual uint8_t *generateBinaryEncoding();
-
-   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
-   };
-
 class PPCDepLabelInstruction : public PPCLabelInstruction
    {
    TR::RegisterDependencyConditions *_conditions;

--- a/compiler/p/codegen/PPCInstruction.hpp
+++ b/compiler/p/codegen/PPCInstruction.hpp
@@ -57,6 +57,37 @@ namespace TR { class SymbolReference; }
 namespace TR
 {
 
+class PPCAlignmentNopInstruction : public TR::Instruction
+   {
+   uint32_t _alignment;
+
+public:
+   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::CodeGenerator *codeGen)
+      : TR::Instruction(op, n, codeGen)
+      {
+      setAlignment(alignment);
+      }
+
+   PPCAlignmentNopInstruction(TR::InstOpCode::Mnemonic op, TR::Node * n, uint32_t alignment, TR::Instruction *precedingInstruction, TR::CodeGenerator *codeGen)
+      : TR::Instruction(op, n, precedingInstruction, codeGen)
+      {
+      setAlignment(alignment);
+      }
+
+   virtual Kind getKind() { return IsAlignmentNop; }
+
+   uint32_t getAlignment() { return _alignment; }
+   void setAlignment(uint32_t alignment)
+      {
+      TR_ASSERT_FATAL((alignment % PPC_INSTRUCTION_LENGTH) == 0, "Alignment must be a multiple of the nop instruction length");
+      _alignment = alignment != 0 ? alignment : PPC_INSTRUCTION_LENGTH;
+      }
+
+   virtual uint8_t *generateBinaryEncoding();
+   virtual int32_t estimateBinaryLength(int32_t currentEstimate);
+   virtual uint8_t getBinaryLengthLowerBound();
+   };
+
 class PPCImmInstruction : public TR::Instruction
    {
    uint32_t _sourceImmediate;

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -169,6 +169,7 @@ namespace TR { class X86ForceRecompilationSnippet; }
 namespace TR { class X86RecompilationSnippet; }
 #endif
 
+namespace TR { class PPCAlignmentNopInstruction;         }
 namespace TR { class PPCDepInstruction;                  }
 namespace TR { class PPCLabelInstruction;                }
 namespace TR { class PPCDepLabelInstruction;             }
@@ -863,6 +864,7 @@ public:
 #ifdef TR_TARGET_POWER
    void printPrefix(TR::FILE *, TR::Instruction *);
 
+   void print(TR::FILE *, TR::PPCAlignmentNopInstruction *);
    void print(TR::FILE *, TR::PPCDepInstruction *);
    void print(TR::FILE *, TR::PPCLabelInstruction *);
    void print(TR::FILE *, TR::PPCDepLabelInstruction *);

--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -991,6 +991,7 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
          // find a new register to shuffle to
          TR::RealRegister * newAssignedRegister = self()->findBestRegisterForShuffle(currInst, targetRegister, availRegMask);
          TR::Instruction *cursor = self()->registerCopy(self()->cg(), kindOfRegister, toRealRegister(assignedRegister), newAssignedRegister, appendInst);
+         targetRegister->setAssignedRegister(newAssignedRegister);
          newAssignedRegister->setAssignedRegister(targetRegister);
          newAssignedRegister->setState(TR::RealRegister::Assigned);
          assignedRegister->setAssignedRegister(NULL);


### PR DESCRIPTION
Fixes an inconsistency in register assignment when copying a virtual register to a new real register. Here, we assign the new real register to the virtual register, but we forget to assign the virtual register to the new real register. This results in an inconsistency in register assignment.