### PR TITLE
AArch64: Add computedCallTargetRegister to ARM64LinkageProperties

### DIFF
--- a/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
+++ b/compiler/aarch64/codegen/ARM64SystemLinkage.cpp
@@ -113,6 +113,7 @@ TR::ARM64SystemLinkage::ARM64SystemLinkage(TR::CodeGenerator *cg)
    _properties._methodMetaDataRegister      = TR::RealRegister::NoReg;
    _properties._stackPointerRegister        = TR::RealRegister::sp;
    _properties._framePointerRegister        = TR::RealRegister::x29;
+   _properties._computedCallTargetRegister  = TR::RealRegister::NoReg;
    _properties._vtableIndexArgumentRegister = TR::RealRegister::NoReg;
    _properties._j9methodArgumentRegister    = TR::RealRegister::NoReg;
 

--- a/compiler/aarch64/codegen/OMRLinkage.hpp
+++ b/compiler/aarch64/codegen/OMRLinkage.hpp
@@ -96,6 +96,7 @@ struct ARM64LinkageProperties
    TR::RealRegister::RegNum _methodMetaDataRegister;
    TR::RealRegister::RegNum _stackPointerRegister;
    TR::RealRegister::RegNum _framePointerRegister;
+   TR::RealRegister::RegNum _computedCallTargetRegister; // for icallVMprJavaSendPatchupVirtual
    TR::RealRegister::RegNum _vtableIndexArgumentRegister; // for icallVMprJavaSendPatchupVirtual
    TR::RealRegister::RegNum _j9methodArgumentRegister; // for icallVMprJavaSendStatic
    uint8_t _numberOfDependencyGPRegisters;
@@ -240,6 +241,11 @@ struct ARM64LinkageProperties
    TR::RealRegister::RegNum getFramePointerRegister() const
       {
       return _framePointerRegister;
+      }
+
+   TR::RealRegister::RegNum getComputedCallTargetRegister() const
+      {
+      return _computedCallTargetRegister;
       }
 
    TR::RealRegister::RegNum getVTableIndexArgumentRegister() const


### PR DESCRIPTION
This commit adds a member computedCallTargetRegister to
ARM64LinkageProperties.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>