### PR TITLE
Refactoring of TR::ternary opcodes to TR::select

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -436,13 +436,13 @@ public:
 	static TR::Register *sRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *GlRegDepsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *lternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *sternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *aternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *fternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *dternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *lselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *bselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *sselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *aselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *fselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *dselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *MethodEnterHookEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *MethodExitHookEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -474,7 +474,7 @@ public:
 	static TR::Register *vicmpanyltEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vicmpanyleEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *vbitselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vpermEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vsplatsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vdmergelEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -541,7 +541,7 @@ public:
 	static TR::Register *vreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vcallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vcalliEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *vternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *v2vEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -408,13 +408,13 @@
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::sRegStore		// Store short global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::bRegStore		// Store byte global register
     TR::TreeEvaluator::GlRegDepsEvaluator, // TR::GlRegDeps		// Global Register Dependency List
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iternaryEvaluator ,	// TR::iternary		// Ternary Operator:  Based on the result of the first child; take the value of the
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lternaryEvaluator ,	// TR::lternary		//   second (first child evaluates to true) or third(first child evaluates to false) child
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bternaryEvaluator ,	// TR::bternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sternaryEvaluator ,	// TR::sternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::aternaryEvaluator ,	// TR::aternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fternaryEvaluator ,	// TR::fternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dternaryEvaluator ,	// TR::dternary   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iselectEvaluator ,	// TR::iselect		// Select Operator:  Based on the result of the first child; take the value of the
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::lselectEvaluator ,	// TR::lselect		//   second (first child evaluates to true) or third(first child evaluates to false) child
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::bselectEvaluator ,	// TR::bselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::sselectEvaluator ,	// TR::sselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::aselectEvaluator ,	// TR::aselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::fselectEvaluator ,	// TR::fselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::dselectEvaluator ,	// TR::dselect   
     TR::TreeEvaluator::treetopEvaluator, // TR::treetop		// tree top to anchor subtrees with side-effects
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::MethodEnterHookEvaluator ,	// TR::MethodEnterHook	// called after a frame is built; temps initialized; and monitor acquired (if necessary)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::MethodExitHookEvaluator ,	// TR::MethodExitHook	// called immediately before returning; frame not yet collapsed; monitor released (if necessary)
@@ -447,7 +447,7 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vicmpanyltEvaluator ,	// TR::vicmpanylt	// vector integer any less than
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vicmpanyleEvaluator ,	// TR::vicmpanyle	// vector integer any less equal
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vnotEvaluator ,	// TR::vnot		// vector boolean not
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vselectEvaluator ,	// TR::vselect		// vector select
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vbitselectEvaluator ,	// TR::vbitselect		// vector bit select
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vpermEvaluator ,	// TR::vperm		// vector permute
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vsplatsEvaluator ,	// TR::vsplats		// vector splats
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vdmergelEvaluator ,	// TR::vdmergel		// vector double merge low
@@ -514,7 +514,7 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vreturnEvaluator ,	// TR::vreturn		// return a vector
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vcallEvaluator ,	// TR::vcall		// direct call returning a vector
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vcalliEvaluator ,	// TR::vcalli		// indirect call returning a vector
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vternaryEvaluator ,	// TR::vternary		// vector ternary operator
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vselectEvaluator ,	// TR::vselect		// vector select operator
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::v2vEvaluator ,	// TR::v2v		// vector to vector conversion. preserves bit pattern (noop); only changes datatype
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vl2vdEvaluator ,	// TR::vl2vd		// vector to vector conversion. converts each long element to double
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vconstEvaluator ,	// TR::vconst		// vector constant

--- a/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/arm/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -519,13 +519,13 @@
    TR::TreeEvaluator::iRegStoreEvaluator,   // TR::sRegStore
    TR::TreeEvaluator::iRegStoreEvaluator,   // TR::bRegStore
    TR::TreeEvaluator::GlRegDepsEvaluator,   // TR::GlRegDeps
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::iternary
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::lternary
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::bternary
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::sternary
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::aternary
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::fternary
-   TR::TreeEvaluator::badILOpEvaluator,     // TR::dternary
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::iselect
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::lselect
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::bselect
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::sselect
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::aselect
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::fselect
+   TR::TreeEvaluator::badILOpEvaluator,     // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,     // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodEnterHook
    TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodExitHook
@@ -560,7 +560,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vicmpanylt
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vicmpanyle
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vnot
-   TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vselect
+   TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vbitselect
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vperm
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vsplats
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vdmergel
@@ -628,7 +628,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vreturn
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vcall
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vcalli
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vternary
+   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vselect
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::v2v
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vl2vd
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vconst

--- a/compiler/codegen/CodeGenPrep.cpp
+++ b/compiler/codegen/CodeGenPrep.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -335,9 +335,9 @@ OMR::CodeGenerator::lowerTreeIfNeeded(
        node->getSymbol()->isParm() && node->getSymbol()->isCollectedReference())
       node->getSymbol()->setParmHasToBeOnStack();
 
-   if (node->getOpCode().isTernary())
+   if (node->getOpCode().isSelect())
       {
-      self()->rematerializeCmpUnderTernary(node);
+      self()->rematerializeCmpUnderSelect(node);
       }
 
    }
@@ -708,7 +708,7 @@ OMR::CodeGenerator::insertDebugCounters()
 
 
 
-void OMR::CodeGenerator::rematerializeCmpUnderTernary(TR::Node *node)
+void OMR::CodeGenerator::rematerializeCmpUnderSelect(TR::Node *node)
    {
    if (node->getFirstChild()->getOpCode().isBooleanCompare() && node->getFirstChild()->getReferenceCount() > 1)
       {

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -557,7 +557,7 @@ class OMR_EXTENSIBLE CodeGenerator
    // --------------------------------------------------------------------------
    // Lower trees
    //
-   void rematerializeCmpUnderTernary(TR::Node*node);
+   void rematerializeCmpUnderSelect(TR::Node*node);
    bool yankIndexScalingOp() {return false;}
 
    void cleanupFlags(TR::Node*node);
@@ -1495,8 +1495,9 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsArrayTranslateTRxx() {return _flags2.testAny(SupportsArrayTranslate);}
    void setSupportsArrayTranslateTRxx() {_flags2.set(SupportsArrayTranslate);}
 
-   bool getSupportsTernary() {return _flags2.testAny(SupportsTernary);}
-   void setSupportsTernary() {_flags2.set(SupportsTernary);}
+   bool getSupportsTernary() {return _flags2.testAny(SupportsSelect);}
+   bool getSupportsSelect() {return _flags2.testAny(SupportsSelect);}
+   void setSupportsSelect() {_flags2.set(SupportsSelect);}
 
    bool getSupportsArrayTranslateTRTO255() {return _flags4.testAny(SupportsArrayTranslateTRTO255);}
    void setSupportsArrayTranslateTRTO255() {_flags4.set(SupportsArrayTranslateTRTO255);}
@@ -1750,7 +1751,7 @@ class OMR_EXTENSIBLE CodeGenerator
       SupportsReadOnlyLocks                               = 0x00000400,
       SupportsArrayTranslateAndTest                       = 0x00000800,
       SupportsDynamicANewArray                            = 0x00001000,
-      SupportsTernary                                     = 0x00002000,
+      SupportsSelect                                      = 0x00002000,
       // AVAILABLE                                        = 0x00004000,
       SupportsPostProcessArrayCopy                        = 0x00008000,
       // AVAILABLE                                        = 0x00010000,

--- a/compiler/il/ILOpCodes.hpp
+++ b/compiler/il/ILOpCodes.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/il/OMRIL.cpp
+++ b/compiler/il/OMRIL.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -499,16 +499,16 @@ TR::ILOpCodes OMR::IL::opCodesForIfCompareGreaterOrEquals[] =
    TR::BadILOp,   // TR::Aggregate
    };
 
-TR::ILOpCodes OMR::IL::opCodesForTernarySelect [] =
+TR::ILOpCodes OMR::IL::opCodesForSelect [] =
    {
    TR::BadILOp,  // NoType
-   TR::bternary, // Int8
-   TR::sternary, // Int16
-   TR::iternary, // Int32
-   TR::lternary, // Int64
-   TR::fternary, // Float
-   TR::dternary, // Double
-   TR::aternary, // Address
+   TR::bselect,  // Int8
+   TR::sselect,  // Int16
+   TR::iselect,  // Int32
+   TR::lselect,  // Int64
+   TR::fselect,  // Float
+   TR::dselect,  // Double
+   TR::aselect,  // Address
    TR::BadILOp,   // TR::VectorInt8
    TR::BadILOp,   // TR::VectorInt16
    TR::BadILOp,   // TR::VectorInt32
@@ -660,9 +660,17 @@ OMR::IL::opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode)
 TR::ILOpCodes
 OMR::IL::opCodeForTernarySelect(TR::DataType dt)
    {
-   TR_ASSERT(dt < TR::NumOMRTypes, "unexpcted opcode");
+   TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");
 
-   return OMR::IL::opCodesForTernarySelect[dt];
+   return OMR::IL::opCodesForSelect[dt];
+   }
+
+TR::ILOpCodes
+OMR::IL::opCodeForSelect(TR::DataType dt)
+   {
+   TR_ASSERT(dt < TR::NumOMRTypes, "Unexpected data type");
+
+   return OMR::IL::opCodesForSelect[dt];
    }
 
 TR::ILOpCodes

--- a/compiler/il/OMRIL.hpp
+++ b/compiler/il/OMRIL.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -68,12 +68,13 @@ class OMR_EXTENSIBLE IL
    static TR::ILOpCodes opCodesForCompareGreaterOrEquals[];
    static TR::ILOpCodes opCodesForIfCompareGreaterThan[];
    static TR::ILOpCodes opCodesForIfCompareGreaterOrEquals[];
-   static TR::ILOpCodes opCodesForTernarySelect[];
+   static TR::ILOpCodes opCodesForSelect[];
 
    TR::ILOpCodes opCodeForCorrespondingIndirectLoad(TR::ILOpCodes loadOpCode);
    TR::ILOpCodes opCodeForCorrespondingIndirectStore(TR::ILOpCodes storeOpCode);
 
    TR::ILOpCodes opCodeForTernarySelect(TR::DataType dt);
+   TR::ILOpCodes opCodeForSelect(TR::DataType dt);
    TR::ILOpCodes opCodeForConst(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectLoad(TR::DataType dt);
    TR::ILOpCodes opCodeForDirectReadBarrier(TR::DataType dt);

--- a/compiler/il/OMRILOpCodeProperties.hpp
+++ b/compiler/il/OMRILOpCodeProperties.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -6198,10 +6198,10 @@
    },
 
    {
-   /* .opcode               = */ TR::iternary,
-   /* .name                 = */ "iternary",
+   /* .opcode               = */ TR::iselect,
+   /* .name                 = */ "iselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int32,
@@ -6214,10 +6214,10 @@
    },
 
    {
-   /* .opcode               = */ TR::lternary,
-   /* .name                 = */ "lternary",
+   /* .opcode               = */ TR::lselect,
+   /* .name                 = */ "lselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int64,
@@ -6230,10 +6230,10 @@
    },
 
    {
-   /* .opcode               = */ TR::bternary,
-   /* .name                 = */ "bternary",
+   /* .opcode               = */ TR::bselect,
+   /* .name                 = */ "bselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int8,
@@ -6246,10 +6246,10 @@
    },
 
    {
-   /* .opcode               = */ TR::sternary,
-   /* .name                 = */ "sternary",
+   /* .opcode               = */ TR::sselect,
+   /* .name                 = */ "sselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int16,
@@ -6262,10 +6262,10 @@
    },
 
    {
-   /* .opcode               = */ TR::aternary,
-   /* .name                 = */ "aternary",
+   /* .opcode               = */ TR::aselect,
+   /* .name                 = */ "aselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Address,
@@ -6278,10 +6278,10 @@
    },
 
    {
-   /* .opcode               = */ TR::fternary,
-   /* .name                 = */ "fternary",
+   /* .opcode               = */ TR::fselect,
+   /* .name                 = */ "fselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Float,
@@ -6294,10 +6294,10 @@
    },
 
    {
-   /* .opcode               = */ TR::dternary,
-   /* .name                 = */ "dternary",
+   /* .opcode               = */ TR::dselect,
+   /* .name                 = */ "dselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Double,
@@ -6842,8 +6842,8 @@
    },
 
    {
-   /* .opcode               = */ TR::vselect,
-   /* .name                 = */ "vselect",
+   /* .opcode               = */ TR::vbitselect,
+   /* .name                 = */ "vbitselect",
    /* .properties1          = */ 0,
    /* .properties2          = */ 0,
    /* .properties3          = */ 0,
@@ -7913,10 +7913,10 @@
    },
 
    {
-   /* .opcode               = */ TR::vternary,
-   /* .name                 = */ "vternary",
+   /* .opcode               = */ TR::vselect,
+   /* .name                 = */ "vselect",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Ternary,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::Select,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::NoType,
@@ -10543,7 +10543,7 @@
    /* .opcode               = */ TR::iuaddc,
    /* .name                 = */ "iuaddc",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::TernaryAdd,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::SelectAdd,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int32,
@@ -10559,7 +10559,7 @@
    /* .opcode               = */ TR::luaddc,
    /* .name                 = */ "luaddc",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::TernaryAdd,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::SelectAdd,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int64,
@@ -10575,7 +10575,7 @@
    /* .opcode               = */ TR::iusubb,
    /* .name                 = */ "iusubb",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::TernarySub,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::SelectSub,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int32,
@@ -10591,7 +10591,7 @@
    /* .opcode               = */ TR::lusubb,
    /* .name                 = */ "lusubb",
    /* .properties1          = */ 0,
-   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::TernarySub,
+   /* .properties2          = */ ILProp2::ValueNumberShare | ILProp2::SupportedForPRE | ILProp2::SelectSub,
    /* .properties3          = */ 0,
    /* .properties4          = */ 0,
    /* .dataType             = */ TR::Int64,

--- a/compiler/il/OMRILOpCodesEnum.hpp
+++ b/compiler/il/OMRILOpCodesEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -457,13 +457,14 @@
    sRegStore, // Store short global register
    bRegStore, // Store byte global register
    GlRegDeps, // Global Register Dependency List
-   iternary,   // Ternary Operator:  Based on the result of the first child, take the value of the
-   lternary,   //   second (first child evaluates to true) or third(first child evaluates to false) child
-   bternary,   //
-   sternary,   //
-   aternary,   //
-   fternary,   //
-   dternary,   //
+   iselect,   // Select Operator:  Based on the result of the first child, take the value of the
+   lselect,   //   second (first child evaluates to true) or third(first child evaluates to false) child
+   bselect,   //
+   sselect,   //
+   aselect,   //
+   aternary = aselect,   //
+   fselect,   //
+   dselect,   //
    treetop,  // tree top to anchor subtrees with side-effects
    MethodEnterHook, // called after a frame is built, temps initialized, and monitor acquired (if necessary)
    MethodExitHook,  // called immediately before returning, frame not yet collapsed, monitor released (if necessary)
@@ -500,7 +501,7 @@
    vicmpanyle,       // vector integer any less equal
 
    vnot,          // vector boolean not
-   vselect,       // vector select
+   vbitselect,       // vector bit select
    vperm,         // vector permute
 
    vsplats,       // vector splats
@@ -574,7 +575,7 @@
    vreturn,    // return a vector
    vcall,      // direct call returning a vector
    vcalli,     // indirect call returning a vector
-   vternary,   // vector ternary operator
+   vselect,    // vector select operator
    v2v,        // vector to vector conversion. preserves bit pattern (noop), only changes datatype
    vl2vd,      // vector to vector conversion. converts each long element to double
    vconst,     // vector constant

--- a/compiler/il/OMRILOps.hpp
+++ b/compiler/il/OMRILOps.hpp
@@ -228,10 +228,11 @@ public:
    bool isRotate()                   const { return properties2().testAny(ILProp2::LeftRotate); }
    bool isUnsignedCompare()          const { return properties2().testAny(ILProp2::UnsignedCompare); }
    bool isOverflowCompare()          const { return properties2().testAny(ILProp2::OverflowCompare); }
-   bool isTernary()                  const { return properties2().testAny(ILProp2::Ternary); }
-   bool isTernaryAdd()               const { return properties2().testAny(ILProp2::TernaryAdd); }
-   bool isTernarySub()               const { return properties2().testAny(ILProp2::TernarySub); }
-   bool isArithmetic()               const { return isAdd() || isSub() || isMul() || isDiv() || isRem() || isLeftShift() || isRightShift() || isShiftLogical() || isAnd() || isXor() || isOr() || isNeg() || isTernaryAdd() || isTernarySub(); }
+   bool isTernary()                  const { return properties2().testAny(ILProp2::Select); }
+   bool isSelect()                   const { return properties2().testAny(ILProp2::Select); }
+   bool isSelectAdd()                const { return properties2().testAny(ILProp2::SelectAdd); }
+   bool isSelectSub()                const { return properties2().testAny(ILProp2::SelectSub); }
+   bool isArithmetic()               const { return isAdd() || isSub() || isMul() || isDiv() || isRem() || isLeftShift() || isRightShift() || isShiftLogical() || isAnd() || isXor() || isOr() || isNeg() || isSelectAdd() || isSelectSub(); }
    bool isCondCodeComputation()      const { return properties2().testAny(ILProp2::CondCodeComputation); }
    bool isJumpWithMultipleTargets()  const { return properties2().testAny(ILProp2::JumpWithMultipleTargets); }  // Transactional Memory uses this
    bool isLoadAddr()                 const { return properties2().testAny(ILProp2::LoadAddress); }
@@ -1125,15 +1126,15 @@ public:
       return TR::BadILOp;
       }
 
-   static TR::ILOpCodes ternaryOpCode(TR::DataType type)
+   static TR::ILOpCodes selectOpCode(TR::DataType type)
       {
       switch(type)
          {
-         case TR::Int8:     return TR::bternary;
-         case TR::Int16:    return TR::sternary;
-         case TR::Int32:    return TR::iternary;
-         case TR::Int64:    return TR::lternary;
-         case TR::Address:  return TR::aternary;
+         case TR::Int8:     return TR::bselect;
+         case TR::Int16:    return TR::sselect;
+         case TR::Int32:    return TR::iselect;
+         case TR::Int64:    return TR::lselect;
+         case TR::Address:  return TR::aselect;
          default: return TR::BadILOp;
          }
       }

--- a/compiler/il/OMRILProps.hpp
+++ b/compiler/il/OMRILProps.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -217,8 +217,9 @@ namespace ILProp2
       UnsignedCompare              = 0x00002000,
       OverflowCompare              = 0x00004000,
       Ternary                      = 0x00008000,
-      TernaryAdd                   = 0x00010000,
-      TernarySub                   = 0x00020000,
+      Select                       = 0x00008000,
+      SelectAdd                    = 0x00010000,
+      SelectSub                    = 0x00020000,
       CondCodeComputation          = 0x00040000,
       JumpWithMultipleTargets      = 0x00080000,
       LoadAddress                  = 0x00100000,

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -518,7 +518,7 @@ public:
    ///
    bool                   isDualHigh();
 
-   /// Whether this node is high part of a ternary subtract or addition, like a dual this
+   /// Whether this node is high part of a select subtract or addition, like a dual this
    /// is a composite operator, made from a high order part and its adjunct operator
    /// which is the first child of its third child. It returns true if the node has the form:
    ///
@@ -532,8 +532,12 @@ public:
    ///
    /// and the opcodes for highOp/adjunctOp are luaddc/luadd, or lusubb/lusub.
    ///
-   bool                   isTernaryHigh();
+   bool                   isSelectHigh();
 
+   /// isTernaryHigh is now deprecated. Use isSelectHigh instead.
+   ///
+   bool                   isTernaryHigh();
+   
    /// Whether this node is the high or low part of a "dual", in cyclic representation.
    /// ie it represents a composite operator, together with its pair.
    /// The node and its pair have each other as its third child, completing the cycle.

--- a/compiler/ilgen/OMRIlBuilder.cpp
+++ b/compiler/ilgen/OMRIlBuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2687,7 +2687,7 @@ OMR::IlBuilder::Select(TR::IlValue * condition, TR::IlValue * trueValue, TR::IlV
    TR::DataType dt = trueValue->getDataType();
    TR_ASSERT_FATAL(dt == falseValue->getDataType(),
                      "Select requires trueValue and falseValue to be of the same type");
-   TR::ILOpCodes opCode = TR::ILOpCode::ternaryOpCode(dt);
+   TR::ILOpCodes opCode = TR::ILOpCode::selectOpCode(dt);
    TR::IlValue * result = NULL;
    if (opCode == TR::BadILOp)
       {

--- a/compiler/ilgen/OMRIlBuilder.hpp
+++ b/compiler/ilgen/OMRIlBuilder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corp. and others
+ * Copyright (c) 2016, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -586,7 +586,7 @@ public:
                      TR::IlBuilder **caseBuilder,
                      int32_t caseFallsThrough);
 
-   // ternary
+   // select
    /**
     * @brief Service to select a value based on a condition without branching
     *

--- a/compiler/optimizer/InductionVariable.cpp
+++ b/compiler/optimizer/InductionVariable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1639,7 +1639,7 @@ void TR_LoopStrider::examineOpCodesForInductionVariableUse(TR::Node* node, TR::N
             (!parent->getOpCode().isShift() || node != parent->getSecondChild()) &&
             !parent->getOpCode().isCall() &&
             !parent->getOpCode().isConversion() &&
-            parent->getOpCodeValue() != TR::lternary)
+            parent->getOpCodeValue() != TR::lselect)
             {
             TR::Node *i2lNode = TR::Node::create(TR::i2l, 1, node);
             node->decReferenceCount();

--- a/compiler/optimizer/OMRCFGSimplifier.hpp
+++ b/compiler/optimizer/OMRCFGSimplifier.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,7 @@ class CFGSimplifier : public TR::Optimization
    /**
     * \brief
     *    This function tries to match a simple diamond or traigle that performs conditional store in a temp 
-    *    and repalce with an appropriate ternary node.
+    *    and repalce with an appropriate select node.
     *
     * \parm needToDuplicateTree
     *    Boolean to indicate whether or not to duplicate node.
@@ -101,7 +101,7 @@ class CFGSimplifier : public TR::Optimization
    /**
     * \brief
     *    This function tries to match diamond or traigle that performs conditional stores in temps 
-    *    and repalce with seqeunce of appropriate ternary nodes.
+    *    and repalce with seqeunce of appropriate select nodes.
     *
     * \parm needToDuplicateTree
     *    Boolean to indicate whether or not to duplicate node.

--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -15446,10 +15446,10 @@ TR::Node *endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
    }
 
 //---------------------------------------------------------------------
-// Ternary
+// Select
 //
 
-TR::Node *ternarySimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
+TR::Node *selectSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s)
    {
    simplifyChildren(node, block, s);
 

--- a/compiler/optimizer/OMRSimplifierHandlers.hpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,7 +205,7 @@ TR::Node * sucmpleSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier 
 TR::Node * lcmpSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * passThroughSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * endBlockSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
-TR::Node * ternarySimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
+TR::Node * selectSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * a2iSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * a2lSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);
 TR::Node * v2vSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * s);

--- a/compiler/optimizer/OMRSimplifierTableEnum.hpp
+++ b/compiler/optimizer/OMRSimplifierTableEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -422,13 +422,13 @@
    dftSimplifier,           // TR::bRegStore
    dftSimplifier,           // TR::GlRegDeps
 
-   ternarySimplifier,       // TR::iternary
-   ternarySimplifier,       // TR::lternary
-   ternarySimplifier,       // TR::bternary
-   ternarySimplifier,       // TR::sternary
-   ternarySimplifier,       // TR::aternary
-   ternarySimplifier,       // TR::fternary
-   ternarySimplifier,       // TR::dternary
+   selectSimplifier,       // TR::iselect
+   selectSimplifier,       // TR::lselect
+   selectSimplifier,       // TR::bselect
+   selectSimplifier,       // TR::sselect
+   selectSimplifier,       // TR::aselect
+   selectSimplifier,       // TR::fselect
+   selectSimplifier,       // TR::dselect
    treetopSimplifier,       // TR::treetop
    lowerTreeSimplifier,     // TR::MethodEnterHook
    lowerTreeSimplifier,     // TR::MethodExitHook
@@ -465,7 +465,7 @@
    dftSimplifier,           // TR::vicmpanyle
 
    dftSimplifier,           // TR::vnot
-   dftSimplifier,           // TR::vselect
+   dftSimplifier,           // TR::vbitselect
    dftSimplifier,           // TR::vperm
 
    dftSimplifier,           // TR::vsplats
@@ -536,7 +536,7 @@
    dftSimplifier,           // TR::vreturn
    dftSimplifier,           // TR::vcall
    dftSimplifier,           // TR::vcalli
-   dftSimplifier,           // TR::vternary
+   dftSimplifier,           // TR::vselect
    v2vSimplifier,           // TR::v2v
    dftSimplifier,           // TR::vl2vd
    dftSimplifier,           // TR::vconst

--- a/compiler/optimizer/ValuePropagationTable.hpp
+++ b/compiler/optimizer/ValuePropagationTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -563,13 +563,13 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,        // TR::bRegStore
    constrainChildren,        // TR::GlRegDeps
 
-   constrainChildrenFirstToLast,        // TR::iternary
-   constrainChildrenFirstToLast,        // TR::lternary
-   constrainChildrenFirstToLast,        // TR::bternary
-   constrainChildrenFirstToLast,        // TR::sternary
-   constrainChildrenFirstToLast,        // TR::aternary
-   constrainChildrenFirstToLast,        // TR::fternary
-   constrainChildrenFirstToLast,        // TR::dternary
+   constrainChildrenFirstToLast,        // TR::iselect
+   constrainChildrenFirstToLast,        // TR::lselect
+   constrainChildrenFirstToLast,        // TR::bselect
+   constrainChildrenFirstToLast,        // TR::sselect
+   constrainChildrenFirstToLast,        // TR::aselect
+   constrainChildrenFirstToLast,        // TR::fselect
+   constrainChildrenFirstToLast,        // TR::dselect
    constrainChildren,        // TR::treetop
    constrainChildren,        // TR::MethodEnterHook
    constrainChildren,        // TR::MethodExitHook
@@ -606,7 +606,7 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,        // TR::vicmpanyle
 
    constrainChildren,        // TR::vnot
-   constrainChildren,        // TR::vselect
+   constrainChildren,        // TR::vbitselect
    constrainChildren,        // TR::vperm
 
    constrainChildren,        // TR::vsplats
@@ -675,7 +675,7 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainReturn,          // TR::vreturn
    constrainCall,            // TR::vcall
    constrainCall,            // TR::vcalli
-   constrainChildrenFirstToLast,        // TR::vternary
+   constrainChildrenFirstToLast,        // TR::vselect
    constrainChildren,        // TR::v2v
    constrainChildren,        // TR::vl2vd
    constrainChildren,        // TR::vconst
@@ -1176,9 +1176,9 @@ const ValuePropagationPtr constraintHandlers[] =
    constrainChildren,           // TR::ddRegStore
    constrainChildren,           // TR::deRegStore
 
-   constrainChildrenFirstToLast,        // TR::dfternary
-   constrainChildrenFirstToLast,        // TR::ddternary
-   constrainChildrenFirstToLast,        // TR::deternary
+   constrainChildrenFirstToLast,        // TR::dfselect
+   constrainChildrenFirstToLast,        // TR::ddselect
+   constrainChildrenFirstToLast,        // TR::deselect
 
    constrainChildren,           // TR::dfexp
    constrainChildren,           // TR::ddexp

--- a/compiler/p/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/p/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -937,7 +937,7 @@ static TR::InstOpCode::Mnemonic cmp2cmpi(TR::ILOpCodes op, TR::CodeGenerator *cg
     }
 
 
-TR::Register *OMR::Power::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::Power::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::DataType type = node->getType();
    bool two_reg = (cg->comp()->target().is32Bit()) && type.getDataType() == TR::Int64;
@@ -1058,7 +1058,7 @@ TR::Register *OMR::Power::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::C
          }
       else
          {
-         TR_ASSERT(false, "Unsupported compare type for ternary\n");
+         TR_ASSERT(false, "Unsupported compare type for select\n");
          }
 
       TR::RegisterDependencyConditions *dep = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, two_reg ? 8 : 5, cg->trMemory());
@@ -1098,7 +1098,7 @@ TR::Register *OMR::Power::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::C
       TR::Register *ccr       = cg->allocateRegister(TR_CCR);
       bool useRegPairForCond = (condReg->getRegisterPair() != NULL);
       TR::PPCControlFlowInstruction *i = (TR::PPCControlFlowInstruction*)
-            generateControlFlowInstruction(cg, TR::InstOpCode::iternary, node, NULL, 0, two_reg, useRegPairForCond);
+            generateControlFlowInstruction(cg, TR::InstOpCode::iselect, node, NULL, 0, two_reg, useRegPairForCond);
       i->addTargetRegister(ccr);
       if (two_reg)
          {

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -204,7 +204,7 @@ OMR::Power::CodeGenerator::CodeGenerator() :
     self()->setSupportsVirtualGuardNOPing();
     self()->setSupportsPrimitiveArrayCopy();
     self()->setSupportsReferenceArrayCopy();
-    self()->setSupportsTernary();
+    self()->setSupportsSelect();
 
     // disabled for now
     //

--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -565,7 +565,7 @@
    lrem,             // long remainder for 64 bit target
    d2i,              // converts from double to integer
    d2l,              // converts from double to long
-   iternary,         // ternary evaluator
+   iselect,          // select evaluator
 // bcdcpsgn_r,       // Decimal copySign & record
 // bcdcfn_r,         // Decimal convert from national & record
 // bcdcfsq_r,        // Decimal convert from signed qword & record

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -6017,9 +6017,9 @@
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::iternary,
-   /* .name        = */ "iternary",
-   /* .description =    "ternary evaluator", */
+   /* .mnemonic    = */ OMR::InstOpCode::iselect,
+   /* .name        = */ "iselect",
+   /* .description =    "select evaluator", */
    /* .opcode      = */ 0x00000000,
    /* .format      = */ UNKNOWN_FORMAT,
    /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -1711,7 +1711,7 @@ TR::Register *OMR::Power::TreeEvaluator::inlineVectorBinaryOp(TR::Node *node, TR
    return resReg;
 }
 
-TR::Register *OMR::Power::TreeEvaluator::inlineVectorTernaryOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op) {
+TR::Register *OMR::Power::TreeEvaluator::inlineVectorBitSelectOp(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op) {
    TR::Node *firstChild  = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
    TR::Node *thirdChild  = node->getThirdChild();
@@ -2391,22 +2391,22 @@ TR::Register *OMR::Power::TreeEvaluator::vimergeEvaluator(TR::Node *node, TR::Co
 
 TR::Register *OMR::Power::TreeEvaluator::vdmaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvmaddadp);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::xvmaddadp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdnmsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvnmsubadp);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::xvnmsubadp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdmsubEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xvmsubadp);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::xvmsubadp);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdselEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::xxsel);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::xxsel);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdcmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -2803,14 +2803,14 @@ TR::Register *OMR::Power::TreeEvaluator::vicmpleEvaluator(TR::Node *node, TR::Co
    return TR::TreeEvaluator::vicmpgeEvaluator(node, cg);
    }
 
-TR::Register *OMR::Power::TreeEvaluator::vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::Power::TreeEvaluator::vbitselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::vsel);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::vsel);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vpermEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::vperm);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::vperm);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vdmergeEvaluator(TR::Node *node, TR::CodeGenerator *cg)

--- a/compiler/p/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -95,7 +95,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *lreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *freturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *returnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *indirectCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -397,7 +397,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vxorEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vnotEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *vbitselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vpermEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vicmpeqEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *vicmpgtEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -470,7 +470,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineVectorUnaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
    static TR::Register *inlineVectorBinaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
-   static TR::Register *inlineVectorTernaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
+   static TR::Register *inlineVectorBitSelectOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
    static bool inlineVectorCompareBranch(TR::Node * node, TR::CodeGenerator *cg, bool isHint, bool likeliness);
    static TR::Register *inlineVectorCompareAllOrAnyOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic vcmpOp, TR::InstOpCode::Mnemonic branchOp);
    static TR::Register *PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/p/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -407,13 +407,13 @@
    TR::TreeEvaluator::gprRegStoreEvaluator,             // TR::sRegStore
    TR::TreeEvaluator::gprRegStoreEvaluator,             // TR::bRegStore
    TR::TreeEvaluator::GlRegDepsEvaluator,               // TR::GlRegDeps
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::iternary
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::lternary
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::bternary
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::sternary
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::aternary
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::fternary
-   TR::TreeEvaluator::iternaryEvaluator,                // TR::dternary
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::iselect
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::lselect
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::bselect
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::sselect
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::aselect
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::fselect
+   TR::TreeEvaluator::iselectEvaluator,                 // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,                 // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodEnterHook (J9)
    TR::TreeEvaluator::badILOpEvaluator,                    // TR::MethodExitHook (J9)
@@ -447,7 +447,7 @@
    TR::TreeEvaluator::vicmpanyltEvaluator,              // TR::vicmpanylt
    TR::TreeEvaluator::vicmpanyleEvaluator,              // TR::vicmpanyle
    TR::TreeEvaluator::vnotEvaluator,                    // TR::vnot
-   TR::TreeEvaluator::vselectEvaluator,                 // TR::vselect
+   TR::TreeEvaluator::vbitselectEvaluator,                 // TR::vbitselect
    TR::TreeEvaluator::vpermEvaluator,                   // TR::vperm
 
    TR::TreeEvaluator::vsplatsEvaluator,                 // TR::vsplats
@@ -516,7 +516,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vreturn
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vcall
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vcalli
-   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vternary
+   TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vselect
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::v2v
    TR::TreeEvaluator::vl2vdEvaluator,                    // TR::vl2vd
    TR::TreeEvaluator::unImpOpEvaluator,                    // TR::vconst

--- a/compiler/p/codegen/PPCBinaryEncoding.cpp
+++ b/compiler/p/codegen/PPCBinaryEncoding.cpp
@@ -925,7 +925,7 @@ int32_t TR::PPCControlFlowInstruction::estimateBinaryLength(int32_t currentEstim
       case TR::InstOpCode::setbool:
       case TR::InstOpCode::idiv:
       case TR::InstOpCode::ldiv:
-      case TR::InstOpCode::iternary:
+      case TR::InstOpCode::iselect:
          if (useRegPairForResult())
             {
             if (!useRegPairForCond())

--- a/compiler/p/codegen/PPCInstruction.cpp
+++ b/compiler/p/codegen/PPCInstruction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1509,7 +1509,7 @@ void TR::PPCControlFlowInstruction::assignRegisters(TR_RegisterKinds kindToBeAss
          cg()->traceRAInstruction(cursor = generateLabelInstruction(cg(), TR::InstOpCode::label, currentNode, label2, cursor));
 
          break;
-      case TR::InstOpCode::iternary:
+      case TR::InstOpCode::iselect:
          {
          cg()->traceRAInstruction(cursor = generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::cmpi4, currentNode, getTargetRegister(0), getSourceRegister(0), 0, cursor));
 

--- a/compiler/ras/Tree.cpp
+++ b/compiler/ras/Tree.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2670,13 +2670,13 @@ int32_t childTypes[] =
    TR::Int16,                      // TR::sRegStore
    TR::Int8,                       // TR::bRegStore
    TR::NoType,                     // TR::GlRegDeps
-   TR::Int32 | (TR::Int32<<8),    // TR::iternary
-   TR::Int64 | (TR::Int32<<8),    // TR::lternary
-   TR::Int8  | (TR::Int32<<8),    // TR::bternary
-   TR::Int16 | (TR::Int32<<8),    // TR::sternary
-   TR::Address | (TR::Int32<<8),   // TR::aternary
-   TR::Float | (TR::Int32<<8),     // TR::fternary
-   TR::Double | (TR::Int32<<8),    // TR::dternary
+   TR::Int32 | (TR::Int32<<8),    // TR::iselect
+   TR::Int64 | (TR::Int32<<8),    // TR::lselect
+   TR::Int8  | (TR::Int32<<8),    // TR::bselect
+   TR::Int16 | (TR::Int32<<8),    // TR::sselect
+   TR::Address | (TR::Int32<<8),   // TR::aselect
+   TR::Float | (TR::Int32<<8),     // TR::fselect
+   TR::Double | (TR::Int32<<8),    // TR::dselect
    TR::NoType,                     // TR::treetop
    TR::NoType,                     // TR::MethodEnterHook
    TR::NoType,                     // TR::MethodExitHook
@@ -2710,7 +2710,7 @@ int32_t childTypes[] =
    TR::VectorInt32,                     // TR_vianylt
    TR::VectorInt32,                     // TR_vianyle
    TR::VectorInt32,                     // TR::vnot
-   TR::VectorInt32,                     // TR::vselect
+   TR::VectorInt32,                     // TR::vbitselect
    TR::VectorInt32,                     // TR::vperm
 
    TR::VectorDouble | (TR::Address<<8),   // TR::dloadi
@@ -2781,7 +2781,7 @@ int32_t childTypes[] =
    TR::NoType,                           //TR::vreturn
    TR::NoType,                           //TR::vcall
    TR::NoType,                           //TR::vcalli
-   TR::NoType,                           //TR::vternary
+   TR::NoType,                           //TR::vselect
    TR::NoType,                           //TR::v2v
    TR::NoType,                           //TR::vl2vd
    TR::NoType,                           //TR::vconst
@@ -3274,9 +3274,9 @@ int32_t childTypes[] =
    TR::DecimalDouble,                                        // TR::ddRegStore
    TR::DecimalLongDouble,                                    // TR::deRegStore
 
-   TR::DecimalDouble | (TR::Int32<<8),                       // TR::dfternary
-   TR::DecimalFloat | (TR::Int32<<8),                        // TR::ddternary
-   TR::DecimalLongDouble | (TR::Int32<<8),                   // TR::deternary
+   TR::DecimalDouble | (TR::Int32<<8),                       // TR::dfselect
+   TR::DecimalFloat | (TR::Int32<<8),                        // TR::ddselect
+   TR::DecimalLongDouble | (TR::Int32<<8),                   // TR::deselect
 
    TR::DecimalFloat,                                         // TR::dfexp
    TR::DecimalDouble,                                        // TR::ddexp

--- a/compiler/riscv/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/riscv/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -437,13 +437,13 @@ public:
 	static TR::Register *sRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *bRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *GlRegDepsEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *lternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *bternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *sternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *aternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *fternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *dternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *lselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *bselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *sselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *aselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *fselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *dselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *MethodEnterHookEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *MethodExitHookEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -543,7 +543,7 @@ public:
 	static TR::Register *vreturnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vcallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vcalliEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *vternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+	static TR::Register *vselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *v2vEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vl2vdEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *vconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -602,10 +602,6 @@ public:
 	static TR::Register *luRegLoadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *iuRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *luRegStoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *iuternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *luternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *buternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-	static TR::Register *suternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cconstEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *cloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/riscv/codegen/TreeEvaluatorTable.hpp
+++ b/compiler/riscv/codegen/TreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2019 IBM Corp. and others
+ * Copyright (c) 2019, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -408,13 +408,13 @@
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::sRegStore		// Store short global register
     TR::TreeEvaluator::iRegStoreEvaluator, // TR::bRegStore		// Store byte global register
     TR::TreeEvaluator::GlRegDepsEvaluator, // TR::GlRegDeps		// Global Register Dependency List
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::iternaryEvaluator ,	// TR::iternary		// Ternary Operator:  Based on the result of the first child; take the value of the
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::lternaryEvaluator ,	// TR::lternary		//   second (first child evaluates to true) or third(first child evaluates to false) child
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bternaryEvaluator ,	// TR::bternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sternaryEvaluator ,	// TR::sternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::aternaryEvaluator ,	// TR::aternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::fternaryEvaluator ,	// TR::fternary   
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::dternaryEvaluator ,	// TR::dternary   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::iselectEvaluator ,	// TR::iselect		// Select Operator:  Based on the result of the first child; take the value of the
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::lselectEvaluator ,	// TR::lselect		//   second (first child evaluates to true) or third(first child evaluates to false) child
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::bselectEvaluator ,	// TR::bselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::sselectEvaluator ,	// TR::sselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::aselectEvaluator ,	// TR::aselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::fselectEvaluator ,	// TR::fselect   
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::dselectEvaluator ,	// TR::dselect   
     TR::TreeEvaluator::treetopEvaluator, // TR::treetop		// tree top to anchor subtrees with side-effects
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::MethodEnterHookEvaluator ,	// TR::MethodEnterHook	// called after a frame is built; temps initialized; and monitor acquired (if necessary)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::MethodExitHookEvaluator ,	// TR::MethodExitHook	// called immediately before returning; frame not yet collapsed; monitor released (if necessary)
@@ -514,7 +514,7 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vreturnEvaluator ,	// TR::vreturn		// return a vector
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vcallEvaluator ,	// TR::vcall		// direct call returning a vector
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vcalliEvaluator ,	// TR::vcalli		// indirect call returning a vector
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vternaryEvaluator ,	// TR::vternary		// vector ternary operator
+    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vselectEvaluator ,	// TR::vselect		// vector select operator
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::v2vEvaluator ,	// TR::v2v		// vector to vector conversion. preserves bit pattern (noop); only changes datatype
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vl2vdEvaluator ,	// TR::vl2vd		// vector to vector conversion. converts each long element to double
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:RV: Enable when Implemented: TR::TreeEvaluator::vconstEvaluator ,	// TR::vconst		// vector constant

--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -408,13 +408,13 @@
    TR::TreeEvaluator::iRegStoreEvaluator,                              // TR::sRegStore
    TR::TreeEvaluator::iRegStoreEvaluator,                              // TR::bRegStore
    TR::TreeEvaluator::GlRegDepsEvaluator,                              // TR::GlRegDeps
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::iternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::lternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::bternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::sternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::aternary
-   TR::TreeEvaluator::badILOpEvaluator,                                // TR::fternary
-   TR::TreeEvaluator::badILOpEvaluator,                                // TR::dternary
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::iselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::lselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::bselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::sselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::aselect
+   TR::TreeEvaluator::badILOpEvaluator,                                // TR::fselect
+   TR::TreeEvaluator::badILOpEvaluator,                                // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,                                // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::MethodEnterHook (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::MethodExitHook (J9)
@@ -447,7 +447,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vicmpanylt
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vicmpanyle
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vnot
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vselect
+   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vbitselect
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vperm
    TR::TreeEvaluator::SIMDsplatsEvaluator,                             // TR::vsplats
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vdmergel
@@ -514,7 +514,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vreturn
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vcall
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vcalli
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vternary
+   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vselect
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::v2v
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vl2vd
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vconst

--- a/compiler/x/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/x/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -1290,8 +1290,8 @@ TR::Register *OMR::X86::TreeEvaluator::returnEvaluator(TR::Node *node, TR::CodeG
    return NULL;
    }
 
-// also handles lternary, aternary
-TR::Register *OMR::X86::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+// also handles lselect, aselect
+TR::Register *OMR::X86::TreeEvaluator::iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *condition = node->getChild(0);
    TR::Node *trueVal   = node->getChild(1);
@@ -1331,7 +1331,7 @@ TR::Register *OMR::X86::TreeEvaluator::iternaryEvaluator(TR::Node *node, TR::Cod
       generateRegRegInstruction(CMOVERegReg(trueValIs64Bit), node, trueReg, falseReg, cg);
       }
 
-   if (node->getOpCodeValue() == TR::bternary &&
+   if (node->getOpCodeValue() == TR::bselect &&
        cg->enableRegisterInterferences())
       cg->getLiveRegisters(TR_GPR)->setByteRegisterAssociation(trueReg);
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -409,7 +409,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setSupportsEfficientNarrowUnsignedIntComputation();
    self()->setSupportsVirtualGuardNOPing();
    self()->setSupportsDynamicANewArray();
-   self()->setSupportsTernary();
+   self()->setSupportsSelect();
 
    // allows [i/l]div to decompose to [i/l]mulh in TreeSimplifier
    //

--- a/compiler/x/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -89,7 +89,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *tableEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *igotoEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *returnEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *iternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *iselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *indirectCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *treetopEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3608,7 +3608,7 @@ TR::Register *OMR::X86::I386::TreeEvaluator::iflcmpleEvaluator(TR::Node *node, T
    }
 
 
-TR::Register *OMR::X86::I386::TreeEvaluator::lternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+TR::Register *OMR::X86::I386::TreeEvaluator::lselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *condition = node->getChild(0);
    TR::Node *trueVal   = node->getChild(1);

--- a/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -111,7 +111,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::X86::TreeEvaluator
    static TR::Register *integerPairUshrEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerPairByteswapEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerPairMinMaxEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *lternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *lselectEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *lcmpsetEvaluator(TR::Node *n, TR::CodeGenerator *cg);
    static TR::Register *awrtbarEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *awrtbariEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -408,13 +408,13 @@
    TR::TreeEvaluator::iRegStoreEvaluator,                              // TR::sRegStore
    TR::TreeEvaluator::iRegStoreEvaluator,                              // TR::bRegStore
    TR::TreeEvaluator::GlRegDepsEvaluator,                              // TR::GlRegDeps
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::iternary
-   TR::TreeEvaluator::lternaryEvaluator,                               // TR::lternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::bternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::sternary
-   TR::TreeEvaluator::iternaryEvaluator,                               // TR::aternary
-   TR::TreeEvaluator::badILOpEvaluator,                                // TR::fternary
-   TR::TreeEvaluator::badILOpEvaluator,                                // TR::dternary
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::iselect
+   TR::TreeEvaluator::lselectEvaluator,                                // TR::lselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::bselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::sselect
+   TR::TreeEvaluator::iselectEvaluator,                                // TR::aselect
+   TR::TreeEvaluator::badILOpEvaluator,                                // TR::fselect
+   TR::TreeEvaluator::badILOpEvaluator,                                // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,                                // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::MethodEnterHook (J9)
    TR::TreeEvaluator::badILOpEvaluator,                                // TR::MethodExitHook (J9)
@@ -447,7 +447,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vicmpanylt
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vicmpanyle
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vnot
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vselect
+   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vbitselect
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vperm
    TR::TreeEvaluator::SIMDsplatsEvaluator,                             // TR::vsplats
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vdmergel
@@ -514,7 +514,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vreturn
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vcall
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vcalli
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vternary
+   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vselect
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::v2v
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vl2vd
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::vconst

--- a/compiler/z/codegen/ControlFlowEvaluator.cpp
+++ b/compiler/z/codegen/ControlFlowEvaluator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -2331,7 +2331,7 @@ OMR::Z::TreeEvaluator::inlineIfBifEvaluator(TR::Node * ifNode, TR::CodeGenerator
    }
 
 /**
- * Ternary Evaluator - evaluates all types of ternary opcodes
+ * Select Evaluator - evaluates all types of select opcodes
  */
 TR::InstOpCode::S390BranchCondition OMR::Z::TreeEvaluator::getBranchConditionFromCompareOpCode(TR::ILOpCodes opCode)
    {
@@ -2385,7 +2385,7 @@ TR::InstOpCode::S390BranchCondition OMR::Z::TreeEvaluator::getBranchConditionFro
          break;
       default:
          {
-         TR_ASSERT_FATAL(0, "Unsupported compare type under ternary");
+         TR_ASSERT_FATAL(0, "Unsupported compare type under select");
          return TR::InstOpCode::COND_BE;      //not a valid return value.  We should never ever get here.
          }
          break;
@@ -2496,7 +2496,7 @@ int32_t OMR::Z::TreeEvaluator::countReferencesInTree(TR::Node *treeNode, TR::Nod
 bool
 OMR::Z::TreeEvaluator::treeContainsAllOtherUsesForNode(TR::Node *treeNode, TR::Node *node)
    {
-   static const char *x = feGetEnv("disableTernaryEvaluatorImprovement");
+   static const char *x = feGetEnv("disableSelectEvaluatorImprovement");
    if (x)
       {
       return false;
@@ -2519,7 +2519,7 @@ OMR::Z::TreeEvaluator::treeContainsAllOtherUsesForNode(TR::Node *treeNode, TR::N
    }
 
 TR::Register *
-OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+OMR::Z::TreeEvaluator::selectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
 
@@ -2529,7 +2529,7 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    TR::Node *falseVal   = node->getThirdChild();
 
    if (comp->getOption(TR_TraceCG))
-      traceMsg(comp, "Starting evaluation of ternary node %p condition %p (in reg %p) trueVal %p (in reg %p) falseVal %p (in reg %p)\n",node,condition,condition->getRegister(), trueVal, trueVal->getRegister(), falseVal, falseVal->getRegister());
+      traceMsg(comp, "Starting evaluation of select node %p condition %p (in reg %p) trueVal %p (in reg %p) falseVal %p (in reg %p)\n",node,condition,condition->getRegister(), trueVal, trueVal->getRegister(), falseVal, falseVal->getRegister());
 
   TR::Register *trueReg = 0;
   if(TR::TreeEvaluator::treeContainsAllOtherUsesForNode(condition,trueVal) &&
@@ -2689,9 +2689,9 @@ OMR::Z::TreeEvaluator::ternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    return trueReg;
 }
 
-// Take advantage of VRF/FPR overlap and use vector compare and select instructions to implement dternary
+// Take advantage of VRF/FPR overlap and use vector compare and select instructions to implement dselect
 TR::Register *
-OMR::Z::TreeEvaluator::dternaryEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+OMR::Z::TreeEvaluator::dselectEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *conditionNode = node->getFirstChild();
    TR::Node *trueValueNode = node->getSecondChild();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -453,7 +453,7 @@ OMR::Z::CodeGenerator::CodeGenerator()
 
    self()->setMultiplyIsDestructive();
 
-   self()->setSupportsTernary();
+   self()->setSupportsSelect();
 
    self()->setIsOutOfLineHotPath(false);
 

--- a/compiler/z/codegen/OMRLinkage.hpp
+++ b/compiler/z/codegen/OMRLinkage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -157,7 +157,7 @@ enum TR_S390LinkageConventions
  *      i.e (i >= TR::RealRegister::FirstFPR)/    <<-----
  *          ...                                             | Notice the equal indentation
  *          FPREGINDEX(i)                            <<-----
- * 4. REGINDEX(i) is the default i.e GPR index, and so lacks a matching ternary condition.
+ * 4. REGINDEX(i) is the default i.e GPR index, and so lacks a matching select condition.
  * 5. Each unrelated condition or answer to a condition is separated by TR indentation rule i.e 3 spaces
  *
  * Feel free to refactor this into if/else conditions :)

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -14391,9 +14391,9 @@ OMR::Z::TreeEvaluator::inlineVectorBinaryOp(TR::Node * node, TR::CodeGenerator *
    }
 
 TR::Register *
-OMR::Z::TreeEvaluator::inlineVectorTernaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op)
+OMR::Z::TreeEvaluator::inlineVectorBitSelectOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op)
    {
-   TR_ASSERT(node->getNumChildren() >= 3,"Ternary Node must contain 3 or more children");
+   TR_ASSERT(node->getNumChildren() >= 3,"Select Node must contain 3 or more children");
    // TODO Bullet proof this code better and handle more children better.
    TR::Node *firstChild  = node->getFirstChild();
    TR::Node *secondChild = node->getSecondChild();
@@ -14424,7 +14424,7 @@ OMR::Z::TreeEvaluator::inlineVectorTernaryOp(TR::Node * node, TR::CodeGenerator 
          breakInst = generateVRReInstruction(cg, op, node, targetReg, sourceReg1, sourceReg2, sourceReg3, 3, mask5);
          break;
       default:
-         TR_ASSERT(false, "Ternary Vector IL evaluation unimplemented for node : %s", cg->getDebug()->getName(node));
+         TR_ASSERT(false, "Select Vector IL evaluation unimplemented for node : %s", cg->getDebug()->getName(node));
       }
 
    cg->decReferenceCount(firstChild);
@@ -14531,7 +14531,7 @@ OMR::Z::TreeEvaluator::vdremEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 TR::Register *
 OMR::Z::TreeEvaluator::vdmaddEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::inlineVectorTernaryOp(node, cg, TR::InstOpCode::VFMA);
+   return TR::TreeEvaluator::inlineVectorBitSelectOp(node, cg, TR::InstOpCode::VFMA);
    }
 
 TR::Register *

--- a/compiler/z/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -413,8 +413,8 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::InstOpCode::S390BranchCondition getBranchConditionFromCompareOpCode(TR::ILOpCodes opCode);
    static TR::InstOpCode::S390BranchCondition mapBranchConditionToLOCRCondition(TR::InstOpCode::S390BranchCondition incomingBc);
    static TR::InstOpCode::Mnemonic getCompareOpFromNode(TR::CodeGenerator *cg, TR::Node *node);
-   static TR::Register *ternaryEvaluator(TR::Node * node, TR::CodeGenerator * cg);
-   static TR::Register *dternaryEvaluator(TR::Node * node, TR::CodeGenerator * cg);
+   static TR::Register *selectEvaluator(TR::Node * node, TR::CodeGenerator * cg);
+   static TR::Register *dselectEvaluator(TR::Node * node, TR::CodeGenerator * cg);
    static bool treeContainsAllOtherUsesForNode(TR::Node *condition, TR::Node *trueVal);
    static int32_t countReferencesInTree(TR::Node *treeNode, TR::Node *node);
    static TR::Register *NOPEvaluator(TR::Node *node, TR::CodeGenerator *cg);
@@ -462,7 +462,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluator
    static TR::Register *vsetelemEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineVectorUnaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
    static TR::Register *inlineVectorBinaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
-   static TR::Register *inlineVectorTernaryOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
+   static TR::Register *inlineVectorBitSelectOp(TR::Node * node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op);
 
    static TR::Register *bitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    

--- a/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/z/codegen/OMRTreeEvaluatorTable.hpp
@@ -437,13 +437,13 @@
    TR::TreeEvaluator::iRegStoreEvaluator,   // TR::sRegStore
    TR::TreeEvaluator::iRegStoreEvaluator,   // TR::bRegStore
    TR::TreeEvaluator::GlRegDepsEvaluator,   // TR::GlRegDeps
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::iternary
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::lternary
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::bternary
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::sternary
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::aternary
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::fternary
-   TR::TreeEvaluator::dternaryEvaluator,     // TR::dternary
+   TR::TreeEvaluator::selectEvaluator,      // TR::iselect
+   TR::TreeEvaluator::selectEvaluator,      // TR::lselect
+   TR::TreeEvaluator::selectEvaluator,      // TR::bselect
+   TR::TreeEvaluator::selectEvaluator,      // TR::sselect
+   TR::TreeEvaluator::selectEvaluator,      // TR::aselect
+   TR::TreeEvaluator::selectEvaluator,      // TR::fselect
+   TR::TreeEvaluator::dselectEvaluator,     // TR::dselect
    TR::TreeEvaluator::treetopEvaluator,     // TR::treetop
    TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodEnterHook
    TR::TreeEvaluator::badILOpEvaluator,     // TR::MethodExitHook
@@ -478,7 +478,7 @@
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vicmpanylt
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vicmpanyle
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vnot
-   TR::TreeEvaluator::vselEvaluator,        //  TR::vselect
+   TR::TreeEvaluator::vselEvaluator,        //  TR::vbitselect
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vperm
    TR::TreeEvaluator::vsplatsEvaluator,     //  TR::vsplats
    TR::TreeEvaluator::unImpOpEvaluator,         //  TR::vdmergel
@@ -546,7 +546,7 @@
    TR::TreeEvaluator::vreturnEvaluator,     // TR::vreturn
    TR::TreeEvaluator::directCallEvaluator,  // TR::vcall
    TR::TreeEvaluator::indirectCallEvaluator,// TR::vcalli
-   TR::TreeEvaluator::ternaryEvaluator,     // TR::vternary
+   TR::TreeEvaluator::unImpOpEvaluator,      // TR::vselect
    TR::TreeEvaluator::passThroughEvaluator, // TR::v2v
    TR::TreeEvaluator::vl2vdEvaluator,       // TR::vl2vd 
    TR::TreeEvaluator::vconstEvaluator,      // TR::vconst

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -92,7 +92,7 @@ add_executable(compilertest
 	tests/injectors/OpIlInjector.cpp
 	tests/injectors/Qux2IlInjector.cpp
 	tests/injectors/StoreOpIlInjector.cpp
-	tests/injectors/TernaryOpIlInjector.cpp
+	tests/injectors/SelectOpIlInjector.cpp
 	tests/injectors/UnaryOpIlInjector.cpp
 )
 

--- a/fvtest/compilertest/README.md
+++ b/fvtest/compilertest/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2016, 2017 IBM Corp. and others
+Copyright (c) 2016, 2020 IBM Corp. and others
 
 This program and the accompanying materials are made available under
 the terms of the Eclipse Public License 2.0 which accompanies this
@@ -86,7 +86,7 @@ its corresponding test group.
 
 Each OpCode test need to be paired with an ILInjector. ILInjectors should
 be put in `<omr_root_folder>/fvtest/compilertest/ilgen/`. Examples can be
-found in *`BinaryOpIlInjector`*, *`TernaryOpIlInjector`* and *`UnaryOpIlInjector`*.
+found in *`BinaryOpIlInjector`*, *`SelectOpIlInjector`* and *`UnaryOpIlInjector`*.
 
 Coding style in Test compiler is mostly using Whitesmiths format and Camel case.  
 Some guidelines for naming convention:

--- a/fvtest/compilertest/build/files/common.mk
+++ b/fvtest/compilertest/build/files/common.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corp. and others
+# Copyright (c) 2016, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -216,7 +216,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     $(JIT_PRODUCT_DIR)/tests/injectors/CmpBranchOpIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/injectors/OpIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/injectors/StoreOpIlInjector.cpp \
-    $(JIT_PRODUCT_DIR)/tests/injectors/TernaryOpIlInjector.cpp \
+    $(JIT_PRODUCT_DIR)/tests/injectors/SelectOpIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/injectors/UnaryOpIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/injectors/BarIlInjector.cpp \
     $(JIT_PRODUCT_DIR)/tests/injectors/CallIlInjector.cpp \

--- a/fvtest/compilertest/tests/OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -38,7 +38,7 @@
 #include "tests/injectors/IndirectLoadIlInjector.hpp"
 #include "tests/injectors/IndirectStoreIlInjector.hpp"
 #include "tests/injectors/StoreOpIlInjector.hpp"
-#include "tests/injectors/TernaryOpIlInjector.hpp"
+#include "tests/injectors/SelectOpIlInjector.hpp"
 #include "tests/injectors/UnaryOpIlInjector.hpp"
 
 #include "tests/OpCodesTest.hpp"
@@ -144,13 +144,13 @@ TR::DataType OpCodesTest::_argTypesBinaryFloat[_numberOfBinaryArgs] = {TR::Float
 TR::DataType OpCodesTest::_argTypesBinaryDouble[_numberOfBinaryArgs] = {TR::Double, TR::Double};
 TR::DataType OpCodesTest::_argTypesBinaryAddress[_numberOfBinaryArgs] = {TR::Address, TR::Address};
 
-TR::DataType OpCodesTest::_argTypesTernaryByte[_numberOfTernaryArgs] = {TR::Int32,TR::Int8, TR::Int8};
-TR::DataType OpCodesTest::_argTypesTernaryShort[_numberOfTernaryArgs] = {TR::Int32,TR::Int16, TR::Int16};
-TR::DataType OpCodesTest::_argTypesTernaryInt[_numberOfTernaryArgs] = {TR::Int32,TR::Int32, TR::Int32};
-TR::DataType OpCodesTest::_argTypesTernaryLong[_numberOfTernaryArgs] = {TR::Int32,TR::Int64, TR::Int64};
-TR::DataType OpCodesTest::_argTypesTernaryFloat[_numberOfTernaryArgs] = {TR::Int32,TR::Float, TR::Float};
-TR::DataType OpCodesTest::_argTypesTernaryDouble[_numberOfTernaryArgs] = {TR::Int32,TR::Double, TR::Double};
-TR::DataType OpCodesTest::_argTypesTernaryAddress[_numberOfTernaryArgs] = {TR::Int32,TR::Address, TR::Address};
+TR::DataType OpCodesTest::_argTypesSelectByte[_numberOfSelectArgs] = {TR::Int32,TR::Int8, TR::Int8};
+TR::DataType OpCodesTest::_argTypesSelectShort[_numberOfSelectArgs] = {TR::Int32,TR::Int16, TR::Int16};
+TR::DataType OpCodesTest::_argTypesSelectInt[_numberOfSelectArgs] = {TR::Int32,TR::Int32, TR::Int32};
+TR::DataType OpCodesTest::_argTypesSelectLong[_numberOfSelectArgs] = {TR::Int32,TR::Int64, TR::Int64};
+TR::DataType OpCodesTest::_argTypesSelectFloat[_numberOfSelectArgs] = {TR::Int32,TR::Float, TR::Float};
+TR::DataType OpCodesTest::_argTypesSelectDouble[_numberOfSelectArgs] = {TR::Int32,TR::Double, TR::Double};
+TR::DataType OpCodesTest::_argTypesSelectAddress[_numberOfSelectArgs] = {TR::Int32,TR::Address, TR::Address};
 
 TR::DataType OpCodesTest::_argTypesBinaryAddressByte[_numberOfBinaryArgs] = {TR::Address, TR::Int8};
 TR::DataType OpCodesTest::_argTypesBinaryAddressShort[_numberOfBinaryArgs] = {TR::Address,TR::Int16};
@@ -463,13 +463,13 @@ unsignedCompareSignatureCharSS_I_testMethodType * OpCodesTest::_ifSuCmpge = 0;
 unsignedCompareSignatureCharSS_I_testMethodType * OpCodesTest::_ifSuCmpgt = 0;
 unsignedCompareSignatureCharSS_I_testMethodType * OpCodesTest::_ifSuCmple = 0;
 
-//Ternary operators
-signatureCharIBB_B_testMethodType * OpCodesTest::_bternary = 0;
-signatureCharISS_S_testMethodType * OpCodesTest::_sternary = 0;
-signatureCharIII_I_testMethodType * OpCodesTest::_iternary = 0;
-signatureCharIJJ_J_testMethodType * OpCodesTest::_lternary = 0;
-signatureCharIFF_F_testMethodType * OpCodesTest::_fternary = 0;
-signatureCharIDD_D_testMethodType * OpCodesTest::_dternary = 0;
+//Select operators
+signatureCharIBB_B_testMethodType * OpCodesTest::_bselect = 0;
+signatureCharISS_S_testMethodType * OpCodesTest::_sselect = 0;
+signatureCharIII_I_testMethodType * OpCodesTest::_iselect = 0;
+signatureCharIJJ_J_testMethodType * OpCodesTest::_lselect = 0;
+signatureCharIFF_F_testMethodType * OpCodesTest::_fselect = 0;
+signatureCharIDD_D_testMethodType * OpCodesTest::_dselect = 0;
 
 //Address opcodes
 signatureCharL_L_testMethodType * OpCodesTest::_acall = 0;
@@ -503,7 +503,7 @@ signatureCharLL_I_testMethodType * OpCodesTest::_ifacmplt = 0;
 signatureCharLL_I_testMethodType * OpCodesTest::_ifacmpge = 0;
 signatureCharLL_I_testMethodType * OpCodesTest::_ifacmple = 0;
 signatureCharLL_I_testMethodType * OpCodesTest::_ifacmpgt = 0;
-signatureCharILL_L_testMethodType * OpCodesTest::_aternary = 0;
+signatureCharILL_L_testMethodType * OpCodesTest::_aselect = 0;
 
 
 void
@@ -665,11 +665,11 @@ OpCodesTest::compileCompareTestMethods()
    }
 
 void
-OpCodesTest::compileTernaryTestMethods()
+OpCodesTest::compileSelectTestMethods()
    {
    int32_t rc = 0;
 
-   compileOpCodeMethod(_iternary, _numberOfTernaryArgs, TR::iternary, "iTernary", _argTypesTernaryInt, TR::Int32, rc);
+   compileOpCodeMethod(_iselect, _numberOfSelectArgs, TR::iselect, "iSelect", _argTypesSelectInt, TR::Int32, rc);
    }
 
 void
@@ -2234,14 +2234,14 @@ compileOpCodeMethod(      luCompareConst,
    }
 
 void
-OpCodesTest::invokeTernaryTests()
+OpCodesTest::invokeSelectTests()
    {
    int32_t rc = 0;
    char resolvedMethodName [RESOLVED_METHOD_NAME_LENGTH];
    uint32_t testCaseNum = 0;
    uint32_t testCaseNumCheck = 0;
 
-   int32_t iternaryChild1Arr[] =
+   int32_t iselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_MAXIMUM, INT_MINIMUM, INT_POS, INT_ZERO, INT_MINIMUM, INT_POS, INT_ZERO, INT_NEG,
       INT_NEG, INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_ZERO, INT_MINIMUM, INT_MAXIMUM, INT_POS
@@ -2269,42 +2269,42 @@ OpCodesTest::invokeTernaryTests()
       INT_MINIMUM, INT_POS
       };
 
-   testCaseNum = sizeof(iternaryChild1Arr) / sizeof(iternaryChild1Arr[0]);
+   testCaseNum = sizeof(iselectChild1Arr) / sizeof(iselectChild1Arr[0]);
    testCaseNumCheck = sizeof(intArr) / sizeof(intArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in iternary input array");
-   signatureCharIII_I_testMethodType * iTernaryConst = 0;
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in iselect input array");
+   signatureCharIII_I_testMethodType * iSelectConst = 0;
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      sprintf(resolvedMethodName, "iTernaryConst%d", i + 1);
-      OMR_CT_EXPECT_EQ(_iternary, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), _iternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]));
+      sprintf(resolvedMethodName, "iSelectConst%d", i + 1);
+      OMR_CT_EXPECT_EQ(_iselect, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), _iselect(iselectChild1Arr[i], intArr[i][0], intArr[i][1]));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 6, 1, &iternaryChild1Arr[i], 2, &intArr[i][0], 3, &intArr[i][1]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 6, 1, &iselectChild1Arr[i], 2, &intArr[i][0], 3, &intArr[i][1]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 2, &intArr[i][0]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, intArr[i][1]));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 4, 1, &iselectChild1Arr[i], 2, &intArr[i][0]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(INT_PLACEHOLDER_1, INT_PLACEHOLDER_2, intArr[i][1]));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 1, &iternaryChild1Arr[i], 3, &intArr[i][1]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], INT_PLACEHOLDER_3));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 4, 1, &iselectChild1Arr[i], 3, &intArr[i][1]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(INT_PLACEHOLDER_1, intArr[i][0], INT_PLACEHOLDER_3));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 4, 2, &intArr[i][0], 3, &intArr[i][1]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 4, 2, &intArr[i][0], 3, &intArr[i][1]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(iselectChild1Arr[i], INT_PLACEHOLDER_2, INT_PLACEHOLDER_3));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 1, &iternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(INT_PLACEHOLDER_1, intArr[i][0], intArr[i][1]));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 2, 1, &iselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(INT_PLACEHOLDER_1, intArr[i][0], intArr[i][1]));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 2, &intArr[i][0]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], INT_PLACEHOLDER_1, intArr[i][1]));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 2, 2, &intArr[i][0]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(iselectChild1Arr[i], INT_PLACEHOLDER_1, intArr[i][1]));
 
-compileOpCodeMethod(      iTernaryConst, _numberOfTernaryArgs, TR::iternary,
-            resolvedMethodName, _argTypesTernaryInt, TR::Int32, rc, 2, 3, &intArr[i][1]);
-      OMR_CT_EXPECT_EQ(iTernaryConst, ternary(iternaryChild1Arr[i], intArr[i][0], intArr[i][1]), iTernaryConst(iternaryChild1Arr[i], intArr[i][0], INT_PLACEHOLDER_1));
+compileOpCodeMethod(      iSelectConst, _numberOfSelectArgs, TR::iselect,
+            resolvedMethodName, _argTypesSelectInt, TR::Int32, rc, 2, 3, &intArr[i][1]);
+      OMR_CT_EXPECT_EQ(iSelectConst, select(iselectChild1Arr[i], intArr[i][0], intArr[i][1]), iSelectConst(iselectChild1Arr[i], intArr[i][0], INT_PLACEHOLDER_1));
       }
    }
 
@@ -2411,11 +2411,11 @@ TEST(JITCrossPlatformsOpCodesTest, CompareTest)
    compareTest.invokeCompareTests();
    }
 
-TEST(JITCrossPlatformsOpCodesTest, TernaryTest)
+TEST(JITCrossPlatformsOpCodesTest, SelectTest)
    {
-   ::TestCompiler::OpCodesTest ternaryTest;
-   ternaryTest.compileTernaryTestMethods();
-   ternaryTest.invokeTernaryTests();
+   ::TestCompiler::OpCodesTest selectTest;
+   selectTest.compileSelectTestMethods();
+   selectTest.invokeSelectTests();
    }
 
 TEST(JITCrossPlatformsOpCodesTest, AddressTest)

--- a/fvtest/compilertest/tests/OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/OpCodesTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,7 +41,7 @@
 #include "tests/injectors/IndirectLoadIlInjector.hpp"
 #include "tests/injectors/IndirectStoreIlInjector.hpp"
 #include "tests/injectors/StoreOpIlInjector.hpp"
-#include "tests/injectors/TernaryOpIlInjector.hpp"
+#include "tests/injectors/SelectOpIlInjector.hpp"
 #include "tests/injectors/UnaryOpIlInjector.hpp"
 
 #if defined(J9ZOS390) || defined(AIXPPC)
@@ -175,7 +175,7 @@ class OpCodesTest : public TestDriver
    virtual void compileUnaryTestMethods();
    virtual void compileBitwiseMethods();
    virtual void compileCompareTestMethods();
-   virtual void compileTernaryTestMethods();
+   virtual void compileSelectTestMethods();
    virtual void compileAddressTestMethods();
    virtual void compileDisabledOpCodesTests();
 
@@ -184,7 +184,7 @@ class OpCodesTest : public TestDriver
    virtual void invokeUnaryTests();
    virtual void invokeBitwiseTests();
    virtual void invokeCompareTests();
-   virtual void invokeTernaryTests();
+   virtual void invokeSelectTests();
    virtual void invokeAddressTests();
    virtual void invokeDisabledOpCodesTests();
 
@@ -221,7 +221,7 @@ class OpCodesTest : public TestDriver
    CmpBranchOpIlInjector        cmpBranchIlInjector(&types, this, opCode);
    BinaryOpIlInjector           opCodeBinaryIlInjector(&types, this, opCode);
    UnaryOpIlInjector            opCodeUnaryInjector(&types, this, opCode);
-   TernaryOpIlInjector          ternaryOpIlInjector(&types, this, opCode);
+   SelectOpIlInjector          selectOpIlInjector(&types, this, opCode);
    ChildlessUnaryOpIlInjector   childlessUnaryOpIlInjector(&types, this, opCode);
    StoreOpIlInjector            storeOpIlInjector(&types, this, opCode);
    IndirectLoadIlInjector       indirectLoadIlInjector(&types, this, opCode);
@@ -231,9 +231,9 @@ class OpCodesTest : public TestDriver
       {
       opCodeInjector = &cmpBranchIlInjector;
       }
-   else if (op.isTernary())
+   else if (op.isSelect())
       {
-      opCodeInjector = &ternaryOpIlInjector;
+      opCodeInjector = &selectOpIlInjector;
       }
    else if (op.isStoreIndirect())
       {
@@ -421,7 +421,7 @@ class OpCodesTest : public TestDriver
    static const int32_t RESOLVED_METHOD_NAME_LENGTH = 50;
    static const int32_t _numberOfUnaryArgs = 1;
    static const int32_t _numberOfBinaryArgs = 2;
-   static const int32_t _numberOfTernaryArgs = 3;
+   static const int32_t _numberOfSelectArgs = 3;
 
    //commonly used variables
    static const int64_t LONG_NEG;
@@ -793,13 +793,13 @@ class OpCodesTest : public TestDriver
    static unsignedCompareSignatureCharSS_I_testMethodType *_ifSuCmpgt;
    static unsignedCompareSignatureCharSS_I_testMethodType *_ifSuCmple;
 
-   //Ternary operators
-   static signatureCharIBB_B_testMethodType *_bternary;
-   static signatureCharISS_S_testMethodType *_sternary;
-   static signatureCharIII_I_testMethodType *_iternary;
-   static signatureCharIJJ_J_testMethodType *_lternary;
-   static signatureCharIFF_F_testMethodType *_fternary;
-   static signatureCharIDD_D_testMethodType *_dternary;
+   //Select operators
+   static signatureCharIBB_B_testMethodType *_bselect;
+   static signatureCharISS_S_testMethodType *_sselect;
+   static signatureCharIII_I_testMethodType *_iselect;
+   static signatureCharIJJ_J_testMethodType *_lselect;
+   static signatureCharIFF_F_testMethodType *_fselect;
+   static signatureCharIDD_D_testMethodType *_dselect;
 
    static signatureCharI_I_testMethodType *_int32CompiledMethod;
    static signatureCharJ_J_testMethodType *_int64CompiledMethod;
@@ -862,7 +862,7 @@ class OpCodesTest : public TestDriver
    static signatureCharLL_I_testMethodType *_ifacmpge;
    static signatureCharLL_I_testMethodType *_ifacmple;
    static signatureCharLL_I_testMethodType *_ifacmpgt;
-   static signatureCharILL_L_testMethodType *_aternary;
+   static signatureCharILL_L_testMethodType *_aselect;
 
    static TR::DataType _argTypesUnaryByte[_numberOfUnaryArgs];
    static TR::DataType _argTypesUnaryShort[_numberOfUnaryArgs];
@@ -880,13 +880,13 @@ class OpCodesTest : public TestDriver
    static TR::DataType _argTypesBinaryDouble[_numberOfBinaryArgs];
    static TR::DataType _argTypesBinaryAddress[_numberOfBinaryArgs];
 
-   static TR::DataType _argTypesTernaryByte[_numberOfTernaryArgs];
-   static TR::DataType _argTypesTernaryShort[_numberOfTernaryArgs];
-   static TR::DataType _argTypesTernaryInt[_numberOfTernaryArgs];
-   static TR::DataType _argTypesTernaryLong[_numberOfTernaryArgs];
-   static TR::DataType _argTypesTernaryFloat[_numberOfTernaryArgs];
-   static TR::DataType _argTypesTernaryDouble[_numberOfTernaryArgs];
-   static TR::DataType _argTypesTernaryAddress[_numberOfTernaryArgs];
+   static TR::DataType _argTypesSelectByte[_numberOfSelectArgs];
+   static TR::DataType _argTypesSelectShort[_numberOfSelectArgs];
+   static TR::DataType _argTypesSelectInt[_numberOfSelectArgs];
+   static TR::DataType _argTypesSelectLong[_numberOfSelectArgs];
+   static TR::DataType _argTypesSelectFloat[_numberOfSelectArgs];
+   static TR::DataType _argTypesSelectDouble[_numberOfSelectArgs];
+   static TR::DataType _argTypesSelectAddress[_numberOfSelectArgs];
 
    static TR::DataType _argTypesBinaryAddressByte[_numberOfBinaryArgs];
    static TR::DataType _argTypesBinaryAddressShort[_numberOfBinaryArgs];
@@ -956,7 +956,7 @@ class OpCodesTest : public TestDriver
    template <typename T> static int32_t compareLE(T a, T b) { return a <= b;}
    template <typename T> static int32_t comparel(T a, T b) { return std::isnan(static_cast<long double>(a)) ? -1 : std::isnan(static_cast<long double>(b)) ? -1 : a > b ? 1 : a == b ? 0 : -1 ; }
    template <typename T> static int32_t compareg(T a, T b) { return std::isnan(static_cast<long double>(a)) ? 1 :  std::isnan(static_cast<long double>(b)) ? 1 : a > b ? 1 : a == b ? 0 : -1 ; }
-   template <typename C, typename T> static T ternary(C a, T b, T c) {return a ? b : c;}
+   template <typename C, typename T> static T select(C a, T b, T c) {return a ? b : c;}
    };
 
 } // namespace TestCompiler

--- a/fvtest/compilertest/tests/PPCOpCodesTest.cpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -77,11 +77,11 @@ PPCOpCodesTest::compileMemoryOperationTestMethods()
    }
 
 void
-PPCOpCodesTest::compileTernaryTestMethods()
+PPCOpCodesTest::compileSelectTestMethods()
    {
    int32_t rc = 0;
-   compileOpCodeMethod(_bternary, _numberOfTernaryArgs, TR::bternary, "bTernary", _argTypesTernaryByte, TR::Int8, rc);
-   compileOpCodeMethod(_sternary, _numberOfTernaryArgs, TR::sternary, "sTernary", _argTypesTernaryShort, TR::Int16, rc);
+   compileOpCodeMethod(_bselect, _numberOfSelectArgs, TR::bselect, "bselect", _argTypesSelectByte, TR::Int8, rc);
+   compileOpCodeMethod(_sselect, _numberOfSelectArgs, TR::sselect, "sselect", _argTypesSelectShort, TR::Int16, rc);
    }
 
 void
@@ -156,7 +156,7 @@ PPCOpCodesTest::compileAddressTestMethods()
    compileOpCodeMethod(_ifacmpge, _numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc);
    compileOpCodeMethod(_ifacmple, _numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc);
    compileOpCodeMethod(_ifacmpgt, _numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc);
-   compileOpCodeMethod(_aternary, _numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc);
+   compileOpCodeMethod(_aselect, _numberOfSelectArgs, TR::aselect, "aselect", _argTypesSelectAddress, TR::Address, rc);
 
    }
 
@@ -1452,7 +1452,7 @@ PPCOpCodesTest::invokeAddressTests()
       (uintptrj_t) &INT_POS,   (uintptrj_t) &INT_POS
       };
 
-   int32_t aternaryChild1Arr[] =
+   int32_t aselectChild1Arr[] =
       {
       INT_MAXIMUM,
       INT_MAXIMUM,
@@ -1470,7 +1470,7 @@ PPCOpCodesTest::invokeAddressTests()
       INT_ZERO,
       INT_ZERO
       };
-   uintptrj_t aternaryArr[][2] =
+   uintptrj_t aselectArr[][2] =
       {
       (uintptrj_t) &INT_MAXIMUM, (uintptrj_t) &INT_ZERO,
       (uintptrj_t) &INT_POS,     (uintptrj_t) &INT_MAXIMUM,
@@ -1501,7 +1501,7 @@ PPCOpCodesTest::invokeAddressTests()
    unsignedSignatureCharJ_L_testMethodType *lu2aConst = 0;
 
    signatureCharLL_I_testMethodType *aCompareConst = 0;
-   signatureCharILL_L_testMethodType *aTernaryConst = 0;
+   signatureCharILL_L_testMethodType *aSelectConst = 0;
 
 
 
@@ -1847,61 +1847,61 @@ PPCOpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(aCompareConst, compareLE(ifacmpleDataArr[i][0], ifacmpleDataArr[i][1]), aCompareConst(ifacmpleDataArr[i][0], ADDRESS_PLACEHOLDER_2));
       }
 
-   TR_ASSERT((sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0])) == sizeof(aternaryArr) / sizeof(aternaryArr[0]),
+   TR_ASSERT((sizeof(aselectChild1Arr) / sizeof(aselectChild1Arr[0])) == sizeof(aselectArr) / sizeof(aselectArr[0]),
          "Child1 array size is not equal to Child2 and Child3 array");
-   testCaseNum = sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0]);
+   testCaseNum = sizeof(aselectChild1Arr) / sizeof(aselectChild1Arr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(_aselect, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), _aselect(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst1_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 6, 1, &aselectChild1Arr[i], 2, &aselectArr[i][0], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst2_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 1, &aselectChild1Arr[i], 2, &aselectArr[i][0]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst3_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 1, &aselectChild1Arr[i], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, aselectArr[i][0], ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst4_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 2, &aselectArr[i][0], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst5_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 1, &aselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, aselectArr[i][0], aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst6_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 2, &aselectArr[i][0]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], ADDRESS_PLACEHOLDER_1, aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "aSelectConst7_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], aselectArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
 
    }
 
 void
-PPCOpCodesTest::invokeTernaryTests()
+PPCOpCodesTest::invokeSelectTests()
    {
    int32_t rc = 0;
-   int32_t bternaryChild1Arr[] =
+   int32_t bselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_POS, INT_MAXIMUM, INT_MINIMUM, INT_ZERO, INT_ZERO, INT_MINIMUM, INT_POS, INT_NEG,
       INT_NEG, INT_NEG, INT_ZERO, INT_POS, INT_MAXIMUM, INT_NEG, INT_ZERO, INT_MINIMUM, INT_POS
       };
-   int32_t sternaryChild1Arr[] =
+   int32_t sselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_MINIMUM, INT_POS, INT_ZERO, INT_NEG, INT_MINIMUM, INT_POS, INT_MAXIMUM, INT_ZERO,
       INT_NEG, INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_ZERO, INT_MINIMUM, INT_MAXIMUM, INT_POS
@@ -1955,93 +1955,93 @@ PPCOpCodesTest::invokeTernaryTests()
    uint32_t testCaseNumCheck = 0;
    uint32_t testCaseNum = 0;
 
-   signatureCharIBB_B_testMethodType * bTernaryConst = 0;
-   signatureCharISS_S_testMethodType * sTernaryConst = 0;
+   signatureCharIBB_B_testMethodType * bSelectConst = 0;
+   signatureCharISS_S_testMethodType * sSelectConst = 0;
 
-   testCaseNum = sizeof(bternaryChild1Arr) / sizeof(bternaryChild1Arr[0]);
+   testCaseNum = sizeof(bselectChild1Arr) / sizeof(bselectChild1Arr[0]);
    testCaseNumCheck = sizeof(byteDataArr) / sizeof(byteDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in bternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in bselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_bternary, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bselect, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bselect(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "bSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 6, 1, &bselectChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "bTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
+      sprintf(resolvedMethodName, "bSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 4, 1, &bselectChild1Arr[i], 2, &byteDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "bSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 4, 1, &bselectChild1Arr[i], 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "bTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "bSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(bselectChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "bTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
+      sprintf(resolvedMethodName, "bSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 2, 1, &bselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
+      sprintf(resolvedMethodName, "bSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(bselectChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "bSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(bselectChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
       }
 
-   testCaseNum = sizeof(sternaryChild1Arr) / sizeof(sternaryChild1Arr[0]);
+   testCaseNum = sizeof(sselectChild1Arr) / sizeof(sselectChild1Arr[0]);
    testCaseNumCheck = sizeof(shortDataArr) / sizeof(shortDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in sternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in sselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_sternary, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sselect, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sselect(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "sSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 6, 1, &sselectChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "sTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
+      sprintf(resolvedMethodName, "sSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 4, 1, &sselectChild1Arr[i], 2, &shortDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "sSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 4, 1, &sselectChild1Arr[i], 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "sTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "sSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(sselectChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "sTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
+      sprintf(resolvedMethodName, "sSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 2, 1, &sselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
+      sprintf(resolvedMethodName, "sSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(sselectChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "sSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(sselectChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
       }
    }
 
@@ -4431,32 +4431,32 @@ PPCOpCodesTest::invokeDisabledBitwiseTests()
    }
 
 void
-PPCOpCodesTest::compileDisabledTernaryTestMethods()
+PPCOpCodesTest::compileDisabledSelectTestMethods()
    {
    int32_t rc = 0;
    //Jazz103 Work Item 109979
-   compileOpCodeMethod(_fternary, _numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float, rc);
-   compileOpCodeMethod(_dternary, _numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double, rc);
-   compileOpCodeMethod(_lternary, _numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_fselect, _numberOfSelectArgs, TR::fselect, "fSelect", _argTypesSelectFloat, TR::Float, rc);
+   compileOpCodeMethod(_dselect, _numberOfSelectArgs, TR::dselect, "dSelect", _argTypesSelectDouble, TR::Double, rc);
+   compileOpCodeMethod(_lselect, _numberOfSelectArgs, TR::lselect, "lSelect", _argTypesSelectLong, TR::Int64, rc);
 
    }
 
 void
-PPCOpCodesTest::invokeDisabledTernaryTest()
+PPCOpCodesTest::invokeDisabledSelectTest()
    {
 
    int32_t rc = 0;
-   int32_t fternaryChild1Arr[] =
+   int32_t fselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_POS, INT_MAXIMUM, INT_MINIMUM, INT_ZERO, INT_MINIMUM, INT_POS, INT_ZERO, INT_NEG,
       INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_POS, INT_NEG, INT_ZERO, INT_MINIMUM, INT_MAXIMUM
       };
-   int32_t dternaryChild1Arr[] =
+   int32_t dselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_ZERO, INT_MAXIMUM, INT_MINIMUM, INT_MINIMUM, INT_POS, INT_ZERO, INT_POS, INT_NEG,
       INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_ZERO, INT_MAXIMUM, INT_MINIMUM, INT_NEG, INT_POS
       };
-   int32_t lternaryChild1Arr[] =
+   int32_t lselectChild1Arr[] =
       {
       INT_ZERO,INT_MINIMUM,INT_NEG,INT_MAXIMUM,INT_POS,INT_MINIMUM,
       INT_MAXIMUM,INT_POS,INT_ZERO,INT_MAXIMUM,INT_MAXIMUM
@@ -4525,132 +4525,132 @@ PPCOpCodesTest::invokeDisabledTernaryTest()
    uint32_t testCaseNumCheck = 0;
    uint32_t testCaseNum = 0;
 
-   signatureCharIJJ_J_testMethodType * lTernaryConst = 0;
-   signatureCharIFF_F_testMethodType * fTernaryConst = 0;
-   signatureCharIDD_D_testMethodType * dTernaryConst = 0;
+   signatureCharIJJ_J_testMethodType * lSelectConst = 0;
+   signatureCharIFF_F_testMethodType * fSelectConst = 0;
+   signatureCharIDD_D_testMethodType * dSelectConst = 0;
 
 
-   testCaseNum = sizeof(fternaryChild1Arr) / sizeof(fternaryChild1Arr[0]);
+   testCaseNum = sizeof(fselectChild1Arr) / sizeof(fselectChild1Arr[0]);
    testCaseNumCheck = sizeof(floatDataArr) / sizeof(floatDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in fternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in fselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_fternary, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fselect, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fselect(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "fSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 6, 1, &fselectChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "fTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
+      sprintf(resolvedMethodName, "fSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 4, 1, &fselectChild1Arr[i], 2, &floatDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "fSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 4, 1, &fselectChild1Arr[i], 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "fTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "fSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(fselectChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "fTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
+      sprintf(resolvedMethodName, "fSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 2, 1, &fselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
+      sprintf(resolvedMethodName, "fSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(fselectChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "fSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(fselectChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
       }
 
-   testCaseNum = sizeof(dternaryChild1Arr) / sizeof(dternaryChild1Arr[0]);
+   testCaseNum = sizeof(dselectChild1Arr) / sizeof(dselectChild1Arr[0]);
    testCaseNumCheck = sizeof(doubleDataArr) / sizeof(doubleDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in dternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in dselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_dternary, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dselect, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dselect(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "dSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 6, 1, &dselectChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "dTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
+      sprintf(resolvedMethodName, "dSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 4, 1, &dselectChild1Arr[i], 2, &doubleDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "dSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 4, 1, &dselectChild1Arr[i], 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "dTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "dSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(dselectChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "dTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
+      sprintf(resolvedMethodName, "dSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 2, 1, &dselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
+      sprintf(resolvedMethodName, "dSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(dselectChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "dSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(dselectChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
       }
 
-   testCaseNum = sizeof(lternaryChild1Arr) / sizeof(lternaryChild1Arr[0]);
+   testCaseNum = sizeof(lselectChild1Arr) / sizeof(lselectChild1Arr[0]);
    testCaseNumCheck = sizeof(longArr) / sizeof(longArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in lternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in lselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
-      OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
+      sprintf(resolvedMethodName, "lSelectConst%d", i + 1);
+      OMR_CT_EXPECT_EQ(_lselect, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), _lselect(lselectChild1Arr[i], longArr[i][0], longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 6, 1, &lselectChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 1, &lselectChild1Arr[i], 2, &longArr[i][0]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 1, &lselectChild1Arr[i], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 1, &lselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
 
@@ -4710,11 +4710,11 @@ TEST(JITPPCOpCodesTest, MemoryOperationTest)
    PPCMemoryOperationTest.invokeMemoryOperationTests();
    }
 
-TEST(JITPPCOpCodesTest, TernaryTest)
+TEST(JITPPCOpCodesTest, SelectTest)
    {
-   ::TestCompiler::PPCOpCodesTest PPCTernaryTest;
-   PPCTernaryTest.compileTernaryTestMethods();
-   PPCTernaryTest.invokeTernaryTests();
+   ::TestCompiler::PPCOpCodesTest PPCSelectTest;
+   PPCSelectTest.compileSelectTestMethods();
+   PPCSelectTest.invokeSelectTests();
    }
 
 TEST(JITPPCOpCodesTest, CompareTest)
@@ -4805,12 +4805,12 @@ TEST(JITPPCOpCodesTest, DISABLED_PPCLEBitwiseTest)
    disabledPPCLEBitwiseTest.invokeDisabledBitwiseTests();
    }
 
-TEST(JITPPCOpCodesTest, DISABLED_PPCLETernaryTest)
+TEST(JITPPCOpCodesTest, DISABLED_PPCLESelectTest)
    {
    //Jazz103 Work Item 109979
-   ::TestCompiler::PPCOpCodesTest disabledPPCLETernaryTest;
-   disabledPPCLETernaryTest.compileDisabledTernaryTestMethods();
-   disabledPPCLETernaryTest.invokeDisabledTernaryTest();
+   ::TestCompiler::PPCOpCodesTest disabledPPCLESelectTest;
+   disabledPPCLESelectTest.compileDisabledSelectTestMethods();
+   disabledPPCLESelectTest.invokeDisabledSelectTest();
    }
 
 TEST(JITPPCOpCodesTest, DISABLED_PPCLEDirectCallTest)

--- a/fvtest/compilertest/tests/PPCOpCodesTest.hpp
+++ b/fvtest/compilertest/tests/PPCOpCodesTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -28,14 +28,14 @@ class PPCOpCodesTest : public OpCodesTest
    public:
    virtual void compileUnaryTestMethods();
    virtual void compileMemoryOperationTestMethods();
-   virtual void compileTernaryTestMethods();
+   virtual void compileSelectTestMethods();
    virtual void compileCompareTestMethods();
    virtual void compileBitwiseTestMethods();
    virtual void compileAddressTestMethods();
 
    virtual void invokeUnaryTests();
    virtual void invokeMemoryOperationTests();
-   virtual void invokeTernaryTests();
+   virtual void invokeSelectTests();
    virtual void invokeCompareTests();
    virtual void invokeBitwiseTests();
    virtual void invokeAddressTests();
@@ -48,7 +48,7 @@ class PPCOpCodesTest : public OpCodesTest
    virtual void compileDisabledMemoryOperationTestMethods();
    virtual void compileDisabledUnaryTestMethods();
    virtual void compileDisabledBitwiseTestMethods();
-   virtual void compileDisabledTernaryTestMethods();
+   virtual void compileDisabledSelectTestMethods();
    virtual void compileDisabledDirectCallTestMethods();
 
    virtual void invokeDisabledConvertTests();
@@ -58,7 +58,7 @@ class PPCOpCodesTest : public OpCodesTest
    virtual void invokeDisabledMemoryOperationTests();
    virtual void invokeDisabledUnaryTests();
    virtual void invokeDisabledBitwiseTests();
-   virtual void invokeDisabledTernaryTest();
+   virtual void invokeDisabledSelectTest();
    virtual void invokeDisabledDirectCallTest();
    };
 

--- a/fvtest/compilertest/tests/S390OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -119,10 +119,10 @@ S390OpCodesTest::compileBitwiseTestMethods()
    }
 
 void
-S390OpCodesTest::compileTernaryTestMethods()
+S390OpCodesTest::compileSelectTestMethods()
    {
    int32_t rc = 0;
-   compileOpCodeMethod(_lternary, _numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lselect, _numberOfSelectArgs, TR::lselect, "lSelect", _argTypesSelectLong, TR::Int64, rc);
 
    }
 
@@ -216,7 +216,7 @@ S390OpCodesTest::compileAddressTestMethods()
    compileOpCodeMethod(_ifacmpge, _numberOfBinaryArgs, TR::ifacmpge, "ifacmpge", _argTypesBinaryAddress, TR::Int32, rc);
    compileOpCodeMethod(_ifacmple, _numberOfBinaryArgs, TR::ifacmple, "ifacmple", _argTypesBinaryAddress, TR::Int32, rc);
    compileOpCodeMethod(_ifacmpgt, _numberOfBinaryArgs, TR::ifacmpgt, "ifacmpgt", _argTypesBinaryAddress, TR::Int32, rc);
-   compileOpCodeMethod(_aternary, _numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc);
+   compileOpCodeMethod(_aselect, _numberOfSelectArgs, TR::aselect, "aselect", _argTypesSelectAddress, TR::Address, rc);
    }
 
 void
@@ -930,14 +930,14 @@ S390OpCodesTest::invokeBitwiseTests()
    }
 
 void
-S390OpCodesTest::invokeTernaryTests()
+S390OpCodesTest::invokeSelectTests()
    {
    int32_t rc = 0;
    char resolvedMethodName [RESOLVED_METHOD_NAME_LENGTH];
    uint32_t testCaseNum = 0;
    uint32_t testCaseNumCheck = 0;
 
-   int32_t lternaryChild1Arr[] =
+   int32_t lselectChild1Arr[] =
       {
       INT_ZERO,INT_MINIMUM,INT_NEG,INT_MAXIMUM,INT_POS,INT_MINIMUM,
       INT_MAXIMUM,INT_POS,INT_ZERO,INT_MAXIMUM,INT_MAXIMUM
@@ -958,42 +958,42 @@ S390OpCodesTest::invokeTernaryTests()
       LONG_MAXIMUM, LONG_NEG
       };
 
-   testCaseNum = sizeof(lternaryChild1Arr) / sizeof(lternaryChild1Arr[0]);
+   testCaseNum = sizeof(lselectChild1Arr) / sizeof(lselectChild1Arr[0]);
    testCaseNumCheck = sizeof(longArr) / sizeof(longArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in lternary input array");
-   signatureCharIJJ_J_testMethodType * lTernaryConst = 0;
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in lselect input array");
+   signatureCharIJJ_J_testMethodType * lSelectConst = 0;
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
-      OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
+      sprintf(resolvedMethodName, "lSelectConst%d", i + 1);
+      OMR_CT_EXPECT_EQ(_lselect, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), _lselect(lselectChild1Arr[i], longArr[i][0], longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 6, 1, &lselectChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 1, &lselectChild1Arr[i], 2, &longArr[i][0]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 1, &lselectChild1Arr[i], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 1, &lselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
 
@@ -3820,39 +3820,39 @@ S390OpCodesTest::invokeDisabledIntegerArithmeticTests()
    }
 
 void
-S390OpCodesTest::compileDisabledTernaryTestMethods()
+S390OpCodesTest::compileDisabledSelectTestMethods()
    {
    //Jazz103 WI 104092
    //Jazz103 WI 109994
    int32_t rc = 0;
-   compileOpCodeMethod(_bternary, _numberOfTernaryArgs, TR::bternary, "bTernary", _argTypesTernaryByte, TR::Int8, rc);
-   compileOpCodeMethod(_sternary, _numberOfTernaryArgs, TR::sternary, "sTernary", _argTypesTernaryShort, TR::Int16, rc);
-   compileOpCodeMethod(_fternary, _numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float, rc);
-   compileOpCodeMethod(_dternary, _numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double, rc);
+   compileOpCodeMethod(_bselect, _numberOfSelectArgs, TR::bselect, "bSelect", _argTypesSelectByte, TR::Int8, rc);
+   compileOpCodeMethod(_sselect, _numberOfSelectArgs, TR::sselect, "sSelect", _argTypesSelectShort, TR::Int16, rc);
+   compileOpCodeMethod(_fselect, _numberOfSelectArgs, TR::fselect, "fSelect", _argTypesSelectFloat, TR::Float, rc);
+   compileOpCodeMethod(_dselect, _numberOfSelectArgs, TR::dselect, "dSelect", _argTypesSelectDouble, TR::Double, rc);
    }
 
 void
-S390OpCodesTest::invokeDisabledTernaryTests()
+S390OpCodesTest::invokeDisabledSelectTests()
    {
 
    int32_t rc = 0;
 
-   int32_t bternaryChild1Arr[] =
+   int32_t bselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_POS, INT_MAXIMUM, INT_MINIMUM, INT_ZERO, INT_ZERO, INT_MINIMUM, INT_POS, INT_NEG,
       INT_NEG, INT_NEG, INT_ZERO, INT_POS, INT_MAXIMUM, INT_NEG, INT_ZERO, INT_MINIMUM, INT_POS
       };
-   int32_t sternaryChild1Arr[] =
+   int32_t sselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_MINIMUM, INT_POS, INT_ZERO, INT_NEG, INT_MINIMUM, INT_POS, INT_MAXIMUM, INT_ZERO,
       INT_NEG, INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_ZERO, INT_MINIMUM, INT_MAXIMUM, INT_POS
       };
-   int32_t fternaryChild1Arr[] =
+   int32_t fselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_POS, INT_MAXIMUM, INT_MINIMUM, INT_ZERO, INT_MINIMUM, INT_POS, INT_ZERO, INT_NEG,
       INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_POS, INT_NEG, INT_ZERO, INT_MINIMUM, INT_MAXIMUM
       };
-   int32_t dternaryChild1Arr[] =
+   int32_t dselectChild1Arr[] =
       {
       INT_MAXIMUM, INT_ZERO, INT_MAXIMUM, INT_MINIMUM, INT_MINIMUM, INT_POS, INT_ZERO, INT_POS, INT_NEG,
       INT_NEG, INT_ZERO, INT_POS, INT_NEG, INT_ZERO, INT_MAXIMUM, INT_MINIMUM, INT_NEG, INT_POS
@@ -3951,181 +3951,181 @@ S390OpCodesTest::invokeDisabledTernaryTests()
    uint32_t testCaseNumCheck = 0;
    uint32_t testCaseNum = 0;
 
-   signatureCharIBB_B_testMethodType * bTernaryConst = 0;
-   signatureCharISS_S_testMethodType * sTernaryConst = 0;
-   signatureCharIFF_F_testMethodType * fTernaryConst = 0;
-   signatureCharIDD_D_testMethodType * dTernaryConst = 0;
+   signatureCharIBB_B_testMethodType * bSelectConst = 0;
+   signatureCharISS_S_testMethodType * sSelectConst = 0;
+   signatureCharIFF_F_testMethodType * fSelectConst = 0;
+   signatureCharIDD_D_testMethodType * dSelectConst = 0;
 
-   testCaseNum = sizeof(bternaryChild1Arr) / sizeof(bternaryChild1Arr[0]);
+   testCaseNum = sizeof(bselectChild1Arr) / sizeof(bselectChild1Arr[0]);
    testCaseNumCheck = sizeof(byteDataArr) / sizeof(byteDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in bternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in bselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_bternary, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_bselect, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), _bselect(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 6, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "bSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 6, 1, &bselectChild1Arr[i], 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "bTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 2, &byteDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
+      sprintf(resolvedMethodName, "bSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 4, 1, &bselectChild1Arr[i], 2, &byteDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, BYTE_PLACEHOLDER_2, byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 1, &bternaryChild1Arr[i], 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "bSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 4, 1, &bselectChild1Arr[i], 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], BYTE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "bTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "bSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 4, 2, &byteDataArr[i][0], 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(bselectChild1Arr[i], BYTE_PLACEHOLDER_2, BYTE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "bTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 1, &bternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
+      sprintf(resolvedMethodName, "bSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 2, 1, &bselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(BYTE_PLACEHOLDER_1, byteDataArr[i][0], byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
+      sprintf(resolvedMethodName, "bSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 2, 2, &byteDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(bselectChild1Arr[i], BYTE_PLACEHOLDER_1, byteDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "bTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(bTernaryConst, _numberOfTernaryArgs, TR::bternary,
-            resolvedMethodName, _argTypesTernaryByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(bTernaryConst, ternary(bternaryChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bTernaryConst(bternaryChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "bSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(bSelectConst, _numberOfSelectArgs, TR::bselect,
+            resolvedMethodName, _argTypesSelectByte, TR::Int8, rc, 2, 3, &byteDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(bSelectConst, select(bselectChild1Arr[i], byteDataArr[i][0], byteDataArr[i][1]), bSelectConst(bselectChild1Arr[i], byteDataArr[i][0], BYTE_PLACEHOLDER_1));
       }
 
-   testCaseNum = sizeof(sternaryChild1Arr) / sizeof(sternaryChild1Arr[0]);
+   testCaseNum = sizeof(sselectChild1Arr) / sizeof(sselectChild1Arr[0]);
    testCaseNumCheck = sizeof(shortDataArr) / sizeof(shortDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in sternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in sselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_sternary, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_sselect, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), _sselect(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 6, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "sSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 6, 1, &sselectChild1Arr[i], 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "sTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 2, &shortDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
+      sprintf(resolvedMethodName, "sSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 4, 1, &sselectChild1Arr[i], 2, &shortDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, SHORT_PLACEHOLDER_2, shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 1, &sternaryChild1Arr[i], 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "sSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 4, 1, &sselectChild1Arr[i], 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], SHORT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "sTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "sSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 4, 2, &shortDataArr[i][0], 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(sselectChild1Arr[i], SHORT_PLACEHOLDER_2, SHORT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "sTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 1, &sternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
+      sprintf(resolvedMethodName, "sSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 2, 1, &sselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(SHORT_PLACEHOLDER_1, shortDataArr[i][0], shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
+      sprintf(resolvedMethodName, "sSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 2, 2, &shortDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(sselectChild1Arr[i], SHORT_PLACEHOLDER_1, shortDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "sTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(sTernaryConst, _numberOfTernaryArgs, TR::sternary,
-            resolvedMethodName, _argTypesTernaryShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(sTernaryConst, ternary(sternaryChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sTernaryConst(sternaryChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "sSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(sSelectConst, _numberOfSelectArgs, TR::sselect,
+            resolvedMethodName, _argTypesSelectShort, TR::Int16, rc, 2, 3, &shortDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(sSelectConst, select(sselectChild1Arr[i], shortDataArr[i][0], shortDataArr[i][1]), sSelectConst(sselectChild1Arr[i], shortDataArr[i][0], SHORT_PLACEHOLDER_1));
       }
 
-   testCaseNum = sizeof(fternaryChild1Arr) / sizeof(fternaryChild1Arr[0]);
+   testCaseNum = sizeof(fselectChild1Arr) / sizeof(fselectChild1Arr[0]);
    testCaseNumCheck = sizeof(floatDataArr) / sizeof(floatDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in fternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in fselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_fternary, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_fselect, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), _fselect(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 6, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "fSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 6, 1, &fselectChild1Arr[i], 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "fTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 2, &floatDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
+      sprintf(resolvedMethodName, "fSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 4, 1, &fselectChild1Arr[i], 2, &floatDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, FLOAT_PLACEHOLDER_2, floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 1, &fternaryChild1Arr[i], 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "fSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 4, 1, &fselectChild1Arr[i], 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], FLOAT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "fTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "fSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 4, 2, &floatDataArr[i][0], 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(fselectChild1Arr[i], FLOAT_PLACEHOLDER_2, FLOAT_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "fTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 1, &fternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
+      sprintf(resolvedMethodName, "fSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 2, 1, &fselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(FLOAT_PLACEHOLDER_1, floatDataArr[i][0], floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
+      sprintf(resolvedMethodName, "fSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 2, 2, &floatDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(fselectChild1Arr[i], FLOAT_PLACEHOLDER_1, floatDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "fTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(fTernaryConst, _numberOfTernaryArgs, TR::fternary,
-            resolvedMethodName, _argTypesTernaryFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(fTernaryConst, ternary(fternaryChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fTernaryConst(fternaryChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "fSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(fSelectConst, _numberOfSelectArgs, TR::fselect,
+            resolvedMethodName, _argTypesSelectFloat, TR::Float, rc, 2, 3, &floatDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(fSelectConst, select(fselectChild1Arr[i], floatDataArr[i][0], floatDataArr[i][1]), fSelectConst(fselectChild1Arr[i], floatDataArr[i][0], FLOAT_PLACEHOLDER_1));
       }
 
-   testCaseNum = sizeof(dternaryChild1Arr) / sizeof(dternaryChild1Arr[0]);
+   testCaseNum = sizeof(dselectChild1Arr) / sizeof(dselectChild1Arr[0]);
    testCaseNumCheck = sizeof(doubleDataArr) / sizeof(doubleDataArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in dternary input array");
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in dselect input array");
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_dternary, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
+      OMR_CT_EXPECT_EQ(_dselect, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), _dselect(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst1_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 6, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "dSelectConst1_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 6, 1, &dselectChild1Arr[i], 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "dTernaryConst2_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 2, &doubleDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
+      sprintf(resolvedMethodName, "dSelectConst2_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 4, 1, &dselectChild1Arr[i], 2, &doubleDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, DOUBLE_PLACEHOLDER_2, doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst3_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 1, &dternaryChild1Arr[i], 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "dSelectConst3_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 4, 1, &dselectChild1Arr[i], 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], DOUBLE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "dTernaryConst4_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "dSelectConst4_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 4, 2, &doubleDataArr[i][0], 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(dselectChild1Arr[i], DOUBLE_PLACEHOLDER_2, DOUBLE_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "dTernaryConst5_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 1, &dternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
+      sprintf(resolvedMethodName, "dSelectConst5_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 2, 1, &dselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(DOUBLE_PLACEHOLDER_1, doubleDataArr[i][0], doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst6_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
+      sprintf(resolvedMethodName, "dSelectConst6_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 2, 2, &doubleDataArr[i][0]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(dselectChild1Arr[i], DOUBLE_PLACEHOLDER_1, doubleDataArr[i][1]));
 
-      sprintf(resolvedMethodName, "dTernaryConst7_Testcase%d", i + 1);
-      compileOpCodeMethod(dTernaryConst, _numberOfTernaryArgs, TR::dternary,
-            resolvedMethodName, _argTypesTernaryDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]);
-      OMR_CT_EXPECT_EQ(dTernaryConst, ternary(dternaryChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dTernaryConst(dternaryChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "dSelectConst7_Testcase%d", i + 1);
+      compileOpCodeMethod(dSelectConst, _numberOfSelectArgs, TR::dselect,
+            resolvedMethodName, _argTypesSelectDouble, TR::Double, rc, 2, 3, &doubleDataArr[i][1]);
+      OMR_CT_EXPECT_EQ(dSelectConst, select(dselectChild1Arr[i], doubleDataArr[i][0], doubleDataArr[i][1]), dSelectConst(dselectChild1Arr[i], doubleDataArr[i][0], DOUBLE_PLACEHOLDER_1));
       }
    }
 
@@ -4510,7 +4510,7 @@ S390OpCodesTest::invokeAddressTests()
       (uintptrj_t) &INT_POS,   (uintptrj_t) &INT_POS
       };
 
-   int32_t aternaryChild1Arr[] =
+   int32_t aselectChild1Arr[] =
       {
       INT_MAXIMUM,
       INT_MAXIMUM,
@@ -4528,7 +4528,7 @@ S390OpCodesTest::invokeAddressTests()
       INT_ZERO,
       INT_ZERO
       };
-   uintptrj_t aternaryArr[][2] =
+   uintptrj_t aselectArr[][2] =
       {
       (uintptrj_t) &INT_MAXIMUM, (uintptrj_t) &INT_ZERO,
       (uintptrj_t) &INT_POS,     (uintptrj_t) &INT_MAXIMUM,
@@ -4562,7 +4562,7 @@ S390OpCodesTest::invokeAddressTests()
    unsignedSignatureCharJ_L_testMethodType *lu2aConst = 0;
 
    signatureCharLL_I_testMethodType *aCompareConst = 0;
-   signatureCharILL_L_testMethodType *aTernaryConst = 0;
+   signatureCharILL_L_testMethodType *aSelectConst = 0;
 
    //address convert unary opcodes
 #if !defined(TR_TARGET_64BIT)
@@ -4903,47 +4903,47 @@ S390OpCodesTest::invokeAddressTests()
       }
 
 
-   TR_ASSERT((sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0])) == sizeof(aternaryArr) / sizeof(aternaryArr[0]),
+   TR_ASSERT((sizeof(aselectChild1Arr) / sizeof(aselectChild1Arr[0])) == sizeof(aselectArr) / sizeof(aselectArr[0]),
          "Child1 array is not equal to Child2 and Child3 array");
-   testCaseNum = sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0]);
+   testCaseNum = sizeof(aselectChild1Arr) / sizeof(aselectChild1Arr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(_aselect, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), _aselect(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst1_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 6, 1, &aselectChild1Arr[i], 2, &aselectArr[i][0], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst2_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 1, &aselectChild1Arr[i], 2, &aselectArr[i][0]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst3_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 1, &aselectChild1Arr[i], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, aselectArr[i][0], ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst4_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 2, &aselectArr[i][0], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(INT_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst5_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 1, &aselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(INT_PLACEHOLDER_1, aselectArr[i][0], aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst6_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 2, &aselectArr[i][0]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], ADDRESS_PLACEHOLDER_1, aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "aSelectConst7_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], aselectArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
    }
 
@@ -5094,11 +5094,11 @@ TEST(JITS390OpCodesTest, BitwiseTest)
    BitwiseTest.invokeBitwiseTests();
    }
 
-TEST(JITS390OpCodesTest, TernaryTest)
+TEST(JITS390OpCodesTest, SelectTest)
    {
-   ::TestCompiler::S390OpCodesTest S390TernaryTest;
-   S390TernaryTest.compileTernaryTestMethods();
-   S390TernaryTest.invokeTernaryTests();
+   ::TestCompiler::S390OpCodesTest S390SelectTest;
+   S390SelectTest.compileSelectTestMethods();
+   S390SelectTest.invokeSelectTests();
    }
 
 TEST(JITS390OpCodesTest, CompareTest)
@@ -5153,14 +5153,14 @@ TEST(JITS390OpCodesTest, DISABLED_S390UnaryTests)
    disabledS390CompareTest.invokeDisabledUnaryTests();
    }
 
-TEST(JITS390OpCodesTest, DISABLED_S390TernaryTests)
+TEST(JITS390OpCodesTest, DISABLED_S390SelectTests)
    {
    //Jazz103 WI 104092
    //Jazz103 WI 109994
    //To temporarily enable "DISABLED" test, append " --gtest_also_run_disabled_tests" in the command line.
    ::TestCompiler::S390OpCodesTest disabledS390CompareTest;
-   disabledS390CompareTest.compileDisabledTernaryTestMethods();
-   disabledS390CompareTest.invokeDisabledTernaryTests();
+   disabledS390CompareTest.compileDisabledSelectTestMethods();
+   disabledS390CompareTest.invokeDisabledSelectTests();
    }
 
 TEST(JITS390OpCodesTest, DISABLED_S390MemoryOperationTest)

--- a/fvtest/compilertest/tests/S390OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/S390OpCodesTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -31,7 +31,7 @@ class S390OpCodesTest : public OpCodesTest
    virtual void compileMemoryOperationTestMethods();
    virtual void compileUnaryTestMethods();
    virtual void compileBitwiseTestMethods();
-   virtual void compileTernaryTestMethods();
+   virtual void compileSelectTestMethods();
    virtual void compileCompareTestMethods();
    virtual void compileDirectCallTestMethods();
    virtual void compileAddressTestMethods();
@@ -41,7 +41,7 @@ class S390OpCodesTest : public OpCodesTest
    virtual void invokeMemoryOperationTests();
    virtual void invokeUnaryTests();
    virtual void invokeBitwiseTests();
-   virtual void invokeTernaryTests();
+   virtual void invokeSelectTests();
    virtual void invokeCompareTests();
    virtual void invokeDirectCallTests();
    virtual void invokeAddressTests();
@@ -49,7 +49,7 @@ class S390OpCodesTest : public OpCodesTest
    virtual void compileDisabledCompareOpCodesTestMethods();
    virtual void compileDisabledIntegerArithmeticTestMethods();
    virtual void compileDisabledUnaryTestMethods();
-   virtual void compileDisabledTernaryTestMethods();
+   virtual void compileDisabledSelectTestMethods();
    virtual void compileDisabledMemoryOperationTestMethods();
    virtual void compileDisabledBitwiseTestMethods();
    virtual void compileDisabledDirectCallTestMethods();
@@ -58,7 +58,7 @@ class S390OpCodesTest : public OpCodesTest
    virtual void invokeDisabledCompareOpCodesTests();
    virtual void invokeDisabledIntegerArithmeticTests();
    virtual void invokeDisabledUnaryTests();
-   virtual void invokeDisabledTernaryTests();
+   virtual void invokeDisabledSelectTests();
    virtual void invokeDisabledMemoryOperationTests();
    virtual void invokeDisabledBitwiseTests();
    virtual void invokeDisabledDirectCallTests();

--- a/fvtest/compilertest/tests/X86OpCodesTest.cpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -273,10 +273,10 @@ X86OpCodesTest::compileCompareTestMethods()
    }
 
 void
-X86OpCodesTest::compileTernaryTestMethods()
+X86OpCodesTest::compileSelectTestMethods()
    {
    int32_t rc = 0;
-   compileOpCodeMethod(_lternary, _numberOfTernaryArgs, TR::lternary, "lTernary", _argTypesTernaryLong, TR::Int64, rc);
+   compileOpCodeMethod(_lselect, _numberOfSelectArgs, TR::lselect, "lselect", _argTypesSelectLong, TR::Int64, rc);
 
    }
 
@@ -291,7 +291,7 @@ X86OpCodesTest::compileAddressTestMethods()
 #if defined(TR_TARGET_64BIT)
    compileOpCodeMethod(_l2a, _numberOfUnaryArgs, TR::l2a, "l2a", _argTypesUnaryLong, TR::Address, rc);
    compileOpCodeMethod(_a2l, _numberOfUnaryArgs, TR::a2l, "a2l", _argTypesUnaryAddress, TR::Int64, rc);
-   compileOpCodeMethod(_aternary, _numberOfTernaryArgs, TR::aternary, "aternary", _argTypesTernaryAddress, TR::Address, rc);
+   compileOpCodeMethod(_aselect, _numberOfSelectArgs, TR::aselect, "aselect", _argTypesSelectAddress, TR::Address, rc);
 #endif
 
    compileOpCodeMethod(_acmpeq, _numberOfBinaryArgs, TR::acmpeq, "acmpeq", _argTypesBinaryAddress, TR::Int32, rc);
@@ -3913,7 +3913,7 @@ X86OpCodesTest::invokeAddressTests()
       (uintptrj_t) &INT_POS,   (uintptrj_t) &INT_POS
       };
 
-   int32_t aternaryChild1Arr[] =
+   int32_t aselectChild1Arr[] =
       {
          INT_MAXIMUM,
          INT_MAXIMUM,
@@ -3931,7 +3931,7 @@ X86OpCodesTest::invokeAddressTests()
          INT_ZERO,
          INT_ZERO
       };
-   uintptrj_t aternaryArr[][2] =
+   uintptrj_t aselectArr[][2] =
       {
       (uintptrj_t) &INT_MAXIMUM, (uintptrj_t) &INT_ZERO,
       (uintptrj_t) &INT_POS,     (uintptrj_t) &INT_MAXIMUM,
@@ -3961,7 +3961,7 @@ X86OpCodesTest::invokeAddressTests()
    unsignedSignatureCharI_L_testMethodType *iu2aConst = 0;
 
    signatureCharLL_I_testMethodType *aCompareConst = 0;
-   signatureCharILL_L_testMethodType *aTernaryConst = 0;
+   signatureCharILL_L_testMethodType *aSelectConst = 0;
 
    testCaseNum = sizeof(aUnaryDataArr) / sizeof(aUnaryDataArr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
@@ -4042,48 +4042,48 @@ X86OpCodesTest::invokeAddressTests()
       OMR_CT_EXPECT_EQ(a2lConst, convert(aUnaryDataArr[i], LONG_POS), a2lConst(ADDRESS_PLACEHOLDER_1));
       }
 
-   //aternary
-   TR_ASSERT((sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0])) == sizeof(aternaryArr) / sizeof(aternaryArr[0]),
+   //aselect
+   TR_ASSERT((sizeof(aselectChild1Arr) / sizeof(aselectChild1Arr[0])) == sizeof(aselectArr) / sizeof(aselectArr[0]),
          "Child1 array is not equal to Child2 and Child3 array");
-   testCaseNum = sizeof(aternaryChild1Arr) / sizeof(aternaryChild1Arr[0]);
+   testCaseNum = sizeof(aselectChild1Arr) / sizeof(aselectChild1Arr[0]);
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      OMR_CT_EXPECT_EQ(_aternary, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), _aternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]));
+      OMR_CT_EXPECT_EQ(_aselect, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), _aselect(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst1_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 6, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst1_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 6, 1, &aselectChild1Arr[i], 2, &aselectArr[i][0], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst2_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 2, &aternaryArr[i][0]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst2_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 1, &aselectChild1Arr[i], 2, &aselectArr[i][0]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(ADDRESS_PLACEHOLDER_1, ADDRESS_PLACEHOLDER_2, aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst3_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 1, &aternaryChild1Arr[i], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst3_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 1, &aselectChild1Arr[i], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(ADDRESS_PLACEHOLDER_1, aselectArr[i][0], ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst4_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 4, 2, &aternaryArr[i][0], 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
+      sprintf(resolvedMethodName, "aSelectConst4_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 4, 2, &aselectArr[i][0], 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], ADDRESS_PLACEHOLDER_2, ADDRESS_PLACEHOLDER_3));
 
-      sprintf(resolvedMethodName, "aTernaryConst5_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 1, &aternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(ADDRESS_PLACEHOLDER_1, aternaryArr[i][0], aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst5_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 1, &aselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(ADDRESS_PLACEHOLDER_1, aselectArr[i][0], aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst6_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 2, &aternaryArr[i][0]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], ADDRESS_PLACEHOLDER_1, aternaryArr[i][1]));
+      sprintf(resolvedMethodName, "aSelectConst6_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 2, &aselectArr[i][0]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], ADDRESS_PLACEHOLDER_1, aselectArr[i][1]));
 
-      sprintf(resolvedMethodName, "aTernaryConst7_TestCase%d", i + 1);
-      compileOpCodeMethod(aTernaryConst,
-            _numberOfTernaryArgs, TR::aternary, resolvedMethodName, _argTypesTernaryAddress, TR::Address, rc, 2, 3, &aternaryArr[i][1]);
-      OMR_CT_EXPECT_EQ(aTernaryConst, ternary(aternaryChild1Arr[i], aternaryArr[i][0], aternaryArr[i][1]), aTernaryConst(aternaryChild1Arr[i], aternaryArr[i][0], ADDRESS_PLACEHOLDER_1));
+      sprintf(resolvedMethodName, "aSelectConst7_TestCase%d", i + 1);
+      compileOpCodeMethod(aSelectConst,
+            _numberOfSelectArgs, TR::aselect, resolvedMethodName, _argTypesSelectAddress, TR::Address, rc, 2, 3, &aselectArr[i][1]);
+      OMR_CT_EXPECT_EQ(aSelectConst, select(aselectChild1Arr[i], aselectArr[i][0], aselectArr[i][1]), aSelectConst(aselectChild1Arr[i], aselectArr[i][0], ADDRESS_PLACEHOLDER_1));
       }
 #endif //defined(TR_TARGET_64BIT)
 
@@ -4343,14 +4343,14 @@ X86OpCodesTest::invokeAddressTests()
    }
 
 void
-X86OpCodesTest::invokeTernaryTests()
+X86OpCodesTest::invokeSelectTests()
    {
    int32_t rc = 0;
    char resolvedMethodName [RESOLVED_METHOD_NAME_LENGTH];
    uint32_t testCaseNum = 0;
    uint32_t testCaseNumCheck = 0;
 
-   int32_t lternaryChild1Arr[] =
+   int32_t lselectChild1Arr[] =
       {
       INT_ZERO,INT_MINIMUM,INT_NEG,INT_MAXIMUM,INT_POS,INT_MINIMUM,
       INT_MAXIMUM,INT_POS,INT_ZERO,INT_MAXIMUM,INT_MAXIMUM
@@ -4371,42 +4371,42 @@ X86OpCodesTest::invokeTernaryTests()
       LONG_MAXIMUM, LONG_NEG
       };
 
-   testCaseNum = sizeof(lternaryChild1Arr) / sizeof(lternaryChild1Arr[0]);
+   testCaseNum = sizeof(lselectChild1Arr) / sizeof(lselectChild1Arr[0]);
    testCaseNumCheck = sizeof(longArr) / sizeof(longArr[0]);
-   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in lternary input array");
-   signatureCharIJJ_J_testMethodType * lTernaryConst = 0;
+   TR_ASSERT( (testCaseNum > 0) && (testCaseNum == testCaseNumCheck), "There is problem in lselect input array");
+   signatureCharIJJ_J_testMethodType * lSelectConst = 0;
    for (int32_t i = 0 ; i < testCaseNum ; i++)
       {
-      sprintf(resolvedMethodName, "lTernaryConst%d", i + 1);
-      OMR_CT_EXPECT_EQ(_lternary, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), _lternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]));
+      sprintf(resolvedMethodName, "lSelectConst%d", i + 1);
+      OMR_CT_EXPECT_EQ(_lselect, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), _lselect(lselectChild1Arr[i], longArr[i][0], longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 6, 1, &lternaryChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 6, 1, &lselectChild1Arr[i], 2, &longArr[i][0], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 2, &longArr[i][0]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 1, &lselectChild1Arr[i], 2, &longArr[i][0]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, LONG_PLACEHOLDER_2, longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 1, &lternaryChild1Arr[i], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 1, &lselectChild1Arr[i], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, longArr[i][0], LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 4, 2, &longArr[i][0], 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], LONG_PLACEHOLDER_2, LONG_PLACEHOLDER_3));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 1, &lternaryChild1Arr[i]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 1, &lselectChild1Arr[i]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(LONG_PLACEHOLDER_1, longArr[i][0], longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 2, &longArr[i][0]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], LONG_PLACEHOLDER_1, longArr[i][1]));
 
-      compileOpCodeMethod(lTernaryConst, _numberOfTernaryArgs, TR::lternary,
-            resolvedMethodName, _argTypesTernaryLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
-      OMR_CT_EXPECT_EQ(lTernaryConst, ternary(lternaryChild1Arr[i], longArr[i][0], longArr[i][1]), lTernaryConst(lternaryChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
+      compileOpCodeMethod(lSelectConst, _numberOfSelectArgs, TR::lselect,
+            resolvedMethodName, _argTypesSelectLong, TR::Int64, rc, 2, 3, &longArr[i][1]);
+      OMR_CT_EXPECT_EQ(lSelectConst, select(lselectChild1Arr[i], longArr[i][0], longArr[i][1]), lSelectConst(lselectChild1Arr[i], longArr[i][0], LONG_PLACEHOLDER_1));
       }
    }
 
@@ -4418,9 +4418,9 @@ X86OpCodesTest::UnsupportedOpCodesTests()
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2f, "lu2f", _argTypesUnaryLong, TR::Float);
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::lu2d, "lu2d", _argTypesUnaryLong, TR::Double);
 
-   //bternary, sternary, fternary, dternary
-   addUnsupportedOpCodeTest(_numberOfTernaryArgs, TR::fternary, "fTernary", _argTypesTernaryFloat, TR::Float);
-   addUnsupportedOpCodeTest(_numberOfTernaryArgs, TR::dternary, "dTernary", _argTypesTernaryDouble, TR::Double);
+   //bselect, sselect, fselect, dselect
+   addUnsupportedOpCodeTest(_numberOfSelectArgs, TR::fselect, "fSelect", _argTypesSelectFloat, TR::Float);
+   addUnsupportedOpCodeTest(_numberOfSelectArgs, TR::dselect, "dSelect", _argTypesSelectDouble, TR::Double);
 
    //iu2f, iu2d
    addUnsupportedOpCodeTest(_numberOfUnaryArgs, TR::iu2f, "iu2f", _argTypesUnaryInt, TR::Float);
@@ -4619,11 +4619,11 @@ TEST(JITX86OpCodesTest, CompareTest)
    X86CompareTest.invokeCompareTests();
    }
 
-TEST(JITX86OpCodesTest, TernaryTest)
+TEST(JITX86OpCodesTest, SelectTest)
    {
-   ::TestCompiler::X86OpCodesTest X86TernaryTest;
-   X86TernaryTest.compileTernaryTestMethods();
-   X86TernaryTest.invokeTernaryTests();
+   ::TestCompiler::X86OpCodesTest X86SelectTest;
+   X86SelectTest.compileSelectTestMethods();
+   X86SelectTest.invokeSelectTests();
    }
 
 TEST(JITX86OpCodesTest, X86AddressTest)

--- a/fvtest/compilertest/tests/X86OpCodesTest.hpp
+++ b/fvtest/compilertest/tests/X86OpCodesTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -33,7 +33,7 @@ class X86OpCodesTest : public OpCodesTest
    virtual void compileBitwiseTestMethods();
    virtual void compileDirectCallTestMethods();
    virtual void compileCompareTestMethods();
-   virtual void compileTernaryTestMethods();
+   virtual void compileSelectTestMethods();
    virtual void compileAddressTestMethods();
 
    virtual void invokeIntegerArithmeticTests();
@@ -43,7 +43,7 @@ class X86OpCodesTest : public OpCodesTest
    virtual void invokeBitwiseTests();
    virtual void invokeDirectCallTests();
    virtual void invokeCompareTests();
-   virtual void invokeTernaryTests();
+   virtual void invokeSelectTests();
    virtual void invokeAddressTests();
    virtual void UnsupportedOpCodesTests();
 

--- a/fvtest/compilertest/tests/injectors/OpIlInjector.hpp
+++ b/fvtest/compilertest/tests/injectors/OpIlInjector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -133,7 +133,7 @@ class OpIlInjector : public TR::IlInjector
 
    TR::ILOpCodes _opCode;
    TR::DataType _dataType; // datatype of OpCode child/children
-   TR::DataType _conditionalDataType; // return type of Ternary opcodes
+   TR::DataType _conditionalDataType; // return type of Select opcodes
 
    ParmNode **_optArgs;  // holds args that are not on stack params
    uint32_t _numOptArgs;

--- a/fvtest/compilertest/tests/injectors/SelectOpIlInjector.cpp
+++ b/fvtest/compilertest/tests/injectors/SelectOpIlInjector.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -21,12 +21,12 @@
 
 #include "compile/Compilation.hpp"
 #include "env/FrontEnd.hpp"
-#include "tests/injectors/TernaryOpIlInjector.hpp"
+#include "tests/injectors/SelectOpIlInjector.hpp"
 
 namespace TestCompiler
 {
 bool
-TernaryOpIlInjector::injectIL()
+SelectOpIlInjector::injectIL()
    {
    if (!isOpCodeSupported())
       {

--- a/fvtest/compilertest/tests/injectors/SelectOpIlInjector.hpp
+++ b/fvtest/compilertest/tests/injectors/SelectOpIlInjector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -19,8 +19,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#ifndef TEST_TERNARYOPILINJECTOR_INCL
-#define TEST_TERNARYOPILINJECTOR_INCL
+#ifndef TEST_SELECTOPILINJECTOR_INCL
+#define TEST_SELECTOPILINJECTOR_INCL
 
 #include "tests/injectors/OpIlInjector.hpp"
 
@@ -28,10 +28,10 @@ namespace TR { class TypeDictionary; }
 
 namespace TestCompiler
 {
-class TernaryOpIlInjector : public OpIlInjector
+class SelectOpIlInjector : public OpIlInjector
    {
    public:
-   TernaryOpIlInjector(TR::TypeDictionary *types, TestDriver *test, TR::ILOpCodes opCode)
+   SelectOpIlInjector(TR::TypeDictionary *types, TestDriver *test, TR::ILOpCodes opCode)
       : OpIlInjector(types, test, opCode)
       {
       initOptArgs(3);
@@ -44,4 +44,4 @@ class TernaryOpIlInjector : public OpIlInjector
 
 } /* namespace TestCompiler */
 
-#endif // !define (TEST_TERNARYOPILINJECTOR_INCL)
+#endif // !define (TEST_SELECTOPILINJECTOR_INCL)

--- a/fvtest/compilertriltest/CMakeLists.txt
+++ b/fvtest/compilertriltest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 IBM Corp. and others
+# Copyright (c) 2017, 2020 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -47,7 +47,7 @@ add_executable(comptest
 	MaxMinTest.cpp
 	CompareTest.cpp
 	TypeConversionTest.cpp
-	TernaryTest.cpp
+	SelectTest.cpp
 	MinimalTest.cpp
 )
 

--- a/fvtest/compilertriltest/SelectTest.cpp
+++ b/fvtest/compilertriltest/SelectTest.cpp
@@ -25,19 +25,19 @@
 
 // C++11 upgrade (Issue #1916).
 template <typename CompareType, typename ValType>
-class TernaryTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>, ValType (*)(CompareType, CompareType, ValType, ValType)>> {};
+class SelectTest : public TRTest::JitTest, public ::testing::WithParamInterface<std::tuple<std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>, ValType (*)(CompareType, CompareType, ValType, ValType)>> {};
 
 /** \brief
- *     Struct equivalent of the TernaryTestParamStruct tuple.
+ *     Struct equivalent of the SelectTestParamStruct tuple.
  *
  *  \tparam CompareType
- *     The type of the compare child of the ternary opcode.
+ *     The type of the compare child of the select opcode.
  *
  *  \tparam ValType
- *     The type that the ternary opcode returns.
+ *     The type that the select opcode returns.
  */
 template <typename CompareType, typename ValType>
-struct TernaryTestParamStruct
+struct SelectTestParamStruct
    {
    CompareType c1;
    CompareType c2;
@@ -47,12 +47,12 @@ struct TernaryTestParamStruct
    };
 
 /** \brief
- *     Given an instance of TernaryTestParamStruct, returns an equivalent instance of TernaryTestParamStruct.
+ *     Given an instance of SelectTestParamStruct, returns an equivalent instance of SelectTestParamStruct.
  */
 template <typename CompareType, typename ValType>
-TernaryTestParamStruct<CompareType, ValType> to_struct(std::tuple<std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>, ValType (*)(CompareType, CompareType, ValType, ValType)> param)
+SelectTestParamStruct<CompareType, ValType> to_struct(std::tuple<std::tuple<CompareType, CompareType>, std::tuple<ValType, ValType>, ValType (*)(CompareType, CompareType, ValType, ValType)> param)
    {
-   TernaryTestParamStruct<CompareType, ValType> s;
+   SelectTestParamStruct<CompareType, ValType> s;
 
    s.c1 = std::get<0>(std::get<0>(param));
    s.c2 = std::get<1>(std::get<0>(param));
@@ -63,7 +63,7 @@ TernaryTestParamStruct<CompareType, ValType> to_struct(std::tuple<std::tuple<Com
    }
 
 /** \brief
- *     The oracle function which computes the expected result of the ternary test.
+ *     The oracle function which computes the expected result of the select test.
  *
  *  \tparam CompareType
  *     The type of the values compared by oracle function.
@@ -71,7 +71,7 @@ TernaryTestParamStruct<CompareType, ValType> to_struct(std::tuple<std::tuple<Com
  *     The return type of the oracle function.
  */
 template <typename CompareType, typename ValType>
-static ValType xternaryOracle(CompareType c1, CompareType c2, ValType v1, ValType v2)
+static ValType xselectOracle(CompareType c1, CompareType c2, ValType v1, ValType v2)
    {
    return ((c1 < c2) ? v1 : v2);
    }
@@ -96,7 +96,7 @@ static std::vector<std::tuple<T, T>> compareInputs()
    }
 
 /** \brief
- *     The function computes the true/false result vector of pairs for the ternary node.
+ *     The function computes the true/false result vector of pairs for the select node.
  */
 template <typename T>
 static std::vector<std::tuple<T, T>> resultInputs()
@@ -109,9 +109,9 @@ static std::vector<std::tuple<T, T>> resultInputs()
    return std::vector<std::tuple<T, T>>(inputArray, inputArray + sizeof(inputArray)/sizeof(std::tuple<T, T>));
    }
 
-class Int32TernaryInt32CompareTest : public TernaryTest<int32_t, int32_t> {};
+class Int32SelectInt32CompareTest : public SelectTest<int32_t, int32_t> {};
 
-TEST_P(Int32TernaryInt32CompareTest, UsingLoadParam) {
+TEST_P(Int32SelectInt32CompareTest, UsingLoadParam) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -119,7 +119,7 @@ TEST_P(Int32TernaryInt32CompareTest, UsingLoadParam) {
         "(method return=Int32 args=[Int32, Int32, Int32, Int32]"
         "  (block"
         "    (ireturn"
-        "      (iternary"
+        "      (iselect"
         "        (icmplt"
         "          (iload parm=0)"
         "          (iload parm=1))"
@@ -139,7 +139,7 @@ TEST_P(Int32TernaryInt32CompareTest, UsingLoadParam) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(Int32TernaryInt32CompareTest, UsingConst) {
+TEST_P(Int32SelectInt32CompareTest, UsingConst) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -147,7 +147,7 @@ TEST_P(Int32TernaryInt32CompareTest, UsingConst) {
         "(method return=Int32"
         "  (block"
         "    (ireturn"
-        "      (iternary"
+        "      (iselect"
         "        (icmplt"
         "          (iconst %d)"
         "          (iconst %d))"
@@ -171,15 +171,15 @@ TEST_P(Int32TernaryInt32CompareTest, UsingConst) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point());
 }
 
-INSTANTIATE_TEST_CASE_P(TernaryTest, Int32TernaryInt32CompareTest,
+INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectInt32CompareTest,
         ::testing::Combine(
             ::testing::ValuesIn(compareInputs<int32_t>()),
             ::testing::ValuesIn(resultInputs<int32_t>()),
-            ::testing::Values(xternaryOracle<int32_t, int32_t>)));
+            ::testing::Values(xselectOracle<int32_t, int32_t>)));
 
-class Int64TernaryInt64CompareTest : public TernaryTest<int64_t, int64_t> {};
+class Int64SelectInt64CompareTest : public SelectTest<int64_t, int64_t> {};
 
-TEST_P(Int64TernaryInt64CompareTest, UsingLoadParam) {
+TEST_P(Int64SelectInt64CompareTest, UsingLoadParam) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -187,7 +187,7 @@ TEST_P(Int64TernaryInt64CompareTest, UsingLoadParam) {
         "(method return=Int64 args=[Int64, Int64, Int64, Int64]"
         "  (block"
         "    (lreturn"
-        "      (lternary"
+        "      (lselect"
         "        (lcmplt"
         "          (lload parm=0)"
         "          (lload parm=1))"
@@ -207,7 +207,7 @@ TEST_P(Int64TernaryInt64CompareTest, UsingLoadParam) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(Int64TernaryInt64CompareTest, UsingConst) {
+TEST_P(Int64SelectInt64CompareTest, UsingConst) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -215,7 +215,7 @@ TEST_P(Int64TernaryInt64CompareTest, UsingConst) {
         "(method return=Int64"
         "  (block"
         "    (lreturn"
-        "      (lternary"
+        "      (lselect"
         "        (lcmplt"
         "          (lconst %" OMR_PRId64 ")"
         "          (lconst %" OMR_PRId64 "))"
@@ -239,16 +239,16 @@ TEST_P(Int64TernaryInt64CompareTest, UsingConst) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point());
 }
 
-INSTANTIATE_TEST_CASE_P(TernaryTest, Int64TernaryInt64CompareTest,
+INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectInt64CompareTest,
         ::testing::Combine(
             ::testing::ValuesIn(compareInputs<int64_t>()),
             ::testing::ValuesIn(resultInputs<int64_t>()),
-            ::testing::Values(xternaryOracle<int64_t, int64_t>)));
+            ::testing::Values(xselectOracle<int64_t, int64_t>)));
 
 
-class Int64TernaryDoubleCompareTest : public TernaryTest<double, int64_t> {};
+class Int64SelectDoubleCompareTest : public SelectTest<double, int64_t> {};
 
-TEST_P(Int64TernaryDoubleCompareTest, UsingLoadParam) {
+TEST_P(Int64SelectDoubleCompareTest, UsingLoadParam) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -256,7 +256,7 @@ TEST_P(Int64TernaryDoubleCompareTest, UsingLoadParam) {
         "(method return=Int64 args=[Double, Double, Int64, Int64]"
         "  (block"
         "    (lreturn"
-        "      (lternary"
+        "      (lselect"
         "        (dcmplt"
         "          (dload parm=0)"
         "          (dload parm=1))"
@@ -276,7 +276,7 @@ TEST_P(Int64TernaryDoubleCompareTest, UsingLoadParam) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(Int64TernaryDoubleCompareTest, UsingConst) {
+TEST_P(Int64SelectDoubleCompareTest, UsingConst) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -284,7 +284,7 @@ TEST_P(Int64TernaryDoubleCompareTest, UsingConst) {
         "(method return=Int64 args=[Double, Double]"
         "  (block"
         "    (lreturn"
-        "      (lternary"
+        "      (lselect"
         "        (dcmplt"
         "          (dload parm=0)"
         "          (dload parm=1))"
@@ -306,15 +306,15 @@ TEST_P(Int64TernaryDoubleCompareTest, UsingConst) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(TernaryTest, Int64TernaryDoubleCompareTest,
+INSTANTIATE_TEST_CASE_P(SelectTest, Int64SelectDoubleCompareTest,
         ::testing::Combine(
             ::testing::ValuesIn(compareInputs<double>()),
             ::testing::ValuesIn(resultInputs<int64_t>()),
-            ::testing::Values(xternaryOracle<double, int64_t>)));
+            ::testing::Values(xselectOracle<double, int64_t>)));
 
-class Int32TernaryDoubleCompareTest : public TernaryTest<double, int32_t> {};
+class Int32SelectDoubleCompareTest : public SelectTest<double, int32_t> {};
 
-TEST_P(Int32TernaryDoubleCompareTest, UsingLoadParam) {
+TEST_P(Int32SelectDoubleCompareTest, UsingLoadParam) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -322,7 +322,7 @@ TEST_P(Int32TernaryDoubleCompareTest, UsingLoadParam) {
         "(method return=Int32 args=[Double, Double, Int32, Int32]"
         "  (block"
         "    (ireturn"
-        "      (iternary"
+        "      (iselect"
         "        (dcmplt"
         "          (dload parm=0)"
         "          (dload parm=1))"
@@ -342,7 +342,7 @@ TEST_P(Int32TernaryDoubleCompareTest, UsingLoadParam) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(Int32TernaryDoubleCompareTest, UsingConst) {
+TEST_P(Int32SelectDoubleCompareTest, UsingConst) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -350,7 +350,7 @@ TEST_P(Int32TernaryDoubleCompareTest, UsingConst) {
         "(method return=Int32 args=[Double, Double]"
         "  (block"
         "    (ireturn"
-        "      (iternary"
+        "      (iselect"
         "        (dcmplt"
         "          (dload parm=0)"
         "          (dload parm=1))"
@@ -372,16 +372,16 @@ TEST_P(Int32TernaryDoubleCompareTest, UsingConst) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(TernaryTest, Int32TernaryDoubleCompareTest,
+INSTANTIATE_TEST_CASE_P(SelectTest, Int32SelectDoubleCompareTest,
         ::testing::Combine(
             ::testing::ValuesIn(compareInputs<double>()),
             ::testing::ValuesIn(resultInputs<int32_t>()),
-            ::testing::Values(xternaryOracle<double, int32_t>)));
+            ::testing::Values(xselectOracle<double, int32_t>)));
 
 
-class ShortTernaryDoubleCompareTest : public TernaryTest<double, int16_t> {};
+class ShortSelectDoubleCompareTest : public SelectTest<double, int16_t> {};
 
-TEST_P(ShortTernaryDoubleCompareTest, UsingLoadParam) {
+TEST_P(ShortSelectDoubleCompareTest, UsingLoadParam) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -390,7 +390,7 @@ TEST_P(ShortTernaryDoubleCompareTest, UsingLoadParam) {
         "  (block"
         "    (ireturn"
         "      (s2i"
-        "        (sternary"
+        "        (sselect"
         "          (dcmplt"
         "            (dload parm=0)"
         "            (dload parm=1))"
@@ -410,7 +410,7 @@ TEST_P(ShortTernaryDoubleCompareTest, UsingLoadParam) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2, param.v1, param.v2));
 }
 
-TEST_P(ShortTernaryDoubleCompareTest, UsingConst) {
+TEST_P(ShortSelectDoubleCompareTest, UsingConst) {
     auto param = to_struct(GetParam());
 
     char inputTrees[512] = {0};
@@ -419,7 +419,7 @@ TEST_P(ShortTernaryDoubleCompareTest, UsingConst) {
         "  (block"
         "    (ireturn"
         "      (s2i"
-        "        (sternary"
+        "        (sselect"
         "          (dcmplt"
         "            (dload parm=0)"
         "            (dload parm=1))"
@@ -441,8 +441,8 @@ TEST_P(ShortTernaryDoubleCompareTest, UsingConst) {
     ASSERT_EQ(param.oracle(param.c1, param.c2, param.v1, param.v2), entry_point(param.c1, param.c2));
 }
 
-INSTANTIATE_TEST_CASE_P(TernaryTest, ShortTernaryDoubleCompareTest,
+INSTANTIATE_TEST_CASE_P(SelectTest, ShortSelectDoubleCompareTest,
         ::testing::Combine(
             ::testing::ValuesIn(compareInputs<double>()),
             ::testing::ValuesIn(resultInputs<int16_t>()),
-            ::testing::Values((xternaryOracle<double, int16_t>))));
+            ::testing::Values((xselectOracle<double, int16_t>))));


### PR DESCRIPTION
Refactoring of TR::ternary opcodes to TR::select

Replacing of the ternary OpCodes such as TR::bternary etc. to
TR::bselect etc. and the associated items respectively.

The changes are made onto the followings:
- Components of various data types such as- Int8, Float, Double
  (iternary, bternary etc) etc..
- Corresponding evaluators such as- bselectEvaluator, iselectEvaluator
  etc. and other functions where the IL OpCodes are used.
- Corresponding outputs of texts such as- "iselect" etc. and comments
  (//ternary).

Closes: GitHub issue #681

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>