### PR TITLE
Consider callee type in exceptionRaised query

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -666,7 +666,8 @@ bool OMR::Compilation::isPotentialOSRPoint(TR::Node *node, TR::Node **osrPointNo
             potentialOSRPoint = true;
             }
          else if (callSymRef->getReferenceNumber() >=
-             self()->getSymRefTab()->getNonhelperIndex(self()->getSymRefTab()->getLastCommonNonhelperSymbol()))
+             self()->getSymRefTab()->getNonhelperIndex(self()->getSymRefTab()->getLastCommonNonhelperSymbol())
+             && !((TR::MethodSymbol*)(callSymRef->getSymbol()))->functionCallDoesNotYieldOSR())
             {
             potentialOSRPoint = (disableGuardedCallOSR == NULL);
             }

--- a/compiler/il/OMRMethodSymbol.hpp
+++ b/compiler/il/OMRMethodSymbol.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -194,6 +194,7 @@ public:
    bool safeToSkipZeroInitializationOnNewarrays() { return false; }
    bool safeToSkipChecksOnArrayCopies() { return false; }
 
+   bool functionCallDoesNotYieldOSR() { return false; }
    bool isPureFunction() { return false; }
 
 protected:

--- a/compiler/il/OMRNode.cpp
+++ b/compiler/il/OMRNode.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -3679,9 +3679,9 @@ OMR::Node::exceptionsRaised()
       default:
        if (node->getOpCode().isCall() && !node->isOSRFearPointHelperCall())
             {
-            possibleExceptions |= TR::Block::CanCatchOSR;
-            if (node->getSymbolReference()->canGCandExcept()
-               )
+            if (!((TR::MethodSymbol*)node->getSymbolReference()->getSymbol())->functionCallDoesNotYieldOSR())
+               possibleExceptions |= TR::Block::CanCatchOSR;
+            if (!node->isPureCall() && node->getSymbolReference()->canGCandExcept())
                possibleExceptions |= TR::Block::CanCatchUserThrows;
             }
          break;


### PR DESCRIPTION
This commit contains mainly following two changes.
1. Create a list of methods calls to which does not yield to OSR and use this information in the query to know if a call node can catch OSR.
2. Method calls which does not have any side-effects are marked as pure function. Calls to those method does not throw an exception. Use this information in query to know if a call can raise exceptions.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>