### PR TITLE
Stop re-downloading config.guess and config.sub

### DIFF
--- a/buildenv/jenkins/jobs/builds/Build-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/builds/Build-linux_x86-64_cmprssptrs
@@ -33,7 +33,7 @@ pipeline {
                     sh '''ccache -s -z'''
                     
                     echo 'Configure...'
-                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc HAS_AUTOCONF=1 distclean all'''
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc HAS_AUTOCONF=1 all'''
                     
                     echo 'Compile...'
                     sh '''make -j4'''

--- a/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64_cmprssptrs
+++ b/buildenv/jenkins/jobs/pull-requests/PullRequest-linux_x86-64_cmprssptrs
@@ -19,7 +19,7 @@ pipeline {
                     sh '''ccache -s -z'''
                     
                     echo 'Configure...'
-                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc HAS_AUTOCONF=1 distclean all'''
+                    sh '''make -f run_configure.mk OMRGLUE=./example/glue SPEC=linux_x86-64_cmprssptrs PLATFORM=amd64-linux64-gcc HAS_AUTOCONF=1 all'''
                     
                     echo 'Compile...'
                     sh '''make -j4'''

--- a/run_configure.mk
+++ b/run_configure.mk
@@ -133,7 +133,7 @@ sh configure --disable-auto-build-flag 'OMRGLUE=$(OMRGLUE)' 'SPEC=$(SPEC)' $(CON
 touch $(CONFIGURE_OUTPUT_FILES)
 endef
 
-CONFIGURE_DEPENDENCIES := SPEC config.guess config.sub configure tools/configure
+CONFIGURE_DEPENDENCIES := SPEC configure tools/configure
 CONFIGURE_OUTPUT_FILES := include_core/omrcfg.h include_core/omrversionstrings.h omrmakefiles/configure.mk ./omr.rc tools/toolconfigure.mk CONFIGURE_SENTINEL_FILE
 CONFIGURE_INPUT_FILES := include_core/omrcfg.h.in include_core/omrversionstrings.h.in omrmakefiles/configure.mk.in ./omr.rc.in tools/toolconfigure.mk.in
 CONFIGURE_BYPRODUCTS := config.cache config.status config.log autom4te.cache tools/config.cache tools/config.status toolconfig/config.log tools/autom4te.cache
@@ -153,12 +153,6 @@ ifeq ($(HAS_AUTOCONF),1)
 else
 	@echo "WARNING: autoconf needs to be re-run in $$PWD/tools.  You should do this by hand, or set HAS_AUTOCONF=1 to have this makefile do it for you."
 endif
-
-config.guess:
-	curl -o config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
-
-config.sub:
-	curl -o config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD"
 
 # Since configure has many output files, we are using a 'sentinel file' to make
 # sure that this recipe is only executed once when running configure in parallel.

--- a/scripts/build-on-travis.sh
+++ b/scripts/build-on-travis.sh
@@ -23,7 +23,7 @@
 
 set -evx
 
-time make -f run_configure.mk OMRGLUE=./example/glue SPEC=${SPEC} PLATFORM=${PLATFORM} HAS_AUTOCONF=1 distclean all
+time make -f run_configure.mk OMRGLUE=./example/glue SPEC=${SPEC} PLATFORM=${PLATFORM} HAS_AUTOCONF=1 all
 if test "x$RUN_LINT" = "xyes"; then
   llvm-config --version
   clang++ --version


### PR DESCRIPTION
config.guess and config.sub are not generated files, they are checked in to our repository. With this PR, `make -f run_configure.mk distclean` will no longer remove these scripts. I've also removed the rules for downloading new versions, and stopped calling distclean at the beginning of our builds.