### PR TITLE
Misc. Z RegisterDependency cleanup

### DIFF
--- a/compiler/z/codegen/OMRInstruction.cpp
+++ b/compiler/z/codegen/OMRInstruction.cpp
@@ -1531,7 +1531,7 @@ OMR::Z::Instruction::renameRegister(TR::Register *from, TR::Register *to)
     }
 
   TR::RegisterDependencyConditions *conds = self()->getDependencyConditions();
-  if (conds && !conds->getConflictsResolved())
+  if (conds)
     {
     TR_S390RegisterDependencyGroup *preConds = conds->getPreConditions();
     TR_S390RegisterDependencyGroup *postConds = conds->getPostConditions();

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -104,7 +104,6 @@ OMR::Z::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeGener
    _numPostConditions = totalNum;
    _addCursorForPost = 0;
    _isUsed = false;
-   _isHint = false;
    _conflictsResolved = false;
 
    for (i = 0; i < totalNum; i++)
@@ -171,7 +170,6 @@ OMR::Z::RegisterDependencyConditions::RegisterDependencyConditions(TR::RegisterD
      _addCursorForPre(0),
      _numPostConditions((iConds?iConds->getNumPostConditions():0)+numNewPostConds),
      _addCursorForPost(0),
-     _isHint(false),
      _isUsed(false),
      _conflictsResolved(false),
      _cg(cg)
@@ -233,7 +231,6 @@ OMR::Z::RegisterDependencyConditions::RegisterDependencyConditions(TR::RegisterD
      _numPostConditions(conds_1->getNumPostConditions()+conds_2->getNumPostConditions()),
      _addCursorForPost(0),
      _isUsed(false),
-     _isHint(false),
      _conflictsResolved(false),
      _cg(cg)
    {

--- a/compiler/z/codegen/OMRRegisterDependency.cpp
+++ b/compiler/z/codegen/OMRRegisterDependency.cpp
@@ -104,7 +104,6 @@ OMR::Z::RegisterDependencyConditions::RegisterDependencyConditions(TR::CodeGener
    _numPostConditions = totalNum;
    _addCursorForPost = 0;
    _isUsed = false;
-   _conflictsResolved = false;
 
    for (i = 0; i < totalNum; i++)
       {
@@ -171,7 +170,6 @@ OMR::Z::RegisterDependencyConditions::RegisterDependencyConditions(TR::RegisterD
      _numPostConditions((iConds?iConds->getNumPostConditions():0)+numNewPostConds),
      _addCursorForPost(0),
      _isUsed(false),
-     _conflictsResolved(false),
      _cg(cg)
    {
      int32_t i;
@@ -231,7 +229,6 @@ OMR::Z::RegisterDependencyConditions::RegisterDependencyConditions(TR::RegisterD
      _numPostConditions(conds_1->getNumPostConditions()+conds_2->getNumPostConditions()),
      _addCursorForPost(0),
      _isUsed(false),
-     _conflictsResolved(false),
      _cg(cg)
    {
    int32_t i;

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -208,7 +208,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    uint16_t                         _numPostConditions;
    uint16_t                         _addCursorForPost;
    bool                            _isUsed;
-   bool                            _conflictsResolved;
    TR::CodeGenerator               *_cg;
 
    public:
@@ -239,7 +238,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _numPostConditions(numPostConds),
         _addCursorForPost(numPostConds),
         _isUsed(false),
-        _conflictsResolved(false),
 	_cg(cg)
       {}
 
@@ -251,7 +249,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _numPostConditions(0),
         _addCursorForPost(0),
         _isUsed(false),
-        _conflictsResolved(false),
 	_cg(NULL)
       {}
 
@@ -266,7 +263,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _numPostConditions(numPostConds + NUM_VM_THREAD_REG_DEPS),
         _addCursorForPost(0),
         _isUsed(false),
-        _conflictsResolved(false),
         _cg(cg)
       {
       for(int32_t i=0;i<numPreConds;i++)
@@ -291,9 +287,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    bool getIsUsed() {return _isUsed;}
    void setIsUsed() {_isUsed=true;}
    void resetIsUsed() {_isUsed=false;}
-   bool getConflictsResolved() {return _conflictsResolved;}
-   void setConflictsResolved() {_conflictsResolved=true;}
-   void resetConflictsResolved() {_conflictsResolved=false;}
 
    TR_S390RegisterDependencyGroup *getPreConditions()  {return _preConditions;}
 

--- a/compiler/z/codegen/OMRRegisterDependency.hpp
+++ b/compiler/z/codegen/OMRRegisterDependency.hpp
@@ -160,15 +160,7 @@ class TR_S390RegisterDependencyGroup
                         TR_RegisterKinds kindToBeAssigned,
                         uint32_t         numberOfRegisters,
                         TR::CodeGenerator *cg);
-   void decFutureUseCounts(uint32_t         numberOfRegisters,
-                           TR::CodeGenerator *cg)
-      {
-      for (uint32_t i = 0; i< numberOfRegisters; i++)
-         {
-         TR::Register *virtReg = _dependencies[i].getRegister();
-         virtReg->decFutureUseCount();
-         }
-      }
+
    void blockRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg)
       {
       for (uint32_t i = 0; i < numberOfRegisters; i++)
@@ -216,7 +208,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    uint16_t                         _numPostConditions;
    uint16_t                         _addCursorForPost;
    bool                            _isUsed;
-   bool                            _isHint;
    bool                            _conflictsResolved;
    TR::CodeGenerator               *_cg;
 
@@ -247,7 +238,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _addCursorForPre(numPreConds),
         _numPostConditions(numPostConds),
         _addCursorForPost(numPostConds),
-        _isHint(false),
         _isUsed(false),
         _conflictsResolved(false),
 	_cg(cg)
@@ -260,7 +250,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _addCursorForPre(0),
         _numPostConditions(0),
         _addCursorForPost(0),
-        _isHint(false),
         _isUsed(false),
         _conflictsResolved(false),
 	_cg(NULL)
@@ -276,7 +265,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _addCursorForPre(0),
         _numPostConditions(numPostConds + NUM_VM_THREAD_REG_DEPS),
         _addCursorForPost(0),
-        _isHint(false),
         _isUsed(false),
         _conflictsResolved(false),
         _cg(cg)
@@ -303,9 +291,6 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    bool getIsUsed() {return _isUsed;}
    void setIsUsed() {_isUsed=true;}
    void resetIsUsed() {_isUsed=false;}
-   bool getIsHint() {return _isHint;}
-   void setIsHint() {_isHint = true;}
-   void resetIsHint() {_isUsed = false;}
    bool getConflictsResolved() {return _conflictsResolved;}
    void setConflictsResolved() {_conflictsResolved=true;}
    void resetConflictsResolved() {_conflictsResolved=false;}
@@ -454,10 +439,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          {
          cg->clearRegisterAssignmentFlags();
          cg->setRegisterAssignmentFlag(TR_PostDependencyCoercion);
-         if (getIsHint())
-            _postConditions->decFutureUseCounts(_addCursorForPost, cg);
-         else
-            _postConditions->assignRegisters(currentInstruction, kindToBeAssigned, _addCursorForPost, cg);
+         _postConditions->assignRegisters(currentInstruction, kindToBeAssigned, _addCursorForPost, cg);
          }
       }
 


### PR DESCRIPTION
* Remove unused isHint from Z register dependencies
* Remove unused conflictsResolved field from Z RegisterDependencyConditions

Signed-off-by: Daryl Maier <maier@ca.ibm.com>