### PR TITLE
Add byte and short multiplier on x86

### DIFF
--- a/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/amd64/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,8 +120,8 @@
    TR::TreeEvaluator::integerMulEvaluator,                             // TR::lmul
    TR::TreeEvaluator::fmulEvaluator,                                   // TR::fmul
    TR::TreeEvaluator::dmulEvaluator,                                   // TR::dmul
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::bmul
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::smul
+   TR::TreeEvaluator::integerMulEvaluator,                             // TR::bmul
+   TR::TreeEvaluator::integerMulEvaluator,                             // TR::smul
    TR::TreeEvaluator::integerDivOrRemEvaluator,                        // TR::idiv
    TR::TreeEvaluator::integerDivOrRemEvaluator,                        // TR::ldiv
    TR::TreeEvaluator::fdivEvaluator,                                   // TR::fdiv

--- a/compiler/x/codegen/X86Ops.hpp
+++ b/compiler/x/codegen/X86Ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -187,6 +187,38 @@ inline TR_X86OpCodes SubMemImm4 (bool is64Bit, bool isWithBorrow) { return isWit
 inline TR_X86OpCodes SubMemReg  (bool is64Bit, bool isWithBorrow) { return isWithBorrow  ? SBBMemReg(is64Bit)  : SUBMemReg(is64Bit)  ; }
 inline TR_X86OpCodes SubRegReg  (bool is64Bit, bool isWithBorrow) { return isWithBorrow  ? SBBRegReg(is64Bit)  : SUBRegReg(is64Bit)  ; }
 inline TR_X86OpCodes SubRegMem  (bool is64Bit, bool isWithBorrow) { return isWithBorrow  ? SBBRegMem(is64Bit)  : SUBRegMem(is64Bit)  ; }
+
+//Broader sized parameterized opcodes 
+template <TR_X86OpCodes Op64, TR_X86OpCodes Op32, TR_X86OpCodes Op16, TR_X86OpCodes Op8>
+inline TR_X86OpCodes SizedParameterizedOpCode(int size =
+#ifdef TR_TARGET_64BIT
+   8
+#else
+   4
+#endif
+)
+   {
+   TR_X86OpCodes op = BADIA32Op;
+   switch (size)
+      {
+      case 8:  op = Op64;      break;
+      case 4:  op = Op32;      break;
+      case 2:  op = Op16;      break;
+      case 1:  op = Op8;       break;
+      default: op = BADIA32Op; break;
+      }
+   TR_ASSERT(op != BADIA32Op , "Unsupported operand size %d", size);
+   return op;
+   }
+
+// Data type based opcodes
+#define MovRegReg      SizedParameterizedOpCode<MOV8RegReg      , MOV4RegReg      , MOV2RegReg      , MOV1RegReg  >
+#define IMulRegReg     SizedParameterizedOpCode<IMUL8RegReg     , IMUL4RegReg     , IMUL2RegReg     , IMUL1AccReg >
+#define IMulRegMem     SizedParameterizedOpCode<IMUL8RegMem     , IMUL4RegMem     , IMUL2RegMem     , IMUL1AccMem >
+#define IMulRegRegImms SizedParameterizedOpCode<IMUL8RegRegImms , IMUL4RegRegImms , IMUL2RegRegImms , BADIA32Op   >
+#define IMulRegRegImm4 SizedParameterizedOpCode<IMUL8RegRegImm4 , IMUL4RegRegImm4 , IMUL2RegRegImm2 , BADIA32Op   >
+#define IMulRegMemImms SizedParameterizedOpCode<IMUL8RegMemImms , IMUL4RegMemImms , IMUL2RegMemImms , BADIA32Op   >
+#define IMulRegMemImm4 SizedParameterizedOpCode<IMUL8RegMemImm4 , IMUL4RegMemImm4 , IMUL2RegMemImm2 , BADIA32Op   >
 
 // Property flags
 //

--- a/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/x/i386/codegen/OMRTreeEvaluatorTable.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -120,8 +120,8 @@
    TR::TreeEvaluator::integerPairMulEvaluator,                         // TR::lmul
    TR::TreeEvaluator::fmulEvaluator,                                   // TR::fmul
    TR::TreeEvaluator::dmulEvaluator,                                   // TR::dmul
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::bmul
-   TR::TreeEvaluator::unImpOpEvaluator,                                // TR::smul
+   TR::TreeEvaluator::integerMulEvaluator,                             // TR::bmul
+   TR::TreeEvaluator::integerMulEvaluator,                             // TR::smul
    TR::TreeEvaluator::integerDivOrRemEvaluator,                        // TR::idiv
    TR::TreeEvaluator::unImpOpEvaluator,                                // TR::ldiv
    TR::TreeEvaluator::fdivEvaluator,                                   // TR::fdiv

--- a/fvtest/compilertriltest/ArithmeticTest.cpp
+++ b/fvtest/compilertriltest/ArithmeticTest.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -323,9 +323,6 @@ TEST_P(Int16Arithmetic, UsingConst) {
     SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
         << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
-        << "smul/sdiv not yet implemented on x86 (see Issue #4408)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -361,9 +358,6 @@ TEST_P(Int16Arithmetic, UsingLoadParam) {
     SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
         << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
 
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
-        << "smul/sdiv not yet implemented on x86 (see Issue #4408)";
-
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};
@@ -394,9 +388,6 @@ TEST_P(Int8Arithmetic, UsingConst) {
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
     SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
         << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
-
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
-        << "bmul/bdiv not yet implemented on x86 (see Issue #4408)";
 
     auto param = TRTest::to_struct(GetParam());
 
@@ -432,8 +423,6 @@ TEST_P(Int8Arithmetic, UsingLoadParam) {
         << "The Z code generator incorrectly spills sub-integer types arguments (see issue #3525)";
     SKIP_IF(OMRPORT_ARCH_PPC64 == arch || OMRPORT_ARCH_PPC == arch, KnownBug)
         << "The Power code generator incorrectly spills sub-integer type arguments on big-endian machines (see issue #3525)";
-    SKIP_IF(OMRPORT_ARCH_X86 == arch || OMRPORT_ARCH_HAMMER == arch, MissingImplementation)
-        << "bmul/bdiv not yet implemented on x86 (see Issue #4408)";
     auto param = TRTest::to_struct(GetParam());
 
     char inputTrees[1024] = {0};

--- a/fvtest/compilertriltest/JitTest.hpp
+++ b/fvtest/compilertriltest/JitTest.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corp. and others
+ * Copyright (c) 2017, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -305,6 +305,7 @@ template <typename T> const T one_value() { return static_cast<T>(1); }
 template <typename T> const T negative_one_value() { return static_cast<T>(-1); }
 template <typename T> const T positive_value() { return static_cast<T>(42); }
 template <typename T> const T negative_value() { return static_cast<T>(-42); }
+template <typename T> const T two_square_value() { return static_cast<T>(64); }
 
 /**
  * @brief Convenience function returning possible test inputs of the specified type
@@ -317,6 +318,7 @@ std::vector<T> const_values()
                       negative_one_value<T>(),
                       positive_value<T>(),
                       negative_value<T>(),
+                      two_square_value<T>(),
                       std::numeric_limits<T>::min(),
                       std::numeric_limits<T>::max(),
                       static_cast<T>(std::numeric_limits<T>::min() + 1),
@@ -337,6 +339,7 @@ inline std::vector<int64_t> const_values<int64_t>()
                       negative_one_value<int64_t>(),
                       positive_value<int64_t>(),
                       negative_value<int64_t>(),
+                      two_square_value<int64_t>(),
                       std::numeric_limits<int64_t>::min(),
                       std::numeric_limits<int64_t>::max(),
                       static_cast<int64_t>(std::numeric_limits<int64_t>::min() + 1),
@@ -365,6 +368,7 @@ inline std::vector<uint64_t> const_values<uint64_t>()
                       negative_one_value<uint64_t>(),
                       positive_value<uint64_t>(),
                       negative_value<uint64_t>(),
+                      two_square_value<uint64_t>(),
                       std::numeric_limits<uint64_t>::min(),
                       std::numeric_limits<uint64_t>::max(),
                       static_cast<uint64_t>(std::numeric_limits<uint64_t>::min() + 1),
@@ -397,6 +401,7 @@ inline std::vector<int32_t> const_values<int32_t>()
                       negative_one_value<int32_t>(),
                       positive_value<int32_t>(),
                       negative_value<int32_t>(),
+                      two_square_value<int32_t>(),
                       std::numeric_limits<int32_t>::min(),
                       std::numeric_limits<int32_t>::max(),
                       static_cast<int32_t>(std::numeric_limits<int32_t>::min() + 1),
@@ -423,6 +428,7 @@ inline std::vector<uint32_t> const_values<uint32_t>()
                       negative_one_value<uint32_t>(),
                       positive_value<uint32_t>(),
                       negative_value<uint32_t>(),
+                      two_square_value<uint32_t>(),
                       std::numeric_limits<uint32_t>::min(),
                       std::numeric_limits<uint32_t>::max(),
                       static_cast<uint32_t>(std::numeric_limits<uint32_t>::min() + 1),


### PR DESCRIPTION
Implementation for bmul and smul evaluators and change TRIL to reenable the corresponding tests.

Closes: #4408