### PR TITLE
AArch64: Implement generateARM64OutOfLineCodeSectionDispatch()

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -864,6 +864,22 @@ OMR::ARM64::TreeEvaluator::PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *
    return NULL;
    }
 
+TR::Register *
+OMR::ARM64::TreeEvaluator::performCall(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg)
+   {
+   TR::SymbolReference *symRef = node->getSymbolReference();
+   TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
+   TR::Linkage *linkage = cg->getLinkage(callee->getLinkageConvention());
+   TR::Register *returnRegister;
+
+   if (isIndirect)
+      returnRegister = linkage->buildIndirectDispatch(node);
+   else
+      returnRegister = linkage->buildDirectDispatch(node);
+
+   return returnRegister;
+   }
+
 TR::Instruction *
 OMR::ARM64::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *dstReg, TR::Register *srcReg, TR::Instruction *preced)
    {

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.hpp
@@ -784,10 +784,12 @@ public:
 	static TR::Register *lbitpermuteEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 	static TR::Register *PrefetchEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
+	static TR::Register *performCall(TR::Node *node, bool isIndirect, TR::CodeGenerator *cg);
+
 	static TR::Instruction *generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *dstReg, TR::Register *srcReg, TR::Instruction *preced=NULL);
 	static TR::Instruction *generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node, TR::Register *reg, TR::Instruction *preced=NULL);
    };
 
-}
-}
+} // ARM64
+} // OMR
 #endif //OMR_ARM64_TREE_EVALUATOR_INCL


### PR DESCRIPTION
This commit implements generateARM64OutOfLineCodeSectionDispatch()
in TR_ARM64OutOfLineCodeSection.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>