### PR TITLE
Remove definitions and uses of J9VM_ flags

### DIFF
--- a/gc/base/Configuration.cpp
+++ b/gc/base/Configuration.cpp
@@ -476,7 +476,7 @@ MM_Configuration::initializeGCParameters(MM_EnvironmentBase* env)
 		if (extensions->scavengerEnabled) {
 			extensions->splitFreeListSplitAmount = (extensions->gcThreadCount - 1) / 8  +  1;
 		} else
-	#endif /* J9VM_GC_MODRON_SCAVENGER */
+	#endif /* OMR_GC_MODRON_SCAVENGER */
 		{
 			OMRPORT_ACCESS_FROM_OMRPORT(env->getPortLibrary());
 			extensions->splitFreeListSplitAmount = (omrsysinfo_get_number_CPUs_by_type(OMRPORT_CPU_ONLINE) - 1) / 8  +  1;

--- a/gc/base/modronopt.h
+++ b/gc/base/modronopt.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2019 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -35,7 +35,6 @@
  * @{
  */
 #define J9MODRON_TGC_PARALLEL_STATISTICS
-#define J9VM_INTERP_NATIVE_SUPPORT
 /** @} */
 
 #endif /* MODRONOPT_H_ */

--- a/gc/base/standard/ParallelGlobalGC.cpp
+++ b/gc/base/standard/ParallelGlobalGC.cpp
@@ -501,12 +501,10 @@ MM_ParallelGlobalGC::masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_Allo
 	compactedThisCycle = _compactThisCycle;
 #endif /* OMR_GC_MODRON_COMPACTION */
 
-	/* If the J9VM_DEBUG_ATTRIBUTE_ALLOW_USER_HEAP_WALK flag is set then fix the heap so that it can be walked
-	 * by debugging tools
-	 */
+	/* If the delegate has isAllowUserHeapWalk set, fix the heap so that it can be walked */
 	if (_delegate.isAllowUserHeapWalk() || env->_cycleState->_gcCode.isRASDumpGC()) {
 		if (!_fixHeapForWalkCompleted) {
-#if defined(J9VM_GC_MODRON_COMPACTION)
+#if defined(OMR_GC_MODRON_COMPACTION)
 			if (compactedThisCycle) {
 				OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 				U_64 startTime = omrtime_hires_clock();
@@ -514,7 +512,7 @@ MM_ParallelGlobalGC::masterThreadGarbageCollect(MM_EnvironmentBase *env, MM_Allo
 				_extensions->globalGCStats.fixHeapForWalkTime = omrtime_hires_delta(startTime, omrtime_hires_clock(), OMRPORT_TIME_DELTA_IN_MICROSECONDS);
 				_extensions->globalGCStats.fixHeapForWalkReason = FIXUP_DEBUG_TOOLING;
 			} else
-#endif /* J9VM_GC_MODRON_COMPACTION */
+#endif /* OMR_GC_MODRON_COMPACTION */
 			{
 				fixHeapForWalk(env, MEMORY_TYPE_RAM, FIXUP_DEBUG_TOOLING, fixObject);
 			}

--- a/include_core/omr.h
+++ b/include_core/omr.h
@@ -43,7 +43,7 @@
 
 #if !defined(OMR_GC_COMPRESSED_POINTERS)
 #define OMR_GC_FULL_POINTERS
-#endif /* defined(J9VM_GC_FULL_POINTERS) */
+#endif /* !defined(OMR_GC_COMPRESSED_POINTERS) */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -601,8 +601,4 @@ typedef struct U_128 {
 #define OMR_LOG_POINTER_SIZE 2
 #endif /* defined(OMR_ENV_DATA64) */
 
-/* Legacy defines - remove once code cleanup is complete */
-#define J9VM_ENV_DIRECT_FUNCTION_POINTERS
-#define J9VM_OPT_REMOVE_CONSTANT_POOL_SPLITTING
-
 #endif /* OMRCOMP_H */


### PR DESCRIPTION
Remove always-defined flags and use OMR_ flags instead of J9VM_ ones.

Signed-off-by: Graham Chapman <graham_chapman@ca.ibm.com>