### PR TITLE
Add TR::Region::reset helper function

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -2722,8 +2722,7 @@ void OMR::Compilation::invalidateAliasRegion()
    {
    if (self()->_aliasRegion.bytesAllocated() > (ALIAS_REGION_LOAD_FACTOR) * TR::Region::initialSize())
       {
-      self()->_aliasRegion.~Region();
-      new (&self()->_aliasRegion) TR::Region(_heapMemoryRegion);
+      TR::Region::reset(self()->_aliasRegion, _heapMemoryRegion);
       }
    }
 

--- a/compiler/env/Region.hpp
+++ b/compiler/env/Region.hpp
@@ -113,6 +113,12 @@ public:
 
    void deallocate(void * allocation, size_t = 0) throw();
 
+   static void reset(TR::Region& targetRegion, TR::Region& prototypeRegion)
+      {
+      targetRegion.~Region(); 
+      new (&targetRegion) TR::Region(prototypeRegion);
+      }
+
    friend bool operator ==(const TR::Region &lhs, const TR::Region &rhs)
       {
       return &lhs == &rhs;

--- a/compiler/il/NodePool.cpp
+++ b/compiler/il/NodePool.cpp
@@ -41,8 +41,7 @@ TR::NodePool::NodePool(TR::Compilation * comp, const TR::Allocator &allocator) :
 void
 TR::NodePool::cleanUp()
    {
-   _nodeRegion.~Region();
-   new (&_nodeRegion) TR::Region(_comp->trMemory()->heapMemoryRegion());
+   TR::Region::reset(_nodeRegion, _comp->trMemory()->heapMemoryRegion());
    }
 
 TR::Node *

--- a/compiler/infra/OMRCfg.cpp
+++ b/compiler/infra/OMRCfg.cpp
@@ -326,8 +326,7 @@ TR_Structure *
 OMR::CFG::invalidateStructure()
    {
    setStructure(NULL);
-   _structureRegion.~Region();
-   new (&_structureRegion) TR::Region(comp()->trMemory()->heapMemoryRegion());
+   TR::Region::reset(_structureRegion, comp()->trMemory()->heapMemoryRegion());
    return getStructure();
    }
 

--- a/compiler/optimizer/RegisterCandidate.hpp
+++ b/compiler/optimizer/RegisterCandidate.hpp
@@ -349,8 +349,7 @@ public:
    TR_RegisterCandidate *newCandidate(TR::SymbolReference *ref);
 
    void releaseCandidates() {
-     _candidateRegion.~Region();
-     new (_candidateRegion) TR::Region(_trMemory->heapMemoryRegion());
+      TR::Region::reset(_candidateRegion, _trMemory->heapMemoryRegion());
    }
 
    void collectCfgProperties(TR::Block **, int32_t);


### PR DESCRIPTION
Add a helper function that correctly releases memory managed by TR::Region.
Implemented the helper functions throughout all instances listed on #4649.

Fixes #4649 