### PR TITLE
CMake: Link ddr tooling against omr thread/port libraries

### DIFF
--- a/ddr/tools/blob_reader/CMakeLists.txt
+++ b/ddr/tools/blob_reader/CMakeLists.txt
@@ -32,8 +32,8 @@ target_link_libraries(omr_blob_reader
 	omr_ddr_macros
 	omr_ddr_scanner
 	omrutil
-	${OMR_PORT_LIB}
-	${OMR_THREAD_LIB}
+	omrport
+	j9thrstatic
 )
 
 if(OMRPORT_OMRSIG_SUPPORT)

--- a/ddr/tools/ddrgen/CMakeLists.txt
+++ b/ddr/tools/ddrgen/CMakeLists.txt
@@ -34,8 +34,8 @@ target_link_libraries(omr_ddrgen
 	omr_ddr_ir
 	omr_ddr_macros
 	omr_ddr_scanner
-	${OMR_PORT_LIB}
-	${OMR_THREAD_LIB}
+	omrport
+	j9thrstatic
 )
 
 if(OMRPORT_OMRSIG_SUPPORT)


### PR DESCRIPTION
Its not gauranteed that consumers of omr will export the symbols we need
from their versions of the port and thread libraries

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>