### PR TITLE
Deprecate assignRegistersNoDependencies as it is no longer used

### DIFF
--- a/compiler/z/codegen/S390Instruction.cpp
+++ b/compiler/z/codegen/S390Instruction.cpp
@@ -1470,17 +1470,6 @@ TR::S390RegInstruction::generateBinaryEncoding()
    return cursor;
    }
 
-void
-TR::S390RegInstruction::assignRegistersNoDependencies(TR_RegisterKinds kindToBeAssigned)
-   {
-   TR::Machine *machine = cg()->machine();
-   setRegisterOperand(1,machine->assignBestRegister(getRegisterOperand(1), this, BOOKKEEPING));
-
-   return;
-   }
-
-// TR::S390RRInstruction:: member functions /////////////////////////////////////////
-
 bool
 TR::S390RRInstruction::refsRegister(TR::Register * reg)
    {

--- a/compiler/z/codegen/S390Instruction.hpp
+++ b/compiler/z/codegen/S390Instruction.hpp
@@ -1363,8 +1363,6 @@ class S390RegInstruction : public TR::Instruction
 
    virtual uint8_t *generateBinaryEncoding();
 
-   virtual void assignRegistersNoDependencies(TR_RegisterKinds kindToBeAssigned);
-
    virtual bool refsRegister(TR::Register *reg);
 
    TR::InstOpCode::S390BranchCondition getBranchCondition()  {return _branchCondition;}


### PR DESCRIPTION
This API is not used anywhere and its current implementation looks
incomplete. We remove it here to prevent people using it.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>