### PR TITLE
Fix JNI performance regression

### DIFF
--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -352,6 +352,16 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    self()->comp()->setReturnInfo(returnInfo);
    }
 
+TR::Linkage *
+OMR::Power::CodeGenerator::deriveCallingLinkage(TR::Node *node, bool isIndirect)
+    {
+    TR::SymbolReference *symRef     = node->getSymbolReference();
+    TR::MethodSymbol    *callee = symRef->getSymbol()->castToMethodSymbol();
+    TR::Linkage         *linkage = self()->getLinkage(callee->getLinkageConvention());
+
+    return linkage;
+    }
+
 uintptrj_t *
 OMR::Power::CodeGenerator::getTOCBase()
     {

--- a/compiler/p/codegen/OMRCodeGenerator.hpp
+++ b/compiler/p/codegen/OMRCodeGenerator.hpp
@@ -187,6 +187,16 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
 
+   /**
+    * Return the proper linkage for this call, especially for the case when the methodSymbol
+    * doesn't capture the complete information.
+    *
+    * @param[in] node, this calling node
+    * @param[in] isIndirect true if this call is an indirect call
+    * @return    appropriate linkage for this call
+    */
+   TR::Linkage *deriveCallingLinkage(TR::Node *node, bool isIndirect);
+
    bool isSnippetMatched(TR::Snippet *, int32_t, TR::SymbolReference *);
 
    bool mulDecompositionCostIsJustified(int numOfOperations, char bitPosition[], char operationType[], int64_t value);

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5413,9 +5413,7 @@ bool OMR::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&
 
 TR::Register *OMR::Power::TreeEvaluator::performCall(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg)
    {
-   TR::SymbolReference *symRef     = node->getSymbolReference();
-   TR::MethodSymbol    *callee = symRef->getSymbol()->castToMethodSymbol();
-   TR::Linkage      *linkage = cg->getLinkage(callee->getLinkageConvention());
+   TR::Linkage      *linkage = cg->deriveCallingLinkage(node, isIndirect);
    TR::Register *returnRegister;
 
    if (isIndirect)

--- a/compiler/p/codegen/PPCOutOfLineCodeSection.cpp
+++ b/compiler/p/codegen/PPCOutOfLineCodeSection.cpp
@@ -45,6 +45,11 @@ TR_PPCOutOfLineCodeSection::TR_PPCOutOfLineCodeSection(TR::Node  *callNode,
                             TR::CodeGenerator *cg) :
                             TR_OutOfLineCodeSection(callNode,callOp,targetReg,entryLabel,restartLabel,cg)
    {
+   if(callNode->isPreparedForDirectJNI())
+      {
+      _callNode->setPreparedForDirectJNI();
+      }
+
    generatePPCOutOfLineCodeSectionDispatch();
    }
 


### PR DESCRIPTION
This is to check in the OMR portion ...

It was caused by changes committed for OpenJ9 issue #4893. When JNILinkage is not
set on the method symbol anymore, OutOfLine performCall eventully evaluated it
through PrivateLinkage and stuck in interpreter. The fundamental reason is that
a new node is created for performCall but the isPreparedForJNI flag is not copied
over and performCall doesn't get the linkage right.

Resolve: #4132

Signed-off-by: Julian Wang <zlwang@ca.ibm.com>