### PR TITLE
CMake: Add exported symbol support for gcc

### DIFF
--- a/cmake/modules/platform/toolcfg/gnu_exports.exp.in
+++ b/cmake/modules/platform/toolcfg/gnu_exports.exp.in
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2020 IBM Corp. and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
+
+{
+	global :
+	$<JOIN:$<TARGET_PROPERTY:@TARGET_NAME@,EXPORTED_SYMBOLS>,
+	;>;
+	local : *;
+};


### PR DESCRIPTION
Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>