### PR TITLE
CMake: Add ability to handle split debug info

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -204,3 +204,5 @@ set(OMR_ENV_GCC OFF CACHE BOOL "TODO: Document")
 set(OMR_OPT_CUDA ${CUDA_FOUND} CACHE BOOL "Enable CUDA support in OMR")
 
 set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GNU or Clang")
+
+set(OMR_SEPARATE_DEBUG_INFO OFF CACHE BOOL "Maintain debug info in a separate file")

--- a/cmake/modules/OmrDDRSupport.cmake
+++ b/cmake/modules/OmrDDRSupport.cmake
@@ -140,7 +140,15 @@ function(target_enable_ddr tgt)
 		"$<JOIN:$<TARGET_PROPERTY:${tgt},DDR_PREINCLUDES>,\n>"
 	)
 	if((target_type MATCHES "EXECUTABLE|SHARED_LIBRARY") AND (NOT opt_NO_DEBUG_INFO))
-		set(MAGIC_TEMPLATE "OUTPUT_FILE\n$<TARGET_FILE:${tgt}>\n${MAGIC_TEMPLATE}")
+		# OMR_SEPARATE_DEBUG_INFO has no impact on windows since it already
+		# uses separate .pdb files
+		if(OMR_SEPARATE_DEBUG_INFO AND (NOT OMR_OS_WINDOWS))
+			set(MAGIC_TEMPLATE "OUTPUT_FILE\n$<TARGET_FILE:${tgt}>.dbg\n${MAGIC_TEMPLATE}")
+			# Add rules to generate the split debug info
+			omr_split_debug("${tgt}")
+		else()
+			set(MAGIC_TEMPLATE "OUTPUT_FILE\n$<TARGET_FILE:${tgt}>\n${MAGIC_TEMPLATE}")
+		endif()
 	endif()
 
 	file(GENERATE OUTPUT "${DDR_INFO_DIR}/targets/${tgt}.txt" CONTENT "${MAGIC_TEMPLATE}\n")

--- a/cmake/modules/OmrPlatform.cmake
+++ b/cmake/modules/OmrPlatform.cmake
@@ -138,6 +138,16 @@ function(omr_add_exports target)
 	omr_process_exports(${target})
 endfunction()
 
+
+# omr_split_debug(<target>)
+# Moves debug info from a  target to a separate file
+function(omr_split_debug target)
+	omr_assert(FATAL_ERROR TEST TARGET ${target} MESSAGE "omr_split_debug called on invalid target '${target}'")
+	if(COMMAND _omr_toolchain_separate_debug_symbols)
+		_omr_toolchain_separate_debug_symbols("${target}")
+	endif()
+endfunction()
+
 ###
 ### Flags we aren't using
 ###

--- a/cmake/modules/platform/toolcfg/xlc.cmake
+++ b/cmake/modules/platform/toolcfg/xlc.cmake
@@ -209,4 +209,15 @@ else()
 		)
 		set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-bE:${TARGET_NAME}.exp")
 	endfunction()
+
+	function(_omr_toolchain_separate_debug_symbols tgt)
+		set(exe_file "$<TARGET_FILE:${tgt}>")
+		set(dbg_file "$<TARGET_FILE:${tgt}>.dbg")
+		add_custom_command(
+			TARGET "${tgt}"
+			POST_BUILD
+			COMMAND "${CMAKE_COMMAND}" -E copy ${exe_file} ${dbg_file}
+			COMMAND "${CMAKE_STRIP}" -X32_64 -t ${dbg_file}
+		)
+	endfunction()
 endif()


### PR DESCRIPTION
Add new flag OMR_SEPARATE_DEBUG_INFO. If set, debug info for a target
is copied into <target_file>.dbg, and debug info from <target_file> is
stripped.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>