### PR TITLE
WIP: Use isCollected query when allocating virtual register

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -5480,7 +5480,7 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
 
    if (mref->getUnresolvedSnippet() != NULL)
       {
-      resultReg = sym->isLocalObject() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
+      resultReg = sym->isCollectedReference() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
       if (mref->useIndexedForm())
          {
          generateTrg1MemInstruction(cg, TR::InstOpCode::add, node, resultReg, mref);
@@ -5494,7 +5494,7 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
       {
       if (mref->useIndexedForm())
          {
-         resultReg = sym->isLocalObject() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
+         resultReg = sym->isCollectedReference() ?  cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
          generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, resultReg, mref->getBaseRegister(), mref->getIndexRegister());
          }
       else
@@ -5502,7 +5502,7 @@ TR::Register *OMR::Power::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::C
          int32_t  offset = mref->getOffset(*comp);
          if (mref->hasDelayedOffset() || offset!=0 || comp->getOption(TR_AOT))
             {
-            resultReg = sym->isLocalObject() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
+            resultReg = sym->isCollectedReference() ? cg->allocateCollectedReferenceRegister() : cg->allocateRegister();
             if (mref->hasDelayedOffset())
                {
                generateTrg1MemInstruction(cg, TR::InstOpCode::addi2, node, resultReg, mref);

--- a/compiler/x/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/x/codegen/OMRTreeEvaluator.cpp
@@ -3230,7 +3230,7 @@ TR::Register *OMR::X86::TreeEvaluator::generateLEAForLoadAddr(TR::Node *node,
 
    //memRef maybe not directly generated from symRef, for example symRef plus second child in analyzeLea
    // So we need also check if it is an internal pointer when allocate regsiter
-   if (symRef->getSymbol()->isLocalObject() && !isInternalPointer)
+   if (symRef->getSymbol()->isCollectedReference() && !isInternalPointer)
       targetRegister = cg->allocateCollectedReferenceRegister();
    else
       targetRegister = cg->allocateRegister();

--- a/compiler/z/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/z/codegen/OMRTreeEvaluator.cpp
@@ -6471,7 +6471,7 @@ OMR::Z::TreeEvaluator::checkAndAllocateReferenceRegister(TR::Node * node,
       {
       dynLitPoolLoad = true;
 
-      if (symbol->isLocalObject())
+      if (symbol->isCollectedReference())
          {
          tempReg = cg->allocateCollectedReferenceRegister();
          }
@@ -9507,7 +9507,7 @@ OMR::Z::TreeEvaluator::loadaddrEvaluator(TR::Node * node, TR::CodeGenerator * cg
    TR::SymbolReference * symRef = node->getSymbolReference();
    TR::Compilation *comp = cg->comp();
 
-   if (symRef->getSymbol()->isLocalObject())
+   if (symRef->getSymbol()->isCollectedReference())
       {
       targetRegister = cg->allocateCollectedReferenceRegister();
       }


### PR DESCRIPTION
In evaluators of all platforms, isLocalObject was used to decide whether
the allocated virutual register should be collected or not which is
incorrect. A LocalObject is uncollected if it doesn't contain
any reference type fields. Allocating collected virtual register for
uncollected LocalObject would result in crashes in GC.

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>