### PR TITLE
CMake: Fix ddr on osx

### DIFF
--- a/cmake/modules/ddr/cmake_ddr.awk
+++ b/cmake/modules/ddr/cmake_ddr.awk
@@ -22,10 +22,10 @@
 
 function get_basename(){
 	n = split(FILENAME, array, "/")
-	split(array[n], array, ".")
+	split(array[n], filename_array, ".")
 
 	#capitalize the first letter
-	return toupper(substr(array[1], 1, 1)) substr(array[1], 2)
+	return toupper(substr(filename_array[1], 1, 1)) substr(filename_array[1], 2)
 }
 
 function set_default_namespaces() {


### PR DESCRIPTION
awk on osx does not behave properly when the result of split() overwrites
the input.

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>