### PR TITLE
Add option disabling inline JSR292 without peeking

### DIFF
--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -429,6 +429,7 @@ TR::OptionTable OMR::Options::_jitOptions[] = {
    {"disableMergeNew",                    "O\tdisable merge new",                              SET_OPTION_BIT(TR_DisableMergeNew), "F"},
    {"disableMergeStackMaps",              "O\tdisable stack map merging",                      SET_OPTION_BIT(TR_DisableMergeStackMaps), "P"},
    {"disableMetadataReclamation",         "I\tdisable J9JITExceptionTable reclamation", SET_OPTION_BIT(TR_DisableMetadataReclamation), "F", NOT_IN_SUBSET},
+   {"disableMethodHandleInlineWithoutPeeking", "O\tInline method handle thunks using peeking in inliner ", SET_OPTION_BIT(TR_DisableMHInlineWithoutPeeking), "F" },
    {"disableMethodHandleInvokeOpts",      "O\tdo not perform any special optimizations on calls to MethodHandle.invoke",   SET_OPTION_BIT(TR_DisableMethodHandleInvokeOpts), "F", NOT_IN_SUBSET},
    {"disableMethodHandleThunks",          "D\tdo not produce jitted bodies to accelerate JSR292 MethodHandle invocation",   SET_OPTION_BIT(TR_DisableMethodHandleThunks), "F", NOT_IN_SUBSET},
    {"disableMethodIsCold",                "O\tdo not use heuristics to determine whether whole methods are cold based on how many times they have been interpreted",   SET_OPTION_BIT(TR_DisableMethodIsCold), "F"},

--- a/compiler/control/OMROptions.hpp
+++ b/compiler/control/OMROptions.hpp
@@ -355,7 +355,7 @@ enum TR_CompilationOptions
    // Available                           = 0x08000000 + 8,
    TR_DisableLiveRangeSplitter            = 0x10000000 + 8,
    TR_DisableHalfSlotSpills               = 0x20000000 + 8,
-   // Available                           = 0x40000000 + 8,
+   TR_DisableMHInlineWithoutPeeking       = 0x40000000 + 8,
    // Available                           = 0x80000000 + 8,
 
 


### PR DESCRIPTION
Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>