### PR TITLE
Merge TR_SymAliasSetInterface to TR_AliasSetInterface

### DIFF
--- a/compiler/il/AliasSetInterface.hpp
+++ b/compiler/il/AliasSetInterface.hpp
@@ -36,10 +36,6 @@
 #include "infra/Assert.hpp"
 #include "infra/BitVector.hpp"
 
-typedef enum {
-   useDefAliasSet,
-   UseOnlyAliasSet
-} AliasSetInterface;
 
 template <AliasSetInterface _AliasSetInterface>
 class TR_AliasSetInterface {
@@ -260,7 +256,7 @@ public:
    setAliases_impl(TR::SparseBitVector &aliasesToModify, bool value, bool isDirectCall, bool includeGCSafePoint)
       {
       TR::Compilation *comp = TR::comp();
-      TR_ASSERT_FATAL(_AliasSetInterface == useDefAliasSet || _AliasSetInterface ==  UseOnlyAliasSet, "failed: can only call setAliases_impl for UseOnly or useDef presently");
+      TR_ASSERT_FATAL(_AliasSetInterface == UseDefAliasSet || _AliasSetInterface ==  UseOnlyAliasSet, "failed: can only call setAliases_impl for UseOnly or useDef presently");
 
          {
          TR::SparseBitVector::Cursor aliasCursor(aliasesToModify);
@@ -278,7 +274,7 @@ public:
       {
       TR::Compilation *comp = TR::comp();
       LexicalTimer t("removeAllAliases", comp->phaseTimer());
-      TR_ASSERT_FATAL(_AliasSetInterface == useDefAliasSet || _AliasSetInterface ==  UseOnlyAliasSet, "failed: can only call removeAllAliases for UseOnly or useDef presently");
+      TR_ASSERT_FATAL(_AliasSetInterface == UseDefAliasSet || _AliasSetInterface ==  UseOnlyAliasSet, "failed: can only call removeAllAliases for UseOnly or useDef presently");
 
       }
 private:
@@ -294,18 +290,18 @@ private:
 /*
  * Interface to initialize TR_AliasSetInterface
  */
-struct TR_UseDefAliasSetInterface : public TR_AliasSetInterface<useDefAliasSet> {
+struct TR_UseDefAliasSetInterface : public TR_AliasSetInterface<UseDefAliasSet> {
   TR_UseDefAliasSetInterface(TR::SymbolReference *symRef,
                              bool isDirectCall = false,
                              bool includeGCSafePoint = false) :
-  TR_AliasSetInterface<useDefAliasSet>
+  TR_AliasSetInterface<UseDefAliasSet>
     (symRef, isDirectCall, includeGCSafePoint) {}
 
    TR_UseDefAliasSetInterface(bool shares_symbol,
                               TR::SymbolReference *symRef,
                               bool isDirectCall = false,
                               bool includeGCSafePoint = false) :
-  TR_AliasSetInterface<useDefAliasSet>
+  TR_AliasSetInterface<UseDefAliasSet>
     (shares_symbol, symRef, isDirectCall, includeGCSafePoint) {}
 };
 
@@ -321,7 +317,7 @@ struct TR_UseOnlyAliasSetInterface: public TR_AliasSetInterface<UseOnlyAliasSet>
  * Member function definitions of class TR_AliasSetInterface
  */
 template <> inline
-TR_BitVector *TR_AliasSetInterface<useDefAliasSet>::getTRAliases_impl(bool isDirectCall, bool includeGCSafePoint)
+TR_BitVector *TR_AliasSetInterface<UseDefAliasSet>::getTRAliases_impl(bool isDirectCall, bool includeGCSafePoint)
    {
    if(_symbolReference)
       {
@@ -361,10 +357,10 @@ void TR_AliasSetInterface<_AliasSetInterface>::setAlias_impl(TR::SymbolReference
    if (symRef2 == NULL)
       return;
 
-   TR_ASSERT_FATAL(_AliasSetInterface == useDefAliasSet || _AliasSetInterface ==  UseOnlyAliasSet, "failed: can only call setAlias_impl for UseOnly or useDef presently");
+   TR_ASSERT_FATAL(_AliasSetInterface == UseDefAliasSet || _AliasSetInterface ==  UseOnlyAliasSet, "failed: can only call setAlias_impl for UseOnly or useDef presently");
 
       {
-      if (_AliasSetInterface == useDefAliasSet)
+      if (_AliasSetInterface == UseDefAliasSet)
          {
          // carry out symmetrically
          setSymRef1KillsSymRef2Asymmetrically(_symbolReference, symRef2, includeGCSafePoint, value);

--- a/compiler/il/AliasSetInterface.hpp
+++ b/compiler/il/AliasSetInterface.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -290,6 +290,36 @@ private:
    //shows if the _symbolReference can have alias. Could only be false when called from Node::mayKill() function
    bool _shares_symbol;
 };
+
+/*
+ * Interface to initialize TR_AliasSetInterface
+ */
+struct TR_UseDefAliasSetInterface : public TR_AliasSetInterface<useDefAliasSet> {
+  TR_UseDefAliasSetInterface(TR::SymbolReference *symRef,
+                             bool isDirectCall = false,
+                             bool includeGCSafePoint = false) :
+  TR_AliasSetInterface<useDefAliasSet>
+    (symRef, isDirectCall, includeGCSafePoint) {}
+
+   TR_UseDefAliasSetInterface(bool shares_symbol,
+                              TR::SymbolReference *symRef,
+                              bool isDirectCall = false,
+                              bool includeGCSafePoint = false) :
+  TR_AliasSetInterface<useDefAliasSet>
+    (shares_symbol, symRef, isDirectCall, includeGCSafePoint) {}
+};
+
+struct TR_UseOnlyAliasSetInterface: public TR_AliasSetInterface<UseOnlyAliasSet> {
+  TR_UseOnlyAliasSetInterface(TR::SymbolReference *symRef,
+                              bool isDirectCall = false,
+                              bool includeGCSafePoint = false) :
+  TR_AliasSetInterface<UseOnlyAliasSet>
+    (symRef, isDirectCall, includeGCSafePoint) {}
+};
+
+/*
+ * Member function definitions of class TR_AliasSetInterface
+ */
 template <> inline
 TR_BitVector *TR_AliasSetInterface<useDefAliasSet>::getTRAliases_impl(bool isDirectCall, bool includeGCSafePoint)
    {
@@ -417,33 +447,6 @@ void TR_AliasSetInterface<_AliasSetInterface>::setSymRef1KillsSymRef2Asymmetrica
       removeSymRef1KillsSymRef2Asymmetrically(symRef1, symRef2, includeGCSafePoint);
    }
 
-////////////////// SYMREF-BASED ALIASING
-
-
-struct TR_UseDefAliasSetInterface : public TR_SymAliasSetInterface<useDefAliasSet> {
-  TR_UseDefAliasSetInterface(TR::SymbolReference *symRef,
-                             bool isDirectCall = false,
-                             bool includeGCSafePoint = false) :
-  TR_SymAliasSetInterface<useDefAliasSet>
-    (symRef, isDirectCall, includeGCSafePoint) {}
-
-   TR_UseDefAliasSetInterface(bool shares_symbol,
-                              TR::SymbolReference *symRef,
-                              bool isDirectCall = false,
-                              bool includeGCSafePoint = false) :
-  TR_SymAliasSetInterface<useDefAliasSet>
-    (shares_symbol, symRef, isDirectCall, includeGCSafePoint) {}
-};
-
-struct TR_UseOnlyAliasSetInterface: public TR_SymAliasSetInterface<UseOnlyAliasSet> {
-  TR_UseOnlyAliasSetInterface(TR::SymbolReference *symRef,
-                              bool isDirectCall = false,
-                              bool includeGCSafePoint = false) :
-  TR_SymAliasSetInterface<UseOnlyAliasSet>
-    (symRef, isDirectCall, includeGCSafePoint) {}
-};
-
-
 template <class T>
 void CountUseDefAliases( T& t, const TR::SparseBitVector &syms)
    {
@@ -473,9 +476,11 @@ void CountUseDefAliases( T& t, const TR::SparseBitVector &syms)
       }
    }
 
-///////////////////////////////////////
 
-
+/*
+ * Interface to initialize TR_AliasSetInterface from OMR::SymbolReference
+ * (Member function definitions of class OMR::SymbolReference)
+ */
 inline TR_UseOnlyAliasSetInterface
 OMR::SymbolReference::getUseonlyAliases()
    {

--- a/compiler/il/OMRSymbolReference.hpp
+++ b/compiler/il/OMRSymbolReference.hpp
@@ -47,6 +47,11 @@ namespace OMR { typedef OMR::SymbolReference SymbolReferenceConnector; }
 #include "infra/BitVector.hpp"
 #include "infra/Flags.hpp"
 
+typedef enum {
+   UseDefAliasSet,
+   UseOnlyAliasSet
+} AliasSetInterface;
+
 class TR_Debug;
 class TR_ResolvedMethod;
 class TR_UseDefAliasSetInterface;
@@ -55,7 +60,7 @@ namespace TR { class Register; }
 namespace TR { class ResolvedMethodSymbol; }
 namespace TR { class SymbolReference; }
 template <class T> class TR_Array;
-template <uint32_t> class TR_SymAliasSetInterface;
+template <AliasSetInterface> class TR_AliasSetInterface ;
 typedef TR::SparseBitVector SharedSparseBitVector;
 
 // Extra symbol reference info for allocation nodes.
@@ -309,8 +314,8 @@ protected:
 
    friend class ::TR_Debug;
 
-   template <uint32_t>
-   friend class ::TR_SymAliasSetInterface;
+   template <AliasSetInterface>
+   friend class ::TR_AliasSetInterface;
 
    TR_BitVector *getUseonlyAliasesBV(TR::SymbolReferenceTable *symRefTab);
    TR_BitVector *getUseDefAliasesBV( bool isDirectCall = false, bool gcSafe = false);


### PR DESCRIPTION
Since `TR_SymAliasSetInterface` is the only subclass of `TR_AliasSetInterface`, we can merge the subclass into its parent class.
After this PR, any reference to `AliasSet` will be initialized from `TR_AliasSetInterface` directly.

Issue: #4623 
Signed-off-by: Bohao(Aaron) Wang aaronwang0407@gmail.com