### PR TITLE
AArch64: Add Constant Data Snippet

### DIFF
--- a/compiler/aarch64/CMakeLists.txt
+++ b/compiler/aarch64/CMakeLists.txt
@@ -28,6 +28,7 @@ compiler_library(aarch64
 	${CMAKE_CURRENT_LIST_DIR}/codegen/ARM64OutOfLineCodeSection.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/ARM64SystemLinkage.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/BinaryEvaluator.cpp
+	${CMAKE_CURRENT_LIST_DIR}/codegen/ConstantDataSnippet.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/ControlFlowEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/FPTreeEvaluator.cpp
 	${CMAKE_CURRENT_LIST_DIR}/codegen/GenerateInstructions.cpp

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -28,6 +28,7 @@
 #include "codegen/ARM64HelperCallSnippet.hpp"
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/ConstantDataSnippet.hpp"
 #include "codegen/GCRegisterMap.hpp"
 #include "codegen/InstOpCode.hpp"
 #include "codegen/MemoryReference.hpp"
@@ -831,17 +832,19 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1ImmSymInstruction *instr)
    printPrefix(pOutFile, instr);
    trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
    print(pOutFile, instr->getTargetRegister(), TR_WordReg);
+   trfprintf(pOutFile, ", ");
+
    uint32_t imm = instr->getSourceImmediate() & 0x7FFFF;
    TR::LabelSymbol *label = instr->getLabelSymbol();
    TR::Snippet *snippet = label ? label->getSnippet() : NULL;
    if (snippet)
       {
       print(pOutFile, label);
-      trfprintf(pOutFile, " (%s)", getName(snippet));
+      trfprintf(pOutFile, "(%s)", getName(snippet));
       }
    else
       {
-      trfprintf(pOutFile, " " POINTER_PRINTF_FORMAT, instr->getBinaryEncoding() + (imm << 2));
+      trfprintf(pOutFile, POINTER_PRINTF_FORMAT, instr->getBinaryEncoding() + (imm << 2));
       }
 
    trfflush(_comp->getOutFile());
@@ -1350,6 +1353,9 @@ TR_Debug::getNamea64(TR::Snippet * snippet)
       case TR::Snippet::IsUnresolvedData:
          return "Unresolved Data Snippet";
          break;
+      case TR::Snippet::IsConstantData:
+         return "Constant Data Snippet";
+         break;
       case TR::Snippet::IsRecompilation:
          return "Recompilation Snippet";
          break;
@@ -1403,7 +1409,9 @@ TR_Debug::printa64(TR::FILE *pOutFile, TR::Snippet * snippet)
       case TR::Snippet::IsUnresolvedData:
          print(pOutFile, (TR::UnresolvedDataSnippet *)snippet);
          break;
-
+      case TR::Snippet::IsConstantData:
+         print(pOutFile, (TR::ARM64ConstantDataSnippet*)snippet);
+         break;
 
       case TR::Snippet::IsMonitorExit:
       case TR::Snippet::IsMonitorEnter:

--- a/compiler/aarch64/codegen/ConstantDataSnippet.cpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.cpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "aarch64/codegen/ConstantDataSnippet.hpp"
+
+#include <stdint.h>
+#include <string.h>
+#include "codegen/CodeGenerator.hpp"
+#include "compile/Compilation.hpp"
+#include "env/CompilerEnv.hpp"
+#include "env/IO.hpp"
+#include "env/TRMemory.hpp"
+#include "env/jittypes.h"
+#include "il/LabelSymbol.hpp"
+#include "il/Node_inlines.hpp"
+#include "ras/Debug.hpp"
+#include "codegen/Relocation.hpp"
+
+namespace TR { class Node; }
+
+TR::ARM64ConstantDataSnippet::ARM64ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node * n, void *c, size_t size, TR_ExternalRelocationTargetKind reloType)
+   : TR::Snippet(cg, n, TR::LabelSymbol::create(cg->trHeapMemory(),cg), false),
+     _data(size, 0, getTypedAllocator<uint8_t>(TR::comp()->allocator())),
+     _reloType(reloType)
+   {
+   if (c)
+      memcpy(_data.data(), c, size);
+   else
+      memset(_data.data(), 0, size);
+   }
+
+
+void
+TR::ARM64ConstantDataSnippet::addMetaDataForCodeAddress(uint8_t *cursor)
+   {
+   TR::Compilation *comp = cg()->comp();
+   if (cg()->profiledPointersRequireRelocation())
+      {
+      auto reloType = _reloType;
+      auto node = getNode();
+      TR::SymbolType symbolKind = TR::SymbolType::typeClass;
+      switch (reloType)
+         {
+         case TR_RamMethod:
+         case TR_MethodPointer:
+            symbolKind = TR::SymbolType::typeMethod;
+            // intentional fall through
+         case TR_ClassPointer:
+            AOTcgDiag2(comp, "add relocation (%d) cursor=%x\n", reloType, cursor);
+            if (cg()->comp()->getOption(TR_UseSymbolValidationManager))
+               {
+               TR_ASSERT_FATAL(getData<uint8_t *>(), "Static Sym can not be NULL");
+               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                                    getData<uint8_t *>(),
+                                                                                    reinterpret_cast<uint8_t *>(symbolKind),
+                                                                                    TR_SymbolFromManager,
+                                                                                    cg()),
+                                                                                    __FILE__, __LINE__,
+                                                                                    node);
+               }
+            else
+               {
+               cg()->addExternalRelocation(new (cg()->trHeapMemory()) TR::ExternalRelocation(cursor,
+                                                                                    reinterpret_cast<uint8_t *>(node),
+                                                                                    reloType,
+                                                                                    cg()),
+                                                                                    __FILE__, __LINE__,
+                                                                                    node);
+               }
+            break;
+
+         default:
+            break;
+         }
+      }
+   else
+      {
+      if (std::find(comp->getSnippetsToBePatchedOnClassRedefinition()->begin(), comp->getSnippetsToBePatchedOnClassRedefinition()->end(), this) != comp->getSnippetsToBePatchedOnClassRedefinition()->end())
+         {
+         cg()->jitAddPicToPatchOnClassRedefinition(getData<void *>(), static_cast<void *>(cursor));
+         }
+
+      if (std::find(comp->getSnippetsToBePatchedOnClassUnload()->begin(), comp->getSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getSnippetsToBePatchedOnClassUnload()->end())
+         {
+         cg()->jitAddPicToPatchOnClassUnload(getData<void *>(), static_cast<void *>(cursor));
+         }
+
+      if (std::find(comp->getMethodSnippetsToBePatchedOnClassUnload()->begin(), comp->getMethodSnippetsToBePatchedOnClassUnload()->end(), this) != comp->getMethodSnippetsToBePatchedOnClassUnload()->end())
+         {
+         auto classPointer = cg()->fe()->createResolvedMethod(cg()->trMemory(), getData<TR_OpaqueMethodBlock *>(), comp->getCurrentMethod())->classOfMethod();
+         cg()->jitAddPicToPatchOnClassUnload(static_cast<void *>(classPointer), static_cast<void *>(cursor));
+         }
+      }
+   }
+
+
+uint8_t *TR::ARM64ConstantDataSnippet::emitSnippetBody()
+   {
+   uint8_t *cursor = cg()->getBinaryBufferCursor();
+
+   // align to 8 bytes
+   if (getDataSize() % 8 == 0)
+      {
+      cursor = (uint8_t*)(((intptrj_t)(cursor + 7)) & (~7));
+      }
+
+   getSnippetLabel()->setCodeLocation(cursor);
+
+   memcpy(cursor, getRawData(), getDataSize());
+
+   addMetaDataForCodeAddress(cursor);
+
+
+   cursor += getDataSize();
+
+   return cursor;
+   }
+
+void TR::ARM64ConstantDataSnippet::print(TR::FILE* pOutFile, TR_Debug* debug)
+   {
+   if (pOutFile == NULL)
+      return;
+
+   uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
+
+   debug->printSnippetLabel(pOutFile, getSnippetLabel(), bufferPos, debug->getName(this));
+   debug->printPrefix(pOutFile, NULL, bufferPos, getDataSize());
+
+   switch (getDataSize())
+      {
+      case 2:
+         trfprintf(pOutFile, "0x%04x | %d",
+                   0xffff & (int32_t)getData<int16_t>(),
+                   (int32_t)getData<int16_t>());
+         break;
+      case 4:
+         trfprintf(pOutFile, "0x%08x | %d | float %g",
+                   getData<int32_t>(),
+                   getData<int32_t>(),
+                   getData<float>());
+         break;
+      case 8:
+         trfprintf(pOutFile, "0x%016llx | %lld | double %g",
+                   getData<int64_t>(),
+                   getData<int64_t>(),
+                   getData<double>());
+         break;
+      default:
+         trfprintf(pOutFile, "VECTOR VALUE");
+         break;
+      }
+
+   }

--- a/compiler/aarch64/codegen/ConstantDataSnippet.hpp
+++ b/compiler/aarch64/codegen/ConstantDataSnippet.hpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ARM64CONSTANTDATASNIPPET_INCL
+#define ARM64CONSTANTDATASNIPPET_INCL
+
+#include "codegen/Snippet.hpp"
+
+#include <stdint.h>
+#include "infra/vector.hpp"
+#include "runtime/Runtime.hpp"
+
+namespace TR { class CodeGenerator; }
+namespace TR { class Node; }
+
+namespace TR {
+
+/**
+ * ConstantDataSnippet is used to hold constant data
+ */
+class ARM64ConstantDataSnippet : public TR::Snippet
+   {
+   public:
+
+   ARM64ConstantDataSnippet(TR::CodeGenerator *cg, TR::Node *n, void *c, size_t size, TR_ExternalRelocationTargetKind reloType = TR_NoRelocation);
+
+   virtual Kind                   getKind()                                { return IsConstantData; }
+   uint8_t*                       getRawData()                             { return _data.data(); }
+   virtual size_t                 getDataSize() const                      { return _data.size(); }
+   virtual uint32_t               getLength(int32_t estimatedSnippetStart) { return getDataSize(); }
+   template <typename T> inline T getData()                                { return *(reinterpret_cast<T*>(getRawData())); }
+
+   virtual uint8_t*               emitSnippetBody();
+   virtual void                   print(TR::FILE* pOutFile, TR_Debug* debug);
+   void                           addMetaDataForCodeAddress(uint8_t *cursor);
+   TR_ExternalRelocationTargetKind getReloType() { return _reloType; }
+   void                           setReloType(TR_ExternalRelocationTargetKind reloType) { _reloType = reloType; }
+
+   private:
+   TR::vector<uint8_t>            _data;
+   TR_ExternalRelocationTargetKind _reloType;
+   };
+
+}
+#endif

--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -26,6 +26,7 @@
 #include "codegen/ARM64SystemLinkage.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/CodeGenerator_inlines.hpp"
+#include "codegen/ConstantDataSnippet.hpp"
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/GCStackMap.hpp"
 #include "codegen/GenerateInstructions.hpp"
@@ -40,7 +41,7 @@
 
 OMR::ARM64::CodeGenerator::CodeGenerator() :
       OMR::CodeGenerator(),
-      _constantData(NULL),
+      _dataSnippetList(getTypedAllocator<TR::ARM64ConstantDataSnippet*>(TR::comp()->allocator())),
       _outOfLineCodeSectionList(getTypedAllocator<TR_ARM64OutOfLineCodeSection*>(self()->comp()->allocator()))
    {
    // Initialize Linkage for Code Generator
@@ -315,42 +316,68 @@ TR::Linkage *OMR::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)
 
 void OMR::ARM64::CodeGenerator::emitDataSnippets()
    {
-   TR_UNIMPLEMENTED();
-   /*
-    * Commented out until TR::ConstantDataSnippet is implemented
-   self()->setBinaryBufferCursor(_constantData->emitSnippetBody());
-    */
-   }
-
-bool OMR::ARM64::CodeGenerator::hasDataSnippets()
-   {
-   return (_constantData == NULL) ? false : true;
+   for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
+      {
+      self()->setBinaryBufferCursor((*iterator)->emitSnippetBody());
+      }
    }
 
 int32_t OMR::ARM64::CodeGenerator::setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart)
    {
-   TR_UNIMPLEMENTED();
-   return 0;
-   /*
-    * Commented out until TR::ConstantDataSnippet is implemented
-   return estimatedSnippetStart + _constantData->getLength();
-    */
+   // Assume constants should be aligned according to their size.
+   for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
+      {
+      auto size = (*iterator)->getDataSize();
+      estimatedSnippetStart = ((estimatedSnippetStart+size-1)/size) * size;
+      (*iterator)->getSnippetLabel()->setEstimatedCodeLocation(estimatedSnippetStart);
+      estimatedSnippetStart += (*iterator)->getLength(estimatedSnippetStart);
+      }
+   return estimatedSnippetStart;
+   }
+
+TR::ARM64ConstantDataSnippet *OMR::ARM64::CodeGenerator::findOrCreateConstantDataSnippet(TR::Node * node, void * c, size_t s)
+   {
+   // A simple linear search should suffice for now since the number of data constants
+   // produced is typically very small.  Eventually, this should be implemented as an
+   // ordered list or a hash table.
+   for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
+      {
+      if ((*iterator)->getKind() == TR::Snippet::IsConstantData &&
+          (*iterator)->getDataSize() == s)
+         {
+         // if pointers require relocation, then not all pointers may be relocated for the same reason
+         //   so be conservative and do not combine them (e.g. HCR versus profiled inlined site enablement)
+         if (!memcmp((*iterator)->getRawData(), c, s) &&
+                (!self()->profiledPointersRequireRelocation() || (*iterator)->getNode() == node))
+            {
+            return (*iterator);
+            }
+         }
+      }
+
+   // Constant was not found: create a new snippet for it and add it to the constant list.
+   //
+   auto snippet = new (self()->trHeapMemory()) TR::ARM64ConstantDataSnippet(self(), node, c, s);
+   _dataSnippetList.push_back(snippet);
+   return snippet;
+   }
+
+TR::ARM64ConstantDataSnippet *OMR::ARM64::CodeGenerator::findOrCreate8ByteConstant(TR::Node * n, int64_t c)
+   {
+   return self()->findOrCreateConstantDataSnippet(n, &c, 8);
    }
 
 
-#ifdef DEBUG
 void OMR::ARM64::CodeGenerator::dumpDataSnippets(TR::FILE *outFile)
    {
    if (outFile == NULL)
       return;
 
-   TR_UNIMPLEMENTED();
-   /*
-    * Commented out until TR::ConstantDataSnippet is implemented
-   _constantData->print(outFile);
-    */
+   for (auto iterator = _dataSnippetList.begin(); iterator != _dataSnippetList.end(); ++iterator)
+      {
+      (*iterator)->print(outFile, self()->getDebug());
+      }
    }
-#endif
 
 
 TR::Instruction *OMR::ARM64::CodeGenerator::generateSwitchToInterpreterPrePrologue(TR::Instruction *cursor, TR::Node *node)

--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -40,7 +40,7 @@ namespace OMR { typedef OMR::ARM64::CodeGenerator CodeGeneratorConnector; }
 
 class TR_ARM64OutOfLineCodeSection;
 namespace TR { class ARM64LinkageProperties; }
-namespace TR { class ConstantDataSnippet; }
+namespace TR { class ARM64ConstantDataSnippet; }
 
 /**
  * @brief Generates instructions for loading 32-bit integer value to a register
@@ -113,7 +113,7 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     * @brief Has data snippets or not
     * @return true if it has data snippets, false otherwise
     */
-   bool hasDataSnippets();
+   bool hasDataSnippets() { return !_dataSnippetList.empty();}
 
    /**
     * @brief Sets estimated locations for data snippet labels
@@ -122,13 +122,11 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     */
    int32_t setEstimatedLocationsForDataSnippetLabels(int32_t estimatedSnippetStart);
 
-#ifdef DEBUG
    /**
     * @brief Dumps data snippets
     * @param[in] outFile : FILE for output
     */
    void dumpDataSnippets(TR::FILE *outFile);
-#endif
 
    /**
     * @brief Generates switch-to-interpreter pre-prologue
@@ -189,6 +187,27 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
     * @param[in] label : label
     */
    void apply32BitLabelRelativeRelocation(int32_t *cursor, TR::LabelSymbol *label);
+
+   /**
+    * @brief find or create a constant data snippet for 8 byte constant.
+    *
+    * @param[in] node : the node which this constant data snippet belongs to
+    * @param[in] c    : 8 byte constant
+    *
+    * @return : a constant data snippet
+    */
+   TR::ARM64ConstantDataSnippet *findOrCreate8ByteConstant(TR::Node *node, int64_t c);
+
+   /**
+    * @brief find or create a constant data snippet.
+    *
+    * @param[in] node : the node which this constant data snippet belongs to
+    * @param[in] data : a pointer to initial data or NULL for skipping initialization
+    * @param[in] size : the size of this constant data snippet
+    *
+    * @return : a constant data snippet with specified size
+    */
+   TR::ARM64ConstantDataSnippet* findOrCreateConstantDataSnippet(TR::Node* node, void* data, size_t size);
 
    /**
     * @brief Status of IsOutOfLineHotPath flag
@@ -334,9 +353,9 @@ class OMR_EXTENSIBLE CodeGenerator : public OMR::CodeGenerator
    TR::RealRegister *_stackPtrRegister;
    TR::RealRegister *_methodMetaDataRegister;
    TR::ARM64ImmInstruction *_returnTypeInfoInstruction;
-   TR::ConstantDataSnippet *_constantData;
    const TR::ARM64LinkageProperties *_linkageProperties;
    TR::list<TR_ARM64OutOfLineCodeSection*> _outOfLineCodeSectionList;
+   TR::vector<TR::ARM64ConstantDataSnippet*> _dataSnippetList;
 
    };
 

--- a/compiler/aarch64/codegen/OMRSnippet.hpp
+++ b/compiler/aarch64/codegen/OMRSnippet.hpp
@@ -81,6 +81,7 @@ class OMR_EXTENSIBLE Snippet : public OMR::Snippet
       IsForceRecompilation,
       IsStackCheckFailure,
       IsUnresolvedData,
+      IsConstantData,
       numKinds
       };
 

--- a/jitbuilder/build/files/target/aarch64.mk
+++ b/jitbuilder/build/files/target/aarch64.mk
@@ -29,6 +29,7 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ARM64SystemLinkage.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/BinaryEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ControlFlowEvaluator.cpp \
+    $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/ConstantDataSnippet.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/FPTreeEvaluator.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/GenerateInstructions.cpp \
     $(JIT_OMR_DIRTY_DIR)/aarch64/codegen/OMRCodeGenerator.cpp \


### PR DESCRIPTION
This commit adds Constant Data Snippet for aarch64.
The code generator is changed to have a list of constant data snippets
as x/z code generator does.
The snippet adds minimal meta data to the address as ppc version does.

The data at the snippet can be loaded by `ldr` literal instruction, which does pc relative load.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>