### PR TITLE
Avoid narrowing conversions for signed integer minimum values

### DIFF
--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -355,11 +355,11 @@ typedef struct {
  * MIN and MAX data types
  */
 #define U_8_MAX ((uint8_t)-1)
-#define I_8_MIN ((int8_t)1 << ((sizeof(int8_t) * 8) - 1))
+#define I_8_MIN ((int8_t)(1 << ((sizeof(int8_t) * 8) - 1)))
 #define I_8_MAX ((int8_t)((uint8_t)I_8_MIN - 1))
 
 #define U_16_MAX ((uint16_t)-1)
-#define I_16_MIN ((int16_t)1 << ((sizeof(int16_t) * 8) - 1))
+#define I_16_MIN ((int16_t)(1 << ((sizeof(int16_t) * 8) - 1)))
 #define I_16_MAX ((int16_t)((uint16_t)I_16_MIN - 1))
 
 #define U_32_MAX ((uint32_t)-1)


### PR DESCRIPTION
References to `I_8_MIN` and `I_16_MIN` have errors reported for narrowing conversions if they are used in initializers.  Modified the way the expressions are written to avoid the narrowing conversions.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>