### PR TITLE
Move arithmeticNeedsLiteralFromPool function from OMR to OpenJ9

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1344,7 +1344,6 @@ class OMR_EXTENSIBLE CodeGenerator
 
    // the following functions evaluate whether a codegen for the node or for static
    // symbol reference requires entry in the literal pool
-   bool arithmeticNeedsLiteralFromPool(TR::Node *node) { return false; }
    bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child) { return false; }
    void setOnDemandLiteralPoolRun(bool answer) {}
    bool isLiteralPoolOnDemandOn () { return false; }

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -4468,17 +4468,6 @@ OMR::Z::CodeGenerator::getGlobalRegisterNumber(uint32_t realRegNum)
    return self()->machine()->getGlobalReg((TR::RealRegister::RegNum)(realRegNum+1));
    }
 
-/**
- * Check if arithmetic operations with a constant requires entry in the literal pool.
- */
-bool
-OMR::Z::CodeGenerator::arithmeticNeedsLiteralFromPool(TR::Node *node)
-   {
-   int64_t value = getIntegralValue(node);
-
-   return value > GE_MAX_IMMEDIATE_VAL || value < GE_MIN_IMMEDIATE_VAL;
-   }
-
 bool
 OMR::Z::CodeGenerator::bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child)
    {

--- a/compiler/z/codegen/OMRCodeGenerator.hpp
+++ b/compiler/z/codegen/OMRCodeGenerator.hpp
@@ -784,9 +784,6 @@ public:
    uint32_t getJitMethodEntryAlignmentThreshold();
 
    // LL: move to .cpp
-   bool arithmeticNeedsLiteralFromPool(TR::Node *node);
-
-   // LL: move to .cpp
    bool bitwiseOpNeedsLiteralFromPool(TR::Node *parent, TR::Node *child);
 
    virtual bool isDispInRange(int64_t disp);


### PR DESCRIPTION
Move arithmeticNeedsLiteralFromPool function from OMR to OpenJ9

This commit moves arithmeticNeedsLiteralFromPool function from OMR to
OpenJ9. arithmeticNeedsLiteralFromPool is not used in OMR, but it is
used in OpenJ9 for Z codegen implementation.

Fixes: #1870
Signed-off-by: Md. Ariful Haque <mhaque5@unb.ca>