### PR TITLE
Share implementation to re-reserve trampolines on code cache switch

### DIFF
--- a/compiler/arm/codegen/ARMBinaryEncoding.cpp
+++ b/compiler/arm/codegen/ARMBinaryEncoding.cpp
@@ -260,22 +260,7 @@ uint8_t *TR::ARMImmSymInstruction::generateBinaryEncoding()
 
       if (cg()->hasCodeCacheSwitched())
          {
-         TR::SymbolReference *calleeSymRef = NULL;
-
-         if (label == NULL)
-            calleeSymRef = getSymbolReference();
-         else if (getNode() != NULL)
-            calleeSymRef = getNode()->getSymbolReference();
-
-         if (calleeSymRef != NULL)
-            {
-            if (calleeSymRef->getReferenceNumber()>=TR_ARMnumRuntimeHelpers)
-               cg()->fe()->reserveTrampolineIfNecessary(comp, calleeSymRef, true);
-            }
-         else
-            {
-            TR_ASSERT(0, "Missing possible re-reservation for trampolines.\n");
-            }
+         cg()->redoTrampolineReservationIfNecessary(this, getSymbolReference());
          }
 
       TR::ResolvedMethodSymbol *sym = getSymbolReference()->getSymbol()->getResolvedMethodSymbol();

--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -3251,3 +3251,32 @@ OMR::CodeGenerator::switchCodeCacheTo(TR::CodeCache *newCodeCache)
       }
 
    }
+
+
+void
+OMR::CodeGenerator::redoTrampolineReservationIfNecessary(TR::Instruction *callInstr, TR::SymbolReference *instructionSymRef)
+   {
+   TR_ASSERT_FATAL(instructionSymRef, "Expecting instruction to have a SymbolReference");
+
+   /**
+    * Determine the callee symbol reference based on the target of the call instruction
+    */
+   TR::LabelSymbol *labelSymbol = instructionSymRef->getSymbol()->getLabelSymbol();
+   TR::SymbolReference *calleeSymRef = NULL;
+
+   if (labelSymbol == NULL)
+      {
+      calleeSymRef = instructionSymRef;
+      }
+   else if (callInstr->getNode() != NULL)
+      {
+      calleeSymRef = callInstr->getNode()->getSymbolReference();
+      }
+
+   TR_ASSERT_FATAL(calleeSymRef != NULL, "Missing possible re-reservation for trampolines");
+
+   if (calleeSymRef->getReferenceNumber() >= TR_numRuntimeHelpers)
+      {
+      self()->fe()->reserveTrampolineIfNecessary(self()->comp(), calleeSymRef, true);
+      }
+   }

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -761,7 +761,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
    uint32_t getPreJitMethodEntrySize() {return _preJitMethodEntrySize;}
    uint32_t setPreJitMethodEntrySize(uint32_t s) {return (_preJitMethodEntrySize = s);}
-   
+
    /** \brief
     *     Determines whether the code generator supports or allows JIT-to-JIT method entry point alignment.
     */
@@ -772,7 +772,7 @@ class OMR_EXTENSIBLE CodeGenerator
     *     specified to be \c x and the JIT-to-JIT method entry point to be \c y then <c>y & (x - 1) == 0</c>.
     */
    uint32_t getJitMethodEntryAlignmentBoundary();
-   
+
    /** \brief
     *     Determines the byte threshold at which the JIT-to-JIT method entry point boundary alignment will not be
     *     performed. If the JIT-to-JIT method entry point is already close to the boundary then it may not make sense
@@ -1073,7 +1073,7 @@ class OMR_EXTENSIBLE CodeGenerator
 
    TR::list<TR::Register*> *getSpilledRegisterList() {return _spilledRegisterList;}
    TR::list<TR::Register*> *setSpilledRegisterList(TR::list<TR::Register*> *r) {return _spilledRegisterList = r;}
-   
+
    TR_BackingStore *allocateSpill(bool containsCollectedReference, int32_t *offset, bool reuse=true);
    TR_BackingStore *allocateSpill(int32_t size, bool containsCollectedReference, int32_t *offset, bool reuse=true);
    TR_BackingStore *allocateInternalPointerSpill(TR::AutomaticSymbol *pinningArrayPointer);
@@ -1402,7 +1402,24 @@ class OMR_EXTENSIBLE CodeGenerator
       return true;
       }
 
-   // --------------------------------------------------------------------------	
+   /**
+    * @brief
+    *    Redo the trampoline reservation for a call target, if a trampoline might be
+    *    required for the target.  This is typically required if a new code cache is
+    *    allocated between the instruction selection and binary encoding phases.
+    *
+    * @details
+    *    Note that the instructionSymRef cannot simply be read from the provided instruction
+    *    because this function is shared across multiple architectures with incompatible
+    *    instruction hierarchies.
+    *
+    * @param[in] callInstr : the call instruction to which this trampoline applies
+    * @param[in] instructionSymRef : the TR::SymbolReference present on the instruction
+    *
+    */
+   void redoTrampolineReservationIfNecessary(TR::Instruction *callInstr, TR::SymbolReference *instructionSymRef);
+
+   // --------------------------------------------------------------------------
 
    bool constantAddressesCanChangeSize(TR::Node *node);
    bool profiledPointersRequireRelocation();
@@ -1892,7 +1909,7 @@ class OMR_EXTENSIBLE CodeGenerator
    TR::list<TR::Register*> *_spilledRegisterList;
    TR::list<OMR::RegisterUsage*> *_referencedRegistersList;
    int32_t _currentPathDepth;
-   
+
 
 
    TR_Array<void *> _monitorMapping;

--- a/compiler/x/codegen/X86BinaryEncoding.cpp
+++ b/compiler/x/codegen/X86BinaryEncoding.cpp
@@ -1220,23 +1220,7 @@ uint8_t* TR::X86ImmSymInstruction::generateOperand(uint8_t* cursor)
 
          if (TR::Compiler->target.is64Bit() && cg()->hasCodeCacheSwitched() && getOpCodeValue() == CALLImm4)
             {
-            TR::SymbolReference *calleeSymRef = NULL;
-            TR::LabelSymbol *labelSym = sym->getLabelSymbol();
-
-            if (labelSym==NULL)
-               calleeSymRef = getSymbolReference();
-            else if (getNode() != NULL)
-               calleeSymRef = getNode()->getSymbolReference();
-
-            if (calleeSymRef != NULL)
-               {
-               if (calleeSymRef->getReferenceNumber()>=TR_AMD64numRuntimeHelpers)
-                  cg()->fe()->reserveTrampolineIfNecessary(comp, calleeSymRef, true);
-               }
-            else
-               {
-               TR_ASSERT(0, "Missing possible re-reservation for trampolines.\n");
-               }
+            cg()->redoTrampolineReservationIfNecessary(this, getSymbolReference());
             }
 
          intptrj_t currentInstructionAddress = (intptrj_t)(cursor-1);

--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -2392,21 +2392,7 @@ TR::S390RILInstruction::generateBinaryEncoding()
          {
          if (cg()->hasCodeCacheSwitched())
             {
-            TR::SymbolReference *calleeSymRef = NULL;
-
-            calleeSymRef = getSymbolReference();
-
-            if (calleeSymRef != NULL)
-               {
-               if (calleeSymRef->getReferenceNumber()>=TR_S390numRuntimeHelpers)
-                  cg()->fe()->reserveTrampolineIfNecessary(comp, calleeSymRef, true);
-               }
-            else
-               {
-#ifdef DEBUG
-               printf("Missing possible re-reservation for trampolines.\n");
-#endif
-               }
+            cg()->redoTrampolineReservationIfNecessary(this, getSymbolReference());
             }
          }
 #endif


### PR DESCRIPTION
Each code generator duplicates logic to re-reserve a trampoline for a
call target if the code cache is switched between the time the trampoline
is first reserved (likely instruction selection) and binary encoding.

The logic is nearly the same in all cases.  Provide a common version
that is shared by all code generators.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>