### PR TITLE
Remove uses of J9VM_OUT_OF_PROCESS

### DIFF
--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -96,21 +96,6 @@ typedef struct omrthread_monitor_walk_state_t {
 } omrthread_monitor_walk_state_t;
 
 /* ---------------- omrthreadinspect.c ---------------- */
-#if defined (J9VM_OUT_OF_PROCESS)
-/* redefine thread functions */
-#define omrthread_monitor_walk dbg_omrthread_monitor_walk
-#define omrthread_monitor_walk_no_locking dbg_omrthread_monitor_walk_no_locking
-#define omrthread_tls_get dbg_omrthread_tls_get
-#define omrthread_get_priority dbg_omrthread_get_priority
-#define omrthread_get_flags dbg_omrthread_get_flags
-#define omrthread_get_state dbg_omrthread_get_state
-#define omrthread_get_osId dbg_omrthread_get_osId
-#define omrthread_monitor_get_name dbg_omrthread_monitor_get_name
-#define omrthread_get_stack_range dbg_omrthread_get_stack_range
-#define omrthread_monitor_get_tracing dbg_omrthread_monitor_get_tracing
-#define getVMThreadRawState dbgGetVMThreadRawState
-#endif
-
 
 /**
 * @brief

--- a/thread/common/omrthreadinspect.c
+++ b/thread/common/omrthreadinspect.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2018 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -379,9 +379,5 @@ omrthread_monitor_get_tracing(omrthread_monitor_t monitor)
 static omrthread_library_t
 get_default_library(void)
 {
-#if defined (J9VM_OUT_OF_PROCESS)
-	return dbgGetThreadLibrary();
-#else
 	return GLOBAL_DATA(default_library);
-#endif
 }


### PR DESCRIPTION
This define is never set, and the code guarded by it no longer compiles.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>