### PR TITLE
Redefine CG queries to return correct answer

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.cpp
+++ b/compiler/codegen/OMRCodeGenerator.cpp
@@ -1056,6 +1056,42 @@ OMR::CodeGenerator::needRelocationsForLookupEvaluationData()
    }
 
 bool
+OMR::CodeGenerator::needClassAndMethodPointerRelocations()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
+OMR::CodeGenerator::needRelocationsForStatics()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
+OMR::CodeGenerator::needRelocationsForBodyInfoData()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
+OMR::CodeGenerator::needRelocationsForPersistentInfoData()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
+OMR::CodeGenerator::needRelocationsForCurrentMethodPC()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
+OMR::CodeGenerator::needRelocationsForHelpers()
+   {
+   return self()->comp()->compileRelocatableCode();
+   }
+
+bool
 OMR::CodeGenerator::isGlobalVRF(TR_GlobalRegisterNumber n)
    {
    return self()->hasGlobalVRF() &&

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1154,16 +1154,16 @@ class OMR_EXTENSIBLE CodeGenerator
    void apply32BitLabelTableRelocation(int32_t * cursor, TR::LabelSymbol *);
 
 
-   bool needClassAndMethodPointerRelocations() { return false; }
-   bool needRelocationsForStatics() { return false; }
-   bool needRelocationsForBodyInfoData() { return false; }
-   bool needRelocationsForPersistentInfoData() { return false; }
+   bool needClassAndMethodPointerRelocations();
+   bool needRelocationsForStatics();
+   bool needRelocationsForBodyInfoData();
+   bool needRelocationsForPersistentInfoData();
    bool needRelocationsForLookupEvaluationData();
-   bool needRelocationsForCurrentMethodPC() { return false; }
+   bool needRelocationsForCurrentMethodPC();
 
    // This query can be used if we need to decide whether data represented by TR_HelperAddress or TR_AbsoluteHelperAddress
    // relocation type needs a relocation record.
-   bool needRelocationsForHelpers() { return false; }
+   bool needRelocationsForHelpers();
 
    // --------------------------------------------------------------------------
    // Snippets

--- a/compiler/x/amd64/codegen/OMRMemoryReference.cpp
+++ b/compiler/x/amd64/codegen/OMRMemoryReference.cpp
@@ -247,7 +247,7 @@ bool OMR::X86::AMD64::MemoryReference::needsAddressLoadInstruction(intptrj_t rip
       }
    else if (_baseRegister || _indexRegister)
       return !IS_32BIT_SIGNED(displacement);
-   else if (cg->needClassAndMethodPointerRelocations() || cg->needRelocationsForStatics())
+   else if (cg->needClassAndMethodPointerRelocations())
       return true;
    else if (sr.getSymbol() && sr.getSymbol()->isRecompilationCounter() && cg->needRelocationsForBodyInfoData())
       return true;
@@ -419,7 +419,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
          }
       else if (sr.getSymbol()->isCountForRecompile())
          {
-         if (cg->needRelocationsForStatics() || cg->needRelocationsForPersistentInfoData())
+         if (cg->needRelocationsForPersistentInfoData())
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(
                                    displacementLocation, (uint8_t *) TR_CountForRecompile, TR_GlobalValue, cg),
                                  __FILE__,
@@ -428,7 +428,7 @@ OMR::X86::AMD64::MemoryReference::addMetaDataForCodeAddressWithLoad(
          }
       else if (sr.getSymbol()->isRecompilationCounter())
          {
-         if (cg->needRelocationsForStatics() || cg->needRelocationsForBodyInfoData())
+         if (cg->needRelocationsForBodyInfoData())
             cg->addExternalRelocation(new (cg->trHeapMemory()) TR::ExternalRelocation(displacementLocation, 0, TR_BodyInfoAddress, cg),
                                  __FILE__,__LINE__,containingInstruction->getNode());
          }


### PR DESCRIPTION
The queries modified in this PR are used to replace the
generic compileRelocatableCode() query so that it is easier
for downstream projects to override them on a case-by-case
basis. Since the queries are replacing the original
compileRelocatableCode() call, they should be returning the
same result as before in OMR. This commit fixes that issue.

Signed-off-by: Dhruv Chopra <Dhruv.C.Chopra@ibm.com>