### PR TITLE
DDR: add support for xlc/xlclang version 16

### DIFF
--- a/ddr/include/ddr/config.hpp
+++ b/ddr/include/ddr/config.hpp
@@ -39,14 +39,13 @@
 
 /* C++ TR1 support */
 
-#if (defined(AIXPPC) && (__xlC__ < 0x1000)) || defined(J9ZOS390)
+#if (__cplusplus < 201103) && (defined(AIXPPC) || defined(J9ZOS390))
 #if !defined(__IBMCPP_TR1__)
 #define __IBMCPP_TR1__ 1
 #endif
-#define OMR_HAVE_TR1 1
 #else
 #define OMR_HAVE_CXX11 1
-#endif /* !defined(AIXPPC) && !defined(J9ZOS390) */
+#endif /* (__cplusplus < 201103) && (defined(AIXPPC) || defined(J9ZOS390)) */
 
 /* Why is this disabled? */
 

--- a/ddr/include/ddr/scanner/dwarf/AixSymbolTableParser.hpp
+++ b/ddr/include/ddr/scanner/dwarf/AixSymbolTableParser.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,6 +18,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
+
+#ifndef AixSymbolTableParser_HPP
+#define AixSymbolTableParser_HPP
 
 #include <sys/types.h>
 #include <sys/errno.h>
@@ -49,7 +52,7 @@ const string BUILT_IN_TYPES_THAT_ARE_TYPEDEFS[NUM_BUILT_IN_TYPES + 1] = {"", "",
 "", "", "unsigned", "", "", "", "", "", "integer", "", "short real", "real", "", "character", "", "", "", "",
 "", "", "integer*1", "integer*2", "integer*4", "wchar", "", "", "logical*8", "integer*8", "", "", ""
 };
-const int BUILT_IN_TYPE_SIZES[NUM_BUILT_IN_TYPES +1 ] = {0, 32, 8, 16, 32, 8, 8, 16, 32, 32,
+const int BUILT_IN_TYPE_SIZES[NUM_BUILT_IN_TYPES + 1] = {0, 32, 8, 16, 32, 8, 8, 16, 32, 32,
 32, 0, 32, 64, 128, 32, 8, 32, 64, PTR_SIZE, 8, 8, 16, 32, 32, 64, 128,
 8, 16, 32, 16, 64, 64, 64, 64, 64, 64, 64};
 
@@ -57,15 +60,16 @@ const string START_OF_FILE[3] = {"debug", "3", "FILE"};
 const string FILE_NAME = "a0";
 const string DECL_FILE[3] = {"debug", "0", "decl"};
 
-int extractFileID(const string data);
-int extractTypeID(const string data, const int index = 1);
-void split(const string data, char delimeters, str_vect *elements);
-str_vect split(const string data, char delimeters);
-string strip(const string str, const char chr);
-string stripLeading(const string str, const char chr);
-string stripTrailing(const string str, const char chr);
-double shiftDecimal(const double value);
-double toDouble(const string value);
-int toInt(const string value);
-size_t toSize(const string size);
-string toString(const int value);
+int extractFileID(const string & data);
+int extractTypeID(const string & data, int index = 1);
+void split(const string & data, char delimeters, str_vect *elements);
+str_vect split(const string & data, char delimeters);
+string strip(const string & str, char chr);
+string stripLeading(const string & str, char chr);
+string stripTrailing(const string & str, char chr);
+double toDouble(const string & value);
+int toInt(const string & value);
+size_t toSize(const string & size);
+string toString(int value);
+
+#endif /* AixSymbolTableParser_HPP */

--- a/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfFunctions.hpp
@@ -50,16 +50,15 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
-#if defined(OMR_HAVE_TR1)
+#if defined(OMR_HAVE_CXX11)
+using std::get;
+using std::make_tuple;
+using std::tuple;
+#else /* OMR_HAVE_CXX11 */
 using std::tr1::get;
 using std::tr1::make_tuple;
 using std::tr1::tuple;
-#else /* OMR_HAVE_TR1 */
-using std::get;
-using std::make_tuple;
-using std::runtime_error;
-using std::tuple;
-#endif /* OMR_HAVE_TR1 */
+#endif /* OMR_HAVE_CXX11 */
 
 struct Dwarf_Attribute_s;
 struct Dwarf_Debug_s;
@@ -139,6 +138,10 @@ typedef vector<string> str_vect;
 #define DW_FORM_udata 0x05
 #define DW_FORM_sdata 0x06
 #define DW_FORM_string 0x07
+#define DW_FORM_block  0x08
+#define DW_FORM_block1 0x09
+#define DW_FORM_block2 0x0a
+#define DW_FORM_block4 0x0b
 #define DW_FORM_flag 0x0c
 #define DW_FORM_exprloc 0x18
 

--- a/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
+++ b/ddr/include/ddr/scanner/dwarf/DwarfScanner.hpp
@@ -59,12 +59,6 @@ using std::make_pair;
 using std::map;
 using std::string;
 
-#if defined(OMR_HAVE_TR1)
-using std::tr1::hash;
-#else
-using std::hash;
-#endif
-
 class DwarfScanner : public Scanner
 {
 public:

--- a/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
+++ b/ddr/include/ddr/scanner/pdb/PdbScanner.hpp
@@ -39,7 +39,6 @@
 #include "ddr/scanner/Scanner.hpp"
 #include "ddr/ir/Symbol_IR.hpp"
 
-using std::hash;
 using std::map;
 using std::pair;
 using std::set;

--- a/ddr/include/ddr/std/unordered_map.hpp
+++ b/ddr/include/ddr/std/unordered_map.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corp. and others
+ * Copyright (c) 2013, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -30,15 +30,12 @@
 #undef tolower
 #endif /* defined(J9ZOS390) */
 
+#include <unordered_map>
+
 #if defined(OMR_HAVE_CXX11)
-#include <unordered_map>
 using std::unordered_map;
-#elif defined(OMR_HAVE_TR1)
-#include <unordered_map>
-using std::tr1::hash;
-using std::tr1::unordered_map;
 #else /* defined(OMR_HAVE_CXX11) */
-#error "Need std::unordered_map defined in TR1 or C++11."
+using std::tr1::unordered_map;
 #endif /* defined(OMR_HAVE_CXX11) */
 
 #if defined(J9ZOS390)

--- a/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
+++ b/ddr/lib/ddr-blobgen/java/genBlobJava.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 IBM Corp. and others
+ * Copyright (c) 2015, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -18,10 +18,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
-
-#if defined(AIXPPC) || defined(J9ZOS390)
-#define __IBMCPP_TR1__ 1
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
 
 #include "ddr/blobgen/genBlob.hpp"
 #include "ddr/blobgen/java/genBinaryBlob.hpp"

--- a/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfFunctions.cpp
@@ -285,12 +285,15 @@ dwarf_offdie_b(Dwarf_Debug dbg,
 	if (NULL == return_die) {
 		ret = DW_DLV_ERROR;
 		setError(error, DW_DLE_IA);
-	} else if (Dwarf_Die_s::refMap.end() != Dwarf_Die_s::refMap.find(offset)) {
-		/* Return any Die from its global offset. */
-		*return_die = Dwarf_Die_s::refMap[offset];
 	} else {
-		ret = DW_DLV_NO_ENTRY;
-		setError(error, DW_DLE_BADOFF);
+		unordered_map<Dwarf_Off, Dwarf_Die>::const_iterator iter = Dwarf_Die_s::refMap.find(offset);
+		if ((Dwarf_Die_s::refMap.end() != iter) && (NULL != iter->second)) {
+			/* Return any Die from its global offset. */
+			*return_die = iter->second;
+		} else {
+			ret = DW_DLV_NO_ENTRY;
+			setError(error, DW_DLE_BADOFF);
+		}
 	}
 	return ret;
 }

--- a/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
+++ b/ddr/lib/ddr-scanner/dwarf/DwarfScanner.cpp
@@ -272,6 +272,16 @@ Done:
 	return rc;
 }
 
+#if defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC)
+static bool
+isOnlyDigits(const char *text)
+{
+	size_t digitCount = strspn(text, "0123456789");
+
+	return '\0' == text[digitCount];
+}
+#endif /* defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC) */
+
 static bool
 isUnnamed(const char *name)
 {
@@ -283,15 +293,13 @@ isUnnamed(const char *name)
 		return true;
 	}
 
-#if defined(J9ZOS390) || defined(LINUXPPC)
+#if defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC)
 	if (0 == strncmp(name, "__", 2)) {
-		size_t digitCount = strspn(name + 2, "0123456789");
-
-		if ('\0' == name[digitCount + 2]) {
-			return true;
-		}
+		return isOnlyDigits(name + 2);
+	} else if (0 == strncmp(name, "#bit_field_", 11)) {
+		return isOnlyDigits(name + 11);
 	}
-#endif /* defined(J9ZOS390) || defined(LINUXPPC) */
+#endif /* defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC) */
 
 	return false;
 }
@@ -968,13 +976,14 @@ DwarfVisitor::visitNamespace(NamespaceUDT *newClass) const
 static bool
 isVtablePointer(const char *fieldName)
 {
+	return false
+#if defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC)
+		|| (0 == strcmp(fieldName, "__vfp"))
+#endif /* defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC) */
 #if defined(__GNUC__)
-	return 0 == strncmp(fieldName, "_vptr.", 6);
-#elif defined(AIXPPC) || defined(J9ZOS390) || defined(LINUXPPC)
-	return 0 == strcmp(fieldName, "__vfp");
-#else /* defined(__GNUC__) */
-	return false;
+		|| (0 == strncmp(fieldName, "_vptr.", 6))
 #endif /* defined(__GNUC__) */
+		;
 }
 
 /* A Die for a class/struct/union has children Die's for all of its properties,
@@ -1091,13 +1100,84 @@ DwarfVisitor::visitUnion(UnionUDT *newType) const
 	return rc;
 }
 
+/*
+ * Given an attribute of type DW_AT_const_value, return its value.
+ */
+static DDR_RC
+getConstValue(Dwarf_Debug debug, Dwarf_Attribute attr, uint64_t *value)
+{
+	DDR_RC rc = DDR_RC_ERROR;
+	Dwarf_Error error = NULL;
+	Dwarf_Half form = 0;
+
+	/* Get the literal value form. */
+	/* Get the literal value. */
+	if (DW_DLV_ERROR == dwarf_whatform(attr, &form, &error)) {
+		ERRMSG("Getting form of const_value attribute: %s\n", dwarf_errmsg(error));
+	} else if ((DW_FORM_block  == form) || (DW_FORM_block1 == form)
+			|| (DW_FORM_block2 == form) || (DW_FORM_block4 == form)) {
+		Dwarf_Block *block = NULL;
+		if (DW_DLV_ERROR == dwarf_formblock(attr, &block, &error)) {
+			ERRMSG("Getting block of const_value attribute: %s\n", dwarf_errmsg(error));
+		} else {
+			/* Note: This assumes the host byte-order. */
+			switch (block->bl_len) {
+			case 1:
+				*value = *(uint8_t *)(void *)block->bl_data;
+				rc = DDR_RC_OK;
+				break;
+			case 2:
+				*value = *(uint16_t *)(void *)block->bl_data;
+				rc = DDR_RC_OK;
+				break;
+			case 4:
+				*value = *(uint32_t *)(void *)block->bl_data;
+				rc = DDR_RC_OK;
+				break;
+			case 8:
+				*value = *(uint64_t *)(void *)block->bl_data;
+				rc = DDR_RC_OK;
+				break;
+			default:
+				ERRMSG("Unsupported const_value block size: %d\n", (int )block->bl_len);
+				break;
+			}
+			dwarf_dealloc(debug, block, DW_DLA_BLOCK);
+		}
+	} else if (DW_FORM_udata == form) {
+		Dwarf_Unsigned uvalue = 0;
+
+		if (DW_DLV_ERROR == dwarf_formudata(attr, &uvalue, &error)) {
+			ERRMSG("Getting const_value of enum: %s\n", dwarf_errmsg(error));
+		} else {
+			*value = uvalue;
+			rc = DDR_RC_OK;
+		}
+	} else {
+		Dwarf_Signed svalue = 0;
+
+		if (DW_DLV_ERROR == dwarf_formsdata(attr, &svalue, &error)) {
+			ERRMSG("Getting const_value of enum: %s\n", dwarf_errmsg(error));
+		} else {
+			*value = (uint64_t)(int64_t)svalue;
+			rc = DDR_RC_OK;
+		}
+	}
+
+	if (NULL != error) {
+		dwarf_dealloc(debug, error, DW_DLA_ERROR);
+	}
+
+	return rc;
+}
+
 /* Add an enum member to an enum UDT from a Die. */
 DDR_RC
 DwarfScanner::addEnumMember(Dwarf_Die die, NamespaceUDT *outerUDT, EnumUDT *newEnum)
 {
 	Dwarf_Attribute attr = NULL;
 	string enumName = "";
-	int enumValue = 0;
+	uint64_t enumValue = 0;
 	Dwarf_Error error = NULL;
 	vector<EnumMember *> *members = NULL;
 
@@ -1128,49 +1208,20 @@ DwarfScanner::addEnumMember(Dwarf_Die die, NamespaceUDT *outerUDT, EnumUDT *newE
 		goto AddEnumMemberError;
 	}
 
-	if (NULL != attr) {
-		Dwarf_Half form = 0;
+	rc = getConstValue(_debug, attr, &enumValue);
+	dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
 
-		/* Get the literal value form. */
-		if (DW_DLV_ERROR == dwarf_whatform(attr, &form, &error)) {
-			ERRMSG("Getting form of const_value attribute: %s\n", dwarf_errmsg(error));
-			goto AddEnumMemberError;
-		}
-
-		/* Get the literal value. */
-		if (DW_FORM_udata == form) {
-			Dwarf_Unsigned value = 0;
-
-			if (DW_DLV_ERROR == dwarf_formudata(attr, &value, &error)) {
-				ERRMSG("Getting const value of enum: %s\n", dwarf_errmsg(error));
-				goto AddEnumMemberError;
-			}
-			enumValue = (int)value;
-		} else {
-			Dwarf_Signed value = 0;
-
-			if (DW_DLV_ERROR == dwarf_formsdata(attr, &value, &error)) {
-				ERRMSG("Getting const value of enum: %s\n", dwarf_errmsg(error));
-				goto AddEnumMemberError;
-			}
-			enumValue = (int)value;
-		}
-	}
-
-	{
+	if (DDR_RC_OK == rc) {
 		/* Create new enum member. */
 		EnumMember *newEnumMember = new EnumMember;
 
 		newEnumMember->_name = enumName;
-		newEnumMember->_value = enumValue;
+		newEnumMember->_value = (int)(int64_t)enumValue;
 
 		members->push_back(newEnumMember);
 	}
 
 AddEnumMemberDone:
-	if (NULL != attr) {
-		dwarf_dealloc(_debug, attr, DW_DLA_ATTR);
-	}
 	if (NULL != error) {
 		dwarf_dealloc(_debug, error, DW_DLA_ERROR);
 	}

--- a/ddr/tools/ddrgen/ddrgen.cpp
+++ b/ddr/tools/ddrgen/ddrgen.cpp
@@ -19,9 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
-#if defined(AIXPPC) || defined(J9ZOS390)
-#define __IBMCPP_TR1__ 1
-#endif /* defined(AIXPPC) || defined(J9ZOS390) */
+#include "ddr/config.hpp"
 
 #include <stdlib.h>
 #include <string.h>

--- a/gc/base/standard/CompactScheme.hpp
+++ b/gc/base/standard/CompactScheme.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2016 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -147,7 +147,7 @@ public:
      * In Compressed Mark Map one bit represents twice more space then one bit of regular Mark Map
      * So, sizeof_page should be double of number of bytes represented by one uintptr_t in Mark Map
      */
-    enum { sizeof_page = 2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_SLOT };
+    ddr_constant(sizeof_page, 2 * J9MODRON_HEAP_BYTES_PER_HEAPMAP_SLOT);
 
 private:
     omrobjectptr_t freeChunkEnd(omrobjectptr_t chunk);
@@ -158,7 +158,6 @@ private:
 protected:
 	virtual bool initialize(MM_EnvironmentBase *env);
 	virtual void tearDown(MM_EnvironmentBase *env);
-
 
     void createSubAreaTable(MM_EnvironmentStandard *env, bool singleThreaded);
     /**

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -49,7 +49,7 @@
 extern "C" {
 #endif
 
-#define OMR_OS_STACK_SIZE	256 * 1024 /* Corresponds to desktopBigStack in builder */
+#define OMR_OS_STACK_SIZE 256 * 1024 /* Corresponds to desktopBigStack in builder */
 
 typedef enum {
 	OMR_ERROR_NONE = 0,
@@ -82,7 +82,7 @@ struct UtThreadData;
 struct OMR_TraceThread;
 
 typedef struct OMR_RuntimeConfiguration {
-	uintptr_t _maximum_vm_count;		/* 0 for unlimited */
+	uintptr_t _maximum_vm_count; /* 0 for unlimited */
 } OMR_RuntimeConfiguration;
 
 typedef struct OMR_Runtime {
@@ -96,7 +96,7 @@ typedef struct OMR_Runtime {
 } OMR_Runtime;
 
 typedef struct OMR_VMConfiguration {
-	uintptr_t _maximum_thread_count;		/* 0 for unlimited */
+	uintptr_t _maximum_thread_count; /* 0 for unlimited */
 } OMR_VMConfiguration;
 
 typedef struct movedObjectHashCode {
@@ -371,7 +371,6 @@ void omr_vmthread_reattach(OMR_VMThread *currentThread, const char *threadName);
  */
 void omr_vmthread_redetach(OMR_VMThread *omrVMThread);
 
-
 /**
  * Get the current OMR_VMThread, if the current thread is attached.
  *
@@ -446,9 +445,6 @@ void omr_vm_preFork(OMR_VM *vm);
 
 #endif /* defined(OMR_THR_FORK_SUPPORT) */
 
-
-
-
 /*
  * LANGUAGE VM GLUE
  * The following functions must be implemented by the language VM.
@@ -462,7 +458,7 @@ void omr_vm_preFork(OMR_VM *vm);
  *
  * @param[in] omrVM the OMR vm
  * @param[in] threadName An optional name for the thread. May be NULL.
- * 	 It is the responsibility of the caller to ensure this string remains valid for the lifetime of the thread.
+ *   It is the responsibility of the caller to ensure this string remains valid for the lifetime of the thread.
  * @param[out] omrVMThread the current OMR VMThread
  * @return an OMR error code
  */
@@ -561,7 +557,21 @@ int OMR_Glue_GetMethodDictionaryPropertyNum(void);
 const char * const *OMR_Glue_GetMethodDictionaryPropertyNames(void);
 
 #ifdef __cplusplus
-}
-#endif
+/*
+ * Not all compilers retain debugging information for anonymous enum types.
+ * This macro works around that behavior by declaring a static member
+ * (that will not be defined). It must be applied selectively because
+ * not all compilers generate debugging information for static members
+ * (__xlC__ is defined by xlC_r, __ibmxl_version__ is defined by xlclang++).
+ */
+#if (defined(__xlC__) && ((__xlC__ >> 8) >= 16)) \
+ || (defined(__ibmxl_version__) && (__ibmxl_version__ >= 16))
+#define ddr_constant(name, value) static enum { name = value } ddr_ref_ ## name
+#else /* defined(__ibmxl_version__) && (__ibmxl_version__ >= 16) */
+#define ddr_constant(name, value)        enum { name = value }
+#endif /* defined(__ibmxl_version__) && (__ibmxl_version__ >= 16) */
+
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* omr_h */


### PR DESCRIPTION
This is an updated version of #4620 with two essential differences:
* the macro `ddr_constant` expands to the same declaration except for xlc/xlclang version 16 or newer
* unrecognized STABS tags are not considered fatal, as proposed in #4636