### PR TITLE
AArch64: Implement OMR::ARM64::RegisterDependencyConditions::clone

### DIFF
--- a/compiler/aarch64/codegen/OMRRegisterDependency.cpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.cpp
@@ -146,10 +146,46 @@ void OMR::ARM64::RegisterDependencyConditions::incRegisterTotalUseCounts(TR::Cod
 TR::RegisterDependencyConditions *
 OMR::ARM64::RegisterDependencyConditions::clone(
    TR::CodeGenerator *cg,
-   TR::RegisterDependencyConditions *added)
+   TR::RegisterDependencyConditions *added,
+   bool omitPre, bool omitPost)
    {
-   TR_UNIMPLEMENTED();
-   return NULL;
+   int preNum = omitPre ? 0 : getAddCursorForPre();
+   int postNum = omitPost ? 0 : getAddCursorForPost();
+   int addPreNum = 0;
+   int addPostNum = 0;
+
+   if (added != NULL)
+      {
+      addPreNum = omitPre ? 0 : added->getAddCursorForPre();
+      addPostNum = omitPost ? 0 : added->getAddCursorForPost();
+      }
+   
+   TR::RegisterDependencyConditions *result =  new (cg->trHeapMemory()) TR::RegisterDependencyConditions(preNum + addPreNum, postNum + addPostNum, cg->trMemory());
+   for (int i = 0; i < preNum; i++)
+      {
+      auto singlePair = getPreConditions()->getRegisterDependency(i);
+      result->addPreCondition(singlePair->getRegister(), singlePair->getRealRegister(), singlePair->getFlags());
+      }
+
+   for (int i = 0; i < postNum; i++)
+      {
+      auto singlePair = getPostConditions()->getRegisterDependency(i);
+      result->addPostCondition(singlePair->getRegister(), singlePair->getRealRegister(), singlePair->getFlags());
+      }
+
+   for (int i = 0; i < addPreNum; i++)
+      {
+      auto singlePair = added->getPreConditions()->getRegisterDependency(i);
+      result->addPreCondition(singlePair->getRegister(), singlePair->getRealRegister(), singlePair->getFlags());
+      }
+
+   for (int i = 0; i < addPostNum; i++)
+      {
+      auto singlePair = added->getPostConditions()->getRegisterDependency(i);
+      result->addPostCondition(singlePair->getRegister(), singlePair->getRealRegister(), singlePair->getFlags());
+      }
+
+   return result;
    }
 
 void TR_ARM64RegisterDependencyGroup::assignRegisters(

--- a/compiler/aarch64/codegen/OMRRegisterDependency.hpp
+++ b/compiler/aarch64/codegen/OMRRegisterDependency.hpp
@@ -231,9 +231,27 @@ class RegisterDependencyConditions: public OMR::RegisterDependencyConditions
     * @brief Clones RegisterDependencyConditions
     * @param[in] cg : CodeGenerator
     * @param[in] added : conditions to be added
+    * @param[in] omitPre : if true, result will have empty pre conditions
+    * @param[in] omitPost : if true, result will have empty post conditions
     * @return cloned RegisterDependencyConditions
     */
-   TR::RegisterDependencyConditions *clone(TR::CodeGenerator *cg, TR::RegisterDependencyConditions *added=NULL);
+   TR::RegisterDependencyConditions *clone(TR::CodeGenerator *cg, TR::RegisterDependencyConditions *added=NULL, bool omitPre = false, bool omitPost = false);
+
+   /**
+    * @brief Clones only pre-condition part of RegisterDependencyConditions
+    * @param[in] cg : CodeGenerator
+    * @param[in] added : conditions to be added
+    * @return cloned RegisterDependencyConditions
+    */
+   TR::RegisterDependencyConditions *clonePre(TR::CodeGenerator *cg, TR::RegisterDependencyConditions *added=NULL) { return clone(cg, added, false, true); }
+
+   /**
+    * @brief Clones only post-condition part of RegisterDependencyConditions
+    * @param[in] cg : CodeGenerator
+    * @param[in] added : conditions to be added
+    * @return cloned RegisterDependencyConditions
+    */
+   TR::RegisterDependencyConditions *clonePost(TR::CodeGenerator *cg, TR::RegisterDependencyConditions *added=NULL) { return clone(cg, added, true, false); }
 
    /**
     * @brief Adds NoReg to post-condition


### PR DESCRIPTION
- This commits adds implementation of `OMR::ARM64::RegisterDependencyConditions::clone`.
- It adds optional arguments to `clone` that enables cloning only pre/post part
of original dependency conditions.
- It adds utility methods `clonePre` and `clonePost` which call `clone`.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>