### PR TITLE
WIP: AArch64: Temporary workaround for iuconstEvaluator

### DIFF
--- a/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
+++ b/compiler/aarch64/codegen/OMRTreeEvaluatorTable.hpp
@@ -532,7 +532,7 @@
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vlRegStoreEvaluator ,	// TR::vlRegStore	// Store vector global register
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vfRegStoreEvaluator ,	// TR::vfRegStore	// Store vector global register
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::vdRegStoreEvaluator ,	// TR::vdRegStore	// Store vector global register
-    TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iuconstEvaluator ,	// TR::iuconst		// load unsigned integer constant (32-but unsigned)
+    TR::TreeEvaluator::iuconstEvaluator ,	// TR::iuconst		// load unsigned integer constant (32-but unsigned)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::luconstEvaluator ,	// TR::luconst		// load unsigned long integer constant (64-bit unsigned)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::buconstEvaluator ,	// TR::buconst		// load unsigned byte integer constant (8-bit unsigned)
     TR::TreeEvaluator::unImpOpEvaluator ,        // TODO:ARM64: Enable when Implemented: TR::TreeEvaluator::iuloadEvaluator ,	// TR::iuload		// load unsigned integer

--- a/compiler/aarch64/codegen/UnaryEvaluator.cpp
+++ b/compiler/aarch64/codegen/UnaryEvaluator.cpp
@@ -68,6 +68,13 @@ TR::Register *OMR::ARM64::TreeEvaluator::lconstEvaluator(TR::Node *node, TR::Cod
    return node->setRegister(tempReg);
    }
 
+TR::Register *OMR::ARM64::TreeEvaluator::iuconstEvaluator(TR::Node *node, TR::CodeGenerator *cg)
+   {
+   // Only temporary
+   cg->comp()->failCompilation<TR::AssertionFailure>("iuconstEvaluator");
+   return NULL;
+   }
+
 TR::Register *OMR::ARM64::TreeEvaluator::inegEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Node *firstChild = node->getFirstChild();


### PR DESCRIPTION
This commit adds iuconstEvaluator() for AArch64 that fails immediately
as a temporary workaround.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>