### PR TITLE
Rename getX86Description to fix build error on X

### DIFF
--- a/port/common/omrsysinfo_helpers.c
+++ b/port/common/omrsysinfo_helpers.c
@@ -77,7 +77,7 @@
  * @return 0 on success, -1 on failure
  */
 intptr_t
-getX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
+OMRgetX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
 {
 	uint32_t CPUInfo[4] = {0};
 	char vendor[12];
@@ -87,13 +87,13 @@ getX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
 	desc->processor = OMR_PROCESSOR_X86_UNKNOWN;
 
 	/* vendor */
-	getX86CPUID(CPUID_VENDOR_INFO, CPUInfo);
+	OMRgetX86CPUID(CPUID_VENDOR_INFO, CPUInfo);
 	memcpy(vendor + 0, &CPUInfo[1], sizeof(uint32_t));
 	memcpy(vendor + 4, &CPUInfo[3], sizeof(uint32_t));
 	memcpy(vendor + 8, &CPUInfo[2], sizeof(uint32_t));
 
 	/* family and model */
-	getX86CPUID(CPUID_FAMILY_INFO, CPUInfo);
+	OMRgetX86CPUID(CPUID_FAMILY_INFO, CPUInfo);
 	processorSignature = CPUInfo[0];
 	familyCode = (processorSignature & CPUID_SIGNATURE_FAMILY) >> CPUID_SIGNATURE_FAMILY_SHIFT;
 	if (0 == strncmp(vendor, CPUID_VENDOR_INTEL, CPUID_VENDOR_LENGTH)) {
@@ -183,7 +183,7 @@ getX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc)
  */
 
 void
-getX86CPUID(uint32_t leaf, uint32_t *cpuInfo)
+OMRgetX86CPUID(uint32_t leaf, uint32_t *cpuInfo)
 {
 	cpuInfo[0] = leaf;
 

--- a/port/common/omrsysinfo_helpers.h
+++ b/port/common/omrsysinfo_helpers.h
@@ -31,9 +31,9 @@
 #include "omrport.h"
 
 extern void
-getX86CPUID(uint32_t leaf, uint32_t *cpuInfo);
+OMRgetX86CPUID(uint32_t leaf, uint32_t *cpuInfo);
 
 extern intptr_t
-getX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
+OMRgetX86Description(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc);
 
 #endif /* SYSINFOHELPERS_H_ */

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -601,7 +601,7 @@ omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProc
 		memset(desc, 0, sizeof(OMRProcessorDesc));
 
 #if (defined(J9X86) || defined(J9HAMMER))
-		rc = getX86Description(portLibrary, desc);
+		rc = OMRgetX86Description(portLibrary, desc);
 #elif defined(LINUXPPC)
 		rc = getLinuxPPCDescription(portLibrary, desc);
 #elif defined(AIXPPC)

--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -99,7 +99,7 @@ omrsysinfo_get_processor_description(struct OMRPortLibrary *portLibrary, OMRProc
 	
 	if (NULL != desc) {
 		memset(desc, 0, sizeof(OMRProcessorDesc));
-		rc = getX86Description(portLibrary, desc);
+		rc = OMRgetX86Description(portLibrary, desc);
 	}
 	
 	Trc_PRT_sysinfo_get_processor_description_Exit(rc);


### PR DESCRIPTION
OpenJ9 already has a function named getX86Description which causes a build failure. Renaming the added function should fix this issue.

Build: https://ci.eclipse.org/openj9/job/Build_JDK11_x86-64_linux_cm_OMR/413
