### PR TITLE
Fixes bug found in Real Register Assignment

### DIFF
--- a/compiler/z/codegen/OMRMachine.cpp
+++ b/compiler/z/codegen/OMRMachine.cpp
@@ -991,6 +991,7 @@ OMR::Z::Machine::assignBestRegisterSingle(TR::Register    *targetRegister,
          // find a new register to shuffle to
          TR::RealRegister * newAssignedRegister = self()->findBestRegisterForShuffle(currInst, targetRegister, availRegMask);
          TR::Instruction *cursor = self()->registerCopy(self()->cg(), kindOfRegister, toRealRegister(assignedRegister), newAssignedRegister, appendInst);
+         targetRegister->setAssignedRegister(newAssignedRegister);
          newAssignedRegister->setAssignedRegister(targetRegister);
          newAssignedRegister->setState(TR::RealRegister::Assigned);
          assignedRegister->setAssignedRegister(NULL);


### PR DESCRIPTION
When we assign a new real register to a virtual register (for GPRs), we were not
updating the virtual register to hold its new real register. This led to a
discrepancy between the real->virtual and virtual->real mapping between registers. This
commit ensures that the virtual register now knows of its new real register.

Signed-off-by: Pushkar Bettadpur <pushkar.bettadpur@gmail.com>