### PR TITLE
Rename VMX record form compare instructions

### DIFF
--- a/compiler/p/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeEnum.hpp
@@ -770,27 +770,36 @@
 // vcmpeqfp,         // Vector Compare Equal To Floating-Point
 // vcmpeqfp_r,       // Vector Compare Equal To Floating-Point Rc=1
    vcmpequb,         // vector compare equal unsigned byte
+   vcmpequb_r,       // vector compare equal unsigned byte with record
+   vcmpeubr = vcmpequb_r,
 // vcmpequd,         // Vector Compare Equal Unsigned Dword
 // vcmpequd_r,       // Vector Compare Equal Unsigned Dword Rc=1
-   vcmpeubr,         // vector compare equal unsigned byte with record
    vcmpequh,         // vector compare equal unsigned halfword
-   vcmpeuhr,         // vector compare equal unsigned halfword with record
+   vcmpequh_r,       // vector compare equal unsigned halfword with record
+   vcmpeuhr = vcmpequh_r,
    vcmpequw,         // vector compare equal unsigned word
-   vcmpeuwr,         // vector compare equal unsigned word with record
+   vcmpequw_r,       // vector compare equal unsigned word with record
+   vcmpeuwr = vcmpequw_r,
    vcmpgtsb,         // vector compare greater than signed byte
+   vcmpgtsb_r,       // vector compare greater than signed byte with record
+   vcmpgsbr = vcmpgtsb_r,
 // vcmpgtsd,         // Vector Compare Greater Than Signed Dword
 // vcmpgtsd_r,       // Vector Compare Greater Than Signed Dword Rc=1
-   vcmpgsbr,         // vector compare greater than signed byte with record
    vcmpgtsh,         // vector compare greater than signed halfword
-   vcmpgshr,         // vector compare greater than signed halfword with record
+   vcmpgtsh_r,       // vector compare greater than signed halfword with record
+   vcmpgshr = vcmpgtsh_r,
    vcmpgtsw,         // vector compare greater than signed word
-   vcmpgswr,         // vector compare greater than signed word with record
+   vcmpgtsw_r,       // vector compare greater than signed word with record
+   vcmpgswr = vcmpgtsw_r,
    vcmpgtub,         // vector compare greater than unsigned byte
-   vcmpgubr,         // vector compare greater than unsigned byte with record
+   vcmpgtub_r,       // vector compare greater than unsigned byte with record
+   vcmpgubr = vcmpgtub_r,
    vcmpgtuh,         // vector compare greater than unsigned halfword
-   vcmpguhr,         // vector compare greater than unsigned halfword with record
+   vcmpgtuh_r,       // vector compare greater than unsigned halfword with record
+   vcmpguhr = vcmpgtuh_r,
    vcmpgtuw,         // vector compare greater than unsigned word
-   vcmpguwr,         // vector compare greater than unsigned word with record
+   vcmpgtuw_r,       // vector compare greater than unsigned word with record
+   vcmpguwr = vcmpgtuw_r,
 // vcmpneb,          // vector compare not equal Byte
 // vcmpneb_r,        // vector compare not equal Byte Rc=1
 // vcmpneh,          // vector compare not equal Hword

--- a/compiler/p/codegen/OMRInstOpCodeProperties.hpp
+++ b/compiler/p/codegen/OMRInstOpCodeProperties.hpp
@@ -8355,7 +8355,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpequb_r,
+   /* .name        = */ "vcmpequb.",
+   /* .description =    "vector compare equal unsigned byte with record", */
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequb].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequb].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequb].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequb].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    /* { */
@@ -8382,19 +8393,6 @@
    /* }, */
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpeubr,
-   /* .name        = */ "vcmpeubr",
-   /* .description =    "vector compare equal unsigned byte with record", */
-   /* .opcode      = */ 0x10000406,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::vcmpequh,
    /* .name        = */ "vcmpequh",
    /* .description =    "vector compare equal unsigned halfword", */
@@ -8403,20 +8401,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpeuhr,
-   /* .name        = */ "vcmpeuhr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpequh_r,
+   /* .name        = */ "vcmpequh.",
    /* .description =    "vector compare equal unsigned halfword with record", */
-   /* .opcode      = */ 0x10000446,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequh].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequh].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequh].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequh].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    {
@@ -8428,20 +8424,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpeuwr,
-   /* .name        = */ "vcmpeuwr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpequw_r,
+   /* .name        = */ "vcmpequw.",
    /* .description =    "vector compare equal unsigned word with record", */
-   /* .opcode      = */ 0x10000486,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequw].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequw].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequw].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpequw].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    {
@@ -8453,7 +8447,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
+   },
+
+   {
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpgtsb_r,
+   /* .name        = */ "vcmpgtsb.",
+   /* .description =    "vector compare greater than signed byte with record", */
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsb].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsb].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsb].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsb].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    /* { */
@@ -8480,19 +8485,6 @@
    /* }, */
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpgsbr,
-   /* .name        = */ "vcmpgsbr",
-   /* .description =    "vector compare greater than signed byte with record", */
-   /* .opcode      = */ 0x10000706,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
-   },
-
-   {
    /* .mnemonic    = */ OMR::InstOpCode::vcmpgtsh,
    /* .name        = */ "vcmpgtsh",
    /* .description =    "vector compare greater than signed halfword", */
@@ -8501,20 +8493,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpgshr,
-   /* .name        = */ "vcmpgshr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpgtsh_r,
+   /* .name        = */ "vcmpgtsh.",
    /* .description =    "vector compare greater than signed halfword with record", */
-   /* .opcode      = */ 0x10000746,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsh].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsh].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsh].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsh].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    {
@@ -8526,20 +8516,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpgswr,
-   /* .name        = */ "vcmpgswr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpgtsw_r,
+   /* .name        = */ "vcmpgtsw.",
    /* .description =    "vector compare greater than signed word with record", */
-   /* .opcode      = */ 0x10000786,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsw].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsw].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsw].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtsw].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    {
@@ -8551,20 +8539,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpgubr,
-   /* .name        = */ "vcmpgubr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpgtub_r,
+   /* .name        = */ "vcmpgtub.",
    /* .description =    "vector compare greater than unsigned byte with record", */
-   /* .opcode      = */ 0x10000606,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtub].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtub].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtub].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtub].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    {
@@ -8576,20 +8562,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpguhr,
-   /* .name        = */ "vcmpguhr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpgtuh_r,
+   /* .name        = */ "vcmpgtuh.",
    /* .description =    "vector compare greater than unsigned halfword with record", */
-   /* .opcode      = */ 0x10000646,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuh].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuh].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuh].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuh].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    {
@@ -8601,20 +8585,18 @@
    /* .minimumALS  = */ TR_Processor::TR_PPCp6,
    /* .properties  = */ PPCOpProp_IsVMX |
                         PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+                        PPCOpProp_SyncSideEffectFree |
+                        PPCOpProp_HasRecordForm,
    },
 
    {
-   /* .mnemonic    = */ OMR::InstOpCode::vcmpguwr,
-   /* .name        = */ "vcmpguwr",
+   /* .mnemonic    = */ OMR::InstOpCode::vcmpgtuw_r,
+   /* .name        = */ "vcmpgtuw.",
    /* .description =    "vector compare greater than unsigned word with record", */
-   /* .opcode      = */ 0x10000686,
-   /* .format      = */ UNKNOWN_FORMAT,
-   /* .minimumALS  = */ TR_Processor::TR_DefaultPPCProcessor,
-   /* .properties  = */ PPCOpProp_IsVMX |
-                        PPCOpProp_IsRecordForm |
-                        PPCOpProp_CompareOp |
-                        PPCOpProp_SyncSideEffectFree,
+   /* .opcode      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuw].opcode | 0x400,
+   /* .format      = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuw].format,
+   /* .minimumALS  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuw].minimumALS,
+   /* .properties  = */ OMR::Power::InstOpCode::metadata[OMR::InstOpCode::vcmpgtuw].properties & ~PPCOpProp_HasRecordForm | PPCOpProp_IsRecordForm,
    },
 
    /* { */

--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -2876,20 +2876,20 @@ OMR::Power::TreeEvaluator::inlineVectorCompareBranch(TR::Node * node, TR::CodeGe
    TR::InstOpCode::Mnemonic branchOp = TR::InstOpCode::bad, vcmpOp = TR::InstOpCode::bad;
 
    switch (ilOp) {
-      case TR::vicmpalleq: vcmpOp = TR::InstOpCode::vcmpeuwr; branchOp = branchIfTrue ? PPCOp_bva  : PPCOp_bvna; break;
-      case TR::vicmpanyeq: vcmpOp = TR::InstOpCode::vcmpeuwr; branchOp = branchIfTrue ? PPCOp_bvnn : PPCOp_bvn;  break;
-      case TR::vicmpallne: vcmpOp = TR::InstOpCode::vcmpeuwr; branchOp = branchIfTrue ? PPCOp_bvn  : PPCOp_bvnn; break;
-      case TR::vicmpanyne: vcmpOp = TR::InstOpCode::vcmpeuwr; branchOp = branchIfTrue ? PPCOp_bvna : PPCOp_bva;  break;
+      case TR::vicmpalleq: vcmpOp = TR::InstOpCode::vcmpequw_r; branchOp = branchIfTrue ? PPCOp_bva  : PPCOp_bvna; break;
+      case TR::vicmpanyeq: vcmpOp = TR::InstOpCode::vcmpequw_r; branchOp = branchIfTrue ? PPCOp_bvnn : PPCOp_bvn;  break;
+      case TR::vicmpallne: vcmpOp = TR::InstOpCode::vcmpequw_r; branchOp = branchIfTrue ? PPCOp_bvn  : PPCOp_bvnn; break;
+      case TR::vicmpanyne: vcmpOp = TR::InstOpCode::vcmpequw_r; branchOp = branchIfTrue ? PPCOp_bvna : PPCOp_bva;  break;
 
-      case TR::vicmpallgt: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bva  : PPCOp_bvna; break;
-      case TR::vicmpanygt: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bvnn : PPCOp_bvn;  break;
-      case TR::vicmpallle: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bvn  : PPCOp_bvnn; break;
-      case TR::vicmpanyle: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bvna : PPCOp_bva;  break;
+      case TR::vicmpallgt: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bva  : PPCOp_bvna; break;
+      case TR::vicmpanygt: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bvnn : PPCOp_bvn;  break;
+      case TR::vicmpallle: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bvn  : PPCOp_bvnn; break;
+      case TR::vicmpanyle: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bvna : PPCOp_bva;  break;
 
-      case TR::vicmpalllt: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bva  : PPCOp_bvna; vecCmpNode->swapChildren(); break;
-      case TR::vicmpanylt: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bvnn : PPCOp_bvn;  vecCmpNode->swapChildren(); break;
-      case TR::vicmpallge: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bvn  : PPCOp_bvnn; vecCmpNode->swapChildren(); break;
-      case TR::vicmpanyge: vcmpOp = TR::InstOpCode::vcmpgswr; branchOp = branchIfTrue ? PPCOp_bvna : PPCOp_bva;  vecCmpNode->swapChildren(); break;
+      case TR::vicmpalllt: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bva  : PPCOp_bvna; vecCmpNode->swapChildren(); break;
+      case TR::vicmpanylt: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bvnn : PPCOp_bvn;  vecCmpNode->swapChildren(); break;
+      case TR::vicmpallge: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bvn  : PPCOp_bvnn; vecCmpNode->swapChildren(); break;
+      case TR::vicmpanyge: vcmpOp = TR::InstOpCode::vcmpgtsw_r; branchOp = branchIfTrue ? PPCOp_bvna : PPCOp_bva;  vecCmpNode->swapChildren(); break;
    }
 
    TR::Node *firstChild = vecCmpNode->getFirstChild();
@@ -3018,7 +3018,7 @@ TR::Register *OMR::Power::TreeEvaluator::vicmpanyHelper(TR::Node *node, TR::Code
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpalleqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpeuwr, 25);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpequw_r, 25);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpallneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3027,26 +3027,26 @@ TR::Register *OMR::Power::TreeEvaluator::vicmpallneEvaluator(TR::Node *node, TR:
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallgtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 25);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallgeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 27);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 25);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpallleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpallHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 27);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyeqEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpeuwr, 27);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpequw_r, 27);
    }
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyneEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -3056,21 +3056,21 @@ TR::Register *OMR::Power::TreeEvaluator::vicmpanyneEvaluator(TR::Node *node, TR:
 
 TR::Register *OMR::Power::TreeEvaluator::vicmpanygtEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 27);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpanygeEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 25);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyltEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    node->swapChildren();
-   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 27);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 27);
    }
 TR::Register *OMR::Power::TreeEvaluator::vicmpanyleEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgswr, 25);
+   return TR::TreeEvaluator::vicmpanyHelper(node, cg, TR::InstOpCode::vcmpgtsw_r, 25);
    }
 
 


### PR DESCRIPTION
Previously, the enumeration value names for the VMX record-form compare
instructions did not follow the general rule of adding '_r' to the name
of their non-record-form instructions. This was needlessly confusing and
inconsistent. These instructions have now had their names updated to
follow the usual style. Note that aliases have been left for the old
names, since OpenJ9 is referencing some of these instructions directly.

Additionally, the instruction properties table has been updated to
derive the properties of the VMX record-form compare instructions from
those of their non-record-form counterparts.

Signed-off-by: Ben Thomas <ben@benthomas.ca>