### PR TITLE
Enable simplifying conditional store in CFG simplifier on x, p,…

### DIFF
--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1496,6 +1496,9 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsArrayTranslateTRxx() {return _flags2.testAny(SupportsArrayTranslate);}
    void setSupportsArrayTranslateTRxx() {_flags2.set(SupportsArrayTranslate);}
 
+   bool getSupportsTernary() {return _flags2.testAny(SupportsTernary);}
+   void setSupportsTernary() {_flags2.set(SupportsTernary);}
+
    bool getSupportsArrayTranslateTRTO255() {return _flags4.testAny(SupportsArrayTranslateTRTO255);}
    void setSupportsArrayTranslateTRTO255() {_flags4.set(SupportsArrayTranslateTRTO255);}
 
@@ -1748,7 +1751,7 @@ class OMR_EXTENSIBLE CodeGenerator
       SupportsReadOnlyLocks                               = 0x00000400,
       SupportsArrayTranslateAndTest                       = 0x00000800,
       SupportsDynamicANewArray                            = 0x00001000,
-      // AVAILABLE                                        = 0x00002000,
+      SupportsTernary                                     = 0x00002000,
       // AVAILABLE                                        = 0x00004000,
       SupportsPostProcessArrayCopy                        = 0x00008000,
       // AVAILABLE                                        = 0x00010000,

--- a/compiler/optimizer/OMRCFGSimplifier.cpp
+++ b/compiler/optimizer/OMRCFGSimplifier.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <stddef.h>
+#include "codegen/CodeGenerator.hpp"
 #include "compile/Compilation.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/TRMemory.hpp"
@@ -368,8 +369,7 @@ static bool containsIndirectOperation(TR::Compilation *comp, TR::TreeTop *treeto
 
 bool OMR::CFGSimplifier::simplifyCondStoreSequence(bool needToDuplicateTree)
    {
-   static char *disableSimplifyCondStoreSequence = feGetEnv("TR_disableSimplifyCondStoreSequence");
-   if (disableSimplifyCondStoreSequence != NULL)
+   if (!(comp()->cg()->getSupportsTernary()))
       return false;
 
    if (trace())
@@ -474,8 +474,7 @@ bool OMR::CFGSimplifier::simplifyCondStoreSequence(bool needToDuplicateTree)
 
 bool OMR::CFGSimplifier::simplifySimpleStore(bool needToDuplicateTree)
    {
-   static char *disableSimplifySimpleStore = feGetEnv("TR_disableSimplifySimpleStore");
-   if (disableSimplifySimpleStore != NULL)
+   if (!(comp()->cg()->getSupportsTernary()))
       return false;
 
    if (trace())
@@ -737,8 +736,7 @@ bool OMR::CFGSimplifier::simplifyNullToException(bool needToDuplicateTree)
 //
 bool OMR::CFGSimplifier::simplifyBooleanStore(bool needToDuplicateTree)
    {
-   static char *enableSimplifyBooleanStore = feGetEnv("TR_enableSimplifyBooleanStore");
-   if (enableSimplifyBooleanStore == NULL)
+   if (!(comp()->cg()->getSupportsTernary()))
       return false;
 
    if (trace())

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -212,6 +212,7 @@ OMR::Power::CodeGenerator::CodeGenerator() :
     self()->setSupportsVirtualGuardNOPing();
     self()->setSupportsPrimitiveArrayCopy();
     self()->setSupportsReferenceArrayCopy();
+    self()->setSupportsTernary();
 
     // disabled for now
     //

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -409,6 +409,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
    self()->setSupportsEfficientNarrowUnsignedIntComputation();
    self()->setSupportsVirtualGuardNOPing();
    self()->setSupportsDynamicANewArray();
+   self()->setSupportsTernary();
 
    // allows [i/l]div to decompose to [i/l]mulh in TreeSimplifier
    //

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -453,6 +453,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
 
    self()->setMultiplyIsDestructive();
 
+   self()->setSupportsTernary();
+
    self()->setIsOutOfLineHotPath(false);
 
    self()->setUsesRegisterPairsForLongs();


### PR DESCRIPTION
Ternary used in cfg simplifier is only supported on x, p and z
now, so a codegen capability query for ternary support is added. 
Capability check to guard ternary generation in CFGSimplifier is thus added in
so that simplifying conditional store is turned on for those three platforms.
   
Signed-off-by: Yiling Han <Yiling.Han@ibm.com>