### PR TITLE
Relocate getMonClass and addMonClass to OpenJ9

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -193,7 +193,6 @@ OMR::CodeGenerator::CodeGenerator() :
      _lastOverlappedGlobalVRF(-1),
      _overlapOffsetBetweenFPRandVRFgrns(0),
      _supportedLiveRegisterKinds(0),
-     _monitorMapping(self()->comp()->trMemory(), 256),
      _blocksWithCalls(NULL),
      _codeCache(0),
      _committedToCodeCache(false),
@@ -2584,27 +2583,6 @@ OMR::CodeGenerator::shutdown(TR_FrontEnd *fe, TR::FILE *logFile)
    {
    }
 #endif
-
-// I need to preserve the type information for monitorenter/exit through
-// code generation, but the secondChild is being used for other monitor
-// optimizations and I can't find anywhere to stick it on the TR::Node.
-// Creating the node with more children doesn't seem to help either.
-//
-void
-OMR::CodeGenerator::addMonClass(TR::Node* monNode, TR_OpaqueClassBlock* clazz)
-   {
-   _monitorMapping.add(monNode);
-   _monitorMapping.add(clazz);
-   }
-
-TR_OpaqueClassBlock *
-OMR::CodeGenerator::getMonClass(TR::Node* monNode)
-   {
-   for (int i = 0; i < _monitorMapping.size(); i += 2)
-      if (_monitorMapping[i] == monNode)
-         return (TR_OpaqueClassBlock *) _monitorMapping[i+1];
-   return 0;
-   }
 
 
 #if !(defined(TR_HOST_POWER) && (defined(__IBMC__) || defined(__IBMCPP__) || defined(__ibmxl__)))

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1352,9 +1352,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg) { return false; }
 
-   // J9 only, move to trj9
-   TR_OpaqueClassBlock* getMonClass(TR::Node* monNode);
-
    void setCurrentBlock(TR::Block *b);
    TR::Block *getCurrentBlock() { return _currentBlock; }
 
@@ -1895,8 +1892,6 @@ class OMR_EXTENSIBLE CodeGenerator
    
 
 
-   TR_Array<void *> _monitorMapping;
-
    uint32_t _largestOutgoingArgSize;
 
    uint32_t _estimatedCodeLength;
@@ -1942,8 +1937,6 @@ class OMR_EXTENSIBLE CodeGenerator
    protected:
 
    bool _disableInternalPointers;
-
-   void addMonClass(TR::Node* monNode, TR_OpaqueClassBlock* clazz);
 
    TR::RegisterIterator *_gpRegisterIterator;
    TR::RegisterIterator *_fpRegisterIterator;


### PR DESCRIPTION
Relocate getMonClass and addMonClass to OpenJ9

The OMR::CodeGenerator functions- getMonClass and addMonClass are
relocated to OpenJ9 CodeGenerator and removed from OMR.

The changes also include the array- _monitorMapping moving from OMR
to OpenJ9.

Closes: #1869

Signed-off-by: Md. Alvee Noor <mnoor@unb.ca>