### PR TITLE
WIP: Replace TR_X86RegisterDependencyIndex class with a uint32_t

### DIFF
--- a/compiler/x/codegen/OMRRegisterDependency.cpp
+++ b/compiler/x/codegen/OMRRegisterDependency.cpp
@@ -77,7 +77,7 @@ static void generateRegcopyDebugCounter(TR::CodeGenerator *cg, const char *categ
 OMR::X86::RegisterDependencyConditions::RegisterDependencyConditions(
       TR::Node *node,
       TR::CodeGenerator *cg,
-      TR_X86RegisterDependencyIndex additionalRegDeps,
+      uint32_t additionalRegDeps,
       List<TR::Register> *popRegisters)
    :_numPreConditions(-1),_numPostConditions(-1),
     _addCursorForPre(0),_addCursorForPost(0)
@@ -85,7 +85,7 @@ OMR::X86::RegisterDependencyConditions::RegisterDependencyConditions(
    TR::Register      *copyReg = NULL;
    TR::Register      *highCopyReg = NULL;
    List<TR::Register> registers(cg->trMemory());
-   TR_X86RegisterDependencyIndex          numFPGlobalRegs = 0,
+   uint32_t          numFPGlobalRegs = 0,
                      totalNumFPGlobalRegs = 0;
    int32_t           i;
    TR::Machine *machine = cg->machine();
@@ -398,9 +398,9 @@ OMR::X86::RegisterDependencyConditions::RegisterDependencyConditions(
    }
 
 
-TR_X86RegisterDependencyIndex OMR::X86::RegisterDependencyConditions::unionDependencies(
+uint32_t OMR::X86::RegisterDependencyConditions::unionDependencies(
    TR_X86RegisterDependencyGroup *deps,
-   TR_X86RegisterDependencyIndex  cursor,
+   uint32_t  cursor,
    TR::Register                  *vr,
    TR::RealRegister::RegNum       rr,
    TR::CodeGenerator             *cg,
@@ -433,7 +433,7 @@ TR_X86RegisterDependencyIndex OMR::X86::RegisterDependencyConditions::unionDepen
          return cursor;
          }
 
-      for (TR_X86RegisterDependencyIndex candidate = 0; candidate < cursor; candidate++)
+      for (uint32_t candidate = 0; candidate < cursor; candidate++)
          {
          TR::RegisterDependency  *dep = deps->getRegisterDependency(candidate);
          if (dep->getRegister() == vr)
@@ -480,9 +480,9 @@ void OMR::X86::RegisterDependencyConditions::unionNoRegPostCondition(TR::Registe
    }
 
 
-TR_X86RegisterDependencyIndex OMR::X86::RegisterDependencyConditions::unionRealDependencies(
+uint32_t OMR::X86::RegisterDependencyConditions::unionRealDependencies(
    TR_X86RegisterDependencyGroup *deps,
-   TR_X86RegisterDependencyIndex  cursor,
+   uint32_t  cursor,
    TR::Register                  *vr,
    TR::RealRegister::RegNum       rr,
    TR::CodeGenerator             *cg,
@@ -529,7 +529,7 @@ TR_X86RegisterDependencyIndex OMR::X86::RegisterDependencyConditions::unionRealD
    }
 
 
-TR::RegisterDependencyConditions  *OMR::X86::RegisterDependencyConditions::clone(TR::CodeGenerator *cg, TR_X86RegisterDependencyIndex additionalRegDeps)
+TR::RegisterDependencyConditions  *OMR::X86::RegisterDependencyConditions::clone(TR::CodeGenerator *cg, uint32_t additionalRegDeps)
    {
    TR::RegisterDependencyConditions  *other =
       new (cg->trHeapMemory()) TR::RegisterDependencyConditions(_numPreConditions  + additionalRegDeps,
@@ -652,10 +652,10 @@ void OMR::X86::RegisterDependencyConditions::useRegisters(TR::Instruction *instr
    }
 
 
-void TR_X86RegisterDependencyGroup::blockRealDependencyRegisters(TR_X86RegisterDependencyIndex numberOfRegisters, TR::CodeGenerator *cg)
+void TR_X86RegisterDependencyGroup::blockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg)
    {
    TR::Machine *machine = cg->machine();
-   for (TR_X86RegisterDependencyIndex i = 0; i < numberOfRegisters; i++)
+   for (uint32_t i = 0; i < numberOfRegisters; i++)
       {
       if (_dependencies[i].getRealRegister() != TR::RealRegister::NoReg)
          {
@@ -665,10 +665,10 @@ void TR_X86RegisterDependencyGroup::blockRealDependencyRegisters(TR_X86RegisterD
    }
 
 
-void TR_X86RegisterDependencyGroup::unblockRealDependencyRegisters(TR_X86RegisterDependencyIndex numberOfRegisters, TR::CodeGenerator *cg)
+void TR_X86RegisterDependencyGroup::unblockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg)
    {
    TR::Machine *machine = cg->machine();
-   for (TR_X86RegisterDependencyIndex i = 0; i < numberOfRegisters; i++)
+   for (uint32_t i = 0; i < numberOfRegisters; i++)
       {
       if (_dependencies[i].getRealRegister() != TR::RealRegister::NoReg)
          {
@@ -680,7 +680,7 @@ void TR_X86RegisterDependencyGroup::unblockRealDependencyRegisters(TR_X86Registe
 
 void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentInstruction,
                                                     TR_RegisterKinds  kindsToBeAssigned,
-                                                    TR_X86RegisterDependencyIndex          numberOfRegisters,
+                                                    uint32_t          numberOfRegisters,
                                                     TR::CodeGenerator *cg)
    {
    TR::Register             *virtReg              = NULL;
@@ -1056,7 +1056,7 @@ void TR_X86RegisterDependencyGroup::assignRegisters(TR::Instruction   *currentIn
 
 
 void TR_X86RegisterDependencyGroup::setDependencyInfo(
-   TR_X86RegisterDependencyIndex  index,
+   uint32_t  index,
    TR::Register                  *vr,
    TR::RealRegister::RegNum       rr,
    TR::CodeGenerator             *cg,
@@ -1146,7 +1146,7 @@ TR::RealRegister *OMR::X86::RegisterDependencyConditions::getRealRegisterFromVir
 
 void TR_X86RegisterDependencyGroup::assignFPRegisters(TR::Instruction   *prevInstruction,
                                                        TR_RegisterKinds  kindsToBeAssigned,
-                                                       TR_X86RegisterDependencyIndex          numberOfRegisters,
+                                                       uint32_t          numberOfRegisters,
                                                        TR::CodeGenerator *cg)
    {
 
@@ -1363,7 +1363,7 @@ void TR_X86RegisterDependencyGroup::assignFPRegisters(TR::Instruction   *prevIns
 //
 void TR_X86RegisterDependencyGroup::orderGlobalRegsOnFPStack(TR::Instruction    *cursor,
                                                               TR_RegisterKinds   kindsToBeAssigned,
-                                                              TR_X86RegisterDependencyIndex          numberOfRegisters,
+                                                              uint32_t          numberOfRegisters,
                                                               List<TR::Register> *poppedRegisters,
                                                               TR::CodeGenerator  *cg)
    {
@@ -1546,8 +1546,8 @@ uint32_t OMR::X86::RegisterDependencyConditions::numReferencedGPRegisters(TR::Co
 ////////////////////////////////////////////////////////////////////////////////
 
 TR::RegisterDependencyConditions  *
-generateRegisterDependencyConditions(TR_X86RegisterDependencyIndex numPreConds,
-                                     TR_X86RegisterDependencyIndex numPostConds,
+generateRegisterDependencyConditions(uint32_t numPreConds,
+                                     uint32_t numPostConds,
                                      TR::CodeGenerator * cg)
    {
    return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(numPreConds, numPostConds, cg->trMemory());
@@ -1556,7 +1556,7 @@ generateRegisterDependencyConditions(TR_X86RegisterDependencyIndex numPreConds,
 TR::RegisterDependencyConditions  *
 generateRegisterDependencyConditions(TR::Node           *node,
                                      TR::CodeGenerator  *cg,
-                                     TR_X86RegisterDependencyIndex           additionalRegDeps,
+                                     uint32_t           additionalRegDeps,
                                      List<TR::Register> *popRegisters)
    {
    return new (cg->trHeapMemory()) TR::RegisterDependencyConditions(node, cg, additionalRegDeps, popRegisters);

--- a/compiler/x/codegen/OMRRegisterDependency.hpp
+++ b/compiler/x/codegen/OMRRegisterDependency.hpp
@@ -90,12 +90,12 @@ class TR_X86RegisterDependencyGroup
       return numDependencies ? new (numDependencies, m) TR_X86RegisterDependencyGroup : 0;
       }
 
-   TR::RegisterDependency  *getRegisterDependency(TR_X86RegisterDependencyIndex index)
+   TR::RegisterDependency  *getRegisterDependency(uint32_t index)
       {
       return &_dependencies[index];
       }
 
-   void setDependencyInfo(TR_X86RegisterDependencyIndex   index,
+   void setDependencyInfo(uint32_t   index,
                           TR::Register                   *vr,
                           TR::RealRegister::RegNum        rr,
                           TR::CodeGenerator              *cg,
@@ -103,19 +103,19 @@ class TR_X86RegisterDependencyGroup
                           bool                            isAssocRegDependency = false);
 
 
-   TR::RegisterDependency *findDependency(TR::Register *vr, TR_X86RegisterDependencyIndex stop)
+   TR::RegisterDependency *findDependency(TR::Register *vr, uint32_t stop)
       {
       TR::RegisterDependency *result = NULL;
-      for (TR_X86RegisterDependencyIndex i=0; !result && (i < stop); i++)
+      for (uint32_t i=0; !result && (i < stop); i++)
          if (_dependencies[i].getRegister() == vr)
             result = _dependencies+i;
       return result;
       }
 
-   TR::RegisterDependency *findDependency(TR::RealRegister::RegNum rr, TR_X86RegisterDependencyIndex stop)
+   TR::RegisterDependency *findDependency(TR::RealRegister::RegNum rr, uint32_t stop)
       {
       TR::RegisterDependency *result = NULL;
-      for (TR_X86RegisterDependencyIndex i=0; !result && (i < stop); i++)
+      for (uint32_t i=0; !result && (i < stop); i++)
          if (_dependencies[i].getRealRegister() == rr)
             result = _dependencies+i;
       return result;
@@ -123,25 +123,25 @@ class TR_X86RegisterDependencyGroup
 
    void assignRegisters(TR::Instruction   *currentInstruction,
                         TR_RegisterKinds  kindsToBeAssigned,
-                        TR_X86RegisterDependencyIndex          numberOfRegisters,
+                        uint32_t          numberOfRegisters,
                         TR::CodeGenerator *cg);
 
    void assignFPRegisters(TR::Instruction   *currentInstruction,
                           TR_RegisterKinds  kindsToBeAssigned,
-                          TR_X86RegisterDependencyIndex          numberOfRegisters,
+                          uint32_t          numberOfRegisters,
                           TR::CodeGenerator *cg);
 
 
    void orderGlobalRegsOnFPStack(TR::Instruction    *cursor,
                                  TR_RegisterKinds   kindsToBeAssigned,
-                                 TR_X86RegisterDependencyIndex           numberOfRegisters,
+                                 uint32_t           numberOfRegisters,
                                  List<TR::Register> *poppedRegisters,
                                  TR::CodeGenerator  *cg);
 
 
-   void blockRegisters(TR_X86RegisterDependencyIndex numberOfRegisters)
+   void blockRegisters(uint32_t numberOfRegisters)
       {
-      for (TR_X86RegisterDependencyIndex i = 0; i < numberOfRegisters; i++)
+      for (uint32_t i = 0; i < numberOfRegisters; i++)
          {
          if (_dependencies[i].getRegister())
             {
@@ -150,7 +150,7 @@ class TR_X86RegisterDependencyGroup
          }
       }
 
-   void unblockRegisters(TR_X86RegisterDependencyIndex numberOfRegisters)
+   void unblockRegisters(uint32_t numberOfRegisters)
       {
       for (uint32_t i = 0; i < numberOfRegisters; i++)
          {
@@ -167,8 +167,8 @@ class TR_X86RegisterDependencyGroup
    void setNeedToClearFPStack(bool b) {_needToClearFPStack = b;}
    bool getNeedToClearFPStack() {return _needToClearFPStack;}
 
-   void blockRealDependencyRegisters(TR_X86RegisterDependencyIndex numberOfRegisters, TR::CodeGenerator *cg);
-   void unblockRealDependencyRegisters(TR_X86RegisterDependencyIndex numberOfRegisters, TR::CodeGenerator *cg);
+   void blockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
+   void unblockRealDependencyRegisters(uint32_t numberOfRegisters, TR::CodeGenerator *cg);
    };
 
 namespace OMR
@@ -179,13 +179,13 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    {
    TR_X86RegisterDependencyGroup *_preConditions;
    TR_X86RegisterDependencyGroup *_postConditions;
-   TR_X86RegisterDependencyIndex  _numPreConditions;
-   TR_X86RegisterDependencyIndex  _addCursorForPre;
-   TR_X86RegisterDependencyIndex  _numPostConditions;
-   TR_X86RegisterDependencyIndex  _addCursorForPost;
+   uint32_t  _numPreConditions;
+   uint32_t  _addCursorForPre;
+   uint32_t  _numPostConditions;
+   uint32_t  _addCursorForPost;
 
-   TR_X86RegisterDependencyIndex unionDependencies(TR_X86RegisterDependencyGroup *deps, TR_X86RegisterDependencyIndex cursor, TR::Register *vr, TR::RealRegister::RegNum rr, TR::CodeGenerator *cg, uint8_t flag, bool isAssocRegDependency);
-   TR_X86RegisterDependencyIndex unionRealDependencies(TR_X86RegisterDependencyGroup *deps, TR_X86RegisterDependencyIndex cursor, TR::Register *vr, TR::RealRegister::RegNum rr, TR::CodeGenerator *cg, uint8_t flag, bool isAssocRegDependency);
+   uint32_t unionDependencies(TR_X86RegisterDependencyGroup *deps, uint32_t cursor, TR::Register *vr, TR::RealRegister::RegNum rr, TR::CodeGenerator *cg, uint8_t flag, bool isAssocRegDependency);
+   uint32_t unionRealDependencies(TR_X86RegisterDependencyGroup *deps, uint32_t cursor, TR::Register *vr, TR::RealRegister::RegNum rr, TR::CodeGenerator *cg, uint8_t flag, bool isAssocRegDependency);
 
    public:
 
@@ -200,7 +200,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _addCursorForPost(0)
       {}
 
-   RegisterDependencyConditions(TR_X86RegisterDependencyIndex numPreConds, TR_X86RegisterDependencyIndex numPostConds, TR_Memory * m)
+   RegisterDependencyConditions(uint32_t numPreConds, uint32_t numPostConds, TR_Memory * m)
       : _preConditions(TR_X86RegisterDependencyGroup::create(numPreConds, m)),
         _postConditions(TR_X86RegisterDependencyGroup::create(numPostConds, m)),
         _numPreConditions(numPreConds),
@@ -209,11 +209,11 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
         _addCursorForPost(0)
       {}
 
-   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, TR_X86RegisterDependencyIndex additionalRegDeps = 0, List<TR::Register> * = 0);
+   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, uint32_t additionalRegDeps = 0, List<TR::Register> * = 0);
 
    void unionNoRegPostCondition(TR::Register *reg, TR::CodeGenerator *cg);
 
-   TR::RegisterDependencyConditions  *clone(TR::CodeGenerator *cg, TR_X86RegisterDependencyIndex additionalRegDeps = 0);
+   TR::RegisterDependencyConditions  *clone(TR::CodeGenerator *cg, uint32_t additionalRegDeps = 0);
 
    TR_X86RegisterDependencyGroup *getPreConditions()  {return _preConditions;}
 
@@ -236,9 +236,9 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
          }
       }
 
-   TR_X86RegisterDependencyIndex getNumPreConditions() {return _numPreConditions;}
+   uint32_t getNumPreConditions() {return _numPreConditions;}
 
-   TR_X86RegisterDependencyIndex setNumPreConditions(TR_X86RegisterDependencyIndex n, TR_Memory * m)
+   uint32_t setNumPreConditions(uint32_t n, TR_Memory * m)
       {
       if (_preConditions == NULL)
          {
@@ -247,8 +247,8 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
       return (_numPreConditions = n);
       }
 
-   TR_X86RegisterDependencyIndex getNumPostConditions() {return _numPostConditions;}
-   TR_X86RegisterDependencyIndex setNumPostConditions(TR_X86RegisterDependencyIndex n, TR_Memory * m)
+   uint32_t getNumPostConditions() {return _numPostConditions;}
+   uint32_t setNumPostConditions(uint32_t n, TR_Memory * m)
       {
       if (_postConditions == NULL)
          {
@@ -257,11 +257,11 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
       return (_numPostConditions = n);
       }
 
-   TR_X86RegisterDependencyIndex getAddCursorForPre() {return _addCursorForPre;}
-   TR_X86RegisterDependencyIndex setAddCursorForPre(TR_X86RegisterDependencyIndex a) {return (_addCursorForPre = a);}
+   uint32_t getAddCursorForPre() {return _addCursorForPre;}
+   uint32_t setAddCursorForPre(uint32_t a) {return (_addCursorForPre = a);}
 
-   TR_X86RegisterDependencyIndex getAddCursorForPost() {return _addCursorForPost;}
-   TR_X86RegisterDependencyIndex setAddCursorForPost(TR_X86RegisterDependencyIndex a) {return (_addCursorForPost = a);}
+   uint32_t getAddCursorForPost() {return _addCursorForPost;}
+   uint32_t setAddCursorForPost(uint32_t a) {return (_addCursorForPost = a);}
 
    void addPreCondition(TR::Register              *vr,
                         TR::RealRegister::RegNum   rr,
@@ -269,7 +269,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
                         uint8_t                    flag = UsesDependentRegister,
                         bool                       isAssocRegDependency = false)
       {
-      TR_X86RegisterDependencyIndex newCursor = unionRealDependencies(_preConditions, _addCursorForPre, vr, rr, cg, flag, isAssocRegDependency);
+      uint32_t newCursor = unionRealDependencies(_preConditions, _addCursorForPre, vr, rr, cg, flag, isAssocRegDependency);
       TR_ASSERT(newCursor <= _numPreConditions, "Too many dependencies");
       if (newCursor == _addCursorForPre)
          _numPreConditions--; // A vmThread/ebp dependency was displaced, so there is now one less condition.
@@ -283,7 +283,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
                           uint8_t                    flag = UsesDependentRegister,
                           bool                       isAssocRegDependency = false)
       {
-      TR_X86RegisterDependencyIndex newCursor = unionDependencies(_preConditions, _addCursorForPre, vr, rr, cg, flag, isAssocRegDependency);
+      uint32_t newCursor = unionDependencies(_preConditions, _addCursorForPre, vr, rr, cg, flag, isAssocRegDependency);
       TR_ASSERT(newCursor <= _numPreConditions, "Too many dependencies");
       if (newCursor == _addCursorForPre)
          _numPreConditions--; // A union occurred, so there is now one less condition
@@ -299,7 +299,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
                          uint8_t                    flag = UsesDependentRegister,
                          bool                       isAssocRegDependency = false)
       {
-      TR_X86RegisterDependencyIndex newCursor = unionRealDependencies(_postConditions, _addCursorForPost, vr, rr, cg, flag, isAssocRegDependency);
+      uint32_t newCursor = unionRealDependencies(_postConditions, _addCursorForPost, vr, rr, cg, flag, isAssocRegDependency);
       TR_ASSERT(newCursor <= _numPostConditions, "Too many dependencies");
       if (newCursor == _addCursorForPost)
          _numPostConditions--; // A vmThread/ebp dependency was displaced, so there is now one less condition.
@@ -313,7 +313,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
                            uint8_t                    flag = UsesDependentRegister,
                            bool                       isAssocRegDependency = false)
       {
-      TR_X86RegisterDependencyIndex newCursor = unionDependencies(_postConditions, _addCursorForPost, vr, rr, cg, flag, isAssocRegDependency);
+      uint32_t newCursor = unionDependencies(_postConditions, _addCursorForPost, vr, rr, cg, flag, isAssocRegDependency);
       TR_ASSERT(newCursor <= _numPostConditions, "Too many dependencies");
       if (newCursor == _addCursorForPost)
          _numPostConditions--; // A union occurred, so there is now one less condition
@@ -434,7 +434,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
    uint32_t numReferencedFPRegisters(TR::CodeGenerator *);
    void printFullRegisterDependencyInfo(FILE *pOutFile);
    void printDependencyConditions(TR_X86RegisterDependencyGroup *conditions,
-                                  TR_X86RegisterDependencyIndex   numConditions,
+                                  uint32_t   numConditions,
                                   char                           *prefix,
                                   FILE                           *pOutFile);
 #endif
@@ -447,7 +447,7 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
 // Generate Routines
 ////////////////////////////////////////////////////
 
-TR::RegisterDependencyConditions  * generateRegisterDependencyConditions(TR::Node *, TR::CodeGenerator *, TR_X86RegisterDependencyIndex = 0, List<TR::Register> * = 0);
-TR::RegisterDependencyConditions  * generateRegisterDependencyConditions(TR_X86RegisterDependencyIndex, TR_X86RegisterDependencyIndex, TR::CodeGenerator *);
+TR::RegisterDependencyConditions  * generateRegisterDependencyConditions(TR::Node *, TR::CodeGenerator *, uint32_t = 0, List<TR::Register> * = 0);
+TR::RegisterDependencyConditions  * generateRegisterDependencyConditions(uint32_t, uint32_t, TR::CodeGenerator *);
 
 #endif

--- a/compiler/x/codegen/OMRRegisterDependencyStruct.hpp
+++ b/compiler/x/codegen/OMRRegisterDependencyStruct.hpp
@@ -40,21 +40,6 @@ namespace OMR { typedef OMR::X86::RegisterDependencyExt RegisterDependency; }
 
 #define GlobalRegisterFPDependency    0x04
 
-class TR_X86RegisterDependencyIndex
-   {
-   int32_t _index;
-
-   public:
-
-   TR_X86RegisterDependencyIndex(int32_t index):_index(index){}
-
-   operator int32_t() const { return _index; }
-   TR_X86RegisterDependencyIndex operator++()    { ++_index; return *this; }
-   TR_X86RegisterDependencyIndex operator--()    { --_index; return *this; }
-   TR_X86RegisterDependencyIndex operator++(int) { int32_t oldIndex = _index; _index++; return oldIndex; }
-   TR_X86RegisterDependencyIndex operator--(int) { int32_t oldIndex = _index; _index--; return oldIndex; }
-
-   };
 
 namespace OMR
 {

--- a/compiler/x/codegen/RegisterDependency.hpp
+++ b/compiler/x/codegen/RegisterDependency.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
+ * Copyright (c) 2000, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -41,10 +41,10 @@ class RegisterDependencyConditions : public OMR::RegisterDependencyConditionsCon
 
    RegisterDependencyConditions() : OMR::RegisterDependencyConditionsConnector () {}
 
-   RegisterDependencyConditions(TR_X86RegisterDependencyIndex numPreConds, TR_X86RegisterDependencyIndex numPostConds, TR_Memory * m) :
+   RegisterDependencyConditions(uint32_t numPreConds, uint32_t numPostConds, TR_Memory * m) :
       OMR::RegisterDependencyConditionsConnector(numPreConds, numPostConds, m) {}
 
-   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, TR_X86RegisterDependencyIndex additionalRegDeps = 0, List<TR::Register> *reglist = 0) :
+   RegisterDependencyConditions(TR::Node *node, TR::CodeGenerator *cg, uint32_t additionalRegDeps = 0, List<TR::Register> *reglist = 0) :
       OMR::RegisterDependencyConditionsConnector(node, cg, additionalRegDeps, reglist) {}
 
    };


### PR DESCRIPTION
There is no need to define it as a class as it exhibits the same
behaviour as a uint32_t.

Signed-off-by: Daryl Maier <maier@ca.ibm.com>