### PR TITLE
Fixes to match prototypes to old socket API

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1692,7 +1692,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsock.c::omrsock_getaddrinfo_length "omrsock_getaddrinfo_length"*/
 	int32_t (*sock_getaddrinfo_length)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length) ;
 	/** see @ref omrsock.c::omrsock_getaddrinfo_family "omrsock_getaddrinfo_family"*/
-	int32_t (*sock_getaddrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int32_t index )	;
+	int32_t (*sock_getaddrinfo_family)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index )	;
 	/** see @ref omrsock.c::omrsock_getaddrinfo_socktype "omrsock_getaddrinfo_socktype"*/
 	int32_t (*sock_getaddrinfo_socktype)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index) ;
 	/** see @ref omrsock.c::omrsock_getaddrinfo_protocol "omrsock_getaddrinfo_protocol"*/
@@ -1700,7 +1700,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsock.c::omrsock_freeaddrinfo "omrsock_freeaddrinfo"*/
 	int32_t (*sock_freeaddrinfo)(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle) ;
 	/** see @ref omrsock.c::omrsock_socket "omrsock_socket"*/
-	int32_t (*sock_socket)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol) ;
+	int32_t (*sock_socket)(struct OMRPortLibrary *portLibrary, omrsock_socket_t *sock, int32_t family, int32_t socktype, int32_t protocol) ;
 	/** see @ref omrsock.c::omrsock_bind "omrsock_bind"*/
 	int32_t (*sock_bind)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr) ;
 	/** see @ref omrsock.c::omrsock_listen "omrsock_listen"*/
@@ -1718,7 +1718,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsock.c::omrsock_recvfrom "omrsock_recvfrom"*/
 	int32_t (*sock_recvfrom)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle) ;
 	/** see @ref omrsock.c::omrsock_close "omrsock_close"*/
-	int32_t (*sock_close)(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock) ;
+	int32_t (*sock_close)(struct OMRPortLibrary *portLibrary, omrsock_socket_t *sock) ;
 #if defined(OMR_OPT_CUDA)
 	/** CUDA configuration data */
 	J9CudaConfig *cuda_configData;

--- a/port/common/omrsock.c
+++ b/port/common/omrsock.c
@@ -105,7 +105,7 @@ omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_
  * @return 0, if no errors occurred, otherwise return an error.
  */
 int32_t
-omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int32_t index)
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
@@ -171,7 +171,7 @@ omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hand
  * @return 0, if no errors occurred, otherwise return an error.
  */
 int32_t
-omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol)
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t *sock, int32_t family, int32_t socktype, int32_t protocol)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }
@@ -362,7 +362,7 @@ omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint
  * @return 0, if no errors occurred, otherwise return an error.
  */
 int32_t
-omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock)
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t *sock)
 {
 	return OMRPORT_ERROR_NOT_SUPPORTED_ON_THIS_PLATFORM;
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -608,7 +608,7 @@ omrsock_getaddrinfo(struct OMRPortLibrary *portLibrary, char *node, char *servic
 extern J9_CFUNC int32_t
 omrsock_getaddrinfo_length(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t hints, uint32_t *length);
 extern J9_CFUNC int32_t
-omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t *handle, int32_t *family, int32_t index);
+omrsock_getaddrinfo_family(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *family, int32_t index);
 extern J9_CFUNC int32_t
 omrsock_getaddrinfo_socktype(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle, int32_t *socktype, int32_t index);
 extern J9_CFUNC int32_t
@@ -616,7 +616,7 @@ omrsock_getaddrinfo_protocol(struct OMRPortLibrary *portLibrary, omrsock_addrinf
 extern J9_CFUNC int32_t
 omrsock_freeaddrinfo(struct OMRPortLibrary *portLibrary, omrsock_addrinfo_t handle);
 extern J9_CFUNC int32_t
-omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, int32_t family, int32_t socktype, int32_t protocol);
+omrsock_socket(struct OMRPortLibrary *portLibrary, omrsock_socket_t *sock, int32_t family, int32_t socktype, int32_t protocol);
 extern J9_CFUNC int32_t
 omrsock_bind(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, omrsock_sockaddr_t addr);
 extern J9_CFUNC int32_t
@@ -634,7 +634,7 @@ omrsock_recv(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t 
 extern J9_CFUNC int32_t
 omrsock_recvfrom(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock, uint8_t *buf, int32_t nbyte, int32_t flags, omrsock_sockaddr_t addrHandle);
 extern J9_CFUNC int32_t
-omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t sock);
+omrsock_close(struct OMRPortLibrary *portLibrary, omrsock_socket_t *sock);
 
 /* J9SourceJ9Str*/
 extern J9_CFUNC uintptr_t


### PR DESCRIPTION
Decided to match with old API until new socket API is done implementing.

-Made sure the function prototypes have the same arguments

Issue: #4102

Signed-off-by: Haley Cao <haleycao88@hotmail.com>