### PR TITLE
Added ASTToTRNode class to refactor Tril ilgen

### DIFF
--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/ilgen/OMRTypeDictionary.cpp
+++ b/compiler/ilgen/OMRTypeDictionary.cpp
@@ -447,6 +447,14 @@ OMR::TypeDictionary::MemoryManager::~MemoryManager()
    ::operator delete(_segmentProvider, TR::Compiler->persistentAllocator());
    }
 
+// Copy constructor is private but it must be defined
+// to avoid undefined behavior, since we can't use `delete`
+OMR::TypeDictionary::TypeDictionary(const TypeDictionary &src) : 
+   _client(0),
+   _structsByName(str_comparator, trMemory()->heapMemoryRegion()),
+   _unionsByName(str_comparator, trMemory()->heapMemoryRegion()) 
+   {}
+
 OMR::TypeDictionary::TypeDictionary() :
    _client(0),
    _structsByName(str_comparator, trMemory()->heapMemoryRegion()),

--- a/compiler/ilgen/OMRTypeDictionary.hpp
+++ b/compiler/ilgen/OMRTypeDictionary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corp. and others
+ * Copyright (c) 2016, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this

--- a/compiler/ilgen/OMRTypeDictionary.hpp
+++ b/compiler/ilgen/OMRTypeDictionary.hpp
@@ -45,11 +45,11 @@ namespace OMR
 
 class TypeDictionary
    {
+   TypeDictionary(const TypeDictionary &src); // = delete;
 public:
    TR_ALLOC(TR_Memory::IlGenerator)
 
    TypeDictionary();
-   TypeDictionary(const TypeDictionary &src); // = delete;
    ~TypeDictionary() throw();
 
    TR::IlType * LookupStruct(const char *structName);

--- a/fvtest/tril/test/IlGenTest.cpp
+++ b/fvtest/tril/test/IlGenTest.cpp
@@ -50,7 +50,10 @@ TEST_F(IlGenTest, Return3) {
     auto Int32 = types.PrimitiveType(TR::Int32);
     TR::IlType* argTypes[] = { Int32 };
 
-    Tril::TRLangBuilder injector(trees, &types);
+    Tril::GenericNodeConverter genericNodeConverter;
+    Tril::CallConverter callConverter(&genericNodeConverter);
+
+    Tril::TRLangBuilder injector(trees, &types, &callConverter);
     TR::ResolvedMethod compilee(__FILE__, LINETOSTR(__LINE__), "Return3InIL", sizeof(argTypes)/sizeof(TR::IlType*), argTypes, Int32, 0, &injector);
     TR::IlGeneratorMethodDetails methodDetails(&compilee);
     int32_t rc = 0;

--- a/fvtest/tril/tril/CMakeLists.txt
+++ b/fvtest/tril/tril/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(tril STATIC
 	ast.cpp
 	parser.cpp
 	ilgen.cpp
+	CallConverter.cpp
+	GenericNodeConverter.cpp
 	simple_compiler.cpp
 )
 

--- a/fvtest/tril/tril/CallConverter.cpp
+++ b/fvtest/tril/tril/CallConverter.cpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "CallConverter.hpp"
+#include "ilgen.hpp"
+
+namespace Tril {
+
+TR::Node* CallConverter::impl(const ASTNode* tree, IlGenState* state) {
+    TR::Node* node = NULL;
+    auto childCount = tree->getChildCount();
+    auto opcode = OpCodeTable(tree->getName());
+    if (opcode.isCall()) {
+        auto compilation = TR::comp();
+
+        const auto addressArg = tree->getArgByName("address");
+        if (addressArg == NULL) {
+            TraceIL("  Found call without required address associated\n");
+            throw CallGenError("Found call without required address associated");
+        }
+        /* I don't want to extend the ASTValue type system to include pointers at this moment,
+        * so for now, we do the reinterpret_cast to pointer type from long
+        */
+#if defined(OMR_ENV_DATA64)
+            TraceIL("  is call with target 0x%016llX", addressArg->getValue()->get<uintptr_t>());
+#else
+            TraceIL("  is call with target 0x%08lX", addressArg->getValue()->get<uintptr_t>());
+#endif /* OMR_ENV_DATA64 */
+            const auto targetAddress = reinterpret_cast<void*>(addressArg->getValue()->get<uintptr_t>());
+
+            /* To generate a call, will create a ResolvedMethodSymbol, but we need to know the
+            * signature. The return type is intuitable from the call node, but the arguments
+            * must be provided explicitly, hence the args list, that mimics the args list of
+            * (method ...)
+            */
+            const auto argList = parseArgTypes(tree);
+            auto argIlTypes = std::vector<TR::IlType*>(argList.size());
+            auto output = argIlTypes.begin();
+            for (auto iter = argList.begin(); iter != argList.end(); iter++, output++) {
+                *output = state->getTypes()->PrimitiveType(*iter);
+            }
+            auto returnIlType = state->getTypes()->PrimitiveType(opcode.getType());
+            TR::ResolvedMethod* method = new (compilation->trHeapMemory()) TR::ResolvedMethod("file",
+                                                                                            "line",
+                                                                                            "name",
+                                                                                            argIlTypes.size(),
+                                                                                            &argIlTypes[0],
+                                                                                            returnIlType,
+                                                                                            targetAddress,
+                                                                                            0);
+            
+            TR::SymbolReference *methodSymRef = state->symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, method);
+
+            /* Default linkage is always system, unless overridden */
+            TR_LinkageConventions linkageConvention = TR_System;
+
+            /* Calls can have a customized linkage */
+            const auto* linkageArg= tree->getArgByName("linkage");
+            if (linkageArg != NULL) {
+                const auto* linkageString = linkageArg->getValue()->getString();
+                linkageConvention = convertStringToLinkage(linkageString);
+                if (linkageConvention == TR_None) {
+                    TraceIL("  failed to find customized linkage %s, aborting parsing\n", linkageString);
+                    std::string linkageString_str(linkageString);
+                    throw CallGenError("Failed to find customized linkage " + linkageString_str + ", aborting parsing");              
+                }
+                TraceIL("  customizing linakge of call to %s (linkageConvention=%d)\n", linkageString, linkageConvention);
+            }
+
+            /* Set linkage explicitly */
+            methodSymRef->getSymbol()->castToMethodSymbol()->setLinkage(linkageConvention);
+            return TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, methodSymRef);
+     }
+     else {
+        return NULL;
+     }
+}
+
+} // namespace Tril

--- a/fvtest/tril/tril/CallConverter.hpp
+++ b/fvtest/tril/tril/CallConverter.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef CALLCONVERTER_HPP
+#define CALLCONVERTER_HPP
+
+#include "converter.hpp"
+
+namespace Tril {
+
+class CallConverter: public ASTToTRNode {
+    public:
+        /**
+         * @brief Constructs an instance of Tril::CallConverter
+         * @param next is the next object that gets a chance to convert the AST node if the current on fails
+         */
+        explicit CallConverter(ASTToTRNode* next = NULL) : ASTToTRNode(next) {}
+
+    protected:
+        /**
+         * @brief Generates the TR::Node for AST structure if the opcode isCall
+         * @param tree the AST structure
+         * @param state the object that encapsulating the IL generator state
+         * @return TR::Node represented by the AST
+         */
+        TR::Node* impl(const ASTNode* tree, IlGenState* state); /* override */
+};
+
+class CallGenError : public ILGenError {
+    public:
+	    explicit CallGenError(std::string message): ILGenError(message) {}
+};
+
+}
+#endif

--- a/fvtest/tril/tril/GenericNodeConverter.cpp
+++ b/fvtest/tril/tril/GenericNodeConverter.cpp
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#include "GenericNodeConverter.hpp"
+#include "ilgen.hpp"
+
+namespace Tril {
+
+TR::Node* GenericNodeConverter::impl(const ASTNode* tree, IlGenState* state) {
+    TR::Node* node = NULL;
+
+    auto childCount = tree->getChildCount();
+
+    if (strcmp("@id", tree->getName()) == 0) {
+        auto id = tree->getPositionalArg(0)->getValue()->getString();
+        auto iter = state->findNodeByID(id);
+        if (iter != state->nodeMapEnd()) {
+            auto n = iter->second;
+            TraceIL("Commoning node n%dn (%p) from ASTNode %p (@id \"%s\")\n",n->getGlobalIndex(), n, tree, id);
+            return n;
+        }
+        else {
+            TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
+            std::string id_str(id);
+            throw GenericNodeGenError("Failed to find node for commoning (@id  \"" + id_str + "\")");
+        }
+    }
+    else if (strcmp("@common", tree->getName()) == 0) {
+        auto id = tree->getArgByName("id")->getValue()->getString();
+        TraceIL("WARNING: Using @common is deprecated. Please use (@id \"%s\") instead.\n", id);
+        fprintf(stderr, "WARNING: Using @common is deprecated. Please use (@id \"%s\") instead.", id);
+        auto iter = state->findNodeByID(id);
+        if (iter != state->nodeMapEnd()) {
+            auto n = iter->second;
+            TraceIL("Commoning node n%dn (%p) from ASTNode %p (@id \"%s\")\n", n->getGlobalIndex(), n, tree, id);
+            return n;
+        }
+        else {
+            std::string id_str(id);
+            TraceIL("Failed to find node for commoning (@id \"%s\")\n", id);
+            throw GenericNodeGenError("Failed to find node for commoning (@id  \"" + id_str + "\")");
+        }
+    }
+
+    auto opcode = OpCodeTable(tree->getName());
+
+    TraceIL("Creating %s from ASTNode %p\n", opcode.getName(), tree);
+    if (opcode.isLoadConst()) {
+        TraceIL("  is load const of ", "");
+        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
+        auto value = tree->getPositionalArg(0)->getValue();
+
+        // assume the constant to be loaded is the first argument of the AST node
+        if (opcode.isIntegerOrAddress()) {
+            auto v = value->get<int64_t>();
+            node->set64bitIntegralValue(v);
+            TraceIL("integral value %d\n", v);
+        }
+        else {
+            switch (opcode.getType()) {
+                case TR::Float:
+                    node->setFloat(value->get<float>());
+                    break;
+                case TR::Double:
+                    node->setDouble(value->get<double>());
+                    break;
+                default:
+                    throw GenericNodeGenError("Failed to find node type when opcode isLoadConst");
+            }
+            TraceIL("floating point value %f\n", value->getFloatingPoint());
+        }
+    }
+    else if (opcode.isLoadDirect()) {
+        TraceIL("  is direct load of ", "");
+
+        // the name of the first argument tells us what kind of symref we're loading
+        if (tree->getArgByName("parm") != NULL) {
+            auto arg = tree->getArgByName("parm")->getValue()->get<int32_t>();
+            TraceIL("parameter %d\n", arg);
+            auto symref = state->symRefTab()->findOrCreateAutoSymbol(state->methodSymbol(), arg, opcode.getType() );
+            node = TR::Node::createLoad(symref);
+        }
+        else if (tree->getArgByName("temp") != NULL) {
+            const auto symName = tree->getArgByName("temp")->getValue()->getString();
+            TraceIL("temporary %s\n", symName);
+            auto symref = state->findSymRefByName(symName)->second;
+            node = TR::Node::createLoad(symref);
+        }
+        else {
+            // symref kind not recognized
+            throw GenericNodeGenError("Failed to recognized symref kind when opcode isLoadDirect");
+        }
+    }
+    else if (opcode.isStoreDirect()) {
+        TraceIL("  is direct store of ", "");
+
+        // the name of the first argument tells us what kind of symref we're storing to
+        if (tree->getArgByName("temp") != NULL) {
+            const auto symName = tree->getArgByName("temp")->getValue()->getString();
+            TraceIL("temporary %s\n", symName);
+
+            // check if a symref has already been created for the temp
+            // and if not, create one
+            if (state->findSymRefByName(symName) == state->symRefMapEnd()) {
+                state->setSymRefPair(symName, state->symRefTab()->createTemporary(state->methodSymbol(), opcode.getDataType()));
+            }
+
+            auto symref = state->findSymRefByName(symName)->second;
+            node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
+        }
+        else {
+            // symref kind not recognized
+            throw GenericNodeGenError("Failed to recognize symref kind when opcode isStoreDirect");
+        }
+    }
+    else if (opcode.isLoadIndirect() || opcode.isStoreIndirect()) {
+        TraceIL("  is indirect store/load with ");
+        // If not specified, offset will default to zero.
+        int32_t offset = 0;
+        if (tree->getArgByName("offset")) {
+            offset = tree->getArgByName("offset")->getValue()->get<int32_t>();
+        } else {
+            TraceIL(" (default) ");
+        }
+        TraceIL("offset %d ", offset);
+
+        const auto name = tree->getName();
+        auto compilation = TR::comp();
+        TR::DataType type;
+        if (opcode.isVector()) {
+            // Vector types in TR IL are "typeless", insofar as they are
+            // supposed to infer the vector type depending on the children.
+            // Loads determine their data type based on the symref. However,
+            // given that we are creating a symref here, we need a hint as to
+            // what type of symref to create. So, vloadi and vstorei will take
+            // an extra argument "type" to annotate the type desired.
+            if (tree->getArgByName("type") != NULL) {
+                auto nameoftype = tree->getArgByName("type")->getValue()->getString();
+                type = getTRDataTypes(nameoftype);
+                TraceIL(" of vector type %s\n", nameoftype);
+            } else {
+                throw GenericNodeGenError("Failed to find argument with name type");
+            }
+        } else {
+            TraceIL("\n");
+            type = opcode.getType();
+        }
+        TR::Symbol* sym = TR::Symbol::createNamedShadow(compilation->trHeapMemory(), type, TR::DataType::getSize(opcode.getType()), (char*)name);
+        TR::SymbolReference* symref = new (compilation->trHeapMemory()) TR::SymbolReference(compilation->getSymRefTab(), sym, compilation->getMethodSymbol()->getResolvedMethodIndex(), -1);
+        symref->setOffset(offset);
+        node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
+    }
+    else if (opcode.isIf()) {
+        const auto targetName = tree->getArgByName("target")->getValue()->getString();
+        auto targetId = state->findBlockByName(targetName);
+        auto targetEntry = state->blocks()[targetId]->getEntry();
+        TraceIL("  is if with target block %d (%s, entry = %p", targetId, targetName, targetEntry);
+
+        /* If jumps must be created using `TR::Node::createif()`, which expected
+        * two child nodes to be given as argument. However, because children
+        * are only processed at the end, we create a dummy `BadILOp` node and
+        * pass it as both the first and second child. When the children are
+        * eventually created, they will override the dummy.
+        */
+        auto c1 = TR::Node::create(TR::BadILOp);
+        auto c2 = c1;
+        TraceIL("  created temporary %s n%dn (%p)\n", c1->getOpCode().getName(), c1->getGlobalIndex(), c1);
+        node = TR::Node::createif(opcode.getOpCodeValue(), c1, c2, targetEntry);
+    }
+    else if (opcode.isBranch()) {
+        const auto targetName = tree->getArgByName("target")->getValue()->getString();
+        auto targetId = state->findBlockByName(targetName);
+        auto targetEntry = state->blocks()[targetId]->getEntry();
+        TraceIL("  is branch to target block %d (%s, entry = %p", targetId, targetName, targetEntry);
+        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
+        node->setBranchDestination(targetEntry);
+    }
+    else {
+        TraceIL("  unrecognized opcode; using default creation mechanism\n", "");
+        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
+    }
+    return node;
+}
+
+} // namespace Tril

--- a/fvtest/tril/tril/GenericNodeConverter.hpp
+++ b/fvtest/tril/tril/GenericNodeConverter.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef GENERICNODECONVERTER_HPP
+#define GENERICNODECONVERTER_HPP
+
+#include "converter.hpp"
+
+namespace Tril {
+
+class ASTToTRNode;
+
+class GenericNodeConverter: public ASTToTRNode {
+    public:
+        /**
+         * @brief Constructs an instance of Tril::GenericNodeConverter
+         * @param next is the next object that gets a chance to convert the AST node if the current on fails
+         */
+        explicit GenericNodeConverter(ASTToTRNode* next = NULL) : ASTToTRNode(next) {}
+
+    protected:
+        /**
+         * @brief Generates the TR::Node for AST structure based on the opcode type
+         * @param tree the AST structure
+         * @param state the object that encapsulating the IL generator state
+         * @return TR::Node represented by the AST 
+         */
+        TR::Node* impl(const ASTNode* tree, IlGenState* state); /* override */
+};
+
+class GenericNodeGenError : public ILGenError {
+    public:
+	    explicit GenericNodeGenError(std::string message): ILGenError(message) {}
+};
+
+}
+#endif

--- a/fvtest/tril/tril/converter.hpp
+++ b/fvtest/tril/tril/converter.hpp
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ASTTOTRNODE_HPP
+#define ASTTOTRNODE_HPP
+
+#include "ast.hpp"
+#include "ilgen/TypeDictionary.hpp"
+#include "state.hpp"
+
+#define TraceEnabled    (state->comp()->getOption(TR_TraceILGen))
+#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(state->comp(), m, ##__VA_ARGS__);}}
+
+namespace Tril {
+
+class ASTToTRNode {
+    public:
+        /**
+         * @brief Given an AST structure and corresponding IlGenState, returns the basic TR::Node
+         * @param tree the AST structure
+         * @param state the object that encapsulating the IL generator state
+         * @return TR::Node represented by the AST
+         */
+        TR::Node* convert(const ASTNode* tree, IlGenState* state) {
+            auto n = impl(tree, state);
+            if (n == NULL && next != NULL) {
+                return next->convert(tree, state);
+            } else {
+                return n;
+            }
+        }
+        /**
+         * @brief Constructs a ASTNode to TRNode
+         * @param n is the next object that gets a chance to convert the AST node if the current on fails
+         */
+        explicit ASTToTRNode(ASTToTRNode* n = NULL) : next(n) {}
+
+    protected:
+        /**
+         * @brief Generates the TR::Node based on the opcode type of the given AST structure
+         * @param tree the AST structure
+         * @param state the object that encapsulating the IL generator state
+         * @return TR::Node represented by the AST
+         */
+        virtual TR::Node* impl(const ASTNode* tree, IlGenState* state) = 0;
+    
+    private:
+        ASTToTRNode* next;
+};
+
+class ILGenError {
+    private:
+        std::string message;
+
+    public:
+        explicit ILGenError(std::string message) : message(message) {}
+
+        const std::string &what() { return message; }
+};
+
+}
+#endif

--- a/fvtest/tril/tril/ilgen.cpp
+++ b/fvtest/tril/tril/ilgen.cpp
@@ -30,322 +30,49 @@
 
 #include <string>
 
-#define TraceEnabled    (comp()->getOption(TR_TraceILGen))
-#define TraceIL(m, ...) {if (TraceEnabled) {traceMsg(comp(), m, ##__VA_ARGS__);}}
-
-/**
- * @brief A table to map the string representation of opcode names to corresponding TR::OpCodes value
- */
-class OpCodeTable : public TR::ILOpCode {
-   public:
-      explicit OpCodeTable(TR::ILOpCodes opcode) : TR::ILOpCode(opcode) {}
-      explicit OpCodeTable(const std::string& name) : TR::ILOpCode(getOpCodeFromName(name)) {}
-
-      /**
-       * @brief Given an opcode name, returns the corresponding TR::OpCodes value
-       */
-      static TR::ILOpCodes getOpCodeFromName(const std::string& name) {
-         auto opcode = _opcodeNameMap.find(name);
-         if (opcode == _opcodeNameMap.end()) {
-            for (int i = TR::FirstOMROp; i< TR::NumIlOps; i++) {
-               const auto p_opCode = static_cast<TR::ILOpCodes>(i);
-               const auto& p = TR::ILOpCode::_opCodeProperties[p_opCode];
-               if (name == p.name) {
-                  _opcodeNameMap[name] = p.opcode;
-                  return p.opcode;
-               }
-            }
-            return TR::BadILOp;
-         }
-         else {
-            return opcode->second;
-         }
-      }
-
-   private:
-      static std::map<std::string, TR::ILOpCodes> _opcodeNameMap;
-};
-
-std::map<std::string, TR::ILOpCodes> OpCodeTable::_opcodeNameMap;
-
-
-
+std::map<std::string, TR::ILOpCodes> Tril::OpCodeTable::_opcodeNameMap;
 
 /*
  * The general algorithm for generating a TR::Node from it's AST representation
  * is like this:
  *
- * 1. Allocate a new TR::Node instance, using the AST node's name
- *    to detemine the opcode
- * 2. Set any special values, flags, or properties on the newly created TR::Node
- *    based on the AST node arguments
- * 3. Recursively call this function to generate the child nodes and set them
+ * 1. Convert AST node into TRNode using the AST node's name and opcode
+ * 2. Recursively call this function to generate the child nodes and set them
  *    as children of the current TR::Node
  *
  * However, certain opcodes must be created using a special interface. For this
  * reason, special opcodes are detected using opcode properties.
  */
-TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
-     TR::Node* node = NULL;
+TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree, IlGenState* state) {
+    TR::Node* node = _converter->convert(tree, state);
+    if (node == NULL) 
+        return NULL;
+    node->setFlags(parseFlags(tree));
 
-     auto childCount = tree->getChildCount();
+    TraceIL("  node address %p\n", node);
+    TraceIL("  node index n%dn\n", node->getGlobalIndex());
 
-     if (strcmp("@id", tree->getName()) == 0) {
-         auto id = tree->getPositionalArg(0)->getValue()->getString();
-         auto iter = _nodeMap.find(id);
-         if (iter != _nodeMap.end()) {
-             auto n = iter->second;
-             TraceIL("Commoning node n%dn (%p) from ASTNode %p (@id \"%s\")\n", n->getGlobalIndex(), n, tree, id);
-             return n;
-         }
-         else {
-             TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
-             return NULL;
-         }
-     }
-     else if (strcmp("@common", tree->getName()) == 0) {
-         auto id = tree->getArgByName("id")->getValue()->getString();
-         TraceIL("WARNING: Using @common is deprecated. Please use (@id \"%s\") instead.\n", id);
-         fprintf(stderr, "WARNING: Using @common is deprecated. Please use (@id \"%s\") instead.\n", id);
-         auto iter = _nodeMap.find(id);
-         if (iter != _nodeMap.end()) {
-             auto n = iter->second;
-             TraceIL("Commoning node n%dn (%p) from ASTNode %p (@id \"%s\")\n", n->getGlobalIndex(), n, tree, id);
-             return n;
-         }
-         else {
-             TraceIL("Failed to find node for commoning (@id \"%s\")\n", id)
-             return NULL;
-         }
-     }
+    auto nodeIdArg = tree->getArgByName("id");
+    if (nodeIdArg != NULL) {
+        auto id = nodeIdArg->getValue()->getString();
+        state->setNodePair(id, node);
+        TraceIL("  node ID %s\n", id);
+    }
 
-     auto opcode = OpCodeTable(tree->getName());
-
-     TraceIL("Creating %s from ASTNode %p\n", opcode.getName(), tree);
-     if (opcode.isLoadConst()) {
-        TraceIL("  is load const of ", "");
-        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
-        auto value = tree->getPositionalArg(0)->getValue();
-
-        // assume the constant to be loaded is the first argument of the AST node
-        if (opcode.isIntegerOrAddress()) {
-           auto v = value->get<int64_t>();
-           node->set64bitIntegralValue(v);
-           TraceIL("integral value %d\n", v);
-        }
-        else {
-           switch (opcode.getType()) {
-              case TR::Float:
-                 node->setFloat(value->get<float>());
-                 break;
-              case TR::Double:
-                 node->setDouble(value->get<double>());
-                 break;
-              default:
-                 return NULL;
-           }
-           TraceIL("floating point value %f\n", value->getFloatingPoint());
-        }
-     }
-     else if (opcode.isLoadDirect()) {
-        TraceIL("  is direct load of ", "");
-
-        // the name of the first argument tells us what kind of symref we're loading
-        if (tree->getArgByName("parm") != NULL) {
-             auto arg = tree->getArgByName("parm")->getValue()->get<int32_t>();
-             TraceIL("parameter %d\n", arg);
-             auto symref = symRefTab()->findOrCreateAutoSymbol(_methodSymbol, arg, opcode.getType() );
-             node = TR::Node::createLoad(symref);
-         }
-         else if (tree->getArgByName("temp") != NULL) {
-             const auto symName = tree->getArgByName("temp")->getValue()->getString();
-             TraceIL("temporary %s\n", symName);
-             auto symref = _symRefMap[symName];
-             node = TR::Node::createLoad(symref);
-         }
-         else {
-             // symref kind not recognized
-             return NULL;
-         }
-     }
-     else if (opcode.isStoreDirect()) {
-        TraceIL("  is direct store of ", "");
-
-        // the name of the first argument tells us what kind of symref we're storing to
-        if (tree->getArgByName("temp") != NULL) {
-            const auto symName = tree->getArgByName("temp")->getValue()->getString();
-            TraceIL("temporary %s\n", symName);
-
-            // check if a symref has already been created for the temp
-            // and if not, create one
-            if (_symRefMap.find(symName) == _symRefMap.end()) {
-                _symRefMap[symName] = symRefTab()->createTemporary(methodSymbol(), opcode.getDataType());
-            }
-
-            auto symref =_symRefMap[symName];
-            node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
-        }
-        else {
-            // symref kind not recognized
+    // create a set child nodes
+    const ASTNode* t = tree->getChildren();
+    int i = 0;
+    while (t) {
+        auto child = toTRNode(t, state);
+        if (child == NULL)
             return NULL;
-        }
-     }
-     else if (opcode.isLoadIndirect() || opcode.isStoreIndirect()) {
-         TraceIL("  is indirect store/load with ");
-         // If not specified, offset will default to zero.
-         int32_t offset = 0;
-         if (tree->getArgByName("offset")) {
-            offset = tree->getArgByName("offset")->getValue()->get<int32_t>();
-         } else {
-            TraceIL(" (default) ");
-         }
-         TraceIL("offset %d ", offset);
+        TraceIL("Setting n%dn (%p) as child %d of n%dn (%p)\n", child->getGlobalIndex(), child, i, node->getGlobalIndex(), node);
+        node->setAndIncChild(i, child);
+        t = t->next;
+        ++i;
+    }
 
-         const auto name = tree->getName();
-         auto compilation = TR::comp();
-         TR::DataType type;
-         if (opcode.isVector()) {
-            // Vector types in TR IL are "typeless", insofar as they are
-            // supposed to infer the vector type depending on the children.
-            // Loads determine their data type based on the symref. However,
-            // given that we are creating a symref here, we need a hint as to
-            // what type of symref to create. So, vloadi and vstorei will take
-            // an extra argument "type" to annotate the type desired.
-            if (tree->getArgByName("type") != NULL) {
-               auto nameoftype = tree->getArgByName("type")->getValue()->getString();
-               type = getTRDataTypes(nameoftype);
-               TraceIL(" of vector type %s\n", nameoftype);
-            } else {
-               return NULL;
-            }
-         } else {
-            TraceIL("\n");
-            type = opcode.getType();
-         }
-         TR::Symbol *sym = TR::Symbol::createNamedShadow(compilation->trHeapMemory(), type, TR::DataType::getSize(opcode.getType()), (char*)name);
-         TR::SymbolReference *symref = new (compilation->trHeapMemory()) TR::SymbolReference(compilation->getSymRefTab(), sym, compilation->getMethodSymbol()->getResolvedMethodIndex(), -1);
-         symref->setOffset(offset);
-         node = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, symref);
-     }
-     else if (opcode.isIf()) {
-         const auto targetName = tree->getArgByName("target")->getValue()->getString();
-         auto targetId = _blockMap[targetName];
-         auto targetEntry = _blocks[targetId]->getEntry();
-         TraceIL("  is if with target block %d (%s, entry = %p", targetId, targetName, targetEntry);
-
-         /* If jumps must be created using `TR::Node::createif()`, which expected
-          * two child nodes to be given as argument. However, because children
-          * are only processed at the end, we create a dummy `BadILOp` node and
-          * pass it as both the first and second child. When the children are
-          * eventually created, they will override the dummy.
-          */
-         auto c1 = TR::Node::create(TR::BadILOp);
-         auto c2 = c1;
-         TraceIL("  created temporary %s n%dn (%p)\n", c1->getOpCode().getName(), c1->getGlobalIndex(), c1);
-         node = TR::Node::createif(opcode.getOpCodeValue(), c1, c2, targetEntry);
-     }
-     else if (opcode.isBranch()) {
-         const auto targetName = tree->getArgByName("target")->getValue()->getString();
-         auto targetId = _blockMap[targetName];
-         auto targetEntry = _blocks[targetId]->getEntry();
-         TraceIL("  is branch to target block %d (%s, entry = %p", targetId, targetName, targetEntry);
-         node = TR::Node::create(opcode.getOpCodeValue(), childCount);
-         node->setBranchDestination(targetEntry);
-     }
-     else if (opcode.isCall()) {
-        auto compilation = TR::comp();
-
-        const auto addressArg = tree->getArgByName("address");
-        if (addressArg == NULL) {
-           TraceIL("  Found call without required address associated\n");
-           return NULL;
-        }
-
-        /* I don't want to extend the ASTValue type system to include pointers at this moment,
-         * so for now, we do the reinterpret_cast to pointer type from long
-         */
-#if defined(OMR_ENV_DATA64)
-        TraceIL("  is call with target 0x%016llX", addressArg->getValue()->get<uintptr_t>());
-#else
-        TraceIL("  is call with target 0x%08lX", addressArg->getValue()->get<uintptr_t>());
-#endif /* OMR_ENV_DATA64 */
-        const auto targetAddress = reinterpret_cast<void*>(addressArg->getValue()->get<uintptr_t>());
-
-        /* To generate a call, will create a ResolvedMethodSymbol, but we need to know the
-         * signature. The return type is intuitable from the call node, but the arguments
-         * must be provided explicitly, hence the args list, that mimics the args list of
-         * (method ...)
-         */
-        const auto argList = parseArgTypes(tree);
-
-        auto argIlTypes = std::vector<TR::IlType*>(argList.size());
-        auto output = argIlTypes.begin();
-        for (auto iter = argList.begin(); iter != argList.end(); iter++, output++) {
-           *output = _types.PrimitiveType(*iter);
-        }
-
-        auto returnIlType = _types.PrimitiveType(opcode.getType());
-
-        TR::ResolvedMethod* method = new (compilation->trHeapMemory()) TR::ResolvedMethod("file",
-                                                                                          "line",
-                                                                                          "name",
-                                                                                          argIlTypes.size(),
-                                                                                          &argIlTypes[0],
-                                                                                          returnIlType,
-                                                                                          targetAddress,
-                                                                                          0);
-
-        TR::SymbolReference *methodSymRef = symRefTab()->findOrCreateStaticMethodSymbol(JITTED_METHOD_INDEX, -1, method);
-
-        /* Default linkage is always system, unless overridden */
-        TR_LinkageConventions linkageConvention = TR_System;
-
-        /* Calls can have a customized linkage */
-        const auto* linkageArg= tree->getArgByName("linkage");
-        if (linkageArg != NULL) {
-           const auto* linkageString = linkageArg->getValue()->getString();
-           linkageConvention = convertStringToLinkage(linkageString);
-           if (linkageConvention == TR_None) {
-              TraceIL("  failed to find customized linkage %s, aborting parsing\n", linkageString);
-              return NULL;
-           }
-           TraceIL("  customizing linakge of call to %s (linkageConvention=%d)\n", linkageString, linkageConvention);
-        }
-
-        /* Set linkage explicitly */
-        methodSymRef->getSymbol()->castToMethodSymbol()->setLinkage(linkageConvention);
-        node  = TR::Node::createWithSymRef(opcode.getOpCodeValue(), childCount, methodSymRef);
-     }
-     else {
-        TraceIL("  unrecognized opcode; using default creation mechanism\n", "");
-        node = TR::Node::create(opcode.getOpCodeValue(), childCount);
-     }
-     node->setFlags(parseFlags(tree));
-
-     TraceIL("  node address %p\n", node);
-     TraceIL("  node index n%dn\n", node->getGlobalIndex());
-
-     auto nodeIdArg = tree->getArgByName("id");
-     if (nodeIdArg != NULL) {
-         auto id = nodeIdArg->getValue()->getString();
-         _nodeMap[id] = node;
-         TraceIL("  node ID %s\n", id);
-     }
-
-     // create a set child nodes
-     const ASTNode* t = tree->getChildren();
-     int i = 0;
-     while (t) {
-         auto child = toTRNode(t);
-         if (child == NULL)
-            return NULL;
-         TraceIL("Setting n%dn (%p) as child %d of n%dn (%p)\n", child->getGlobalIndex(), child, i, node->getGlobalIndex(), node);
-         node->setAndIncChild(i, child);
-         t = t->next;
-         ++i;
-     }
-
-     return node;
+    return node;
 }
 
 /*
@@ -357,13 +84,13 @@ TR::Node* Tril::TRLangBuilder::toTRNode(const ASTNode* const tree) {
  * For the fall-through edge, the assumption is that one is always needed unless
  * a node specifically adds one (e.g. goto, return, etc.).
  */
-bool Tril::TRLangBuilder::cfgFor(const ASTNode* const tree) {
+bool Tril::TRLangBuilder::cfgFor(const ASTNode* const tree, IlGenState* state) {
    auto isFallthroughNeeded = true;
 
    // visit the children first
    const ASTNode* t = tree->getChildren();
    while (t) {
-       isFallthroughNeeded = isFallthroughNeeded && cfgFor(t);
+       isFallthroughNeeded = isFallthroughNeeded && cfgFor(t, state);
        t = t->next;
    }
 
@@ -376,7 +103,7 @@ bool Tril::TRLangBuilder::cfgFor(const ASTNode* const tree) {
    }
    else if (opcode.isBranch()) {
       const auto targetName = tree->getArgByName("target")->getValue()->getString();
-      auto targetId = _blockMap[targetName];
+      auto targetId = state->findBlockByName(targetName);
       cfg()->addEdge(_currentBlock, _blocks[targetId]);
       isFallthroughNeeded = isFallthroughNeeded && opcode.isIf();
       TraceIL("Added CFG edge from block %d to block %d (\"%s\") -> %s\n", _currentBlockNumber, targetId, targetName, tree->getName());
@@ -397,11 +124,15 @@ bool Tril::TRLangBuilder::cfgFor(const ASTNode* const tree) {
  * 3. Generate the CFG by walking the AST
  */
 bool Tril::TRLangBuilder::injectIL() {
+    auto state = new IlGenState();
+    state->setType(typeDictionary());
+    state->setSymRefTab(_symRefTab);
+    state->setMethodSymbol(_methodSymbol);
+    state->setComp(comp());
     TraceIL("=== %s ===\n", "Generating Blocks");
 
     // the top level nodes of the AST should be all the basic blocks
     createBlocks(countNodes(_trees));
-
     // evaluate the arguments for each basic block
     const ASTNode* block = _trees;
     auto blockIndex = 0;
@@ -410,7 +141,7 @@ bool Tril::TRLangBuilder::injectIL() {
     while (block) {
        if (block->getArgByName("name") != NULL) {
            auto name = block->getArgByName("name")->getValue()->getString();
-           _blockMap[name] = blockIndex;
+           state->setBlockPair(name, blockIndex);
            TraceIL("Name of block %d set to \"%s\"\n", blockIndex, name);
        }
        ++blockIndex;
@@ -422,12 +153,19 @@ bool Tril::TRLangBuilder::injectIL() {
     generateToBlock(0);
 
     // iterate over each treetop in each basic block
+    state->setBlocks(_blocks);
     while (block) {
        const ASTNode* t = block->getChildren();
        while (t) {
-           auto node = toTRNode(t);
-           if (node == NULL)
-              return false;
+           TR::Node* node = NULL;
+            try {
+                node = toTRNode(t, state);
+            } catch (ILGenError &e) {
+                char* e_cstr = new char[e.what().size() + 1];
+                strcpy(e_cstr, e.what().c_str());
+                TraceIL(e_cstr);
+                return false;
+            }
            const auto tt = genTreeTop(node);
            TraceIL("Created TreeTop %p for node n%dn (%p)\n", tt, node->getGlobalIndex(), node);
            t = t->next;
@@ -447,7 +185,7 @@ bool Tril::TRLangBuilder::injectIL() {
        // create CFG edges from the nodes withing the current basic block
        const ASTNode* t = block->getChildren();
        while (t) {
-           isFallthroughNeeded = isFallthroughNeeded && cfgFor(t);
+           isFallthroughNeeded = isFallthroughNeeded && cfgFor(t, state);
            t = t->next;
        }
 
@@ -463,7 +201,9 @@ bool Tril::TRLangBuilder::injectIL() {
                // do nothing, no fall-throught block specified
            }
            else {
-               auto destBlock = _blockMap[target];
+               char* targetName = new char[target.size() + 1];
+               strcpy(targetName, target.c_str());
+               auto destBlock = state->findBlockByName(targetName);
                cfg()->addEdge(_currentBlock, _blocks[destBlock]);
                TraceIL("Added fallthrough edge from block %d to block %d \"%s\"\n", _currentBlockNumber, destBlock, target.c_str());
            }
@@ -477,6 +217,6 @@ bool Tril::TRLangBuilder::injectIL() {
        generateToBlock(_currentBlockNumber + 1);
        block = block->next;
     }
-
+    
     return true;
 }

--- a/fvtest/tril/tril/simple_compiler.cpp
+++ b/fvtest/tril/tril/simple_compiler.cpp
@@ -20,6 +20,8 @@
  *******************************************************************************/
 
 #include "simple_compiler.hpp"
+#include "CallConverter.hpp"
+#include "GenericNodeConverter.hpp"
 
 #include "env/jittypes.h"
 #include "il/DataTypes.hpp"
@@ -47,7 +49,9 @@ int32_t Tril::SimpleCompiler::compileWithVerifier(TR::IlVerifier* verifier) {
     // construct an IL generator for the method
     auto methodInfo = getMethodInfo();
     TR::TypeDictionary types;
-    Tril::TRLangBuilder ilgenerator(methodInfo.getBodyAST(), &types);
+    GenericNodeConverter genericNodeConverter;
+    CallConverter callConverter(&genericNodeConverter);
+    Tril::TRLangBuilder ilgenerator(methodInfo.getBodyAST(), &types, &callConverter);
 
     // get a list of the method's argument types and transform it
     // into a list of `TR::IlType`

--- a/fvtest/tril/tril/state.hpp
+++ b/fvtest/tril/tril/state.hpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2019 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at http://eclipse.org/legal/epl-2.0
+ * or the Apache License, Version 2.0 which accompanies this distribution
+ * and is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License, v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception [1] and GNU General Public
+ * License, version 2 with the OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+#ifndef ILGENSTATE_HPP
+#define ILGENSTATE_HPP
+
+#include "ilgen/TypeDictionary.hpp"
+
+namespace Tril {
+
+class IlGenState {
+    TR::TypeDictionary* _types;
+    std::map<std::string, TR::SymbolReference*> _symRefMap;
+    std::map<std::string, int> _blockMap;
+    std::map<std::string, TR::Node*> _nodeMap;
+
+    private:
+        TR::SymbolReferenceTable*  _symRefTab;
+        TR::ResolvedMethodSymbol* _methodSymbol;
+        TR::Block** _blocks;
+        TR::Compilation* _comp;
+
+    public:
+        // get _symRefMap, _symRefMap and _nodeMap values based on key
+        std::map<std::string, TR::SymbolReference*>::iterator findSymRefByName(const char *symName) {
+            return _symRefMap.find(symName);
+        }
+        std::map<std::string, TR::SymbolReference*>::iterator symRefMapEnd() {
+            return _symRefMap.end();
+        }
+        std::map<std::string, TR::Node*>::iterator findNodeByID(const char* id) {
+            return _nodeMap.find(id);
+        }
+        std::map<std::string, TR::Node*>::iterator nodeMapEnd() {
+            return _nodeMap.end();
+        }
+        int findBlockByName(const char* targetName) {
+            return _blockMap[targetName];
+        }
+
+        // set _symRefMap, _symRefMap and _nodeMap values based on key
+        void setSymRefPair(const char* symName, TR::SymbolReference* symRef) {
+            _symRefMap[symName] = symRef;
+        }
+        void setNodePair(const char* id, TR::Node* node) {
+            _nodeMap[id] = node;
+        }
+        void setBlockPair(const char* name, int blockIndex) {
+            _blockMap[name] = blockIndex;
+        }
+
+        // set _symRefTab, _methodSymbol, _blocks, and _types based on IlInjector
+        void setSymRefTab(TR::SymbolReferenceTable* symRefTab) {
+            _symRefTab = symRefTab;
+        }
+        void setMethodSymbol(TR::ResolvedMethodSymbol* methodSymbol) {
+            _methodSymbol = methodSymbol;
+        }
+        void setBlocks(TR::Block** blocks) {
+            _blocks = blocks;
+        }
+        void setType(TR::TypeDictionary* type) {
+            _types = type;
+        }
+
+        // get _symRefTab, _methodSymbol, _blocks, and _types 
+        TR::SymbolReferenceTable* symRefTab() {
+            return _symRefTab;
+        }
+        TR::ResolvedMethodSymbol* methodSymbol() const {
+            return _methodSymbol;
+        }
+        TR::Block** blocks() const {
+            return _blocks;
+        }
+        TR::TypeDictionary* getTypes() {
+            return _types;
+        }
+
+        // _comp setter and getter for TraceIL
+        TR::Compilation* comp() {
+            return _comp;
+        }
+        void setComp(TR::Compilation* comp) {
+            _comp = comp;
+        }
+};
+
+} // namespace Tril
+#endif


### PR DESCRIPTION
Refactored Tril ilgen `ToTRNode` to use `ASTToTRNode` class, and changes are made to the followings:
- Defined private copy constructor for `TypeDictionary` class
- Added `ASTToTRNode`, its subclasses and each exception classes to make it be extensible
- Added `IlGenState` class to store the maps get from `TRLangBuilder`, and values in `IlInjector`