### PR TITLE
AArch64: Add AOT relocation to address constant

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.hpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.hpp
@@ -37,6 +37,7 @@ namespace OMR { typedef OMR::ARM64::CodeGenerator CodeGeneratorConnector; }
 
 #include "codegen/RegisterConstants.hpp"
 #include "infra/Annotations.hpp"
+#include "runtime/Runtime.hpp"
 
 class TR_ARM64OutOfLineCodeSection;
 namespace TR { class ARM64LinkageProperties; }
@@ -62,6 +63,17 @@ extern TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, in
 extern TR::Instruction *loadConstant64(TR::CodeGenerator *cg, TR::Node *node, int64_t value, TR::Register *trgReg, TR::Instruction *cursor = NULL);
 
 extern TR::Instruction *loadAddressConstant(TR::CodeGenerator *cg, TR::Node *node, intptr_t value, TR::Register *trgReg, TR::Instruction *cursor=NULL, bool isPicSite=false, int16_t typeAddress=-1);
+
+ /* @brief Generates instruction for loading address constant to register using constant data snippet
+ * @param[in] cg : CodeGenerator
+ * @param[in] node: node
+ * @param[in] address : address
+ * @param[in] trgReg : target register
+ * @param[in] reloKind : relocation kind
+ * @param[in] cursor : instruction cursor
+ * @return generated instruction
+ */
+extern TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, intptrj_t address, TR::Register *trgReg, TR_ExternalRelocationTargetKind reloKind, TR::Instruction *cursor=NULL);
 
 /**
  * @brief Helper function for encoding immediate value of logic instructions.

--- a/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluator.cpp
@@ -22,6 +22,7 @@
 #include "codegen/ARM64Instruction.hpp"
 #include "codegen/ARM64ShiftCode.hpp"
 #include "codegen/CodeGenerator.hpp"
+#include "codegen/ConstantDataSnippet.hpp"
 #include "codegen/GenerateInstructions.hpp"
 #include "codegen/Linkage.hpp"
 #include "codegen/Linkage_inlines.hpp"
@@ -35,6 +36,15 @@
 #include "il/Node_inlines.hpp"
 #include "il/ParameterSymbol.hpp"
 #include "il/StaticSymbol.hpp"
+
+TR::Instruction *loadAddressConstantInSnippet(TR::CodeGenerator *cg, TR::Node *node, intptrj_t address, TR::Register *targetRegister, TR_ExternalRelocationTargetKind reloKind, TR::Instruction *cursor)
+   {
+   // We use LDR literal to load a value from the snippet. Offset to PC will be patched by LabelRelative24BitRelocation
+   auto snippet = cg->findOrCreate8ByteConstant(node, address);
+   auto labelSym = snippet->getSnippetLabel();
+   snippet->setReloType(reloKind);
+   return generateTrg1ImmSymInstruction(cg, TR::InstOpCode::ldrx, node, targetRegister, 0, labelSym, cursor);
+   }
 
 TR::Instruction *loadConstant32(TR::CodeGenerator *cg, TR::Node *node, int32_t value, TR::Register *trgReg, TR::Instruction *cursor)
    {


### PR DESCRIPTION
This commit changes aconstEvaluator to add AOT relocation
to address constant.

Depends on https://github.com/eclipse/omr/pull/4588

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>