### PR TITLE
AArch64: Load StartPC constant with pc-relative load instruction

### DIFF
--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -142,7 +142,7 @@ TR::Instruction *generateTrg1ImmInstruction(TR::CodeGenerator *cg, TR::InstOpCod
    }
 
 TR::Instruction *generateTrg1ImmSymInstruction(TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic op, TR::Node *node,
-   TR::Register *treg, uint32_t imm, TR::LabelSymbol *sym, TR::Instruction *preced)
+   TR::Register *treg, uint32_t imm, TR::Symbol *sym, TR::Instruction *preced)
    {
    if (preced)
       return new (cg->trHeapMemory()) TR::ARM64Trg1ImmSymInstruction(op, node, treg, imm, sym, preced, cg);

--- a/compiler/aarch64/codegen/GenerateInstructions.hpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -277,7 +277,7 @@ TR::Instruction *generateTrg1ImmInstruction(
  * @param[in] node : node
  * @param[in] treg : target register
  * @param[in] imm : immediate value
- * @param[in] sym : label symbol
+ * @param[in] sym : symbol
  * @param[in] preced : preceding instruction
  * @return generated instruction
  */
@@ -287,7 +287,7 @@ TR::Instruction *generateTrg1ImmSymInstruction(
                    TR::Node *node,
                    TR::Register *treg,
                    uint32_t imm,
-                   TR::LabelSymbol *sym,
+                   TR::Symbol *sym,
                    TR::Instruction *preced = NULL);
 
 /*

--- a/compiler/aarch64/codegen/OMRMemoryReference.cpp
+++ b/compiler/aarch64/codegen/OMRMemoryReference.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -58,7 +58,7 @@ static void loadRelocatableConstant(TR::Node *node,
 
    if (symbol->isStartPC())
       {
-      TR_UNIMPLEMENTED();
+      generateTrg1ImmSymInstruction(cg, TR::InstOpCode::adr, node, reg, addr, symbol);
       return;
       }
 


### PR DESCRIPTION
This commit enables <s>`ARMTrg1ImmInstruction`</s> `ARMTrg1ImmSymInstruction` to handle StartPC constant,
and change `loadRelocatableConstant` to use it.

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>