### PR TITLE
Revert "DDR: add support for xlc/xlclang version 16"

### DIFF
--- a/ddr/include/ddr/config.hpp
+++ b/ddr/include/ddr/config.hpp
@@ -39,13 +39,14 @@
 
 /* C++ TR1 support */
 
-#if (__cplusplus < 201103) && (defined(AIXPPC) || defined(J9ZOS390))
+#if (defined(AIXPPC) && (__xlC__ < 0x1000)) || defined(J9ZOS390)
 #if !defined(__IBMCPP_TR1__)
 #define __IBMCPP_TR1__ 1
 #endif
+#define OMR_HAVE_TR1 1
 #else
 #define OMR_HAVE_CXX11 1
-#endif /* (__cplusplus < 201103) && (defined(AIXPPC) || defined(J9ZOS390)) */
+#endif /* !defined(AIXPPC) && !defined(J9ZOS390) */
 
 /* Why is this disabled? */
 

--- a/ddr/include/ddr/scanner/dwarf/AixSymbolTableParser.hpp
+++ b/ddr/include/ddr/scanner/dwarf/AixSymbolTableParser.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,9 +18,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-#ifndef AixSymbolTableParser_HPP
-#define AixSymbolTableParser_HPP
 
 #include <sys/types.h>
 #include <sys/errno.h>
@@ -52,7 +49,7 @@ const string BUILT_IN_TYPES_THAT_ARE_TYPEDEFS[NUM_BUILT_IN_TYPES + 1] = {"", "",
 "", "", "unsigned", "", "", "", "", "", "integer", "", "short real", "real", "", "character", "", "", "", "",
 "", "", "integer*1", "integer*2", "integer*4", "wchar", "", "", "logical*8", "integer*8", "", "", ""
 };
-const int BUILT_IN_TYPE_SIZES[NUM_BUILT_IN_TYPES + 1] = {0, 32, 8, 16, 32, 8, 8, 16, 32, 32,
+const int BUILT_IN_TYPE_SIZES[NUM_BUILT_IN_TYPES +1 ] = {0, 32, 8, 16, 32, 8, 8, 16, 32, 32,
 32, 0, 32, 64, 128, 32, 8, 32, 64, PTR_SIZE, 8, 8, 16, 32, 32, 64, 128,
 8, 16, 32, 16, 64, 64, 64, 64, 64, 64, 64};
 
@@ -60,16 +57,15 @@ const string START_OF_FILE[3] = {"debug", "3", "FILE"};
 const string FILE_NAME = "a0";
 const string DECL_FILE[3] = {"debug", "0", "decl"};
 
-int extractFileID(const string & data);
-int extractTypeID(const string & data, int index = 1);
-void split(const string & data, char delimeters, str_vect *elements);
-str_vect split(const string & data, char delimeters);
-string strip(const string & str, char chr);
-string stripLeading(const string & str, char chr);
-string stripTrailing(const string & str, char chr);
-double toDouble(const string & value);
-int toInt(const string & value);
-size_t toSize(const string & size);
-string toString(int value);
-
-#endif /* AixSymbolTableParser_HPP */
+int extractFileID(const string data);
+int extractTypeID(const string data, const int index = 1);
+void split(const string data, char delimeters, str_vect *elements);
+str_vect split(const string data, char delimeters);
+string strip(const string str, const char chr);
+string stripLeading(const string str, const char chr);
+string stripTrailing(const string str, const char chr);
+double shiftDecimal(const double value);
+double toDouble(const string value);
+int toInt(const string value);
+size_t toSize(const string size);
+string toString(const int value);

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -48,15 +48,16 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
-#if defined(OMR_HAVE_CXX11)
-using std::get;
-using std::make_tuple;
-using std::tuple;
-#else /* OMR_HAVE_CXX11 */
+#if defined(OMR_HAVE_TR1)
 using std::tr1::get;
 using std::tr1::make_tuple;
 using std::tr1::tuple;
-#endif /* OMR_HAVE_CXX11 */
+#else /* OMR_HAVE_TR1 */
+using std::get;
+using std::make_tuple;
+using std::runtime_error;
+using std::tuple;
+#endif /* OMR_HAVE_TR1 */
 
 struct Dwarf_Attribute_s;
 struct Dwarf_Debug_s;
@@ -136,10 +137,6 @@ typedef vector<string> str_vect;
 #define DW_FORM_udata 0x05
 #define DW_FORM_sdata 0x06
 #define DW_FORM_string 0x07
-#define DW_FORM_block  0x08
-#define DW_FORM_block1 0x09
-#define DW_FORM_block2 0x0a
-#define DW_FORM_block4 0x0b
 #define DW_FORM_flag 0x0c
 #define DW_FORM_exprloc 0x18
 

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -59,6 +59,12 @@ using std::make_pair;
 using std::map;
 using std::string;
 
+#if defined(OMR_HAVE_TR1)
+using std::tr1::hash;
+#else
+using std::hash;
+#endif
+
 class DwarfScanner : public Scanner
 {
 public:

--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -39,6 +39,7 @@
 #include "ddr/scanner/Scanner.hpp"
 #include "ddr/ir/Symbol_IR.hpp"
 
+using std::hash;
 using std::map;
 using std::pair;
 using std::set;

--- a/ddr/include/ddr/std/unordered_map.hpp
+++ b/ddr/include/ddr/std/unordered_map.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corp. and others
+ * Copyright (c) 2013, 2017 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,12 +30,15 @@
 #undef tolower
 #endif /* defined(J9ZOS390) */
 
-#include <unordered_map>
-
 #if defined(OMR_HAVE_CXX11)
+#include <unordered_map>
 using std::unordered_map;
-#else /* defined(OMR_HAVE_CXX11) */
+#elif defined(OMR_HAVE_TR1)
+#include <unordered_map>
+using std::tr1::hash;
 using std::tr1::unordered_map;
+#else /* defined(OMR_HAVE_CXX11) */
+#error "Need std::unordered_map defined in TR1 or C++11."
 #endif /* defined(OMR_HAVE_CXX11) */
 
 #if defined(J9ZOS390)

--- a/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,6 +18,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+#if defined(AIXPPC) || defined(J9ZOS390)
+#define __IBMCPP_TR1__ 1
+#endif /* defined(AIXPPC) || defined(J9ZOS390) */
 
 #include "ddr/blobgen/genBlob.hpp"
 #include "ddr/blobgen/java/genBinaryBlob.hpp"

--- a/ddr/lib/ddr-scanner/dwarf/AixSymbolTableParser.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/AixSymbolTableParser.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corp. and others
+ * Copyright (c) 2015, 2018 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -37,12 +37,6 @@ static Dwarf_Die _lastDie = NULL;
 static Dwarf_Die _builtInTypeDie = NULL;
 /* _startNewFile is a state counter. */
 static int _startNewFile = 0;
-/*
- * The accumulated (stabs) symbol table string.
- * The stabs format allows for entries to be split (a segment ends with '/' or '?')
- * in which case multiple lines must be read in the output of 'dump'.
- */
-static string stabsString;
 /* Start numbering DIE refs for refMap at one (zero will be for when no ref is found). */
 static Dwarf_Off refNumber = 1;
 /* This is used to initialize declLine to a unique value for each unique DIE every time it is required. */
@@ -52,22 +46,22 @@ Dwarf_CU_Context * Dwarf_CU_Context::_currentCU;
 
 static void checkBitFields(Dwarf_Error *error);
 static void deleteDie(Dwarf_Die die);
-static int parseArray(const string & data, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseBaseType(const string & data, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseNamelessReference(const string & data, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseStabstringDeclarationIntoDwarfDie(const string & data, Dwarf_Error *error);
+static int parseArray(const string data, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseBaseType(const string data, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseNamelessReference(const string data, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseStabstringDeclarationIntoDwarfDie(const string data, Dwarf_Error *error);
 static int parseSymbolTable(const char *line, Dwarf_Error *error);
-static Dwarf_Half parseDeclarationLine(const string & data, int *typeID, declFormat *format, string *declarationData, string *name);
-static int parseEnum(const string & data, string dieName, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseField(const string & data, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseCPPstruct(const string & data, const string & dieName, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseCstruct(const string & data, const string & dieName, Dwarf_Die currentDie, Dwarf_Error *error);
-static int parseTypeDef(const string & data, const string & dieName, Dwarf_Die currentDie, Dwarf_Error *error);
-static int populateAttributeReferences();
+static Dwarf_Half parseDeclarationLine(string data, int *typeID, declFormat *format, string *declarationData, string *name);
+static int parseEnum(const string data, string dieName, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseCPPstruct(const string data, const string dieName, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseCstruct(const string data, const string dieName, Dwarf_Die currentDie, Dwarf_Error *error);
+static int parseTypeDef(const string data, const string dieName, Dwarf_Die currentDie, Dwarf_Error *error);
+static void populateAttributeReferences();
 static int populateBuiltInTypeDies(Dwarf_Error *error);
 static void populateNestedClasses();
 static void removeUselessStubs();
-static int setDieAttributes(const string & dieName, unsigned int dieSize, Dwarf_Die currentDie, Dwarf_Error *error);
+static int setDieAttributes(const string dieName, const unsigned int dieSize, Dwarf_Die currentDie, Dwarf_Error *error);
 
 using std::getline;
 
@@ -111,23 +105,23 @@ dwarf_init(int fd,
 	int ret = DW_DLV_OK;
 	FILE *fp = NULL;
 	char buffer[50000];
+	char filepath[100] = {'\0'};
 	Dwarf_CU_Context::_firstCU = NULL;
 	Dwarf_CU_Context::_currentCU = NULL;
 	refNumber = 1;
 
 	/* Populate the built-in types. */
 	ret = populateBuiltInTypeDies(error);
+	populateAttributeReferences();
 
-	if (DW_DLV_OK == ret) {
-		ret = populateAttributeReferences();
-	}
+	/* Get the path of the file descriptor. */
+	sprintf(filepath, "/proc/%d/fd/%d", getpid(), fd);
 
 	/* Call dump to get the symbol table. */
 	if (DW_DLV_OK == ret) {
-		/* Create the dump command line, using the /proc path for the file descriptor. */
-		stringstream command;
-		command << "dump -tvXany /proc/" << getpid() << "/fd/" << fd << " 2>&1";
-		fp = popen(command.str().c_str(), "r");
+		stringstream ss;
+		ss << "dump -tvXany " << filepath << " 2>&1";
+		fp = popen(ss.str().c_str(), "r");
 		if (NULL == fp) {
 			ret = DW_DLV_ERROR;
 			setError(error, DW_DLE_IOF);
@@ -142,13 +136,10 @@ dwarf_init(int fd,
 
 	if (NULL != fp) {
 		pclose(fp);
-		fp = NULL;
 	}
 
 	/* Populate the references and nested classes of the last file to get parsed. */
-	if (DW_DLV_OK == ret) {
-		ret = populateAttributeReferences();
-	}
+	populateAttributeReferences();
 	populateNestedClasses();
 	removeUselessStubs();
 
@@ -180,7 +171,7 @@ dwarf_init(int fd,
 			newDie->_child = NULL;
 			newDie->_context = newCU;
 			newDie->_attribute = name;
-
+							
 			name->_type = DW_AT_name;
 			name->_nextAttr = NULL;
 			name->_form = DW_FORM_string;
@@ -297,6 +288,7 @@ deleteDie(Dwarf_Die die)
 	delete die;
 }
 
+
 /**
  * Parses the string to file ID. Extracts the integer betwen the square brackets.
  *
@@ -305,7 +297,7 @@ deleteDie(Dwarf_Die die)
  * @return file ID as int
  */
 int
-extractFileID(const string & data)
+extractFileID(const string data)
 {
 	stringstream ss;
 	int ret = 0;
@@ -322,7 +314,7 @@ extractFileID(const string & data)
  * @return typeID as int
  */
 int
-extractTypeID(const string & data, int index)
+extractTypeID(const string data, const int index)
 {
 	stringstream ss;
 	int ret = 0;
@@ -332,25 +324,12 @@ extractTypeID(const string & data, int index)
 }
 
 /**
- * Add a new (type) attribute to the list to resolve later.
- */
-static void
-addRefToPopulate(int typeId, Dwarf_Attribute attribute)
-{
-	if (0 == typeId) {
-		ERRMSG("Bad type reference:\n%s\n", stabsString.c_str());
-		exit(1);
-	}
-	refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)typeId, (Dwarf_Attribute)attribute));
-}
-
-/**
  * Parses data passed in as an array declaration
  * param[in] data: the data to be parsed, should be in the format ar(INDEX_ID);(LOWER_BOUND);(UPPER_BOUND);(ARRAY_TYPE)
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseArray(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
+parseArray(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 {
 	int ret = DW_DLV_OK;
 	if (2 <= data.length()) {
@@ -382,7 +361,7 @@ parseArray(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
 				type->_ref = NULL;
 
 				/* Add the new attribute to the list of attributes to populate. */
-				addRefToPopulate(ID, type);
+				refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)ID, (Dwarf_Attribute)type));
 				currentDie->_attribute = type;
 				newDie->_tag = DW_TAG_subrange_type;
 				newDie->_parent = currentDie;
@@ -400,7 +379,7 @@ parseArray(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
 				subrangeType->_ref = NULL;
 
 				/* Add subrangeType to the list of refs to populate in a second pass. */
-				addRefToPopulate(-37, subrangeType);
+				refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)-37, (Dwarf_Attribute)subrangeType));
 
 				subrangeUpperBound->_type = DW_AT_upper_bound;
 				subrangeUpperBound->_nextAttr = NULL;
@@ -422,14 +401,13 @@ parseArray(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
 	}
 	return ret;
 }
-
 /**
  * Parses the data passed in and populates a DIE as a base type
  * param[in] data: the data to be parsed, it should consist of the following characters only: "1234567890-"
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseBaseType(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
+parseBaseType(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 {
 	int ret = DW_DLV_OK;
 	int index = toInt(data) * -1;
@@ -504,14 +482,13 @@ parseBaseType(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
 	}
 	return ret;
 }
-
 /*
  * Parses the data passed in and populates a DIE as a constant/pointer/volatile/subroutine type (all of those types have the same structure)
  * param[in] data: the data to be parsed, it should be of the form (*|k|V)(TYPE)
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseNamelessReference(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
+parseNamelessReference(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 {
 	int ret = DW_DLV_OK;
 	/* Give the DIE a type attribute. */
@@ -530,7 +507,7 @@ parseNamelessReference(const string & data, Dwarf_Die currentDie, Dwarf_Error *e
 		type->_ref = NULL;
 
 		/* Add the attribute to the list of refs to be populated. */
-		addRefToPopulate(ID, type);
+		refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)ID, (Dwarf_Attribute)type));
 
 		currentDie->_attribute = type;
 	}
@@ -548,7 +525,7 @@ parseNamelessReference(const string & data, Dwarf_Die currentDie, Dwarf_Error *e
  * @param[out] name: the name of the entity being declared
  */
 static Dwarf_Half
-parseDeclarationLine(const string & data,
+parseDeclarationLine(const string data,
 	int *typeID,
 	declFormat *format,
 	string *declarationData,
@@ -600,22 +577,6 @@ parseDeclarationLine(const string & data,
 				break;
 			case 'm': /* Pointer to member type */
 				ret = DW_TAG_ptr_to_member_type;
-				break;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-				/* Typedef declaration */
-				ret = DW_TAG_typedef;
-				break;
-			case 'Z': /* C++ ellipses parameter type */
-				ret = DW_TAG_unspecified_type;
 				break;
 			default:
 				ret = DW_TAG_unknown;
@@ -679,15 +640,16 @@ parseDeclarationLine(const string & data,
  * param[in] line: declaration for an entity. It should be the portion of a declaration line after "^\\[.*\\].*m.*debug.*decl\\s+"
  */
 static int
-parseStabstringDeclarationIntoDwarfDie(const string & line, Dwarf_Error *error)
+parseStabstringDeclarationIntoDwarfDie(const string line, Dwarf_Error *error)
 {
 	int ret = DW_DLV_OK;
 	int typeID = 0;
 	declFormat format = NO_FORMAT;
 	string declarationData;
 	string name;
+	string members;
 
-	/* We are parsing the section of debug info containing type declarations, comprised of lines beginning with "debug      0       decl".
+	/* We are parsing the section of debug info containing type declarations, comprised of lines beginning with "debug		0		decl".
 	 * Each declaration line is of the format: (DECLARATION_NAME):(c|t|T)(INTEGER_TYPE_ID)=(DECLARATION_TYPE)(FIELD_MEMBERS)
 	 * where DECLARATION_TYPE is one of: (*(INTEGER)|a|b|c|C|d|D|e|f|g|i|k|m|M|r|s|S|V|w|Z). See parseDeclarationLine() for more information.
 	 * The format differs for constants, typedefs, structures, etc. First, determine the type of declaration. Then parse that specific format.
@@ -697,10 +659,7 @@ parseStabstringDeclarationIntoDwarfDie(const string & line, Dwarf_Error *error)
 	Dwarf_Half tag = parseDeclarationLine(line, &typeID, &format, &declarationData, &name);
 
 	/* Parse the line further based on the type of the declaration. */
-	if (DW_TAG_unknown == tag) {
-		ERRMSG("Unknown stabs tag: '%s'", line.c_str());
-		ret = DW_DLV_ERROR;
-	} else {
+	if (DW_TAG_unknown != tag) {
 		Dwarf_Die newDie = NULL;
 
 		/* Search for the DIE in createdDies before creating a new one. */
@@ -748,10 +707,10 @@ parseStabstringDeclarationIntoDwarfDie(const string & line, Dwarf_Error *error)
 		if (NULL == newDie) {
 			ret = DW_DLV_ERROR;
 			setError(error, DW_DLE_MAF);
-		} else {
+		} else if (DW_TAG_unknown != tag) {
 			/* Do some preliminary parsing of the declarationData. */
 			str_vect tmp = split(declarationData, '=');
-			string members = tmp[1];
+			members = tmp[1];
 
 			/* Populate the dies. */
 			switch (tag) {
@@ -769,17 +728,7 @@ parseStabstringDeclarationIntoDwarfDie(const string & line, Dwarf_Error *error)
 			case DW_TAG_volatile_type:
 			case DW_TAG_subroutine_type:
 			case DW_TAG_reference_type:
-				ret = parseNamelessReference(members, newDie, error);
-				break;
 			case DW_TAG_ptr_to_member_type:
-				/* skip past optional 'virtual base' specification */
-				if ('v' == members[1]) {
-					members = members.substr(1);
-				}
-				/* skip past optional 'multiple base' specification */
-				if ('m' == members[1]) {
-					members = members.substr(1);
-				}
 				ret = parseNamelessReference(members, newDie, error);
 				break;
 			case DW_TAG_enumeration_type:
@@ -815,6 +764,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 {
 	int ret = DW_DLV_OK;
 	string data = line;
+	string validData = "";
 	string fileName = "";
 
 	/* This state machine processes each stage of the input:
@@ -822,18 +772,15 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 	 * 1: reached the start of a new file: parse to get info about the file and populate Dwarf_CU_Context::_currentCU
 	 * 2: inside of a file: skip the section listing the includes until the first type declaration is found
 	 * 3: parse declarations: parse to get the information to populate dwarf DIEs and check if end of file reached
-	 */
-	if (3 != _startNewFile) {
-		stabsString.clear();
-	}
+ 	 */
 	if (0 == _startNewFile) {
 		/* Ignore the information before the start of the debug information for a file.
-		 * Search for the pattern "debug    3   FILE", indicating the start of a new file, to progress to step 2.
+		 * Search for the pattern "debug	3	FILE", indicating the start of a new file, to progress to step 2.
 		 */
 		size_t indexOfDebug = data.find(START_OF_FILE[0]);
 		if (string::npos != indexOfDebug) {
 			string dataAfterDebug = data.substr(indexOfDebug + START_OF_FILE[0].length());
-			size_t indexOfNumber = dataAfterDebug.find(START_OF_FILE[1]);
+			size_t indexOfNumber  = dataAfterDebug.find(START_OF_FILE[1]);
 			if (string::npos != indexOfNumber) {
 				string dataAfterNumber = dataAfterDebug.substr(indexOfNumber + START_OF_FILE[1].length());
 				size_t indexOfFile = dataAfterNumber.find(START_OF_FILE[2]);
@@ -841,20 +788,18 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 					/* Verify that there are only whitespaces between the words. */
 					if ((indexOfNumber == dataAfterDebug.find_first_not_of(' ')) && (indexOfFile == dataAfterNumber.find_first_not_of(' '))) {
 						/* Populate the attribute references and nested classes from the previous file that we parsed. */
-						ret = populateAttributeReferences();
-						if (DW_DLV_OK == ret) {
-							populateNestedClasses();
+						populateAttributeReferences();
+						populateNestedClasses();
 
-							/* Remove DIEs which have no children, no size, and are not referred to by any other DIE. */
-							removeUselessStubs();
+						/* Remove DIEs which have no children, no size, and are not referred to by any other DIE. */
+						removeUselessStubs();
 
-							/* Clear the unordered_maps we maintained from the last file. */
-							createdDies.clear();
-							nestedClassesToPopulate.clear();
-							refsToPopulate.clear();
-							/* Change state to expect the start of a section of debug info for a file next. */
-							_startNewFile = 1;
-						}
+						/* Clear the unordered_maps we maintained from the last file. */
+						createdDies.clear();
+						nestedClassesToPopulate.clear();
+						refsToPopulate.clear();
+						/* Change state to expect the start of a section of debug info for a file next. */
+						_startNewFile = 1;
 					}
 				}
 			}
@@ -866,7 +811,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 			size_t fileNameIndex = data.find(FILE_NAME) + FILE_NAME.size();
 			size_t index = data.substr(fileNameIndex).find_first_not_of(' ');
 
-			fileName = strip(data.substr(index + fileNameIndex), '\n');
+			fileName = strip(data.substr(index+fileNameIndex), '\n');
 
 			/* Verify that the file has not been parsed through before. */
 			if (filesAdded.end() == filesAdded.find(fileName)) {
@@ -903,7 +848,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 					newDie->_child = NULL;
 					newDie->_context = newCU;
 					newDie->_attribute = name;
-
+						
 					name->_type = DW_AT_name;
 					name->_nextAttr = NULL;
 					name->_form = DW_FORM_string;
@@ -912,6 +857,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 					name->_stringdata = strdup(Dwarf_CU_Context::_fileList.back().c_str());
 					name->_refdata = 0;
 					name->_ref = NULL;
+
 
 					if (NULL == Dwarf_CU_Context::_firstCU) {
 						Dwarf_CU_Context::_firstCU = newCU;
@@ -930,7 +876,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 			}
 		}
 	} else if (2 == _startNewFile) {
-		/* Skip lines of the format "debug      0       (b|e)incl" until finding a line of the format "debug    0       decl".
+		/* Skip lines of the format "debug		0		(b|e)incl" until finding a line of the format "debug	0		decl".
 		 * These first lines in the file list includes before the section listing the type declarations.
 		 */
 		size_t indexOfDebug = data.find(DECL_FILE[0]);
@@ -946,20 +892,8 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 						/* Parse the data line to populate a DIE. */
 						string dataAfterDecl = dataAfterNumber.substr(indexOfDecl + DECL_FILE[2].length());
 						size_t index = dataAfterDecl.find_first_not_of(' ');
-						if (string::npos != index) {
-							stabsString.append(strip(dataAfterDecl.substr(index), '\n'));
-							size_t stabsLength = stabsString.length();
-							if (0 != stabsLength) {
-								char lastChar = stabsString[stabsLength - 1];
-								if (('?' == lastChar) || ('\\' == lastChar)) {
-									/* Erase the last character which marks this entry as a continuation. */
-									stabsString.erase(stabsLength - 1);
-								} else {
-									ret = parseStabstringDeclarationIntoDwarfDie(stabsString, error);
-									stabsString.clear();
-								}
-							}
-						}
+						validData.assign(strip(dataAfterDecl.substr(index), '\n'));
+						ret = parseStabstringDeclarationIntoDwarfDie(validData, error);
 						_startNewFile = 3;
 					}
 				}
@@ -967,7 +901,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 				/* Check if it is the declaration for the start of another file as the previous file may have contained no symbols */
 				indexOfNumber = dataAfterDebug.find(START_OF_FILE[1]);
 				if (string::npos != indexOfNumber) {
-					string dataAfterNumber = dataAfterDebug.substr(indexOfNumber + START_OF_FILE[1].length());
+					string dataAfterNumber = dataAfterDebug.substr(indexOfNumber+START_OF_FILE[1].length());
 					size_t indexOfFile = dataAfterNumber.find(START_OF_FILE[2]);
 					if (string::npos != indexOfFile) {
 						/* Verify that there are only whitespaces between the words */
@@ -983,7 +917,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 		 * declarations in a file are guaranteed to be in a continuous block.
 		 */
 		size_t indexOfDebug = data.find(DECL_FILE[0]);
-		/* Verify that the type declaration section has not ended by checking that the line begins with "debug      0       decl". */
+		/* Verify that the type declaration section has not ended by checking that the line begins with "debug		0		decl". */
 		if (string::npos != indexOfDebug) {
 			string dataAfterDebug = data.substr(indexOfDebug + DECL_FILE[0].length());
 			size_t indexOfNumber = dataAfterDebug.find(DECL_FILE[1]);
@@ -996,19 +930,8 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
 						/* Parse the data line to populate a DIE. */
 						string dataAfterDecl = dataAfterNumber.substr(indexOfDecl + DECL_FILE[2].length());
 						size_t index = dataAfterDecl.find_first_not_of(' ');
-						if (string::npos != index) {
-							stabsString.append(strip(dataAfterDecl.substr(index), '\n'));
-							size_t stabsLength = stabsString.length();
-							if (0 != stabsLength) {
-								char lastChar = stabsString[stabsLength - 1];
-								if (('?' == lastChar) || ('\\' == lastChar)) {
-									stabsString.erase(stabsLength - 1);
-								} else {
-									ret = parseStabstringDeclarationIntoDwarfDie(stabsString, error);
-									stabsString.clear();
-								}
-							}
-						}
+						validData.assign(strip(dataAfterDecl.substr(index), '\n'));
+						ret = parseStabstringDeclarationIntoDwarfDie(validData, error);
 					} else {
 						_startNewFile = 0;
 						_lastDie = NULL;
@@ -1036,7 +959,7 @@ parseSymbolTable(const char *line, Dwarf_Error *error)
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseEnum(const string & data,
+parseEnum(const string data,
 	string dieName,
 	Dwarf_Die currentDie,
 	Dwarf_Error *error)
@@ -1121,7 +1044,7 @@ parseEnum(const string & data,
 							enumeratorValue->_type = DW_AT_const_value;
 							enumeratorValue->_nextAttr = NULL;
 							enumeratorValue->_form = DW_FORM_sdata;
-							enumeratorValue->_sdata = strtoll(tmp.back().c_str(), NULL, 10);
+							enumeratorValue->_sdata = strtoll(tmp.back().c_str(), NULL, 16);
 							enumeratorValue->_udata = 0;
 							enumeratorValue->_refdata = 0;
 							enumeratorValue->_ref = NULL;
@@ -1134,7 +1057,7 @@ parseEnum(const string & data,
 				}
 			}
 		}
-	} else {
+	}	else {
 		ret = DW_DLV_ERROR;
 		setError(error, DW_DLE_IA);
 	}
@@ -1147,7 +1070,7 @@ parseEnum(const string & data,
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseField(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
+parseFields(const string data, Dwarf_Die currentDie, Dwarf_Error *error)
 {
 	int ret = DW_DLV_OK;
 	/* field[0] is the name and field[1] is field attributes. */
@@ -1177,14 +1100,14 @@ parseField(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
 		type->_nextAttr = declFile;
 		type->_form = DW_FORM_ref1;
 
-		int ID = extractTypeID(fieldAttributes[0], 0);
+		int ID = extractTypeID(fieldAttributes[0],0);
 		type->_udata = 0;
 		type->_sdata = 0;
 		type->_refdata = 0;
 		type->_ref = NULL;
 
 		/* Push the type into a vector to populate in a second pass. */
-		addRefToPopulate(ID, type);
+		refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)ID, (Dwarf_Attribute)type));
 		declFile->_type = DW_AT_decl_file;
 		declFile->_form = DW_FORM_udata;
 		declFile->_nextAttr = offset;
@@ -1242,8 +1165,8 @@ parseField(const string & data, Dwarf_Die currentDie, Dwarf_Error *error)
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseCstruct(const string & data,
-	const string & dieName,
+parseCstruct(const string data,
+	const string dieName,
 	Dwarf_Die currentDie,
 	Dwarf_Error *error)
 {
@@ -1271,38 +1194,39 @@ parseCstruct(const string & data,
 			}
 
 			for (unsigned int i = 0; i < members.size(); ++i) {
-				Dwarf_Die newDie = new Dwarf_Die_s;
-				if (NULL == newDie) {
-					ret = DW_DLV_ERROR;
-					setError(error, DW_DLE_MAF);
-					break;
-				}
-				newDie->_tag = DW_TAG_member;
-				newDie->_parent = currentDie;
-				newDie->_sibling = NULL;
-				newDie->_previous = NULL;
-				newDie->_child = NULL;
-				newDie->_context = Dwarf_CU_Context::_currentCU;
-				newDie->_attribute = NULL;
-
-				ret = parseField(members[i], newDie, error);
-
 				if (DW_DLV_OK == ret) {
-					/* Set the member to be a child of the parent DIE. */
-					if (NULL == lastChild) {
-						currentDie->_child = newDie;
+					Dwarf_Die newDie = new Dwarf_Die_s;
+					if (NULL == newDie) {
+						ret = DW_DLV_ERROR;
+						setError(error, DW_DLE_MAF);
 					} else {
-						lastChild->_sibling = newDie;
-						newDie->_previous = lastChild;
+						newDie->_tag = DW_TAG_member;
+						newDie->_parent = currentDie;
+						newDie->_sibling = NULL;
+						newDie->_previous = NULL;
+						newDie->_child = NULL;
+						newDie->_context = Dwarf_CU_Context::_currentCU;
+						newDie->_attribute = NULL;
+
+						ret = parseFields(members[i], newDie, error);
+
+						if (DW_DLV_OK == ret) {
+							/* Set the member to be a child of the parent DIE. */
+							if (NULL == lastChild) {
+								currentDie->_child = newDie;
+							} else {
+								lastChild->_sibling = newDie;
+								newDie->_previous = lastChild;
+							}
+							lastChild = newDie;
+						} else {
+							deleteDie(newDie);
+						}
 					}
-					lastChild = newDie;
-				} else {
-					deleteDie(newDie);
-					break;
 				}
 			}
 		}
-	} else {
+	}	else {
 		ret = DW_DLV_ERROR;
 		setError(error, DW_DLE_IA);
 	}
@@ -1316,8 +1240,8 @@ parseCstruct(const string & data,
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseCPPstruct(const string & data,
-	const string & dieName,
+parseCPPstruct(const string data,
+	const string dieName,
 	Dwarf_Die currentDie,
 	Dwarf_Error *error)
 {
@@ -1354,7 +1278,7 @@ parseCPPstruct(const string & data,
 					inheritanceDie->_child = NULL;
 					inheritanceDie->_context = Dwarf_CU_Context::_currentCU;
 					inheritanceDie->_attribute = type;
-
+					
 					type->_type = DW_AT_type;
 					type->_nextAttr = NULL;
 					type->_form = DW_FORM_ref1;
@@ -1364,7 +1288,7 @@ parseCPPstruct(const string & data,
 					type->_ref = NULL;
 
 					/* Push the type ref into a vector to populate in a second pass. */
-					addRefToPopulate(parentClassID, type);
+					refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)parentClassID, (Dwarf_Attribute)type));
 
 					if (NULL == currentDie->_child) {
 						currentDie->_child = inheritanceDie;
@@ -1379,8 +1303,8 @@ parseCPPstruct(const string & data,
 			}
 
 			if (DW_DLV_OK == ret) {
-				/* Set DIE attributes. */
-				ret = setDieAttributes(dieName, size, currentDie, error);
+			/* Set DIE attributes. */
+			ret = setDieAttributes(dieName, size, currentDie, error);
 			}
 
 			if (DW_DLV_OK == ret) {
@@ -1394,52 +1318,59 @@ parseCPPstruct(const string & data,
 					}
 				}
 				for (unsigned int i = 0; i < members.size(); ++i) {
-					if (2 <= members[i].size()) {
-						size_t indexOfFirstColon = members[i].find_first_of(':');
-						if (string::npos != members[i].find_first_of('[')) {
-							/* Ignore member function. */
-						} else if (string::npos != members[i].find_first_of(']')) {
-							/* Ignore friend function. */
-						} else if (string::npos != members[i].find_first_of(':')) {
-							/* Check to see if the data member is valid. */
-							if ((indexOfFirstColon > 0) && ('s' == members[i].at(indexOfFirstColon - 1))) {
-								/* Ignore static field. */
-							} else {
-								Dwarf_Die newDie = new Dwarf_Die_s;
-								if (NULL == newDie) {
-									ret = DW_DLV_ERROR;
-									setError(error, DW_DLE_MAF);
-									break;
-								}
-								newDie->_tag = DW_TAG_member;
-								newDie->_parent = currentDie;
-								newDie->_sibling = NULL;
-								newDie->_previous = NULL;
-								newDie->_child = NULL;
-								newDie->_context = Dwarf_CU_Context::_currentCU;
-								newDie->_attribute = NULL;
-
-								ret = parseField(members[i].substr(indexOfFirstColon + 1), newDie, error);
-								if (DW_DLV_OK == ret) {
-									/* Set the member as a child of the parent die. */
-									if (NULL == lastChild) {
-										currentDie->_child = newDie;
+					if (DW_DLV_OK == ret) {
+						Dwarf_Die newDie = new Dwarf_Die_s;
+						if (NULL == newDie) {
+							ret = DW_DLV_ERROR;
+							setError(error, DW_DLE_MAF);
+						} else {
+							newDie->_tag = DW_TAG_member;
+							newDie->_parent = currentDie;
+							newDie->_sibling = NULL;
+							newDie->_previous = NULL;
+							newDie->_child = NULL;
+							newDie->_context = Dwarf_CU_Context::_currentCU;
+							newDie->_attribute = NULL;
+							if (2 <= members[i].size()) {
+								if (string::npos != members[i].find_first_of('[')) {
+									/* The member is a member function. We will delete the DIE as functions are not necessary. */
+									deleteDie(newDie);
+								} else if (string::npos != members[i].find_first_of(']')) {
+									/* The member is a friend function. We will delete the DIE as functions are not necessary. */
+									deleteDie(newDie);
+								} else if (string::npos != members[i].find_first_of(':')) {
+									/* Check to see if the data member is valid. */
+									size_t indexOfFirstColon  = members[i].find_first_of(':');
+									if (string::npos != indexOfFirstColon) {
+										ret = parseFields(members[i].substr(indexOfFirstColon+1), newDie, error);
+										if (DW_DLV_OK == ret) {
+											/* Set the member as a child of the parent die. */
+											if (NULL == lastChild) {
+												currentDie->_child = newDie;
+											} else {
+												lastChild->_sibling = newDie;
+												newDie->_previous = lastChild;
+											}
+											lastChild = newDie;
+										} else {
+											deleteDie(newDie);
+										}
 									} else {
-										lastChild->_sibling = newDie;
-										newDie->_previous = lastChild;
+										/* Delete DIE's for invalid data members. */
+										deleteDie(newDie);
 									}
-									lastChild = newDie;
+								} else if ('N' == members[i].at(1)) {
+									/* Verift that the nested class is valid. */
+									/* Get the ID of the nested class from tmp[1]. */
+									str_vect tmp = split(members[i], 'N');
+									int ID = toInt(tmp[1]);
+									nestedClassesToPopulate.push_back(make_pair<int, Dwarf_Die>((int)ID, (Dwarf_Die)currentDie));
+
+									deleteDie(newDie);
 								} else {
 									deleteDie(newDie);
-									break;
 								}
 							}
-						} else if ('N' == members[i].at(1)) {
-							/* Verify that the nested class is valid. */
-							/* Get the ID of the nested class from tmp[1]. */
-							str_vect tmp = split(members[i], 'N');
-							int ID = toInt(tmp[1]);
-							nestedClassesToPopulate.push_back(make_pair<int, Dwarf_Die>((int)ID, (Dwarf_Die)currentDie));
 						}
 					}
 				}
@@ -1454,7 +1385,6 @@ parseCPPstruct(const string & data,
 	}
 	return ret;
 }
-
 /**
  * Parses data passed in as a typedef.
  * param[in] data: The data to parse, should be in the format (TYPE)
@@ -1462,8 +1392,8 @@ parseCPPstruct(const string & data,
  * param[out] currentDie: the DIE to populate with the parsed data.
  */
 static int
-parseTypeDef(const string & data,
-	const string & dieName,
+parseTypeDef(const string data,
+	const string dieName,
 	Dwarf_Die currentDie,
 	Dwarf_Error *error)
 {
@@ -1472,7 +1402,7 @@ parseTypeDef(const string & data,
 
 	/* Set attributes for name, type, and declaring file. */
 	Dwarf_Attribute type = new Dwarf_Attribute_s;
-	Dwarf_Attribute name = new Dwarf_Attribute_s;
+	Dwarf_Attribute name  = new Dwarf_Attribute_s;
 	Dwarf_Attribute declFile = new Dwarf_Attribute_s;
 	Dwarf_Attribute declLine = new Dwarf_Attribute_s;
 
@@ -1502,7 +1432,7 @@ parseTypeDef(const string & data,
 		type->_ref = NULL;
 
 		/* Add the new type attribute to the list of refs to populate on a second pass. */
-		addRefToPopulate(ID, type);
+		refsToPopulate.push_back(make_pair<int, Dwarf_Attribute>((int)ID, (Dwarf_Attribute)type));
 		name->_type = DW_AT_name;
 		name->_form = DW_FORM_string;
 		name->_nextAttr = declLine;
@@ -1546,38 +1476,36 @@ parseTypeDef(const string & data,
 /**
  * Looks up and populates the reference attributes which were added while populating Dwarf DIEs
  */
-static int
+static void
 populateAttributeReferences()
 {
-	int ret = DW_DLV_OK;
-
 	/* Iterate through the vector containing all attributes to be populated. */
-	vector<pair<int, Dwarf_Attribute> >::const_iterator fixup = refsToPopulate.begin();
-	for (; refsToPopulate.end() != fixup; ++fixup) {
-		int id = fixup->first;
+	for (unsigned int i = 0; i < refsToPopulate.size(); ++i) {
+		Dwarf_Attribute tmp = refsToPopulate[i].second;
 
-		/* Negative identifiers refer to built-in types, others refer to explicit types. */
-		die_map *dieMap = (id < 0) ? &builtInDies : &createdDies;
+		/* If the reference is to a built-in type then search the unordered_map containing built-in types. */
+		if (0 > refsToPopulate[i].first) {
+			/* Search for the reference in the DIE map. */
+			die_map::iterator existingDieEntry = builtInDies.find(refsToPopulate[i].first);
+			if (builtInDies.end() != existingDieEntry) {
+				tmp->_ref = existingDieEntry->second.second;
 
-		/* Search for the reference in the DIE map. */
-		die_map::const_iterator existingDieEntry = dieMap->find(id);
-
-		if (dieMap->end() == existingDieEntry) {
-			ERRMSG("Cannot resolve reference to type %d\n", id);
-			ret = DW_DLV_ERROR;
+				/* Set _refdata to the correct value and insert the reference into refMap. */
+				tmp->_refdata = existingDieEntry->second.first;
+				Dwarf_Die_s::refMap.insert(make_pair<Dwarf_Off, Dwarf_Die>((Dwarf_Off)existingDieEntry->second.first, (Dwarf_Die)existingDieEntry->second.second));
+			}
 		} else {
-			Dwarf_Attribute attr = fixup->second;
-			Dwarf_Off offset = existingDieEntry->second.first;
-			Dwarf_Die target = existingDieEntry->second.second;
+			/* Search for the reference in the DIE map. */
+			die_map::iterator existingDieEntry = createdDies.find(refsToPopulate[i].first);
+			if (createdDies.end() != existingDieEntry) {
+				tmp->_ref = existingDieEntry->second.second;
 
-			/* Set _ref and _refdata to the correct value and insert the reference into refMap. */
-			attr->_ref = target;
-			attr->_refdata = offset;
-			Dwarf_Die_s::refMap.insert(make_pair<Dwarf_Off, Dwarf_Die>((Dwarf_Off)offset, (Dwarf_Die)target));
+				/* Set _refdata to the correct value and insert the reference into refMap. */
+				tmp->_refdata = existingDieEntry->second.first;
+				Dwarf_Die_s::refMap.insert(make_pair<Dwarf_Off, Dwarf_Die>((Dwarf_Off)existingDieEntry->second.first, (Dwarf_Die)existingDieEntry->second.second));
+			}
 		}
 	}
-
-	return ret;
 }
 
 /**
@@ -1607,10 +1535,10 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 	 * -18 real, ............. IEEE double precision
 	 * -19 stringptr
 	 * -20 character, ........ 8 bit unsigned character type
-	 * -21 logical*1, ........ 8 bit type < FORTRAN
-	 * -22 logical*2, ........ 16 bit type < FORTRAN
-	 * -23 logical*4, ........ 32 bit type for boolean variables < FORTRAN
-	 * -24 logical, .......... 32 bit type < FORTRAN
+	 *	 -21 logical*1, ........ 8 bit type < FORTRAN
+	 *	 -22 logical*2, ........ 16 bit type < FORTRAN
+	 *	 -23 logical*4, ........ 32 bit type for boolean variables < FORTRAN
+	 *	 -24 logical, .......... 32 bit type < FORTRAN
 	 * -25 complex, .......... consisting of two IEEE single-precision floating point values
 	 * -26 complex, .......... consisting of two IEEE double-precision floating point values
 	 * -27 integer*1, ........ 8 bit signed integral type
@@ -1740,7 +1668,7 @@ populateBuiltInTypeDies(Dwarf_Error *error)
 
 				if (DW_DLV_OK == ret) {
 					/* Add the new child to the linked list of DIEs. */
-					if (NULL != previousDie) {
+					if (NULL !=  previousDie) {
 						previousDie->_sibling = newDie;
 						newDie->_previous = previousDie;
 					}
@@ -1862,8 +1790,8 @@ removeUselessStubs()
  * param[out] currentDie: the DIE to populate with the attributes.
  */
 static int
-setDieAttributes(const string & dieName,
-	unsigned int dieSize,
+setDieAttributes(const string dieName,
+	const unsigned int dieSize,
 	Dwarf_Die currentDie,
 	Dwarf_Error *error)
 {
@@ -1885,7 +1813,7 @@ setDieAttributes(const string & dieName,
 		}
 	} else {
 		/* Create attributes for name, size, and declaring file. */
-		Dwarf_Attribute name = new Dwarf_Attribute_s;
+		Dwarf_Attribute name  = new Dwarf_Attribute_s;
 		Dwarf_Attribute size = new Dwarf_Attribute_s;
 		Dwarf_Attribute declFile = new Dwarf_Attribute_s;
 		Dwarf_Attribute declLine = new Dwarf_Attribute_s;
@@ -1940,12 +1868,12 @@ setDieAttributes(const string & dieName,
  * Splits the string 'data' on delimeters in argument 'delim' and writes the output to
  * elements.
  *
- * @param[in]  data   : string that needs to be split
+ * @param[in]  data	  : string that needs to be split
  * @param[in]  delimeters: what the string needs to be seperated on
  * @param[out] elements  : string vector to write out the strings after doing the split to
  */
 void
-split(const string & data, char delimeters, str_vect *elements)
+split(const string data, char delimeters, str_vect *elements)
 {
 	stringstream ss;
 	ss.str(data);
@@ -1961,13 +1889,13 @@ split(const string & data, char delimeters, str_vect *elements)
  * Splits the string data on delimeters in argument delimeters and writes the output to
  * elements.
  *
- * @param[in]  data   : string that needs to be split
+ * @param[in]  data	  : string that needs to be split
  * @param[in]  delimeters: what the string needs to be seperated on
  *
  * @return string vector containing the strings after resulting from the split operation
  */
 str_vect
-split(const string & data, char delimeters)
+split(const string data, char delimeters)
 {
 	str_vect elements;
 	split(data, delimeters, &elements);
@@ -1983,7 +1911,7 @@ split(const string & data, char delimeters)
  * @return string after trimming char from front and back of the string
  */
 string
-strip(const string & str, char chr)
+strip(const string str, const char chr)
 {
 	string ret = str;
 	if (!ret.empty()) {
@@ -2002,7 +1930,7 @@ strip(const string & str, char chr)
  * @return string after trimming char from the start of the string
  */
 string
-stripLeading(const string & str, char chr)
+stripLeading(const string str, const char chr)
 {
 	string ret = str;
 	if (!ret.empty()) {
@@ -2022,7 +1950,7 @@ stripLeading(const string & str, char chr)
  * @return string after trimming char from the end of the string
  */
 string
-stripTrailing(const string & str, char chr)
+stripTrailing(const string str, const char chr)
 {
 	string ret = str;
 	if (!ret.empty()) {
@@ -2035,6 +1963,23 @@ stripTrailing(const string & str, char chr)
 }
 
 /**
+ * Converts value to 0.0value
+ *
+ * @param[in] value: double value that you want to move the decimal point for
+ *
+ * @return double with decimal point shifted left by length of the argument plus 1
+ */
+double
+shiftDecimal(const double value)
+{
+	double ret = value;
+	if (ret >= 1) {
+		ret = shiftDecimal(value/100);
+	}
+	return ret;
+}
+
+/**
  * Converts value from string to double
  *
  * @param[in] value: string value that needs to be converted to double
@@ -2042,7 +1987,7 @@ stripTrailing(const string & str, char chr)
  * @return double equivalent of the string value
  */
 double
-toDouble(const string & value)
+toDouble(const string value)
 {
 	stringstream ss;
 	double ret = 0;
@@ -2059,7 +2004,7 @@ toDouble(const string & value)
  * @return int equivalent of the string value
  */
 int
-toInt(const string & value)
+toInt(const string value)
 {
 	return (int)toDouble(value);
 }
@@ -2072,7 +2017,7 @@ toInt(const string & value)
  * @return size_t
  */
 size_t
-toSize(const string & size)
+toSize(const string size)
 {
 	stringstream ss;
 	size_t ret = 0;
@@ -2089,7 +2034,7 @@ toSize(const string & size)
  * @return argument value as string
  */
 string
-toString(int value)
+toString(const int value)
 {
 	stringstream ss;
 	ss << value;

--- a/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
@@ -285,15 +285,12 @@ dwarf_offdie_b(Dwarf_Debug dbg,
 	if (NULL == return_die) {
 		ret = DW_DLV_ERROR;
 		setError(error, DW_DLE_IA);
+	} else if (Dwarf_Die_s::refMap.end() != Dwarf_Die_s::refMap.find(offset)) {
+		/* Return any Die from its global offset. */
+		*return_die = Dwarf_Die_s::refMap[offset];
 	} else {
-		unordered_map<Dwarf_Off, Dwarf_Die>::const_iterator iter = Dwarf_Die_s::refMap.find(offset);
-		if ((Dwarf_Die_s::refMap.end() != iter) && (NULL != iter->second)) {
-			/* Return any Die from its global offset. */
-			*return_die = iter->second;
-		} else {
-			ret = DW_DLV_NO_ENTRY;
-			setError(error, DW_DLE_BADOFF);
-		}
+		ret = DW_DLV_NO_ENTRY;
+		setError(error, DW_DLE_BADOFF);
 	}
 	return ret;
 }

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -19,7 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#include "ddr/config.hpp"
+#if defined(AIXPPC) || defined(J9ZOS390)
+#define __IBMCPP_TR1__ 1
+#endif /* defined(AIXPPC) || defined(J9ZOS390) */
 
 #include <stdlib.h>
 #include <string.h>

--- a/gc/base/standard/CompactScheme.hpp
+++ b/gc/base/standard/CompactScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2016 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,7 +147,7 @@ public:
      * In Compressed Mark Map one bit represents twice more space then one bit of regular Mark Map
      * So, sizeof_page should be double of number of bytes represented by one uintptr_t in Mark Map
      */
-    ddr_constant(sizeof_page, 2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_SLOT);
+    enum { sizeof_page = 2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_SLOT };
 
 private:
     omrobjectptr_t freeChunkEnd(omrobjectptr_t chunk);
@@ -158,6 +158,7 @@ private:
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
+
 
     void createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded);
     /**

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -49,7 +49,7 @@
 extern "C" {
 #endif
 
-#define OMR_OS_STACK_SIZE 256 * 1024 /* Corresponds to desktopBigStack in builder */
+#define OMR_OS_STACK_SIZE	256 * 1024 /* Corresponds to desktopBigStack in builder */
 
 typedef enum {
 	OMR_ERROR_NONE = 0,
@@ -82,7 +82,7 @@ struct UtThreadData;
 struct OMR_TraceThread;
 
 typedef struct OMR_RuntimeConfiguration {
-	uintptr_t _maximum_vm_count; /* 0 for unlimited */
+	uintptr_t _maximum_vm_count;		/* 0 for unlimited */
 } OMR_RuntimeConfiguration;
 
 typedef struct OMR_Runtime {
@@ -96,7 +96,7 @@ typedef struct OMR_Runtime {
 } OMR_Runtime;
 
 typedef struct OMR_VMConfiguration {
-	uintptr_t _maximum_thread_count; /* 0 for unlimited */
+	uintptr_t _maximum_thread_count;		/* 0 for unlimited */
 } OMR_VMConfiguration;
 
 typedef struct movedObjectHashCode {
@@ -371,6 +371,7 @@ void omr_vmthread_reattach(OMR_VMThread *currentThread, const char *threadName);
  */
 void omr_vmthread_redetach(OMR_VMThread *omrVMThread);
 
+
 /**
  * Get the current OMR_VMThread, if the current thread is attached.
  *
@@ -445,6 +446,9 @@ void omr_vm_preFork(OMR_VM *vm);
 
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
 
+
+
+
 /*
  * LANGUAGE VM GLUE
  * The following functions must be implemented by the language VM.
@@ -458,7 +462,7 @@ void omr_vm_preFork(OMR_VM *vm);
  *
  * @param[in] omrVM the OMR vm
  * @param[in] threadName An optional name for the thread. May be NULL.
- *   It is the responsibility of the caller to ensure this string remains valid for the lifetime of the thread.
+ * 	 It is the responsibility of the caller to ensure this string remains valid for the lifetime of the thread.
  * @param[out] omrVMThread the current OMR VMThread
  * @return an OMR error code
  */
@@ -555,13 +559,6 @@ int OMR_Glue_GetMethodDictionaryPropertyNum(void);
  * @return Method property names
  */
 const char * const *OMR_Glue_GetMethodDictionaryPropertyNames(void);
-
-/*
- * Not all compilers retain debugging information for anonymous enum types.
- * This macro works around that behavior by declaring a static member
- * (that will not be defined).
- */
-#define ddr_constant(name, value) static enum { name = value } ddr_ref_ ## name
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This causes problems for building openj9 on AIX (all versions) and on OSX.
I expect updating the AIX build machines with the new version of `dump` required for use with xlclang 16 with fix that platform, but I'd like to understand the OSX problem rather than doing anything hasty.

Reverts eclipse/omr#4620