### PR TITLE
Add eaEscapeHelperSymbol

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -2034,6 +2034,19 @@ OMR::SymbolReferenceTable::findOrCreateOSRFearPointHelperSymbolRef()
    }
 
 TR::SymbolReference *
+OMR::SymbolReferenceTable::findOrCreateEAEscapeHelperSymbolRef()
+   {
+   if (!element(eaEscapeHelperSymbol))
+      {
+      TR::MethodSymbol* sym = TR::MethodSymbol::create(trHeapMemory(), TR_None);
+      sym->setHelper();
+      TR::SymbolReference* symRef = new (trHeapMemory()) TR::SymbolReference(self(), eaEscapeHelperSymbol, sym);
+      element(eaEscapeHelperSymbol) = symRef;
+      }
+   return element(eaEscapeHelperSymbol);
+   }
+
+TR::SymbolReference *
 OMR::SymbolReferenceTable::getOriginalUnimprovedSymRef(TR::SymbolReference *symRef)
    {
    auto entry = _originalUnimprovedSymRefs.find(symRef->getReferenceNumber());

--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -175,6 +175,21 @@ class SymbolReferenceTable
        *   The call is not to be codegen evaluated, it should be cleaned up before codegen.
        */
       osrFearPointHelperSymbol,
+      /** \brief
+       * 
+       * A call with this symbol marks a place where we want/need escape analysis to add heapifications for any stack allocated
+       * objects. The primary use case is to force escape of all live local objects ahead of a throw to an OSR catch block
+       * but they may also be inserted to facilitate peeking of methods under HCR or other uses. Calls to this helper should
+       * only exist while escape analysis is running
+       *
+       * \code
+       *   call <eaEscapeHelperSymbol>
+       * \endcode
+       *
+       * \note
+       *   The call is not to be codegen evaluated, it should be cleaned up by postEscapeAnalysis.
+       */
+      eaEscapeHelperSymbol,
       lowTenureAddressSymbol,    // on j9vmthread
       highTenureAddressSymbol,   // on j9vmthread
       fragmentParentSymbol,
@@ -461,6 +476,7 @@ class SymbolReferenceTable
    TR::SymbolReference * findOrCreateJProfileValuePlaceHolderWithNullCHKSymbolRef();
    TR::SymbolReference * findOrCreatePotentialOSRPointHelperSymbolRef();
    TR::SymbolReference * findOrCreateOSRFearPointHelperSymbolRef();
+   TR::SymbolReference * findOrCreateEAEscapeHelperSymbolRef();
    TR::SymbolReference * findOrCreateInduceOSRSymbolRef(TR_RuntimeHelper induceOSRHelper);
 
    TR::ParameterSymbol * createParameterSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t slot, TR::DataType, TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN);

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -132,6 +132,13 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             return &symRefTab->aliasBuilder.defaultMethodUseAliases();
             }
 
+         // Aliases for eaEscapeHelper
+         // Ensure EA sees the method as causing an escape for all arguments passed
+         if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol))
+            {
+            return &symRefTab->aliasBuilder.defaultMethodUseAliases();
+            }
+
          if (!methodSymbol->isHelper())
             {
             return &symRefTab->aliasBuilder.defaultMethodUseAliases();
@@ -312,7 +319,8 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
 
          if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::arraySetSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::osrFearPointHelperSymbol) ||
-             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::potentialOSRPointHelperSymbol))
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::potentialOSRPointHelperSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol))
             {
             return &symRefTab->aliasBuilder.defaultMethodDefAliases();
             }

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1241,6 +1241,16 @@ OMR::Node::createOSRFearPointHelperCall(TR::Node* originatingByteCodeNode)
    return callNode;
    }
 
+TR::Node *
+OMR::Node::createEAEscapeHelperCall(TR::Node* originatingByteCodeNode, int32_t numChildren)
+   {
+   TR::Compilation* comp = TR::comp();
+
+   TR_ASSERT(!comp->isPeekingMethod(), "Can not generate the helper call during peeking");
+
+   TR::Node* callNode = TR::Node::createWithSymRef(originatingByteCodeNode, TR::call, numChildren, TR::comp()->getSymRefTab()->findOrCreateEAEscapeHelperSymbolRef());
+   return callNode;
+   }
 
 TR::Node *
 OMR::Node::createLoad(TR::SymbolReference * symRef)
@@ -8694,6 +8704,19 @@ OMR::Node::isPotentialOSRPointHelperCall()
    if (self()->getOpCode().isCall()
        && self()->getSymbol()->isMethod()
        && c->getSymRefTab()->isNonHelper(self()->getSymbolReference(), TR::SymbolReferenceTable::potentialOSRPointHelperSymbol))
+      return true;
+
+   return false;
+   }
+
+bool
+OMR::Node::isEAEscapeHelperCall()
+   {
+   TR::Compilation *c = TR::comp();
+
+   if (self()->getOpCode().isCall()
+       && self()->getSymbol()->isMethod()
+       && c->getSymRefTab()->isNonHelper(self()->getSymbolReference(), TR::SymbolReferenceTable::eaEscapeHelperSymbol))
       return true;
 
    return false;

--- a/compiler/il/OMRNode.hpp
+++ b/compiler/il/OMRNode.hpp
@@ -298,6 +298,13 @@ public:
     *
     */
    static TR::Node *createOSRFearPointHelperCall(TR::Node* originatingByteCodeNode);
+   /**
+    * \brief
+    *    Create a call to eaEscapeHelperSymbol
+    * 
+    * \parm originatingByteCodeNode The node whose bytecode info is used to create the call
+    */
+   static TR::Node *createEAEscapeHelperCall(TR::Node *originatingByteCodeNode, int32_t numChildren);
 
    static TR::Node *createLoad(TR::SymbolReference * symRef);
    static TR::Node *createLoad(TR::Node *originatingByteCodeNode, TR::SymbolReference *);
@@ -556,6 +563,11 @@ public:
     *    Return true if the node is a call with potentialOSRPointHelperSymbol
     */
    bool                   isPotentialOSRPointHelperCall();
+   /**
+    * \brief
+    *    Return true if the node is a call with eaEscapeHelperSymbol
+    */
+   bool                   isEAEscapeHelperCall();
 
    // A common query used by the optimizer
    inline bool            isSingleRef();

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -1651,10 +1651,8 @@ TR_Debug::getName(TR::SymbolReference * symRef)
              return "<potentialOSRPointHelper>";
          case TR::SymbolReferenceTable::osrFearPointHelperSymbol:
              return "<osrFearPointHelper>";
-         case TR::SymbolReferenceTable::jProfileValueSymbol:
-             return "<jProfileValuePlaceHolder>";
-         case TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol:
-             return "<jProfileValueWithNullCHKPlaceHolder>";
+         case TR::SymbolReferenceTable::eaEscapeHelperSymbol:
+             return "<eaEscapeHelper>";
          }
       }
 
@@ -2084,6 +2082,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<osrReturnAddress>",
    "<potentialOSRPointHelper>",
    "<osrFearPointHelper>",
+   "<eaEscapeHelper>",
    "<lowTenureAddress>",
    "<highTenureAddress>",
    "<fragmentParent>",


### PR DESCRIPTION
The OpenJ9 Escape Analysis optimization currently overloads the meaning of the OSR
helper callees as part of its analysis. This change introduces a new non-helper
symbol for this optimization pass to use to avoid overloaded meanings and the
resultant confusion in the codebase.

This helper is added to OMR because its aliasing etc must match that of the various other
helpers used for the same purpose and any other language implementing an escape
analysis-like optimization would benefit from the presence of this non-helper.

Signed-off-by: Andrew Craik <ajcraik@ca.ibm.com>