### PR TITLE
Remove initalize from ObjectScanner

### DIFF
--- a/example/glue/MixedObjectScanner.hpp
+++ b/example/glue/MixedObjectScanner.hpp
@@ -30,8 +30,8 @@ class GC_MixedObjectScanner : public GC_ObjectScanner
 {
 	/* Data Members */
 private:
-	fomrobject_t * const _endPtr;	/**< end scan pointer */
-	fomrobject_t *_mapPtr;			/**< pointer to first slot in current scan segment */
+	fomrobject_t * const _endPtr; /**< end scan pointer */
+	fomrobject_t *_mapPtr;        /**< pointer to first slot in current scan segment */
 
 protected:
 
@@ -52,16 +52,6 @@ protected:
 		, _mapPtr(_scanPtr)
 	{
 		_typeId = __FUNCTION__;
-	}
-
-	/**
-	 * Subclasses must call this method to set up the instance description bits and description pointer.
-	 * @param[in] env The scanning thread environment
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env)
-	{
-		GC_ObjectScanner::initialize(env);
 
 		intptr_t slotCount = _endPtr - _scanPtr;
 
@@ -91,9 +81,7 @@ public:
 	{
 		GC_MixedObjectScanner *objectScanner = NULL;
 		if (NULL != allocSpace) {
-			new(allocSpace) GC_MixedObjectScanner(env, objectPtr, flags);
-			objectScanner = (GC_MixedObjectScanner *)allocSpace;
-			objectScanner->initialize(env);
+			objectScanner = new(allocSpace) GC_MixedObjectScanner(env, objectPtr, flags);
 		}
 		return objectScanner;
 	}

--- a/gc/base/IndexableObjectScanner.hpp
+++ b/gc/base/IndexableObjectScanner.hpp
@@ -73,22 +73,14 @@ protected:
 		, _elementSize(elementSize)
 	{
 		_typeId = __FUNCTION__;
-		if ((endPtr - scanPtr) <= _bitsPerScanMap) {
-			setNoMoreSlots();
-		}
-	}
 
-	/**
-	 * Set up the scanner.
-	 * @param[in] env current environment (per thread)
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env)
-	{
 		Assert_MM_true(_basePtr <= _scanPtr);
 		Assert_MM_true(_scanPtr <= _endPtr);
 		Assert_MM_true(_endPtr <= _limitPtr);
-		GC_ObjectScanner::initialize(env);
+
+		if ((endPtr - scanPtr) <= _bitsPerScanMap) {
+			setNoMoreSlots();
+		}
 	}
 
 public:

--- a/gc/base/ObjectScanner.hpp
+++ b/gc/base/ObjectScanner.hpp
@@ -104,31 +104,6 @@ protected:
 	{
 		_typeId = __FUNCTION__;
 	}
-	
-	/**
-	 * Set up the scanner. Subclasses should provide a non-virtual implementation
-	 * to build next slot map and call it from their constructor or just after
-	 * their constructor. This will obviate the need to make an initial call to
-	 * the virtual getNextSlotMap() function and, in most cases, avoid the need
-	 * to call getNextSlotMap() entirely.
-	 *
-	 * If all of the object reference fields are mapped in the initial slot map,
-	 * the sublcass implementation should call setNoMoreSlots() to indicate that
-	 * the getNextSlotMap() method should not be called to refresh the slot map.
-	 *
-	 * This non-virtual base class implementation should be called directly from
-	 * the sublcass implementation, eg
-	 *
-	 *    MM_ObjectScanner::initialize(env);
-	 *
-	 * @param[in] env Current environment
-	 * @see getNextSlotMap()
-	 * @see putNextSlotMapBit()
-	 */
-	MMINLINE void
-	initialize(MM_EnvironmentBase *env)
-	{
-	}
 
 	/**
 	 * Helper function can be used to rebuild bit map of reference fields in


### PR DESCRIPTION
Functionality from this function is moved into the constructor.
OpenJ9 side of this must be merged first: https://github.com/eclipse/openj9/pull/7896
cc @dmitripivkine 