### PR TITLE
Export omrthread_attr_set_detachstate

### DIFF
--- a/thread/exports.cmake
+++ b/thread/exports.cmake
@@ -124,6 +124,7 @@ omr_add_exports(j9thr_obj
 	omrthread_attr_set_priority
 	omrthread_attr_set_stacksize
 	omrthread_attr_set_category
+	omrthread_attr_set_detachstate
 
 	# for builder use only
 	omrthread_monitor_lock

--- a/thread/thread_include.mk
+++ b/thread/thread_include.mk
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2016 IBM Corp. and others
+# Copyright (c) 2015, 2019 IBM Corp. and others
 # 
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -232,6 +232,7 @@ define WRITE_COMMON_THREAD_EXPORTS
 @echo omrthread_attr_set_priority >>$@
 @echo omrthread_attr_set_stacksize >>$@
 @echo omrthread_attr_set_category >>$@
+@echo omrthread_attr_set_detachstate>>$@
 
 @# for builder use only
 @echo omrthread_monitor_lock >>$@


### PR DESCRIPTION
For some reason omrthread_attr_set_detachstate was not exported,
while other similar functions are.
omrthread_attr_set_detachstate is now needed by OpenJ9 project as part
of this PR: https://github.com/eclipse/openj9/pull/7940.

Signed-off-by: Ashutosh Mehra <mehra.ashutosh@ibm.com>