### PR TITLE
Interface and abstract class can not be final

### DIFF
--- a/compiler/optimizer/LocalOpts.hpp
+++ b/compiler/optimizer/LocalOpts.hpp
@@ -723,12 +723,12 @@ class TR_InvariantArgumentPreexistence : public TR::Optimization
       bool     _classIsPreexistent;
       };
 
-   void traceIfEnabled(const char* format, ...);
    void processNode        (TR::Node *node, TR::TreeTop *treeTop, vcount_t visitCount);
    void processIndirectCall(TR::Node *node, TR::TreeTop *treeTop, vcount_t visitCount);
    void processIndirectLoad(TR::Node *node, TR::TreeTop *treeTop, vcount_t visitCount);
    bool convertCall(TR::Node *node, TR::TreeTop *treeTop);
    bool devirtualizeVirtualCall(TR::Node *node, TR::TreeTop *treeTop, TR_OpaqueClassBlock* clazz);
+   bool classIsCurrentlyFinal(TR_OpaqueClassBlock* clazz);
    TR_YesNoMaybe classIsCompatibleWithMethod(TR_OpaqueClassBlock* thisClazz, TR_ResolvedMethod* method);
 
    ParmInfo *getSuitableParmInfo(TR::Node *node);


### PR DESCRIPTION
For interface and abstract classes, even though they haven't been
extended, we can't treat them as currently final as they will be
extended later.

Also check that `refinedMethod` is not `NULL` before continue.

Signed-off-by: Liqun Liu <liqunl@ca.ibm.com>