### PR TITLE
CMake: Refactor DDR support

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -204,5 +204,3 @@ set(OMR_ENV_GCC OFF CACHE BOOL "TODO: Document")
 set(OMR_OPT_CUDA ${CUDA_FOUND} CACHE BOOL "Enable CUDA support in OMR")
 
 set(OMR_SANITIZE OFF CACHE STRING "Sanitizer selection. Only has an effect on GNU or Clang")
-
-set(OMR_SEPARATE_DEBUG_INFO OFF CACHE BOOL "Maintain debug info in a separate file")

--- a/cmake/modules/platform/toolcfg/gnu.cmake
+++ b/cmake/modules/platform/toolcfg/gnu.cmake
@@ -93,7 +93,7 @@ function(_omr_toolchain_separate_debug_symbols tgt)
 		add_custom_command(
 			TARGET "${tgt}"
 			POST_BUILD
-			COMMAND dysymutil -f ${exe_file} -o ${dbg_file}
+			COMMAND dsymutil -f ${exe_file} -o ${dbg_file}
 		)
 	else()
 		add_custom_command(


### PR DESCRIPTION
- Move the OMR_SEPARATE_DEBUG_INFO flag into OmrDDRSupport as consumers
  may start using ddr before including omr
- Fix typo in osx split debug info support dysymutil->dsymutil
- Force use of split debug info on osx, as debug info is not stored in
  libraries (needs to be extracted from input objects)

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>