### PR TITLE
AArch64: Fix code generation for adr and adrp instructions

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1151,7 +1151,7 @@ class ARM64Trg1ImmInstruction : public ARM64Trg1Instruction
          }
       else if (op == TR::InstOpCode::adr || op == TR::InstOpCode::adrp)
          {
-         *instruction |= ((_sourceImmediate & 0x7ffff) << 5) | ((_sourceImmediate & 0x3) << 29);
+         *instruction |= ((_sourceImmediate & 0x1ffffc) << 3) | ((_sourceImmediate & 0x3) << 29);
          }
       else
          {


### PR DESCRIPTION
This commit fixes the wrong encoding of the immediate value for "adr"
and "adrp" instructions.
Those two instructions encode the lower 2 bits of the immediate value
in bits 29-30 of the instruction word, and the upper 19 bits of the
immediate value in bits 5-23 of the instruction word.
There was a mistake with masking and shifting the upper 19 bits.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>